### PR TITLE
feat: Add Kubernetes deployment manifests

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,15 +1,19 @@
 # Omnigent on Kubernetes
 
 Deploy Omnigent to any Kubernetes cluster using Kustomize. The manifests pull
-the prebuilt image and wire up a persistent volume, health checks, and Ingress
-with TLS.
+the prebuilt image and wire up a persistent volume and health checks, plus an
+**optional** Ingress with TLS. The Ingress — and the ingress-nginx + cert-manager
+add-ons behind it — is only needed to expose the server on a public domain. For
+local or dev use, skip it entirely and reach the server with `kubectl
+port-forward` (see [Verify the deployment](#verify-the-deployment)).
 
 ## What gets provisioned
 
 - **Deployment** — single-replica pod running
   `ghcr.io/omnigent-ai/omnigent-server`, served on port 8000.
 - **Service** — ClusterIP on port 80 → 8000.
-- **Ingress** — HTTPS via cert-manager (nginx ingress class by default).
+- **Ingress** *(optional)* — HTTPS via cert-manager (nginx ingress class by
+  default); only for exposing the server on a public domain.
 - **PVC** — 10 Gi volume at `/data/artifacts` for the artifact store, minted
   cookie secret, and admin credentials.
 - **ConfigMap + Secret** — environment config and database credentials.
@@ -18,12 +22,15 @@ with TLS.
 
 - A Kubernetes cluster (1.25+)
 - `kubectl` with Kustomize support (`kubectl kustomize` or standalone `kustomize`)
-- An Ingress controller (e.g. ingress-nginx) and cert-manager for TLS
 - A PostgreSQL database (managed or in-cluster — see below)
+- *Optional (public Ingress/TLS path only):* an Ingress controller (e.g.
+  ingress-nginx) and cert-manager
 
-### Install the cluster add-ons
+### Install the cluster add-ons (optional)
 
-If your cluster doesn't already have an Ingress controller and cert-manager,
+Only needed for the public Ingress/TLS path — **skip this entirely** if you'll
+reach the server with `kubectl port-forward` or terminate TLS upstream. If you do
+want the Ingress and your cluster lacks an Ingress controller and cert-manager,
 install them (pin the versions to taste):
 
 ```bash
@@ -40,9 +47,10 @@ kubectl wait -n ingress-nginx --for=condition=Ready pod \
 kubectl wait -n cert-manager --for=condition=Available deployment --all --timeout=180s
 ```
 
-### Create a cert-manager issuer
+### Create a cert-manager issuer (optional)
 
-The Ingress requests its TLS cert from a `ClusterIssuer` named `letsencrypt-prod`
+Only needed if you're using the Ingress. The Ingress requests its TLS cert from a
+`ClusterIssuer` named `letsencrypt-prod`
 (the `cert-manager.io/cluster-issuer` annotation in `base/ingress.yaml`). That
 issuer is **not** shipped here — create one before deploying, or change the
 annotation to match an issuer you already have. Two common choices:
@@ -93,9 +101,10 @@ Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
    OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
    ```
 
-2. **Edit the Ingress** — replace `omnigent.example.com` in `base/ingress.yaml`
-   with your actual domain, and make sure the `letsencrypt-prod` ClusterIssuer
-   exists (see [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
+2. **Edit the Ingress** *(only if exposing via Ingress)* — replace
+   `omnigent.example.com` in `base/ingress.yaml` with your actual domain, and make
+   sure the `letsencrypt-prod` ClusterIssuer exists (see
+   [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
 
 3. **Apply:**
 
@@ -123,9 +132,9 @@ with its own 10 Gi PVC. Good for dev/testing clusters.
    OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
    ```
 
-2. **Edit the Ingress hostname** in `base/ingress.yaml`, and make sure the
-   `letsencrypt-prod` ClusterIssuer exists (see
-   [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
+2. **Edit the Ingress hostname** *(only if exposing via Ingress)* in
+   `base/ingress.yaml`, and make sure the `letsencrypt-prod` ClusterIssuer exists
+   (see [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
 
 3. **Apply:**
 
@@ -169,9 +178,11 @@ omnigent host  --server https://omnigent.example.com # register this machine
 The host then appears in the web UI when you start a new chat. See the
 [main README](../../README.md) for the full host/auth reference.
 
-## Use your own IdP instead (OIDC)
+## Use your own IdP instead (OIDC) — optional
 
-Add OIDC env vars to the secret:
+Optional. The default `accounts` provider (username + password) works out of the
+box; use this only to delegate authentication to an external OIDC provider. Add
+OIDC env vars to the secret:
 
 ```bash
 kubectl create secret generic omnigent-oidc -n omnigent \

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -21,6 +21,65 @@ with TLS.
 - An Ingress controller (e.g. ingress-nginx) and cert-manager for TLS
 - A PostgreSQL database (managed or in-cluster — see below)
 
+### Install the cluster add-ons
+
+If your cluster doesn't already have an Ingress controller and cert-manager,
+install them (pin the versions to taste):
+
+```bash
+# ingress-nginx — use the provider manifest that matches your cluster
+# (this is the kind one; for EKS/GKE/AKS use that provider's manifest or Helm chart):
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+# cert-manager:
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+
+# wait until both are ready:
+kubectl wait -n ingress-nginx --for=condition=Ready pod \
+  -l app.kubernetes.io/component=controller --timeout=180s
+kubectl wait -n cert-manager --for=condition=Available deployment --all --timeout=180s
+```
+
+### Create a cert-manager issuer
+
+The Ingress requests its TLS cert from a `ClusterIssuer` named `letsencrypt-prod`
+(the `cert-manager.io/cluster-issuer` annotation in `base/ingress.yaml`). That
+issuer is **not** shipped here — create one before deploying, or change the
+annotation to match an issuer you already have. Two common choices:
+
+```yaml
+# Production — real certificates from Let's Encrypt
+# (needs a public domain and an Ingress reachable from the internet):
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+```
+
+```yaml
+# Local / dev — self-signed (no public DNS needed; browsers will warn):
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  selfSigned: {}
+```
+
+Apply your chosen issuer with `kubectl apply -f <file>`. Without it, cert-manager
+logs `IssuerNotFound` and no certificate is issued (the server still runs — only
+TLS is affected).
+
 ## Deploy with an external database
 
 Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
@@ -35,11 +94,8 @@ Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
    ```
 
 2. **Edit the Ingress** — replace `omnigent.example.com` in `base/ingress.yaml`
-   with your actual domain. The Ingress requests a TLS cert from a cert-manager
-   ClusterIssuer named `letsencrypt-prod` (the `cert-manager.io/cluster-issuer`
-   annotation). That issuer is **not** shipped here — create it first, or change
-   the annotation to match an issuer you already have. Without it cert-manager
-   logs `IssuerNotFound` and no certificate is issued.
+   with your actual domain, and make sure the `letsencrypt-prod` ClusterIssuer
+   exists (see [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
 
 3. **Apply:**
 
@@ -67,7 +123,9 @@ with its own 10 Gi PVC. Good for dev/testing clusters.
    OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
    ```
 
-2. **Edit the Ingress hostname** in `base/ingress.yaml`.
+2. **Edit the Ingress hostname** in `base/ingress.yaml`, and make sure the
+   `letsencrypt-prod` ClusterIssuer exists (see
+   [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
 
 3. **Apply:**
 
@@ -92,6 +150,11 @@ kubectl port-forward -n omnigent svc/omnigent 8000:80
 The first boot runs database migrations before the server starts listening; the
 pod may restart once if the liveness probe fires during that window (see
 [Resource sizing](#resource-sizing)).
+
+To exercise the **Ingress** path locally instead of port-forwarding, set the
+Ingress host to a domain that already resolves to localhost — e.g.
+`omnigent.localtest.me` or `<node-ip>.sslip.io` — pair it with the `selfSigned`
+issuer above, and reach it through your Ingress controller's published port.
 
 ## Next steps: connect a host
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,10 +1,11 @@
 # Omnigent on Kubernetes
 
 Deploy Omnigent to any Kubernetes cluster using Kustomize. The manifests pull
-the prebuilt image and wire up a persistent volume and health checks, plus an
-**optional** Ingress with TLS. The Ingress — and the ingress-nginx + cert-manager
-add-ons behind it — is only needed to expose the server on a public domain. For
-local or dev use, skip it entirely and reach the server with `kubectl
+the prebuilt image and set up a persistent volume and health checks. They also
+include an Ingress so you can serve the app over HTTPS at a public web address,
+but that part is optional — it only matters when people need to reach the server
+over the internet, and it pulls in two extra add-ons (ingress-nginx and
+cert-manager). For local or dev use, ignore it and connect with `kubectl
 port-forward` (see [Verify the deployment](#verify-the-deployment)).
 
 ## What gets provisioned
@@ -12,8 +13,9 @@ port-forward` (see [Verify the deployment](#verify-the-deployment)).
 - **Deployment** — single-replica pod running
   `ghcr.io/omnigent-ai/omnigent-server`, served on port 8000.
 - **Service** — ClusterIP on port 80 → 8000.
-- **Ingress** *(optional)* — HTTPS via cert-manager (nginx ingress class by
-  default); only for exposing the server on a public domain.
+- **Ingress** *(optional)* — serves the app over HTTPS at a public web address,
+  using cert-manager for the certificate. Skip it if the server isn't going on
+  the internet.
 - **PVC** — 10 Gi volume at `/data/artifacts` for the artifact store, minted
   cookie secret, and admin credentials.
 - **ConfigMap + Secret** — environment config and database credentials.
@@ -23,15 +25,16 @@ port-forward` (see [Verify the deployment](#verify-the-deployment)).
 - A Kubernetes cluster (1.25+)
 - `kubectl` with Kustomize support (`kubectl kustomize` or standalone `kustomize`)
 - A PostgreSQL database (managed or in-cluster — see below)
-- *Optional (public Ingress/TLS path only):* an Ingress controller (e.g.
-  ingress-nginx) and cert-manager
+- *Only if you're putting the server on a public web address:* an ingress
+  controller (e.g. ingress-nginx) and cert-manager
 
 ### Install the cluster add-ons (optional)
 
-Only needed for the public Ingress/TLS path — **skip this entirely** if you'll
-reach the server with `kubectl port-forward` or terminate TLS upstream. If you do
-want the Ingress and your cluster lacks an Ingress controller and cert-manager,
-install them (pin the versions to taste):
+Skip this unless you're putting the server on a public web address. (For local
+or dev use you'll reach it with `kubectl port-forward`, or you can let your own
+load balancer or proxy handle HTTPS instead.) Otherwise, if your cluster doesn't
+already have an ingress controller and cert-manager, install them (pin the
+versions to taste):
 
 ```bash
 # ingress-nginx — use the provider manifest that matches your cluster
@@ -49,8 +52,8 @@ kubectl wait -n cert-manager --for=condition=Available deployment --all --timeou
 
 ### Create a cert-manager issuer (optional)
 
-Only needed if you're using the Ingress. The Ingress requests its TLS cert from a
-`ClusterIssuer` named `letsencrypt-prod`
+Skip this unless you're using the Ingress. cert-manager fetches the HTTPS
+certificate for the Ingress from a `ClusterIssuer` named `letsencrypt-prod`
 (the `cert-manager.io/cluster-issuer` annotation in `base/ingress.yaml`). That
 issuer is **not** shipped here — create one before deploying, or change the
 annotation to match an issuer you already have. Two common choices:
@@ -101,9 +104,9 @@ Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
    OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
    ```
 
-2. **Edit the Ingress** *(only if exposing via Ingress)* — replace
-   `omnigent.example.com` in `base/ingress.yaml` with your actual domain, and make
-   sure the `letsencrypt-prod` ClusterIssuer exists (see
+2. **Set your domain** *(skip if you're not using the Ingress)* — replace
+   `omnigent.example.com` in `base/ingress.yaml` with your domain, and make sure
+   the `letsencrypt-prod` ClusterIssuer exists (see
    [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
 
 3. **Apply:**
@@ -132,9 +135,10 @@ with its own 10 Gi PVC. Good for dev/testing clusters.
    OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
    ```
 
-2. **Edit the Ingress hostname** *(only if exposing via Ingress)* in
-   `base/ingress.yaml`, and make sure the `letsencrypt-prod` ClusterIssuer exists
-   (see [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
+2. **Set your domain** *(skip if you're not using the Ingress)* — edit the
+   hostname in `base/ingress.yaml`, and make sure the `letsencrypt-prod`
+   ClusterIssuer exists (see
+   [Create a cert-manager issuer](#create-a-cert-manager-issuer)).
 
 3. **Apply:**
 
@@ -160,10 +164,10 @@ The first boot runs database migrations before the server starts listening; the
 pod may restart once if the liveness probe fires during that window (see
 [Resource sizing](#resource-sizing)).
 
-To exercise the **Ingress** path locally instead of port-forwarding, set the
-Ingress host to a domain that already resolves to localhost — e.g.
-`omnigent.localtest.me` or `<node-ip>.sslip.io` — pair it with the `selfSigned`
-issuer above, and reach it through your Ingress controller's published port.
+To test the Ingress itself instead of port-forwarding, point its hostname at a
+domain that already resolves to localhost — `omnigent.localtest.me` or
+`<node-ip>.sslip.io` — use the self-signed issuer above, and reach it through the
+ingress controller's published port.
 
 ## Next steps: connect a host
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -28,7 +28,7 @@ port-forward` (see [Verify the deployment](#verify-the-deployment)).
 - *Only if you're putting the server on a public web address:* an ingress
   controller (e.g. ingress-nginx) and cert-manager
 
-### Install the cluster add-ons (optional)
+### Install cluster add-ons for ingress and cert management (optional)
 
 Skip this unless you're putting the server on a public web address. (For local
 or dev use you'll reach it with `kubectl port-forward`, or you can let your own

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,104 @@
+# Omnigent on Kubernetes
+
+Deploy Omnigent to any Kubernetes cluster using Kustomize. The manifests pull
+the prebuilt image and wire up a persistent volume, health checks, and Ingress
+with TLS.
+
+## What gets provisioned
+
+- **Deployment** — single-replica pod running
+  `ghcr.io/omnigent-ai/omnigent-server`, served on port 8000.
+- **Service** — ClusterIP on port 80 → 8000.
+- **Ingress** — HTTPS via cert-manager (nginx ingress class by default).
+- **PVC** — 10 Gi volume at `/data/artifacts` for the artifact store, minted
+  cookie secret, and admin credentials.
+- **ConfigMap + Secret** — environment config and database credentials.
+
+## Prerequisites
+
+- A Kubernetes cluster (1.25+)
+- `kubectl` with Kustomize support (`kubectl kustomize` or standalone `kustomize`)
+- An Ingress controller (e.g. ingress-nginx) and cert-manager for TLS
+- A PostgreSQL database (managed or in-cluster — see below)
+
+## Deploy with an external database
+
+Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
+
+1. **Edit the secret** — set your real `DATABASE_URL` and generate a cookie
+   secret:
+
+   ```bash
+   # deploy/kubernetes/base/secret.yaml
+   DATABASE_URL: "postgresql+psycopg://user:pass@your-db-host:5432/omnigent"
+   OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
+   ```
+
+2. **Edit the Ingress hostname** — replace `omnigent.example.com` in
+   `base/ingress.yaml` with your actual domain.
+
+3. **Apply:**
+
+   ```bash
+   kubectl kustomize deploy/kubernetes/base/ | kubectl apply -f -
+   ```
+
+4. **Admin password** prints once in the first-boot logs:
+
+   ```bash
+   kubectl logs -n omnigent deploy/omnigent | grep "password:"
+   ```
+
+   Also written to `/data/admin-credentials` on the volume.
+
+## Deploy with in-cluster Postgres
+
+The `overlays/postgres/` overlay adds a single-replica Postgres 16 StatefulSet
+with its own 10 Gi PVC. Good for dev/testing clusters.
+
+1. **Edit secrets** — in `overlays/postgres/secret-patch.yaml`, replace
+   `changeme` with real passwords:
+
+   ```bash
+   POSTGRES_PASSWORD: "<strong-password>"
+   DATABASE_URL: "postgresql+psycopg://omnigent:<strong-password>@postgres:5432/omnigent"
+   OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
+   ```
+
+2. **Edit the Ingress hostname** in `base/ingress.yaml`.
+
+3. **Apply:**
+
+   ```bash
+   kubectl kustomize deploy/kubernetes/overlays/postgres/ | kubectl apply -f -
+   ```
+
+## Use your own IdP instead (OIDC)
+
+Add OIDC env vars to the secret:
+
+```bash
+kubectl create secret generic omnigent-oidc -n omnigent \
+  --from-literal=OMNIGENT_AUTH_PROVIDER=oidc \
+  --from-literal=OMNIGENT_OIDC_ISSUER=https://github.com \
+  --from-literal=OMNIGENT_OIDC_CLIENT_ID=<client-id> \
+  --from-literal=OMNIGENT_OIDC_CLIENT_SECRET=<client-secret> \
+  --from-literal=OMNIGENT_OIDC_REDIRECT_URI=https://omnigent.example.com/auth/callback \
+  --from-literal=OMNIGENT_OIDC_COOKIE_SECRET=$(openssl rand -hex 32)
+```
+
+Then add `envFrom: [{secretRef: {name: omnigent-oidc}}]` to the Deployment
+container spec (or merge the values into `omnigent-secrets`).
+
+## Resource sizing
+
+The server idles around ~275 MB RSS. The manifests request 512 Mi and limit at
+1 Gi — adjust to taste. The first boot against a remote Postgres runs
+migrations and takes ~1 minute; bump the liveness `initialDelaySeconds` to
+~90s if you see the pod get killed during the first deploy.
+
+## Scaling
+
+The server uses an in-memory runner registry, so **only one replica is
+supported**. Do not increase `replicas` unless the architecture is changed to
+use a shared registry (e.g. Redis).

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -34,8 +34,12 @@ Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
    OMNIGENT_ACCOUNTS_COOKIE_SECRET: "$(openssl rand -hex 32)"
    ```
 
-2. **Edit the Ingress hostname** — replace `omnigent.example.com` in
-   `base/ingress.yaml` with your actual domain.
+2. **Edit the Ingress** — replace `omnigent.example.com` in `base/ingress.yaml`
+   with your actual domain. The Ingress requests a TLS cert from a cert-manager
+   ClusterIssuer named `letsencrypt-prod` (the `cert-manager.io/cluster-issuer`
+   annotation). That issuer is **not** shipped here — create it first, or change
+   the annotation to match an issuer you already have. Without it cert-manager
+   logs `IssuerNotFound` and no certificate is issued.
 
 3. **Apply:**
 
@@ -43,13 +47,11 @@ Use this path when you have a managed Postgres (RDS, Cloud SQL, Neon, etc.).
    kubectl kustomize deploy/kubernetes/base/ | kubectl apply -f -
    ```
 
-4. **Admin password** prints once in the first-boot logs:
-
-   ```bash
-   kubectl logs -n omnigent deploy/omnigent | grep "password:"
-   ```
-
-   Also written to `/data/admin-credentials` on the volume.
+4. **Create the first admin.** Open the app (via your Ingress host, or
+   port-forward for a quick check — see
+   [Verify the deployment](#verify-the-deployment)). With the default `accounts`
+   provider the first visitor claims the instance: the Setup screen prompts for
+   a username + password, and whoever finishes it first becomes the admin.
 
 ## Deploy with in-cluster Postgres
 
@@ -72,6 +74,37 @@ with its own 10 Gi PVC. Good for dev/testing clusters.
    ```bash
    kubectl kustomize deploy/kubernetes/overlays/postgres/ | kubectl apply -f -
    ```
+
+## Verify the deployment
+
+Check the rollout and reach the server without a public domain:
+
+```bash
+kubectl get pods -n omnigent          # omnigent (and, with the overlay, postgres) → Running
+kubectl rollout status deploy/omnigent -n omnigent
+kubectl logs -n omnigent deploy/omnigent          # server logs
+
+# Port-forward the Service and open the app locally:
+kubectl port-forward -n omnigent svc/omnigent 8000:80
+# → http://localhost:8000   (health check: curl localhost:8000/health → {"status":"ok"})
+```
+
+The first boot runs database migrations before the server starts listening; the
+pod may restart once if the liveness probe fires during that window (see
+[Resource sizing](#resource-sizing)).
+
+## Next steps: connect a host
+
+The server is the control plane — agents run on **hosts** that register with it.
+A brand-new deployment has none, so connect at least one machine:
+
+```bash
+omnigent login https://omnigent.example.com          # authenticate the CLI
+omnigent host  --server https://omnigent.example.com # register this machine
+```
+
+The host then appears in the web UI when you start a new chat. See the
+[main README](../../README.md) for the full host/auth reference.
 
 ## Use your own IdP instead (OIDC)
 

--- a/deploy/kubernetes/base/configmap.yaml
+++ b/deploy/kubernetes/base/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: omnigent-config
+  labels:
+    app: omnigent
+data:
+  HOST: "0.0.0.0"
+  PORT: "8000"
+  ARTIFACT_DIR: "/data/artifacts"
+  OMNIGENT_ADMIN_CREDENTIALS_PATH: "/data/admin-credentials"
+  OMNIGENT_AUTH_ENABLED: "1"
+  OMNIGENT_AUTH_PROVIDER: "accounts"
+  OMNIGENT_ACCOUNTS_AUTO_OPEN: "0"

--- a/deploy/kubernetes/base/deployment.yaml
+++ b/deploy/kubernetes/base/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omnigent
+  labels:
+    app: omnigent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: omnigent
+  template:
+    metadata:
+      labels:
+        app: omnigent
+    spec:
+      containers:
+        - name: omnigent
+          image: ghcr.io/omnigent-ai/omnigent-server:latest
+          ports:
+            - containerPort: 8000
+              name: http
+          envFrom:
+            - configMapRef:
+                name: omnigent-config
+            - secretRef:
+                name: omnigent-secrets
+          volumeMounts:
+            - name: artifacts
+              mountPath: /data/artifacts
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: artifacts
+          persistentVolumeClaim:
+            claimName: omnigent-artifacts

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: omnigent
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - omnigent.example.com
+      secretName: omnigent-tls
+  rules:
+    - host: omnigent.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: omnigent
+                port:
+                  name: http

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: omnigent
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/deploy/kubernetes/base/namespace.yaml
+++ b/deploy/kubernetes/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: omnigent

--- a/deploy/kubernetes/base/pvc.yaml
+++ b/deploy/kubernetes/base/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: omnigent-artifacts
+  labels:
+    app: omnigent
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/kubernetes/base/secret.yaml
+++ b/deploy/kubernetes/base/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnigent-secrets
+  labels:
+    app: omnigent
+type: Opaque
+stringData:
+  # Replace with your actual database connection string.
+  DATABASE_URL: "postgresql+psycopg://omnigent:changeme@your-db-host:5432/omnigent"
+  # Generate with: openssl rand -hex 32
+  OMNIGENT_ACCOUNTS_COOKIE_SECRET: "changeme"

--- a/deploy/kubernetes/base/service.yaml
+++ b/deploy/kubernetes/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: omnigent
+  labels:
+    app: omnigent
+spec:
+  type: ClusterIP
+  selector:
+    app: omnigent
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/deploy/kubernetes/overlays/postgres/kustomization.yaml
+++ b/deploy/kubernetes/overlays/postgres/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: omnigent
+
 resources:
   - ../../base
   - statefulset.yaml

--- a/deploy/kubernetes/overlays/postgres/kustomization.yaml
+++ b/deploy/kubernetes/overlays/postgres/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - statefulset.yaml
+  - service.yaml
+
+patches:
+  - path: secret-patch.yaml

--- a/deploy/kubernetes/overlays/postgres/secret-patch.yaml
+++ b/deploy/kubernetes/overlays/postgres/secret-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnigent-secrets
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql+psycopg://omnigent:changeme@postgres:5432/omnigent"
+  POSTGRES_PASSWORD: "changeme"
+  OMNIGENT_ACCOUNTS_COOKIE_SECRET: "changeme"

--- a/deploy/kubernetes/overlays/postgres/service.yaml
+++ b/deploy/kubernetes/overlays/postgres/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: omnigent
+    component: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: omnigent
+    component: postgres
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres

--- a/deploy/kubernetes/overlays/postgres/service.yaml
+++ b/deploy/kubernetes/overlays/postgres/service.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: postgres
   labels:
-    app: omnigent
+    app: omnigent-postgres
     component: postgres
 spec:
   type: ClusterIP
   selector:
-    app: omnigent
+    app: omnigent-postgres
     component: postgres
   ports:
     - port: 5432

--- a/deploy/kubernetes/overlays/postgres/statefulset.yaml
+++ b/deploy/kubernetes/overlays/postgres/statefulset.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: omnigent
+    component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: omnigent
+      component: postgres
+  template:
+    metadata:
+      labels:
+        app: omnigent
+        component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: omnigent
+            - name: POSTGRES_USER
+              value: omnigent
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: omnigent-secrets
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "omnigent"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "omnigent"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/kubernetes/overlays/postgres/statefulset.yaml
+++ b/deploy/kubernetes/overlays/postgres/statefulset.yaml
@@ -3,19 +3,19 @@ kind: StatefulSet
 metadata:
   name: postgres
   labels:
-    app: omnigent
+    app: omnigent-postgres
     component: postgres
 spec:
   serviceName: postgres
   replicas: 1
   selector:
     matchLabels:
-      app: omnigent
+      app: omnigent-postgres
       component: postgres
   template:
     metadata:
       labels:
-        app: omnigent
+        app: omnigent-postgres
         component: postgres
     spec:
       containers:


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

  - Add Kubernetes deployment option under `deploy/kubernetes/` using Kustomize
  (base + overlay, no Helm dependency)
  - Base manifests deploy the server with an external managed database;
  `overlays/postgres/` adds an in-cluster Postgres 16 StatefulSet
  - Includes Deployment, Service, Ingress (cert-manager TLS), PVC, ConfigMap,
  Secret, and health probes matching existing deploy patterns


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->

  Both kustomizations validated with `kubectl kustomize`:
  - `kubectl kustomize deploy/kubernetes/base/` renders 7 resources (Namespace,
  ConfigMap, Secret, Service, PVC, Deployment, Ingress)
  - `kubectl kustomize deploy/kubernetes/overlays/postgres/` renders 9 resources
  (adds StatefulSet + Postgres Service, patches Secret with in-cluster
  DATABASE_URL)

  No runtime tests since these are declarative manifests consumed by `kubectl
  apply`. Correctness depends on cluster-side validation at apply time.
