### PR TITLE
feat(harnesses): add cursor first-party harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### A meta-harness for all your AI agents
 
-Omnigent provides a common layer over Claude Code, Codex, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, keep them in check with policies and sandboxing, and collaborate in real time on the same live session, from any device.
+Omnigent provides a common layer over Claude Code, Codex, Cursor, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, keep them in check with policies and sandboxing, and collaborate in real time on the same live session, from any device.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/omnigent-ai/omnigent/blob/main/LICENSE)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
@@ -145,6 +145,7 @@ omnigent run examples/debby/
 # Run an orchestrator on a different harness (sub-agents keep their own):
 omnigent run examples/polly/ --harness pi
 omnigent run examples/debby/ --harness openai-agents
+omnigent run examples/polly/ --harness cursor  # Cursor CLI (needs cursor-agent + CURSOR_API_KEY)
 ```
 
 **🐙 Polly** is a multi-agent coding orchestrator who writes no code herself.
@@ -336,7 +337,7 @@ name: my_agent
 prompt: You are a helpful data analyst.
 
 executor:
-  harness: claude-sdk          # or: codex, codex-native, claude-native, openai-agents, pi
+  harness: claude-sdk          # or: codex, codex-native, claude-native, cursor, openai-agents, pi
 
 tools:
   # A local Python function (schema auto-generated from the signature)

--- a/ap-web/src/lib/agentLabels.ts
+++ b/ap-web/src/lib/agentLabels.ts
@@ -17,6 +17,7 @@ export const BRAIN_HARNESS_LABELS: Record<string, string> = {
   "claude-sdk": "Claude SDK",
   "openai-agents": "OpenAI Agents SDK",
   codex: "Codex",
+  "cursor": "Cursor",
   pi: "Pi",
 };
 

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -49,7 +49,7 @@ resolved from the YAML file's directory.
 
 ```yaml
 executor:
-  harness: claude-sdk        # claude-sdk, openai-agents, codex, etc.
+  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, pi, etc.
   model: databricks-claude-opus-4-7
   auth:
     type: databricks
@@ -58,6 +58,13 @@ executor:
 
 Set the Databricks profile under `executor.auth`. The older top-level
 `executor.profile` shorthand is legacy and should not be used in new specs.
+
+The `cursor` harness (Cursor's `cursor-agent`) is the exception: it talks
+only to Cursor's own backend and has no custom API base-URL, so the Databricks
+gateway / `auth.type: databricks` does not apply. Authenticate it with
+`CURSOR_API_KEY` (or a prior `cursor-agent login`), optionally pinned via
+`auth: {type: api_key, api_key: ${CURSOR_API_KEY}}`, and choose a Cursor model
+id (e.g. `auto`, `gpt-5`) rather than a `databricks-*` id.
 
 CLI flags such as `--harness` and `--model` can override or supply missing
 executor values for a run. Databricks credentials come from the spec's
@@ -164,6 +171,19 @@ tools:
     os_env: inherit
     pass_history: true
     max_sessions: 2
+```
+
+Each sub-agent picks its own `executor.harness` and `model`, so an orchestrator
+can mix harnesses by role — e.g. a `cursor` coder with a `claude-sdk`
+reviewer:
+
+```yaml
+tools:
+  coder:
+    type: agent
+    executor:
+      harness: cursor      # Cursor model id (e.g. gpt-5, auto), not a databricks-* id
+      model: gpt-5
 ```
 
 Use `tools.<name>: inherit` to inherit a tool from a parent agent, or

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7649,6 +7649,56 @@ def _manage_harness_providers(family: str) -> None:
             status = _manage_credential(row.provider, family)
 
 
+def _manage_cursor_harness() -> None:
+    """Run the level-2 loop for Cursor: install hint, then sign in / out.
+
+    Cursor authenticates against its own backend via ``cursor-agent login``
+    (or ``CURSOR_API_KEY``), so it has no provider/gateway credential to
+    manage — this drives the CLI's own auth instead of the provider menu. An
+    uninstalled CLI shows the manual install command (cursor-agent ships via a
+    curl installer, not npm) and returns; otherwise the loop toggles sign-in /
+    sign-out, confirming each via the CLI's own status.
+
+    :returns: None.
+    """
+    from omnigent.onboarding.harness_install import (
+        CURSOR_KEY,
+        harness_cli_installed,
+        harness_cli_logged_in,
+        harness_install_spec,
+        harness_login,
+        harness_logout,
+    )
+    from omnigent.onboarding.interactive import console, select
+
+    if not harness_cli_installed(CURSOR_KEY):
+        spec = harness_install_spec(CURSOR_KEY)
+        hint = spec.install_hint if spec is not None else None
+        console.print(
+            "  Cursor's CLI (`cursor-agent`) isn't installed. Install it with:\n"
+            f"    [bold]{hint}[/bold]\n"
+            "  then re-open setup to sign in (or set CURSOR_API_KEY)."
+        )
+        return
+
+    status: str | None = None
+    while True:
+        logged_in = harness_cli_logged_in(CURSOR_KEY)
+        action = "Sign out (cursor-agent logout)" if logged_in else "Sign in (cursor-agent login)"
+        idx = select(
+            "Cursor — " + ("signed in" if logged_in else "not signed in"),
+            [action, "← Back"],
+            clear_on_exit=True,
+            status=status,
+        )
+        if idx < 0 or idx == 1:  # Esc / q / Back
+            return
+        if logged_in:
+            status = "Signed out" if harness_logout(CURSOR_KEY) else "Sign-out did not complete"
+        else:
+            status = "✓ Signed in" if harness_login(CURSOR_KEY) else "Sign-in did not complete"
+
+
 def _manage_credential(provider: str, family: str) -> str | None:
     """Run the level-3 loop for one credential: make default / remove.
 
@@ -7928,7 +7978,11 @@ def _run_configure_harnesses_interactive() -> None:
         performs while navigating.
     """
     from omnigent.onboarding.configure_models import family_label
-    from omnigent.onboarding.harness_install import harness_cli_installed
+    from omnigent.onboarding.harness_install import (
+        CURSOR_KEY,
+        harness_cli_installed,
+        harness_cli_logged_in,
+    )
     from omnigent.onboarding.interactive import select
     from omnigent.onboarding.provider_config import (
         ANTHROPIC_FAMILY,
@@ -8004,6 +8058,24 @@ def _run_configure_harnesses_interactive() -> None:
                 options.append(f"  {sub_line}")
                 selectable.append(False)  # a sub-line — cursor skips it
                 row_target.append(None)
+        # Cursor: a login-only harness (its own backend via ``cursor-agent
+        # login`` / ``CURSOR_API_KEY``), so it has no provider credential to
+        # configure — readiness is "CLI installed + signed in", and its
+        # drill-in drives cursor-agent's own auth, not the provider menu.
+        cursor_installed = harness_cli_installed(CURSOR_KEY)
+        cursor_ready = cursor_installed and harness_cli_logged_in(CURSOR_KEY)
+        options.append(f"{'  ' if cursor_ready else '[red]✗[/] '}Cursor")
+        selectable.append(True)
+        row_target.append(CURSOR_KEY)
+        if not cursor_installed:
+            cursor_sub = "[dim]not installed yet — open to install[/]"
+        elif cursor_ready:
+            cursor_sub = "[green]✓[/] signed in via cursor-agent"
+        else:
+            cursor_sub = "[dim]not signed in — open to log in[/]"
+        options.append(f"  {cursor_sub}")
+        selectable.append(False)
+        row_target.append(None)
         options.append("Quit")
         selectable.append(True)
         row_target.append(_QUIT)
@@ -8016,7 +8088,9 @@ def _run_configure_harnesses_interactive() -> None:
         if idx < 0:  # Esc / q — exit
             return
         target = row_target[idx]
-        if target in families:
+        if target == CURSOR_KEY:
+            _manage_cursor_harness()
+        elif target in families:
             _manage_harness_providers(target)
         else:  # Quit row (or, defensively, a non-family row)
             return

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4026,6 +4026,7 @@ def resume(
 # into a materialized copy of the spec before the server starts.
 _HARNESS_CHOICES_HELP = (
     "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
+    "'cursor', "
     "'openai-agents', 'open-responses', or 'pi'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
@@ -4054,6 +4055,9 @@ _DEFAULT_HARNESS_PROMPTS = {
     ),
     "codex": (
         "You are Codex, running through Omnigent. Help the user with software engineering tasks."
+    ),
+    "cursor": (
+        "You are Cursor, running through Omnigent. Help the user with software engineering tasks."
     ),
 }
 _DEFAULT_HARNESS_PROMPT = "You are a helpful coding agent running through Omnigent."

--- a/omnigent/inner/cursor_acp.py
+++ b/omnigent/inner/cursor_acp.py
@@ -1,0 +1,399 @@
+"""Agent Client Protocol (ACP) client for ``cursor-agent acp``.
+
+``cursor-agent acp`` runs Cursor's agent as an ACP server: a JSON-RPC 2.0 peer
+speaking newline-delimited JSON over stdio. A session stays open across turns,
+so the harness drives it turn by turn rather than respawning the CLI.
+
+Covers what the harness needs: ``initialize`` → ``session/new`` (with cwd,
+model, MCP servers) → ``session/prompt`` (streaming ``session/update``
+notifications) → ``session/cancel``. Responses are correlated by JSON-RPC id;
+``session/update`` notifications are queued for the active prompt; server→client
+requests are auto-replied (permission requests auto-allowed, anything else a
+null result) so the server never blocks.
+
+``session/new`` accepts ``{cwd, model, mcpServers}`` and echoes the resolved
+model; ``session/prompt`` returns ``{stopReason}`` at end of turn and streams
+``agent_message_chunk`` / ``agent_thought_chunk`` / ``tool_call`` updates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from asyncio import Future, Queue, Task
+from collections.abc import AsyncIterator
+from typing import Any, TypeAlias
+
+from ._subprocess_lifecycle import close_subprocess_transport
+
+logger = logging.getLogger(__name__)
+
+# One ACP JSON-RPC message (request / response / notification). The schema is
+# owned by the ACP spec + cursor-agent, so it is opaque JSON at this layer.
+AcpMessage: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+
+# ACP protocol revision this client negotiates (integer, per the ACP spec).
+_ACP_PROTOCOL_VERSION = 1
+
+# Read stdout in 64 KiB chunks and split on newlines ourselves so a single
+# large notification line (e.g. a big tool result) can't overflow
+# ``StreamReader.readline``'s 64 KiB cap — same robustness as the pi/cursor
+# stream readers.
+_STREAM_READ_CHUNK_SIZE = 65536
+
+# Default per-request timeout. A single ``session/prompt`` can run the whole
+# agent turn (tool loop, long generation), so it is generous; session
+# setup calls resolve far quicker.
+_REQUEST_TIMEOUT_SECONDS = 600.0
+
+
+async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> asyncio.subprocess.Process:  # type: ignore[explicit-any]
+    """Indirection point for ``asyncio.create_subprocess_exec`` (test seam).
+
+    Mirrors the seam in the pi / cursor executors so tests can stub
+    subprocess creation by patching ``omnigent.inner.cursor_acp._create_subprocess_exec``
+    without touching the global ``asyncio`` singleton.
+    """
+    return await asyncio.create_subprocess_exec(*args, **kwargs)
+
+
+class AcpError(RuntimeError):
+    """An ACP request returned a JSON-RPC error or the server died."""
+
+
+class AcpClient:
+    """A persistent JSON-RPC client over a ``cursor-agent acp`` subprocess."""
+
+    def __init__(
+        self,
+        cursor_path: str,
+        *,
+        env: dict[str, str],
+        cwd: str | None,
+        extra_args: list[str] | None = None,
+    ) -> None:
+        """
+        :param cursor_path: Path to spawn — the ``cursor-agent`` binary.
+        :param env: The COMPLETE subprocess environment (allowlisted by the
+            caller; never the full ``os.environ``).
+        :param cwd: Working directory for the ACP server, or ``None`` to inherit.
+        :param extra_args: Extra CLI args appended to ``cursor-agent acp`` (e.g.
+            ``["--sandbox", "enabled"]``). ``None`` appends nothing.
+        """
+        self._cursor_path = cursor_path
+        self._env = env
+        self._cwd = cwd
+        self._extra_args = list(extra_args or [])
+        self._proc: asyncio.subprocess.Process | None = None
+        self._reader_task: Task[None] | None = None
+        self._stderr_task: Task[None] | None = None
+        self._next_id = 0
+        self._pending: dict[int, Future[AcpMessage]] = {}
+        self._notifications: Queue[AcpMessage] = Queue()
+        self._stderr_lines: list[str] = []
+
+    @property
+    def running(self) -> bool:
+        return self._proc is not None and self._proc.returncode is None
+
+    async def start(self) -> AcpMessage:
+        """Spawn ``cursor-agent acp`` and complete the ACP ``initialize`` handshake.
+
+        :returns: The ``initialize`` result (agent capabilities, auth methods).
+        :raises AcpError: If the process fails to start or initialize.
+        """
+        logger.debug(
+            "AcpClient: spawning %s acp %s", self._cursor_path, " ".join(self._extra_args)
+        )
+        self._proc = await _create_subprocess_exec(
+            self._cursor_path,
+            "acp",
+            *self._extra_args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+            env=self._env,
+        )
+        self._reader_task = asyncio.create_task(self._reader())
+        self._stderr_task = asyncio.create_task(self._stderr_reader())
+        return await self.request(
+            "initialize",
+            {
+                "protocolVersion": _ACP_PROTOCOL_VERSION,
+                # We do not expose host filesystem capabilities to the agent;
+                # cursor-agent uses its own native file tools in its cwd.
+                "clientCapabilities": {"fs": {"readTextFile": False, "writeTextFile": False}},
+            },
+        )
+
+    async def new_session(
+        self,
+        *,
+        cwd: str,
+        model: str | None,
+        mcp_servers: list[AcpMessage] | None = None,
+    ) -> str:
+        """Create a session and return its id.
+
+        :param cwd: Working directory the agent operates in.
+        :param model: Cursor model id to pin (e.g. ``"gpt-5.4-mini"``), or
+            ``None`` to use cursor's configured default.
+        :param mcp_servers: ACP ``mcpServers`` entries (http/sse), or ``None``.
+        :returns: The new session id.
+        """
+        params: AcpMessage = {"cwd": cwd, "mcpServers": mcp_servers or []}
+        if model:
+            params["model"] = model
+        result = await self.request("session/new", params)
+        session_id = result.get("sessionId")
+        if not isinstance(session_id, str) or not session_id:
+            raise AcpError(f"session/new returned no sessionId: {result!r}")
+        return session_id
+
+    async def prompt_stream(
+        self,
+        session_id: str,
+        blocks: list[AcpMessage],
+    ) -> AsyncIterator[tuple[str, AcpMessage]]:
+        """Send ``session/prompt`` and stream the turn.
+
+        Yields ``("update", update)`` for each ``session/update`` notification as
+        it arrives, then exactly one terminal ``("result", {...stopReason...})``
+        or ``("error", {...})`` when the prompt request resolves.
+
+        :param session_id: The session to prompt.
+        :param blocks: ACP prompt content blocks, e.g.
+            ``[{"type": "text", "text": "..."}]``.
+        """
+        # Drain any stray notifications left over from a prior turn (idle
+        # ``available_commands_update`` etc.) so they aren't misattributed.
+        while not self._notifications.empty():
+            self._notifications.get_nowait()
+
+        rid = self._send("session/prompt", {"sessionId": session_id, "prompt": blocks})
+        fut = self._pending[rid]
+
+        while True:
+            getter: Task[AcpMessage] = asyncio.ensure_future(self._notifications.get())
+            done, _pending = await asyncio.wait({getter, fut}, return_when=asyncio.FIRST_COMPLETED)
+            if getter in done:
+                yield ("update", getter.result())
+                continue
+            # The prompt response landed; surface any already-queued updates
+            # before the terminal item, then stop.
+            getter.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await getter
+            while not self._notifications.empty():
+                yield ("update", self._notifications.get_nowait())
+            resp = fut.result()
+            if "error" in resp:
+                yield ("error", resp["error"])
+            else:
+                result = resp.get("result")
+                yield ("result", result if isinstance(result, dict) else {})
+            return
+
+    async def cancel(self, session_id: str) -> None:
+        """Best-effort ``session/cancel`` notification to interrupt the turn."""
+        if not self.running or self._proc is None or self._proc.stdin is None:
+            return
+        with contextlib.suppress(Exception):
+            self._proc.stdin.write(
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/cancel",
+                            "params": {"sessionId": session_id},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                ).encode("utf-8")
+            )
+            await self._proc.stdin.drain()
+
+    async def request(self, method: str, params: AcpMessage) -> AcpMessage:
+        """Send a JSON-RPC request and await its result.
+
+        :raises AcpError: On a JSON-RPC error response, timeout, or dead server.
+        """
+        rid = self._send(method, params)
+        try:
+            resp = await asyncio.wait_for(self._pending[rid], timeout=_REQUEST_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError as exc:
+            raise AcpError(f"ACP {method} timed out") from exc
+        if "error" in resp:
+            raise AcpError(f"ACP {method} failed: {resp['error']}")
+        result = resp.get("result")
+        return result if isinstance(result, dict) else {}
+
+    def stderr_tail(self) -> str:
+        return "\n".join(self._stderr_lines)
+
+    async def close(self) -> None:
+        """Terminate the ACP subprocess and stop the reader tasks."""
+        for task in (self._reader_task, self._stderr_task):
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+        self._reader_task = None
+        self._stderr_task = None
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.cancel()
+        self._pending.clear()
+        if self._proc is not None:
+            with contextlib.suppress(ProcessLookupError):
+                self._proc.terminate()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=2.0)
+            except (asyncio.TimeoutError, ProcessLookupError, RuntimeError):
+                with contextlib.suppress(ProcessLookupError):
+                    self._proc.kill()
+            close_subprocess_transport(self._proc)
+            self._proc = None
+
+    # -- internals ---------------------------------------------------------
+
+    def _send(self, method: str, params: AcpMessage) -> int:
+        """Write a JSON-RPC request; return its id (caller awaits ``_pending[id]``)."""
+        if self._proc is None or self._proc.stdin is None:
+            raise AcpError("ACP server is not running")
+        self._next_id += 1
+        rid = self._next_id
+        fut: Future[AcpMessage] = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        line = json.dumps(
+            {"jsonrpc": "2.0", "id": rid, "method": method, "params": params},
+            separators=(",", ":"),
+        )
+        self._proc.stdin.write((line + "\n").encode("utf-8"))
+        return rid
+
+    def _reply(self, request_id: Any, result: AcpMessage) -> None:  # type: ignore[explicit-any]
+        if self._proc is None or self._proc.stdin is None:
+            return
+        line = json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "result": result}, separators=(",", ":")
+        )
+        self._proc.stdin.write((line + "\n").encode("utf-8"))
+
+    async def _reader(self) -> None:
+        assert self._proc is not None and self._proc.stdout is not None
+        try:
+            async for raw in self._iter_lines(self._proc.stdout):
+                text = raw.decode("utf-8", errors="replace").strip()
+                if not text:
+                    continue
+                try:
+                    msg = json.loads(text)
+                except json.JSONDecodeError:
+                    logger.debug("AcpClient: non-JSON line: %s", text[:200])
+                    continue
+                if isinstance(msg, dict):
+                    self._dispatch(msg)
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:  # noqa: BLE001 — reader logs and exits on any unexpected error
+            logger.debug("AcpClient reader error: %s", exc)
+        finally:
+            # Fail any in-flight requests so awaiters don't hang on a dead server.
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(AcpError("ACP server closed the connection"))
+
+    def _dispatch(self, msg: AcpMessage) -> None:
+        method = msg.get("method")
+        if "id" in msg and method is None:
+            # Response to one of our requests.
+            fut = self._pending.pop(msg["id"], None)
+            if fut is not None and not fut.done():
+                fut.set_result(msg)
+            return
+        if method is not None and "id" in msg:
+            # Server→client request — auto-reply so the server never blocks.
+            self._handle_server_request(msg)
+            return
+        if method == "session/update":
+            # ACP nests the update object under params.update —
+            # ``{"sessionId": ..., "update": {"sessionUpdate": ..., ...}}`` —
+            # so queue the inner update (what the harness maps to events).
+            params = msg.get("params", {})
+            update = params.get("update") if isinstance(params, dict) else None
+            if isinstance(update, dict):
+                self._notifications.put_nowait(update)
+
+    def _handle_server_request(self, msg: AcpMessage) -> None:
+        method = msg.get("method", "")
+        request_id = msg.get("id")
+        if isinstance(method, str) and "permission" in method:
+            # Auto-allow: the harness runs headless, so there is no human to
+            # prompt. Pick an "allow"-flavored option, else the first option.
+            params = msg.get("params", {})
+            options = params.get("options", []) if isinstance(params, dict) else []
+            option_id = _pick_allow_option(options)
+            self._reply(request_id, {"outcome": {"outcome": "selected", "optionId": option_id}})
+            return
+        # Unknown server request (e.g. an fs op we declined capability for):
+        # null result keeps the protocol moving without granting anything.
+        self._reply(request_id, {})
+
+    @staticmethod
+    async def _iter_lines(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+        buffer = bytearray()
+        while True:
+            chunk = await stream.read(_STREAM_READ_CHUNK_SIZE)
+            if not chunk:
+                break
+            buffer.extend(chunk)
+            while True:
+                idx = buffer.find(b"\n")
+                if idx < 0:
+                    break
+                line = bytes(buffer[: idx + 1])
+                del buffer[: idx + 1]
+                yield line
+        if buffer:
+            yield bytes(buffer)
+
+    async def _stderr_reader(self) -> None:
+        if self._proc is None or self._proc.stderr is None:
+            return
+        try:
+            async for raw in self._iter_lines(self._proc.stderr):
+                text = raw.decode("utf-8", errors="replace").rstrip("\n\r")
+                if text:
+                    logger.debug("cursor-agent acp stderr: %s", text)
+                    if len(self._stderr_lines) < 50:
+                        self._stderr_lines.append(text)
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 — best-effort drainer
+            pass
+
+
+def _pick_allow_option(options: list[AcpMessage]) -> str:
+    """Choose an 'allow' permission option id from an ACP request's options.
+
+    :param options: The ``options`` list from a ``session/request_permission``
+        request (each ``{"optionId", "name", "kind"}``).
+    :returns: The id of an allow-flavored option, the first option's id, or
+        ``"allow"`` as a last resort.
+    """
+    for opt in options:
+        if not isinstance(opt, dict):
+            continue
+        marker = f"{opt.get('kind', '')}{opt.get('optionId', '')}".lower()
+        if "allow" in marker:
+            opt_id = opt.get("optionId")
+            if isinstance(opt_id, str):
+                return opt_id
+    if options and isinstance(options[0], dict):
+        first = options[0].get("optionId")
+        if isinstance(first, str):
+            return first
+    return "allow"

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -1,0 +1,471 @@
+"""CursorExecutor: run agents through a persistent ``cursor-agent acp`` session.
+
+Drives Cursor's ``cursor-agent`` CLI over the Agent Client Protocol (ACP,
+``cursor-agent acp``). Per Omnigent conversation it holds one ACP session
+(``session/new``) that stays open across turns; each ``run_turn`` sends one
+``session/prompt`` and translates the streamed ``session/update`` notifications
+into ExecutorEvents (assistant text → :class:`TextChunk`, agent thoughts →
+:class:`ReasoningChunk`, tool calls → :class:`ToolCallRequest` /
+:class:`ToolCallComplete`), completing on the prompt response's ``stopReason``.
+The ACP transport lives in :class:`omnigent.inner.cursor_acp.AcpClient`.
+
+cursor-agent talks only to Cursor's own backend (``CURSOR_API_KEY`` /
+``cursor-agent login``); there is no Databricks gateway, so a ``databricks-*``
+model id is dropped in favor of cursor's default. The system prompt is prepended
+to the first turn (ACP has no system-prompt field). The agent uses its own
+native tools; bridging Omnigent spec-declared tools would require an http/sse
+MCP server via ``session/new`` ``mcpServers``, and ACP reports no token usage.
+
+Requirements:
+    The ``cursor-agent`` CLI must be installed and on PATH (or
+    ``HARNESS_CURSOR_PATH`` set).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import shutil
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from .cursor_acp import AcpClient, AcpError
+from .datamodel import OSEnvSpec
+from .executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    ReasoningChunk,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolSpec,
+    TurnComplete,
+    classify_tool_result,
+)
+
+logger = logging.getLogger(__name__)
+
+# One ACP ``session/update`` payload (the inner ``params.update`` object).
+# Opaque JSON owned by the ACP spec / cursor-agent.
+AcpUpdate: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+
+# Prefix-matched env var names allowed into the cursor-agent subprocess. Only
+# known-safe categories pass: Cursor's own config knobs, proxy/TLS settings,
+# Node.js runtime knobs (cursor-agent bundles a Node runtime), and locale.
+# Credential families (``DATABRICKS_*``, ``AWS_*``, provider API keys, ...)
+# deliberately do NOT match — mirrors :data:`pi_executor._PI_ENV_ALLOW_PREFIXES`.
+_CURSOR_ENV_ALLOW_PREFIXES: tuple[str, ...] = (
+    "CURSOR_",
+    "HTTP_",
+    "HTTPS_",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "SSL_",
+    "NODE_",
+    "XDG_",
+    "LANG",
+    "LC_",
+)
+
+# Exact-matched env var names allowed into the cursor-agent subprocess: the
+# minimal set a POSIX CLI reasonably expects (HOME carries ~/.cursor login).
+_CURSOR_ENV_ALLOW_EXACT: frozenset[str] = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "TERM",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TZ",
+    }
+)
+
+
+def _find_cursor() -> str | None:
+    """Find the ``cursor-agent`` CLI on PATH."""
+    return shutil.which("cursor-agent")
+
+
+def _sandbox_mode(os_env: OSEnvSpec | None) -> str:
+    """Map ``os_env.sandbox`` to cursor-agent's ``--sandbox`` mode.
+
+    Mirrors codex's ``_sandbox_mode``: a restrictive sandbox enables cursor's
+    own sandbox; ``"none"`` / unset (the headless default) disables it for full
+    access. Enforcement is cursor-agent's, not Omnigent's bwrap.
+    """
+    sandbox = os_env.sandbox if os_env is not None else None
+    if sandbox is None or sandbox.type == "none":
+        return "disabled"
+    return "enabled"
+
+
+def _clean_cursor_env(extra_allowed: Sequence[str] | None = None) -> dict[str, str]:
+    """Build a filtered copy of ``os.environ`` for the cursor-agent subprocess.
+
+    Deny-by-default allowlist mirroring :func:`pi_executor._clean_pi_env`: only
+    the known-safe prefixes/exact names pass, so host secrets (cloud tokens,
+    unrelated API keys) never reach the cursor-agent process. ``CURSOR_API_KEY``
+    is allowed via the ``CURSOR_`` prefix; the executor also injects it
+    explicitly from config when provided.
+
+    :param extra_allowed: Extra exact names to pass through, e.g. a spec's
+        ``os_env.sandbox.env_passthrough`` entries. ``None`` means no extras.
+    :returns: Filtered environment dict.
+    """
+    allow_exact = set(_CURSOR_ENV_ALLOW_EXACT)
+    if extra_allowed is not None:
+        allow_exact.update(extra_allowed)
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key in allow_exact or key.startswith(_CURSOR_ENV_ALLOW_PREFIXES)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+
+def _extract_text(msg: Message) -> str:
+    """Extract plain text content from a message dict."""
+    content = msg.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return " ".join(parts)
+    return str(content)
+
+
+def _latest_user_text(messages: list[Message]) -> str:
+    """Return the text of the latest user message (multimodal parts joined)."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return _extract_text(msg)
+    return ""
+
+
+def _build_cursor_prompt(
+    messages: list[Message],
+    *,
+    is_first_turn: bool,
+    system_prompt: str,
+) -> str:
+    """Build the prompt text for a ``session/prompt``.
+
+    cursor-agent's ACP session has no system-prompt field, so on the first turn
+    the Omnigent system prompt is prepended. When the first turn also carries
+    prior history (e.g. a sub-agent with ``pass_history=True``), the
+    conversation is serialized so cursor has context. On subsequent turns the
+    ACP session already holds the history, so only the latest user message is
+    sent.
+
+    :param messages: Omnigent conversation history for the turn.
+    :param is_first_turn: ``True`` when this is the first turn against a fresh
+        cursor session (system prompt + any prior history must be included).
+    :param system_prompt: The Omnigent system prompt. Prepended only on the
+        first turn; pass ``""`` to skip.
+    :returns: The prompt string (empty string when there is nothing to send).
+    """
+    user_messages = [m for m in messages if m.get("role") == "user"]
+    if is_first_turn and len(messages) > 1 and len(user_messages) > 1:
+        lines = ["Conversation so far:"]
+        for msg in messages:
+            role = str(msg.get("role") or "user").replace("_", " ")
+            lines.append(f"{role}: {_extract_text(msg)}")
+        lines.append("")
+        lines.append(
+            "Respond to the latest user message, using the conversation above as context."
+        )
+        body = "\n".join(lines)
+    else:
+        body = _latest_user_text(messages)
+
+    if is_first_turn and system_prompt:
+        return f"{system_prompt}\n\n{body}" if body else system_prompt
+    return body
+
+
+# ---------------------------------------------------------------------------
+# session/update → ExecutorEvent
+# ---------------------------------------------------------------------------
+
+
+def _update_to_event(update: AcpUpdate) -> ExecutorEvent | None:
+    """Map one ACP ``session/update`` to an ExecutorEvent, or ``None`` to skip.
+
+    :param update: The ``params.update`` object from a ``session/update``
+        notification (carries a ``sessionUpdate`` discriminator).
+    :returns: The mapped event, or ``None`` for updates with nothing to surface
+        (mode changes, command lists, plans, echoed user input).
+    """
+    kind = update.get("sessionUpdate")
+    content = update.get("content")
+    text = content.get("text") if isinstance(content, dict) else None
+
+    if kind == "agent_message_chunk":
+        return TextChunk(text=text) if isinstance(text, str) and text else None
+    if kind == "agent_thought_chunk":
+        if isinstance(text, str) and text:
+            return ReasoningChunk(delta=text, event_type="reasoning_text")
+        return None
+    if kind == "tool_call":
+        raw_input = update.get("rawInput")
+        return ToolCallRequest(
+            name=str(update.get("title") or update.get("kind") or "tool"),
+            args=raw_input if isinstance(raw_input, dict) else {},
+            metadata={"call_id": update.get("toolCallId")},
+        )
+    if kind == "tool_call_update" and update.get("status") == "completed":
+        result = update.get("content")
+        classification = classify_tool_result(result)
+        return ToolCallComplete(
+            name=str(update.get("title") or "tool"),
+            status=classification.status,
+            result=result,
+            error=classification.error or None,
+            metadata={"call_id": update.get("toolCallId")},
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CursorExecutor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CursorSessionState:
+    """Per-Omnigent-conversation ACP session state."""
+
+    client: AcpClient | None = None
+    session_id: str | None = None
+    system_prompt: str | None = None
+    model: str | None = None
+    has_sent_prompt: bool = False
+
+
+class CursorExecutor(Executor):
+    """Execute agent turns via a persistent ``cursor-agent acp`` session."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        model: str | None = None,
+        cursor_path: str | None = None,
+        api_key: str | None = None,
+        bundle_dir: Path | None = None,
+        agent_name: str | None = None,
+        skills_filter: str | list[str] = "all",
+    ) -> None:
+        """Create a CursorExecutor.
+
+        :param cwd: Working directory the ACP session operates in. ``None``
+            falls back to ``os_env.cwd`` then the process cwd.
+        :param os_env: Optional OS environment / sandbox spec (its ``cwd`` is
+            used when *cwd* is unset).
+        :param model: Cursor model id (e.g. ``"gpt-5"``); a ``databricks-*`` id
+            is dropped in favor of cursor's default. ``None`` uses the default.
+        :param cursor_path: Absolute path to ``cursor-agent``. ``None`` searches PATH.
+        :param api_key: Cursor API key injected as ``CURSOR_API_KEY``. ``None``
+            relies on an inherited key or a prior ``cursor-agent login``.
+        :param bundle_dir: Reserved for future skill wiring; unused in v1.
+        :param agent_name: Reserved for future use.
+        :param skills_filter: Accepted for parity; cursor has no skill mechanism here.
+        :raises ImportError: When ``cursor-agent`` is not found.
+        """
+        resolved = cursor_path or _find_cursor()
+        if not resolved:
+            raise ImportError(
+                "CursorExecutor requires the 'cursor-agent' CLI on PATH. "
+                "Install it with: curl https://cursor.com/install -fsS | bash"
+            )
+        self._cursor_path = resolved
+        self._cwd = cwd or (os_env.cwd if os_env is not None else None)
+        self._os_env_spec = os_env
+        self._model_override = model
+        self._bundle_dir = bundle_dir
+        self._agent_name = agent_name
+        self._skills_filter = skills_filter
+        passthrough = (
+            os_env.sandbox.env_passthrough if os_env is not None and os_env.sandbox else None
+        )
+        self._env: dict[str, str] = _clean_cursor_env(passthrough)
+        if api_key:
+            self._env["CURSOR_API_KEY"] = api_key
+        self._session_states: dict[str, _CursorSessionState] = {}
+
+    def supports_streaming(self) -> bool:
+        return True
+
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    def handles_tools_internally(self) -> bool:
+        return True
+
+    def supports_live_message_queue(self) -> bool:
+        # Unlike claude-sdk / codex / pi, ACP exposes no confirmed mid-turn
+        # steer, so a message can't be injected into a running turn.
+        return False
+
+    def _session_key(self, messages: list[Message]) -> str:
+        if messages:
+            last = messages[-1]
+            if last.get("session_id"):
+                return str(last["session_id"])
+            meta = last.get("metadata", {})
+            if isinstance(meta, dict) and meta.get("session_id"):
+                return str(meta["session_id"])
+        return "__default__"
+
+    def _resolve_model(self, config: ExecutorConfig | None) -> str | None:
+        """Resolve the cursor model; drop non-cursor ``databricks-*`` ids.
+
+        cursor-agent accepts only Cursor model ids (``auto``, ``gpt-5``,
+        ``claude-4.5-sonnet``, ...) and rejects gateway ids, so a
+        ``databricks-*`` model (from a spec authored for another harness) falls
+        back to cursor's default. Returns ``None`` to use cursor's default.
+        """
+        cfg = config or ExecutorConfig()
+        model = cfg.model or self._model_override
+        if model and model.startswith(("databricks-", "databricks/")):
+            logger.debug("CursorExecutor: %r is not a cursor model; using cursor's default", model)
+            return None
+        return model
+
+    async def _close_state(self, state: _CursorSessionState) -> None:
+        if state.client is not None:
+            await state.client.close()
+            state.client = None
+
+    async def close_session(self, session_key: str) -> None:
+        state = self._session_states.pop(session_key, None)
+        if state is not None:
+            await self._close_state(state)
+
+    async def interrupt_session(self, session_key: str) -> bool:
+        state = self._session_states.get(session_key)
+        if state is None:
+            return False
+        if state.client is not None and state.session_id is not None:
+            with contextlib.suppress(Exception):
+                await state.client.cancel(state.session_id)
+        # Always drop the session so the next turn starts fresh — same rationale
+        # as the pi executor (a resumed turn would bypass the runner's interrupt
+        # marker).
+        try:
+            await self.close_session(session_key)
+            return True
+        except Exception as exc:  # noqa: BLE001 — close failures surface as False
+            logger.debug("CursorExecutor: close after interrupt failed: %s", exc)
+            return False
+
+    async def close(self) -> None:
+        for key in list(self._session_states.keys()):
+            await self.close_session(key)
+
+    async def _ensure_session(self, state: _CursorSessionState, model: str | None) -> None:
+        """Spawn the ACP server and open a session if one isn't live."""
+        if state.client is not None and state.client.running:
+            return
+        cwd = self._cwd or os.getcwd()
+        client = AcpClient(
+            self._cursor_path,
+            env=self._env,
+            cwd=cwd,
+            extra_args=["--sandbox", _sandbox_mode(self._os_env_spec)],
+        )
+        await client.start()
+        state.session_id = await client.new_session(cwd=cwd, model=model, mcp_servers=[])
+        state.client = client
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],  # noqa: ARG002 — cursor uses its own native tools in v1
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        session_key = self._session_key(messages)
+        model = self._resolve_model(config)
+        state = self._session_states.setdefault(session_key, _CursorSessionState())
+
+        # The system prompt is baked into the first turn and the model is fixed
+        # at session creation, so a change to either means a fresh ACP session.
+        if state.client is not None and (
+            state.system_prompt != system_prompt or state.model != model
+        ):
+            await self._close_state(state)
+            state = _CursorSessionState()
+            self._session_states[session_key] = state
+        is_first_turn = not state.has_sent_prompt
+        state.system_prompt = system_prompt
+        state.model = model
+
+        try:
+            await self._ensure_session(state, model)
+        except (AcpError, OSError, ImportError) as exc:
+            await self.close_session(session_key)
+            yield ExecutorError(message=f"Failed to start cursor-agent acp: {exc}")
+            return
+
+        prompt = _build_cursor_prompt(
+            messages, is_first_turn=is_first_turn, system_prompt=system_prompt
+        )
+        if not prompt:
+            yield TurnComplete(response=None)
+            return
+
+        assert state.client is not None and state.session_id is not None
+        state.has_sent_prompt = True
+        response_text = ""
+        try:
+            async for kind, payload in state.client.prompt_stream(
+                state.session_id, [{"type": "text", "text": prompt}]
+            ):
+                if kind == "update":
+                    event = _update_to_event(payload)
+                    if event is not None:
+                        if isinstance(event, TextChunk):
+                            response_text += event.text
+                        yield event
+                elif kind == "error":
+                    yield ExecutorError(
+                        message=f"cursor-agent acp error: {payload}", retryable=True
+                    )
+                    return
+                else:  # "result"
+                    # stopReason in payload; ACP reports no token usage, so the
+                    # turn is left unpriced (usage=None).
+                    yield TurnComplete(response=response_text or None, usage=None)
+                    return
+        except AcpError as exc:
+            # The ACP server died mid-turn — drop the session so the next turn
+            # respawns it, and surface a retryable error.
+            stderr = state.client.stderr_tail() if state.client is not None else ""
+            await self.close_session(session_key)
+            suffix = f" Stderr: {stderr}" if stderr else ""
+            yield ExecutorError(
+                message=f"cursor-agent acp turn failed: {exc}{suffix}", retryable=True
+            )

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -1,0 +1,150 @@
+"""
+``harness: cursor`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"cursor"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.cursor_executor.CursorExecutor`, which
+drives a persistent ``cursor-agent acp`` session. Mirrors the codex / pi wraps'
+env-var config flow.
+
+Unlike the gateway-backed harnesses, cursor has NO gateway /
+Databricks-profile env vars: cursor-agent talks only to Cursor's own backend
+(``CURSOR_API_KEY`` / ``cursor-agent login``) and has no custom API base-URL
+override, so there is nothing for the workflow layer to route through the
+Databricks AI gateway.
+
+Env vars read at startup:
+
+- ``HARNESS_CURSOR_MODEL``: Cursor model id, e.g. ``"gpt-5"`` or ``"auto"``.
+  ``None`` lets cursor-agent pick its configured default. A ``databricks-*`` id
+  (from a spec authored for another harness) is dropped by the executor.
+- ``HARNESS_CURSOR_PATH``: absolute path to a ``cursor-agent`` CLI binary.
+  ``None`` searches ``PATH``.
+- ``HARNESS_CURSOR_CWD``: working directory the session operates in.
+  ``None`` falls back to ``os_env.cwd`` then the process cwd.
+- ``HARNESS_CURSOR_API_KEY``: Cursor API key, injected as ``CURSOR_API_KEY``.
+  ``None`` falls back to an inherited ``CURSOR_API_KEY`` or ``cursor-agent login``.
+- ``HARNESS_CURSOR_OS_ENV``: JSON-encoded :class:`OSEnvSpec` (its ``cwd`` is
+  used when ``HARNESS_CURSOR_CWD`` is unset). Defaults to
+  ``caller_process + sandbox=none``.
+- ``HARNESS_CURSOR_SKILLS_FILTER``: JSON ``str | list[str]`` (parity;
+  cursor has no skill mechanism here). Defaults to ``"all"``.
+- ``HARNESS_CURSOR_BUNDLE_DIR`` / ``HARNESS_CURSOR_AGENT_NAME``:
+  reserved for future use.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from omnigent.inner.cursor_executor import CursorExecutor
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+_ENV_MODEL = "HARNESS_CURSOR_MODEL"
+_ENV_PATH = "HARNESS_CURSOR_PATH"
+_ENV_CWD = "HARNESS_CURSOR_CWD"
+_ENV_API_KEY = "HARNESS_CURSOR_API_KEY"
+_ENV_OS_ENV = "HARNESS_CURSOR_OS_ENV"
+_ENV_SKILLS_FILTER = "HARNESS_CURSOR_SKILLS_FILTER"
+_ENV_BUNDLE_DIR = "HARNESS_CURSOR_BUNDLE_DIR"
+_ENV_AGENT_NAME = "HARNESS_CURSOR_AGENT_NAME"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """Resolve the inner-executor :class:`OSEnvSpec` from :data:`_ENV_OS_ENV`.
+
+    Decodes the JSON-encoded dict Omnigent serialized via
+    :func:`dataclasses.asdict`. When the env var is missing or malformed, falls
+    back to ``caller_process + sandbox=none`` — matches the codex/pi wraps'
+    default for specs without an ``os_env:`` block.
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env", _ENV_OS_ENV, exc
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _resolve_skills_filter() -> str | list[str]:
+    """Resolve ``skills_filter`` from :data:`_ENV_SKILLS_FILTER` (defaults ``"all"``)."""
+    raw = os.environ.get(_ENV_SKILLS_FILTER, "").strip()
+    if not raw:
+        return "all"
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _logger.warning(
+            "%s is not valid JSON (%s); falling back to 'all'", _ENV_SKILLS_FILTER, exc
+        )
+        return "all"
+    if isinstance(decoded, str) and decoded in ("all", "none"):
+        return decoded
+    if isinstance(decoded, list) and all(isinstance(s, str) for s in decoded):
+        return decoded
+    _logger.warning(
+        "%s decoded to unsupported shape %r; falling back to 'all'", _ENV_SKILLS_FILTER, decoded
+    )
+    return "all"
+
+
+def _build_cursor_executor() -> Executor:
+    """Construct a :class:`CursorExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first turn, so an
+    absent ``cursor-agent`` surfaces as a request-time error rather than an
+    app-boot crash.
+
+    :raises ImportError: If ``cursor-agent`` isn't on PATH and
+        ``HARNESS_CURSOR_PATH`` isn't set.
+    """
+    bundle_dir_raw = os.environ.get(_ENV_BUNDLE_DIR, "").strip()
+    bundle_dir = Path(bundle_dir_raw) if bundle_dir_raw else None
+    return CursorExecutor(
+        cwd=os.environ.get(_ENV_CWD) or None,
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL) or None,
+        cursor_path=os.environ.get(_ENV_PATH) or None,
+        api_key=os.environ.get(_ENV_API_KEY) or None,
+        bundle_dir=bundle_dir,
+        agent_name=os.environ.get(_ENV_AGENT_NAME, "").strip() or None,
+        skills_filter=_resolve_skills_filter(),
+    )
+
+
+def create_app() -> FastAPI:
+    """Build the cursor harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(executor_factory=_build_cursor_executor)
+    return adapter.build()

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -26,7 +26,7 @@ _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\[\]-]*$")
 # SDK harnesses whose model override lands in the spawn env — must stay
 # in sync with ``_HARNESS_MODEL_ENV_KEY`` in ``omnigent/runner/app.py``.
 _SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
-    {"claude-sdk", "codex", "pi", "openai-agents"}
+    {"claude-sdk", "codex", "pi", "openai-agents", "cursor"}
 )
 
 

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -45,6 +45,12 @@ from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, OPENAI_FAMILY
 # first-run ``run`` flow falls back to it, so it has install metadata too.
 PI_KEY = "pi"
 
+# Cursor authenticates against its own backend via ``cursor-agent login`` (or
+# ``CURSOR_API_KEY``) — it has no provider/gateway credential, and its CLI ships
+# via a curl installer + self-update rather than npm, so it carries an
+# ``install_hint`` instead of a ``package``.
+CURSOR_KEY = "cursor"
+
 
 @dataclass(frozen=True)
 class HarnessInstallSpec:
@@ -54,7 +60,8 @@ class HarnessInstallSpec:
     :param binary: The CLI executable name looked up on ``PATH``, e.g.
         ``"claude"``.
     :param package: The npm package that provides the binary, e.g.
-        ``"@anthropic-ai/claude-code"``.
+        ``"@anthropic-ai/claude-code"``; ``None`` for a CLI not installed via
+        npm (use *install_hint* instead).
     :param login_args: Argv (after *binary*) for the harness's own interactive
         subscription login, e.g. ``("auth", "login", "--claudeai")`` for Claude
         or ``("login",)`` for Codex; ``None`` when the harness has no login
@@ -65,14 +72,22 @@ class HarnessInstallSpec:
         in?" status command, e.g. ``("auth", "status")`` (Claude, prints JSON
         with a ``loggedIn`` field) / ``("login", "status")`` (Codex, exits 0
         when logged in); ``None`` when the harness has no status command.
+    :param install_hint: Shell command shown to the user to install the CLI
+        when it has no npm *package* (e.g. cursor-agent's curl installer);
+        ``None`` for npm-installable harnesses.
+    :param login_status_key: The boolean field in the status command's JSON
+        output that reports login state, e.g. ``"isAuthenticated"`` for
+        cursor-agent. ``None`` falls back to ``"loggedIn"``, then the exit code.
     """
 
     display: str
     binary: str
-    package: str
+    package: str | None
     login_args: tuple[str, ...] | None = None
     logout_args: tuple[str, ...] | None = None
     status_args: tuple[str, ...] | None = None
+    install_hint: str | None = None
+    login_status_key: str | None = None
 
 
 # Keyed by harness family (Claude=anthropic, Codex=openai) plus the pi
@@ -98,6 +113,16 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         status_args=("login", "status"),
     ),
     PI_KEY: HarnessInstallSpec("Pi", "pi", "@earendil-works/pi-coding-agent"),
+    CURSOR_KEY: HarnessInstallSpec(
+        "Cursor",
+        "cursor-agent",
+        package=None,
+        login_args=("login",),
+        logout_args=("logout",),
+        status_args=("status", "--format", "json"),
+        install_hint="curl https://cursor.com/install -fsS | bash",
+        login_status_key="isAuthenticated",
+    ),
 }
 
 
@@ -106,13 +131,15 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
 # :data:`_HARNESS_INSTALL` family key. Only the CLI-backed harnesses appear
 # here — the ones that cannot launch without a binary on ``PATH``:
 # ``claude-native`` wraps the ``claude`` CLI, ``codex-native`` the ``codex``
-# CLI, and ``pi`` the ``pi`` CLI. SDK-based harnesses (``claude-sdk``,
-# ``codex``, ``openai-agents-sdk``, ``databricks_supervisor``) run in-process
-# and are deliberately absent, so they resolve to "no CLI required".
+# CLI, ``pi`` the ``pi`` CLI, and ``cursor`` the ``cursor-agent`` CLI.
+# SDK-based harnesses (``claude-sdk``, ``codex``, ``openai-agents-sdk``,
+# ``databricks_supervisor``) run in-process and are deliberately absent, so
+# they resolve to "no CLI required".
 _HARNESS_NAME_TO_KEY: dict[str, str] = {
     "claude-native": ANTHROPIC_FAMILY,
     "codex-native": OPENAI_FAMILY,
     PI_KEY: PI_KEY,
+    CURSOR_KEY: CURSOR_KEY,
 }
 
 
@@ -191,8 +218,13 @@ def harness_install_command(key: str) -> list[str]:
         ``["npm", "install", "-g", "@anthropic-ai/claude-code"]``.
     :raises KeyError: If *key* has no install spec (caller should gate on
         :func:`harness_install_spec`).
+    :raises ValueError: If *key* has a spec but no npm ``package`` (a CLI
+        installed out-of-band, e.g. cursor-agent); show its ``install_hint``.
     """
-    return ["npm", "install", "-g", _HARNESS_INSTALL[key].package]
+    package = _HARNESS_INSTALL[key].package
+    if package is None:
+        raise ValueError(f"{key!r} has no npm package; show its install_hint instead")
+    return ["npm", "install", "-g", package]
 
 
 def install_harness_cli(key: str) -> bool:
@@ -208,6 +240,11 @@ def install_harness_cli(key: str) -> bool:
         present), ``False`` if npm is missing or the install failed.
     :raises KeyError: If *key* has no install spec.
     """
+    spec = _HARNESS_INSTALL.get(key)
+    if spec is not None and spec.package is None:
+        # Non-npm CLI (e.g. cursor-agent ships via a curl installer); there is
+        # no auto-install path, so the caller shows its ``install_hint``.
+        return False
     if shutil.which("npm") is None:
         return False
     cmd = harness_install_command(key)
@@ -262,8 +299,9 @@ def harness_cli_logged_in(key: str) -> bool:
         payload = json.loads(result.stdout)
     except (json.JSONDecodeError, ValueError):
         return result.returncode == 0
-    if isinstance(payload, dict) and "loggedIn" in payload:
-        return bool(payload["loggedIn"])
+    status_key = spec.login_status_key or "loggedIn"
+    if isinstance(payload, dict) and status_key in payload:
+        return bool(payload[status_key])
     return result.returncode == 0
 
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -25,7 +25,7 @@ that would actually work.
 from __future__ import annotations
 
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
-from omnigent.onboarding.harness_install import PI_KEY, harness_cli_installed
+from omnigent.onboarding.harness_install import CURSOR_KEY, PI_KEY, harness_cli_installed
 from omnigent.onboarding.provider_config import (
     _EXECUTOR_TYPE_HARNESS_ALIASES,
     _HARNESS_FAMILY,
@@ -88,6 +88,11 @@ def harness_is_configured(harness: str) -> bool:
     canonical = _canonical_harness(harness)
     if canonical in _SDK_HARNESSES:
         return True
+    if canonical == CURSOR_KEY:
+        # Cursor wraps the ``cursor-agent`` CLI but authenticates against its
+        # own backend; the daemon can only verify the binary is on PATH (login
+        # state needs a subprocess), so gate on install like the other CLIs.
+        return harness_cli_installed(CURSOR_KEY)
     if canonical not in _HARNESS_FAMILY and canonical != PI_SURFACE:
         # Unknown harness — the daemon has no install metadata for it, so
         # it can't assess readiness. Fail open (custom/newer harnesses,
@@ -113,4 +118,5 @@ def configured_harness_map() -> dict[str, bool]:
     spellings.update(_EXECUTOR_TYPE_HARNESS_ALIASES)
     spellings.update(HARNESS_ALIASES)
     spellings.add(PI_SURFACE)
+    spellings.add(CURSOR_KEY)
     return {spelling: harness_is_configured(spelling) for spelling in spellings}

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11658,6 +11658,7 @@ _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     "codex": "HARNESS_CODEX_MODEL",
     "pi": "HARNESS_PI_MODEL",
     "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",
+    "cursor": "HARNESS_CURSOR_MODEL",
 }
 
 
@@ -11687,6 +11688,7 @@ def _build_spawn_env_from_spec(
         from omnigent.runtime.workflow import (
             _build_claude_sdk_spawn_env,
             _build_codex_spawn_env,
+            _build_cursor_spawn_env,
             _build_openai_agents_sdk_spawn_env,
             _build_pi_spawn_env,
         )
@@ -11699,6 +11701,8 @@ def _build_spawn_env_from_spec(
             env = _build_pi_spawn_env(spec, workdir=workdir)
         elif harness == "openai-agents":
             env = _build_openai_agents_sdk_spawn_env(spec)
+        elif harness == "cursor":
+            env = _build_cursor_spawn_env(spec, workdir=workdir)
         else:
             # claude-native / codex-native / unknown — no spawn-env.
             return None

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -57,6 +57,9 @@ _HARNESS_MODULES: dict[str, str] = {
     # the underlying SDK package is ``openai-agents`` and the
     # executor class is :class:`OpenAIAgentsSDKExecutor`.
     "openai-agents": "omnigent.inner.openai_agents_sdk_harness",
+    # cursor harness wrap (Cursor's ``cursor-agent`` CLI, headless). See
+    # omnigent/inner/cursor_harness.py.
+    "cursor": "omnigent.inner.cursor_harness",
     # Supervisor harness wrap. See
     # omnigent/inner/databricks_supervisor_harness.py. Drives the Databricks
     # Agent Bricks Supervisor API at

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1391,6 +1391,57 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
     return env
 
 
+def _build_cursor_spawn_env(
+    spec: AgentSpec,
+    *,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """
+    Build the env-var dict the cursor harness wrap reads.
+
+    Maps spec.executor fields → the ``HARNESS_CURSOR_*`` env vars defined
+    in ``omnigent/inner/cursor_harness.py``. Unlike the gateway-backed
+    builders (claude-sdk / codex / pi / openai-agents), there is NO gateway or
+    Databricks-profile resolution: cursor-agent talks only to Cursor's own
+    backend (``CURSOR_API_KEY`` / ``cursor-agent login``) and has no custom API
+    base-URL override, so it never routes through the Databricks AI gateway.
+    That is also why cursor is intentionally absent from
+    :data:`AgentHarnessType` and the gateway/ucode dicts above.
+
+    Auth: an explicit ``executor.auth: {type: api_key, api_key: ...}`` is
+    forwarded as ``HARNESS_CURSOR_API_KEY`` (cursor-agent reads it as
+    ``CURSOR_API_KEY``). With no api-key auth the harness falls back to an
+    inherited ``CURSOR_API_KEY`` or an existing ``cursor-agent login`` — a
+    ``DatabricksAuth`` profile does not apply to cursor and is ignored.
+
+    :param spec: The agent spec.
+    :param workdir: The bundle's on-disk path, threaded as
+        ``HARNESS_CURSOR_BUNDLE_DIR``.
+    :returns: A dict of env-var overrides for
+        :meth:`HarnessProcessManager.get_client(env=...)`.
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_CURSOR_MODEL"] = model
+    # Only an explicit api-key auth maps to cursor's CURSOR_API_KEY; Databricks
+    # / provider auth has no cursor equivalent and is left for cursor's own
+    # login / inherited CURSOR_API_KEY to satisfy.
+    if isinstance(spec.executor.auth, ApiKeyAuth):
+        env["HARNESS_CURSOR_API_KEY"] = spec.executor.auth.api_key
+    # Always set so the wrap doesn't fall back to ``"all"`` and override an
+    # explicit ``skills: none`` from the spec (parity with the peer builders).
+    env["HARNESS_CURSOR_SKILLS_FILTER"] = json.dumps(spec.skills_filter)
+    if spec.name:
+        env["HARNESS_CURSOR_AGENT_NAME"] = spec.name
+    if workdir is not None:
+        env["HARNESS_CURSOR_BUNDLE_DIR"] = str(workdir)
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_CURSOR_OS_ENV"] = os_env_payload
+    return env
+
+
 def _serialize_os_env(value: OSEnvSpec | None) -> str | None:
     """
     Encode an :class:`OSEnvSpec` for the wrap's env-var input.

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -78,6 +78,7 @@ OMNIGENT_HARNESSES = frozenset(
         "claude-sdk",
         "codex",
         "codex-native",
+        "cursor",
         "databricks_supervisor",
         "openai-agents",
         "open-responses",

--- a/tests/e2e/omnigent/test_per_harness_cursor.py
+++ b/tests/e2e/omnigent/test_per_harness_cursor.py
@@ -1,0 +1,105 @@
+"""Per-harness live characterization test — cursor harness, one-shot prompt.
+
+Runs ``omnigent run hello_world.yaml --harness cursor -p "..."`` as a real
+subprocess and asserts structural invariants (exit 0, a non-trivial assistant
+reply). This is the end-to-end gate for the cursor harness: the full path
+from CLI parse → spec materialize → spawn the ``cursor`` harness subprocess
+→ :class:`CursorExecutor` driving ``cursor-agent --print --output-format
+stream-json`` → stream-json parse → ``TurnComplete`` → the ``-p`` one-shot
+printer.
+
+**Prerequisite (skipped when absent):**
+- The ``cursor-agent`` CLI on PATH (``curl https://cursor.com/install -fsS | bash``),
+  authenticated via ``cursor-agent login`` or ``CURSOR_API_KEY``.
+
+Unlike the other per-harness e2e tests, cursor-agent talks only to Cursor's own
+backend and needs a Cursor account — there is no Databricks-gateway path, so
+this test does NOT use ``patched_databrickscfg`` / ``omnigent_credentials_env``.
+Because cursor-agent is an optional external dependency the Omnigent CI does not
+provision, the test **skips** (rather than fails) when the binary is absent so
+the e2e shards stay green; it runs for real wherever cursor-agent is installed
+and authenticated (auth is via the ambient ``cursor-agent login`` / env, which
+this run inherits, so a missing login surfaces as a real failure, not a skip).
+
+**What breaks if this fails (with prerequisites present):**
+- ``CursorExecutor`` regresses (subprocess orchestration, the stream-json →
+  ExecutorEvent translation, session resume, or the system-prompt injection).
+- The ``cursor-agent`` CLI changes its ``--print`` / ``--output-format
+  stream-json`` contract or its event schema.
+- ``omnigent.cli`` for the ``-p`` one-shot path stops printing assistant text
+  to stdout on turn complete, or harness dispatch for ``cursor`` regresses.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+_HARNESS = "cursor"
+_PROMPT = "say hi in 5 words"
+
+# Minimum assistant-text length. Anything longer than "hi" proves the turn
+# produced a genuine model reply (not an empty response or an error banner).
+_MIN_ASSISTANT_CHARS = 4
+
+# cursor-agent cold-starts a session and round-trips to Cursor's backend; 180s
+# matches the headroom the other coding-agent harnesses allow on CI hosts.
+_RUN_TIMEOUT_SEC = 180
+
+
+def test_per_harness_cursor_one_shot(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+) -> None:
+    """``omnigent run hello_world.yaml --harness cursor -p <prompt>`` works.
+
+    :param omnigent_python: Interpreter with omnigent installed and importable.
+    :param omnigent_repo_root: Cwd for the subprocess so the YAML spec and
+        example tool modules resolve on sys.path.
+    """
+    if which("cursor-agent") is None:
+        pytest.skip(
+            "cursor prerequisite missing: the 'cursor-agent' CLI is not on "
+            "PATH (install via 'curl https://cursor.com/install -fsS | bash'). "
+            "cursor-agent is an optional external dependency, so this live gate "
+            "is skipped rather than failed when absent."
+        )
+
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+
+    # cursor-agent needs PATH (to find its bundled runtime) and CURSOR_API_KEY /
+    # ~/.cursor login from the ambient environment, so pass os.environ through.
+    result = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(yaml_path),
+            "--harness",
+            _HARNESS,
+            "-p",
+            _PROMPT,
+            "--no-log",
+            "--no-session",
+        ],
+        env=dict(os.environ),
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+    assistant_text = result.stdout.strip()
+    assert result.returncode == 0, (
+        f"cursor run exited {result.returncode}.\n\n"
+        f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    assert len(assistant_text) >= _MIN_ASSISTANT_CHARS, (
+        f"cursor assistant text shorter than {_MIN_ASSISTANT_CHARS} chars; "
+        f"got {assistant_text!r}\n\nstderr:\n{result.stderr!r}"
+    )

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -179,10 +179,17 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     them through this matrix would hang or crash. Their e2e coverage
     is via native launcher smoke tests (tracked separately as
     native-launcher PTY/REPL smoke tests).
+
+    ``cursor`` is excluded because this matrix authenticates through
+    the Databricks gateway/profile, while cursor-agent talks only to
+    Cursor's own backend (``CURSOR_API_KEY``) and rejects gateway
+    model ids. Its live coverage is the gated row in
+    ``tests/e2e/omnigent/test_per_harness_cursor.py``.
     """
     expected_live_harnesses = set(OMNIGENT_HARNESSES).intersection(_HARNESS_MODULES) - {
         "claude-native",
         "codex-native",
+        "cursor",
     }
     # ``supervisor`` is registered in ``_HARNESS_MODULES`` but is not
     # a coding-agent harness accepted by the ``run --harness`` compat

--- a/tests/inner/test_cursor_acp.py
+++ b/tests/inner/test_cursor_acp.py
@@ -1,0 +1,244 @@
+"""Tests for :class:`omnigent.inner.cursor_acp.AcpClient`.
+
+Drives the client against a bidirectional fake ``cursor-agent acp`` process:
+the fake parses each JSON-RPC request the client writes to stdin and feeds back
+correlated responses (and ``session/update`` notifications) on stdout, so the
+client's id correlation, notification queue, and server-request auto-reply are
+exercised without a real cursor-agent. The subprocess spawn is stubbed via the
+``cursor_acp._create_subprocess_exec`` seam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+from omnigent.inner import cursor_acp
+from omnigent.inner.cursor_acp import AcpClient, AcpError, _pick_allow_option
+
+Responder = Callable[[dict[str, Any]], list[str]]
+
+
+class _FeedableReader:
+    """An async byte stream the fake process feeds on demand."""
+
+    def __init__(self) -> None:
+        self._q: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def feed(self, data: bytes) -> None:
+        self._q.put_nowait(data)
+
+    def feed_eof(self) -> None:
+        self._q.put_nowait(b"")
+
+    async def read(self, _n: int = -1) -> bytes:
+        return await self._q.get()
+
+
+class _FakeStdin:
+    """Captures the client's writes and invokes a responder per JSON-RPC line."""
+
+    def __init__(self, on_message: Callable[[dict[str, Any]], None]) -> None:
+        self._buf = bytearray()
+        self._on_message = on_message
+        self.sent: list[dict[str, Any]] = []
+
+    def write(self, data: bytes) -> None:
+        self._buf.extend(data)
+        while b"\n" in self._buf:
+            idx = self._buf.find(b"\n")
+            line = bytes(self._buf[:idx])
+            del self._buf[: idx + 1]
+            msg = json.loads(line.decode("utf-8"))
+            self.sent.append(msg)
+            self._on_message(msg)
+
+    async def drain(self) -> None:
+        pass
+
+
+class _FakeAcpProcess:
+    def __init__(self, responder: Responder) -> None:
+        self.stdout = _FeedableReader()
+        self.stderr = _FeedableReader()
+        self.stderr.feed_eof()
+        self.returncode: int | None = None
+        self.pid = 4242
+        self._responder = responder
+        self.stdin = _FakeStdin(self._on_message)
+
+    def _on_message(self, msg: dict[str, Any]) -> None:
+        # Only client→server *requests* (those with a method) get responses;
+        # replies the client sends to our server-requests are just recorded.
+        if "method" in msg:
+            for line in self._responder(msg):
+                self.stdout.feed((line + "\n").encode("utf-8"))
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        return self.returncode or 0
+
+
+def _resp(rid: Any, result: dict[str, Any]) -> str:
+    return json.dumps({"jsonrpc": "2.0", "id": rid, "result": result})
+
+
+def _notif(update: dict[str, Any]) -> str:
+    # Real ACP shape: the update object is nested under params.update.
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {"sessionId": "s", "update": update},
+        }
+    )
+
+
+def _patch_spawn(monkeypatch: Any, responder: Responder) -> _FakeAcpProcess:
+    proc = _FakeAcpProcess(responder)
+
+    async def _fake_spawn(*_args: Any, **_kwargs: Any) -> _FakeAcpProcess:
+        return proc
+
+    monkeypatch.setattr(cursor_acp, "_create_subprocess_exec", _fake_spawn)
+    return proc
+
+
+def _make_client() -> AcpClient:
+    return AcpClient("/usr/bin/cursor-agent", env={"PATH": "/usr/bin"}, cwd="/tmp/x")
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_pick_allow_option() -> None:
+    assert _pick_allow_option([{"optionId": "allow_once", "kind": "allow_once"}]) == "allow_once"
+    assert _pick_allow_option([{"optionId": "x", "kind": "reject"}]) == "x"  # first fallback
+    assert _pick_allow_option([]) == "allow"
+
+
+async def test_handshake_session_and_prompt(monkeypatch: Any) -> None:
+    def responder(req: dict[str, Any]) -> list[str]:
+        rid, method = req.get("id"), req.get("method")
+        if method == "initialize":
+            return [_resp(rid, {"agentCapabilities": {}, "authMethods": []})]
+        if method == "session/new":
+            return [_resp(rid, {"sessionId": "sess-1"})]
+        if method == "session/prompt":
+            return [
+                _notif({"sessionUpdate": "agent_message_chunk", "content": {"text": "Hi"}}),
+                _notif({"sessionUpdate": "agent_message_chunk", "content": {"text": " there"}}),
+                _resp(rid, {"stopReason": "end_turn"}),
+            ]
+        return []
+
+    _patch_spawn(monkeypatch, responder)
+    client = _make_client()
+    try:
+        init = await client.start()
+        assert "agentCapabilities" in init
+        sid = await client.new_session(cwd="/tmp/x", model="gpt-5.4-mini")
+        assert sid == "sess-1"
+
+        items = [
+            item async for item in client.prompt_stream(sid, [{"type": "text", "text": "hi"}])
+        ]
+    finally:
+        await client.close()
+
+    updates = [p for kind, p in items if kind == "update"]
+    results = [p for kind, p in items if kind == "result"]
+    assert [u["content"]["text"] for u in updates] == ["Hi", " there"]
+    assert len(results) == 1 and results[0]["stopReason"] == "end_turn"
+
+
+async def test_session_new_requires_session_id(monkeypatch: Any) -> None:
+    def responder(req: dict[str, Any]) -> list[str]:
+        if req.get("method") == "initialize":
+            return [_resp(req.get("id"), {})]
+        if req.get("method") == "session/new":
+            return [_resp(req.get("id"), {})]  # no sessionId
+        return []
+
+    _patch_spawn(monkeypatch, responder)
+    client = _make_client()
+    try:
+        await client.start()
+        try:
+            await client.new_session(cwd="/tmp/x", model=None)
+            raise AssertionError("expected AcpError")
+        except AcpError:
+            pass
+    finally:
+        await client.close()
+
+
+async def test_permission_request_auto_allowed(monkeypatch: Any) -> None:
+    def responder(req: dict[str, Any]) -> list[str]:
+        method = req.get("method")
+        if method == "initialize":
+            return [_resp(req.get("id"), {})]
+        if method == "session/new":
+            return [_resp(req.get("id"), {"sessionId": "s"})]
+        if method == "session/prompt":
+            # Server asks for permission mid-turn, then completes.
+            return [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 999,
+                        "method": "session/request_permission",
+                        "params": {
+                            "options": [
+                                {"optionId": "allow_once", "kind": "allow_once"},
+                                {"optionId": "reject", "kind": "reject_once"},
+                            ]
+                        },
+                    }
+                ),
+                _resp(req.get("id"), {"stopReason": "end_turn"}),
+            ]
+        return []
+
+    proc = _patch_spawn(monkeypatch, responder)
+    client = _make_client()
+    try:
+        await client.start()
+        sid = await client.new_session(cwd="/tmp/x", model=None)
+        _ = [item async for item in client.prompt_stream(sid, [{"type": "text", "text": "go"}])]
+    finally:
+        await client.close()
+
+    # The client auto-replied to the permission request selecting an allow option.
+    replies = [m for m in proc.stdin.sent if m.get("id") == 999 and "result" in m]
+    assert len(replies) == 1
+    assert replies[0]["result"]["outcome"]["optionId"] == "allow_once"
+
+
+async def test_request_failure_raises_acp_error(monkeypatch: Any) -> None:
+    def responder(req: dict[str, Any]) -> list[str]:
+        if req.get("method") == "initialize":
+            return [
+                json.dumps(
+                    {"jsonrpc": "2.0", "id": req.get("id"), "error": {"code": -1, "message": "no"}}
+                )
+            ]
+        return []
+
+    _patch_spawn(monkeypatch, responder)
+    client = _make_client()
+    try:
+        try:
+            await client.start()
+            raise AssertionError("expected AcpError")
+        except AcpError:
+            pass
+    finally:
+        await client.close()

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1,0 +1,335 @@
+"""Tests for :class:`omnigent.inner.cursor_executor.CursorExecutor`.
+
+The cursor harness drives a persistent ``cursor-agent acp`` session. The
+ACP client is replaced with a scripted fake (so no ``cursor-agent`` process
+runs), letting us exercise the executor's ``session/update`` → ExecutorEvent
+mapping, persistent-session reuse across turns, the ``databricks-*`` model drop,
+and interrupt/lifecycle. The real ACP wire protocol is covered separately in
+``tests/inner/test_cursor_acp.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner import cursor_executor as ce
+from omnigent.inner.cursor_executor import (
+    CursorExecutor,
+    _CursorSessionState,
+    _sandbox_mode,
+    _update_to_event,
+)
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import (
+    ExecutorError,
+    Message,
+    ReasoningChunk,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    TurnComplete,
+)
+
+
+def _user(content: str, session_id: str = "conv1") -> Message:
+    return {"role": "user", "content": content, "session_id": session_id}
+
+
+def _make_executor(**kwargs: Any) -> CursorExecutor:
+    with patch(
+        "omnigent.inner.cursor_executor._find_cursor",
+        return_value="/usr/bin/cursor-agent",
+    ):
+        return CursorExecutor(**kwargs)
+
+
+def _patch_acp(
+    monkeypatch: pytest.MonkeyPatch, scripts: list[list[tuple[str, Any]]]
+) -> dict[str, Any]:
+    """Replace ``AcpClient`` with a fake that replays *scripts* (one per prompt).
+
+    :returns: A state dict capturing ``new_session_models`` (the model passed to
+        each ``session/new``) and ``cancelled`` (whether ``cancel`` was called).
+    """
+    state: dict[str, Any] = {
+        "new_session_models": [],
+        "cancelled": False,
+        "closed": 0,
+        "extra_args": None,
+    }
+
+    class _FakeAcp:
+        def __init__(
+            self,
+            path: str,
+            *,
+            env: dict[str, str],
+            cwd: str | None,
+            extra_args: list[str] | None = None,
+        ) -> None:
+            self.running = False
+            state["extra_args"] = extra_args
+
+        async def start(self) -> dict[str, Any]:
+            self.running = True
+            return {"agentCapabilities": {}}
+
+        async def new_session(
+            self, *, cwd: str, model: str | None, mcp_servers: Any = None
+        ) -> str:
+            state["new_session_models"].append(model)
+            return "sess-1"
+
+        async def prompt_stream(
+            self, session_id: str, blocks: Any
+        ) -> AsyncIterator[tuple[str, Any]]:
+            for item in scripts.pop(0):
+                yield item
+
+        async def cancel(self, session_id: str) -> None:
+            state["cancelled"] = True
+
+        async def close(self) -> None:
+            self.running = False
+            state["closed"] += 1
+
+        def stderr_tail(self) -> str:
+            return ""
+
+    monkeypatch.setattr(ce, "AcpClient", _FakeAcp)
+    return state
+
+
+def _chunk(kind: str, text: str) -> tuple[str, dict[str, Any]]:
+    return ("update", {"sessionUpdate": kind, "content": {"type": "text", "text": text}})
+
+
+# ---------------------------------------------------------------------------
+# Pure mapping
+# ---------------------------------------------------------------------------
+
+
+def test_update_to_event_maps_message_thought_and_tools() -> None:
+    assert isinstance(
+        _update_to_event({"sessionUpdate": "agent_message_chunk", "content": {"text": "hi"}}),
+        TextChunk,
+    )
+    thought = _update_to_event(
+        {"sessionUpdate": "agent_thought_chunk", "content": {"text": "hmm"}}
+    )
+    assert isinstance(thought, ReasoningChunk) and thought.event_type == "reasoning_text"
+    req = _update_to_event(
+        {"sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Read", "rawInput": {"p": 1}}
+    )
+    assert isinstance(req, ToolCallRequest) and req.name == "Read" and req.args == {"p": 1}
+    done = _update_to_event(
+        {"sessionUpdate": "tool_call_update", "status": "completed", "title": "Read"}
+    )
+    assert isinstance(done, ToolCallComplete)
+    # Updates with nothing to surface are skipped.
+    assert _update_to_event({"sessionUpdate": "available_commands_update"}) is None
+    assert _update_to_event({"sessionUpdate": "current_mode_update"}) is None
+
+
+def test_sandbox_mode_maps_os_env() -> None:
+    assert _sandbox_mode(None) == "disabled"
+    assert (
+        _sandbox_mode(OSEnvSpec(type="caller_process", sandbox=OSEnvSandboxSpec(type="none")))
+        == "disabled"
+    )
+    assert (
+        _sandbox_mode(
+            OSEnvSpec(type="caller_process", sandbox=OSEnvSandboxSpec(type="linux_bwrap"))
+        )
+        == "enabled"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_missing_cursor_raises_import_error() -> None:
+    with patch("omnigent.inner.cursor_executor._find_cursor", return_value=None):
+        with pytest.raises(ImportError, match="cursor-agent"):
+            CursorExecutor()
+
+
+def test_api_key_injected_into_env() -> None:
+    executor = _make_executor(api_key="cur_xyz")
+    assert executor._env.get("CURSOR_API_KEY") == "cur_xyz"
+
+
+def test_clean_cursor_env_allows_cursor_prefix_denies_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "cur_secret")
+    monkeypatch.setenv("FAKE_HOST_SECRET", "PWNED")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "leak")
+    env = ce._clean_cursor_env()
+    assert env.get("CURSOR_API_KEY") == "cur_secret"
+    assert "FAKE_HOST_SECRET" not in env
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+    assert "PATH" in env
+
+
+# ---------------------------------------------------------------------------
+# run_turn
+# ---------------------------------------------------------------------------
+
+
+async def test_run_turn_streams_and_completes(monkeypatch: pytest.MonkeyPatch) -> None:
+    script = [
+        ("update", {"sessionUpdate": "agent_thought_chunk", "content": {"text": "planning"}}),
+        _chunk("agent_message_chunk", "Hello "),
+        _chunk("agent_message_chunk", "world"),
+        ("result", {"stopReason": "end_turn"}),
+    ]
+    _patch_acp(monkeypatch, [script])
+    executor = _make_executor()
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    assert [e.text for e in events if isinstance(e, TextChunk)] == ["Hello ", "world"]
+    reasoning = [e for e in events if isinstance(e, ReasoningChunk)]
+    assert len(reasoning) == 1 and reasoning[0].delta == "planning"
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    assert completes[0].response == "Hello world"
+    assert completes[0].usage is None
+
+
+async def test_session_reused_across_turns(monkeypatch: pytest.MonkeyPatch) -> None:
+    scripts = [
+        [_chunk("agent_message_chunk", "one"), ("result", {"stopReason": "end_turn"})],
+        [_chunk("agent_message_chunk", "two"), ("result", {"stopReason": "end_turn"})],
+    ]
+    state = _patch_acp(monkeypatch, scripts)
+    executor = _make_executor()
+    try:
+        _ = [e async for e in executor.run_turn([_user("first")], [], "SYS")]
+        _ = [e async for e in executor.run_turn([_user("second")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    # The session is created once (session/new) and reused on turn 2.
+    assert len(state["new_session_models"]) == 1
+
+
+async def test_databricks_model_dropped_at_session_new(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _patch_acp(
+        monkeypatch,
+        [[_chunk("agent_message_chunk", "ok"), ("result", {"stopReason": "end_turn"})]],
+    )
+    executor = _make_executor(model="databricks-claude-sonnet-4-6")
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    # A non-cursor databricks id is dropped → session/new gets model=None.
+    assert state["new_session_models"] == [None]
+
+
+async def test_run_turn_passes_sandbox_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _patch_acp(
+        monkeypatch,
+        [[_chunk("agent_message_chunk", "ok"), ("result", {"stopReason": "end_turn"})]],
+    )
+    executor = _make_executor(
+        os_env=OSEnvSpec(type="caller_process", sandbox=OSEnvSandboxSpec(type="linux_bwrap"))
+    )
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    # os_env sandbox → cursor's own --sandbox mode on the acp launch.
+    assert state["extra_args"] == ["--sandbox", "enabled"]
+
+
+async def test_cursor_model_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _patch_acp(
+        monkeypatch,
+        [[_chunk("agent_message_chunk", "ok"), ("result", {"stopReason": "end_turn"})]],
+    )
+    executor = _make_executor(model="gpt-5.4-mini")
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    assert state["new_session_models"] == ["gpt-5.4-mini"]
+
+
+async def test_tool_call_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    script = [
+        (
+            "update",
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "title": "Read",
+                "rawInput": {"path": "a.txt"},
+            },
+        ),
+        (
+            "update",
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "title": "Read",
+                "status": "completed",
+                "content": [{"type": "text", "text": "data"}],
+            },
+        ),
+        ("result", {"stopReason": "end_turn"}),
+    ]
+    _patch_acp(monkeypatch, [script])
+    executor = _make_executor()
+    try:
+        events = [e async for e in executor.run_turn([_user("read")], [], "SYS")]
+    finally:
+        await executor.close()
+    assert any(isinstance(e, ToolCallRequest) and e.name == "Read" for e in events)
+    assert any(isinstance(e, ToolCallComplete) for e in events)
+
+
+async def test_error_result_yields_executor_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_acp(monkeypatch, [[("error", {"code": -1, "message": "boom"})]])
+    executor = _make_executor()
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1 and errors[0].retryable is True
+
+
+async def test_interrupt_cancels_and_drops_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _patch_acp(monkeypatch, [])
+    executor = _make_executor()
+
+    class _Stub:
+        running = True
+
+        async def cancel(self, session_id: str) -> None:
+            state["cancelled"] = True
+
+        async def close(self) -> None:
+            pass
+
+    executor._session_states["conv1"] = _CursorSessionState(client=_Stub(), session_id="s")  # type: ignore[arg-type]
+    result = await executor.interrupt_session("conv1")
+    assert result is True
+    assert state["cancelled"] is True
+    assert "conv1" not in executor._session_states
+
+
+async def test_interrupt_unknown_session_returns_false() -> None:
+    executor = _make_executor()
+    assert await executor.interrupt_session("nope") is False

--- a/tests/inner/test_cursor_harness.py
+++ b/tests/inner/test_cursor_harness.py
@@ -1,0 +1,135 @@
+"""Tests for the ``harness: cursor`` wrap shape.
+
+Verifies the registry entry (+ ``cursor`` alias), FastAPI routes, and
+env-var-driven lazy executor construction. The inner ``CursorExecutor.__init__``
+is mocked so the test runs without a ``cursor-agent`` binary.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner import cursor_harness
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+
+
+def test_harness_module_registered_in_module_registry() -> None:
+    assert _HARNESS_MODULES.get("cursor") == "omnigent.inner.cursor_harness"
+    assert _HARNESS_MODULES.get("cursor") == "omnigent.inner.cursor_harness"
+
+
+def test_create_app_returns_fastapi_with_required_routes() -> None:
+    app = cursor_harness.create_app()
+    paths = {route.path for route in app.routes}  # type: ignore[attr-defined]
+    assert "/health" in paths
+    assert "/v1/sessions/{conversation_id}/events" in paths
+
+
+def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_CURSOR_MODEL", "gpt-5")
+    monkeypatch.setenv("HARNESS_CURSOR_PATH", "/usr/local/bin/cursor-agent")
+    monkeypatch.setenv("HARNESS_CURSOR_CWD", "/tmp/test-cwd")
+    monkeypatch.setenv("HARNESS_CURSOR_API_KEY", "cur_secret")
+    monkeypatch.setenv("HARNESS_CURSOR_AGENT_NAME", "demo")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.cursor_harness.CursorExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_harness._build_cursor_executor()
+
+    assert captured["model"] == "gpt-5"
+    assert captured["cursor_path"] == "/usr/local/bin/cursor-agent"
+    assert captured["cwd"] == "/tmp/test-cwd"
+    assert captured["api_key"] == "cur_secret"
+    assert captured["agent_name"] == "demo"
+    # Default os_env when unset: caller_process + sandbox=none.
+    os_env_value = captured["os_env"]
+    assert os_env_value is not None
+    assert os_env_value.type == "caller_process"
+    assert os_env_value.sandbox is not None
+    assert os_env_value.sandbox.type == "none"
+
+
+def test_executor_factory_unset_optional_env_passes_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "HARNESS_CURSOR_MODEL",
+        "HARNESS_CURSOR_PATH",
+        "HARNESS_CURSOR_CWD",
+        "HARNESS_CURSOR_API_KEY",
+        "HARNESS_CURSOR_BUNDLE_DIR",
+        "HARNESS_CURSOR_AGENT_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.cursor_harness.CursorExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_harness._build_cursor_executor()
+
+    assert captured["model"] is None
+    assert captured["cursor_path"] is None
+    assert captured["cwd"] is None
+    assert captured["api_key"] is None
+    assert captured["bundle_dir"] is None
+    assert captured["agent_name"] is None
+    assert captured["skills_filter"] == "all"
+
+
+def test_executor_factory_decodes_os_env_and_skills(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "HARNESS_CURSOR_OS_ENV",
+        json.dumps({"type": "caller_process", "cwd": "/srv/app", "sandbox": {"type": "none"}}),
+    )
+    monkeypatch.setenv("HARNESS_CURSOR_SKILLS_FILTER", '["a","b"]')
+    monkeypatch.setenv("HARNESS_CURSOR_BUNDLE_DIR", "/tmp/bundle")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.cursor_harness.CursorExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_harness._build_cursor_executor()
+
+    assert captured["os_env"].cwd == "/srv/app"
+    assert captured["skills_filter"] == ["a", "b"]
+    assert captured["bundle_dir"] == Path("/tmp/bundle")
+
+
+def test_malformed_os_env_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_CURSOR_OS_ENV", "{not-json")
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["os_env"] = kwargs["os_env"]
+
+    with patch(
+        "omnigent.inner.cursor_harness.CursorExecutor.__init__",
+        _fake_init,
+    ):
+        cursor_harness._build_cursor_executor()
+
+    assert captured["os_env"].type == "caller_process"
+    assert captured["os_env"].sandbox.type == "none"

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -31,6 +31,47 @@ def test_install_spec_and_command(key: str, binary: str, package: str) -> None:
     assert hi.harness_install_command(key) == ["npm", "install", "-g", package]
 
 
+def test_cursor_install_spec_is_login_only_no_npm() -> None:
+    """Cursor ships via a curl installer (no npm package) and authenticates
+    through its own CLI login, so it carries an ``install_hint`` + status JSON
+    key instead of a ``package``.
+
+    Drift here (a package sneaking in, or the wrong status key) would make the
+    setup menu offer a bogus ``npm install`` or misread login state.
+    """
+    spec = hi.harness_install_spec(hi.CURSOR_KEY)
+    assert spec is not None
+    assert spec.binary == "cursor-agent"
+    assert spec.package is None
+    assert spec.install_hint is not None and "cursor.com/install" in spec.install_hint
+    assert spec.login_args == ("login",)
+    assert spec.logout_args == ("logout",)
+    assert spec.status_args == ("status", "--format", "json")
+    assert spec.login_status_key == "isAuthenticated"
+
+
+def test_install_command_rejects_non_npm_harness() -> None:
+    """A non-npm harness (cursor) has no npm install command; asking for one is
+    a loud error so the caller shows its ``install_hint`` instead."""
+    with pytest.raises(ValueError):
+        hi.harness_install_command(hi.CURSOR_KEY)
+
+
+def test_install_harness_cli_noop_for_non_npm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``install_harness_cli`` never shells npm for a non-npm CLI (cursor).
+
+    It returns ``False`` without spawning anything, so the menu falls back to
+    the manual ``install_hint`` rather than running a bogus npm command.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _explode(*a: object, **k: object) -> None:
+        raise AssertionError("npm install spawned for a non-npm harness")
+
+    monkeypatch.setattr(hi.subprocess, "run", _explode)
+    assert hi.install_harness_cli(hi.CURSOR_KEY) is False
+
+
 def test_unknown_key_has_no_spec_and_is_not_installed() -> None:
     """A family with no dedicated CLI (e.g. a gateway-only family) → None / False,
     never a crash."""
@@ -44,6 +85,7 @@ def test_unknown_key_has_no_spec_and_is_not_installed() -> None:
         ("claude-native", "claude"),
         ("codex-native", "codex"),
         ("pi", "pi"),
+        ("cursor", "cursor-agent"),
     ],
 )
 def test_required_cli_for_cli_backed_harness(harness: str, binary: str) -> None:
@@ -334,6 +376,37 @@ def test_harness_cli_logged_in_codex_uses_exit_code(
 
     monkeypatch.setattr(hi.subprocess, "run", _run)
     assert hi.harness_cli_logged_in(OPENAI_FAMILY) is expected
+
+
+@pytest.mark.parametrize(
+    "stdout,returncode,expected",
+    [
+        # Cursor prints JSON with ``isAuthenticated``; the field is the verdict
+        # regardless of exit code.
+        ('{"isAuthenticated": true, "status": "authenticated"}', 0, True),
+        ('{"isAuthenticated": false}', 1, False),
+        ('{"isAuthenticated": false}', 0, False),
+    ],
+)
+def test_harness_cli_logged_in_uses_cursor_json_verdict(
+    monkeypatch: pytest.MonkeyPatch, stdout: str, returncode: int, expected: bool
+) -> None:
+    """Cursor's ``status --format json`` reports ``isAuthenticated``.
+
+    Unlike Claude (``loggedIn``) it uses a different key, so the spec's
+    ``login_status_key`` selects it. A regression would misread cursor login
+    state in the setup menu's ✓/✗ marker.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _run(argv: list[str], **k: object):
+        assert argv == ["cursor-agent", "status", "--format", "json"]
+        return subprocess.CompletedProcess(
+            args=argv, returncode=returncode, stdout=stdout, stderr=""
+        )
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_logged_in(hi.CURSOR_KEY) is expected
 
 
 def test_harness_cli_logged_in_false_when_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -61,7 +61,7 @@ def test_sdk_and_unknown_harnesses_are_never_gated(
 # CLI-wrapping harnesses are gated on their binary being on PATH.
 @pytest.mark.parametrize(
     "harness",
-    ["claude-native", "native-claude", "codex", "codex-native", "native-codex", "pi"],
+    ["claude-native", "native-claude", "codex", "codex-native", "native-codex", "pi", "cursor"],
 )
 def test_cli_harness_configured_only_when_binary_installed(
     monkeypatch: pytest.MonkeyPatch, harness: str
@@ -105,6 +105,7 @@ def test_configured_harness_map_covers_all_spellings(
         "agents_sdk",
         "claude",
         "pi",
+        "cursor",
     }
     assert set(result) == expected_keys
 
@@ -133,7 +134,15 @@ def test_configured_harness_map_gates_only_cli_harnesses(
     ):
         assert result[sdk] is True, f"{sdk} should never be gated"
     # CLI-wrapping spellings — gated, so False when the binary is absent.
-    for cli in ("claude-native", "native-claude", "codex", "codex-native", "native-codex", "pi"):
+    for cli in (
+        "claude-native",
+        "native-claude",
+        "codex",
+        "codex-native",
+        "native-codex",
+        "pi",
+        "cursor",
+    ):
         assert result[cli] is False, f"{cli} should be gated on its CLI binary"
 
 

--- a/tests/test_harness_aliases.py
+++ b/tests/test_harness_aliases.py
@@ -17,6 +17,8 @@ from omnigent.harness_aliases import canonicalize_harness, is_native_harness
         # Canonical names pass through unchanged.
         ("openai-agents", "openai-agents"),
         ("pi", "pi"),
+        # Canonical cursor id passes through unchanged (no alias).
+        ("cursor", "cursor"),
         # Unknown names return unchanged so callers keep their own errors.
         ("bogus", "bogus"),
         (None, None),
@@ -51,6 +53,8 @@ def test_canonicalize_harness(alias: str | None, canonical: str | None) -> None:
         ("codex", False),
         # The "claude" shorthand canonicalizes to claude-sdk (not native).
         ("claude", False),
+        # cursor is a headless ACP harness, not a native CLI bridge.
+        ("cursor", False),
         ("some-unknown-harness", False),
         (None, False),
     ],

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -90,6 +90,7 @@ def test_validate_model_override_rejects_unsafe_values(value: str) -> None:
         "codex",
         "pi",
         "openai-agents",
+        "cursor",
     ],
 )
 def test_harness_supports_model_override_for_plumbed_harnesses(harness: str) -> None:


### PR DESCRIPTION
## Summary

Adds Cursor's `cursor-agent` CLI as a first-party Omnigent harness — `cursor-cli`
(alias `cursor`) — alongside claude-sdk / codex / pi / openai-agents. It drives a
persistent `cursor-agent acp` (Agent Client Protocol) session, kept warm for the
whole conversation, and is selectable everywhere the other harnesses are: spec
YAML, `--harness` / `--model`, the REPL `/model` command, sub-agent specs
(mixed-harness orchestrators), and the web-UI harness picker.

**ELI5:** Omnigent already drives Claude Code and Codex. This teaches it to drive
Cursor's agent the same way — pick `cursor-cli`, pick a Cursor model, use it like
any other harness, including as a sub-agent inside a multi-agent orchestrator.

```text
omnigent run … --harness cursor-cli --model gpt-5
      │
      ▼
CursorCliExecutor ── spawns ──► cursor-agent acp   (one persistent session per conversation)
      │  session/new(model, cwd)            │
      │  session/prompt ──────────────────► │  streams session/update
      ◄── TextChunk / ReasoningChunk / ToolCall events
      ◄── TurnComplete (on stopReason)
```

Auth is Cursor-only (`CURSOR_API_KEY` / `cursor-agent login`); there is no
Databricks gateway, so `databricks-*` model ids are dropped in favor of cursor's
default. `os_env.sandbox` maps to cursor's `--sandbox` mode (mirrors codex).

**Known follow-ups (inherent ACP limitations, not regressions):** bridging
Omnigent's spec-declared tools needs an http/sse MCP server via ACP
`session/new` `mcpServers` (cursor uses its own native tools today — the stdio
bridge doesn't apply to ACP); ACP exposes no token usage (`usage=None`) and no
mid-turn steer (`supports_live_message_queue()` is False).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

New unit tests: `tests/inner/test_cursor_acp.py` (ACP handshake / prompt
streaming / permission auto-allow), `tests/inner/test_cursor_cli_executor.py`
(`session/update`→event mapping, persistent-session reuse, `databricks-*` model
drop, `--sandbox` mapping, interrupt), `tests/inner/test_cursor_cli_harness.py`
(env-var config flow); plus `cursor-cli` added to the `test_harness_aliases` and
`test_model_override` parametrizations. New gated live E2E
`tests/e2e/omnigent/test_per_harness_cursor_cli.py` (skips when `cursor-agent`
is absent).

Commands run: `uv run pytest tests/inner/test_cursor_*` (25 pass) plus the
aliases / model-override suites; `uv run pre-commit run --all-files` (ruff +
hygiene) and `tsc -b` (ap-web) both pass; live E2E verified end-to-end against a
real `cursor-agent` (multi-turn warm session).
