### PR TITLE
feat(harness): add cursor agent cli support

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -1,0 +1,340 @@
+"""Executor for Cursor Agent CLI headless mode."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+
+from ._subprocess_lifecycle import close_subprocess_transport
+from .datamodel import OSEnvSandboxSpec, OSEnvSpec
+from .executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    TextChunk,
+    ToolSpec,
+    TurnComplete,
+)
+
+logger = logging.getLogger(__name__)
+
+_STREAM_READ_CHUNK_SIZE = 4096
+
+
+async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> asyncio.subprocess.Process:
+    return await asyncio.create_subprocess_exec(*args, **kwargs)
+
+
+def _find_cursor_cli() -> str | None:
+    return shutil.which("cursor-agent")
+
+
+def _clean_cursor_env(env_passthrough: Sequence[str] | None = None) -> dict[str, str]:
+    allowed = {
+        "CURSOR_API_KEY",
+        "HOME",
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "TERM",
+        "TMPDIR",
+        "USER",
+        "SHELL",
+    }
+    if env_passthrough:
+        allowed.update(env_passthrough)
+    return {key: value for key, value in os.environ.items() if key in allowed}
+
+
+@dataclass(frozen=True)
+class SandboxedCursorCli:
+    launch_path: str
+    sandboxed: bool
+
+
+def _try_sandbox_cursor(
+    cursor_path: str,
+    os_env: OSEnvSpec | None,
+    cwd: str | None,
+    spawn_env_names: Sequence[str] | None = None,
+) -> SandboxedCursorCli:
+    if os_env is None:
+        return SandboxedCursorCli(launch_path=cursor_path, sandboxed=False)
+    sandbox_spec = os_env.sandbox or OSEnvSandboxSpec()
+    if sandbox_spec.type == "none":
+        return SandboxedCursorCli(launch_path=cursor_path, sandboxed=False)
+    try:
+        import pathlib
+
+        from .sandbox import (
+            create_exec_launcher,
+            resolve_sandbox,
+            with_additional_read_roots,
+            with_additional_write_roots,
+            with_spawn_env_allowlist,
+        )
+
+        resolved_cwd = pathlib.Path(cwd or os.getcwd()).resolve(strict=False)
+        sandbox = resolve_sandbox(os_env, resolved_cwd)
+        if not sandbox.active:
+            return SandboxedCursorCli(launch_path=cursor_path, sandboxed=False)
+        cursor_dir = pathlib.Path(cursor_path).resolve().parent.parent
+        sandbox = with_additional_read_roots(sandbox, [cursor_dir])
+        sandbox = with_additional_write_roots(
+            sandbox,
+            [pathlib.Path(os.path.expanduser("~/.cursor")), pathlib.Path("/tmp")],
+        )
+        sandbox = with_spawn_env_allowlist(sandbox, spawn_env_names)
+        launcher = create_exec_launcher(cursor_path, sandbox)
+        return SandboxedCursorCli(launch_path=launcher, sandboxed=True)
+    except (OSError, ImportError, NotImplementedError) as exc:
+        logger.warning("Could not apply sandbox for Cursor: %s", exc)
+        return SandboxedCursorCli(launch_path=cursor_path, sandboxed=False)
+
+
+def _extract_latest_user_text(messages: list[Message]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+            return " ".join(parts)
+        if content is not None:
+            return str(content)
+    return ""
+
+
+def _text_from_cursor_message(message: object) -> str:
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            text = part.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def _cursor_usage(event: dict[str, Any], fallback_model: str | None) -> dict[str, Any] | None:
+    usage = event.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    input_tokens = int(usage.get("inputTokens") or 0)
+    output_tokens = int(usage.get("outputTokens") or 0)
+    cache_read = int(usage.get("cacheReadTokens") or 0)
+    cache_write = int(usage.get("cacheWriteTokens") or 0)
+    if not (input_tokens or output_tokens):
+        return None
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens + cache_read + cache_write,
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_write,
+        "context_tokens": input_tokens + cache_read + cache_write,
+        "model": fallback_model,
+    }
+
+
+class CursorExecutor(Executor):
+    """Execute turns via ``cursor-agent --print --output-format stream-json``."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        model: str | None = None,
+        cursor_path: str | None = None,
+        agent_name: str | None = None,
+    ) -> None:
+        resolved_cursor = cursor_path or _find_cursor_cli()
+        if not resolved_cursor:
+            raise ImportError(
+                "CursorExecutor requires the 'cursor-agent' CLI on PATH. "
+                "Install Cursor Agent and authenticate with `cursor-agent login`."
+            )
+        self._cursor_path = resolved_cursor
+        self._cwd = cwd
+        self._model = model
+        self._agent_name = agent_name
+        self._os_env_spec = os_env
+        self._env = _clean_cursor_env(
+            os_env.sandbox.env_passthrough if os_env is not None and os_env.sandbox else None
+        )
+        sandboxed = _try_sandbox_cursor(
+            self._cursor_path,
+            os_env,
+            cwd,
+            spawn_env_names=[*self._env],
+        )
+        self._cursor_launch_path = sandboxed.launch_path
+        self._sandboxed = sandboxed.sandboxed
+
+    def supports_streaming(self) -> bool:
+        return True
+
+    def _resolve_model(self, config: ExecutorConfig | None) -> str | None:
+        if config is not None and config.model:
+            return config.model
+        return self._model
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        del tools
+        prompt = _extract_latest_user_text(messages)
+        if not prompt:
+            yield TurnComplete(response=None)
+            return
+
+        model = self._resolve_model(config)
+        args = [
+            self._cursor_launch_path,
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--stream-partial-output",
+            "--trust",
+        ]
+        if model:
+            args.extend(["--model", model])
+        workspace = self._cwd or os.getcwd()
+        args.extend(["--workspace", workspace])
+        if system_prompt:
+            prompt = f"{system_prompt}\n\n{prompt}"
+        args.append(prompt)
+
+        process = await _create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=workspace,
+            env=self._env,
+        )
+
+        stderr_task = asyncio.create_task(process.stderr.read() if process.stderr else _empty_bytes())
+        response_text = ""
+        streamed_any = False
+        usage: dict[str, Any] | None = None
+        observed_model = model
+        error_message: str | None = None
+        try:
+            assert process.stdout is not None
+            async for raw in _iter_stream_lines(process.stdout):
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    if line:
+                        yield TextChunk(text=line)
+                        response_text += line
+                        streamed_any = True
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                event_type = event.get("type")
+                if event_type == "system":
+                    raw_model = event.get("model")
+                    if isinstance(raw_model, str) and raw_model:
+                        observed_model = raw_model
+                elif event_type == "assistant":
+                    text = _text_from_cursor_message(event.get("message"))
+                    if text:
+                        # With --stream-partial-output, Cursor emits timestamped
+                        # assistant chunks followed by one non-timestamped
+                        # final assistant message containing the full text.
+                        # Without partial streaming, only that final message is
+                        # emitted. Stream chunks as deltas; treat the final as
+                        # reconciliation to avoid duplicating text.
+                        if "timestamp_ms" in event:
+                            yield TextChunk(text=text)
+                            response_text += text
+                            streamed_any = True
+                        elif not streamed_any:
+                            yield TextChunk(text=text)
+                            response_text = text
+                            streamed_any = True
+                        else:
+                            response_text = text
+                elif event_type == "text":
+                    text = event.get("text") or event.get("delta")
+                    if isinstance(text, str) and text:
+                        yield TextChunk(text=text)
+                        response_text += text
+                        streamed_any = True
+                elif event_type == "result":
+                    result_text = event.get("result")
+                    if isinstance(result_text, str) and result_text and not response_text:
+                        response_text = result_text
+                    usage = _cursor_usage(event, observed_model)
+                    if event.get("is_error"):
+                        error_message = (
+                            result_text if isinstance(result_text, str) and result_text else None
+                        )
+                        break
+        finally:
+            await process.wait()
+            close_subprocess_transport(process)
+
+        stderr = await stderr_task
+        if error_message is not None:
+            yield ExecutorError(message=error_message or "Cursor agent returned an error")
+            return
+        if process.returncode not in (0, None):
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            yield ExecutorError(message=f"Cursor agent failed: {detail or process.returncode}")
+            return
+        _notify_usage_from_dict(model=observed_model, usage=usage)
+        yield TurnComplete(response=response_text, usage=usage)
+
+
+async def _empty_bytes() -> bytes:
+    return b""
+
+
+async def _iter_stream_lines(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+    buffer = bytearray()
+    while True:
+        chunk = await stream.read(_STREAM_READ_CHUNK_SIZE)
+        if not chunk:
+            break
+        buffer.extend(chunk)
+        while True:
+            newline_index = buffer.find(b"\n")
+            if newline_index < 0:
+                break
+            line = bytes(buffer[: newline_index + 1])
+            del buffer[: newline_index + 1]
+            yield line
+    if buffer:
+        yield bytes(buffer)

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -1,0 +1,70 @@
+"""``harness: cursor`` wrap for Cursor Agent CLI."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from fastapi import FastAPI
+
+from omnigent.inner.cursor_executor import CursorExecutor
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+_ENV_MODEL = "HARNESS_CURSOR_MODEL"
+_ENV_CWD = "HARNESS_CURSOR_CWD"
+_ENV_CURSOR_PATH = "HARNESS_CURSOR_PATH"
+_ENV_OS_ENV = "HARNESS_CURSOR_OS_ENV"
+_ENV_AGENT_NAME = "HARNESS_CURSOR_AGENT_NAME"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env",
+                _ENV_OS_ENV,
+                exc,
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _build_cursor_executor() -> Executor:
+    agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
+    return CursorExecutor(
+        cwd=os.environ.get(_ENV_CWD),
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL) or None,
+        cursor_path=os.environ.get(_ENV_CURSOR_PATH) or None,
+        agent_name=agent_name_raw or None,
+    )
+
+
+def create_app() -> FastAPI:
+    """Build the ``cursor`` harness FastAPI app."""
+    adapter = ExecutorAdapter(executor_factory=_build_cursor_executor)
+    return adapter.build()

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11657,6 +11657,7 @@ _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     "claude-sdk": "HARNESS_CLAUDE_SDK_MODEL",
     "codex": "HARNESS_CODEX_MODEL",
     "pi": "HARNESS_PI_MODEL",
+    "cursor": "HARNESS_CURSOR_MODEL",
     "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",
 }
 
@@ -11687,6 +11688,7 @@ def _build_spawn_env_from_spec(
         from omnigent.runtime.workflow import (
             _build_claude_sdk_spawn_env,
             _build_codex_spawn_env,
+            _build_cursor_spawn_env,
             _build_openai_agents_sdk_spawn_env,
             _build_pi_spawn_env,
         )
@@ -11697,6 +11699,8 @@ def _build_spawn_env_from_spec(
             env = _build_codex_spawn_env(spec, workdir=workdir)
         elif harness == "pi":
             env = _build_pi_spawn_env(spec, workdir=workdir)
+        elif harness == "cursor":
+            env = _build_cursor_spawn_env(spec, workdir=workdir)
         elif harness == "openai-agents":
             env = _build_openai_agents_sdk_spawn_env(spec)
         else:

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -41,6 +41,8 @@ _HARNESS_MODULES: dict[str, str] = {
     "claude-native": "omnigent.inner.claude_native_harness",
     # Native Codex TUI terminal bridge used by ``omnigent codex``.
     "codex-native": "omnigent.inner.codex_native_harness",
+    # Cursor Agent CLI harness wrap. See omnigent/inner/cursor_harness.py.
+    "cursor": "omnigent.inner.cursor_harness",
     # Step 4c: codex harness wrap. See
     # omnigent/inner/codex_harness.py.
     "codex": "omnigent.inner.codex_harness",

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1218,6 +1218,30 @@ def _build_pi_spawn_env(
     return env
 
 
+def _build_cursor_spawn_env(
+    spec: AgentSpec,
+    *,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """
+    Build the env-var dict the Cursor harness wrap reads.
+
+    Cursor Agent CLI owns its provider/auth configuration; Omnigent
+    supplies model, cwd/sandbox, and display metadata.
+    """
+    del workdir
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_CURSOR_MODEL"] = model
+    if spec.name:
+        env["HARNESS_CURSOR_AGENT_NAME"] = spec.name
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_CURSOR_OS_ENV"] = os_env_payload
+    return env
+
+
 def _load_global_auth() -> ApiKeyAuth | DatabricksAuth | None:
     """
     Load the ``auth:`` block from ``~/.omnigent/config.yaml``.

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -78,6 +78,7 @@ OMNIGENT_HARNESSES = frozenset(
         "claude-sdk",
         "codex",
         "codex-native",
+        "cursor",
         "databricks_supervisor",
         "openai-agents",
         "open-responses",

--- a/tests/e2e/_harness_probes.py
+++ b/tests/e2e/_harness_probes.py
@@ -144,12 +144,10 @@ HARNESS_PROBES: list[HarnessProbe] = [
     ),
     HarnessProbe(
         harness="cursor",
-        # Cursor speaks the OpenAI Responses API via the Databricks
-        # gateway; the GPT model is the natural fit per CLAUDE.md
-        # (``databricks-gpt-5-4-mini`` is the OpenAI-style
-        # Databricks model). Registry key is ``cursor`` to match
-        # the Omnigent YAML ``executor.harness`` spelling.
-        model=resolve_model("databricks-gpt-5-4-mini", key="probe:cursor"),
+        # Cursor Agent CLI uses Composer 2.5 Fast as its default
+        # model. Registry key is ``cursor`` to match the Omnigent
+        # YAML ``executor.harness`` spelling.
+        model=resolve_model("composer-2.5-fast", key="probe:cursor"),
         env_prefix="HARNESS_CURSOR_",
         marker="CURSOR_E2E_OK",
         cli_binary="cursor-agent",

--- a/tests/e2e/_harness_probes.py
+++ b/tests/e2e/_harness_probes.py
@@ -142,6 +142,18 @@ HARNESS_PROBES: list[HarnessProbe] = [
         # ``openai-agents`` needs a gateway-reachable model.
         cli_binary=None,
     ),
+    HarnessProbe(
+        harness="cursor",
+        # Cursor speaks the OpenAI Responses API via the Databricks
+        # gateway; the GPT model is the natural fit per CLAUDE.md
+        # (``databricks-gpt-5-4-mini`` is the OpenAI-style
+        # Databricks model). Registry key is ``cursor`` to match
+        # the Omnigent YAML ``executor.harness`` spelling.
+        model=resolve_model("databricks-gpt-5-4-mini", key="probe:cursor"),
+        env_prefix="HARNESS_CURSOR_",
+        marker="CURSOR_E2E_OK",
+        cli_binary="cursor-agent",
+    ),
 ]
 
 

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1,0 +1,164 @@
+"""Tests for CursorExecutor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner.cursor_executor import CursorExecutor
+from omnigent.inner.executor import TextChunk, TurnComplete
+
+
+class _FakeStreamReader:
+    def __init__(self, lines: list[bytes]):
+        self._buffer = bytearray(b"".join(lines))
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._buffer:
+            return b""
+        if n < 0 or n > len(self._buffer):
+            n = len(self._buffer)
+        chunk = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return chunk
+
+
+class _FakeProcess:
+    def __init__(self, stdout_lines: list[str], stderr: str = "", returncode: int = 0):
+        self.stdin = None
+        self.stdout = _FakeStreamReader([(line + "\n").encode() for line in stdout_lines])
+        self.stderr = _FakeStreamReader([stderr.encode()])
+        self.returncode = returncode
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_cursor_executor_stream_json_turn(tmp_path: Path) -> None:
+    process = _FakeProcess(
+        [
+            '{"type":"system","model":"Composer 2.5 Fast"}',
+            '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}]}}',
+            (
+                '{"type":"result","subtype":"success","is_error":false,'
+                '"result":"Hi","usage":{"inputTokens":7,"outputTokens":2,'
+                '"cacheReadTokens":3,"cacheWriteTokens":1}}'
+            ),
+        ]
+    )
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_create(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(args)
+        return process
+
+    with (
+        patch("omnigent.inner.cursor_executor._find_cursor_cli", return_value="/usr/bin/cursor-agent"),
+        patch("omnigent.inner.cursor_executor._create_subprocess_exec", fake_create),
+    ):
+        executor = CursorExecutor(cwd=str(tmp_path), model="gpt-5")
+        events = [
+            event
+            async for event in executor.run_turn(
+                [{"role": "user", "content": "say hi"}],
+                [],
+                "",
+            )
+        ]
+
+    assert any(isinstance(event, TextChunk) and event.text == "Hi" for event in events)
+    complete = next(event for event in events if isinstance(event, TurnComplete))
+    assert complete.response == "Hi"
+    assert complete.usage == {
+        "input_tokens": 7,
+        "output_tokens": 2,
+        "total_tokens": 13,
+        "cache_read_input_tokens": 3,
+        "cache_creation_input_tokens": 1,
+        "context_tokens": 11,
+        "model": "Composer 2.5 Fast",
+    }
+    assert calls
+    argv = calls[0]
+    assert argv[:5] == (
+        "/usr/bin/cursor-agent",
+        "--print",
+        "--output-format",
+        "stream-json",
+        "--stream-partial-output",
+    )
+    assert "--trust" in argv
+    assert "--model" in argv
+    assert "gpt-5" in argv
+
+
+@pytest.mark.asyncio
+async def test_cursor_executor_handles_timestamped_partial_assistant_chunks(
+    tmp_path: Path,
+) -> None:
+    process = _FakeProcess(
+        [
+            '{"type":"system","model":"Composer 2.5 Fast"}',
+            (
+                '{"type":"assistant","message":{"role":"assistant","content":'
+                '[{"type":"text","text":"1\\n"}]},"timestamp_ms":1}'
+            ),
+            (
+                '{"type":"assistant","message":{"role":"assistant","content":'
+                '[{"type":"text","text":"2\\n3"}]},"timestamp_ms":2}'
+            ),
+            (
+                '{"type":"assistant","message":{"role":"assistant","content":'
+                '[{"type":"text","text":"1\\n2\\n3"}]}}'
+            ),
+            '{"type":"result","subtype":"success","is_error":false,"result":"1\\n2\\n3"}',
+        ]
+    )
+
+    async def fake_create(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return process
+
+    with (
+        patch("omnigent.inner.cursor_executor._find_cursor_cli", return_value="/usr/bin/cursor-agent"),
+        patch("omnigent.inner.cursor_executor._create_subprocess_exec", fake_create),
+    ):
+        executor = CursorExecutor(cwd=str(tmp_path))
+        events = [
+            event
+            async for event in executor.run_turn(
+                [{"role": "user", "content": "count"}],
+                [],
+                "",
+            )
+        ]
+
+    assert [event.text for event in events if isinstance(event, TextChunk)] == ["1\n", "2\n3"]
+    complete = next(event for event in events if isinstance(event, TurnComplete))
+    assert complete.response == "1\n2\n3"
+
+
+@pytest.mark.asyncio
+async def test_cursor_executor_surfaces_nonzero_stderr(tmp_path: Path) -> None:
+    process = _FakeProcess([], stderr="not logged in", returncode=1)
+
+    async def fake_create(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return process
+
+    with (
+        patch("omnigent.inner.cursor_executor._find_cursor_cli", return_value="/usr/bin/cursor-agent"),
+        patch("omnigent.inner.cursor_executor._create_subprocess_exec", fake_create),
+    ):
+        executor = CursorExecutor(cwd=str(tmp_path))
+        events = [
+            event
+            async for event in executor.run_turn(
+                [{"role": "user", "content": "say hi"}],
+                [],
+                "",
+            )
+        ]
+
+    assert events[0].message == "Cursor agent failed: not logged in"

--- a/tests/inner/test_cursor_harness.py
+++ b/tests/inner/test_cursor_harness.py
@@ -1,0 +1,34 @@
+"""Tests for the Cursor harness wrapper."""
+
+from __future__ import annotations
+
+import json
+
+from omnigent.inner import cursor_harness
+
+
+def test_cursor_harness_builds_executor_from_env(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    seen = {}
+
+    class FakeCursorExecutor:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+    monkeypatch.setattr(cursor_harness, "CursorExecutor", FakeCursorExecutor)
+    monkeypatch.setenv("HARNESS_CURSOR_MODEL", "gpt-5")
+    monkeypatch.setenv("HARNESS_CURSOR_CWD", "/repo")
+    monkeypatch.setenv("HARNESS_CURSOR_PATH", "/bin/cursor-agent")
+    monkeypatch.setenv("HARNESS_CURSOR_AGENT_NAME", "cursor-coder")
+    monkeypatch.setenv(
+        "HARNESS_CURSOR_OS_ENV",
+        json.dumps({"type": "caller_process", "sandbox": {"type": "none"}}),
+    )
+
+    executor = cursor_harness._build_cursor_executor()
+
+    assert isinstance(executor, FakeCursorExecutor)
+    assert seen["model"] == "gpt-5"
+    assert seen["cwd"] == "/repo"
+    assert seen["cursor_path"] == "/bin/cursor-agent"
+    assert seen["agent_name"] == "cursor-coder"
+    assert seen["os_env"].type == "caller_process"

--- a/tests/inner/test_cursor_harness_registry.py
+++ b/tests/inner/test_cursor_harness_registry.py
@@ -1,0 +1,14 @@
+"""Registry tests for the Cursor harness."""
+
+from __future__ import annotations
+
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+from omnigent.spec._omnigent_compat import OMNIGENT_HARNESSES
+
+
+def test_cursor_harness_registered() -> None:
+    assert _HARNESS_MODULES.get("cursor") == "omnigent.inner.cursor_harness"
+
+
+def test_cursor_harness_accepted_by_spec_compat() -> None:
+    assert "cursor" in OMNIGENT_HARNESSES


### PR DESCRIPTION
## Summary
Add a new Cursor harness that runs Cursor Agent CLI in headless stream-json mode and wires it into Omnigent harness registration and runner spawn-env flow.

## Changes
- Add CursorExecutor for cursor-agent.
- Add cursor_harness env wrapper and register harness: cursor.
- Thread model and OS env metadata through runner/workflow spawn env.
- Accept cursor in the Omnigent harness allowlist.
- Add focused tests for stream parsing, partial assistant chunks, harness env wiring, and registry validation.

## Testing
- uv run --extra dev pytest tests/inner/test_cursor_executor.py tests/inner/test_cursor_harness.py tests/inner/test_cursor_harness_registry.py
- Result: 6 passed, 1 warning in 0.10s

## Related Issues
- N/A