### PR TITLE
chore: expand NOTICE with additional distributed deps

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -45,6 +45,18 @@ Copyright 2016 Google LLC.
 opentelemetry-instrumentation-openai-agents-v2 - https://pypi.org/project/opentelemetry-instrumentation-openai-agents-v2/
 Copyright The OpenTelemetry Authors.
 
+cel-expr-python - https://github.com/cel-expr/cel-python/
+Copyright The Cel Expr Python Authors.
+
+modal - https://pypi.org/project/modal/
+Copyright Modal Labs 2022.
+
+daytona - https://pypi.org/project/daytona/
+Copyright 2024 Daytona.
+
+opentelemetry-distro - https://pypi.org/project/opentelemetry-distro/
+Copyright The OpenTelemetry Authors.
+
 ________________
 
 This Software contains code from the following open source projects, licensed under the MIT license (https://opensource.org/license/mit):
@@ -94,6 +106,9 @@ Copyright (c) 2015-2022 José Padilla.
 argon2-cffi - https://pypi.org/project/argon2-cffi/
 Copyright (c) 2015 Hynek Schlawack and the argon2-cffi contributors.
 
+tomlkit - https://pypi.org/project/tomlkit/
+Copyright (c) 2018 Sébastien Eustace.
+
 ________________
 
 This Software contains code from the following open source projects, licensed under the BSD-3 license (https://opensource.org/license/bsd-3-clause):
@@ -112,6 +127,9 @@ Copyright © 2019, Encode OSS Ltd. All rights reserved.
 
 click - https://pypi.org/project/click/
 Copyright 2014 Pallets.
+
+psutil - https://pypi.org/project/psutil/
+Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola. All rights reserved.
 
 ________________
 


### PR DESCRIPTION
## Summary

Expands the `NOTICE` with the third-party dependencies missing from the first cut:

- Core deps (always distributed): `cel-expr-python` (Apache-2.0), `tomlkit` (MIT), `psutil` (BSD-3).
- Optional extras now covered: `modal` (Apache-2.0), `daytona` (Apache-2.0), `opentelemetry-distro` (Apache-2.0).

NOTICE-only change; no code or packaging wiring is affected.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

NOTICE is a static third-party attribution file with no runtime behavior, so there is nothing to unit-test. Verified manually that the diff is exactly the six added attribution entries and that the file keeps its expected plain-text layout; the package build picks it up into the wheel and image automatically.