### PR TITLE
Remove unreachable download_file destination handling

### DIFF
--- a/omnigent/tools/builtins/download_file.py
+++ b/omnigent/tools/builtins/download_file.py
@@ -58,15 +58,6 @@ class DownloadFileTool(Tool):
                             "type": "string",
                             "description": ('The file ID to download, e.g. "file_abc123".'),
                         },
-                        "destination": {
-                            "type": "string",
-                            "description": (
-                                "Optional path within the workspace "
-                                "to save the file. Defaults to the "
-                                "original filename in the workspace "
-                                "root."
-                            ),
-                        },
                     },
                     "required": ["file_id"],
                 },
@@ -77,8 +68,6 @@ class DownloadFileTool(Tool):
         """
         Download a file and save it to the workspace.
 
-        :param arguments: JSON with ``"file_id"`` and optional
-            ``"destination"`` keys.
         :param ctx: Provides workspace path for saving.
         :returns: JSON string with the local file path, or error.
         """
@@ -113,7 +102,6 @@ class DownloadFileTool(Tool):
             )
 
         dest = _resolve_destination(
-            args.get("destination"),
             record.filename,
             ctx.workspace,
         )
@@ -131,20 +119,15 @@ class DownloadFileTool(Tool):
 
 
 def _resolve_destination(
-    destination: str | None,
     filename: str,
     workspace: Path | None,
 ) -> Path:
     """
     Resolve the save path for a downloaded file.
 
-    :param destination: User-specified relative path, or ``None``
-        to use the original filename.
     :param filename: The file's original filename from the store.
     :param workspace: The agent's workspace directory, or ``None``.
     :returns: Absolute path to save the file.
     """
     base = workspace or Path.cwd()
-    if destination:
-        return base / destination
     return base / filename

--- a/tests/tools/builtins/test_file_tools.py
+++ b/tests/tools/builtins/test_file_tools.py
@@ -306,48 +306,6 @@ def test_download_file_saves_to_workspace(
     assert saved.name == "hello.txt"
 
 
-def test_download_file_custom_destination(
-    monkeypatch: pytest.MonkeyPatch,
-    tool_ctx: ToolContext,
-) -> None:
-    """
-    download_file saves to a custom path within the workspace.
-
-    :param monkeypatch: Pytest monkeypatch fixture.
-    :param tool_ctx: Tool execution context.
-    """
-    content = b"data"
-    monkeypatch.setattr(
-        "omnigent.runtime.get_file_store",
-        lambda: _FakeFileStore(
-            [
-                _FakeFile(
-                    "file_xyz",
-                    "data.csv",
-                    len(content),
-                    "text/csv",
-                    1000,
-                    session_id="conv_alice",
-                ),
-            ]
-        ),
-    )
-    monkeypatch.setattr(
-        "omnigent.runtime.get_artifact_store",
-        lambda: _FakeArtifactStore({"file_xyz": content}),
-    )
-
-    tool = DownloadFileTool()
-    result = json.loads(
-        tool.invoke('{"file_id": "file_xyz", "destination": "output/saved.csv"}', tool_ctx)
-    )
-
-    saved = Path(result["path"])
-    assert saved.exists()
-    assert saved.name == "saved.csv"
-    assert "output" in str(saved)
-
-
 def test_download_file_not_found(
     monkeypatch: pytest.MonkeyPatch,
     tool_ctx: ToolContext,


### PR DESCRIPTION
## Summary

Removes the unreachable `destination` argument handling from `download_file` instead of hardening it, because the production dispatch path does not use that argument.

## Why

`download_file` is dispatched in the runner through `_execute_file_tool` (`omnigent/runner/tool_dispatch.py`), which fetches the file content from the server's `/v1/sessions/{id}/resources/files/{file_id}/content` endpoint and returns it as text. That path:

- never calls `DownloadFileTool.invoke()`,
- never writes to the workspace, and
- ignores the `destination` argument entirely.

Keeping `destination` in the LLM-facing schema advertised a no-op option that the real path silently drops.

The reachable download path is already safe independently: the server endpoint enforces session access (`_validate_session`, LEVEL_READ) and scopes the lookup by session (`file_store.get(file_id, session_id=...)`), so cross-session reads return "not found".

## Change

- Drop the `destination` field from the tool schema so the tool no longer advertises a no-op argument.
- Remove the unreachable `destination` parameter and branch from `_resolve_destination`.
- Remove `test_download_file_custom_destination`, which covered the removed feature.

## Validation

- `ruff check omnigent/tools/builtins/download_file.py tests/tools/builtins/test_file_tools.py tests/tools/builtins/test_registry_unified.py` - passed
- `ruff format --check omnigent/tools/builtins/download_file.py tests/tools/builtins/test_file_tools.py tests/tools/builtins/test_registry_unified.py` - passed
- `pytest tests/tools/builtins/test_file_tools.py tests/tools/builtins/test_registry_unified.py` - blocked locally on Windows before collection because `signal.SIGUSR1` is unavailable
- GitHub Actions `Lint` - passed
- GitHub Actions `CI` - passed
