### PR TITLE
desktop: auto-expand Databricks workspace URLs and hide workspace chrome

### DIFF
--- a/ap-web/.oxlintrc.json
+++ b/ap-web/.oxlintrc.json
@@ -53,6 +53,12 @@
         "no-restricted-globals": "off",
         "no-restricted-imports": "off"
       }
+    },
+    {
+      "files": ["electron/**"],
+      "rules": {
+        "no-restricted-globals": "off"
+      }
     }
   ],
   "ignorePatterns": [

--- a/ap-web/electron/src/main.js
+++ b/ap-web/electron/src/main.js
@@ -622,6 +622,99 @@ function normalizeUrl(raw) {
   return url.toString();
 }
 
+/**
+ * Path under a Databricks workspace where the Omnigent web UI is mounted. A
+ * bare workspace URL serves the workspace's own web app at the root, so a user
+ * who pastes just the workspace host (e.g.
+ * ``https://<ws>.azuredatabricks.net``) lands on a 404 unless this suffix is
+ * appended.
+ *
+ * NOTE: the Python CLI records the same UI mount as ``/ml/omnigent``
+ * (singular) in ``omnigent/conversation_browser.py`` (WORKSPACE_UI_PATH); the
+ * plural here is the path that actually resolves on the live workspace. The
+ * two should be reconciled — see also that file's WORKSPACE_API_PATH.
+ */
+const WORKSPACE_UI_PATH = "/ml/omnigents";
+
+/**
+ * CSS that hides the Databricks workspace navigation chrome around a
+ * workspace-hosted Omnigent SPA.
+ *
+ * On a workspace the SPA is mounted as a workspace *page*, so Databricks wraps
+ * it in its top-nav shell (the dark bar with the workspace switcher). In a
+ * dedicated desktop window that chrome is just noise. We promote Omnigent's
+ * own root — ``.omnigent-app``, the wrapper ap-web's embed entry sets
+ * (``ap-web/src/embed.tsx``) — to a full-viewport overlay so it paints over
+ * the workspace bar. Keying on Omnigent's wrapper (defined in THIS repo)
+ * rather than the monolith-owned, unstable workspace nav markup keeps this
+ * from silently breaking when Databricks reshuffles its chrome; on a
+ * standalone (non-embed) build there is no ``.omnigent-app``, so the rule is
+ * a harmless no-op.
+ */
+const WORKSPACE_CHROME_HIDE_CSS = `
+  .omnigent-app {
+    position: fixed !important;
+    inset: 0 !important;
+    z-index: 2147483647 !important;
+  }
+`;
+
+/**
+ * Probe timeout for Databricks workspace detection. Deliberately short: a slow
+ * or unreachable host must not stall the connect flow — on timeout we fall
+ * back to loading the URL exactly as entered.
+ */
+const WORKSPACE_PROBE_TIMEOUT_MS = 8000;
+
+/**
+ * Expand a bare Databricks workspace URL to its Omnigent web-UI mount.
+ *
+ * Mirrors the omni CLI's behavioral detection
+ * (``omnigent/cli.py:_workspace_api_server_url``): rather than match
+ * hostnames, probe the URL and adopt the mount only when the host answers
+ * like a Databricks workspace — a response carrying the ``server: databricks``
+ * header. URLs that already carry a path, or aren't https, are returned
+ * untouched WITHOUT a probe, so a user who pastes the full ``…/ml/omnigents``
+ * URL (or connects to any non-workspace server) is never second-guessed.
+ *
+ * The CLI appends the API mount because it's an API client; the desktop shell
+ * loads the web UI, so it appends the SPA mount instead.
+ *
+ * @param {string} normalized A normalized http(s) URL from {@link normalizeUrl}.
+ * @returns {Promise<string>} The workspace UI URL when expansion applies, else
+ *   the input unchanged.
+ */
+async function expandDatabricksWorkspaceUrl(normalized) {
+  let url;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return normalized;
+  }
+  // Only bare https roots are candidates: a non-root path means the user
+  // already pointed at a specific mount, and Databricks workspaces are
+  // https-only.
+  if (url.protocol !== "https:" || (url.pathname !== "/" && url.pathname !== "")) {
+    return normalized;
+  }
+  let probe;
+  try {
+    probe = await fetch(`${url.origin}/`, {
+      method: "HEAD",
+      redirect: "manual",
+      signal: AbortSignal.timeout(WORKSPACE_PROBE_TIMEOUT_MS),
+    });
+  } catch {
+    // Unreachable / DNS / TLS / timeout: connect to the URL as given and let
+    // the did-fail-load fallback surface any real failure.
+    return normalized;
+  }
+  if ((probe.headers.get("server") ?? "").toLowerCase() !== "databricks") {
+    return normalized;
+  }
+  return `${url.origin}${WORKSPACE_UI_PATH}`;
+}
+
 // ---------------------------------------------------------------------------
 // Window + navigation
 // ---------------------------------------------------------------------------
@@ -857,6 +950,24 @@ function createWindow(targetUrl, opts = {}) {
       void win.loadFile(SETUP_PAGE, { search: params.toString() });
     },
   );
+
+  // Databricks workspace-hosted Omnigent renders inside the workspace's
+  // top-nav chrome (the SPA is a workspace page). On a dedicated desktop
+  // window, hide it by overlaying Omnigent's own root — see
+  // WORKSPACE_CHROME_HIDE_CSS. Re-applied on every full load (a server switch
+  // is a fresh document); the SPA's own client-side routing keeps the same
+  // document, so the injected stylesheet persists across in-app navigation.
+  win.webContents.on("did-finish-load", () => {
+    let pathname = "";
+    try {
+      pathname = new URL(win.webContents.getURL()).pathname;
+    } catch {
+      return;
+    }
+    if (pathname.startsWith(WORKSPACE_UI_PATH)) {
+      void win.webContents.insertCSS(WORKSPACE_CHROME_HIDE_CSS);
+    }
+  });
 
   win.on("closed", () => {
     windows.delete(win);
@@ -1360,12 +1471,15 @@ function registerIpc() {
   // Setup page → persist URL and navigate the SENDING window to it. We target
   // the window that owns the setup page (via its webContents) rather than a
   // global, so connecting from one window doesn't hijack another.
-  ipcMain.handle("omnigent:set-server-url", (event, url) => {
+  ipcMain.handle("omnigent:set-server-url", async (event, url) => {
     if (!isSetupPageSender(event)) {
       // A server page must never be able to re-point which server is saved.
       throw new Error("set-server-url is only available to the setup page");
     }
     const normalized = normalizeUrl(url); // throws → rejects → setup page shows error
+    // Bare Databricks workspace URLs serve a 404 at the root; expand them to
+    // the Omnigent UI mount so the user can paste just the workspace host.
+    const target = await expandDatabricksWorkspaceUrl(normalized);
     const win = BrowserWindow.fromWebContents(event.sender) ?? activeWindow();
     // Multi-server windows connect without touching the saved server —
     // the connection lives and dies with the window.
@@ -1374,22 +1488,22 @@ function registerIpc() {
       const settings = loadSettings();
       // The saved default persists immediately even if this load fails:
       // the failure fallback keeps it pre-filled so Connect retries it.
-      settings.server_url = normalized;
+      settings.server_url = target;
       saveSettings(settings);
     }
     if (win) {
       // The user explicitly chose this server — it becomes the window's
       // trusted origin for privileged IPC and permission grants.
-      pinWindow(win, new URL(normalized).origin);
+      pinWindow(win, new URL(target).origin);
       win
-        .loadURL(normalized)
+        .loadURL(target)
         .then(() => {
           // Only a server that actually responded earns a recents slot —
           // a typo'd or unreachable URL must not show up in the
           // quick-pick list on the setup page.
           if (ephemeral) return;
           const settings = loadSettings();
-          rememberRecentServer(settings, normalized);
+          rememberRecentServer(settings, target);
           saveSettings(settings);
         })
         .catch(() => {


### PR DESCRIPTION
## Summary

Two desktop-shell (Electron) improvements for Databricks-hosted Omnigent:

- **Auto-append the workspace UI mount.** Connecting to a bare workspace URL (e.g. `https://<ws>.azuredatabricks.net`) now probes the host and, when it answers like a Databricks workspace (a `server: databricks` response header), appends the Omnigent UI mount (`/ml/omnigents`) — so users no longer hand-type the suffix. Detection is **behavioral** (no hostname patterns), mirroring the omni CLI's `_workspace_api_server_url`. URLs that already carry a path, or aren't `https`, are passed through untouched (no probe), and any probe failure falls back to loading the URL exactly as entered.
- **Hide the workspace top-nav chrome.** A workspace mounts the Omnigent SPA as a workspace *page*, wrapping it in the Databricks top bar. On a dedicated desktop window that's noise, so we inject CSS that promotes Omnigent's own `.omnigent-app` root (set by `ap-web/src/embed.tsx`) to a full-viewport overlay. Keying on Omnigent's own wrapper — not the monolith-owned, unstable workspace nav markup — keeps it from silently breaking; on a standalone build there is no `.omnigent-app`, so the rule is a no-op.

Also adds a scoped `electron/**` override in `.oxlintrc.json` for the `no-restricted-globals` (bare `fetch`) rule: that rule routes SPA requests through the embed host transport, which doesn't exist in the Node main process.

> **Note:** the live workspace serves the UI at `/ml/omnigents` (plural), but the Python CLI uses `/ml/omnigent` (singular) in `omnigent/conversation_browser.py`. Flagged with a `NOTE` in the new constant — likely a separate CLI bug to reconcile.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

The Electron shell has no test harness in this repo. The URL-expansion logic was verified end-to-end against the actual staging workspace edge by running a standalone replica of `expandDatabricksWorkspaceUrl`:

- `https://adb-…azuredatabricks.net/` → expands to `…/ml/omnigents` (root returns `server: databricks`)
- `…/ml/omnigents` (already pathed) → unchanged
- `http://localhost:6767/` → unchanged (no probe)
- `https://example.com/` → unchanged (not a workspace)

The chrome-hiding CSS injection requires a logged-in workspace session to verify visually and is being confirmed in a local `npm start` run.
