### PR TITLE
Sync 🌊: 4 upstream changes

### DIFF
--- a/ap-web/src/components/PermissionsModal.test.tsx
+++ b/ap-web/src/components/PermissionsModal.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { PermissionsModal } from "./PermissionsModal";
@@ -181,6 +181,45 @@ describe("PermissionsModal", () => {
     await waitFor(() => {
       expect(screen.getByText("'rice' needs manage permission")).toBeInTheDocument();
     });
+  });
+
+  // Regression guard: granting manage (level 3) is backend-only. No level
+  // dropdown in the modal may ever offer "Manage" — not the add-grant form
+  // and not the per-row level select, regardless of the viewer (owners and
+  // managers see the same modal).
+  it("never offers Manage in any level dropdown", async () => {
+    listMock.mockResolvedValue([
+      { user_id: "owner@example.com", conversation_id: "conv_abc", level: 4 },
+      { user_id: "mallory@example.com", conversation_id: "conv_abc", level: 3 },
+      { user_id: "bob@example.com", conversation_id: "conv_abc", level: 1 },
+    ]);
+
+    render(<PermissionsModal sessionId="conv_abc" open={true} onOpenChange={() => {}} />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(screen.getByText("mallory@example.com")).toBeInTheDocument());
+
+    // Exactly two dropdowns exist: bob's row + the add-grant form. If this
+    // count is 3, the pre-existing manage grant regressed from a fixed label
+    // back to an editable (and thus Manage-bearing) select.
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers).toHaveLength(2);
+    // The manage grant's level is still visible to the viewer as static text.
+    expect(screen.getByText("Manage")).toBeInTheDocument();
+
+    for (const trigger of triggers) {
+      trigger.focus();
+      fireEvent.keyDown(trigger, { key: "Enter" });
+      const listbox = await screen.findByRole("listbox");
+      // The full option list is exactly Read and Edit. A "Manage" entry here
+      // means the UI re-exposed grantable manage; any other extra entry means
+      // a new level was added without deciding whether it's grantable.
+      const options = within(listbox).getAllByRole("option");
+      expect(options.map((o) => o.textContent)).toEqual(["Read", "Edit"]);
+      fireEvent.keyDown(listbox, { key: "Escape" });
+      await waitFor(() => expect(screen.queryByRole("listbox")).not.toBeInTheDocument());
+    }
   });
 
   it("does not fetch permissions when closed", () => {

--- a/ap-web/src/components/PermissionsModal.tsx
+++ b/ap-web/src/components/PermissionsModal.tsx
@@ -172,7 +172,6 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
               <SelectContent>
                 <SelectItem value="1">Read</SelectItem>
                 <SelectItem value="2">Edit</SelectItem>
-                <SelectItem value="3">Manage</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -407,14 +406,20 @@ function GrantRow({
   busy: boolean;
 }) {
   const isOwner = permission.level === 4;
+  // Manage is not grantable from the UI, so a pre-existing manage grant
+  // renders as a fixed label rather than a dropdown choice. Unlike the
+  // owner row it can still be revoked.
+  const isManage = permission.level === 3;
 
   return (
     <div className="flex items-center gap-2 rounded-md px-2 py-0.5 hover:bg-muted/50">
       <span className="flex-1 truncate text-sm" title={permission.user_id}>
         {permission.user_id}
       </span>
-      {isOwner ? (
-        <span className="flex h-8 w-28 items-center px-3 text-sm text-muted-foreground">Owner</span>
+      {isOwner || isManage ? (
+        <span className="flex h-8 w-28 items-center px-3 text-sm text-muted-foreground">
+          {isOwner ? "Owner" : "Manage"}
+        </span>
       ) : (
         <Select
           value={String(permission.level)}
@@ -430,7 +435,6 @@ function GrantRow({
           <SelectContent>
             <SelectItem value="1">Read</SelectItem>
             <SelectItem value="2">Edit</SelectItem>
-            <SelectItem value="3">Manage</SelectItem>
           </SelectContent>
         </Select>
       )}

--- a/ap-web/src/hooks/useIdleNotifications.test.tsx
+++ b/ap-web/src/hooks/useIdleNotifications.test.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/browserNotifications";
 import { isNativeShell, setBadgeCount } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
+import { markConversationSeen } from "@/hooks/useUnseenConversations";
 import { useIdleNotifications } from "./useIdleNotifications";
 
 const useConvMock = vi.mocked(useConversations);
@@ -107,6 +108,10 @@ beforeEach(() => {
   // "user looked away" case). Focus-specific tests override this.
   setWindowFocused(false);
   setConversations([]);
+  // The badge derivation reads the real last-seen baselines from
+  // localStorage (useUnseenConversations is intentionally NOT mocked);
+  // start each test with a clean slate.
+  window.localStorage.clear();
 });
 
 afterEach(() => {
@@ -267,40 +272,123 @@ describe("useIdleNotifications badge (native shell)", () => {
     isNativeMock.mockReturnValue(true);
   });
 
-  it("sets the badge to the count of unread sessions on a turn end", () => {
-    setWindowFocused(false);
-    setConversations([conv("a", "running")]);
-    const { rerender } = renderHook(() => useIdleNotifications());
-    setBadgeMock.mockClear();
+  /**
+   * Conversation with an unseen-activity baseline: the user last had it
+   * open at t=50 (persisted via the real `markConversationSeen`) and the
+   * session has activity at t=100 — exactly the state that lights the
+   * sidebar's unread dot.
+   */
+  function unseenConv(id: string, status: Conversation["status"] = "idle"): Conversation {
+    markConversationSeen(id, 50);
+    return { ...conv(id, status), updated_at: 100 };
+  }
 
-    setConversations([conv("a", "idle")]);
-    rerender();
+  it("counts already-unread sessions on the first data tick (no live transition)", () => {
+    // The session finished while the app was closed: its activity postdates
+    // the persisted last-seen baseline, but THIS window never observed the
+    // running -> idle transition. The badge must still count it — this is
+    // the core fix (the old transition-based badge read 0 here).
+    setConversations([unseenConv("a")]);
+    renderHook(() => useIdleNotifications());
 
-    // One unread session -> badge count 1. If 0, the unread set isn't being
-    // populated; if >1, ids are being double-counted.
     expect(setBadgeMock).toHaveBeenCalledWith(1);
   });
 
-  it("accumulates distinct unread sessions across polls", () => {
-    setWindowFocused(false);
-    setConversations([conv("a", "running"), conv("b", "running")]);
+  it("sends 0 on the first computation when nothing is unread", () => {
+    // The Electron main process keeps a per-window badge count that
+    // survives reloads. The first computation must send even when the
+    // count is 0, or a pre-reload badge sticks stale forever.
+    setConversations([conv("a", "idle")]);
+    renderHook(() => useIdleNotifications());
+
+    expect(setBadgeMock).toHaveBeenCalledWith(0);
+  });
+
+  it("sends nothing while the conversations query is still loading", () => {
+    useConvMock.mockReturnValue({ data: undefined } as ReturnType<typeof useConversations>);
     const { rerender } = renderHook(() => useIdleNotifications());
+    // No data yet -> no badge computation (a transient 0 would flicker a
+    // legitimate pre-reload badge before the list arrives).
+    expect(setBadgeMock).not.toHaveBeenCalled();
 
-    setConversations([conv("a", "idle"), conv("b", "running")]);
+    setConversations([unseenConv("a")]);
     rerender();
-    setConversations([conv("a", "idle"), conv("b", "idle")]);
-    rerender();
+    // First resolved fetch computes and sends the real count.
+    expect(setBadgeMock).toHaveBeenCalledWith(1);
+  });
 
-    // Two separate sessions finished across two polls -> badge reaches 2.
-    expect(setBadgeMock).toHaveBeenLastCalledWith(2);
+  it("counts sessions awaiting input (pending elicitations)", () => {
+    // Awaiting-input sessions badge even without an unseen baseline: the
+    // agent is blocked on the user, which the sidebar flags too.
+    setConversations([conv("a", "running", 1)]);
+    renderHook(() => useIdleNotifications());
+
+    expect(setBadgeMock).toHaveBeenCalledWith(1);
+  });
+
+  it("updates the badge when a watched session's turn ends", () => {
+    markConversationSeen("a", 50);
+    // Still running: updated_at past the baseline doesn't count yet
+    // (isConversationUnseen ignores running sessions).
+    setConversations([{ ...conv("a", "running"), updated_at: 100 }]);
+    const { rerender } = renderHook(() => useIdleNotifications());
+    expect(setBadgeMock).toHaveBeenLastCalledWith(0);
+
+    setConversations([{ ...conv("a", "idle"), updated_at: 100 }]);
+    rerender();
+    // The turn ended -> the session is now unseen -> badge 1.
+    expect(setBadgeMock).toHaveBeenLastCalledWith(1);
+  });
+
+  it("does not resend an unchanged count", () => {
+    setConversations([unseenConv("a")]);
+    const { rerender } = renderHook(() => useIdleNotifications());
+    expect(setBadgeMock).toHaveBeenCalledWith(1);
+    setBadgeMock.mockClear();
+
+    // Same unread state on the next tick (fresh data object, same content)
+    // -> the lastSent gate suppresses a redundant IPC send.
+    setConversations([unseenConv("a")]);
+    rerender();
+    expect(setBadgeMock).not.toHaveBeenCalled();
+  });
+
+  it("clears a session from the badge once it's marked seen", () => {
+    setConversations([unseenConv("a")]);
+    const { rerender } = renderHook(() => useIdleNotifications());
+    expect(setBadgeMock).toHaveBeenLastCalledWith(1);
+
+    // The user viewed the session (ChatPage's useMarkConversationSeen
+    // advances the baseline past updated_at); the next data tick must drop
+    // it from the count.
+    markConversationSeen("a", 200);
+    setConversations([{ ...conv("a", "idle"), updated_at: 100 }]);
+    rerender();
+    expect(setBadgeMock).toHaveBeenLastCalledWith(0);
+  });
+
+  it("suppresses the actively-viewed session while the window is focused", () => {
+    setWindowFocused(true);
+    // 'a' is unseen by the baseline, but the user is looking right at it.
+    setConversations([unseenConv("a")]);
+    renderHook(() => useIdleNotifications("a"));
+
+    expect(setBadgeMock).toHaveBeenCalledWith(0);
+  });
+
+  it("counts the open session when the window is blurred", () => {
+    setWindowFocused(false);
+    setConversations([unseenConv("a")]);
+    renderHook(() => useIdleNotifications("a"));
+
+    // Viewing 'a' but blurred -> the user isn't looking, so it counts.
+    expect(setBadgeMock).toHaveBeenCalledWith(1);
   });
 
   it("clears the badge when the window regains focus on the open conversation", () => {
     setWindowFocused(false);
-    setConversations([conv("a", "running")]);
-    const { rerender } = renderHook(() => useIdleNotifications("a"));
-    setConversations([conv("a", "idle")]);
-    rerender();
+    setConversations([unseenConv("a")]);
+    renderHook(() => useIdleNotifications("a"));
     // Precondition: 'a' is unread (badge 1).
     expect(setBadgeMock).toHaveBeenLastCalledWith(1);
     setBadgeMock.mockClear();
@@ -317,10 +405,8 @@ describe("useIdleNotifications badge (native shell)", () => {
 
   it("keeps other unread sessions when focusing clears only the active one", () => {
     setWindowFocused(false);
-    setConversations([conv("a", "running"), conv("b", "running")]);
-    const { rerender } = renderHook(() => useIdleNotifications("a"));
-    setConversations([conv("a", "idle"), conv("b", "idle")]);
-    rerender();
+    setConversations([unseenConv("a"), unseenConv("b")]);
+    renderHook(() => useIdleNotifications("a"));
     // Both unread -> badge 2.
     expect(setBadgeMock).toHaveBeenLastCalledWith(2);
     setBadgeMock.mockClear();
@@ -330,7 +416,7 @@ describe("useIdleNotifications badge (native shell)", () => {
       window.dispatchEvent(new Event("focus"));
     });
 
-    // Focusing on 'a' clears only 'a'; 'b' remains unread -> badge 1.
+    // Focusing on 'a' suppresses only 'a'; 'b' remains unread -> badge 1.
     expect(setBadgeMock).toHaveBeenCalledWith(1);
   });
 });

--- a/ap-web/src/hooks/useIdleNotifications.ts
+++ b/ap-web/src/hooks/useIdleNotifications.ts
@@ -1,19 +1,22 @@
 // Surfaces "a session needs your attention" as OS notifications and a
 // dock/taskbar badge. Rides the existing conversations poll (no new backend
-// signal): each refresh we diff the previous snapshot and react to two
-// "attention" transitions.
+// signal).
 //
-// Attention events (notify + badge):
+// Notifications fire on two "attention" TRANSITIONS, diffed against the
+// previous snapshot:
 //   * a turn finishing — status `running` -> `idle`/`failed`
 //   * a new elicitation — `pending_elicitations_count` increased (the agent
 //     is asking the user for input)
 //
-// The dock badge shows the number of UNREAD sessions at all times — sessions
-// that had an attention event the user hasn't looked at yet. A session is
-// "read" (removed from the badge) when the user is actively viewing it: the
-// window is focused AND it's the open conversation. Notifications follow the
-// same rule — anything that needs attention notifies, except the conversation
-// you're actively looking at.
+// The dock badge is NOT transition-based: it's recomputed from the full
+// conversation list every tick using the same persistent definition as the
+// sidebar — sessions with unseen activity (`isConversationUnseen`, backed by
+// the localStorage last-seen baseline) plus sessions awaiting input (pending
+// elicitations). That keeps it correct across reloads and counts sessions
+// that finished while the app was closed. A session is suppressed only while
+// the user is actively viewing it: the window is focused AND it's the open
+// conversation. Notifications follow the same rule — anything that needs
+// attention notifies, except the conversation you're actively looking at.
 //
 // Notifications are on by default — there's no settings toggle. In a plain
 // browser the Web Notifications API still requires a permission grant, so we
@@ -37,11 +40,12 @@ import { fetchLastAssistantText } from "@/lib/lastAssistantText";
 import {
   buildElicitationMap,
   buildStatusMap,
-  computeUnreadSet,
+  computeUnreadBadgeIds,
   type ConversationStatus,
   detectIdleTransitions,
   detectNewElicitations,
 } from "@/lib/idleTransitions";
+import { isConversationUnseen } from "@/hooks/useUnseenConversations";
 import { conversationDisplayLabel } from "@/shell/sidebarNav";
 
 const IDLE_BODY = "Agent finished and is ready for your input.";
@@ -83,10 +87,13 @@ function isWindowFocused(): boolean {
  * value, so sessions already idle at load never fire — only a fresh
  * transition observed by this client does.
  *
- * The badge reflects the number of unread sessions — those that had an
- * attention event (turn finished or new elicitation) the user hasn't viewed.
- * It updates on every change, regardless of window focus, and clears a
- * session the moment the user actively views it.
+ * The badge reflects the number of unread sessions — the same definition the
+ * sidebar uses: sessions with unseen activity since the user last had them
+ * open (`isConversationUnseen`) plus sessions awaiting input (pending
+ * elicitations). It's recomputed from the conversation list every tick (no
+ * accumulated state), so it survives reloads and counts sessions that
+ * finished while the app was closed. The actively-viewed session is cleared
+ * the moment the user views it.
  *
  * :param activeConversationId: The conversation currently open in the UI, or
  *   undefined on a non-chat route, e.g. ``"conv_abc123"``. Used to suppress
@@ -97,10 +104,18 @@ export function useIdleNotifications(activeConversationId?: string): void {
   const { data } = useConversations();
   const prevStatus = useRef<Map<string, ConversationStatus>>(new Map());
   const prevElicitations = useRef<Map<string, number>>(new Map());
-  // The set of unread session ids backing the badge. A ref (not state) because
-  // it drives an imperative OS call, not a render, and must persist across
-  // polls without re-triggering the effect.
-  const unread = useRef<Set<string>>(new Set());
+  // Last badge count actually sent to the shell. `null` (nothing sent yet)
+  // makes the FIRST computation send unconditionally — including 0 — so a
+  // badge left over in the Electron main process from before a reload (it
+  // keeps a per-window count that survives in-window navigations) is
+  // corrected instead of sticking stale.
+  const lastSentBadge = useRef<number | null>(null);
+  // Latest conversation list, so the focus listener (mounted once) can
+  // recompute the badge without re-subscribing on data changes. `null` until
+  // the first fetch resolves — the badge is never computed from a
+  // still-loading list, so a reload doesn't flash the stale count to 0
+  // before correcting it.
+  const latestConversations = useRef<Conversation[] | null>(null);
 
   useLazyPermissionRequest();
 
@@ -109,22 +124,54 @@ export function useIdleNotifications(activeConversationId?: string): void {
   const activeIdRef = useRef<string | undefined>(activeConversationId);
   activeIdRef.current = activeConversationId;
 
-  // Refocusing the window (or having it focused on the open conversation)
-  // marks that conversation read. Recompute the badge from the existing set
-  // with no new attention ids — `computeUnreadSet` clears the actively-viewed
-  // id. No-op in a plain browser (`setBadgeCount` is inert there).
+  // Send the badge count when it differs from the last one sent. No-op in a
+  // plain browser (`setBadgeCount` is inert outside the desktop shell).
+  const pushBadge = (count: number) => {
+    if (count === lastSentBadge.current) return;
+    lastSentBadge.current = count;
+    void setBadgeCount(count);
+  };
+
+  // Refocusing the window (focused on the open conversation) marks that
+  // conversation read: recompute from the latest list with windowFocused
+  // true, which drops the actively-viewed id from the count. The persistent
+  // last-seen baseline is advanced by ChatPage's `useMarkConversationSeen`,
+  // so the next data tick agrees with this immediate recompute.
   useEffect(() => {
     const onFocus = () => {
-      const next = computeUnreadSet(unread.current, [], activeIdRef.current, true);
-      unread.current = next;
-      void setBadgeCount(next.size);
+      if (latestConversations.current === null) return;
+      const next = computeUnreadBadgeIds(
+        latestConversations.current,
+        activeIdRef.current,
+        true,
+        isConversationUnseen,
+      );
+      pushBadge(next.size);
     };
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
+    // pushBadge only touches refs, so the once-mounted listener stays fresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    const conversations = data?.pages.flatMap((page) => page.data) ?? [];
+    // Still loading — don't compute a badge from an absent list (and don't
+    // bump lastSentBadge), so the first real computation below sends
+    // unconditionally.
+    if (data === undefined) return;
+    const conversations = data.pages.flatMap((page) => page.data);
+    latestConversations.current = conversations;
+
+    // Badge first, before the empty-list bail below: an empty list must
+    // still send 0 so a stale nonzero badge clears.
+    const unread = computeUnreadBadgeIds(
+      conversations,
+      activeConversationId,
+      isWindowFocused(),
+      isConversationUnseen,
+    );
+    pushBadge(unread.size);
+
     if (conversations.length === 0) return;
 
     const idle = detectIdleTransitions(prevStatus.current, conversations);
@@ -136,11 +183,7 @@ export function useIdleNotifications(activeConversationId?: string): void {
     const grantedOrNative = isNativeShell() || getNotificationPermission() === "granted";
 
     // A session is "actively viewed" — and thus suppressed — only when the
-    // window is focused AND it's the open conversation. De-dupe ids that both
-    // finished a turn and raised an elicitation in the same tick.
-    const attentionConvs = new Map<string, Conversation>();
-    for (const c of [...idle, ...newElicitations]) attentionConvs.set(c.id, c);
-
+    // window is focused AND it's the open conversation.
     if (grantedOrNative) {
       for (const conversation of idle) {
         if (windowFocused && conversation.id === activeConversationId) continue;
@@ -157,29 +200,7 @@ export function useIdleNotifications(activeConversationId?: string): void {
         notify(conversation, ELICITATION_BODY, navigate);
       }
     }
-
-    // Recompute the unread set from this tick's attention ids and push the
-    // badge. Done unconditionally (not gated on permission) so the badge
-    // tracks unread state even if web notifications were denied. No-op in a
-    // plain browser since `setBadgeCount` is inert outside the desktop shell.
-    const next = computeUnreadSet(
-      unread.current,
-      [...attentionConvs.keys()],
-      activeConversationId,
-      windowFocused,
-    );
-    if (!setsEqual(next, unread.current)) {
-      unread.current = next;
-      void setBadgeCount(next.size);
-    }
   }, [data, navigate, activeConversationId]);
-}
-
-/** True when two id sets contain exactly the same members. */
-function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
-  if (a.size !== b.size) return false;
-  for (const id of a) if (!b.has(id)) return false;
-  return true;
 }
 
 /** Show one notification for a session transition; click opens the chat. */

--- a/ap-web/src/hooks/useUnseenConversations.test.ts
+++ b/ap-web/src/hooks/useUnseenConversations.test.ts
@@ -1,8 +1,10 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
   isConversationUnseen,
   markConversationSeen,
   nowSeconds,
+  useMarkConversationSeen,
 } from "./useUnseenConversations";
 
 const STORAGE_KEY = "omnigent:last-seen-timestamps";
@@ -125,5 +127,91 @@ describe("isConversationUnseen", () => {
   it("handles non-object localStorage values gracefully", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([1, 2, 3]));
     expect(isConversationUnseen("conv-1", 1000, "idle")).toBe(false);
+  });
+});
+
+describe("useMarkConversationSeen", () => {
+  /** Force the window-focus reading used by the hook (document.hasFocus). */
+  function setWindowFocused(focused: boolean): void {
+    vi.spyOn(document, "hasFocus").mockReturnValue(focused);
+  }
+
+  /** The stored last-seen baseline for an id, or undefined when absent. */
+  function storedBaseline(id: string): number | undefined {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw)[id] : undefined;
+  }
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("marks the thread seen on mount when the window is focused", () => {
+    setWindowFocused(true);
+    vi.useFakeTimers({ now: 5_000_000 });
+    renderHook(() => useMarkConversationSeen("conv-1", 4_000));
+    expect(storedBaseline("conv-1")).toBe(5_000);
+  });
+
+  it("does NOT mark the thread seen while the window is blurred", () => {
+    // The thread is open but the app isn't focused — the user isn't
+    // reading it. Marking it seen here would silently drop the session
+    // from the dock badge the moment its turn finishes in the background.
+    setWindowFocused(false);
+    renderHook(() => useMarkConversationSeen("conv-1", 4_000));
+    expect(storedBaseline("conv-1")).toBeUndefined();
+  });
+
+  it("does not advance the baseline on updatedAt changes while blurred", () => {
+    setWindowFocused(true);
+    vi.useFakeTimers({ now: 1_000_000 });
+    const { rerender } = renderHook(({ updatedAt }) => useMarkConversationSeen("conv-1", updatedAt), {
+      initialProps: { updatedAt: 500 },
+    });
+    expect(storedBaseline("conv-1")).toBe(1_000);
+
+    // The agent finishes a turn (updated_at bumps) while the window is
+    // blurred: the baseline must stay at 1_000 so the session reads
+    // unseen — even though it's the open thread.
+    setWindowFocused(false);
+    vi.setSystemTime(3_000_000);
+    rerender({ updatedAt: 2_000 });
+    expect(storedBaseline("conv-1")).toBe(1_000);
+    expect(isConversationUnseen("conv-1", 2_000, "idle")).toBe(true);
+  });
+
+  it("marks the thread seen when the window regains focus", () => {
+    setWindowFocused(false);
+    vi.useFakeTimers({ now: 2_000_000 });
+    renderHook(() => useMarkConversationSeen("conv-1", 1_500));
+    expect(storedBaseline("conv-1")).toBeUndefined();
+
+    // The user comes back to the window with the thread still open —
+    // NOW they're reading it, so the baseline advances past updated_at.
+    setWindowFocused(true);
+    vi.setSystemTime(4_000_000);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(storedBaseline("conv-1")).toBe(4_000);
+    expect(isConversationUnseen("conv-1", 1_500, "idle")).toBe(false);
+  });
+
+  it("marks seen on unmount only when the window is focused", () => {
+    setWindowFocused(true);
+    vi.useFakeTimers({ now: 1_000_000 });
+    const focused = renderHook(() => useMarkConversationSeen("conv-1", 500));
+    vi.setSystemTime(2_000_000);
+    focused.unmount();
+    // Focused navigation away counts as having read up to now.
+    expect(storedBaseline("conv-1")).toBe(2_000);
+
+    // A blurred unmount (e.g. the session deleted from another client)
+    // must not advance the baseline — the user never saw the updates.
+    setWindowFocused(false);
+    vi.setSystemTime(3_000_000);
+    const blurred = renderHook(() => useMarkConversationSeen("conv-2", 500));
+    blurred.unmount();
+    expect(storedBaseline("conv-2")).toBeUndefined();
   });
 });

--- a/ap-web/src/hooks/useUnseenConversations.ts
+++ b/ap-web/src/hooks/useUnseenConversations.ts
@@ -75,12 +75,25 @@ export function isConversationUnseen(
   return updatedAt > stored;
 }
 
+/** True when the app window currently has focus (SSR-safe default true). */
+function windowHasFocus(): boolean {
+  if (typeof document === "undefined") return true;
+  return typeof document.hasFocus === "function" ? document.hasFocus() : true;
+}
+
 /**
  * Marks the active conversation as seen on mount, on every poll
- * refresh (updatedAt change keeps the stored time fresh), and on
- * cleanup (navigation away). Wall-clock time is stored so any
- * server-side update that happened while the user was viewing is
- * captured, even if the conversations poll hadn't picked it up yet.
+ * refresh (updatedAt change keeps the stored time fresh), on the
+ * window regaining focus, and on cleanup (navigation away).
+ * Wall-clock time is stored so any server-side update that happened
+ * while the user was viewing is captured, even if the conversations
+ * poll hadn't picked it up yet.
+ *
+ * Every mark is gated on the window having focus: a thread open in a
+ * blurred window is NOT being read, so a turn finishing there must
+ * stay unseen (the dock badge counts it) until focus returns. The
+ * focus listener covers the return path — refocusing while the
+ * thread is open marks it seen at that moment.
  */
 export function useMarkConversationSeen(
   conversationId: string | undefined,
@@ -88,7 +101,17 @@ export function useMarkConversationSeen(
 ): void {
   useEffect(() => {
     if (!conversationId || updatedAt === undefined) return;
-    markConversationSeen(conversationId);
-    return () => markConversationSeen(conversationId);
+    const markIfFocused = () => {
+      if (windowHasFocus()) markConversationSeen(conversationId);
+    };
+    markIfFocused();
+    window.addEventListener("focus", markIfFocused);
+    return () => {
+      window.removeEventListener("focus", markIfFocused);
+      // Navigation away normally happens via user interaction (focused);
+      // an unmount in a blurred window (e.g. the session deleted from
+      // another client) must not silently mark the thread read.
+      markIfFocused();
+    };
   }, [conversationId, updatedAt]);
 }

--- a/ap-web/src/lib/idleTransitions.test.ts
+++ b/ap-web/src/lib/idleTransitions.test.ts
@@ -3,7 +3,7 @@ import type { Conversation } from "@/hooks/useConversations";
 import {
   buildElicitationMap,
   buildStatusMap,
-  computeUnreadSet,
+  computeUnreadBadgeIds,
   detectIdleTransitions,
   detectNewElicitations,
   type ConversationStatus,
@@ -165,57 +165,99 @@ describe("buildElicitationMap", () => {
   });
 });
 
-describe("computeUnreadSet", () => {
-  it("adds an attention id when no conversation is active", () => {
-    const next = computeUnreadSet(new Set(), ["a"], undefined, true);
+describe("computeUnreadBadgeIds", () => {
+  /** Conversation with badge-relevant fields under test. */
+  function convB(
+    id: string,
+    opts: { status?: Conversation["status"]; pending?: number; updatedAt?: number } = {},
+  ): Conversation {
+    return {
+      ...conv(id, opts.status ?? "idle"),
+      updated_at: opts.updatedAt ?? 100,
+      pending_elicitations_count: opts.pending ?? 0,
+    };
+  }
+
+  /** Predicate marking exactly the given ids unseen (sidebar dot stand-in). */
+  function unseenIds(...ids: string[]): (id: string) => boolean {
+    const set = new Set(ids);
+    return (id: string) => set.has(id);
+  }
+
+  it("counts a session the unseen predicate flags", () => {
+    const next = computeUnreadBadgeIds([convB("a")], undefined, true, unseenIds("a"));
     expect([...next]).toEqual(["a"]);
   });
 
-  it("adds an attention id for a non-active conversation while focused", () => {
-    // Window focused but viewing 'b' -> 'a' is unread.
-    const next = computeUnreadSet(new Set(), ["a"], "b", true);
+  it("counts a session awaiting input even when not unseen", () => {
+    // Pending elicitation alone (sidebar "awaiting" badge) puts the session
+    // on the dock badge — the user owes it a response.
+    const next = computeUnreadBadgeIds([convB("a", { pending: 1 })], undefined, true, unseenIds());
     expect([...next]).toEqual(["a"]);
   });
 
-  it("suppresses an attention id only when actively viewed (focused + active)", () => {
-    // Focused AND viewing 'a' -> the user is looking at it, so not unread.
-    const next = computeUnreadSet(new Set(), ["a"], "a", true);
-    expect(next.has("a")).toBe(false);
+  it("excludes a seen session with no pending elicitations", () => {
+    // Neither unseen nor awaiting -> contributes nothing. A failure here
+    // means the badge would count every listed session.
+    const next = computeUnreadBadgeIds([convB("a")], undefined, true, unseenIds());
+    expect(next.size).toBe(0);
   });
 
-  it("marks the open conversation unread when the window is blurred", () => {
+  it("suppresses the actively-viewed session (focused + active)", () => {
+    // Focused AND viewing 'a' -> the user is looking at it, so not unread,
+    // even though the predicate flags it and it has a pending elicitation.
+    const next = computeUnreadBadgeIds([convB("a", { pending: 2 })], "a", true, unseenIds("a"));
+    expect(next.size).toBe(0);
+  });
+
+  it("counts the open session when the window is blurred", () => {
     // Active conversation is 'a' but the window is blurred -> the user isn't
-    // looking, so an attention event on 'a' still counts as unread. This is
-    // the core fix: badge tracks unread even with the window focused elsewhere.
-    const next = computeUnreadSet(new Set(), ["a"], "a", false);
-    expect(next.has("a")).toBe(true);
+    // looking, so 'a' still counts. Suppression requires focus AND active.
+    const next = computeUnreadBadgeIds([convB("a")], "a", false, unseenIds("a"));
+    expect([...next]).toEqual(["a"]);
   });
 
-  it("clears the actively-viewed conversation from an existing set", () => {
-    // 'a' was unread; the user focuses the window on 'a' (no new attention
-    // ids) -> 'a' is marked read and removed.
-    const next = computeUnreadSet(new Set(["a", "b"]), [], "a", true);
-    expect([...next].sort()).toEqual(["b"]);
+  it("counts a non-active unseen session while focused elsewhere", () => {
+    // Window focused but viewing 'b' -> 'a' is unread.
+    const next = computeUnreadBadgeIds([convB("a"), convB("b")], "b", true, unseenIds("a"));
+    expect([...next]).toEqual(["a"]);
   });
 
-  it("does not clear the active conversation when the window is blurred", () => {
-    // Refocus path requires focus; a blurred 'focus' can't happen, but guard
-    // the logic: blurred + active 'a' leaves 'a' in the set.
-    const next = computeUnreadSet(new Set(["a"]), [], "a", false);
-    expect(next.has("a")).toBe(true);
+  it("aggregates unseen and awaiting sessions in one set", () => {
+    // 'a' unseen, 'b' awaiting, 'c' both (counted once), 'd' neither,
+    // active 'e' suppressed. Size 3 proves de-dupe and suppression together.
+    const next = computeUnreadBadgeIds(
+      [
+        convB("a"),
+        convB("b", { pending: 1 }),
+        convB("c", { pending: 1 }),
+        convB("d"),
+        convB("e", { pending: 1 }),
+      ],
+      "e",
+      true,
+      unseenIds("a", "c", "e"),
+    );
+    expect([...next].sort()).toEqual(["a", "b", "c"]);
   });
 
-  it("does not mutate the input set", () => {
-    const current = new Set(["a"]);
-    computeUnreadSet(current, ["b"], undefined, true);
-    // Original must be untouched (returns a new set).
-    expect([...current]).toEqual(["a"]);
+  it("passes each session's id, updated_at, and status to the predicate", () => {
+    // The hook wires isConversationUnseen here; wrong arguments would make
+    // the localStorage lookup miss and the badge silently read 0.
+    const calls: Array<{ id: string; updatedAt: number; status: string | undefined }> = [];
+    computeUnreadBadgeIds(
+      [convB("a", { updatedAt: 42, status: "failed" })],
+      undefined,
+      true,
+      (id, updatedAt, status) => {
+        calls.push({ id, updatedAt, status });
+        return false;
+      },
+    );
+    expect(calls).toEqual([{ id: "a", updatedAt: 42, status: "failed" }]);
   });
 
-  it("simultaneously adds non-active ids and clears the active one", () => {
-    // Real-world tick: 'b' and 'c' finished while focused on 'a' -> add both,
-    // and 'a' (actively viewed) is cleared.
-    const next = computeUnreadSet(new Set(["a"]), ["b", "c"], "a", true);
-    expect([...next].sort()).toEqual(["b", "c"]);
+  it("returns an empty set for an empty list", () => {
+    expect(computeUnreadBadgeIds([], undefined, true, unseenIds("a")).size).toBe(0);
   });
 });

--- a/ap-web/src/lib/idleTransitions.ts
+++ b/ap-web/src/lib/idleTransitions.ts
@@ -75,39 +75,45 @@ export function detectNewElicitations(
 }
 
 /**
- * Pure reducer for the "unread sessions" set that drives the dock/taskbar
- * badge. Given the current set and this poll's observations, returns the
- * next set:
+ * Pure derivation of the "unread sessions" set that drives the dock/taskbar
+ * badge. Recomputed from the full conversation list every tick — no
+ * accumulated client-side state — so the badge matches what the sidebar
+ * flags as needing attention, including sessions that finished while this
+ * window wasn't open.
  *
- *   * Each \`attentionId\` (a session that just ended a turn or raised a new
- *     elicitation) is marked unread — UNLESS it's the conversation the user
- *     is actively viewing (the window is focused AND it's the active route).
- *     "Actively viewed" is the ONE suppression rule: if the window is
- *     blurred, even the open conversation counts as unread, because the user
- *     isn't looking at it.
- *   * The actively-viewed conversation is always cleared from the set, so
- *     opening (or refocusing on) a session marks it read.
+ * A session counts as unread when it is NOT actively viewed (the window is
+ * focused AND it's the open conversation — the one suppression rule; a
+ * blurred window means even the open conversation counts) AND either:
  *
- * Returns a NEW set; never mutates \`current\`.
+ *   * it has pending elicitations (the sidebar's "awaiting input" badge), or
+ *   * \`isUnseen\` says it has activity since the user last had it open (the
+ *     sidebar's unread dot — see \`isConversationUnseen\`).
  *
- * :param current: The existing unread-session id set.
- * :param attentionIds: Ids needing attention this tick, e.g. \`["conv_a"]\`.
+ * \`isUnseen\` is injected rather than imported so this module stays free of
+ * localStorage and directly unit-testable.
+ *
+ * :param conversations: The current conversation list.
  * :param activeId: The conversation currently open in the UI, or undefined
  *   when on a non-chat route, e.g. \`"conv_a"\`.
  * :param windowFocused: Whether the app window itself has focus.
- * :returns: The next unread-session id set.
+ * :param isUnseen: Predicate matching \`isConversationUnseen\`'s signature —
+ *   whether a session has unseen activity, given its id, \`updated_at\`, and
+ *   status.
+ * :returns: The unread-session id set; its size is the badge number.
  */
-export function computeUnreadSet(
-  current: ReadonlySet<string>,
-  attentionIds: string[],
+export function computeUnreadBadgeIds(
+  conversations: Conversation[],
   activeId: string | undefined,
   windowFocused: boolean,
+  isUnseen: (id: string, updatedAt: number, status: string | undefined) => boolean,
 ): Set<string> {
-  const next = new Set(current);
-  const isActivelyViewed = (id: string): boolean => windowFocused && id === activeId;
-  for (const id of attentionIds) {
-    if (!isActivelyViewed(id)) next.add(id);
+  const unread = new Set<string>();
+  for (const conversation of conversations) {
+    if (windowFocused && conversation.id === activeId) continue;
+    const awaiting = (conversation.pending_elicitations_count ?? 0) > 0;
+    if (awaiting || isUnseen(conversation.id, conversation.updated_at, conversation.status)) {
+      unread.add(conversation.id);
+    }
   }
-  if (activeId !== undefined && isActivelyViewed(activeId)) next.delete(activeId);
-  return next;
+  return unread;
 }

--- a/omnigent/inner/banner.py
+++ b/omnigent/inner/banner.py
@@ -42,12 +42,12 @@ def _display_width(text: str) -> int:
 
     :func:`rich.cells.cell_len` under-counts an emoji forced to its wide
     presentation by a trailing VARIATION SELECTOR-16 (U+FE0F) — e.g. the
-    subscription ``🎟️`` glyph — as a single cell, while modern terminals
+    cli-config ``⚙️`` glyph — as a single cell, while modern terminals
     render it as two. Adding one cell per VS16 makes the banner box border
     line up under such a glyph instead of drifting one column right.
 
-    :param text: The string to measure, e.g. ``"🎟️ Subscription"``.
-    :returns: The estimated terminal column width, e.g. ``15``.
+    :param text: The string to measure, e.g. ``"⚙️ my-gateway"``.
+    :returns: The estimated terminal column width, e.g. ``13``.
     """
     from rich.cells import cell_len
 
@@ -104,7 +104,7 @@ def startup_banner_strings(
         callers). Ignored when *info_lines* is provided.
     :param info_lines: Explicit dim info rows shown beneath the title,
         e.g. ``[BannerLine("multi-agent orchestrator", dim=True),
-        BannerLine("claude-sonnet-4-6 · 🎟️ Subscription", dim=True),
+        BannerLine("claude-sonnet-4-6 · Subscription", dim=True),
         BannerLine("~/omnigent", dim=True)]``. ``None`` falls
         back to the *hint_line* behavior.
     :param mascot_lines: Mascot art to show to the left of the

--- a/omnigent/inner/mascots.py
+++ b/omnigent/inner/mascots.py
@@ -20,12 +20,8 @@ class MascotPayload(TypedDict):
 
 
 MASCOT_ART_LINES: tuple[str, ...] = (
-    "      ╭────╮     ",
-    "   ╭──╯    ╰──╮  ",
-    "  ╭╯          ╰╮ ",
-    " ╭╯    ◕ᴗ◕     ╰╮",
-    " ╰╮            ╭╯",
-    "  ╰╯  ╰╯  ╰╯  ╰╯ ",
+    "( ◉ ‿ ◉ )",
+    " ~)|)|(~ ",
 )
 
 MASCOT_ART_COL_WIDTH = max(len(line) for line in MASCOT_ART_LINES)
@@ -53,7 +49,7 @@ def random_mascot_lines() -> list[str]:
     The function name is kept for compatibility with the old procedural
     mascot API, but the TUI now uses the single static Omnigent mascot.
 
-    :returns: Centered six-row mascot art.
+    :returns: Centered two-row mascot art.
     """
 
     return list(MASCOT_ART_LINES)

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -246,11 +246,13 @@ class _StartupHeader:
         e.g. ``"claude-sonnet-4-6"``; ``None`` when no model is pinned
         (a subscription / Databricks profile picks it at run time).
     :param credential: The launch harness's credential as glyph + label,
-        e.g. ``"🎟️ Subscription"``; ``None`` when none resolves (e.g. a
-        remote-URL target with no local harness).
+        e.g. ``"🧱 Databricks (my-ws)"`` — a subscription renders
+        glyphless as ``"Subscription"`` (see :func:`_header_glyph`);
+        ``None`` when none resolves (e.g. a remote-URL target with no
+        local harness).
     :param creds_line: The per-family creds disclosure shown beneath the
-        box for multi-vendor agents, e.g. ``"Claude → 🎟️ Subscription
-        ·   Codex → 🎟️ Subscription"``; ``None`` for single-family
+        box for multi-vendor agents, e.g. ``"Claude → Subscription
+        ·   Codex → Subscription"``; ``None`` for single-family
         agents (the box's credential row already says it).
     """
 
@@ -306,6 +308,24 @@ def _summarize_description(description: str | None) -> str | None:
     return first
 
 
+def _header_glyph(kind: str) -> str:
+    """Kind glyph for the startup header's credential labels.
+
+    The header drops the subscription ADMISSION TICKETS glyph — its red
+    rendering is too loud for the banner box — while every other kind
+    keeps its :func:`kind_glyph`. CLI surfaces (``omnigent setup``, the
+    ``/model`` readout) keep the ticket.
+
+    :param kind: The provider kind, e.g. ``"subscription"`` or ``"key"``.
+    :returns: The kind's glyph (e.g. ``"🔑"``), or ``""`` for the
+        subscription kind.
+    """
+    from omnigent.onboarding.configure_models import kind_glyph
+    from omnigent.onboarding.provider_config import SUBSCRIPTION_KIND
+
+    return "" if kind == SUBSCRIPTION_KIND else kind_glyph(kind)
+
+
 def _build_startup_header(
     harness: str | None,
     agent_description: str | None,
@@ -334,7 +354,6 @@ def _build_startup_header(
     from omnigent.onboarding.configure_models import (
         credential_label,
         family_label,
-        kind_glyph,
     )
     from omnigent.onboarding.detected import effective_config_with_detected
     from omnigent.onboarding.provider_config import (
@@ -352,7 +371,7 @@ def _build_startup_header(
         if cred is not None:
             model_label = cred.model
             cred_name = credential_label(cred.kind, cred.provider_name)
-            credential = f"{kind_glyph(cred.kind)} {cred_name}".strip()
+            credential = f"{_header_glyph(cred.kind)} {cred_name}".strip()
 
     creds_line: str | None = None
     families = used_families or []
@@ -372,7 +391,7 @@ def _build_startup_header(
                     profile=entry.profile,
                     display_name=entry.display_name,
                 )
-                label = f"{kind_glyph(entry.kind)} {cred_text}".strip()
+                label = f"{_header_glyph(entry.kind)} {cred_text}".strip()
             parts.append(f"{family_label(fam)} → {label}")
         creds_line = "   ·   ".join(parts)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnigent"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "Omnigent: declarative agent authoring and runtime framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -25,8 +25,8 @@ dependencies = [
     # one version, so a published `omnigent==X` must resolve the SDK wheels
     # built alongside it (release-omnigent.yml verifies these pins match the
     # release tag). Local/editable installs still resolve via tool.uv.sources.
-    "omnigent-client==0.1.0rc1",
-    "omnigent-ui-sdk==0.1.0rc1",
+    "omnigent-client==0.1.0rc2",
+    "omnigent-ui-sdk==0.1.0rc2",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-client"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "Python client SDK for the omnigent server API"
 requires-python = ">=3.12"
 dependencies = [
@@ -15,7 +15,7 @@ dependencies = [
     # editable alongside the root ``omnigent`` package. Version-locked
     # (==) so a published SDK always pairs with the server release it
     # shipped with (release-omnigent.yml verifies the pin).
-    "omnigent==0.1.0rc1",
+    "omnigent==0.1.0rc2",
     "httpx>=0.27",
     "pydantic>=2.0,<3",
 ]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-ui-sdk"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 requires-python = ">=3.12"
 dependencies = [
     # Version-locked (==) with the sibling client SDK; released together
     # at one version (release-omnigent.yml verifies the pin). A `>=`
-    # floor would also reject pre-releases (0.1.0rc1 < 0.1.0 in PEP 440).
-    "omnigent-client==0.1.0rc1",
+    # floor would also reject pre-releases (0.1.0rc2 < 0.1.0 in PEP 440).
+    "omnigent-client==0.1.0rc2",
     "rich>=13",
     "prompt_toolkit>=3",
     "pyyaml>=6.0,<7",

--- a/tests/inner/test_mascots.py
+++ b/tests/inner/test_mascots.py
@@ -12,20 +12,16 @@ from omnigent.inner.mascots import (
 )
 
 
-def test_random_mascot_lines_returns_centered_happy_otto() -> None:
-    """The TUI mascot uses the selected centered Otto-like six-line art."""
+def test_random_mascot_lines_returns_compact_octopus() -> None:
+    """The TUI mascot uses the compact two-line octopus art."""
 
     lines = random_mascot_lines()
 
     assert lines == [
-        "      ╭────╮     ",
-        "   ╭──╯    ╰──╮  ",
-        "  ╭╯          ╰╮ ",
-        " ╭╯    ◕ᴗ◕     ╰╮",
-        " ╰╮            ╭╯",
-        "  ╰╯  ╰╯  ╰╯  ╰╯ ",
+        "( ◉ ‿ ◉ )",
+        " ~)|)|(~ ",
     ]
-    assert MASCOT_ART_COL_WIDTH == 17
+    assert MASCOT_ART_COL_WIDTH == 9
     assert all(len(line) == MASCOT_ART_COL_WIDTH for line in lines)
 
 

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -1401,14 +1401,14 @@ def test_startup_header_box_includes_folder_model_and_credential() -> None:
         folder="~/omnigent",
         description="Multi-agent coding orchestrator",
         model_label="claude-sonnet-4-6",
-        credential="🎟️ Subscription",
+        credential="Subscription",
         creds_line=None,
     )
     plain = re.sub(r"\x1b\[[0-9;]*m", "", _render_startup_banner_ansi("nessie", header=header))
     # Every header field appears in the rendered box.
     assert "Multi-agent coding orchestrator" in plain  # one-line summary row
     assert "claude-sonnet-4-6" in plain  # model row
-    assert "🎟️ Subscription" in plain  # credential row (glyph + shared label)
+    assert "Subscription" in plain  # credential row (glyphless — see _header_glyph)
     assert "~/omnigent" in plain  # working-folder row
     # No separate creds line was requested, so none is appended.
     assert "→" not in plain
@@ -1432,12 +1432,12 @@ def test_startup_header_appends_per_family_creds_line() -> None:
         folder="~/wd",
         description=None,
         model_label="claude-sonnet-4-6",
-        credential="🎟️ Subscription",
-        creds_line="Claude → 🎟️ Subscription   ·   Codex → 🎟️ Subscription",
+        credential="Subscription",
+        creds_line="Claude → Subscription   ·   Codex → Subscription",
     )
     plain = re.sub(r"\x1b\[[0-9;]*m", "", _render_startup_banner_ansi("nessie", header=header))
-    assert "Claude → 🎟️ Subscription" in plain
-    assert "Codex → 🎟️ Subscription" in plain
+    assert "Claude → Subscription" in plain
+    assert "Codex → Subscription" in plain
     # A personality-laden lead-in (with the agent name) precedes the creds line.
     lead = "Try asking nessie to spawn the following sub-agents!"
     assert lead in plain
@@ -1547,8 +1547,10 @@ def test_build_startup_header_subscription_credential(tmp_path, monkeypatch) -> 
     What this proves: the header's model + credential row is sourced from
     the real merged provider config for the launch harness — a Claude
     subscription default surfaces as the "Subscription" credential (with
-    no pinned model, since the CLI login picks it). A regression in the
-    config→header resolution would drop or mislabel the credential.
+    no pinned model, since the CLI login picks it), WITHOUT the 🎟️ kind
+    glyph (dropped from the header by design; CLI surfaces keep it). A
+    regression in the config→header resolution would drop or mislabel
+    the credential; a reappearing 🎟️ means _header_glyph was bypassed.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
@@ -1564,8 +1566,9 @@ def test_build_startup_header_subscription_credential(tmp_path, monkeypatch) -> 
     )
     header = _build_startup_header("claude-sdk", "A test agent.", ["anthropic"])
     assert header.credential is not None
-    assert "Subscription" in header.credential
-    assert "🎟" in header.credential
+    # Exact equality proves both the glyph suppression and that the
+    # empty-glyph join left no stray leading whitespace.
+    assert header.credential == "Subscription"
     # Single family → no per-family creds line (the box row already says it).
     assert header.creds_line is None
     # The description is summarized for the box.
@@ -1609,10 +1612,13 @@ def test_build_startup_header_creds_line_includes_pi_surface(tmp_path, monkeypat
         "pi", "Multi-agent coding orchestrator.", ["anthropic", "openai", "pi"]
     )
     assert header.creds_line is not None
-    # Each surface resolves its own effective credential.
-    assert "Claude → 🎟️ Subscription" in header.creds_line
-    assert "Codex → 🎟️ Subscription" in header.creds_line
+    # Each surface resolves its own effective credential. Subscriptions
+    # render glyphless in the header; other kinds keep their glyph (🧱).
+    assert "Claude → Subscription" in header.creds_line
+    assert "Codex → Subscription" in header.creds_line
     assert "Pi → 🧱 Databricks (my-ws)" in header.creds_line
+    # The ticket glyph never reaches the header creds line.
+    assert "🎟" not in header.creds_line
     # The box's launch-harness row follows the same pi resolution: the
     # explicit pi-scoped Databricks default, not the subscription.
     assert header.credential is not None

--- a/uv.lock
+++ b/uv.lock
@@ -2428,7 +2428,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2582,7 +2582,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "m
 
 [[package]]
 name = "omnigent-client"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -2599,7 +2599,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.1.0rc1" },
+    { name = "omnigent-client", specifier = "==0.1.0rc2" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },


### PR DESCRIPTION
## Summary

The upstream tree, re-exported as one reviewable unit. This round:

- notification: update dekstop count
- ap-web: hide the Manage level from grantable options in the share modal
- Replace startup banner mascot with compact two-line octopus
- repl: drop the red 🎟️ subscription glyph from the startup header

Repo-local infrastructure (maintainer roster, lockfiles) is preserved, as always.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Mechanical re-export from the audited export pipeline; this PR's full CI run validates the synced tree.
