### PR TITLE
fix(pi): handle pi RPC stdout lines larger than 64KB (StreamReader limit)

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -580,6 +580,7 @@ _PI_ENV_ALLOW_EXACT: frozenset[str] = frozenset(
         "TZ",
     }
 )
+_STREAM_READ_CHUNK_SIZE = 65536
 
 
 def _build_models_json(
@@ -817,7 +818,7 @@ class _PiRpcSession:
         """Background task: read lines from Pi stdout and enqueue them."""
         assert self.process is not None and self.process.stdout is not None
         try:
-            async for raw_line in self.process.stdout:
+            async for raw_line in self._iter_stream_lines(self.process.stdout):
                 line = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
                 if line:
                     self._line_queue.put_nowait(line)
@@ -833,7 +834,7 @@ class _PiRpcSession:
         if self.process is None or self.process.stderr is None:
             return
         try:
-            async for raw_line in self.process.stderr:
+            async for raw_line in self._iter_stream_lines(self.process.stderr):
                 text = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
                 if text:
                     logger.debug("pi stderr: %s", text)
@@ -841,6 +842,29 @@ class _PiRpcSession:
                         self._stderr_lines.append(text)
         except (asyncio.CancelledError, Exception):  # noqa: BLE001 — stderr drainer is best-effort; never crashes
             pass
+
+    @staticmethod
+    async def _iter_stream_chunks(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+        while True:
+            chunk = await stream.read(_STREAM_READ_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+
+    @staticmethod
+    async def _iter_stream_lines(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+        buffer = bytearray()
+        async for chunk in _PiRpcSession._iter_stream_chunks(stream):
+            buffer.extend(chunk)
+            while True:
+                newline_index = buffer.find(b"\n")
+                if newline_index < 0:
+                    break
+                line = bytes(buffer[: newline_index + 1])
+                del buffer[: newline_index + 1]
+                yield line
+        if buffer:
+            yield bytes(buffer)
 
     async def send_command(self, command: CodexEvent) -> None:
         """Send a JSONL command to Pi's stdin."""

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -52,15 +52,29 @@ class _FakeStreamReader:
     """Simulates asyncio.StreamReader with pre-loaded lines."""
 
     def __init__(self, lines: list[bytes]):
-        self._lines = list(lines)
-        self._index = 0
+        self._buffer = bytearray(b"".join(lines))
 
     async def readline(self) -> bytes:
-        if self._index < len(self._lines):
-            line = self._lines[self._index]
-            self._index += 1
+        if not self._buffer:
+            return b""
+        newline_index = self._buffer.find(b"\n")
+        if newline_index >= 0:
+            end = newline_index + 1
+            line = bytes(self._buffer[:end])
+            del self._buffer[:end]
             return line
-        return b""
+        line = bytes(self._buffer)
+        self._buffer.clear()
+        return line
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._buffer:
+            return b""
+        if n is None or n < 0 or n > len(self._buffer):
+            n = len(self._buffer)
+        chunk = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return chunk
 
     def __aiter__(self):
         return self
@@ -836,6 +850,35 @@ class TestToolServer(unittest.TestCase):
 
 
 class TestPiRpcSession(unittest.TestCase):
+    def test_reader_accepts_single_stdout_line_larger_than_default_stream_limit(self):
+        async def _test():
+            rpc = _PiRpcSession()
+            stream = asyncio.StreamReader()
+            payload = "x" * (70 * 1024)
+            event = {
+                "type": "tool_execution_end",
+                "toolName": "large_result",
+                "isError": False,
+                "result": {"content": payload},
+            }
+            stream.feed_data((json.dumps(event) + "\n").encode())
+            stream.feed_eof()
+            rpc.process = MagicMock()
+            rpc.process.stdout = stream
+            rpc._line_queue = asyncio.Queue()
+
+            await rpc._reader()
+
+            line = await rpc.read_line(timeout=0.1)
+            self.assertIsNotNone(line)
+            parsed = json.loads(line)
+            self.assertEqual(parsed["type"], "tool_execution_end")
+            self.assertEqual(parsed["toolName"], "large_result")
+            self.assertEqual(parsed["result"]["content"], payload)
+            self.assertIsNone(await rpc.read_line(timeout=0.1))
+
+        _run(_test())
+
     def test_send_command(self):
         async def _test():
             rpc = _PiRpcSession()


### PR DESCRIPTION
## Summary

The Pi harness could fail a turn with `ExecutorError: Pi process ended without response.` whenever Pi emitted a single stdout RPC event larger than asyncio's default ~64KB `StreamReader` line limit — e.g. a `tool_execution_end` event carrying a large inline tool result. The Pi subprocess stayed alive, but the capped line iterator overflowed before Omnigent could parse the JSON. This change makes the Pi RPC reader consume stdout/stderr in fixed-size chunks and split on newlines in Omnigent code, removing the per-line cap, mirroring how the Codex app-server harness already reads its stream. The failure is model/provider-independent — it is determined purely by the size of one stdout JSONL event.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added a regression test `tests/inner/test_pi_executor.py::TestPiRpcSession::test_reader_accepts_single_stdout_line_larger_than_default_stream_limit`, which feeds a single ~70KB stdout line through the reader and asserts it is delivered intact rather than collapsing to the terminal `None` sentinel. Reverting only the reader change makes the test fail (overflow becomes `None`); restoring the fix makes it pass, so the test pins the bug.

Commands run locally (base commit `43947270c4e26269c85814fb76b2930a496d8def`):

- `uv sync --extra dev` — passed
- `uv run pytest tests/inner/test_pi_executor.py::TestPiRpcSession::test_reader_accepts_single_stdout_line_larger_than_default_stream_limit` — passed
- `uv run pytest tests/inner/test_pi_executor.py` — 109 passed, 1 pre-existing failure unrelated to this change (`test_pi_sandbox_launcher_policy_carries_spawn_env_allowlist`, a macOS-only `linux_bwrap` sandbox test)
- `uv run ruff check omnigent/inner/pi_executor.py tests/inner/test_pi_executor.py` — passed
- `uv run ruff format --check omnigent/inner/pi_executor.py tests/inner/test_pi_executor.py` — passed
- `uv run pre-commit run --all-files --show-diff-on-failure` — passed

No E2E coverage was added because this is a unit-level stream-framing defect, fully reproduced by the regression test, with no user-facing flow change.

## Root cause

`omnigent/inner/pi_executor.py` started the Pi subprocess with stdout/stderr pipes but no raised stream `limit` at the subprocess boundary (`_PiRpcSession.start`), and the reader consumed stdout via `async for raw_line in self.process.stdout` (`_PiRpcSession._reader`), which uses `StreamReader.readline()` semantics and enforces the default ~64KB per-line cap. Pi emits each RPC event as one JSON line, with `tool_execution_end` carrying the whole tool result inline, so one large result overflowed the reader before the JSON was parsed.

## Codex asymmetry

The Codex app-server harness already avoids this class of failure by reading stdout/stderr in fixed-size chunks and splitting on `\n` in Omnigent code rather than relying on the per-line iterator. This change brings the Pi RPC session in line: it adds `_iter_stream_chunks()` / `_iter_stream_lines()` helpers, reads both streams in chunks, and splits on newlines without an asyncio per-line cap, keeping subprocess creation and public behavior otherwise unchanged.

## Session-reuse note

Before the fix, once the reader hit the per-line limit it logged at debug, enqueued the terminal `None` sentinel, and exited while the Pi process still had `returncode is None`. A reused session on a later turn could then block until the normal 120s timeout.

## Duplicate search

No existing PR covered this before opening (`gh pr list --state all --search` for "pi StreamReader reader limit", "StreamReader 64KB pi stdout", "Pi process ended without response", and "tool_execution_end 64KB" all returned no matches).
