### PR TITLE
fix(pi): fall back to OMNIGENT_RUNNER_WORKSPACE when HARNESS_PI_CWD is unset

### DIFF
--- a/omnigent/inner/pi_harness.py
+++ b/omnigent/inner/pi_harness.py
@@ -34,8 +34,10 @@ Env vars read at startup:
   URLs keyed by model family, e.g.
   ``{"claude": "https://example.databricks.com/ai-gateway/anthropic"}``.
 - ``HARNESS_PI_CWD``: working directory the executor launches
-  the Pi CLI in. ``None`` falls back to the subprocess's
-  inherited cwd.
+  the Pi CLI in. When unset, falls back to
+  ``OMNIGENT_RUNNER_WORKSPACE`` — the session workspace the
+  native harnesses already honor — and finally to the
+  subprocess's inherited cwd.
 - ``HARNESS_PI_PATH``: absolute path to a ``pi`` CLI binary.
   ``None`` searches ``PATH``.
 - ``HARNESS_PI_OS_ENV``: JSON-encoded :class:`OSEnvSpec`
@@ -74,6 +76,7 @@ from fastapi import FastAPI
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import Executor
 from omnigent.inner.pi_executor import PiExecutor
+from omnigent.runner.identity import RUNNER_WORKSPACE_ENV_VAR
 from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
 
 _logger = logging.getLogger(__name__)
@@ -212,7 +215,7 @@ def _build_pi_executor() -> Executor:
     agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
     agent_name = agent_name_raw or None
     return PiExecutor(
-        cwd=os.environ.get(_ENV_CWD),
+        cwd=os.environ.get(_ENV_CWD) or os.environ.get(RUNNER_WORKSPACE_ENV_VAR),
         os_env=_resolve_os_env(),
         model=os.environ.get(_ENV_MODEL),
         pi_path=os.environ.get(_ENV_PI_PATH),

--- a/tests/inner/test_pi_harness.py
+++ b/tests/inner/test_pi_harness.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 
 from omnigent.inner import pi_harness
+from omnigent.runner.identity import RUNNER_WORKSPACE_ENV_VAR
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 
 
@@ -139,6 +140,47 @@ def test_executor_factory_reads_env_vars(
     assert os_env_value.type == "caller_process"
     assert os_env_value.sandbox is not None
     assert os_env_value.sandbox.type == "none"
+
+
+def test_executor_factory_falls_back_to_runner_workspace_when_cwd_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing ``HARNESS_PI_CWD`` falls back to the runner workspace.
+
+    The Pi harness does not always receive an explicit cwd env var from the
+    runner. In that case it should honor the same session workspace contract
+    as the native harnesses via ``OMNIGENT_RUNNER_WORKSPACE``.
+    """
+    monkeypatch.delenv("HARNESS_PI_CWD", raising=False)
+    monkeypatch.setenv(RUNNER_WORKSPACE_ENV_VAR, "/tmp/runner-workspace")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["cwd"] = kwargs["cwd"]
+
+    with patch("omnigent.inner.pi_harness.PiExecutor.__init__", _fake_init):
+        pi_harness._build_pi_executor()
+
+    assert captured["cwd"] == "/tmp/runner-workspace"
+
+
+def test_executor_factory_prefers_explicit_cwd_over_runner_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit ``HARNESS_PI_CWD`` still wins over the runner workspace."""
+    monkeypatch.setenv("HARNESS_PI_CWD", "/tmp/explicit-cwd")
+    monkeypatch.setenv(RUNNER_WORKSPACE_ENV_VAR, "/tmp/runner-workspace")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["cwd"] = kwargs["cwd"]
+
+    with patch("omnigent.inner.pi_harness.PiExecutor.__init__", _fake_init):
+        pi_harness._build_pi_executor()
+
+    assert captured["cwd"] == "/tmp/explicit-cwd"
 
 
 def test_executor_factory_decodes_os_env_json(


### PR DESCRIPTION
## Summary

The Pi harness ignores the session workspace because the runner does not set `HARNESS_PI_CWD`. When this variable is missing, the Pi executor falls back to the subprocess's inherited cwd — which is the server's launch directory, not the session workspace. The native harnesses (`codex-native`, `claude-native`) already honor the session workspace via `OMNIGENT_RUNNER_WORKSPACE`.

## Fix

Add a secondary fallback: when `HARNESS_PI_CWD` is unset, read `OMNIGENT_RUNNER_WORKSPACE` — the same variable the native harnesses use. `HARNESS_PI_CWD` still takes precedence when explicitly set, keeping the existing override path intact.

## Validation

- Python syntax check passed on the modified file
- `git diff --check` clean (no whitespace errors)
- The change uses Python short-circuit `or`: `HARNESS_PI_CWD` wins when set; fallback only fires when it is `None` or empty
- The runner already exports `OMNIGENT_RUNNER_WORKSPACE` for native harnesses — no new variable contract needed

## Change

- `omnigent/inner/pi_harness.py`: import `RUNNER_WORKSPACE_ENV_VAR` from `omnigent.runner.identity` and use it as a fallback for the `cwd` parameter.

Fixes: #60
