### PR TITLE
fix: sum input+max_tokens for Anthropic context overflow actual_tokens

### DIFF
--- a/omnigent/runtime/llm_retry.py
+++ b/omnigent/runtime/llm_retry.py
@@ -83,11 +83,13 @@ def _detect_context_overflow(body: str) -> _OverflowTokens | None:
         pass
 
     # Anthropic: "{input} + {max_tokens} > {limit}"
-    anthropic_sum = re.search(r"(\d+)\s*\+\s*\d+\s*>\s*(\d+)", body)
+    # The total request size is input + max_tokens; capture both so
+    # actual_tokens reflects the full request (not just the prompt).
+    anthropic_sum = re.search(r"(\d+)\s*\+\s*(\d+)\s*>\s*(\d+)", body)
     if anthropic_sum:
         return _OverflowTokens(
-            max_context_tokens=int(anthropic_sum.group(2)),
-            actual_tokens=int(anthropic_sum.group(1)),
+            max_context_tokens=int(anthropic_sum.group(3)),
+            actual_tokens=int(anthropic_sum.group(1)) + int(anthropic_sum.group(2)),
         )
 
     # Anthropic: "prompt is too long: {actual} tokens > {limit} maximum"

--- a/tests/llms/test_client.py
+++ b/tests/llms/test_client.py
@@ -657,13 +657,13 @@ async def test_context_overflow_anthropic_sum_pattern(
             retry=retry_config,
         )
 
-    # In Anthropic's "a + b > limit" pattern:
-    # group(1)=actual (197202), group(2)=max (200000).
+    # In Anthropic's "a + b > limit" pattern the full request size is
+    # a + b (197202 + 21333 = 218535), not just a (the prompt alone).
     assert exc_info.value.max_context_tokens == 200000, (
         f"Expected max_context_tokens=200000, got {exc_info.value.max_context_tokens}."
     )
-    assert exc_info.value.actual_tokens == 197202, (
-        f"Expected actual_tokens=197202, got {exc_info.value.actual_tokens}."
+    assert exc_info.value.actual_tokens == 218535, (
+        f"Expected actual_tokens=218535 (197202+21333), got {exc_info.value.actual_tokens}."
     )
 
 


### PR DESCRIPTION
## Summary

- `_detect_context_overflow` in `omnigent/runtime/llm_retry.py` parses Anthropic's context overflow error body, which has the form `"{input} + {max_tokens} > {limit}"` (e.g. `"197202 + 21333 > 200000"`).
- The previous regex `r\"(\d+)\s*\+\s*\d+\s*>\s*(\d+)\"` captured only `input` as `actual_tokens` and `limit` as `max_context_tokens`, silently discarding `max_tokens`. This produced a nonsensical error message — `"197202 tokens > 200000 max"` — where the reported actual is *below* the limit, which is impossible for an overflow.
- The true total request size that exceeds the limit is `input + max_tokens`. Fix the regex to capture all three numbers and set `actual_tokens = group(1) + group(2)`, `max_context_tokens = group(3)`.

```python
# Before — actual_tokens = 197202 (just the prompt; less than the 200000 limit)
anthropic_sum = re.search(r\"(\d+)\s*\+\s*\d+\s*>\s*(\d+)\", body)
if anthropic_sum:
    return _OverflowTokens(
        max_context_tokens=int(anthropic_sum.group(2)),   # group(2) = limit ✓
        actual_tokens=int(anthropic_sum.group(1)),        # group(1) = input only ✗
    )

# After — actual_tokens = 218535 (197202 + 21333; correctly exceeds the 200000 limit)
anthropic_sum = re.search(r\"(\d+)\s*\+\s*(\d+)\s*>\s*(\d+)\", body)
if anthropic_sum:
    return _OverflowTokens(
        max_context_tokens=int(anthropic_sum.group(3)),                          # limit ✓
        actual_tokens=int(anthropic_sum.group(1)) + int(anthropic_sum.group(2)), # input + max_tokens ✓
    )
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Updated `test_context_overflow_anthropic_sum_pattern` in `tests/llms/test_client.py` to assert `actual_tokens == 218535` (197202 + 21333) instead of `197202`. The test uses the literal body `\"197202 + 21333 > 200000\"` to match a real Anthropic error, so the expected value directly validates the fix. The pre-fix assertion (`== 197202`) fails on the updated code; the post-fix assertion passes.

Commands run:

- `ruff check omnigent/runtime/llm_retry.py tests/llms/test_client.py`
- `ruff format --check omnigent/runtime/llm_retry.py tests/llms/test_client.py`
- `python -m pytest tests/llms/test_client.py::test_context_overflow_anthropic_sum_pattern -v`