### PR TITLE
feat(ap-web): Ghostty-style session switching with Cmd/Ctrl+Up/Down

### DIFF
--- a/ap-web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/ap-web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -1,0 +1,115 @@
+// Cmd/Ctrl+↓/↑ steps next/prev with wrap; off-list ↓ enters at top, ↑ at
+// bottom; fires inside text fields but ignores Alt/Shift/bare arrows; a no-op
+// step (same id) doesn't navigate.
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionSwitchHotkey } from "./useSessionSwitchHotkey";
+
+const navigate = vi.fn();
+vi.mock("@/lib/routing", () => ({
+  useNavigate: () => navigate,
+}));
+
+/** Dispatch a keydown that bubbles to window from `target` (default: body). */
+function press(
+  key: "ArrowUp" | "ArrowDown",
+  mods: Partial<Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">> = {
+    metaKey: true,
+  },
+  target: HTMLElement = document.body,
+): void {
+  target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...mods }));
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+  document.body.innerHTML = "";
+});
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useSessionSwitchHotkey", () => {
+  const ids = ["a", "b", "c"];
+
+  it("Cmd+↓ opens the next conversation", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "b"));
+    press("ArrowDown");
+    expect(navigate).toHaveBeenCalledWith("/c/c");
+  });
+
+  it("Cmd+↑ opens the previous conversation", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "b"));
+    press("ArrowUp");
+    expect(navigate).toHaveBeenCalledWith("/c/a");
+  });
+
+  it("wraps: ↓ from the last goes to the first, ↑ from the first to the last", () => {
+    const { rerender } = renderHook(({ active }) => useSessionSwitchHotkey(ids, active), {
+      initialProps: { active: "c" },
+    });
+    press("ArrowDown");
+    expect(navigate).toHaveBeenLastCalledWith("/c/a");
+
+    rerender({ active: "a" });
+    press("ArrowUp");
+    expect(navigate).toHaveBeenLastCalledWith("/c/c");
+  });
+
+  it("off-list: ↓ enters at the top, ↑ at the bottom", () => {
+    const { rerender } = renderHook(({ active }) => useSessionSwitchHotkey(ids, active), {
+      initialProps: { active: undefined as string | undefined },
+    });
+    press("ArrowDown");
+    expect(navigate).toHaveBeenLastCalledWith("/c/a");
+
+    rerender({ active: undefined });
+    press("ArrowUp");
+    expect(navigate).toHaveBeenLastCalledWith("/c/c");
+  });
+
+  it("Ctrl+↓ also works (Windows/Linux)", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    press("ArrowDown", { ctrlKey: true });
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
+  it("ignores Alt+chord (reserved for message navigation)", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    press("ArrowDown", { metaKey: true, altKey: true });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("ignores Shift+chord", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    press("ArrowDown", { metaKey: true, shiftKey: true });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a bare arrow with no Cmd/Ctrl", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    press("ArrowDown", {});
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("still switches while a text field is focused (no click-out needed)", () => {
+    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    press("ArrowDown", { metaKey: true }, ta);
+    expect(navigate).toHaveBeenCalledWith("/c/b");
+  });
+
+  it("does nothing when the list is empty", () => {
+    renderHook(() => useSessionSwitchHotkey([], "a"));
+    press("ArrowDown");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when the step lands on the already-active id", () => {
+    renderHook(() => useSessionSwitchHotkey(["only"], "only"));
+    press("ArrowDown");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/ap-web/src/hooks/useSessionSwitchHotkey.ts
+++ b/ap-web/src/hooks/useSessionSwitchHotkey.ts
@@ -1,0 +1,51 @@
+// Cmd+↑/↓ (Ctrl+↑/↓ on Win/Linux) opens the previous / next sidebar session,
+// wrapping at the ends. Sibling to ChatPage's Cmd+Alt+↑/↓ message nav; they
+// don't collide (that one requires Alt, this one requires Alt up). Fires even
+// in a focused text field so you can switch mid-compose. Bind ONCE.
+
+import { useEffect, useRef } from "react";
+import { useNavigate } from "@/lib/routing";
+
+/**
+ * @param orderedIds Conversation ids in sidebar render order, visible sections
+ *   only (the rows the user can actually see).
+ * @param activeId The open conversation (route param), or undefined off-list
+ *   (new-chat / inbox).
+ */
+export function useSessionSwitchHotkey(
+  orderedIds: readonly string[],
+  activeId: string | undefined,
+): void {
+  const navigate = useNavigate();
+  // Bound once; the ref keeps the handler reading the live list/route.
+  const latest = useRef({ orderedIds, activeId });
+  latest.current = { orderedIds, activeId };
+
+  useEffect(() => {
+    const handler = (e: globalThis.KeyboardEvent): void => {
+      // Cmd/Ctrl, not Alt (Alt+arrow is the message hotkey); Shift left to selection.
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+
+      const { orderedIds: ids, activeId: active } = latest.current;
+      if (ids.length === 0) return;
+
+      e.preventDefault(); // also suppresses the native caret-to-start/end in fields
+      const dir = e.key === "ArrowDown" ? 1 : -1;
+      const current = active ? ids.indexOf(active) : -1;
+      // Off-list: ↓ enters at the top, ↑ at the bottom. Otherwise step + wrap.
+      const next =
+        current === -1
+          ? dir === 1
+            ? 0
+            : ids.length - 1
+          : (current + dir + ids.length) % ids.length;
+
+      const nextId = ids[next];
+      if (nextId && nextId !== active) navigate(`/c/${nextId}`);
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [navigate]);
+}

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -65,6 +65,7 @@ import { isConversationUnseen } from "@/hooks/useUnseenConversations";
 import { sumPendingApprovals } from "@/lib/inbox";
 import { cn } from "@/lib/utils";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
+import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { absoluteTime, relativeTime } from "@/lib/relativeTime";
 import { ThemeModeMenu } from "@/components/theme/ThemeModeMenu";
 import { AccountMenu } from "./AccountMenu";
@@ -444,6 +445,20 @@ function ConversationList({
       return next;
     });
   }, []);
+
+  // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
+  // session hotkey. Titles must match the <ConversationSection> props below.
+  const orderedConversationIds = useMemo(() => {
+    const visible = (title: string, list: readonly Conversation[]) =>
+      collapsedSections.includes(title) ? [] : list;
+    return [
+      ...visible("Pinned", sections.pinned),
+      ...visible("Recent", sections.sessions),
+      ...visible("Shared with me", sections.shared),
+      ...visible("Archived", sections.archived),
+    ].map((c) => c.id);
+  }, [sections, collapsedSections]);
+  useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Only normalize pinned ids once all pages are loaded; a pin that
   // lives on an unloaded page should not be dropped prematurely


### PR DESCRIPTION
## Summary

Adds Ghostty-style keyboard switching for the sidebar session list. Cmd+Up/Down (Ctrl+Up/Down on Windows/Linux) opens the previous/next conversation and wraps at the ends, so you can move through sessions without reaching for the mouse, the same way you'd flip through terminal tabs.

- Fires even while the composer is focused, so you don't have to click out first.
- Walks the visible sidebar order (Pinned, Recent, Shared with me, Archived) and skips collapsed sections, so it matches exactly what you see.
- Sibling to ChatPage's existing Cmd+Alt+Up/Down user-message navigation. The two never collide: message nav requires Alt, this one requires Alt to be up.

ELI5: a keyboard shortcut that flips you between chats in the left list, like Cmd+Up/Down for tabs.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

New hook `useSessionSwitchHotkey` ships with 11 unit tests (`src/hooks/useSessionSwitchHotkey.test.tsx`) covering direction, wrap-around, off-list entry (new-chat/inbox), the Ctrl variant, ignoring Alt/Shift and bare arrows, firing while a text field is focused, an empty list, and the no-op same-id step.

Commands run, all clean: `npx vitest run` on the new test (11/11), the touched shell suites `AppShell`/`WorkspacePanel`/`ChatHeader` (86/86), `tsc -b`, `oxlint`, and `npm run build`. Manually verified in a local dev build against a running server: Cmd+Up/Down steps through sessions including while typing in the composer, and wraps at both ends. No E2E added since this is a client-only keyboard binding with no server interaction.
