### PR TITLE
maintainer-approval: fix fork-PR gate via pull_request_target job-as-check (mlflow pattern)

### DIFF
--- a/.github/workflows/maintainer-approval-rerun-run.yml
+++ b/.github/workflows/maintainer-approval-rerun-run.yml
@@ -1,0 +1,83 @@
+name: Maintainer Approval Rerun Run
+
+# Privileged half of the approval re-run relay. Triggered by the
+# completion of maintainer-approval-rerun.yml, this runs from the base
+# repo on `workflow_run`, so it gets a writable token (`actions: write`)
+# even when the underlying PR is from a fork, and is not held behind the
+# fork-approval gate. It reads the PR number recorded by the bridge and
+# re-runs the failed Maintainer Approval check on the PR head, which
+# re-evaluates the (now-present) approval and turns the check green.
+
+on:
+  workflow_run:
+    workflows: [Maintainer Approval Rerun]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maintainer-approval-rerun-run-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  rerun:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write   # re-run the Maintainer Approval workflow
+    steps:
+      - name: Download recorded PR number
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const arts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: context.payload.workflow_run.id,
+            });
+            const art = arts.data.artifacts.find(a => a.name === 'maintainer-approval-pr-number');
+            if (!art) {
+              core.info('No PR-number artifact on the triggering run; nothing to do.');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner, repo, artifact_id: art.id, archive_format: 'zip',
+            });
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(dl.data));
+      - name: Unzip
+        run: unzip -o pr_number.zip
+      - name: Re-run Maintainer Approval for the approved PR
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            if (!fs.existsSync('pr_number')) {
+              core.info('No pr_number file; nothing to do.');
+              return;
+            }
+            const pull_number = Number(fs.readFileSync('pr_number', 'utf8').trim());
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+            const checks = await github.paginate(github.rest.checks.listForRef, {
+              owner, repo, ref: pr.head.sha,
+            });
+            const runIds = [...new Set(
+              checks
+                .filter(c =>
+                  c.app && c.app.slug === 'github-actions' &&
+                  c.name === 'Maintainer Approval' &&
+                  c.status === 'completed' && c.conclusion === 'failure')
+                .map(c => (c.details_url || c.html_url || '').match(/\/actions\/runs\/(\d+)/))
+                .filter(Boolean)
+                .map(m => m[1])
+            )];
+            if (runIds.length === 0) {
+              core.info('No failed Maintainer Approval run on the PR head to re-run.');
+              return;
+            }
+            for (const run_id of runIds) {
+              core.info(`Re-running Maintainer Approval run ${run_id} for PR #${pull_number}`);
+              await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: Number(run_id) });
+            }

--- a/.github/workflows/maintainer-approval-rerun.yml
+++ b/.github/workflows/maintainer-approval-rerun.yml
@@ -1,0 +1,45 @@
+name: Maintainer Approval Rerun
+
+# Bridges a maintainer's approving review to a re-run of the Maintainer
+# Approval check. `pull_request_target` does not fire on reviews, so
+# something has to re-trigger the check when an approval lands.
+#
+# A fork PR's `pull_request_review` token is read-only AND the run is
+# held behind the fork-approval gate, so it cannot re-run a workflow
+# itself. This job therefore only records the PR number as an artifact;
+# the privileged re-run happens in maintainer-approval-rerun-run.yml,
+# which runs from the base repo on `workflow_run`.
+# See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maintainer-approval-rerun-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  record:
+    # Only approvals can flip the check green; skip everything else.
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Record PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p pr
+          echo "$PR_NUMBER" > pr/pr_number
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: maintainer-approval-pr-number
+          path: pr/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -1,81 +1,61 @@
 name: Maintainer Approval
 
-# Posts a `Maintainer Approval` commit status on the PR head SHA.
-# That status is a required check in branch protection (added to the
-# contexts list by .github/scripts/apply-main-branch-protection.sh).
+# Gates merge on a maintainer's approval. The job *is* the required
+# check: it exits non-zero until a maintainer has approved, and GitHub
+# reports that pass/fail as the `Maintainer Approval` status check
+# automatically. We do NOT post a commit status, so no `statuses: write`
+# token is needed.
 #
-# State is success when either:
-#   - the PR author is listed in .github/MAINTAINER on main, OR
-#   - some maintainer's latest non-COMMENTED review on this PR is
-#     APPROVED.
-# Otherwise the state is pending with a "waiting for maintainer
-# approval" description -- branch protection treats pending as not
-# satisfied, so the PR cannot merge.
+# Why this matters for fork PRs: a fork's `pull_request` /
+# `pull_request_review` token is forced read-only regardless of the
+# `permissions:` block, so the old `gh api .../statuses` POST always
+# 403'd on contributor PRs. Making the check the job result sidesteps
+# the API write entirely.
 #
-# Why we read .github/MAINTAINER from main's tip and not the PR head
-# SHA: otherwise a PR editing MAINTAINER to add its author could
-# self-grant the gate. The same property is documented in
-# merge-ready.yml's force-merge eligibility step.
+# Trigger is `pull_request_target`, so the workflow always runs from the
+# base branch (main) with the base repo's token, even for fork PRs:
+#   - it is not held behind the "approve fork-PR workflows" gate, so it
+#     reports immediately on open instead of sitting in action_required;
+#   - the PR-head copy of this file never runs, so a malicious PR cannot
+#     edit the check to weaken it.
+# This is safe because the job checks out nothing and runs no PR code --
+# it only reads .github/MAINTAINER from main and queries the API.
 #
-# Fork-PR token note: the status is posted through the GitHub API,
-# which needs `statuses: write`. A fork PR's `pull_request` token is
-# forced read-only regardless of the `permissions:` block, so the POST
-# would 403 for any contributor PR from a fork. The step below detects
-# that case and skips the POST (rather than erroring): with no status
-# reported, branch protection leaves the required `Maintainer Approval`
-# check unsatisfied -- which is exactly the gate we want -- until a
-# maintainer reviews. The `pull_request_review` event runs in the base
-# repo with a writable token even for forks, so it posts the result
-# then. (We deliberately do not use a base-context PR trigger that runs
-# with secrets on fork code: the public CI leak gate forbids it.)
+# `pull_request_target` does not fire on reviews, so an approval does
+# not re-run this check by itself. maintainer-approval-rerun.yml +
+# maintainer-approval-rerun-run.yml re-run this workflow when a
+# maintainer submits an approving review, flipping the check green.
 #
-# Defense-in-depth note: a malicious PR could edit *this* workflow to
-# drop `?ref=main`. On its own `pull_request_review` and `pull_request`
-# events the modified workflow would run from the PR branch, which
-# could let the PR self-grant the status. The remaining defense is
-# `required_pull_request_reviews` in branch protection -- a real
-# maintainer still has to click Merge, and every change arrives through
-# a PR (no direct push to main).
+# Why read .github/MAINTAINER from main's tip (not the PR head): a PR
+# that adds its own author to MAINTAINER must not be able to self-grant.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
 
-# Read-only at the top level (Scorecard Token-Permissions); the write
-# scopes live on the job below.
 permissions:
   contents: read
 
 concurrency:
+  # Do not cancel in-progress runs: a superseded run cancelled mid-flight
+  # leaves the check red, and queued re-evaluation is cheap.
   group: maintainer-approval-${{ github.event.pull_request.number }}
-  # Do not cancel in-progress runs. For a fork PR the pull_request_review
-  # run is the only one that can post the status (the fork pull_request
-  # token is read-only and skips the POST), so cancelling it would leave
-  # the required check permanently unreported. Each run re-reads live
-  # review state and the POST is idempotent, so letting queued runs finish
-  # in order is safe and converges on the latest verdict.
   cancel-in-progress: false
 
 jobs:
-  evaluate:
-    name: evaluate
+  approve:
+    name: Maintainer Approval
     permissions:
       contents: read
       pull-requests: read
-      statuses: write   # post the Maintainer Approval status
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: Evaluate maintainer approval
+      - name: Require maintainer approval
         env:
           GH_TOKEN: ${{ github.token }}
           REPO:     ${{ github.repository }}
           PR:       ${{ github.event.pull_request.number }}
-          SHA:      ${{ github.event.pull_request.head.sha }}
-          EVENT:    ${{ github.event_name }}
-          IS_FORK:  ${{ github.event.pull_request.head.repo.fork }}
         run: |
           # --- Load maintainers from .github/MAINTAINER at main's tip ---
           set +e
@@ -83,81 +63,47 @@ jobs:
           RC=$?
           set -e
           if [[ $RC -ne 0 || -z "$CONTENT_B64" ]]; then
-            STATE=pending
-            DESC=".github/MAINTAINER not found on main"
-          else
-            CONTENT=$(echo "$CONTENT_B64" | base64 -d)
-            # Strip comments and blanks; flatten to a space-separated list.
-            # `grep -v` exits 1 with no matches; wrap so the pipeline
-            # stays 0 under pipefail and we reach the empty-list branch.
-            MAINTAINERS=$(echo "$CONTENT" | sed -E 's/#.*$//' | tr -s '[:space:]' '\n' | { grep -v '^$' || true; } | tr '\n' ' ')
-            MAINTAINERS_LC=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
+            echo "::error::.github/MAINTAINER not found on main"
+            exit 1
+          fi
 
-            if [[ -z "${MAINTAINERS_LC// /}" ]]; then
-              STATE=pending
-              DESC=".github/MAINTAINER on main has no entries"
-            else
-              AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login')
-              AUTHOR_LC=$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')
+          CONTENT=$(echo "$CONTENT_B64" | base64 -d)
+          # Strip comments and blanks; flatten to a space-separated list.
+          # `grep -v` exits 1 with no matches; wrap so the pipeline stays
+          # 0 under pipefail and we reach the empty-list branch.
+          MAINTAINERS=$(echo "$CONTENT" | sed -E 's/#.*$//' | tr -s '[:space:]' '\n' | { grep -v '^$' || true; } | tr '\n' ' ')
+          MAINTAINERS_LC=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
+          if [[ -z "${MAINTAINERS_LC// /}" ]]; then
+            echo "::error::.github/MAINTAINER on main has no entries"
+            exit 1
+          fi
 
-              STATE=""
-              DESC=""
+          AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login')
+          AUTHOR_LC=$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')
 
-              # Case 1: author is a maintainer.
-              for m in $MAINTAINERS_LC; do
-                if [[ "$m" == "$AUTHOR_LC" ]]; then
-                  STATE=success
-                  DESC="Author @$AUTHOR is a maintainer"
-                  break
-                fi
-              done
-
-              # Case 2: latest non-COMMENTED review state of some
-              # maintainer is APPROVED. Matches GitHub's UI semantics
-              # (COMMENTED doesn't supersede APPROVED; CHANGES_REQUESTED
-              # and DISMISSED do).
-              if [[ -z "$STATE" ]]; then
-                APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-                  --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login')
-                for u in $APPROVERS; do
-                  u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
-                  for m in $MAINTAINERS_LC; do
-                    if [[ "$m" == "$u_lc" ]]; then
-                      STATE=success
-                      DESC="Approved by maintainer @$u"
-                      break 2
-                    fi
-                  done
-                done
-              fi
-
-              # Case 3: nothing yet -- pending.
-              if [[ -z "$STATE" ]]; then
-                STATE=pending
-                DESC="Awaiting approval from a maintainer"
-              fi
+          # Case 1: author is a maintainer.
+          for m in $MAINTAINERS_LC; do
+            if [[ "$m" == "$AUTHOR_LC" ]]; then
+              echo "Author @$AUTHOR is a maintainer."
+              exit 0
             fi
-          fi
+          done
 
-          # GitHub commit-status descriptions max out at 140 chars.
-          if [[ ${#DESC} -gt 140 ]]; then
-            DESC="${DESC:0:137}..."
-          fi
+          # Case 2: latest non-COMMENTED review state of some maintainer
+          # is APPROVED. Matches GitHub's UI semantics (COMMENTED does
+          # not supersede APPROVED; CHANGES_REQUESTED and DISMISSED do).
+          APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+            --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login')
+          for u in $APPROVERS; do
+            u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
+            for m in $MAINTAINERS_LC; do
+              if [[ "$m" == "$u_lc" ]]; then
+                echo "Approved by maintainer @$u."
+                exit 0
+              fi
+            done
+          done
 
-          # A fork PR's pull_request token is read-only, so the status
-          # POST would 403. Skip it on that event/fork combination -- the
-          # required check stays unreported (which blocks merge, the
-          # intended gate) until a maintainer reviews, at which point the
-          # writable pull_request_review token posts the result.
-          if [[ "$EVENT" == "pull_request" && "$IS_FORK" == "true" ]]; then
-            echo "Fork PR on pull_request event: token is read-only, " \
-              "skipping status POST. Awaiting maintainer review " \
-              "(would post Maintainer Approval=$STATE: $DESC)."
-            exit 0
-          fi
-
-          gh api "repos/$REPO/statuses/$SHA" \
-            -f state="$STATE" \
-            -f context="Maintainer Approval" \
-            -f description="$DESC" >/dev/null
-          echo "Posted Maintainer Approval=$STATE on $SHA ($DESC)"
+          # Case 3: nothing yet -- fail the check so merge stays blocked.
+          echo "::error::Awaiting approval from a maintainer (one of: $MAINTAINERS)."
+          exit 1


### PR DESCRIPTION
## Summary

The Maintainer Approval gate could never go green for outside-contributor
(fork) PRs. Root cause, confirmed empirically on PR #31: GitHub forces **both**
the `pull_request` **and** the `pull_request_review` `GITHUB_TOKEN` to read-only
on fork PRs (`Statuses: read`), so the `gh api .../statuses` POST always 403'd.
The earlier fork-guard only hid the red X on open; it could never post the
verdict, so approving never flipped the check.

This adopts the job-as-check pattern from `mlflow/mlflow`:

- **`maintainer-approval.yml`** now runs on **`pull_request_target`** and the
  job *is* the `Maintainer Approval` check — it exits non-zero until a
  maintainer has approved. No commit status is posted, so `statuses: write` is
  never needed and the read-only fork token no longer matters. Running from base
  context also (a) avoids the `action_required` fork-approval gate, so it reports
  immediately on open, and (b) stops a PR from editing its own check. The job
  checks out nothing and runs no PR code — it only reads `.github/MAINTAINER`
  from `main` and queries the API.
- **`maintainer-approval-rerun.yml`** (`pull_request_review`) records the PR
  number as an artifact when an approval lands (a fork's review token is
  read-only, so it can't re-run anything itself).
- **`maintainer-approval-rerun-run.yml`** (`workflow_run`) runs from base
  context with a writable token and re-runs the failed Maintainer Approval check
  on the PR head, flipping it green once the approval is present.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [ ] Not applicable

## Coverage rationale

YAML validated; `bash -n` on the approval step; confirmed no `statuses:` POST
and no `statuses: write` permission remain; action SHAs pinned. The end-to-end
fork-PR behaviour (check reports red on open, flips green on maintainer approval)
needs to be verified live on a fork PR after merge — see the checklist in the
comments.

## Notes

- The required-check **context name is unchanged** (`Maintainer Approval`) — the
  job is named `Maintainer Approval`, so its check run satisfies the same name a
  branch-protection rule would require.
- `main` currently has **no branch protection** (classic protection 404s, repo
  rulesets are empty). This PR fixes the *check*; to actually **enforce** it,
  branch protection must require the `Maintainer Approval` (and `Merge Ready`)
  contexts again. Happy to set that up once this lands.
