### PR TITLE
Fix UTF-8 corruption in OpenAI Responses streaming

### DIFF
--- a/omnigent/llms/adapters/openai.py
+++ b/omnigent/llms/adapters/openai.py
@@ -7,6 +7,7 @@ provider that speaks the OpenAI Chat Completions API format.
 
 from __future__ import annotations
 
+import codecs
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -535,6 +536,11 @@ class OpenAIAdapter(OpenAICompatibleAdapter):
         """
         current_event: str | None = None
         buf = ""
+        # Decode incrementally: httpx yields arbitrary byte chunks, so a
+        # multi-byte UTF-8 character can be split across a chunk boundary.
+        # An incremental decoder buffers the partial sequence until the rest
+        # arrives, instead of emitting U+FFFD replacement chars per chunk.
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         async with (
             httpx.AsyncClient(timeout=timeout) as client,
             client.stream(
@@ -553,7 +559,7 @@ class OpenAIAdapter(OpenAICompatibleAdapter):
                 )
             resp.raise_for_status()
             async for chunk in resp.aiter_bytes():
-                buf += chunk.decode("utf-8", errors="replace")
+                buf += decoder.decode(chunk)
                 while "\n" in buf:
                     line, buf = buf.split("\n", 1)
                     line = line.rstrip("\r")

--- a/tests/llms/test_openai_adapter.py
+++ b/tests/llms/test_openai_adapter.py
@@ -1,12 +1,17 @@
 """Tests for llms.adapters.openai — payload building and SSE parsing."""
 
+import asyncio
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 
 from omnigent.llms.adapters.openai import (
     OpenAIAdapter,
     OpenAICompatibleAdapter,
     _parse_sse_line,
 )
+from omnigent.llms.types import ResponseTextDeltaEvent
 
 # ── Payload building ─────────────────────────────────────
 
@@ -159,11 +164,6 @@ def test_stream_request_aread_called_before_raise_for_status() -> None:
     has been reverted and bad-model 404s will again show
     ``"<unreadable response body>"``.
     """
-    import asyncio
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    import httpx
-
     adapter = OpenAICompatibleAdapter(base_url="https://fake-host/v1", api_key_env=None)
 
     aread_called = False
@@ -235,13 +235,6 @@ def test_stream_responses_decodes_utf8_split_across_chunks() -> None:
     reintroduced and non-ASCII streamed output (accents, CJK, emoji) is being
     silently corrupted.
     """
-    import asyncio
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    import httpx
-
-    from omnigent.llms.types import ResponseTextDeltaEvent
-
     adapter = OpenAIAdapter(base_url="https://fake-host/v1")
 
     # SSE for one text delta containing 'é', split mid-character.

--- a/tests/llms/test_openai_adapter.py
+++ b/tests/llms/test_openai_adapter.py
@@ -2,7 +2,11 @@
 
 import json
 
-from omnigent.llms.adapters.openai import OpenAICompatibleAdapter, _parse_sse_line
+from omnigent.llms.adapters.openai import (
+    OpenAIAdapter,
+    OpenAICompatibleAdapter,
+    _parse_sse_line,
+)
 
 # ── Payload building ─────────────────────────────────────
 
@@ -215,3 +219,67 @@ def test_stream_request_aread_called_before_raise_for_status() -> None:
         "the message, producing '<unreadable response body>' instead of the "
         "actual provider error text."
     )
+
+
+def test_stream_responses_decodes_utf8_split_across_chunks() -> None:
+    """
+    ``_stream_responses`` must decode the byte stream incrementally so a
+    multi-byte UTF-8 character split across two ``aiter_bytes`` chunks is
+    reassembled, not turned into U+FFFD replacement characters.
+
+    ``httpx`` yields arbitrary network-sized byte chunks, so the two bytes of
+    ``é`` (0xC3 0xA9) can land in different chunks. Decoding each chunk in
+    isolation corrupts the character; an incremental decoder preserves it.
+
+    Failure meaning: if the assertion fires, per-chunk decoding has been
+    reintroduced and non-ASCII streamed output (accents, CJK, emoji) is being
+    silently corrupted.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import httpx
+
+    from omnigent.llms.types import ResponseTextDeltaEvent
+
+    adapter = OpenAIAdapter(base_url="https://fake-host/v1")
+
+    # SSE for one text delta containing 'é', split mid-character.
+    sse = 'event: response.output_text.delta\ndata: {"delta": "café"}\n\n'.encode()
+    split = sse.index(b"\xc3\xa9") + 1  # between the two bytes of 'é'
+    chunks = [sse[:split], sse[split:]]
+
+    async def _aiter_bytes():
+        for c in chunks:
+            yield c
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = _aiter_bytes
+
+    mock_stream_ctx = AsyncMock()
+    mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=mock_stream_ctx)
+
+    mock_client_ctx = AsyncMock()
+    mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    async def _run() -> str:
+        with patch("httpx.AsyncClient", return_value=mock_client_ctx):
+            deltas = [
+                event.delta
+                async for event in adapter._stream_responses(
+                    "https://fake-host/v1/responses",
+                    {},
+                    {"stream": True},
+                )
+                if isinstance(event, ResponseTextDeltaEvent)
+            ]
+        return "".join(deltas)
+
+    assert asyncio.run(_run()) == "café"


### PR DESCRIPTION
## Summary

- `OpenAIAdapter._stream_responses` (`omnigent/llms/adapters/openai.py`) decoded each `aiter_bytes()` chunk independently with `chunk.decode("utf-8", errors="replace")`. `httpx` yields arbitrary network-sized byte chunks, so a multi-byte UTF-8 character can be split across a chunk boundary — and decoding each chunk in isolation turns the partial bytes into U+FFFD replacement characters, silently corrupting any non-ASCII streamed output (accented Latin, CJK, emoji).
- Impact is on a common path: every OpenAI Responses streaming call with non-ASCII content. There's no crash or log — the agent just emits corrupted text, and the longer the response, the more chunk boundaries and the more likely the damage.
- Fix: use an incremental UTF-8 decoder (`codecs.getincrementaldecoder`) that buffers an incomplete byte sequence until the rest arrives. The sibling Chat Completions path (`_stream_request`) and the Gemini adapter both rely on `aiter_lines()`, which buffers partial bytes correctly — only this hand-rolled byte path was wrong, so this aligns the Responses path with them.

ELI5: text is read off the network in chunks, and a letter like "é" takes two bytes. If those two bytes arrive in different chunks, the old code mangled the letter into question-mark blobs. The fix waits for the whole letter before turning bytes into text.

```
"café" streamed with "é" (bytes C3 A9) split across two chunks:

BEFORE: "caf" + U+FFFD + U+FFFD      (silently corrupted)
AFTER:  "café"                        (correct)
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `test_stream_responses_decodes_utf8_split_across_chunks` in `tests/llms/test_openai_adapter.py`. It mocks `httpx.AsyncClient` (no network), feeds the SSE for a `response.output_text.delta` carrying "café" with the two bytes of "é" split across two `aiter_bytes` chunks, drives the real `_stream_responses`, and asserts the reassembled delta equals "café". The test fails on the pre-fix code (it produces "caf" + two U+FFFD chars) and passes after. All pre-existing OpenAI adapter tests continue to pass.
