### PR TITLE
Sync 🌊: upstream catch-up

### DIFF
--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -221,6 +221,14 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
+          # TestPyPI is the retry-prone dry-run index and PyPI never allows a
+          # filename to be re-uploaded: without this, a re-run after a partial
+          # publish (e.g. one package's Trusted Publisher misconfigured)
+          # aborts on the first already-landed file and never reaches the
+          # packages that still need publishing. The real-PyPI step below
+          # deliberately omits it — a prod release must fail loud on any
+          # collision.
+          skip-existing: true
 
       - name: Publish to PyPI
         # Real PyPI only via a deliberate manual dispatch with


### PR DESCRIPTION
## Summary

The upstream tree, re-exported as one reviewable unit. Repo-local infrastructure (maintainer roster, lockfiles) is preserved, as always.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Mechanical re-export from the audited export pipeline; this PR's full CI run validates the synced tree.
