### PR TITLE
feat: Add OpenShift deployment overlay

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -146,6 +146,33 @@ with its own 10 Gi PVC. Good for dev/testing clusters.
    kubectl kustomize deploy/kubernetes/overlays/postgres/ | kubectl apply -f -
    ```
 
+## Deploy on Red Hat OpenShift
+
+The `overlays/openshift/` overlay replaces the Ingress with an OpenShift Route
+(edge TLS, managed by the platform) and adds a `restricted-v2`-compatible
+SecurityContext. No ingress controller or cert-manager add-ons needed.
+
+1. **Edit the secret** in `base/secret.yaml` (same as the external-database
+   path above).
+
+2. **Set your route hostname** — replace `omnigent.apps.example.com` in
+   `overlays/openshift/route.yaml` with your cluster's apps domain.
+
+3. **Apply:**
+
+   ```bash
+   kubectl kustomize deploy/kubernetes/overlays/openshift/ | oc apply -f -
+   ```
+
+For in-cluster Postgres on OpenShift, use `overlays/openshift-postgres/`
+instead — it combines the Postgres StatefulSet, OpenShift Route, and restricted
+security contexts:
+
+```bash
+# edit overlays/openshift-postgres/secret-patch.yaml with real passwords first
+kubectl kustomize deploy/kubernetes/overlays/openshift-postgres/ | oc apply -f -
+```
+
 ## Verify the deployment
 
 Check the rollout and reach the server without a public domain:

--- a/deploy/kubernetes/overlays/openshift-postgres/deployment-patch.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/deployment-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omnigent
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: omnigent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/deploy/kubernetes/overlays/openshift-postgres/kustomization.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: omnigent
+
+resources:
+  - ../../base
+  - statefulset.yaml
+  - service.yaml
+  - route.yaml
+
+patches:
+  - path: deployment-patch.yaml
+  - path: secret-patch.yaml
+  - path: postgres-deployment-patch.yaml
+  - target:
+      kind: Ingress
+      name: omnigent
+    patch: |
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: omnigent

--- a/deploy/kubernetes/overlays/openshift-postgres/postgres-deployment-patch.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/postgres-deployment-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: postgres
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/deploy/kubernetes/overlays/openshift-postgres/route.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: omnigent
+  labels:
+    app: omnigent
+spec:
+  host: omnigent.apps.example.com
+  to:
+    kind: Service
+    name: omnigent
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/deploy/kubernetes/overlays/openshift-postgres/secret-patch.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/secret-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnigent-secrets
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql+psycopg://omnigent:changeme@postgres:5432/omnigent"
+  POSTGRES_PASSWORD: "changeme"
+  OMNIGENT_ACCOUNTS_COOKIE_SECRET: "changeme"

--- a/deploy/kubernetes/overlays/openshift-postgres/service.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: omnigent-postgres
+    component: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: omnigent-postgres
+    component: postgres
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres

--- a/deploy/kubernetes/overlays/openshift-postgres/statefulset.yaml
+++ b/deploy/kubernetes/overlays/openshift-postgres/statefulset.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: omnigent-postgres
+    component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: omnigent-postgres
+      component: postgres
+  template:
+    metadata:
+      labels:
+        app: omnigent-postgres
+        component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: omnigent
+            - name: POSTGRES_USER
+              value: omnigent
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: omnigent-secrets
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "omnigent"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "omnigent"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/kubernetes/overlays/openshift/deployment-patch.yaml
+++ b/deploy/kubernetes/overlays/openshift/deployment-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omnigent
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: omnigent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/deploy/kubernetes/overlays/openshift/kustomization.yaml
+++ b/deploy/kubernetes/overlays/openshift/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: omnigent
+
+resources:
+  - ../../base
+  - route.yaml
+
+patches:
+  - path: deployment-patch.yaml
+  - target:
+      kind: Ingress
+      name: omnigent
+    patch: |
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: omnigent

--- a/deploy/kubernetes/overlays/openshift/route.yaml
+++ b/deploy/kubernetes/overlays/openshift/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: omnigent
+  labels:
+    app: omnigent
+spec:
+  host: omnigent.apps.example.com
+  to:
+    kind: Service
+    name: omnigent
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Add OpenShift deployment overlays under  `deploy/kubernetes/overlays/openshift/` and  `deploy/kubernetes/overlays/openshift-postgres/`
- Replaces Ingress with an OpenShift Route (edge TLS, no cert-manager needed)  and adds `restricted-v2`-compatible SecurityContext (runAsNonRoot, drop ALL  capabilities, RuntimeDefault seccomp)
- Combined `openshift-postgres` overlay bundles both OpenShift adaptations and  in-cluster Postgres StatefulSet


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->

  Declarative manifests — runtime correctness validated at `oc apply` time on a live cluster.

