### PR TITLE
fix: reject branch names where any path component ends with .lock

### DIFF
--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -60,8 +60,8 @@ def validate_branch_name(name: str) -> None:
         raise WorktreeError(f"branch name must not start or end with '/': {name!r}")
     if name.endswith("."):
         raise WorktreeError(f"branch name must not end with '.': {name!r}")
-    if name.endswith(".lock"):
-        raise WorktreeError(f"branch name must not end with '.lock': {name!r}")
+    if any(part.endswith(".lock") for part in name.split("/")):
+        raise WorktreeError(f"branch name path components must not end with '.lock': {name!r}")
     if ".." in name:
         raise WorktreeError(f"branch name must not contain '..': {name!r}")
     if "//" in name:

--- a/tests/host/test_git_worktree.py
+++ b/tests/host/test_git_worktree.py
@@ -317,7 +317,19 @@ def test_remove_worktree_missing_path_fails(git_repo: Path) -> None:
 
 @pytest.mark.parametrize(
     "bad",
-    ["", "-leading", "a..b", "a/.hidden", "x.lock", "a b", "a~b", "a:b", "/lead", "trail/"],
+    [
+        "",
+        "-leading",
+        "a..b",
+        "a/.hidden",
+        "x.lock",
+        "x.lock/y",
+        "a b",
+        "a~b",
+        "a:b",
+        "/lead",
+        "trail/",
+    ],
 )
 def test_validate_branch_name_rejects_bad(bad: str) -> None:
     """Branch names violating git ref-format are rejected before reaching argv."""


### PR DESCRIPTION
## Summary

- `validate_branch_name` in `omnigent/host/git_worktree.py` checked `name.endswith(\".lock\")` to enforce git's ref-format rule that no ref component may end with `.lock`. That only catches the final segment of a slash-delimited name.
- A branch name like `\"x.lock/y\"` has an intermediate component (`x.lock`) ending with `.lock`, which `git check-ref-format` rejects, but the previous check let it pass. The failure surfaced later as an opaque `git worktree add` error rather than the friendly `WorktreeError` with a clear message.
- Fix: split the name on `\"/\"` and check every component with `any(part.endswith(\".lock\") for part in name.split(\"/\"))`.

```
# Before
if name.endswith(".lock"):                          # misses "x.lock/y"
    raise WorktreeError(...)

# After
if any(part.endswith(".lock") for part in name.split("/")):   # catches all components
    raise WorktreeError(...)
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `\"x.lock/y\"` to the `@pytest.mark.parametrize` bad-name list in `test_validate_branch_name_rejects_bad`. This case failed on the old check and passes after the fix. All pre-existing bad-name cases continue to be rejected and all good-name cases continue to pass.

Commands run:

- `ruff check omnigent/host/git_worktree.py tests/host/test_git_worktree.py`
- `ruff format --check omnigent/host/git_worktree.py tests/host/test_git_worktree.py`
- `python -m pytest tests/host/test_git_worktree.py::test_validate_branch_name_rejects_bad -v`