### PR TITLE
docs: fix broken example references in AGENT_YAML_SPEC

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -265,8 +265,8 @@ tools:
   Databricks-only configuration unless the example is explicitly internal.
 - Prefer `instructions: AGENTS.md` for long prompts that are shared with other
   tooling.
-- Start from a bundled example such as `examples/kimi_agent.yaml` or
-  `examples/knowledge_work_agent.yaml` and remove tools you do not need.
+- Start from a bundled example such as `examples/polly/config.yaml` or
+  `examples/debby/config.yaml` and remove tools you do not need.
 - Run the YAML before publishing it:
 
   ```bash


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

Fixed broken example paths in docs/AGENT_YAML_SPEC.md
Replace non-existent `kimi_agent` and `knowledge_work_agent` files
Update documentation to point to valid `polly` and `debby` configs

  ## Type of change

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor / chore
  - [x] Docs
  - [ ] Test / CI
  - [ ] Breaking change

  ## Test coverage

  - [ ] Unit tests added / updated
  - [ ] Integration tests added / updated
  - [ ] E2E tests added / updated
  - [x] Manual verification completed
  - [ ] Existing tests cover this change
  - [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
