### PR TITLE
ci: gate PRs on e2e (same-repo), fork PRs skip

### DIFF
--- a/.github/scripts/merge-ready/required.sh
+++ b/.github/scripts/merge-ready/required.sh
@@ -1,7 +1,10 @@
-# Sourced by evaluate-checks.sh. Only always-on checks are required (unit
-# tests, lint, type-check). The e2e and integration suites run on
-# schedule/dispatch only and are intentionally absent from REQUIRED and
-# ALLOW_SKIP so missing checks do not block contributor PRs.
+# Sourced by evaluate-checks.sh. The unit/lint/type-check checks gate every PR.
+# The e2e + e2e-ui suites also gate PRs, but only run with secrets on same-repo
+# PRs (maintainer branches); fork PRs cannot read the LLM_API_KEY /
+# GATEWAY_BASE_URL secrets, so their e2e jobs skip via a workflow fork guard.
+# The e2e check names are therefore in BOTH REQUIRED (a same-repo PR must pass
+# them) and ALLOW_SKIP (a fork PR's skipped check still satisfies the gate). The
+# integration suite runs on schedule/dispatch only and is intentionally absent.
 # Generated file -- do not hand-edit; it is replaced wholesale on every sync.
 
 REQUIRED=(
@@ -19,6 +22,13 @@ REQUIRED=(
   "Pytest (server-rest)"
   "Pytest (spec-llms)"
   "Pytest (misc)"
+  "E2E Tests (shard 0/4)"
+  "E2E Tests (shard 1/4)"
+  "E2E Tests (shard 2/4)"
+  "E2E Tests (shard 3/4)"
+  "E2E UI Tests (shard 0/3)"
+  "E2E UI Tests (shard 1/3)"
+  "E2E UI Tests (shard 2/3)"
 )
 
 ALLOW_SKIP=(
@@ -35,18 +45,26 @@ ALLOW_SKIP=(
   "Pytest (server-rest)"
   "Pytest (spec-llms)"
   "Pytest (misc)"
+  "E2E Tests (shard 0/4)"
+  "E2E Tests (shard 1/4)"
+  "E2E Tests (shard 2/4)"
+  "E2E Tests (shard 3/4)"
+  "E2E UI Tests (shard 0/3)"
+  "E2E UI Tests (shard 1/3)"
+  "E2E UI Tests (shard 2/3)"
 )
 
 is_allow_skip() { printf '%s\n' "${ALLOW_SKIP[@]}" | grep -qxF "$1"; }
 
 # Maps an ALLOW_SKIP check to the workflow that produces it, so
-# evaluate-checks.sh can tell a genuine path-skip from a check that is
-# merely absent because its workflow is still queued or re-running. In
-# the public variant the only skippable checks are the CI Pytest jobs;
-# everything else echoes "" (unmapped).
+# evaluate-checks.sh can tell a genuine skip (a CI Pytest shard path-skip, or
+# the fork guard skipping an e2e job) from a check that is merely absent
+# because its workflow is still queued or re-running.
 workflow_for() {
   case "$1" in
-    "Pytest ("*) echo "CI" ;;
-    *)           echo "" ;;
+    "Pytest ("*)             echo "CI" ;;
+    "E2E Tests (shard "*)    echo "E2E Tests" ;;
+    "E2E UI Tests (shard "*) echo "E2E UI Tests" ;;
+    *)                       echo "" ;;
   esac
 }

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -18,6 +18,8 @@ name: E2E UI Tests
 #                       ref.
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 9 * * *"
   workflow_dispatch:
@@ -73,7 +75,11 @@ jobs:
     # Skip on draft PRs; the `ready_for_review` trigger re-fires the
     # workflow when the draft is converted, so the check won't strand
     # pending on the eventual ready-for-review state.
-    if: ${{ !github.event.pull_request.draft }}
+    # Public-only: also skip fork PRs — they can't read the LLM_API_KEY /
+    # GATEWAY_BASE_URL secrets; see _E2E_GUARD_IF_BLOCK.
+    if: ${{ !github.event.pull_request.draft
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,9 @@ name: E2E Tests
 on:
   schedule:
     - cron: "0 9 * * *"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore: ['ap-web/**']
   workflow_dispatch:
     inputs:
       branch:
@@ -83,6 +86,11 @@ jobs:
     # we trip rate limits, drop ``-n`` to 1 first; only fall back to
     # ``max-parallel`` reduction if QPS still hurts.
     name: E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    # Public-only: skip draft PRs and fork PRs (forks can't read the
+    # LLM_API_KEY / GATEWAY_BASE_URL secrets); see _E2E_GUARD_IF_BLOCK.
+    if: ${{ !github.event.pull_request.draft
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     strategy:
       # One red shard shouldn't cancel siblings; we want every shard's


### PR DESCRIPTION
## Summary

Re-enable the `E2E Tests` and `E2E UI Tests` suites on `pull_request` (push trigger dropped; `schedule` + `workflow_dispatch` unchanged) so PRs get a real end-to-end signal before merge, with a job-level guard that keeps secrets away from forks:

- Both workflows gain a job-level fork guard: `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`. GitHub withholds the `LLM_API_KEY` / `GATEWAY_BASE_URL` secrets from fork PRs, so a fork's e2e job **skips** cleanly instead of auth-failing. Same-repo PRs (maintainer branches) run the full suite. For `e2e-ui` the guard is ANDed into the existing draft-skip condition.
- `required.sh` lists the e2e / e2e-ui shard checks in **both** `REQUIRED` (a same-repo PR must pass them) and `ALLOW_SKIP` (a fork PR's skipped check still satisfies `Merge Ready`, so a fork PR never wedges the gate). `workflow_for` maps the names so a fork-skip isn't misread as still-pending.

Fork PRs still get the unit + lint gate; full e2e on a fork requires a maintainer to bring the branch in-repo (or re-dispatch). Closing that gap entirely is a separate mock-LLM-in-the-gate effort.

## Notes

The shard check names match this repo's current matrix (e2e 0–3/4, e2e-ui 0–2/3).