### PR TITLE
Sync 🌊: 2 upstream changes

### DIFF
--- a/ap-web/src/lib/agentLabels.ts
+++ b/ap-web/src/lib/agentLabels.ts
@@ -13,10 +13,11 @@
  * harness options or pill suffix at all.
  */
 export const BRAIN_HARNESS_LABELS: Record<string, string> = {
+  // Insertion order IS the fly-out's menu order.
   "claude-sdk": "Claude SDK",
+  "openai-agents": "OpenAI Agents SDK",
   codex: "Codex",
   pi: "Pi",
-  "openai-agents": "OpenAI Agents SDK",
 };
 
 /**

--- a/ap-web/src/shell/sidebarNav.test.ts
+++ b/ap-web/src/shell/sidebarNav.test.ts
@@ -206,7 +206,7 @@ describe("getConversationIconKind", () => {
 });
 
 describe("conversationDisplayLabel", () => {
-  it("uses the title when present and a compact id fallback otherwise", () => {
+  it("uses the title when present and a 'New session' fallback otherwise", () => {
     expect(
       conversationDisplayLabel(
         conversation("conv_abcdefghijklmnopqrstuvwxyz", "Named chat", new Date(2026, 4, 14, 9)),
@@ -216,7 +216,7 @@ describe("conversationDisplayLabel", () => {
       conversationDisplayLabel(
         conversation("conv_abcdefghijklmnopqrstuvwxyz", null, new Date(2026, 4, 14, 9)),
       ),
-    ).toBe("conv_abcdefgh...");
+    ).toBe("New session");
   });
 
   it("falls back to 'Claude Code' for claude-native sessions with no title", () => {

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -60,7 +60,7 @@ export function conversationDisplayLabel(conversation: Conversation): string {
   if (conversation.title) return conversation.title;
   const label = nativeWrapperLabel(conversation);
   if (label !== null) return label;
-  return truncateConversationId(conversation.id);
+  return UNTITLED_CONVERSATION_LABEL;
 }
 
 export function filterConversations(
@@ -135,9 +135,4 @@ export function normalizePinnedConversationIds(
   }
 
   return normalized;
-}
-
-function truncateConversationId(id: string): string {
-  if (id.length <= 14) return id;
-  return `${id.slice(0, 13)}...`;
 }


### PR DESCRIPTION
## Summary

The upstream tree, re-exported as one reviewable unit. This round:

- style(web): reorder the agent-harness menu (Claude SDK / OpenAI Agents SDK / Codex / Pi)
- fix(ap-web): show "New session" for untitled sessions in the sidebar
- fix(ap-web): override the full transitive @tiptap/* set to 3.23.4

Repo-local infrastructure (maintainer roster, lockfiles) is preserved, as always.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Mechanical re-export from the audited export pipeline; this PR's full CI run validates the synced tree.
