### PR TITLE
fix(coding): harden grep and edit error handling

### DIFF
--- a/omnigent/client_tools/coding.py
+++ b/omnigent/client_tools/coding.py
@@ -148,7 +148,10 @@ def Edit(
         if replace_all
         else text.replace(old_string, new_string, 1)
     )
-    target.write_text(result)
+    try:
+        target.write_text(result)
+    except OSError as exc:
+        return _truncate(f"Error writing {target}: {exc}")
     replacements = count if replace_all else 1
     return _truncate(f"Replaced {replacements} occurrence(s) in {target}")
 
@@ -203,7 +206,7 @@ def Grep(
             ``count`` (match counts).
     """
     search_path = path if path is not None else "."
-    cmd = ["rg", pattern, search_path, "--no-heading"]
+    cmd = ["rg", "-e", pattern, search_path, "--no-heading"]
     if glob is not None:
         cmd.extend(["--glob", glob])
     mode = output_mode if output_mode is not None else "files_with_matches"
@@ -218,17 +221,25 @@ def Grep(
             text=True,
             timeout=30,
         )
-        return _truncate(result.stdout.strip() or "No matches found.")
+    except subprocess.TimeoutExpired:
+        return _truncate("Search timed out after 30s")
     except FileNotFoundError:
         # ripgrep not installed — fall back to grep.
-        grep_cmd = ["grep", "-r", pattern, search_path]
-        result = subprocess.run(
-            grep_cmd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        return _truncate(result.stdout.strip() or "No matches found.")
+        grep_cmd = ["grep", "-r", "-e", pattern, search_path]
+        try:
+            result = subprocess.run(
+                grep_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except FileNotFoundError:
+            return _truncate("Search failed: neither ripgrep nor grep is available.")
+        except subprocess.TimeoutExpired:
+            return _truncate("Search timed out after 30s")
+    if result.returncode > 1:
+        return _truncate(f"Search failed (exit {result.returncode}): {result.stderr.strip()}")
+    return _truncate(result.stdout.strip() or "No matches found.")
 
 
 @tool(strict=False)

--- a/tests/client_tools/test_coding_d7_migration.py
+++ b/tests/client_tools/test_coding_d7_migration.py
@@ -230,3 +230,28 @@ def test_grep_smoke() -> None:
     """``Grep`` smoke-test against this file's known content."""
     out = Grep(pattern="def test_grep_smoke", path=__file__)
     assert __file__ in out, f"Grep should find this test file; got {out!r}"
+
+
+def test_grep_invalid_regex_returns_error() -> None:
+    """``Grep`` with an invalid regex returns an error string, not a crash.
+
+    Both rg and grep exit with code 2 on a bad pattern; the tool must
+    surface that rather than silently returning "No matches found."
+    """
+    out = Grep(pattern="[invalid", path=__file__)
+    assert "Search failed" in out, f"Expected error for invalid regex; got {out!r}"
+
+
+def test_edit_write_error_returns_error_string() -> None:
+    """``Edit`` returns an error string (not raise) when write_text raises OSError."""
+    from unittest.mock import patch
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+        tmp.write("hello world")
+        path = tmp.name
+    try:
+        with patch.object(Path, "write_text", side_effect=OSError("disk full")):
+            result = Edit(file_path=path, old_string="hello", new_string="goodbye")
+        assert "Error writing" in result, f"Expected write-error message; got {result!r}"
+    finally:
+        Path(path).unlink()


### PR DESCRIPTION
## Summary

in `client_tools/coding.py` :

- `Grep`: use `-e pattern` for both `rg` and the `grep` fallback so option-shaped patterns (e.g. `--help`) are never parsed as flags by the search binary
- `Grep`: check `returncode > 1` after both paths (exit 1 = no matches is normal; exit 2+ is an error) so a bad regex or permission denial surfaces as an error string rather than a silent `"No matches found."`
- `Grep`: catch `TimeoutExpired` from `rg` and add a nested `try/except` in the fallback so `FileNotFoundError` and `TimeoutExpired` from `grep` also return strings instead of propagating
- `Edit`: wrap `write_text` in `try/except OSError`, matching the guard already present in `Write`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

two new unit tests added to `tests/client_tools/test_coding_d7_migration.py`:

- `test_grep_invalid_regex_returns_error` : passes `[invalid` (unclosed bracket) to `Grep`; both `rg` and `grep` exit 2 for this, exercising the new `returncode > 1` path and asserting `"Search failed"` is returned instead of the old silent `"No matches found."`
- `test_edit_write_error_returns_error_string` : patches `Path.write_text` to raise `OSError("disk full")` and asserts `Edit` returns an `"Error writing"` string rather than propagating