### PR TITLE
fix: use thinking.type.adaptive instead of enabled for Opus 4.6+

### DIFF
--- a/omnigent/llms/adapters/anthropic.py
+++ b/omnigent/llms/adapters/anthropic.py
@@ -160,10 +160,12 @@ def _chat_to_anthropic(
     if reasoning_effort := extra.pop("reasoning_effort", None):
         effort = validate_effort_or_llm_error(reasoning_effort, "Anthropic", ANTHROPIC_EFFORTS)
         if effort is not None:
-            payload["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": _effort_to_budget(effort, max_tokens),
-            }
+            payload["thinking"] = {"type": "adaptive"}
+            payload.setdefault("output_config", {})["effort"] = effort
+            # Adaptive thinking on newer models (Opus 4.6+) does not support
+            # temperature or top_p — remove them if they were set.
+            payload.pop("temperature", None)
+            payload.pop("top_p", None)
 
     return payload
 


### PR DESCRIPTION
## Problem

When using `reasoning_effort` with Claude Opus 4.6 or later models, the API returns:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}
```

## Root Cause

`omnigent/llms/adapters/anthropic.py` was using the old `thinking.type.enabled` + `budget_tokens` API, which is not supported on Claude Opus 4.6+ (deprecated on 4.6, fully removed on 4.7).

## Fix

- Replace `thinking: {type: "enabled", budget_tokens: N}` with `thinking: {type: "adaptive"}`
- Forward the effort level via `output_config.effort` instead of `budget_tokens`
- Strip `temperature` and `top_p` from the payload when adaptive thinking is active, as these parameters are incompatible with adaptive thinking on Opus 4.6+