### PR TITLE
ci: run e2e on fork PRs with maintainer approval

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,13 +19,14 @@ name: E2E Tests
 #                       parallel; leans heavily on
 #                       ``tests/known_failures.yaml`` quarantines
 #                       (~290 entries today) tracked under #532.
-#   push (main)         Post-merge verification run, matches the
-#                       pattern in ci.yml / nightly.yml.
 
 on:
   schedule:
     - cron: "0 9 * * *"
-  pull_request:
+  # pull_request_target (not pull_request) so fork PRs run in the base-repo
+  # context with secrets, gated by the fork-e2e environment below. Same-repo
+  # and internal PRs run ungated (empty environment).
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: ['ap-web/**']
   workflow_dispatch:
@@ -86,11 +87,11 @@ jobs:
     # we trip rate limits, drop ``-n`` to 1 first; only fall back to
     # ``max-parallel`` reduction if QPS still hurts.
     name: E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
-    # Public-only: skip draft PRs and fork PRs (forks can't read the
-    # LLM_API_KEY / GATEWAY_BASE_URL secrets); see _E2E_GUARD_IF_BLOCK.
-    if: ${{ !github.event.pull_request.draft
-      && (github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Fork PRs gate behind the fork-e2e environment (maintainer approval) before
+    # any fork code/secret runs; same-repo and internal PRs get an empty
+    # environment, i.e. no gate. Draft PRs skip.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-e2e' || '' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
       # One red shard shouldn't cancel siblings; we want every shard's
@@ -116,7 +117,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
+          # Test the merge result: refs/pull/N/merge is the PR head merged into
+          # the base by GitHub. It is absent when the PR conflicts, so a
+          # conflicted PR fails checkout here by design (resolve conflicts
+          # first). Fork code still runs only after the env gate above. Non-PR
+          # events fall back to the dispatch branch / ref.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -89,7 +89,10 @@ jobs:
       ) ||
       (
         github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request'
+        (
+          github.event.workflow_run.event == 'pull_request' ||
+          github.event.workflow_run.event == 'pull_request_target'
+        )
       ) ||
       (
         github.event_name == 'issue_comment' &&
@@ -125,6 +128,13 @@ jobs:
           else
             PR=$(echo "$WF_PRS" | jq -r '.[0].number // empty')
             SHA="${{ github.event.workflow_run.head_sha }}"
+            if [[ -z "$PR" ]]; then
+              # Fork-PR upstream runs leave workflow_run.pull_requests empty
+              # (GitHub omits cross-repo PR refs), so resolve the open PR from
+              # the head SHA. SHA is a commit hash from the event (no injection).
+              PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+                --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true)
+            fi
             if [[ -z "$PR" ]]; then
               echo "::notice::Skipped: workflow_run has no associated PR (push to main, etc)"
               echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Run the e2e suite on fork (community) PRs with real coverage, gated by maintainer approval, and make the merge gate post correctly for fork PRs.

- **`e2e.yml` runs PRs via `pull_request_target`.** Fork PRs run in the base-repo context (secrets available) behind the **`fork-e2e` environment** (required reviewers = maintainers), so no fork code or secret runs until a maintainer approves the diff. Same-repo PRs get an empty `environment` (no gate) and run as before. Checkout uses the **PR merge result** (`refs/pull/N/merge`), so e2e exercises the post-merge state; a conflicting PR fails checkout by design, so conflicts get resolved first. Check names are unchanged.
- **`merge-ready.yml` posts the gate status for fork PRs.** Its `workflow_run` job (writable, base context) now accepts `pull_request_target` upstreams and resolves the PR from the head SHA when `github.event.workflow_run.pull_requests` is empty (GitHub omits it for fork upstreams), so a fork PR gets a "Merge Ready" status it previously never received.

## ELI5

Outside contributors send PRs from their own copy ("fork") of the repo. We want the end-to-end tests to run on their changes, but those tests need secret keys (to reach the model gateway). GitHub deliberately hides secrets from outsiders' PRs so a stranger can't steal them, which also meant e2e couldn't run on community PRs and the merge gate got stuck.

This lets e2e run on community PRs, but only after a maintainer clicks **Approve**, like a bouncer checking ID before letting someone into the room with the secrets. Until then, nothing from the PR runs and no secret is exposed. Team PRs skip the gate. We test the change **as it would look merged into `main`**; if it conflicts, the merged view can't be built, so it fails fast and the contributor rebases first.

## How it flows

```text
PR opened / synced
        │
        ▼
e2e.yml  (trigger: pull_request_target — base-repo context, secrets available)
        │
   draft PR? ──── yes ──▶ job skips
        │ no
        ▼
   head.repo.fork ?
        │
        ├───────────── YES (community / fork PR) ─────────────┐
        │                                       environment: fork-e2e
        │                                    ┌──────────────────────────────┐
        │                                    │  ⛔ JOB PAUSES                │
        │                                    │  maintainer must Approve      │
        │                                    │  (re-required on every push)  │
        │                                    └───────────────┬──────────────┘
        │                                  no code/secret has run yet         │
        │                                                    │ approved
        └───────── NO (team PR) ──────────────────────┐      │
                                  environment: ''      ▼      ▼
                                  ┌──────────────────────────────────────────┐
                                  │ checkout refs/pull/N/merge                │
                                  │   • absent on conflict → checkout FAILS   │
                                  │ read-only GITHUB_TOKEN                    │
                                  └─────────────────┬────────────────────────┘
                                                    ▼
                                    run e2e shards  →  "E2E Tests (shard N/4)"
                                                    ▼
            workflow_run("E2E Tests") ─────▶ merge-ready posts "Merge Ready"
                                                    ▼
                                   branch-protection gate  ✓ / ✗
```

For a fork PR the `fork-e2e` gate is a **job-level** pause, so the runner never checks out any code and no secret is in scope until a maintainer approves. The only untrusted code in the merge ref is the contributor's diff (layered onto trusted `main`). The e2e job's `GITHUB_TOKEN` is read-only.

## Security notes

Introducing `pull_request_target` means fork-PR runs can see repo secrets, so the safety rests on the `fork-e2e` **environment approval gate** (a maintainer must approve before any code/secret runs; GitHub re-requires approval on every new push) plus the read-only job token. The exposed values are scoped: `GATEWAY_BASE_URL` is not sensitive on its own (the gateway rejects unauthenticated calls; worst case is endpoint DDoS, rate-limited), and `LLM_API_KEY` is a least-privilege, revocable, rotatable gateway credential (a leak is bounded to gateway usage until revoked).

**Setup required before this helps fork PRs:** create the `fork-e2e` environment (Settings -> Environments) with required reviewers set to the maintainers. Same-repo PRs are unaffected (empty environment, no gate).

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

CI workflow change (YAML only). Verified via a `workflow_dispatch` run that the conditional `environment: ${{ ... || '' }}` expression resolves to no-gate for non-fork events: all four e2e shards reached `in_progress`, confirming GitHub accepts the empty-environment string. The maintainer-gated fork path validates on the next community fork PR once the `fork-e2e` environment is configured; same-repo PR behavior is unchanged.
