### PR TITLE
Sync 🌊: 2 upstream changes

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -138,15 +138,13 @@ jobs:
         with:
           node-version: "20"
 
-      # Resolve only distributions uploaded > 7 days ago, so a freshly
-      # regenerated lock never pins a release younger than a week (gives
-      # a window for a compromised/yanked upload to be caught). Inline
-      # rather than a local composite action: this job checks out the
-      # PR author's tree, where a `./.github/actions/...` reference may
-      # not exist; a `run:` step comes from the base-branch workflow.
-      - name: Pin uv resolution cutoff (exclude-newer)
-        run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
-
+      # The 7-day dependency cooldown comes from the repo's uv.toml
+      # (`exclude-newer = "P7D"`), which uv records in the lock as a
+      # relative span — so `uv sync --locked` stays consistent without
+      # this workflow injecting a cutoff. (An env-var UV_EXCLUDE_NEWER
+      # here would override the config with an absolute date and stamp
+      # it into the lock, breaking every later `uv sync --locked` that
+      # runs without the same env.)
       - name: Regenerate lockfiles against public PyPI/npm
         run: |
           uv lock

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -67,13 +67,11 @@ jobs:
         with:
           node-version: "20"
 
-      # 1. Regenerate uv.lock from pyproject against public PyPI.
-      # Resolve only distributions uploaded > 7 days ago, so the lock
-      # never pins a release younger than a week (gives a window for a
-      # compromised/yanked upload to surface before we pin it).
-      - name: Pin uv resolution cutoff (exclude-newer)
-        run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
-
+      # 1. Regenerate uv.lock from pyproject against public PyPI. The
+      # 7-day dependency cooldown comes from the repo's uv.toml
+      # (`exclude-newer = "P7D"`), recorded in the lock as a relative
+      # span — an env-var cutoff here would instead stamp an absolute
+      # date into the lock and break later `uv sync --locked` runs.
       - name: Regenerate uv.lock
         run: uv lock
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnigent"
-version = "0.1.0rc4"
+version = "0.1.0"
 description = "Omnigent: declarative agent authoring and runtime framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -25,8 +25,8 @@ dependencies = [
     # one version, so a published `omnigent==X` must resolve the SDK wheels
     # built alongside it (release-omnigent.yml verifies these pins match the
     # release tag). Local/editable installs still resolve via tool.uv.sources.
-    "omnigent-client==0.1.0rc4",
-    "omnigent-ui-sdk==0.1.0rc4",
+    "omnigent-client==0.1.0",
+    "omnigent-ui-sdk==0.1.0",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-client"
-version = "0.1.0rc4"
+version = "0.1.0"
 description = "Python client SDK for the omnigent server API"
 requires-python = ">=3.12"
 dependencies = [
@@ -15,7 +15,7 @@ dependencies = [
     # editable alongside the root ``omnigent`` package. Version-locked
     # (==) so a published SDK always pairs with the server release it
     # shipped with (release-omnigent.yml verifies the pin).
-    "omnigent==0.1.0rc4",
+    "omnigent==0.1.0",
     "httpx>=0.27",
     "pydantic>=2.0,<3",
 ]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -4,14 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-ui-sdk"
-version = "0.1.0rc4"
+version = "0.1.0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 requires-python = ">=3.12"
 dependencies = [
     # Version-locked (==) with the sibling client SDK; released together
     # at one version (release-omnigent.yml verifies the pin). A `>=`
-    # floor would also reject pre-releases (0.1.0rc4 < 0.1.0 in PEP 440).
-    "omnigent-client==0.1.0rc4",
+    # floor would also reject pre-releases (e.g. 0.1.0rc1 < 0.1.0 in
+    # PEP 440).
+    "omnigent-client==0.1.0",
     "rich>=13",
     "prompt_toolkit>=3",
     "pyyaml>=6.0,<7",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-06T00:21:27Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "aiofiles"

--- a/uv.lock
+++ b/uv.lock
@@ -8,8 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer = "2026-06-06T00:21:27Z"
 
 [[package]]
 name = "aiofiles"
@@ -2432,7 +2431,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.1.0rc4"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2588,7 +2587,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "m
 
 [[package]]
 name = "omnigent-client"
-version = "0.1.0rc4"
+version = "0.1.0"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -2605,7 +2604,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.1.0rc4"
+version = "0.1.0"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -2616,7 +2615,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.1.0rc4" },
+    { name = "omnigent-client", specifier = "==0.1.0" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },


### PR DESCRIPTION
## Summary

The upstream tree, re-exported as one reviewable unit. This round:

- chore(release): 0.1.0 — the official launch version bump
- fix(oss): ship a public uv.toml (P7D cooldown) and drop the regen env-var cutoff

Repo-local infrastructure (maintainer roster, lockfiles) is preserved, as always.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Mechanical re-export from the audited export pipeline; this PR's full CI run validates the synced tree.
