### PR TITLE
docs: add Tuning Engines gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ and a key. The base URL depends on which agent you point it at:
 |---|---|---|---|
 | **OpenRouter** | Claude Code | `https://openrouter.ai/api` | your OpenRouter key (`sk-or-…`) |
 | **OpenRouter** | Codex / OpenAI agents | `https://openrouter.ai/api/v1` | your OpenRouter key (`sk-or-…`) |
+| **Tuning Engines** | Codex / OpenAI agents | `https://api.tuningengines.com/v1` | your Tuning Engines inference key (`sk-te-…`) |
 | **Ollama** (local) | Codex / OpenAI agents | `http://localhost:11434/v1` | any value (Ollama ignores it) |
 
 For Claude Code, point at OpenRouter's Anthropic-compatible endpoint


### PR DESCRIPTION
## Summary

- adds Tuning Engines to the existing gateway base URL table
- keeps the example scoped to Codex / OpenAI agents, matching the OpenAI-compatible `/v1` endpoint
- does not change setup behavior or runtime code

## Notes

Docs-only change.
