### PR TITLE
[codex] add islo sandbox provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Omnigent lets you:
   conversation to continue on their own.
 
 - **☁️ Run agents in cloud sandboxes.** No laptop required: run sessions in
-  disposable [Modal](https://modal.com) or [Daytona](https://www.daytona.io)
-  sandboxes, launched from the CLI or provisioned by the server per session
-  (*managed hosts*). More providers coming soon.
+  disposable [Modal](https://modal.com), [Daytona](https://www.daytona.io), or
+  [Islo](https://islo.dev) sandboxes, launched from the CLI or provisioned by
+  the server per session (*managed hosts*).
 
 - **🛡️ Govern your agents.** Create
   [policies](#6-govern-your-agents-with-policies) to pause for your approval

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -192,22 +192,23 @@ omnigent run path/to/agent.yaml --server https://your-host
 
 Don't want a laptop to be the host? Run the host in a cloud sandbox instead.
 
-**From the CLI (Modal or Daytona).** Install the extra
-(`pip install 'omnigent[modal]'` or `'omnigent[daytona]'`), authenticate
-(`modal token new`, or set `DAYTONA_API_KEY`), then:
+**From the CLI (Modal, Daytona, or Islo).** Install the provider extra when
+needed (`pip install 'omnigent[modal]'` or `'omnigent[daytona]'`; Islo uses the
+built-in HTTP client), authenticate (`modal token new`, `DAYTONA_API_KEY`, or
+`ISLO_API_KEY`), then:
 
 ```bash
-omnigent sandbox create --provider modal     # or --provider daytona
+omnigent sandbox create --provider modal     # or --provider daytona / islo
 omnigent sandbox connect --provider modal --sandbox-id <id> --server https://your-host
 ```
 
 > [!NOTE]
 > Modal caps sandbox lifetime at 24 hours. Re-run `create` + `connect` to
-> roll the host onto a fresh sandbox. Daytona has no lifetime cap, but
-> free-tier orgs restrict egress to an allowlist; see
+> roll the host onto a fresh sandbox. Daytona and Islo have no Omnigent-imposed
+> lifetime cap; Daytona free-tier orgs restrict egress to an allowlist; see
 > [`daytona/README.md`](daytona/README.md) for the relay workaround.
 
-**Server-managed (Modal or Daytona).** With *managed hosts*, creating a
+**Server-managed (Modal, Daytona, or Islo).** With *managed hosts*, creating a
 session with `"host_type": "managed"` (e.g.
 `POST /v1/sessions {"agent_id": ..., "host_type": "managed"}`) makes the
 server provision a sandbox, start a host in it, and run the session there.
@@ -223,6 +224,8 @@ sandbox:
 
 Modal credentials come from the server's environment (`MODAL_TOKEN_ID` /
 `MODAL_TOKEN_SECRET`, or a mounted `~/.modal.toml`), not the config file.
+Daytona reads `DAYTONA_API_KEY`; Islo reads `ISLO_API_KEY` (and optional
+`ISLO_BASE_URL`) from the server environment.
 Each sandbox authenticates back with a server-minted, per-launch token, so
 no user credentials ever enter the sandbox.
 
@@ -252,7 +255,8 @@ sandbox:
 For private registries, set `OMNIGENT_MODAL_REGISTRY_SECRET` on the server
 to the name of a Modal secret holding `REGISTRY_USERNAME` /
 `REGISTRY_PASSWORD`; for CLI-launched sandboxes, `OMNIGENT_MODAL_HOST_IMAGE`
-(or `OMNIGENT_DAYTONA_HOST_IMAGE`) overrides the image ref.
+(or `OMNIGENT_DAYTONA_HOST_IMAGE` / `OMNIGENT_ISLO_HOST_IMAGE`) overrides the
+image ref.
 
 **LLM credentials for managed sessions.** A fresh sandbox has no API keys.
 Park your provider credentials in a [Modal secret](https://modal.com/secrets)
@@ -273,6 +277,18 @@ sandbox:
   server_url: https://your-host
   modal:
     secrets: [omnigent-llm]
+```
+
+For Daytona and Islo, list server environment variable names under
+`sandbox.daytona.env` or `sandbox.islo.env`; the launcher copies the current
+server env values into each sandbox:
+
+```yaml
+sandbox:
+  provider: islo
+  server_url: https://your-host
+  islo:
+    env: [OPENAI_API_KEY, GIT_TOKEN]
 ```
 
 Using a **Claude subscription** instead of an API key? Run

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -72,6 +72,9 @@ deploy/
 │   ├── src/index.js      server deploy target. See its README.md.
 │   └── README.md
 │
+├── islo/              ← Islo sandbox-provider guide (gateway credential
+│   └── README.md         injection); NOT a server deploy target.
+│
 └── docker/            ← common Docker image + compose stack
     ├── Dockerfile         multi-stage slim image (node web build → python builder → runtime)
     ├── docker-compose.yaml   omnigent + postgres for any Docker host
@@ -308,7 +311,9 @@ fetch/push.
 
 The full Modal guide (CLI sandboxes, custom images, LLM and git credentials,
 troubleshooting) lives at [`modal/README.md`](modal/README.md); the Daytona
-guide lives at [`daytona/README.md`](daytona/README.md).
+guide lives at [`daytona/README.md`](daytona/README.md); the Islo guide
+(including its gateway credential-injection model) lives at
+[`islo/README.md`](islo/README.md).
 
 ## Auth
 

--- a/deploy/islo/README.md
+++ b/deploy/islo/README.md
@@ -1,0 +1,499 @@
+# Omnigent on Islo
+
+[Islo](https://islo.dev) sandboxes give you disposable cloud machines for
+running Omnigent hosts, two ways:
+
+- **CLI-launched**: `omnigent sandbox create` / `connect` provisions a
+  sandbox from your terminal, ships your local checkout into it, and
+  registers it as a host with your server.
+- **Server-managed**: the server provisions a sandbox automatically when
+  a session is created with `"host_type": "managed"` and terminates it
+  when the session is deleted.
+
+Sandboxes boot from the official prebaked host image, so startup is
+seconds. Unlike Modal and Daytona, the Islo launcher talks to the Islo
+HTTP API directly through `httpx` (already an Omnigent dependency), so
+there is **no provider SDK extra to install** — just an API key.
+
+What makes Islo different from the other providers, and shapes the rest
+of this guide:
+
+- **A credential gateway.** Islo can inject LLM/API keys into a sandbox's
+  outbound traffic at the network layer, so the raw key never reaches the
+  sandbox process. This is a first-class, recommended path for model
+  credentials (see [Model credentials](#model-credentials-llm-keys)) and
+  has no equivalent on Modal or Daytona.
+- **No local port forward.** Islo can't forward a sandbox→laptop callback
+  port, so the interactive in-sandbox `omnigent login` / App OAuth step is
+  skipped automatically (as on Modal and Daytona).
+- **No lifetime cap.** Islo sandboxes run until deleted (like Daytona,
+  unlike Modal's 24 h).
+
+## Prerequisites
+
+Install the [Islo CLI](https://docs.islo.dev) and create an API key, then
+make it available where the launcher runs — your shell for the CLI flow,
+the **server** process for managed sandboxes:
+
+```bash
+curl -fsSL https://islo.dev/install.sh | sh   # install the islo CLI
+islo login                                     # browser OAuth (one-time)
+islo api-key create omnigent --show            # prints an islo_key_… value
+export ISLO_API_KEY=islo_key_…
+# Optional: a non-default API endpoint
+# export ISLO_BASE_URL=https://api.islo.dev
+```
+
+`ISLO_API_KEY` is exchanged for a short-lived session token at
+`POST /auth/token`; the token is cached until shortly before expiry. The
+key is the only required credential — no SDK, no `~/.config` file.
+
+> [!NOTE]
+> **Islo cannot forward a local callback port into the sandbox.** The
+> interactive `omnigent login` browser flow (and the in-sandbox App OAuth
+> callback) needs a sandbox→laptop port forward, which Islo doesn't
+> provide — so the CLI skips that step automatically, exactly as it does
+> for Modal and Daytona. For a server that requires authentication, inject
+> the credentials instead (see
+> [Connecting to an authenticated server](#connecting-to-an-authenticated-server)).
+
+## The host image
+
+Sandboxes boot from `ghcr.io/omnigent-ai/omnigent-host:latest`, published
+by CI from the `host` target of
+[`deploy/docker/Dockerfile`](../docker/Dockerfile) with Omnigent and its
+dependencies preinstalled — including the coding-harness CLIs (`claude`,
+`codex`, `pi`), so agents on any harness run without an in-sandbox
+install.
+
+To use a different image (a fork, or extra tooling baked in), build the
+same target and push it anywhere Islo can pull from:
+
+```bash
+docker build -f deploy/docker/Dockerfile --target host \
+  --platform linux/amd64 \
+  -t docker.io/<you>/omnigent-host:latest .
+docker push docker.io/<you>/omnigent-host:latest
+```
+
+Then point Omnigent at it — `OMNIGENT_ISLO_HOST_IMAGE` for the CLI flow,
+or `sandbox.islo.image` in the server config for the managed flow. For a
+private registry, configure the pull credentials on the Islo side (Islo
+pulls the image, not Omnigent).
+
+> [!IMPORTANT]
+> **Native terminals need `bubblewrap`.** The `claude-native` /
+> `codex-native` / `pi` harnesses wrap each agent terminal in a bubblewrap
+> (`bwrap`) OS-sandbox, and on Linux that isolation is mandatory and
+> fail-loud — a host image without the `bwrap` binary makes those terminals
+> fail to start (`linux_bwrap sandbox requires the 'bwrap' binary on PATH`).
+> The `host` Dockerfile target installs `bubblewrap`; if you bring your own
+> image, install it there too. See [Troubleshooting](#troubleshooting).
+
+## CLI-launched sandboxes
+
+Provision a sandbox and ship your local checkout into it:
+
+```bash
+omnigent sandbox create --provider islo
+```
+
+This pulls the host image, builds wheels from your local checkout, and
+overlays them on top — so the sandbox runs *your* code, not whatever the
+image was built from. Then register it as a host with your server:
+
+```bash
+omnigent sandbox connect --provider islo \
+  --sandbox-id <id-printed-by-create> \
+  --server https://your-host
+```
+
+`connect` runs `omnigent host` inside the sandbox and holds the
+connection open in your terminal — Ctrl-C tears it down. New sessions
+targeting that host now run in the sandbox.
+
+Running multiple sandboxes against one server? Pass a unique
+`--host-name <label>` to each `connect` — the server keys hosts on
+(owner, name), and sandboxes that share a hostname collide.
+
+Sandboxes are disposable. When your code changes, create a new one — and
+delete the old one (Islo sandboxes have no lifetime cap, so an abandoned
+sandbox keeps billing until removed via `islo rm <id>` or the
+[dashboard](https://app.islo.dev)).
+
+To inject LLM/git credentials into a CLI-launched sandbox, set
+`OMNIGENT_ISLO_SANDBOX_ENV` in your shell to a comma-separated list of
+variable names (e.g. `ANTHROPIC_API_KEY,GIT_TOKEN`) before running
+`create` — the named variables are copied from your environment into the
+sandbox at provision time. A listed name that is **not** set fails the
+launch loudly (it would otherwise surface much later as an opaque harness
+auth failure inside the sandbox).
+
+### Connecting to an authenticated server
+
+`connect` runs `omnigent host` inside the sandbox, and that host must
+present credentials when it dials back to a server that requires
+authentication. The interactive `omnigent login` browser flow can't run
+inside an Islo sandbox (no callback port forward), so inject the keys for
+the relevant server instead — name them in `OMNIGENT_ISLO_SANDBOX_ENV`
+before `create`:
+
+```bash
+export OMNIGENT_ISLO_SANDBOX_ENV=DATABRICKS_HOST,DATABRICKS_TOKEN
+omnigent sandbox create --provider islo
+```
+
+The in-sandbox host mints a fresh bearer token from those credentials on
+every connect and reconnect. For a Databricks-fronted server, inject
+`DATABRICKS_HOST` plus either `DATABRICKS_TOKEN` (a PAT) or
+`DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET` (an OAuth service
+principal — re-minting keeps a long-lived sandbox connected past any
+single token's expiry).
+
+A server with no authentication on the host tunnel needs none of this,
+and neither do [server-managed sandboxes](#server-managed-sandboxes) —
+those authenticate with a server-minted per-launch token automatically.
+
+## Server-managed sandboxes
+
+Add a `sandbox:` section to the server config (`omnigent server -c
+config.yaml`, or `<data_dir>/config.yaml`):
+
+```yaml
+sandbox:
+  provider: islo
+  server_url: https://your-host    # public URL sandboxes dial back to
+```
+
+`server_url` must be reachable *from Islo's cloud* — a public HTTPS URL,
+not `localhost`. The server itself needs `ISLO_API_KEY` (and optional
+`ISLO_BASE_URL`) in its environment. Sessions created with
+`host_type: "managed"` (the API call or the Web UI's New Sandbox option)
+then run on a fresh Islo sandbox; the create returns immediately and
+provisioning happens in the background, exactly like the [Modal managed
+flow](../modal/README.md#server-managed-sandboxes) — including repository
+workspaces, the first-message rendezvous, and dead-sandbox relaunch.
+
+```bash
+curl -X POST https://your-host/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "agent_...", "host_type": "managed"}'
+```
+
+Each managed sandbox authenticates back with a server-minted, per-launch
+token (7-day TTL — see [Lifecycle](#lifecycle-notes)); no user
+credentials enter the sandbox for the server connection.
+
+### Managed hosts and server auth
+
+How the dial-back authenticates depends on how the **server** does auth,
+and there is one interaction worth knowing before you deploy. A managed
+sandbox opens two kinds of connections back to the server:
+
+- the **host tunnel** (`/v1/hosts/<id>/tunnel`), which the per-launch
+  token authenticates directly — the server mints it, scopes it to one
+  host, and resolves the owner from it. This always works.
+- one **runner tunnel** per session (`/v1/runners/<token>/tunnel`), opened
+  by the runner subprocess the host spawns. The runner authenticates with
+  *whatever server credential it can resolve* — a proxy-injected identity
+  (header / OIDC), or a stored `omnigent login` token (local hosts only; a
+  fresh managed sandbox has none) — **not** the per-launch host token.
+
+The consequence:
+
+- **Header / OIDC-proxy auth, or single-user (no-auth) servers** — the
+  runner tunnel needs no extra identity, so managed hosts work out of the
+  box. **Verified end-to-end on a single-user server**: a session created
+  with `host_type: "managed"` provisioned an Islo sandbox from the bwrap
+  image, the launcher cleared the seeded `apiKeyHelper`, the host *and*
+  runner tunnels connected, and a native Claude terminal ran on the
+  injected `CLAUDE_CODE_OAUTH_TOKEN` subscription.
+- **The built-in `accounts` provider (`OMNIGENT_AUTH_ENABLED=1`)** — the
+  runner tunnel additionally requires a *user* identity, which the
+  per-launch host token does not carry, so the runner dial-back is refused
+  (`403`) even though the host tunnel connects. This is a framework-level
+  managed-host interaction shared by **all** sandbox providers (Modal /
+  Daytona / Islo), not specific to Islo.
+
+So for a managed Islo deployment, front the server with **header or OIDC
+auth** (a reverse proxy / IdP injects the user identity on every request,
+including the runner WebSocket — see
+[`deploy/README.md#auth`](../README.md#auth)), or run it single-user. The
+`accounts` provider is fine for CLI-launched hosts (you `omnigent login`,
+and that token is what the in-sandbox host forwards), but not yet for the
+managed runner dial-back.
+
+Optional `islo:` settings:
+
+```yaml
+sandbox:
+  provider: islo
+  server_url: https://your-host
+  islo:
+    image: docker.io/<you>/omnigent-host:latest   # default: official image
+    env: [OPENAI_API_KEY, GIT_TOKEN]               # copy from server env
+    base_url: https://api.islo.dev                 # non-default API endpoint
+    gateway_profile: default                       # Islo gateway for egress + credential injection
+    snapshot_name: warm-host                       # boot from a prebaked snapshot
+    workdir: /root/workspace                       # sandbox working directory
+    vcpus: 2
+    memory_mb: 4096
+    disk_gb: 20
+```
+
+## Model credentials (LLM keys)
+
+A fresh sandbox has no model credentials of your own. Islo offers **two
+distinct ways** to give the agent a model — and they interact, so pick one
+deliberately per harness.
+
+### Option A — Islo gateway integration (recommended)
+
+This is the Islo-native path with no Modal/Daytona equivalent. Islo
+[gateways](https://docs.islo.dev/cli/gateways) "automatically attach API
+keys, tokens, and secrets to outbound requests" at the **network layer** —
+*"credentials never reach the sandbox process."* You connect a provider
+once, server-side, and every sandbox picks it up:
+
+```bash
+islo login --tool claude     # OAuth-connect Anthropic (alias: --tool anthropic)
+islo login --tool openai     # …and/or OpenAI
+islo status                  # shows connected integrations
+```
+
+This is **not Claude-specific** — it's how Islo supplies model
+credentials to *every* harness. Islo pre-seeds each sandbox with a
+**phantom** placeholder key (`islo_phantom_…`) in whatever location the
+harness reads, per provider:
+
+| Harness | Phantom key location | Provider endpoint |
+|---|---|---|
+| Claude Code (`claude-native`, `claude-sdk`, `pi`) | `apiKeyHelper` in `~/.claude/settings.json` | `api.anthropic.com` |
+| Codex / OpenAI agents | `OPENAI_API_KEY` env var | `api.openai.com` |
+
+The harness sends that placeholder to its provider endpoint; the gateway
+intercepts the request and swaps it for your connected credential before
+forwarding. The raw key never lands in the sandbox, and the connection is
+team-wide — other members don't need their own. (We observed both phantom
+keys pre-seeded in a single sandbox.)
+
+These integrations connect **provider API keys** (per-token billing), not
+plan/subscription auth — `--tool claude` gives an Anthropic API key, not a
+Claude Pro/Max subscription; `--tool openai` gives an OpenAI API key, not
+a ChatGPT plan. To use a subscription or plan token on any harness (a
+Claude Pro/Max token, a Codex access token), use
+[Option B](#option-b--omnigent-env-injection-your-own-key-or-a-subscription).
+
+> [!IMPORTANT]
+> If `islo status` shows **"No integrations connected"** for a provider,
+> its phantom key resolves to nothing — the harness falls back to a failing
+> request (Claude reports "API Usage Billing" and retries). Connect the
+> integration for each provider whose harness you use.
+
+#### Path A under managed hosts
+
+This is where the gateway shines: when the **server** launches sandboxes,
+you configure **no model credential on the Omnigent side at all**. The
+flow:
+
+```
+admin (once):  islo login --tool claude   → connects Anthropic to the Islo ACCOUNT
+                                                              │
+server ──ISLO_API_KEY──▶ Islo API "create sandbox" ──▶ sandbox under that account
+                                                              │ Islo pre-seeds the
+                                                              │ phantom apiKeyHelper
+                                                              ▼
+   agent's claude → api.anthropic.com (phantom key) ──▶ Islo gateway swaps in the real key
+```
+
+The Omnigent server only ever holds `ISLO_API_KEY` — the credential it
+uses to *create* sandboxes. Because every managed sandbox is created under
+that Islo account, and integrations are connected at the **account/team**
+level, each one inherits the connected Claude credential through the
+gateway automatically. The only Omnigent-side knob is which gateway a
+managed sandbox uses:
+
+```yaml
+sandbox:
+  provider: islo
+  server_url: https://your-host
+  islo:
+    gateway_profile: default     # the Islo gateway carrying the connected integration
+```
+
+Two consequences worth internalizing:
+
+- **No model secret lives in the Omnigent server's config or
+  environment** — nothing to leak there. Contrast [Option B under managed
+  hosts](#option-b--omnigent-env-injection-your-own-key-or-a-subscription),
+  where the key sits in `sandbox.islo.env` (copied from the server's env
+  into each sandbox).
+- **The integration must be connected on the same Islo account the
+  server's `ISLO_API_KEY` belongs to.** If your server runs under a
+  dedicated service/CI Islo account, run `islo login --tool claude` while
+  authenticated as *that* account — not a personal laptop login.
+
+### Option B — Omnigent env injection (your own key or a subscription)
+
+Bring your own credential by naming it in `OMNIGENT_ISLO_SANDBOX_ENV`
+(CLI) or `sandbox.islo.env` (managed); the launcher copies the value from
+the launching environment into the sandbox, and the in-sandbox host
+forwards the standard harness credential vars to its runners:
+
+| Variable | Enables |
+|---|---|
+| `ANTHROPIC_API_KEY` | Claude models on the Anthropic API |
+| `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` | Anthropic-compatible gateways (LiteLLM, Bedrock/Vertex bridges, corporate proxies) |
+| `CLAUDE_CODE_OAUTH_TOKEN` | claude-code with a Claude **subscription** (no API key) |
+| `OPENAI_API_KEY` / `OPENAI_BASE_URL` | OpenAI or any OpenAI-compatible endpoint (OpenRouter, vLLM, Ollama, …) |
+| `CODEX_ACCESS_TOKEN` | codex with a ChatGPT Business/Enterprise workspace |
+| `GEMINI_API_KEY` | Gemini on the Google AI API |
+
+The full per-plan recipes (subscriptions, gateways, open-source models)
+are identical to Modal — see the [variable table and
+recipes](../modal/README.md#llm-credentials-for-managed-sandboxes). For a
+Claude **subscription** specifically, run `claude setup-token` on your own
+machine (one-time browser auth) and inject the resulting long-lived token
+as `CLAUDE_CODE_OAUTH_TOKEN`. For env vars beyond the standard set, inject
+`OMNIGENT_RUNNER_ENV_PASSTHROUGH=NAME1,NAME2`.
+
+> [!NOTE]
+> **Your injected Claude credential automatically wins over Islo's phantom
+> helper.** Islo seeds an `apiKeyHelper` into every sandbox, and Claude Code
+> would normally prefer it over a `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY`
+> in the environment. So when you inject one of those, the Islo launcher
+> strips the seeded `apiKeyHelper` at provision time — for **both**
+> CLI-launched and server-managed sandboxes — leaving your credential as the
+> sole auth path. No manual step, nothing to run inside the sandbox.
+
+Codex/OpenAI needs nothing special either — its phantom is the
+`OPENAI_API_KEY` env var, which your injected `OPENAI_API_KEY` simply
+overrides.
+
+### Choosing between A and B
+
+| | Option A — gateway | Option B — env injection |
+|---|---|---|
+| Credential | provider **API key** (Anthropic, OpenAI, …) | your API key **or** subscription/plan token |
+| Billing | per-token API | API key, or your subscription/plan |
+| Key in sandbox? | **No** (gateway injects out-of-band) | Yes (in the sandbox env) |
+| Scope | account/team-wide, all sandboxes | per-sandbox |
+| Managed-host config | just `gateway_profile`; no secret on server | key in `sandbox.islo.env` |
+| Best for | **managed / production**, API-key billing | your own **subscription** or key; CLI or managed |
+| Catch | needs a connected integration | the injected var must be set where the launcher runs |
+
+Pick **one per harness** — connect Islo's integration *or* inject your own
+credential, never both. Both work in either launch flow: the launcher
+strips Islo's seeded `apiKeyHelper` automatically when you inject a Claude
+credential. The same two patterns apply to Codex/OpenAI (`islo login --tool
+openai`, or inject `OPENAI_API_KEY` / `CODEX_ACCESS_TOKEN`).
+
+### Git credentials (private repositories)
+
+Inject an HTTPS token as `GIT_TOKEN` (GitLab: add `GIT_USERNAME=oauth2`)
+via `OMNIGENT_ISLO_SANDBOX_ENV` / `sandbox.islo.env`. The host image's git
+credential helper answers HTTPS auth from it for both the launch-time
+clone and the agent's later `fetch` / `push`, writing nothing to disk. Use
+HTTPS repository URLs. Details by provider match the [Modal git
+guide](../modal/README.md#git-credentials-private-repositories).
+
+## Security considerations
+
+- **Path A keeps the model key out of the sandbox — a real advantage.**
+  With the gateway, the agent process only ever sees the phantom
+  placeholder; the real key is injected at Islo's network edge. A
+  prompt-injected or compromised agent can't exfiltrate a key it never
+  holds. This is the strongest credential posture of the three providers
+  for model keys, and the reason to prefer Option A where API-key billing
+  is acceptable.
+- **The gateway terminates TLS to inject.** Credential injection means
+  Islo's gateway sits in the path of the agent's outbound LLM traffic and
+  re-originates it — so that traffic (prompts, completions, tool output
+  sent to the model) is visible at Islo's edge. Acceptable for most teams,
+  but weigh it for highly sensitive workloads, and scope the
+  `gateway_profile` to exactly the egress you intend.
+- **Option B puts the key in the sandbox.** A subscription token or API key
+  named in `sandbox.islo.env` is copied into the sandbox environment at
+  provision time and lives there for the sandbox's life. Prefer scoped,
+  short-lived credentials, and rely on the per-terminal `bwrap` sandbox
+  (below) to keep the agent away from it.
+- **The agent terminal is sandboxed away from those secrets.** Native
+  harness terminals run under a bubblewrap OS-sandbox that masks dotfiles
+  (`~/.ssh`, `~/.aws`, the injected `~/.omnigent` server token) and pins
+  the agent to its workspace — defense-in-depth *inside* the Islo sandbox,
+  independent of Islo's own isolation. This is why the image must ship
+  `bwrap` (see [the host image](#the-host-image)).
+- **All managed sandboxes share one Islo org + `ISLO_API_KEY`.**
+  Cross-user isolation rides on Islo's sandbox boundaries, and the shared
+  org key can enumerate and delete any sandbox — the same single-tenant-org
+  shape as the Modal and Daytona providers. Scope the org to this workload.
+- **The launch token's lifetime is 7 days.** Islo sandboxes have no
+  platform lifetime cap, so the per-launch host token must outlive a
+  long-running sandbox across reconnects (a longer replay window than
+  Modal's ~24 h; same as Daytona). A relaunch mints a fresh one.
+
+## Lifecycle notes
+
+- **No platform lifetime cap.** Unlike Modal's 24-hour limit, Islo
+  sandboxes run until deleted. The managed flow deletes a sandbox when its
+  session is deleted, and the dead-sandbox relaunch path replaces one that
+  crashed or was removed out-of-band. CLI-launched sandboxes you delete
+  yourself (`islo rm <id>`).
+- **Resources.** Sandboxes default to 2 vCPUs and 4 GiB of memory;
+  override per managed launch with `vcpus` / `memory_mb` / `disk_gb`.
+- **Warm starts.** Set `sandbox.islo.snapshot_name` to boot from a
+  prebaked Islo snapshot instead of a cold image pull.
+- **Provider-side lifecycle** (list / status / delete / stop) — use the
+  `islo` CLI (`islo ls`, `islo rm <id>`) or the
+  [dashboard](https://app.islo.dev) directly.
+
+## Cost
+
+Islo bills usage with no seat licenses or idle fees: ~$0.07/CPU-hour,
+~$0.04/GB-hour of memory, ~$0.0007/GB-hour of disk — about $0.25/hour for
+the default 2 vCPU / 4 GiB sandbox while it runs. New accounts get $50 of
+free credits. Rates: [islo.dev](https://islo.dev).
+
+## Troubleshooting
+
+- **Native Claude/Codex terminal fails with `linux_bwrap sandbox requires
+  the 'bwrap' binary on PATH`.** The native harnesses wrap each agent
+  terminal in a bubblewrap OS-sandbox; the host image must ship
+  `bubblewrap`. The `host` Dockerfile target installs it — rebuild from a
+  current image, or for a one-off on a CLI-launched sandbox run
+  `apt-get install -y bubblewrap` inside it.
+- **Claude shows "API Usage Billing" / "both `CLAUDE_CODE_OAUTH_TOKEN` and
+  `apiKeyHelper` set."** You injected your own Claude credential (Option B)
+  but Islo's phantom `apiKeyHelper` is still present — the launcher strips it
+  automatically at provision, so this means the strip didn't run: confirm the
+  credential is named in `OMNIGENT_ISLO_SANDBOX_ENV` / `sandbox.islo.env` (the
+  signal the launcher keys on), and check the provision log for the
+  "clearing Islo's seeded apiKeyHelper" line.
+- **Requests retry then fail with no obvious error.** `islo status` shows
+  no connected integration, so the phantom `apiKeyHelper` resolves to
+  nothing. Connect one (Option A) or switch to Option B.
+- **"managed host did not come online within 120s."** Check that
+  `server_url` is publicly reachable from Islo's cloud, then inspect the
+  in-sandbox host log: `~/.omnigent/logs/host-runner/*.log`.
+- **UI stuck on "Provisioning sandbox…" but a refresh shows the reply.**
+  The host and runner are connected — the browser just isn't receiving live
+  updates. The Web UI streams session state over SSE
+  (`/v1/sessions/{id}/stream`), and some dev tunnels (cloudflared / ngrok
+  quick tunnels) buffer streaming responses. Use an ingress that doesn't
+  buffer SSE, or point your browser directly at the server — `server_url`
+  only needs to be reachable from Islo's cloud for the sandbox dial-back,
+  not from your browser.
+- **Agent has no credentials.** Verify the injected var names match the
+  forwarded set above (or are named in `OMNIGENT_RUNNER_ENV_PASSTHROUGH`),
+  and that each name was actually set in the launching environment.
+
+## Environment variable reference
+
+| Variable | Where it's read | Purpose |
+|---|---|---|
+| `ISLO_API_KEY` | CLI machine / server | Islo API credentials (required) |
+| `ISLO_BASE_URL` | CLI machine / server | Non-default Islo API endpoint (default `https://api.islo.dev`) |
+| `OMNIGENT_ISLO_HOST_IMAGE` | CLI machine / server | Override the host image ref (`sandbox.islo.image` takes precedence for managed) |
+| `OMNIGENT_ISLO_SANDBOX_ENV` | CLI machine / server | Comma-separated launcher-side env var names to inject (`sandbox.islo.env` takes precedence for managed) |
+| `OMNIGENT_RUNNER_ENV_PASSTHROUGH` | inside the sandbox (injected) | Extra env var names the host forwards to runners |
+| `GIT_TOKEN` / `GIT_USERNAME` | inside the sandbox (injected) | HTTPS credentials for private repository clone / fetch / push |

--- a/omnigent/cli_sandbox.py
+++ b/omnigent/cli_sandbox.py
@@ -169,10 +169,13 @@ def sandbox() -> None:
                Free-tier (Tier 1/2) orgs only reach allowlisted
                domains, so `connect` needs an allowlisted --server
                (see deploy/daytona/README.md).
+      islo     Uses the built-in HTTP client. Needs ISLO_API_KEY
+               (and optionally ISLO_BASE_URL for non-default API
+               endpoints).
 
     For provider-side sandbox lifecycle (list / status / delete /
-    start / stop), use the provider's own CLI directly (e.g.
-    `modal sandbox list`).
+    start / stop), use the provider's own CLI or dashboard directly
+    (e.g. `modal sandbox list`).
     """
 
 

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -58,6 +58,7 @@ _LAUNCHERS: dict[str, str] = {
     "lakebox": "omnigent.onboarding.sandboxes.lakebox:LakeboxLauncher",
     "modal": "omnigent.onboarding.sandboxes.modal:ModalSandboxLauncher",
     "daytona": "omnigent.onboarding.sandboxes.daytona:DaytonaSandboxLauncher",
+    "islo": "omnigent.onboarding.sandboxes.islo:IsloSandboxLauncher",
 }
 
 

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -1,0 +1,529 @@
+"""
+Islo sandbox launcher.
+
+Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
+for `Islo <https://islo.dev>`_ sandboxes. The integration talks to the
+Islo HTTP API directly through ``httpx`` (already a base Omnigent
+dependency), so there is no provider SDK extra to install.
+
+Platform notes that shape this launcher:
+
+- **API-key auth.** ``ISLO_API_KEY`` is exchanged for a short-lived
+  session token via ``POST /auth/token``. The token is cached until
+  shortly before expiry, mirroring Islo's Go SDK.
+- **Prebaked host image.** Like Modal and Daytona, sandboxes boot from
+  the official Omnigent host image unless overridden. That keeps
+  server-managed launches fast.
+- **No local port forwarding.** Islo can run commands and upload files
+  through its API, but it does not provide a local-to-sandbox port
+  forward for the in-sandbox App OAuth callback. The CLI therefore
+  skips that auth step automatically, just as it does for Modal and
+  Daytona.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import re
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterator, Sequence
+from pathlib import Path
+from typing import Any, ClassVar
+from urllib.parse import quote, urlencode
+
+import click
+import httpx
+
+from omnigent.onboarding.sandboxes.base import (
+    DEFAULT_HOST_IMAGE,
+    RemoteCommandResult,
+    RemoteProcess,
+    SandboxLauncher,
+    host_image_wheel_install_command,
+)
+
+API_BASE_URL_ENV_VAR: str = "ISLO_BASE_URL"
+"""Optional Islo API base URL override. Defaults to
+``https://api.islo.dev``."""
+
+API_KEY_ENV_VAR: str = "ISLO_API_KEY"
+"""Islo API key read from the server/CLI process environment."""
+
+HOST_IMAGE_ENV_VAR: str = "OMNIGENT_ISLO_HOST_IMAGE"
+"""Environment variable overriding :data:`DEFAULT_HOST_IMAGE` for Islo
+sandboxes."""
+
+SANDBOX_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_ISLO_SANDBOX_ENV"
+"""Comma-separated server-process environment variable names injected
+into created Islo sandboxes."""
+
+_DEFAULT_BASE_URL = "https://api.islo.dev"
+_TOKEN_REFRESH_MARGIN_S = 60.0
+_SANDBOX_CPU = 2
+_SANDBOX_MEMORY_MB = 4096
+_REQUEST_TIMEOUT_S = 30.0
+
+
+class _IsloAPIError(RuntimeError):
+    """Provider-boundary error with a user-facing message."""
+
+
+class _IsloClient:
+    """Small synchronous Islo HTTP API client."""
+
+    def __init__(self, *, base_url: str, api_key: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._client = httpx.Client(timeout=_REQUEST_TIMEOUT_S)
+        self._token: str | None = None
+        self._token_expires_at = 0.0
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._client.close()
+
+    def create_sandbox(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a sandbox and return the response object."""
+        return self._request_json("POST", "/sandboxes/", json=payload)
+
+    def get_sandbox(self, name: str) -> dict[str, Any]:
+        """Fetch a sandbox by name."""
+        return self._request_json("GET", f"/sandboxes/{_url_component(name)}")
+
+    def delete_sandbox(self, name: str) -> None:
+        """Delete a sandbox by name. Missing sandboxes are treated as gone."""
+        try:
+            self._request("DELETE", f"/sandboxes/{_url_component(name)}")
+        except _IsloAPIError as exc:
+            if "HTTP 404" not in str(exc):
+                raise
+
+    def upload_file(self, name: str, local_path: Path, remote_path: str) -> None:
+        """Upload one file to an absolute path in the sandbox."""
+        params = urlencode({"path": remote_path})
+        endpoint = f"/sandboxes/{_url_component(name)}/files?{params}"
+        with local_path.open("rb") as file_obj:
+            files = {"file": (local_path.name, file_obj, "application/octet-stream")}
+            self._request("POST", endpoint, files=files)
+
+    def exec_stream(
+        self,
+        name: str,
+        command: Sequence[str],
+        *,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+    ) -> int:
+        """Execute a command and stream SSE stdout/stderr callbacks."""
+        body: dict[str, Any] = {"command": list(command)}
+        if workdir is not None:
+            body["workdir"] = workdir
+        if env:
+            body["env"] = env
+        headers = self._auth_headers()
+        headers["Accept"] = "text/event-stream"
+        url = self._url(f"/sandboxes/{_url_component(name)}/exec/stream")
+        try:
+            with self._client.stream(
+                "POST",
+                url,
+                headers=headers,
+                json=body,
+                timeout=None,
+            ) as response:
+                if response.status_code >= 400:
+                    raise self._response_error("POST", url, response)
+                return _parse_exec_sse(
+                    response.iter_lines(),
+                    on_stdout=on_stdout,
+                    on_stderr=on_stderr,
+                )
+        except httpx.HTTPError as exc:
+            raise _IsloAPIError(f"islo exec stream failed: {exc}") from exc
+
+    def _request_json(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        response = self._request(method, endpoint, **kwargs)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise _IsloAPIError(f"islo {method} {endpoint} returned invalid JSON") from exc
+        if not isinstance(data, dict):
+            raise _IsloAPIError(f"islo {method} {endpoint} returned a non-object response")
+        return data
+
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> httpx.Response:
+        url = self._url(endpoint)
+        headers = kwargs.pop("headers", None) or {}
+        headers = {**headers, **self._auth_headers()}
+        try:
+            response = self._client.request(method, url, headers=headers, **kwargs)
+        except httpx.HTTPError as exc:
+            raise _IsloAPIError(f"islo {method} {endpoint} failed: {exc}") from exc
+        if response.status_code >= 400:
+            raise self._response_error(method, endpoint, response)
+        return response
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._session_token()}"}
+
+    def _session_token(self) -> str:
+        now = time.time()
+        if self._token is not None and now < self._token_expires_at:
+            return self._token
+        try:
+            response = self._client.post(
+                self._url("/auth/token"),
+                json={"access_key": self._api_key},
+                timeout=_REQUEST_TIMEOUT_S,
+            )
+        except httpx.HTTPError as exc:
+            raise _IsloAPIError(f"islo token exchange failed: {exc}") from exc
+        if response.status_code >= 400:
+            raise self._response_error("POST", "/auth/token", response)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise _IsloAPIError("islo token exchange returned invalid JSON") from exc
+        token = data.get("session_token") if isinstance(data, dict) else None
+        if not isinstance(token, str) or not token:
+            raise _IsloAPIError("islo token exchange response missing session_token")
+        max_age = data.get("cookie_max_age", 0) if isinstance(data, dict) else 0
+        ttl = (
+            max(float(max_age) - _TOKEN_REFRESH_MARGIN_S, 0.0)
+            if isinstance(max_age, (int, float))
+            else 0.0
+        )
+        self._token = token
+        self._token_expires_at = now + ttl
+        return token
+
+    def _url(self, endpoint: str) -> str:
+        return self._base_url + endpoint
+
+    def _response_error(
+        self, method: str, endpoint: str, response: httpx.Response
+    ) -> _IsloAPIError:
+        try:
+            text = response.text
+        except httpx.ResponseNotRead:
+            text = response.read().decode("utf-8", errors="replace")
+        snippet = text.strip()[:1024]
+        detail = f": {snippet}" if snippet else ""
+        return _IsloAPIError(
+            f"islo {method} {endpoint} failed with HTTP {response.status_code}{detail}"
+        )
+
+
+class _IsloRemoteProcess(RemoteProcess):
+    """Thread-backed :class:`RemoteProcess` over Islo exec streaming."""
+
+    def __init__(self, client: _IsloClient, sandbox_id: str, command: str) -> None:
+        self._client = client
+        self._sandbox_id = sandbox_id
+        self._command = command
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._returncode: int | None = None
+        self._error: BaseException | None = None
+        self._thread = threading.Thread(target=self._run, name="islo-remote-process", daemon=True)
+        self._thread.start()
+
+    @property
+    def lines(self) -> Iterator[str]:
+        """Iterator over combined stdout/stderr lines."""
+        while True:
+            item = self._lines.get()
+            if item is None:
+                return
+            yield item
+
+    def wait(self) -> int:
+        """Block until the remote exec finishes and return its exit code."""
+        self._thread.join()
+        if self._error is not None:
+            raise click.ClickException(str(self._error)) from self._error
+        return self._returncode if self._returncode is not None else 1
+
+    def close(self) -> None:
+        """Best-effort cleanup; Islo exec streams do not expose a kill handle."""
+        return
+
+    def _run(self) -> None:
+        try:
+            self._returncode = self._client.exec_stream(
+                self._sandbox_id,
+                ["bash", "-lc", self._command],
+                on_stdout=self._enqueue,
+                on_stderr=self._enqueue,
+            )
+        except BaseException as exc:
+            self._error = exc
+        finally:
+            self._lines.put(None)
+
+    def _enqueue(self, text: str) -> None:
+        for line in text.splitlines(keepends=True):
+            self._lines.put(line)
+        if text and not text.endswith(("\n", "\r")):
+            self._lines.put("\n")
+
+
+class IsloSandboxLauncher(SandboxLauncher):
+    """
+    :class:`SandboxLauncher` for Islo sandboxes.
+
+    All primitives use Islo's HTTP API: sandbox create/delete for
+    lifecycle, exec streaming for commands, and file upload for wheel
+    shipping.
+    """
+
+    provider: ClassVar[str] = "islo"
+    supports_local_port_forward: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        *,
+        image: str | None = None,
+        env: Sequence[str] | None = None,
+        base_url: str | None = None,
+        gateway_profile: str | None = None,
+        snapshot_name: str | None = None,
+        workdir: str | None = None,
+        vcpus: int | None = None,
+        memory_mb: int | None = None,
+        disk_gb: int | None = None,
+    ) -> None:
+        self._image_ref = image
+        self._env_names = tuple(env) if env is not None else None
+        self._base_url = base_url
+        self._gateway_profile = gateway_profile
+        self._snapshot_name = snapshot_name
+        self._workdir = workdir
+        self._vcpus = vcpus
+        self._memory_mb = memory_mb
+        self._disk_gb = disk_gb
+        self._client: _IsloClient | None = None
+
+    def prepare(self) -> None:
+        """Verify Islo credentials are available."""
+        if not os.environ.get(API_KEY_ENV_VAR):
+            raise click.ClickException(
+                "No Islo credentials found. Create an API key at "
+                "https://islo.dev and set ISLO_API_KEY."
+            )
+
+    def provision(self, name: str) -> str:
+        """Create a new Islo sandbox from the host image."""
+        resolved_ref = self._image_ref or os.environ.get(HOST_IMAGE_ENV_VAR) or DEFAULT_HOST_IMAGE
+        sandbox_name = _new_sandbox_name(name)
+        payload: dict[str, Any] = {
+            "name": sandbox_name,
+            "image": resolved_ref,
+            "vcpus": self._vcpus or _SANDBOX_CPU,
+            "memory_mb": self._memory_mb or _SANDBOX_MEMORY_MB,
+            "init": {"type": "minimal"},
+        }
+        env_vars = self._resolve_sandbox_env()
+        if env_vars:
+            payload["env"] = env_vars
+        if self._workdir:
+            payload["workdir"] = self._workdir
+        if self._gateway_profile:
+            payload["gateway_profile"] = self._gateway_profile
+        if self._snapshot_name:
+            payload["snapshot_name"] = self._snapshot_name
+        if self._disk_gb is not None:
+            payload["disk_gb"] = self._disk_gb
+        click.echo(f"▸ Creating Islo sandbox '{sandbox_name}' from {resolved_ref}")
+        try:
+            sandbox = self._islo().create_sandbox(payload)
+        except _IsloAPIError as exc:
+            raise click.ClickException(f"Islo sandbox creation failed: {exc}") from exc
+        created_name = sandbox.get("name")
+        if not isinstance(created_name, str) or not created_name:
+            raise click.ClickException("Islo sandbox creation returned no sandbox name")
+        click.echo(f"  → created {created_name}")
+        return created_name
+
+    def attach(self, sandbox_id: str) -> None:
+        """Validate access to an existing Islo sandbox."""
+        click.echo(f"▸ Reusing existing Islo sandbox '{sandbox_id}'")
+        try:
+            self._islo().get_sandbox(sandbox_id)
+        except _IsloAPIError as exc:
+            raise click.ClickException(
+                f"Could not attach to Islo sandbox '{sandbox_id}': {exc}"
+            ) from exc
+
+    def keep_alive(self, sandbox_id: str) -> None:
+        """No local keep-alive setting is exposed by the Islo API."""
+        click.echo(f"  → Islo sandbox '{sandbox_id}' remains active until deleted")
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        """Run a shell command in the sandbox and capture its output."""
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+
+        def _stdout(text: str) -> None:
+            stdout_chunks.append(text)
+            if text:
+                click.echo(text, nl=False)
+
+        def _stderr(text: str) -> None:
+            stderr_chunks.append(text)
+            if text:
+                click.echo(text, nl=False, err=True)
+
+        try:
+            returncode = self._islo().exec_stream(
+                sandbox_id,
+                ["bash", "-lc", command],
+                on_stdout=_stdout,
+                on_stderr=_stderr,
+            )
+        except _IsloAPIError as exc:
+            raise click.ClickException(
+                f"Remote command failed to execute on Islo sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        stdout = "".join(stdout_chunks)
+        stderr = "".join(stderr_chunks)
+        if check and returncode != 0:
+            raise click.ClickException(
+                f"Remote command failed on Islo sandbox '{sandbox_id}' "
+                f"(exit {returncode}): {command}"
+            )
+        return RemoteCommandResult(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
+        """Copy a local file into the sandbox."""
+        try:
+            self._islo().upload_file(sandbox_id, local_path, remote_path)
+        except _IsloAPIError as exc:
+            raise click.ClickException(
+                f"File upload to Islo sandbox '{sandbox_id}' failed: {exc}"
+            ) from exc
+
+    def stream_exec(self, sandbox_id: str, command: str, *, pty: bool = False) -> RemoteProcess:
+        """Spawn a command in the sandbox and stream combined output."""
+        del pty
+        return _IsloRemoteProcess(self._islo(), sandbox_id, command)
+
+    def exec_foreground(self, sandbox_id: str, command: str) -> int:
+        """Run *command* in the sandbox, echoing output until it exits."""
+        process = self.stream_exec(sandbox_id, f"TERM=xterm-256color exec {command}", pty=True)
+        try:
+            for line in process.lines:
+                click.echo(line, nl=False)
+            return process.wait()
+        except KeyboardInterrupt:
+            click.echo("\n  → detached; Islo exec streams do not expose a remote kill handle")
+            raise
+
+    def wheel_install_command(self, remote_tgz_path: str) -> str:
+        """Remote command that overlays shipped wheels onto the host image."""
+        return host_image_wheel_install_command(remote_tgz_path)
+
+    def terminate(self, sandbox_id: str) -> None:
+        """Delete a sandbox, releasing its compute."""
+        try:
+            self._islo().delete_sandbox(sandbox_id)
+        finally:
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+
+    def _islo(self) -> _IsloClient:
+        if self._client is None:
+            api_key = os.environ.get(API_KEY_ENV_VAR)
+            if not api_key:
+                raise click.ClickException(
+                    "No Islo credentials found. Create an API key at "
+                    "https://islo.dev and set ISLO_API_KEY."
+                )
+            base_url = self._base_url or os.environ.get(API_BASE_URL_ENV_VAR) or _DEFAULT_BASE_URL
+            self._client = _IsloClient(base_url=base_url, api_key=api_key)
+        return self._client
+
+    def _resolve_sandbox_env(self) -> dict[str, str]:
+        if self._env_names is not None:
+            names: Sequence[str] = self._env_names
+        else:
+            names = [
+                name.strip()
+                for name in os.environ.get(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+                if name.strip()
+            ]
+        resolved: dict[str, str] = {}
+        for name in names:
+            value = os.environ.get(name)
+            if value is None:
+                raise click.ClickException(
+                    f"sandbox env passthrough names '{name}' but it is not set "
+                    "in the server's environment — set it (or remove it from "
+                    f"sandbox.islo.env / {SANDBOX_ENV_PASSTHROUGH_ENV_VAR})."
+                )
+            resolved[name] = value
+        return resolved
+
+
+def _url_component(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _new_sandbox_name(label: str) -> str:
+    base = re.sub(r"[^a-z0-9-]+", "-", label.lower()).strip("-")
+    base = re.sub(r"-+", "-", base) or "host"
+    return f"omnigent-{base[:40]}-{uuid.uuid4().hex[:6]}"
+
+
+def _parse_exec_sse(
+    lines: Iterator[str],
+    *,
+    on_stdout: Callable[[str], None] | None,
+    on_stderr: Callable[[str], None] | None,
+) -> int:
+    exit_code = 1
+    seen_exit = False
+    event = ""
+    data: list[str] = []
+
+    def flush() -> None:
+        nonlocal event, data, exit_code, seen_exit
+        if not event and not data:
+            return
+        payload = "\n".join(data)
+        if event == "stdout" and on_stdout is not None:
+            on_stdout(payload)
+        elif event == "stderr" and on_stderr is not None:
+            on_stderr(payload)
+        elif event == "exit":
+            try:
+                exit_code = int(payload.strip())
+            except ValueError as exc:
+                raise _IsloAPIError(f"islo exec stream invalid exit event {payload!r}") from exc
+            seen_exit = True
+        event = ""
+        data = []
+
+    for raw_line in lines:
+        line = raw_line.rstrip("\r")
+        if line == "":
+            flush()
+            continue
+        if line.startswith(":"):
+            continue
+        field, sep, value = line.partition(":")
+        if sep:
+            value = value.removeprefix(" ")
+        if field == "event":
+            event = value
+        elif field == "data":
+            data.append(value)
+    flush()
+    if not seen_exit:
+        raise _IsloAPIError("islo exec stream ended without exit event")
+    return exit_code

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import os
 import queue
 import re
+import shlex
 import threading
 import time
 import uuid
@@ -65,6 +66,27 @@ _TOKEN_REFRESH_MARGIN_S = 60.0
 _SANDBOX_CPU = 2
 _SANDBOX_MEMORY_MB = 4096
 _REQUEST_TIMEOUT_S = 30.0
+
+# Claude credentials a user injects via sandbox env passthrough that must win
+# over the gateway ``apiKeyHelper`` Islo pre-seeds into every sandbox. When one
+# is present we strip the seeded helper (see
+# :meth:`IsloSandboxLauncher._clear_seeded_api_key_helper`).
+_USER_CLAUDE_CRED_ENV_VARS = ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
+
+# In-sandbox script that removes a seeded ``apiKeyHelper`` from Claude Code's
+# settings. Best effort: a sandbox without the settings file is left untouched.
+_CLEAR_API_KEY_HELPER_SCRIPT = """\
+import json, os
+path = os.path.expanduser("~/.claude/settings.json")
+try:
+    with open(path) as handle:
+        settings = json.load(handle)
+except (FileNotFoundError, ValueError):
+    raise SystemExit(0)
+if isinstance(settings, dict) and settings.pop("apiKeyHelper", None) is not None:
+    with open(path, "w") as handle:
+        json.dump(settings, handle, indent=2)
+"""
 
 
 class _IsloAPIError(RuntimeError):
@@ -347,7 +369,39 @@ class IsloSandboxLauncher(SandboxLauncher):
         if not isinstance(created_name, str) or not created_name:
             raise click.ClickException("Islo sandbox creation returned no sandbox name")
         click.echo(f"  → created {created_name}")
+        self._clear_seeded_api_key_helper(created_name, env_vars)
         return created_name
+
+    def _clear_seeded_api_key_helper(self, sandbox_id: str, env_vars: dict[str, str]) -> None:
+        """
+        Strip Islo's gateway ``apiKeyHelper`` when the user injected their
+        own Claude credential.
+
+        Islo pre-seeds ``~/.claude/settings.json`` with an ``apiKeyHelper``
+        that resolves, through Islo's gateway, to a connected provider
+        integration. Claude Code prefers that helper over a
+        ``CLAUDE_CODE_OAUTH_TOKEN`` / ``ANTHROPIC_API_KEY`` in the
+        environment, so a user who brings their own credential through
+        sandbox env passthrough would be silently overridden. When such a
+        credential is among the injected vars, remove the seeded helper so
+        the user's credential is the sole auth path. Best effort: a sandbox
+        with no seeded settings file is left untouched, and a failed strip
+        warns rather than aborting the launch.
+        """
+        if not any(name in env_vars for name in _USER_CLAUDE_CRED_ENV_VARS):
+            return
+        click.echo(
+            "  → clearing Islo's seeded apiKeyHelper so your injected "
+            "Claude credential takes precedence"
+        )
+        try:
+            self.run(
+                sandbox_id,
+                f"python3 -c {shlex.quote(_CLEAR_API_KEY_HELPER_SCRIPT)}",
+                check=False,
+            )
+        except click.ClickException as exc:
+            click.echo(f"  → warning: could not clear seeded apiKeyHelper: {exc}", err=True)
 
     def attach(self, sandbox_id: str) -> None:
         """Validate access to an existing Islo sandbox."""

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1297,14 +1297,14 @@ def create_app(
         # managed_sandboxes_enabled gates the web UI's sandbox
         # option on the new-session screen: true only when a `sandbox:`
         # config is wired AND its provider can actually serve a managed
-        # launch (staged providers like daytona/lakebox parse but
-        # reject at launch — they must not advertise the option).
+        # launch (staged providers parse but reject at launch — they
+        # must not advertise the option).
         managed_sandboxes_enabled = (
             sandbox_config is not None and sandbox_config.managed_launch_supported
         )
         # sandbox_provider names the backing provider (e.g. "modal",
-        # "lakebox") so the web UI can label the option per provider
-        # ("Modal Sandbox" / "Databricks Sandbox") instead of the
+        # "islo") so the web UI can label the option per provider
+        # ("Modal Sandbox" / "Islo Sandbox") instead of the
         # generic "New Sandbox". Only surfaced when the option is
         # actually offered; None when no provider is named (embedding
         # configs may leave it unset) so the UI keeps the generic label.

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -120,9 +120,7 @@ _logger = logging.getLogger(__name__)
 # managed session today. (Deployments that construct
 # ManagedSandboxConfig directly are not constrained by either set —
 # their launcher factory IS the support.)
-SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
-    {"lakebox", "modal", "daytona", "islo"}
-)
+SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset({"lakebox", "modal", "daytona", "islo"})
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset({"modal", "daytona", "islo"})
 
 # How long a managed launch waits for the sandboxed host to register
@@ -955,9 +953,7 @@ def _parse_provider_positive_int(raw: dict[str, object], provider: str, key: str
     if value is None:
         return None
     if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise ValueError(
-            f"server config 'sandbox.{provider}.{key}' must be a positive integer"
-        )
+        raise ValueError(f"server config 'sandbox.{provider}.{key}' must be a positive integer")
     return value
 
 

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -32,7 +32,7 @@ stores into ``create_app``):
    ``<data_dir>/config.yaml``)::
 
        sandbox:
-         provider: modal          # lakebox | modal | daytona
+         provider: modal          # lakebox | modal | daytona | islo
          server_url: https://omnigent.example.com
          modal:                   # optional block
            image: docker.io/me/omnigent-host:latest  # default: official image
@@ -43,6 +43,17 @@ stores into ``create_app``):
            env: [OPENAI_API_KEY, GIT_TOKEN]  # SERVER env var NAMES whose
                                              # values are injected as
                                              # sandbox env
+         islo:                    # optional block (provider: islo)
+           image: docker.io/me/omnigent-host:latest  # default: official image
+           env: [OPENAI_API_KEY, GIT_TOKEN]  # SERVER env var NAMES injected
+                                             # as sandbox env
+           base_url: https://api.islo.dev    # optional API override
+           gateway_profile: default          # optional Islo gateway profile
+           snapshot_name: warm-host          # optional Islo snapshot name
+           workdir: /root/workspace          # optional sandbox workdir
+           vcpus: 2
+           memory_mb: 4096
+           disk_gb: 20
 
    The image defaults to the official prebaked host image
    (``ghcr.io/omnigent-ai/omnigent-host:latest``; see
@@ -52,9 +63,11 @@ stores into ``create_app``):
    (12-factor): the Modal launcher reads ``MODAL_TOKEN_ID`` /
    ``MODAL_TOKEN_SECRET`` (or ``~/.modal.toml``) and the Daytona
    launcher reads ``DAYTONA_API_KEY`` (plus optional
-   ``DAYTONA_API_URL`` / ``DAYTONA_TARGET``) from the server process
-   environment. ``modal`` and ``daytona`` have managed-launch
-   support; ``lakebox`` parses but rejects at launch.
+   ``DAYTONA_API_URL`` / ``DAYTONA_TARGET``), and the Islo launcher
+   reads ``ISLO_API_KEY`` (plus optional ``ISLO_BASE_URL``) from the
+   server process environment. ``modal``, ``daytona``, and ``islo``
+   have managed-launch support; ``lakebox`` parses but rejects at
+   launch.
 
 2. **Direct construction** (embedding deployments): build
    :class:`ManagedSandboxConfig` with a custom
@@ -102,13 +115,15 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # Providers the YAML `sandbox:` section accepts. Parsing accepts all
-# three so a deployment can stage config ahead of support landing, but
-# only PROVIDERS_WITH_MANAGED_LAUNCH can actually serve a managed
-# session today. (Deployments that construct ManagedSandboxConfig
-# directly are not constrained by either set — their launcher factory
-# IS the support.)
-SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset({"lakebox", "modal", "daytona"})
-PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset({"modal", "daytona"})
+# known providers so a deployment can stage config ahead of support
+# landing, but only PROVIDERS_WITH_MANAGED_LAUNCH can actually serve a
+# managed session today. (Deployments that construct
+# ManagedSandboxConfig directly are not constrained by either set —
+# their launcher factory IS the support.)
+SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
+    {"lakebox", "modal", "daytona", "islo"}
+)
+PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset({"modal", "daytona", "islo"})
 
 # How long a managed launch waits for the sandboxed host to register
 # before declaring failure. The image is pre-baked (no pip install at
@@ -134,6 +149,11 @@ MODAL_MANAGED_TOKEN_TTL_S = 25 * 3600
 # session past 7 days going through the dead-host relaunch path) mints
 # a fresh token.
 DAYTONA_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# Launch-token lifetime for the YAML islo path. Islo sandboxes are
+# deleted by managed-session teardown; use the same 7-day policy bound
+# as Daytona for long-lived hosts and stale-token cleanup.
+ISLO_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 
 # Where the in-sandbox host process logs — named in launch-failure
 # errors so an operator knows where to look inside the sandbox.
@@ -505,10 +525,9 @@ def _unsupported_launcher_factory(provider: str) -> Callable[[], SandboxLauncher
     """
     Build a factory that rejects launch for a not-yet-supported provider.
 
-    Lets a deployment stage ``sandbox:`` config for ``lakebox`` /
-    ``daytona`` before managed-launch support lands: parsing succeeds,
-    and the clear 400 only surfaces if a managed session is actually
-    requested.
+    Lets a deployment stage ``sandbox:`` config for a provider before
+    managed-launch support lands: parsing succeeds, and the clear 400
+    only surfaces if a managed session is actually requested.
 
     :param provider: The configured provider name, e.g. ``"daytona"``.
     :returns: A factory that raises ``HTTPException`` 400 when called.
@@ -569,6 +588,19 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             _parse_daytona_image(raw), _parse_daytona_env(raw)
         )
         token_ttl_s = DAYTONA_MANAGED_TOKEN_TTL_S
+    elif provider == "islo":
+        launcher_factory = _islo_launcher_factory(
+            image=_parse_provider_image(raw, "islo"),
+            env=_parse_provider_env(raw, "islo"),
+            base_url=_parse_provider_string(raw, "islo", "base_url"),
+            gateway_profile=_parse_provider_string(raw, "islo", "gateway_profile"),
+            snapshot_name=_parse_provider_string(raw, "islo", "snapshot_name"),
+            workdir=_parse_provider_string(raw, "islo", "workdir"),
+            vcpus=_parse_provider_positive_int(raw, "islo", "vcpus"),
+            memory_mb=_parse_provider_positive_int(raw, "islo", "memory_mb"),
+            disk_gb=_parse_provider_positive_int(raw, "islo", "disk_gb"),
+        )
+        token_ttl_s = ISLO_MANAGED_TOKEN_TTL_S
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -757,6 +789,176 @@ def _parse_daytona_env(raw: dict[str, object]) -> list[str] | None:
             "'GIT_TOKEN']"
         )
     return [name.strip() for name in env]
+
+
+def _islo_launcher_factory(
+    *,
+    image: str | None,
+    env: list[str] | None,
+    base_url: str | None,
+    gateway_profile: str | None,
+    snapshot_name: str | None,
+    workdir: str | None,
+    vcpus: int | None,
+    memory_mb: int | None,
+    disk_gb: int | None,
+) -> Callable[[], SandboxLauncher]:
+    """
+    Build the launcher factory for the YAML ``provider: islo`` path.
+
+    :param image: Registry image reference with omnigent pre-installed,
+        e.g. ``"docker.io/me/omnigent-host:latest"``, or ``None`` to
+        use the official prebaked host image (env-overridable; see
+        :class:`omnigent.onboarding.sandboxes.islo.IsloSandboxLauncher`).
+    :param env: Names of server-process environment variables injected
+        into every sandbox, e.g. ``["OPENAI_API_KEY", "GIT_TOKEN"]``,
+        or ``None`` to resolve from the launcher's env-var fallback /
+        inject nothing.
+    :param base_url: Optional Islo API base URL override.
+    :param gateway_profile: Optional Islo gateway profile name.
+    :param snapshot_name: Optional Islo snapshot name.
+    :param workdir: Optional sandbox working directory.
+    :param vcpus: Optional vCPU count.
+    :param memory_mb: Optional memory allocation in MiB.
+    :param disk_gb: Optional disk allocation in GiB.
+    :returns: A factory producing parameterized Islo launchers.
+    """
+
+    def _build() -> SandboxLauncher:
+        """Construct the Islo launcher."""
+        from omnigent.onboarding.sandboxes.islo import IsloSandboxLauncher
+
+        return IsloSandboxLauncher(
+            image=image,
+            env=env,
+            base_url=base_url,
+            gateway_profile=gateway_profile,
+            snapshot_name=snapshot_name,
+            workdir=workdir,
+            vcpus=vcpus,
+            memory_mb=memory_mb,
+            disk_gb=disk_gb,
+        )
+
+    return _build
+
+
+def _parse_provider_section(raw: dict[str, object], provider: str) -> dict[str, object] | None:
+    """
+    Extract a provider-specific optional config block.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :param provider: Provider block name, e.g. ``"islo"``.
+    :returns: The provider mapping, or ``None`` when omitted.
+    :raises ValueError: When the block is present but not a mapping.
+    """
+    section = raw.get(provider)
+    if section is None:
+        return None
+    if not isinstance(section, dict):
+        raise ValueError(f"server config 'sandbox.{provider}' must be a mapping")
+    return section
+
+
+def _parse_provider_image(raw: dict[str, object], provider: str) -> str | None:
+    """
+    Extract and validate a provider image from the raw ``sandbox`` dict.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :param provider: Provider block name, e.g. ``"islo"``.
+    :returns: The validated image reference, or ``None`` to use the
+        official default.
+    :raises ValueError: When the provider block or image value is
+        malformed.
+    """
+    section = _parse_provider_section(raw, provider)
+    if section is None:
+        return None
+    image = section.get("image")
+    if image is None:
+        return None
+    if not isinstance(image, str) or not image.strip():
+        raise ValueError(
+            f"server config 'sandbox.{provider}.image' must be a registry image "
+            "reference with omnigent pre-installed, e.g. "
+            "'docker.io/me/omnigent-host:latest' (omit it to use the "
+            "official image)"
+        )
+    return image.strip()
+
+
+def _parse_provider_env(raw: dict[str, object], provider: str) -> list[str] | None:
+    """
+    Extract and validate provider env passthrough names.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :param provider: Provider block name, e.g. ``"islo"``.
+    :returns: Validated environment variable names, or ``None`` when
+        not configured.
+    :raises ValueError: When the provider block or env list is
+        malformed.
+    """
+    section = _parse_provider_section(raw, provider)
+    if section is None:
+        return None
+    env = section.get("env")
+    if env is None:
+        return None
+    if not isinstance(env, list) or not all(
+        isinstance(name, str) and name.strip() for name in env
+    ):
+        raise ValueError(
+            f"server config 'sandbox.{provider}.env' must be a list of server "
+            "environment variable NAMES to inject, e.g. ['OPENAI_API_KEY', "
+            "'GIT_TOKEN']"
+        )
+    return [name.strip() for name in env]
+
+
+def _parse_provider_string(raw: dict[str, object], provider: str, key: str) -> str | None:
+    """
+    Extract and validate an optional provider string field.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :param provider: Provider block name, e.g. ``"islo"``.
+    :param key: Field name under the provider block.
+    :returns: The stripped string, or ``None`` when omitted.
+    :raises ValueError: When the field is present but not a non-empty
+        string.
+    """
+    section = _parse_provider_section(raw, provider)
+    if section is None:
+        return None
+    value = section.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"server config 'sandbox.{provider}.{key}' must be a non-empty string")
+    return value.strip()
+
+
+def _parse_provider_positive_int(raw: dict[str, object], provider: str, key: str) -> int | None:
+    """
+    Extract and validate an optional positive integer provider field.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :param provider: Provider block name, e.g. ``"islo"``.
+    :param key: Field name under the provider block.
+    :returns: The integer, or ``None`` when omitted.
+    :raises ValueError: When the field is present but is not a positive
+        integer.
+    """
+    section = _parse_provider_section(raw, provider)
+    if section is None:
+        return None
+    value = section.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(
+            f"server config 'sandbox.{provider}.{key}' must be a positive integer"
+        )
+    return value
 
 
 async def launch_managed_host(

--- a/tests/onboarding/sandboxes/test_islo.py
+++ b/tests/onboarding/sandboxes/test_islo.py
@@ -253,6 +253,44 @@ def test_provision_env_passthrough_missing_var_fails_loud(
     assert fake.create_payloads == []
 
 
+@pytest.mark.parametrize("cred_var", ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"])
+def test_provision_clears_seeded_helper_when_user_injects_claude_cred(
+    monkeypatch: pytest.MonkeyPatch, cred_var: str
+) -> None:
+    """
+    A user-injected Claude credential strips Islo's gateway ``apiKeyHelper``
+    so the injected credential wins (covers both CLI and managed launches,
+    which share ``provision``).
+    """
+    monkeypatch.setenv(cred_var, "secret-value")
+    monkeypatch.setattr(islo_mod, "_new_sandbox_name", lambda label: "omnigent-byo")
+    fake = _FakeIsloAPI()
+    launcher = IsloSandboxLauncher(env=[cred_var])
+    monkeypatch.setattr(launcher, "_islo", lambda: fake)
+
+    launcher.provision("host")
+
+    strip_calls = [call for call in fake.exec_calls if "apiKeyHelper" in call.command[-1]]
+    assert len(strip_calls) == 1
+    assert strip_calls[0].sandbox_id == "omnigent-byo"
+    assert strip_calls[0].command[:2] == ["bash", "-lc"]
+
+
+def test_provision_keeps_seeded_helper_without_user_claude_cred(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway users (Option A) inject no Claude credential, so the seeded helper stays."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(islo_mod, "_new_sandbox_name", lambda label: "omnigent-gw")
+    fake = _FakeIsloAPI()
+    launcher = IsloSandboxLauncher(env=["OPENAI_API_KEY"])
+    monkeypatch.setattr(launcher, "_islo", lambda: fake)
+
+    launcher.provision("host")
+
+    assert all("apiKeyHelper" not in call.command[-1] for call in fake.exec_calls)
+
+
 def test_run_streams_stdout_and_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
     """``run`` calls Islo exec streaming through ``bash -lc`` and captures both streams."""
     fake = _FakeIsloAPI()

--- a/tests/onboarding/sandboxes/test_islo.py
+++ b/tests/onboarding/sandboxes/test_islo.py
@@ -1,0 +1,298 @@
+"""Tests for :mod:`omnigent.onboarding.sandboxes.islo`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+
+import omnigent.onboarding.sandboxes.islo as islo_mod
+from omnigent.onboarding.sandboxes.base import DEFAULT_HOST_IMAGE
+from omnigent.onboarding.sandboxes.islo import (
+    API_KEY_ENV_VAR,
+    HOST_IMAGE_ENV_VAR,
+    SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
+    IsloSandboxLauncher,
+    _IsloClient,
+    _parse_exec_sse,
+)
+
+
+@dataclass
+class _HttpRequest:
+    """One recorded fake HTTP request."""
+
+    method: str
+    url: str
+    headers: dict[str, str]
+    kwargs: dict[str, Any]
+
+
+class _FakeResponse:
+    """Minimal ``httpx.Response`` stand-in for the Islo client tests."""
+
+    def __init__(self, status_code: int, data: dict[str, Any], text: str = "") -> None:
+        self.status_code = status_code
+        self._data = data
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        """Return the canned JSON body."""
+        return self._data
+
+
+class _FakeHTTPClient:
+    """Recorder for the subset of ``httpx.Client`` used by ``_IsloClient``."""
+
+    def __init__(self) -> None:
+        self.token_posts: list[dict[str, Any]] = []
+        self.requests: list[_HttpRequest] = []
+        self.closed = False
+
+    def post(self, url: str, *, json: dict[str, Any], timeout: float) -> _FakeResponse:
+        """Record the token exchange and return a cacheable session token."""
+        self.token_posts.append({"url": url, "json": json, "timeout": timeout})
+        return _FakeResponse(200, {"session_token": "session-123", "cookie_max_age": 120})
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        """Record an authenticated API request and return an object body."""
+        self.requests.append(_HttpRequest(method=method, url=url, headers=headers, kwargs=kwargs))
+        return _FakeResponse(200, {"ok": True})
+
+    def close(self) -> None:
+        """Record close."""
+        self.closed = True
+
+
+@dataclass
+class _ExecCall:
+    """One fake Islo exec-stream invocation."""
+
+    sandbox_id: str
+    command: list[str]
+
+
+@dataclass
+class _FakeIsloAPI:
+    """Recorder for the launcher-facing Islo API client."""
+
+    create_payloads: list[dict[str, Any]] = field(default_factory=list)
+    exec_calls: list[_ExecCall] = field(default_factory=list)
+    uploads: list[tuple[str, Path, str]] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+
+    def create_sandbox(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Record a create request and echo the sandbox name back."""
+        self.create_payloads.append(dict(payload))
+        return {"name": payload["name"]}
+
+    def get_sandbox(self, name: str) -> dict[str, Any]:
+        """Return a canned sandbox object."""
+        return {"name": name}
+
+    def delete_sandbox(self, name: str) -> None:
+        """Record deletion."""
+        self.deleted.append(name)
+
+    def upload_file(self, name: str, local_path: Path, remote_path: str) -> None:
+        """Record file upload."""
+        self.uploads.append((name, local_path, remote_path))
+
+    def exec_stream(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        on_stdout: Any = None,
+        on_stderr: Any = None,
+    ) -> int:
+        """Record command execution and emit one chunk per stream."""
+        del workdir, env
+        self.exec_calls.append(_ExecCall(sandbox_id=name, command=command))
+        if on_stdout is not None:
+            on_stdout("out\n")
+        if on_stderr is not None:
+            on_stderr("err\n")
+        return 0
+
+
+def test_client_exchanges_access_key_for_cached_bearer_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``ISLO_API_KEY`` is not sent to sandbox endpoints directly; it is
+    exchanged for a session token that authenticates API calls.
+    """
+    fake = _FakeHTTPClient()
+    monkeypatch.setattr(islo_mod.httpx, "Client", lambda **kwargs: fake)
+
+    client = _IsloClient(base_url="https://api.islo.dev/", api_key="ak-test")
+
+    assert client.create_sandbox({"name": "sb-1"}) == {"ok": True}
+    assert client.get_sandbox("sb/1") == {"ok": True}
+
+    assert fake.token_posts == [
+        {
+            "url": "https://api.islo.dev/auth/token",
+            "json": {"access_key": "ak-test"},
+            "timeout": 30.0,
+        }
+    ]
+    assert [req.headers["Authorization"] for req in fake.requests] == [
+        "Bearer session-123",
+        "Bearer session-123",
+    ]
+    assert fake.requests[1].url == "https://api.islo.dev/sandboxes/sb%2F1"
+
+
+def test_prepare_requires_islo_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preflight fails before provisioning when ``ISLO_API_KEY`` is absent."""
+    monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    with pytest.raises(click.ClickException, match="ISLO_API_KEY"):
+        IsloSandboxLauncher().prepare()
+
+    monkeypatch.setenv(API_KEY_ENV_VAR, "ak-test")
+    IsloSandboxLauncher().prepare()
+
+
+def test_provision_builds_islo_create_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Provisioning sends the official host image defaults plus configured
+    env passthrough and Islo-specific resource/profile fields.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("GIT_TOKEN", "ghp-test")
+    monkeypatch.setattr(islo_mod, "_new_sandbox_name", lambda label: "omnigent-fixed")
+    fake = _FakeIsloAPI()
+    launcher = IsloSandboxLauncher(
+        image="docker.io/me/omnigent-host:latest",
+        env=["OPENAI_API_KEY", "GIT_TOKEN"],
+        gateway_profile="default",
+        snapshot_name="warm-host",
+        workdir="/root/workspace",
+        vcpus=4,
+        memory_mb=8192,
+        disk_gb=40,
+    )
+    monkeypatch.setattr(launcher, "_islo", lambda: fake)
+
+    sandbox_id = launcher.provision("Managed Host")
+
+    assert sandbox_id == "omnigent-fixed"
+    assert fake.create_payloads == [
+        {
+            "name": "omnigent-fixed",
+            "image": "docker.io/me/omnigent-host:latest",
+            "vcpus": 4,
+            "memory_mb": 8192,
+            "init": {"type": "minimal"},
+            "env": {"OPENAI_API_KEY": "sk-test", "GIT_TOKEN": "ghp-test"},
+            "workdir": "/root/workspace",
+            "gateway_profile": "default",
+            "snapshot_name": "warm-host",
+            "disk_gb": 40,
+        }
+    ]
+
+
+def test_provision_uses_image_and_env_var_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Without constructor fields, host image and sandbox env names resolve
+    from process env vars; otherwise the official image and empty env apply.
+    """
+    monkeypatch.setenv(HOST_IMAGE_ENV_VAR, "docker.io/env/host:1")
+    monkeypatch.setenv(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "OPENAI_API_KEY")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(islo_mod, "_new_sandbox_name", lambda label: "omnigent-env")
+    fake = _FakeIsloAPI()
+    launcher = IsloSandboxLauncher()
+    monkeypatch.setattr(launcher, "_islo", lambda: fake)
+
+    launcher.provision("a")
+
+    [payload] = fake.create_payloads
+    assert payload["image"] == "docker.io/env/host:1"
+    assert payload["env"] == {"OPENAI_API_KEY": "sk-test"}
+
+    monkeypatch.delenv(HOST_IMAGE_ENV_VAR)
+    monkeypatch.delenv(SANDBOX_ENV_PASSTHROUGH_ENV_VAR)
+    fake2 = _FakeIsloAPI()
+    launcher2 = IsloSandboxLauncher()
+    monkeypatch.setattr(launcher2, "_islo", lambda: fake2)
+
+    launcher2.provision("b")
+
+    [payload2] = fake2.create_payloads
+    assert payload2["image"] == DEFAULT_HOST_IMAGE
+    assert "env" not in payload2
+
+
+def test_provision_env_passthrough_missing_var_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured but unset env name aborts before creating a sandbox."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    fake = _FakeIsloAPI()
+    launcher = IsloSandboxLauncher(env=["OPENAI_API_KEY"])
+    monkeypatch.setattr(launcher, "_islo", lambda: fake)
+
+    with pytest.raises(click.ClickException, match="OPENAI_API_KEY"):
+        launcher.provision("a")
+    assert fake.create_payloads == []
+
+
+def test_run_streams_stdout_and_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run`` calls Islo exec streaming through ``bash -lc`` and captures both streams."""
+    fake = _FakeIsloAPI()
+    launcher = IsloSandboxLauncher()
+    monkeypatch.setattr(launcher, "_islo", lambda: fake)
+
+    result = launcher.run("sb-1", "printf hi")
+
+    assert fake.exec_calls == [_ExecCall(sandbox_id="sb-1", command=["bash", "-lc", "printf hi"])]
+    assert result.returncode == 0
+    assert result.stdout == "out\n"
+    assert result.stderr == "err\n"
+
+
+def test_parse_exec_sse_routes_events_and_requires_exit() -> None:
+    """Islo exec SSE events are routed by event type and must include an exit code."""
+    stdout: list[str] = []
+    stderr: list[str] = []
+
+    returncode = _parse_exec_sse(
+        iter(
+            [
+                "event: stdout",
+                "data: hello",
+                "",
+                "event: stderr",
+                "data: warn",
+                "",
+                "event: exit",
+                "data: 7",
+                "",
+            ]
+        ),
+        on_stdout=stdout.append,
+        on_stderr=stderr.append,
+    )
+
+    assert returncode == 7
+    assert stdout == ["hello"]
+    assert stderr == ["warn"]
+
+    with pytest.raises(RuntimeError, match="without exit event"):
+        _parse_exec_sse(iter(["event: stdout", "data: hello", ""]), on_stdout=None, on_stderr=None)

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -183,6 +183,13 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.image: str | None = None
         self.secrets: list[str] | None = None
         self.env: list[str] | None = None
+        self.base_url: str | None = None
+        self.gateway_profile: str | None = None
+        self.snapshot_name: str | None = None
+        self.workdir: str | None = None
+        self.vcpus: int | None = None
+        self.memory_mb: int | None = None
+        self.disk_gb: int | None = None
         self.prepared = False
         self.provisioned_names: list[str] = []
         self.commands: list[str] = []
@@ -330,6 +337,51 @@ def install_fake_daytona_launcher(
         return fake
 
     monkeypatch.setattr(daytona_mod, "DaytonaSandboxLauncher", _ctor)
+
+
+def install_fake_islo_launcher(
+    monkeypatch: Any,  # pytest.MonkeyPatch — Any avoids importing pytest in a helpers module
+    fake: FakeSandboxLauncher,
+) -> None:
+    """
+    Substitute the fake for ``IsloSandboxLauncher`` at its public seam.
+
+    The managed flow constructs ``IsloSandboxLauncher(image=…, env=…,
+    base_url=…, gateway_profile=…, snapshot_name=…, workdir=…,
+    vcpus=…, memory_mb=…, disk_gb=…)``; the shim records those
+    constructor args on the fake and hands it back, so production code
+    runs unmodified against it.
+
+    :param monkeypatch: The test's ``pytest.MonkeyPatch``.
+    :param fake: The fake launcher to substitute.
+    """
+    import omnigent.onboarding.sandboxes.islo as islo_mod
+
+    def _ctor(
+        *,
+        image: str | None = None,
+        env: list[str] | None = None,
+        base_url: str | None = None,
+        gateway_profile: str | None = None,
+        snapshot_name: str | None = None,
+        workdir: str | None = None,
+        vcpus: int | None = None,
+        memory_mb: int | None = None,
+        disk_gb: int | None = None,
+    ) -> FakeSandboxLauncher:
+        """Stand-in constructor recording the construction wiring."""
+        fake.image = image
+        fake.env = env
+        fake.base_url = base_url
+        fake.gateway_profile = gateway_profile
+        fake.snapshot_name = snapshot_name
+        fake.workdir = workdir
+        fake.vcpus = vcpus
+        fake.memory_mb = memory_mb
+        fake.disk_gb = disk_gb
+        return fake
+
+    monkeypatch.setattr(islo_mod, "IsloSandboxLauncher", _ctor)
 
 
 async def wait_for_completion(

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -15,6 +15,7 @@ from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
 from omnigent.server.managed_hosts import (
     DAYTONA_MANAGED_TOKEN_TTL_S,
+    ISLO_MANAGED_TOKEN_TTL_S,
     MODAL_MANAGED_TOKEN_TTL_S,
     ManagedSandboxConfig,
     RepoWorkspace,
@@ -33,6 +34,7 @@ from tests.server.helpers import (
     FakeSandboxLauncher,
     HostStartInvocation,
     install_fake_daytona_launcher,
+    install_fake_islo_launcher,
     install_fake_modal_launcher,
 )
 
@@ -194,6 +196,74 @@ def test_parse_daytona_without_section_defaults(
     assert fake.env is None
 
 
+def test_parse_valid_islo_config_builds_parameterized_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The documented islo YAML shape parses into a config whose factory
+    constructs Islo launchers carrying image, env names, API override,
+    and optional Islo sandbox sizing/profile fields.
+    """
+    cfg = parse_sandbox_config(
+        {
+            "provider": "islo",
+            "server_url": "https://srv.example.com/",
+            "islo": {
+                "image": "docker.io/me/omnigent-host:latest",
+                "env": ["OPENAI_API_KEY", "GIT_TOKEN"],
+                "base_url": "https://api.islo.dev/",
+                "gateway_profile": "default",
+                "snapshot_name": "warm-host",
+                "workdir": "/root/workspace",
+                "vcpus": 4,
+                "memory_mb": 8192,
+                "disk_gb": 40,
+            },
+        }
+    )
+    assert cfg is not None
+    assert cfg.server_url == "https://srv.example.com"
+    assert cfg.token_ttl_s == ISLO_MANAGED_TOKEN_TTL_S
+    assert cfg.managed_launch_supported is True
+    assert cfg.provider == "islo"
+    fake = FakeSandboxLauncher()
+    install_fake_islo_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.image == "docker.io/me/omnigent-host:latest"
+    assert fake.env == ["OPENAI_API_KEY", "GIT_TOKEN"]
+    assert fake.base_url == "https://api.islo.dev/"
+    assert fake.gateway_profile == "default"
+    assert fake.snapshot_name == "warm-host"
+    assert fake.workdir == "/root/workspace"
+    assert fake.vcpus == 4
+    assert fake.memory_mb == 8192
+    assert fake.disk_gb == 40
+
+
+def test_parse_islo_without_section_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    `provider: islo` + `server_url` is a complete config: optional
+    constructor fields reach the launcher as None so its env-var
+    fallbacks / official-image default apply.
+    """
+    cfg = parse_sandbox_config({"provider": "islo", "server_url": "https://s.example.com"})
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_islo_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.image is None
+    assert fake.env is None
+    assert fake.base_url is None
+    assert fake.gateway_profile is None
+    assert fake.snapshot_name is None
+    assert fake.workdir is None
+    assert fake.vcpus is None
+    assert fake.memory_mb is None
+    assert fake.disk_gb is None
+
+
 @pytest.mark.parametrize(
     ("raw", "expected_fragment"),
     [
@@ -224,6 +294,32 @@ def test_parse_daytona_without_section_defaults(
         (
             {"provider": "daytona", "server_url": "https://s", "daytona": {"env": ["", "X"]}},
             "sandbox.daytona.env",
+        ),
+        # islo section present but malformed.
+        ({"provider": "islo", "server_url": "https://s", "islo": "x"}, "sandbox.islo"),
+        (
+            {"provider": "islo", "server_url": "https://s", "islo": {"image": "  "}},
+            "sandbox.islo.image",
+        ),
+        (
+            {"provider": "islo", "server_url": "https://s", "islo": {"env": "OPENAI"}},
+            "sandbox.islo.env",
+        ),
+        (
+            {"provider": "islo", "server_url": "https://s", "islo": {"env": ["", "X"]}},
+            "sandbox.islo.env",
+        ),
+        (
+            {"provider": "islo", "server_url": "https://s", "islo": {"base_url": "  "}},
+            "sandbox.islo.base_url",
+        ),
+        (
+            {"provider": "islo", "server_url": "https://s", "islo": {"vcpus": 0}},
+            "sandbox.islo.vcpus",
+        ),
+        (
+            {"provider": "islo", "server_url": "https://s", "islo": {"memory_mb": "large"}},
+            "sandbox.islo.memory_mb",
         ),
     ],
 )
@@ -360,6 +456,8 @@ def _capability_probe_app(
         # Daytona has managed-launch support like modal → offered and
         # named so the UI can label it ("Daytona Sandbox").
         ({"provider": "daytona", "server_url": "https://s.example.com"}, True, "daytona"),
+        # Islo has managed-launch support too → offered and provider-labeled.
+        ({"provider": "islo", "server_url": "https://s.example.com"}, True, "islo"),
     ],
 )
 async def test_info_reports_managed_sandboxes_capability(


### PR DESCRIPTION
## Summary

- Add an Islo sandbox launcher using the Islo HTTP API with `ISLO_API_KEY` token exchange, sandbox lifecycle, file upload, and exec streaming support.
- Register `islo` as a sandbox provider and wire it into server-managed sandbox config, including image/env/API/profile/resource options.
- Update CLI/docs and add focused launcher plus managed-host parser tests.

## Validation

- `python -m ruff check omnigent/onboarding/sandboxes/islo.py omnigent/onboarding/sandboxes/__init__.py omnigent/server/managed_hosts.py omnigent/server/app.py omnigent/cli_sandbox.py tests/onboarding/sandboxes/test_islo.py tests/server/helpers.py tests/server/test_managed_hosts.py`
- `python -m py_compile omnigent/onboarding/sandboxes/islo.py omnigent/server/managed_hosts.py tests/onboarding/sandboxes/test_islo.py tests/server/test_managed_hosts.py tests/server/helpers.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/omnigent-uv-env UV_CACHE_DIR=/tmp/omnigent-uv-cache uv --no-config run --project . --extra dev python -m pytest tests/onboarding/sandboxes/test_islo.py tests/server/test_managed_hosts.py -q` (`72 passed`)
