### PR TITLE
chore(oss): regenerate public lockfiles against public PyPI/npm

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-06-05T18:41:08Z"
+
 [[package]]
 name = "aiofiles"
 version = "24.1.0"


### PR DESCRIPTION
Automated: regenerated uv.lock + ap-web/package-lock.json against public PyPI/npm, validated by a Docker build + omnigent --help smoke (run 27435709605). Merge to keep the public lockfiles current and buildable.