### PR TITLE
maintainer-approval: don't cancel in-progress runs (fork PR status poster)

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -50,7 +50,13 @@ permissions:
 
 concurrency:
   group: maintainer-approval-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Do not cancel in-progress runs. For a fork PR the pull_request_review
+  # run is the only one that can post the status (the fork pull_request
+  # token is read-only and skips the POST), so cancelling it would leave
+  # the required check permanently unreported. Each run re-reads live
+  # review state and the POST is idempotent, so letting queued runs finish
+  # in order is safe and converges on the latest verdict.
+  cancel-in-progress: false
 
 jobs:
   evaluate:


### PR DESCRIPTION
## Summary

Follow-up to the fork-PR Maintainer Approval fix.

For a fork PR the `pull_request_review` run is the **only** run that can post
the `Maintainer Approval` status — the fork's `pull_request` token is read-only
and now deliberately skips the POST. The workflow's `cancel-in-progress: true`
was cancelling that review run whenever another PR event (push, a second review
event) landed in the same `maintainer-approval-<pr>` concurrency group, killing
the poster ~1s in and leaving the required check **permanently unreported** — so
the gate never flipped green even after a maintainer approved.

Flip `cancel-in-progress` to `false`. Each run re-reads live review state and the
status POST is idempotent, so queuing runs (instead of cancelling) is safe and
converges on the latest verdict. Runs are ~5s, so the queue cost is negligible.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [ ] Not applicable

## Coverage rationale

Observed live on PR #23: a maintainer approval started a `pull_request_review`
maintainer-approval run that was cancelled after 1s by the concurrency group,
so the `Maintainer Approval` status was never posted. With `cancel-in-progress:
false` the review run runs to completion and posts the verdict. YAML validated.
