### PR TITLE
Land server/web hardening (CSWSH, CSRF, stored-XSS) and policy-param fixes

### DIFF
--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -23,6 +23,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { capitalizeAgentName } from "@/lib/agentLabels";
+import { coercePolicyParams } from "@/lib/policyParams";
 import { useChatStore } from "@/store/chatStore";
 
 /** Trigger-pill display aliases for native agents. */
@@ -188,6 +189,7 @@ function AddPolicyDialog({
   const [selected, setSelected] = useState<string>("");
   const [filter, setFilter] = useState("");
   const [factoryParams, setFactoryParams] = useState<Record<string, string>>({});
+  const [paramError, setParamError] = useState<string | null>(null);
   const addPolicy = useAddPolicy(sessionId);
 
   const entry = registry.find((r) => r.handler === selected);
@@ -215,29 +217,21 @@ function AddPolicyDialog({
     setSelected(handler);
     setFilter("");
     setFactoryParams({});
+    setParamError(null);
   }
 
   function handleAdd() {
     if (!entry) return;
     let parsedParams: Record<string, unknown> | undefined;
     if (entry.kind === "factory" && paramKeys.length > 0) {
-      parsedParams = {};
-      for (const key of paramKeys) {
-        const raw = factoryParams[key];
-        const prop = properties[key];
-        if (raw !== undefined && raw !== "") {
-          if (prop?.type === "integer") parsedParams[key] = parseInt(raw, 10);
-          else if (prop?.type === "number") parsedParams[key] = parseFloat(raw);
-          else if (prop?.type === "boolean") parsedParams[key] = raw === "true";
-          else if (prop?.type === "array")
-            parsedParams[key] = raw
-              .split(",")
-              .map((s) => s.trim())
-              .filter(Boolean);
-          else parsedParams[key] = raw;
-        }
+      const result = coercePolicyParams(paramKeys, properties, factoryParams);
+      if (!result.ok) {
+        setParamError(result.error);
+        return;
       }
+      parsedParams = result.params;
     }
+    setParamError(null);
     // Always send factory_params for factory-kind policies (even
     // if empty) so the stored entity has ``factory_params={}``
     // instead of ``None``. The builder uses ``arguments is not
@@ -330,6 +324,7 @@ function AddPolicyDialog({
                   onClick={() => {
                     setSelected("");
                     setFactoryParams({});
+                    setParamError(null);
                   }}
                   className="text-[11px] text-muted-foreground hover:text-foreground"
                 >
@@ -460,6 +455,14 @@ function AddPolicyDialog({
                   </div>
                 );
               })}
+            </div>
+          )}
+          {(paramError || addPolicy.isError) && (
+            <div
+              role="alert"
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {paramError ?? addPolicy.error?.message}
             </div>
           )}
           <div className="flex justify-end gap-2 pt-1">

--- a/ap-web/src/hooks/usePromptHistory.test.ts
+++ b/ap-web/src/hooks/usePromptHistory.test.ts
@@ -3,10 +3,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { appendPromptHistoryEntry, usePromptHistory } from "./usePromptHistory";
 
-const STORAGE_KEY = "omnigent:prompt-history";
+const STORAGE_PREFIX = "omnigent:prompt-history";
 
-function storedHistory(): string[] {
-  const raw = localStorage.getItem(STORAGE_KEY);
+// History is keyed per conversation; tests must read the same scoped key the
+// production code writes, or they'd assert against an always-empty slot.
+function scopedKey(scope?: string | null): string {
+  return scope ? `${STORAGE_PREFIX}:${scope}` : STORAGE_PREFIX;
+}
+
+function storedHistory(scope?: string | null): string[] {
+  const raw = localStorage.getItem(scopedKey(scope));
   return raw ? (JSON.parse(raw) as string[]) : [];
 }
 
@@ -14,50 +20,71 @@ describe("appendPromptHistoryEntry", () => {
   beforeEach(() => localStorage.clear());
   afterEach(() => localStorage.clear());
 
-  it("persists a trimmed entry and returns the new history", () => {
+  it("persists a trimmed entry under the conversation's key", () => {
     // The leading/trailing whitespace must be stripped before storage so
     // recall returns the prompt the way it was composed, not with stray
     // padding — and the return value is what the hook syncs its ref to.
-    const result = appendPromptHistoryEntry("  read the README  ");
+    const result = appendPromptHistoryEntry("  read the README  ", "conv_a");
     expect(result).toEqual(["read the README"]);
-    expect(storedHistory()).toEqual(["read the README"]);
+    expect(storedHistory("conv_a")).toEqual(["read the README"]);
+  });
+
+  it("isolates history per conversation — one chat never sees another's", () => {
+    // The core bug: chats shared one global key, so ArrowUp recalled the last
+    // prompt sent anywhere. Fails if scoping regresses to a single key.
+    appendPromptHistoryEntry("sent in A", "conv_a");
+    expect(storedHistory("conv_a")).toEqual(["sent in A"]);
+    expect(storedHistory("conv_b")).toEqual([]);
+
+    appendPromptHistoryEntry("sent in B", "conv_b");
+    // Each conversation's stack holds only its own prompt — no cross-bleed.
+    expect(storedHistory("conv_a")).toEqual(["sent in A"]);
+    expect(storedHistory("conv_b")).toEqual(["sent in B"]);
   });
 
   it("skips empty / whitespace-only text without writing", () => {
     // A blank landing composer must never push an empty entry — pressing
     // ArrowUp afterwards would otherwise recall "" and clear the input.
-    expect(appendPromptHistoryEntry("   ")).toBeNull();
-    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(appendPromptHistoryEntry("   ", "conv_a")).toBeNull();
+    expect(localStorage.getItem(scopedKey("conv_a"))).toBeNull();
   });
 
   it("collapses a consecutive duplicate against the persisted tail", () => {
     // Sending the same prompt from the landing composer and then again in the
     // chat must not store it twice (shell HISTCONTROL=ignoredups). The second
     // call returns the unchanged history so the caller still syncs correctly.
-    appendPromptHistoryEntry("hello");
-    const result = appendPromptHistoryEntry("hello");
+    appendPromptHistoryEntry("hello", "conv_a");
+    const result = appendPromptHistoryEntry("hello", "conv_a");
     expect(result).toEqual(["hello"]);
-    expect(storedHistory()).toEqual(["hello"]);
+    expect(storedHistory("conv_a")).toEqual(["hello"]);
   });
 
   it("keeps a non-consecutive repeat (only the immediate tail dedupes)", () => {
-    appendPromptHistoryEntry("a");
-    appendPromptHistoryEntry("b");
-    appendPromptHistoryEntry("a");
-    expect(storedHistory()).toEqual(["a", "b", "a"]);
+    appendPromptHistoryEntry("a", "conv_a");
+    appendPromptHistoryEntry("b", "conv_a");
+    appendPromptHistoryEntry("a", "conv_a");
+    expect(storedHistory("conv_a")).toEqual(["a", "b", "a"]);
   });
 
   it("caps at 100 entries with FIFO eviction of the oldest", () => {
-    for (let i = 0; i < 105; i++) appendPromptHistoryEntry(`p${i}`);
-    const history = storedHistory();
+    for (let i = 0; i < 105; i++) appendPromptHistoryEntry(`p${i}`, "conv_a");
+    const history = storedHistory("conv_a");
     expect(history).toHaveLength(100);
     // The five oldest (p0..p4) are evicted; the newest survives at the tail.
     expect(history[0]).toBe("p5");
     expect(history[history.length - 1]).toBe("p104");
   });
+
+  it("falls back to the bare legacy key when no scope is given", () => {
+    // Surfaces with no bound conversation (null scope) share the prefix-only
+    // key. Guards the degenerate path the hook uses before a conversation id
+    // is known.
+    appendPromptHistoryEntry("unscoped", null);
+    expect(localStorage.getItem(STORAGE_PREFIX)).toBe(JSON.stringify(["unscoped"]));
+  });
 });
 
-describe("usePromptHistory — landing → chat handoff", () => {
+describe("usePromptHistory — per-conversation recall", () => {
   beforeEach(() => localStorage.clear());
   afterEach(() => {
     cleanup();
@@ -65,12 +92,10 @@ describe("usePromptHistory — landing → chat handoff", () => {
   });
 
   it("recalls an entry written by appendPromptHistoryEntry before the hook mounted", () => {
-    // This is the exact landing-composer flow: the home page writes the
-    // prompt to localStorage, then navigates so a fresh chat composer mounts.
-    // The hook hydrates from localStorage on mount, so the first ArrowUp must
-    // return that prompt — proving the cross-surface handoff works.
-    appendPromptHistoryEntry("the prompt I just sent");
-    const { result } = renderHook(() => usePromptHistory());
+    // Landing-composer handoff: home page writes under the new session id, then
+    // the chat composer mounts bound to that id and hydrates from the same key.
+    appendPromptHistoryEntry("the prompt I just sent", "conv_a");
+    const { result } = renderHook(() => usePromptHistory("conv_a"));
     let recalled: string | null = null;
     act(() => {
       recalled = result.current.recallPrevious("");
@@ -78,14 +103,52 @@ describe("usePromptHistory — landing → chat handoff", () => {
     expect(recalled).toBe("the prompt I just sent");
   });
 
-  it("appendEntry from the chat composer is itself recallable", () => {
-    const { result } = renderHook(() => usePromptHistory());
+  it("does not recall a prompt that belongs to a different conversation", () => {
+    // The bug through the composer's actual recall path: conv_a's prompt must
+    // be invisible to a composer bound to conv_b.
+    appendPromptHistoryEntry("typed in conv_a", "conv_a");
+    const { result } = renderHook(() => usePromptHistory("conv_b"));
+    let recalled: string | null = "sentinel";
+    act(() => {
+      recalled = result.current.recallPrevious("");
+    });
+    // null = nothing to recall in conv_b. If this returns "typed in conv_a",
+    // the global-history bug is back.
+    expect(recalled).toBeNull();
+  });
+
+  it("re-hydrates when the bound conversation changes", () => {
+    // The composer persists across some session switches; flipping the scope
+    // prop must swap which conversation's stack ArrowUp walks.
+    appendPromptHistoryEntry("a-prompt", "conv_a");
+    appendPromptHistoryEntry("b-prompt", "conv_b");
+    const { result, rerender } = renderHook(({ scope }) => usePromptHistory(scope), {
+      initialProps: { scope: "conv_a" },
+    });
+    let recalled: string | null = null;
+    act(() => {
+      recalled = result.current.recallPrevious("");
+    });
+    expect(recalled).toBe("a-prompt");
+
+    rerender({ scope: "conv_b" });
+    act(() => {
+      recalled = result.current.recallPrevious("");
+    });
+    // After the scope change the hook re-read conv_b's key and dropped the
+    // conv_a cursor, so the first ArrowUp lands on b's prompt, not a's.
+    expect(recalled).toBe("b-prompt");
+  });
+
+  it("appendEntry from the chat composer is itself recallable in that conversation", () => {
+    const { result } = renderHook(() => usePromptHistory("conv_a"));
     act(() => result.current.appendEntry("typed in chat"));
     let recalled: string | null = null;
     act(() => {
       recalled = result.current.recallPrevious("");
     });
     expect(recalled).toBe("typed in chat");
-    expect(storedHistory()).toEqual(["typed in chat"]);
+    // appendEntry routed the write to conv_a's scoped key, not the global one.
+    expect(storedHistory("conv_a")).toEqual(["typed in chat"]);
   });
 });

--- a/ap-web/src/hooks/usePromptHistory.ts
+++ b/ap-web/src/hooks/usePromptHistory.ts
@@ -2,18 +2,35 @@
 //
 // Mirrors the terminal REPL's up-arrow history (prompt-toolkit's FileHistory
 // against ~/.omnigent_history). Web-side, history persists across tabs and
-// reloads via a single localStorage key; the recall cursor is in-memory only,
-// matching shell semantics where each new login starts at the bottom.
+// reloads via localStorage; the recall cursor is in-memory only, matching
+// shell semantics where each new login starts at the bottom.
+//
+// History is scoped per conversation: each chat keeps its own recall stack
+// under a conversation-specific key, so ArrowUp in one chat never surfaces a
+// prompt typed in another. A surface with no bound conversation falls back to
+// the bare legacy key.
 
 import { useCallback, useEffect, useRef } from "react";
 
-const STORAGE_KEY = "omnigent:prompt-history";
+const STORAGE_PREFIX = "omnigent:prompt-history";
 const MAX_ENTRIES = 100;
 
-function readHistory(): string[] {
+/**
+ * Resolve the localStorage key for a given history scope.
+ *
+ * @param scope The conversation id the history belongs to, e.g.
+ *   ``"conv_abc123"``. When `null`/`undefined` (no bound conversation), returns
+ *   the bare legacy key so unscoped surfaces share one stack.
+ * @returns The localStorage key, e.g. ``"omnigent:prompt-history:conv_abc123"``.
+ */
+function scopedKey(scope: string | null | undefined): string {
+  return scope ? `${STORAGE_PREFIX}:${scope}` : STORAGE_PREFIX;
+}
+
+function readHistory(key: string): string[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(key);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -23,10 +40,10 @@ function readHistory(): string[] {
   }
 }
 
-function writeHistory(entries: string[]): void {
+function writeHistory(key: string, entries: string[]): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    window.localStorage.setItem(key, JSON.stringify(entries));
   } catch {
     // Quota exceeded or storage disabled — non-fatal; recall just stops
     // persisting until the next successful write.
@@ -34,30 +51,38 @@ function writeHistory(entries: string[]): void {
 }
 
 /**
- * Append `text` to the persisted prompt history (localStorage), trimming
- * first and skipping empty / consecutive-duplicate entries (matching shell
- * ``HISTCONTROL=ignoredups``). Caps at {@link MAX_ENTRIES} with FIFO
+ * Append `text` to the persisted prompt history for `scope` (localStorage),
+ * trimming first and skipping empty / consecutive-duplicate entries (matching
+ * shell ``HISTCONTROL=ignoredups``). Caps at {@link MAX_ENTRIES} with FIFO
  * eviction.
  *
  * Standalone (not part of the hook) so non-composer surfaces can contribute
- * to the same history — notably the home-page landing composer, whose first
- * message should be recallable with ArrowUp in the freshly-opened chat (the
- * chat composer's `usePromptHistory` re-reads localStorage on mount).
+ * to a conversation's history — notably the home-page landing composer, which
+ * already knows the new session id and writes under it so the first message is
+ * recallable with ArrowUp in the freshly-opened chat (the chat composer's
+ * `usePromptHistory` reads that same scoped key on mount).
  *
+ * @param text The prompt text to record, e.g. ``"read the README"``.
+ * @param scope The conversation id to scope the entry to, e.g.
+ *   ``"conv_abc123"``; `null`/omitted writes to the shared legacy key.
  * @returns The new persisted history (unchanged on a skipped duplicate), or
  *   `null` when `text` was empty/whitespace and nothing was written.
  */
-export function appendPromptHistoryEntry(text: string): string[] | null {
+export function appendPromptHistoryEntry(
+  text: string,
+  scope?: string | null,
+): string[] | null {
   const trimmed = text.trim();
   if (!trimmed) return null;
-  const history = readHistory();
+  const key = scopedKey(scope);
+  const history = readHistory(key);
   // Collapse consecutive duplicates against the persisted tail, so the same
   // prompt sent from the landing composer and then again in-chat isn't stored
   // twice.
   if (history.length > 0 && history[history.length - 1] === trimmed) return history;
   const next = [...history, trimmed];
   const capped = next.length > MAX_ENTRIES ? next.slice(-MAX_ENTRIES) : next;
-  writeHistory(capped);
+  writeHistory(key, capped);
   return capped;
 }
 
@@ -88,24 +113,34 @@ export interface PromptHistory {
 }
 
 /**
- * Imperative recall API. The hook does not trigger re-renders — callers
- * read history values from the returned methods inside event handlers
- * (keydown, submit) and apply them to whatever input state they own.
+ * Imperative recall API, scoped to a single conversation. The hook does not
+ * trigger re-renders — callers read history values from the returned methods
+ * inside event handlers (keydown, submit) and apply them to whatever input
+ * state they own.
  *
  * Cursor convention: 0 = newest, increasing = older. When `cursor` is
  * `null`, no recall is in progress and `draft` is undefined.
+ *
+ * @param scope The conversation id whose history to recall, e.g.
+ *   ``"conv_abc123"``. Changing it re-hydrates from that conversation's key and
+ *   drops any in-progress recall, so ArrowUp never surfaces another chat's
+ *   prompts. `null`/omitted uses the shared legacy key (no bound conversation).
  */
-export function usePromptHistory(): PromptHistory {
+export function usePromptHistory(scope?: string | null): PromptHistory {
   const historyRef = useRef<string[]>([]);
   const cursorRef = useRef<number | null>(null);
   const draftRef = useRef<string | null>(null);
+  // Live scope for the stable appendEntry callback (avoids recreating it per switch).
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
 
-  // Hydrate on mount. Synchronous read — localStorage is fast and we want
-  // the first ArrowUp to find existing entries even if it fires before a
-  // re-render.
+  // Re-read the active conversation's stack on mount and each switch; reset the
+  // cursor so the previous chat's in-progress recall can't bleed in.
   useEffect(() => {
-    historyRef.current = readHistory();
-  }, []);
+    historyRef.current = readHistory(scopedKey(scope));
+    cursorRef.current = null;
+    draftRef.current = null;
+  }, [scope]);
 
   const resetCursor = useCallback(() => {
     cursorRef.current = null;
@@ -117,7 +152,7 @@ export function usePromptHistory(): PromptHistory {
       // Persist via the shared module helper (trims, dedupes, caps), then
       // sync our in-memory ref to the returned history so recall sees the new
       // entry without a re-read. `null` means nothing was written (empty text).
-      const capped = appendPromptHistoryEntry(text);
+      const capped = appendPromptHistoryEntry(text, scopeRef.current);
       if (capped !== null) historyRef.current = capped;
       resetCursor();
     },

--- a/ap-web/src/lib/claudeNativeModels.ts
+++ b/ap-web/src/lib/claudeNativeModels.ts
@@ -10,7 +10,8 @@
  */
 export const CLAUDE_NATIVE_MODELS = [
   // Ordered by capability tier, most powerful first.
-  { id: "fable", label: "Fable" },
+  // Fable temporarily withheld while Anthropic has Fable access disabled.
+  // { id: "fable", label: "Fable" },
   { id: "opus", label: "Opus" },
   { id: "sonnet", label: "Sonnet" },
   { id: "haiku", label: "Haiku" },
@@ -20,10 +21,12 @@ export const CLAUDE_NATIVE_MODELS = [
  * Is `model` something a Claude Code (claude-native) session can actually
  * run — i.e. a Claude model rather than a foreign harness's id?
  *
- * Accepts the version-agnostic aliases (`fable` / `opus` / `sonnet` /
- * `haiku`) and any fully-qualified Anthropic id (anything containing
- * `claude`, e.g. `claude-fable-5`, `anthropic/claude-opus-4-8`,
- * `databricks-claude-sonnet-4-6`). Rejects everything else — notably the
+ * Accepts the version-agnostic aliases (`opus` / `sonnet` / `haiku`) and
+ * any fully-qualified Anthropic id (anything containing `claude`, e.g.
+ * `claude-fable-5`, `anthropic/claude-opus-4-8`,
+ * `databricks-claude-sonnet-4-6`). The bare `fable` alias no longer
+ * matches while Fable is withheld, but pinned `claude-fable-5` sessions
+ * still pass via the `claude` branch. Rejects everything else — notably the
  * Codex / OpenAI defaults (`gpt-5.4`, `gpt-5.4-mini`, …) that leak into the
  * cross-harness global picker selection.
  *

--- a/ap-web/src/lib/policyParams.test.ts
+++ b/ap-web/src/lib/policyParams.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { coercePolicyParams } from "./policyParams";
+
+describe("coercePolicyParams", () => {
+  it("parses object-typed fields from a JSON object literal", () => {
+    const result = coercePolicyParams(
+      ["tool_points"],
+      { tool_points: { type: "object" } },
+      { tool_points: '{"sys_os_shell": 10}' },
+    );
+    // The whole point of the fix: the object reaches the server as a dict,
+    // not the raw string that previously broke the create.
+    expect(result).toEqual({
+      ok: true,
+      params: { tool_points: { sys_os_shell: 10 } },
+    });
+  });
+
+  it("rejects malformed JSON in an object field instead of submitting it", () => {
+    const result = coercePolicyParams(
+      ["tool_points"],
+      { tool_points: { type: "object" } },
+      { tool_points: "{sys_os_shell: 10" },
+    );
+    expect(result.ok).toBe(false);
+    // "valid JSON" is unique to the parse-failure branch (the non-object
+    // branch says "JSON object"), so this proves we took the parse path.
+    if (!result.ok) expect(result.error).toContain("valid JSON");
+  });
+
+  it("rejects a JSON array where an object is required", () => {
+    const result = coercePolicyParams(
+      ["tool_points"],
+      { tool_points: { type: "object" } },
+      { tool_points: "[1, 2]" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("JSON object");
+  });
+
+  it("coerces integer, number, boolean, and array fields", () => {
+    const result = coercePolicyParams(
+      ["threshold", "ratio", "flag", "guarded_tools"],
+      {
+        threshold: { type: "integer" },
+        ratio: { type: "number" },
+        flag: { type: "boolean" },
+        guarded_tools: { type: "array" },
+      },
+      {
+        threshold: "20",
+        ratio: "0.5",
+        flag: "true",
+        guarded_tools: "sys_os_shell, sys_os_write ,",
+      },
+    );
+    expect(result).toEqual({
+      ok: true,
+      params: {
+        threshold: 20,
+        ratio: 0.5,
+        flag: true,
+        guarded_tools: ["sys_os_shell", "sys_os_write"],
+      },
+    });
+  });
+
+  it("passes string and unmapped types through verbatim", () => {
+    const result = coercePolicyParams(
+      ["state_key"],
+      { state_key: { type: "string" } },
+      { state_key: "risk_score" },
+    );
+    expect(result).toEqual({ ok: true, params: { state_key: "risk_score" } });
+  });
+
+  it("omits empty and unset fields", () => {
+    const result = coercePolicyParams(
+      ["a", "b"],
+      { a: { type: "string" }, b: { type: "string" } },
+      { a: "" },
+    );
+    // `a` is empty and `b` is unset, so neither reaches factory_params —
+    // an empty field must not be sent as "" (which the server would reject).
+    expect(result).toEqual({ ok: true, params: {} });
+  });
+});

--- a/ap-web/src/lib/policyParams.ts
+++ b/ap-web/src/lib/policyParams.ts
@@ -1,0 +1,77 @@
+/**
+ * Coerce raw policy factory-parameter form values into the typed shape the
+ * server expects.
+ *
+ * The add-policy dialogs in ``PoliciesPage`` (global defaults) and
+ * ``AgentInfo`` (per-session) both capture every field as a string and must
+ * turn ``"20"`` into ``20``, ``"a, b"`` into ``["a", "b"]``, and a typed-in
+ * JSON object literal into a real object before sending ``factory_params``.
+ *
+ * ``object``-typed fields (e.g. the risk-score policy's ``tool_points`` /
+ * ``sensitive_labels``) were previously passed through as raw strings because
+ * the coercion had no ``object`` branch — the server then rejected the
+ * non-dict value and the create silently failed. This helper is the single
+ * source of truth for that conversion so the two dialogs can't drift.
+ */
+
+export interface PolicyParamProp {
+  type?: string;
+}
+
+export type PolicyParamsResult =
+  | { ok: true; params: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * Convert string-valued form inputs to typed factory params, driven by each
+ * parameter's JSON-schema ``type``. Empty / unset fields are omitted. Returns
+ * a discriminated result so callers can surface a precise error (e.g. invalid
+ * JSON in an ``object`` field) instead of submitting a value the server will
+ * reject.
+ */
+export function coercePolicyParams(
+  paramKeys: string[],
+  properties: Record<string, PolicyParamProp | undefined>,
+  rawValues: Record<string, string>,
+): PolicyParamsResult {
+  const params: Record<string, unknown> = {};
+  for (const key of paramKeys) {
+    const raw = rawValues[key];
+    if (raw === undefined || raw === "") continue;
+    const type = properties[key]?.type;
+    if (type === "integer") {
+      params[key] = parseInt(raw, 10);
+    } else if (type === "number") {
+      params[key] = parseFloat(raw);
+    } else if (type === "boolean") {
+      params[key] = raw === "true";
+    } else if (type === "array") {
+      params[key] = raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (type === "object") {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        return {
+          ok: false,
+          error: `${key} must be valid JSON, e.g. {"web_search": 10}`,
+        };
+      }
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return {
+          ok: false,
+          error: `${key} must be a JSON object, e.g. {"web_search": 10}`,
+        };
+      }
+      params[key] = parsed;
+    } else {
+      // "string" and any unmapped schema type pass through verbatim — the
+      // server validates the concrete value.
+      params[key] = raw;
+    }
+  }
+  return { ok: true, params };
+}

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -2780,7 +2780,10 @@ export function Composer({
   // Auto-grow the textarea from 1 row up to 10 rows, then let it scroll.
   useAutoGrowTextarea(textareaRef, value);
 
-  const { appendEntry, recallPrevious, recallNext, resetCursor } = usePromptHistory();
+  // Scope recall to the active conversation so ArrowUp surfaces only this
+  // chat's prompts, not the last thing typed in any other chat.
+  const { appendEntry, recallPrevious, recallNext, resetCursor } =
+    usePromptHistory(conversationId);
   // Set just before recall sets `value`; cleared when the resulting onChange
   // fires. Lets onChange distinguish "user typed" (reset cursor) from
   // "recall replaced the value" (keep cursor).

--- a/ap-web/src/pages/PoliciesPage.tsx
+++ b/ap-web/src/pages/PoliciesPage.tsx
@@ -40,6 +40,7 @@ import {
   type PolicyRegistryEntry,
 } from "@/hooks/usePolicies";
 import { getMe } from "@/lib/accountsApi";
+import { coercePolicyParams } from "@/lib/policyParams";
 
 // ---------------------------------------------------------------------------
 // Add-policy dialog (registry-driven, same UX as session policies)
@@ -61,6 +62,7 @@ function AddDefaultPolicyDialog({
   const [factoryParams, setFactoryParams] = useState<Record<string, string>>(
     {},
   );
+  const [paramError, setParamError] = useState<string | null>(null);
   const addPolicy = useAddDefaultPolicy();
 
   const entry = registry.find((r) => r.handler === selected);
@@ -88,31 +90,21 @@ function AddDefaultPolicyDialog({
     setSelected(handler);
     setFilter("");
     setFactoryParams({});
+    setParamError(null);
   }
 
   function handleAdd() {
     if (!entry) return;
     let parsedParams: Record<string, unknown> | undefined;
     if (entry.kind === "factory" && paramKeys.length > 0) {
-      parsedParams = {};
-      for (const key of paramKeys) {
-        const raw = factoryParams[key];
-        const prop = properties[key];
-        if (raw !== undefined && raw !== "") {
-          if (prop?.type === "integer") parsedParams[key] = parseInt(raw, 10);
-          else if (prop?.type === "number")
-            parsedParams[key] = parseFloat(raw);
-          else if (prop?.type === "boolean")
-            parsedParams[key] = raw === "true";
-          else if (prop?.type === "array")
-            parsedParams[key] = raw
-              .split(",")
-              .map((s) => s.trim())
-              .filter(Boolean);
-          else parsedParams[key] = raw;
-        }
+      const result = coercePolicyParams(paramKeys, properties, factoryParams);
+      if (!result.ok) {
+        setParamError(result.error);
+        return;
       }
+      parsedParams = result.params;
     }
+    setParamError(null);
     const includeFactoryParams =
       entry.kind === "factory"
         ? { factory_params: parsedParams ?? {} }
@@ -204,6 +196,7 @@ function AddDefaultPolicyDialog({
                   onClick={() => {
                     setSelected("");
                     setFactoryParams({});
+                    setParamError(null);
                   }}
                   className="text-[11px] text-muted-foreground hover:text-foreground"
                 >
@@ -349,12 +342,12 @@ function AddDefaultPolicyDialog({
               })}
             </div>
           )}
-          {addPolicy.isError && (
+          {(paramError || addPolicy.isError) && (
             <div
               role="alert"
               className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
             >
-              {addPolicy.error.message}
+              {paramError ?? addPolicy.error?.message}
             </div>
           )}
           <div className="flex justify-end gap-2 pt-1">

--- a/ap-web/src/pages/modelPicker.test.ts
+++ b/ap-web/src/pages/modelPicker.test.ts
@@ -11,20 +11,15 @@ describe("CLAUDE_NATIVE_MODELS", () => {
     // the installed version supports, so the list never drifts. Guard
     // against a regression back to version-numbered IDs.
     const ids = CLAUDE_NATIVE_MODELS.map((m) => m.id);
-    // Capability order, most powerful first: Fable is the tier above Opus.
-    expect(ids).toEqual(["fable", "opus", "sonnet", "haiku"]);
+    // Capability order, most powerful first. Fable is temporarily withheld.
+    expect(ids).toEqual(["opus", "sonnet", "haiku"]);
     for (const id of ids) {
       expect(id).not.toMatch(/\d/); // an alias carries no version digits
     }
   });
 
   it("labels each alias by tier", () => {
-    expect(CLAUDE_NATIVE_MODELS.map((m) => m.label)).toEqual([
-      "Fable",
-      "Opus",
-      "Sonnet",
-      "Haiku",
-    ]);
+    expect(CLAUDE_NATIVE_MODELS.map((m) => m.label)).toEqual(["Opus", "Sonnet", "Haiku"]);
   });
 });
 

--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -23,7 +23,10 @@ const navigateMock = vi.fn();
 const setPendingInitialPromptMock = vi.fn();
 
 const RECENT_KEY = "omnigent:recent-workspaces";
-const PROMPT_HISTORY_KEY = "omnigent:prompt-history";
+// Prompt history is scoped per conversation; the landing composer writes under
+// the newly created session id (``conv_new`` in these tests), so the recall
+// stack lives at the prefixed key, not the bare one.
+const PROMPT_HISTORY_KEY = "omnigent:prompt-history:conv_new";
 // The seeded working directory (from the host's persisted recent) that the
 // create body must carry through.
 const SEEDED_WORKSPACE = "/Users/corey/universe/src/foo";
@@ -382,8 +385,8 @@ describe("NewChatLandingScreen create flow", () => {
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
 
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
-    // appendPromptHistoryEntry is unmocked, so it really wrote to the shared
-    // localStorage key the chat composer's usePromptHistory reads on mount.
+    // appendPromptHistoryEntry is unmocked, so it really wrote to conv_new's
+    // scoped key — the one the chat composer reads once bound to that session.
     const history = JSON.parse(localStorage.getItem(PROMPT_HISTORY_KEY) ?? "[]");
     // The stored entry is the SANITIZED prompt: the \x07 bell is gone (proving
     // sanitizeInitialPrompt ran — a bare trim would have kept it) and the

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -1277,4 +1277,29 @@ describe("NewChatLandingScreen attachments", () => {
     fireEvent.click(screen.getByRole("button", { name: "Remove notes.txt" }));
     expect(screen.queryByText("notes.txt")).toBeNull();
   });
+
+  it("attaches files dropped onto the composer and surfaces a drop overlay", () => {
+    renderLanding();
+    const composer = screen.getByTestId("new-chat-landing-composer");
+    // Dragging over the composer lifts the drop-target overlay.
+    fireEvent.dragOver(composer, { dataTransfer: { files: [] } });
+    expect(screen.getByText("Drop files here")).toBeTruthy();
+    // Dropping a file attaches it (chip proves it reached state) and clears
+    // the overlay.
+    const file = new File(["hello"], "dropped.txt", { type: "text/plain" });
+    fireEvent.drop(composer, { dataTransfer: { files: [file] } });
+    expect(screen.getByText("dropped.txt")).toBeTruthy();
+    expect(screen.queryByText("Drop files here")).toBeNull();
+  });
+
+  it("clears the drop overlay when the drag leaves the composer", () => {
+    renderLanding();
+    const composer = screen.getByTestId("new-chat-landing-composer");
+    fireEvent.dragEnter(composer, { dataTransfer: { files: [] } });
+    expect(screen.getByText("Drop files here")).toBeTruthy();
+    // relatedTarget defaults to null (outside the composer), so the active
+    // state clears rather than sticking when moving between child elements.
+    fireEvent.dragLeave(composer, { dataTransfer: { files: [] } });
+    expect(screen.queryByText("Drop files here")).toBeNull();
+  });
 });

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1008,12 +1008,10 @@ export function NewChatLandingScreen() {
           : matchSkillInvocation(initialPrompt, agent?.skills ?? []),
         files,
       });
-      // Record the prompt in the shared composer history so the user can
-      // recall it with ArrowUp in the freshly-opened chat (e.g. to retry
-      // after a failed send). The chat composer's usePromptHistory re-reads
-      // localStorage on mount, so it picks this up on navigate. Use the
-      // sanitized text so recall matches exactly what was sent.
-      appendPromptHistoryEntry(initialPrompt);
+      // Scope the recall entry to the new session id so ArrowUp surfaces it in
+      // the freshly-opened chat (whose composer reads the same per-conversation
+      // key). Sanitized text so recall reproduces exactly what was sent.
+      appendPromptHistoryEntry(initialPrompt, data.id);
       navigate(`/c/${data.id}`);
     } catch {
       setCreateError("Couldn't reach the server. Check your connection and try again.");

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@/lib/routing";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -43,6 +43,7 @@ import { getCliServerUrl } from "@/lib/host";
 import { getOmnigentHostConfig } from "@/lib/host";
 import { readLastAgentId, writeLastAgentId } from "@/lib/agentPreferences";
 import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
+import { cn } from "@/lib/utils";
 import { useHosts, type Host } from "@/hooks/useHosts";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
@@ -611,6 +612,39 @@ export function NewChatLandingScreen() {
   const addFiles = (incoming: File[]) => setFiles((prev) => [...prev, ...incoming]);
   const removeFile = (index: number) => setFiles((prev) => prev.filter((_, i) => i !== index));
 
+  // Drag-and-drop onto the composer — same behavior as the in-session
+  // composer (drop files anywhere on the box; an inset ring + overlay
+  // signal the drop target).
+  const [isDragActive, setIsDragActive] = useState(false);
+
+  const handleDrop = (e: DragEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragActive(false);
+    const dropped = Array.from(e.dataTransfer.files);
+    if (dropped.length > 0) addFiles(dropped);
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragActive(true);
+  };
+
+  const handleDragEnter = (e: DragEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragActive(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // Only clear the active state when the pointer leaves the container
+    // itself, not when it moves between child elements inside it.
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setIsDragActive(false);
+  };
+
   // Gates the sandbox host option: only servers whose sandbox
   // config can actually serve a managed launch advertise it. "loading"
   // fails closed (option hidden) until the boot probe resolves.
@@ -1056,16 +1090,29 @@ export function NewChatLandingScreen() {
               e.preventDefault();
               void handleCreate();
             }}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
             // Two visual states only (no hover): resting --border, and
             // --foreground while the textarea itself has focus (has-[]
             // scopes it so focusing footer buttons doesn't trigger it).
             // dark:bg-card-solid: the footer tray below tucks its top
             // edge behind this card (-mt-9), and the dark glass --card
             // is 60% alpha — the tucked strip ghosts through a
-            // translucent card. Mirrors the chat composer card.
-            className="relative z-10 flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-[0_12px_20px_-20px_rgba(0,0,0,0.14),0_20px_28px_-28px_rgba(0,0,0,0.1)] transition-[border-color,box-shadow] duration-150 has-[textarea:focus]:border-foreground"
+            // translucent card. Mirrors the chat composer card. Drag-over
+            // lifts an inset ring (overlay below).
+            className={cn(
+              "relative z-10 flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-[0_12px_20px_-20px_rgba(0,0,0,0.14),0_20px_28px_-28px_rgba(0,0,0,0.1)] transition-[border-color,box-shadow] duration-150 has-[textarea:focus]:border-foreground",
+              isDragActive && "ring-2 ring-ring ring-inset",
+            )}
             data-testid="new-chat-landing-composer"
           >
+            {isDragActive && (
+              <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-card/80">
+                <span className="text-sm font-medium text-ring">Drop files here</span>
+              </div>
+            )}
             {/* Skill suggestions — floats above the composer box. */}
             {slashMenuOpen && (
               <SlashCommandMenu

--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -224,13 +224,13 @@ Scans user messages and LLM prompts for PII patterns (SSN, credit card, email, p
 
 #### `cost_budget`
 
-Gates a session on cumulative LLM spend, at the tool-call phase. ASKs the first time spend crosses each soft warning threshold. At the hard limit it acts as a **downgrade gate**, not a hard stop: it DENYs tool calls only while the session is on an expensive model -- telling the user to switch to a cheaper one with `/model` -- and allows them again once the session has switched.
+Gates a session on cumulative LLM spend, at the **request** phase (before the LLM turn, so text-only turns are budgeted too) and the **tool-call** phase. ASKs the first time spend crosses each soft warning threshold. At the hard limit it acts as a **downgrade gate**, not a hard stop: it DENYs (the whole turn on `request`, or each tool call on `tool_call`) only while the session is on an expensive model -- telling the user to switch to a cheaper one with `/model` -- and allows them again once the session has switched.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_cost_usd` | number | (required) | Hard spend limit in USD. Once reached, tool calls are blocked while the session is on an expensive model. |
+| `max_cost_usd` | number | (required) | Hard spend limit in USD. Once reached, the turn / tool calls are blocked while the session is on an expensive model. |
 | `ask_thresholds_usd` | number[] | `null` | Soft warning checkpoints that ASK the first time spend crosses each (each must be < `max_cost_usd`) |
-| `expensive_models` | string[] | Opus + GPT-5.5 | Case-insensitive substring tokens for the model tiers blocked once over budget (e.g. `"opus"` matches any Opus deployment). `[]` disables the hard limit, leaving only the soft thresholds. |
+| `expensive_models` | string[] | Fable + Opus + GPT-5 (excl. `-mini`/`-nano`) | Case-insensitive substring tokens for the model tiers blocked once over budget (e.g. `"opus"` matches any Opus deployment). The default's broad `gpt-5` token matches the whole GPT-5 family except the cheap `-mini`/`-nano` variants; an explicit list is matched literally with no exclusions. `[]` disables the hard limit, leaving only the soft thresholds. |
 
 ```yaml
 budget:
@@ -239,7 +239,7 @@ budget:
   factory_params:
     max_cost_usd: 5.00
     ask_thresholds_usd: [1.00, 3.00]
-    expensive_models: ["opus", "gpt-5.5"]
+    expensive_models: ["opus", "gpt-5"]
 ```
 
 #### `user_daily_cost_budget`
@@ -248,9 +248,9 @@ Same ASK / downgrade-gate behavior as `cost_budget`, but the budget is the **ses
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_cost_usd` | number | (required) | Hard daily limit in USD. Once the owner's spend for the day reaches it, tool calls are blocked while on an expensive model. |
+| `max_cost_usd` | number | (required) | Hard daily limit in USD. Once the owner's spend for the day reaches it, the turn / tool calls are blocked while on an expensive model. |
 | `ask_thresholds_usd` | number[] | `null` | Soft daily warning checkpoints that ASK the first time the owner's daily spend crosses each (each must be < `max_cost_usd`) |
-| `expensive_models` | string[] | Opus + GPT-5.5 | Case-insensitive substring tokens for the model tiers blocked once over the daily budget. `[]` disables the hard limit, leaving only the soft thresholds. |
+| `expensive_models` | string[] | Fable + Opus + GPT-5 (excl. `-mini`/`-nano`) | Case-insensitive substring tokens for the model tiers blocked once over the daily budget. An explicit list is matched literally with no exclusions. `[]` disables the hard limit, leaving only the soft thresholds. |
 
 ```yaml
 # server_config.yaml -- a per-user daily cap applied to every session

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -4032,16 +4032,23 @@ def _websocket_connect(attach_url: str, *, headers: dict[str, str]) -> Any:
     """
     import websockets
 
+    from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+
+    # Identify as a first-party client so the server's WebSocket origin
+    # guard (CSWSH protection) allows the handshake — this attach client
+    # is not a browser. Set on a copy so the caller's dict (which also
+    # carries auth headers and may be reused) is not mutated here.
+    handshake_headers = {**headers, "Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
     try:
         return websockets.connect(
             attach_url,
-            additional_headers=headers,
+            additional_headers=handshake_headers,
             close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
         )
     except TypeError:
         return websockets.connect(
             attach_url,
-            extra_headers=headers,
+            extra_headers=handshake_headers,
             close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
         )
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4013,7 +4013,8 @@ def resume(
 
     run_resume(
         target=target,
-        server=server,
+        # A bare Databricks workspace URL means its /api/2.0/omnigent mount.
+        server=_workspace_api_server_url(server) if server else server,
     )
 
 
@@ -4532,7 +4533,8 @@ def _resolve_attach_server(server: str | None, configured_server: str | None) ->
     """
     chosen = server if server is not None else configured_server
     if chosen:
-        return chosen.rstrip("/")
+        # A bare Databricks workspace URL means its /api/2.0/omnigent mount.
+        return _workspace_api_server_url(chosen.rstrip("/"))
     local = local_server_url_if_healthy()
     return local.rstrip("/") if local else None
 
@@ -5069,7 +5071,8 @@ def _resolve_host_server(server: str | None) -> str | None:
     if server is None:
         configured = _load_effective_config().get("server")
         server = str(configured) if configured else None
-    return server.rstrip("/") if server else None
+    # A bare Databricks workspace URL means its /api/2.0/omnigent mount.
+    return _workspace_api_server_url(server.rstrip("/")) if server else None
 
 
 def _daemon_base_url(record: _HostDaemonRecord) -> str | None:

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 # server (API) base onto the UI mount so browser links land on the SPA
 # instead of the JSON API.
 WORKSPACE_API_PATH = "/api/2.0/omnigent"
-WORKSPACE_UI_PATH = "/ml/omnigent"
+WORKSPACE_UI_PATH = "/omnigent"
 
 
 def conversation_url(base_url: str, conversation_id: str) -> str:
@@ -23,7 +23,7 @@ def conversation_url(base_url: str, conversation_id: str) -> str:
     For Databricks workspace-hosted servers
     (``https://<ws>/api/2.0/omnigent``) the web UI lives on the
     workspace SPA mount, so the link becomes
-    ``https://<ws>/ml/omnigent/c/<id>`` — with the ``?o=<org>``
+    ``https://<ws>/omnigent/c/<id>`` — with the ``?o=<org>``
     workspace selector appended when ``omnigent login`` recorded the
     org id.
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1283,8 +1283,14 @@ class HostProcess:
             managed-host token header or — only when a token could be
             minted — ``{"Authorization": "Bearer <token>"}``.
         """
-        headers: dict[str, str] = {}
         from omnigent.host.identity import HOST_TOKEN_ENV_VAR, MANAGED_HOST_TOKEN_HEADER
+        from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+
+        # Identify as a first-party client so the server's WebSocket origin
+        # guard (CSWSH protection) allows the handshake — the host process
+        # is not a browser. Seeded before either auth branch so it is sent
+        # on both the managed-token and Bearer paths.
+        headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
 
         managed_token = os.environ.get(HOST_TOKEN_ENV_VAR)
         if managed_token:

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -1,24 +1,30 @@
 """Built-in cost-budget policy.
 
 A single factory, :func:`cost_budget`, that gates a session on its
-cumulative LLM spend (USD) at the **tool-call** phase — the one point a
-native ``PreToolUse`` hook can actually block before the action runs:
+cumulative LLM spend (USD) at the **request** phase (before the LLM
+turn, so text-only turns are budgeted too) and the **tool-call** phase
+(the point a native ``PreToolUse`` hook can block before the action
+runs):
 
-- ``ask_thresholds_usd`` (optional, soft): a list of warning
-  checkpoints. The first time the session's ``total_cost_usd`` crosses
-  each checkpoint, the tool call is parked for user approval (ASK). Each
-  checkpoint prompts at most once *per approval* — the highest-approved
-  checkpoint is remembered in ``session_state``, so approving lets spend
-  continue to the next checkpoint. A decline blocks that one tool call
-  but does not record the checkpoint, so the next tool call over the
-  same threshold re-asks until it is approved.
-- ``max_cost_usd`` (required, hard): once spend reaches this, the
-  policy forces a model downgrade. Rather than stopping the session, it
-  DENYs every tool call **while the session is still on an expensive
-  model** (``expensive_models``), telling the user to switch to a
+- ``ask_thresholds_usd`` (optional, soft, **tool-call phase only**): a
+  list of warning checkpoints. The first time the session's
+  ``total_cost_usd`` crosses each checkpoint, the tool call is parked for
+  user approval (ASK). Each checkpoint prompts at most once *per
+  approval* — the highest-approved checkpoint is remembered in
+  ``session_state``, so approving lets spend continue to the next
+  checkpoint. A decline blocks that one tool call but does not record the
+  checkpoint, so the next tool call over the same threshold re-asks until
+  it is approved. (The soft gate is tool-call only because the
+  request-phase policy path has no approval round-trip — an ASK there
+  would surface as a plain denial.)
+- ``max_cost_usd`` (required, hard, **request + tool-call phases**): once
+  spend reaches this, the policy forces a model downgrade. Rather than
+  stopping the session, it DENYs **while the session is still on an
+  expensive model** (``expensive_models``) — the whole turn at the
+  request phase, or each tool call — telling the user to switch to a
   cheaper model with ``/model``. Once the session has switched off an
-  expensive model the tool calls are allowed again — the budget becomes
-  a "downgrade gate," not a hard stop.
+  expensive model it is allowed again — the budget becomes a "downgrade
+  gate," not a hard stop.
 
 It reads cumulative spend from
 ``event["context"]["usage"]["total_cost_usd"]`` — the running session
@@ -29,11 +35,13 @@ the agent spec's ``llm.model``, resolved by the policy engine). When
 pricing is unavailable the cost stays ``0.0`` and the policy never trips
 (it cannot budget what it cannot price).
 
-Because the gate runs on ``tool_call``, a DENY/ASK blocks that specific
-tool call (the native hook returns ``deny`` / parks for approval) rather
-than ending the session. Text-only turns with no tool calls are not
-gated. Cost is refreshed at turn boundaries, so a single very expensive
-turn can still overshoot before the next check.
+On the ``tool_call`` phase a DENY/ASK blocks that specific tool call
+(the native hook returns ``deny`` / parks for approval) rather than
+ending the session. On the ``request`` phase a DENY blocks the whole
+turn before the model runs — so text-only turns with no tool calls are
+budgeted too; its DENY reason is surfaced straight to the user. Cost is
+refreshed at turn boundaries, so a single very expensive turn can still
+overshoot before the next check.
 
 YAML usage::
 
@@ -45,7 +53,7 @@ YAML usage::
           arguments:
             max_cost_usd: 5.0
             ask_thresholds_usd: [1.0, 2.5]
-            expensive_models: ["opus", "gpt-5.5"]
+            expensive_models: ["opus", "gpt-5"]
 
 The factory must be referenced via ``function: {path, arguments}`` with
 a non-empty ``arguments`` block (the registry declares it
@@ -54,6 +62,7 @@ a non-empty ``arguments`` block (the registry declares it
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from omnigent.policies.schema import (
@@ -65,6 +74,11 @@ from omnigent.policies.schema import (
 )
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
+
+# Phases the budget gate fires on. ``tool_call`` is the native ``PreToolUse``
+# block point; ``request`` runs before the LLM turn so text-only turns (no
+# tool call) are budgeted too. Every other phase abstains (ALLOW).
+_GATED_PHASES = frozenset({"request", "tool_call"})
 
 # session_state key recording the highest ``ask_thresholds_usd`` checkpoint
 # the user has already approved continuing past (a USD float; 0.0 when none).
@@ -79,11 +93,22 @@ _ASK_APPROVED_KEY = SESSION_COST_ASK_APPROVED_STATE_KEY
 # ``max_cost_usd``. Matched as substrings of the active model id so a single
 # token hits every deployment spelling AND the tier aliases the native
 # ``/model`` command stores: ``"opus"`` matches ``claude-opus-4-8``,
-# ``databricks-claude-opus-4-7``, and the bare alias ``"opus"``; GPT-5.5
-# ships as ``databricks-gpt-5-5`` (dashes) in this stack, so both the dash
-# and dot spellings are listed. Fable (``claude-fable-5``, the tier above
-# Opus at 2x its price), Opus, and GPT-5.5 are the costly tiers today.
-_DEFAULT_EXPENSIVE_MODELS = ("fable", "opus", "gpt-5.5", "gpt-5-5")
+# ``databricks-claude-opus-4-7``, and the bare alias ``"opus"``; ``"gpt-5"``
+# matches the whole GPT-5 family (``gpt-5``, ``gpt-5.5``, the dash spelling
+# ``databricks-gpt-5-5``, …) EXCEPT the cheap variants carved out by
+# ``_DEFAULT_EXPENSIVE_EXCLUDES`` below. Fable (``claude-fable-5``, the tier
+# above Opus at 2x its price), Opus, and GPT-5 are the costly tiers today.
+_DEFAULT_EXPENSIVE_MODELS = ("fable", "opus", "gpt-5")
+
+# Default substring tokens (case-insensitive) that OVERRIDE a match in
+# ``_DEFAULT_EXPENSIVE_MODELS`` back to "not expensive". The broad ``"gpt-5"``
+# token above also matches the cheap ``gpt-5-mini`` / ``gpt-5-nano`` variants,
+# which should NOT be budget-blocked, so they are excluded here. The leading
+# dash is deliberate: a bare ``"mini"`` would also match unrelated models like
+# ``gemini``. Applied only to the built-in default set — when the caller passes
+# an explicit ``expensive_models`` list, those tokens are matched literally
+# with no exclusions (the caller controls the set exactly).
+_DEFAULT_EXPENSIVE_EXCLUDES = ("-mini", "-nano")
 
 
 def _session_cost_usd(event: PolicyEvent) -> float:
@@ -140,11 +165,19 @@ def _over_budget_deny_reason(
     expensive_tokens: tuple[str, ...],
     harness: str | None,
     *,
+    phase: str = "tool_call",
     policy_label: str = "session cost-budget",
     budget_label: str = "cost budget",
     subject_user: str | None = None,
 ) -> str:
-    """Build the over-budget DENY reason for the tool-call gate.
+    """Build the over-budget DENY reason for the budget gate.
+
+    On the ``request`` phase the DENY reason is surfaced directly to the
+    user (the turn never reaches the model), so it is the plain
+    user-facing message — no "relay this verbatim" / "re-issue the tool
+    call" wrapper. On the ``tool_call`` phase the reason is handed to the
+    model by native harnesses, so it is phrased as a DIRECTIVE (see
+    below).
 
     Phrased as a DIRECTIVE to the agent (not a statement): native harnesses
     hand this reason to the model, which otherwise paraphrases it and drops
@@ -164,10 +197,13 @@ def _over_budget_deny_reason(
     :param cost: Current cumulative session spend in USD, e.g. ``6.0``.
     :param max_cost_usd: The hard limit in USD, e.g. ``5.0``.
     :param expensive_tokens: The high-cost model substring tokens, listed for
-        the user, e.g. ``("opus", "gpt-5.5", "gpt-5-5")``.
+        the user, e.g. ``("opus", "gpt-5")``.
     :param harness: The harness name from the event (see
         :func:`_current_harness`), e.g. ``"codex-native"``; ``None`` when
         unstamped.
+    :param phase: The enforcement phase the DENY is for — ``"request"``
+        (user-facing message) or ``"tool_call"`` (model-directed directive).
+        Defaults to ``"tool_call"``.
     :param policy_label: Which budget policy is speaking, woven into
         "Blocked by the {policy_label} policy". Defaults to
         ``"session cost-budget"``; the per-user daily variant passes
@@ -191,6 +227,13 @@ def _over_budget_deny_reason(
         f"You've hit the ${max_cost_usd:.2f} {budget_label}. High-cost models "
         f"({expensive_list}) are blocked over budget — {switch_hint}."
     )
+    if phase == "request":
+        # Request-phase DENY: surfaced straight to the user (the turn never
+        # reaches the model), so this is the plain message — no relay wrapper.
+        return (
+            f"Blocked by the {policy_label} policy: {spend_subject} ${cost:.2f} reached the "
+            f"${max_cost_usd:.2f} limit. {verbatim}"
+        )
     return (
         f"Blocked by the {policy_label} policy: {spend_subject} ${cost:.2f} reached the "
         f"${max_cost_usd:.2f} limit, and tool calls are blocked while on a high-cost "
@@ -201,27 +244,100 @@ def _over_budget_deny_reason(
     )
 
 
-def _model_blocked_over_budget(model: str | None, expensive_tokens: tuple[str, ...]) -> bool:
+def _model_blocked_over_budget(
+    model: str | None,
+    expensive_tokens: tuple[str, ...],
+    exclude_tokens: tuple[str, ...] = (),
+) -> bool:
     """Decide whether the active model is blocked once over budget.
 
     Returns ``True`` when the session must downgrade to keep calling
-    tools — i.e. the model matches one of the expensive tokens, OR the
-    model is undeterminable (``None``). Failing closed on an unknown
-    model keeps the budget enforceable: rather than silently allowing
-    unbounded spend, it asks the user to pick a cheaper model with
-    ``/model`` (which sets ``model_override``, making the model
-    knowable and — if cheap — unblocking the session).
+    tools — i.e. the model matches one of the expensive tokens (and is
+    not carved out by an exclude token), OR the model is undeterminable
+    (``None``). Failing closed on an unknown model keeps the budget
+    enforceable: rather than silently allowing unbounded spend, it asks
+    the user to pick a cheaper model with ``/model`` (which sets
+    ``model_override``, making the model knowable and — if cheap —
+    unblocking the session).
+
+    An exclude token takes precedence over an expensive token: a model
+    matching both (e.g. ``gpt-5-mini`` matches ``"gpt-5"`` and the
+    exclude ``"-mini"``) is NOT blocked. This lets a broad expensive
+    token (``"gpt-5"``) cover a whole family while exempting its cheap
+    variants.
 
     :param model: The active model id, or ``None`` when
         undeterminable.
     :param expensive_tokens: Lowercased substring tokens identifying
-        expensive models, e.g. ``("opus", "gpt-5.5")``.
+        expensive models, e.g. ``("opus", "gpt-5")``.
+    :param exclude_tokens: Lowercased substring tokens that override an
+        expensive match back to "not expensive", e.g.
+        ``("-mini", "-nano")``. Defaults to empty (no exclusions).
     :returns: ``True`` when tool calls should be DENYed over budget.
     """
     if model is None:
         return True
     low = model.lower()
+    if any(token in low for token in exclude_tokens):
+        return False
     return any(token in low for token in expensive_tokens)
+
+
+@dataclass(frozen=True)
+class _ExpensiveModelConfig:
+    """Resolved expensive-model matching configuration for a budget factory.
+
+    :param expensive_tokens: Lowercased substring tokens that mark a
+        model as expensive, e.g. ``("fable", "opus", "gpt-5")``.
+    :param exclude_tokens: Lowercased substring tokens that override an
+        expensive match back to "not expensive", e.g. ``("-mini",
+        "-nano")``. Non-empty only for the built-in default set; empty
+        when the caller supplies an explicit ``expensive_models`` list.
+    :param hard_cap_enabled: Whether the hard over-budget DENY gate is
+        active. ``False`` only when the caller passes an empty
+        ``expensive_models`` list (soft thresholds only).
+    """
+
+    expensive_tokens: tuple[str, ...]
+    exclude_tokens: tuple[str, ...]
+    hard_cap_enabled: bool
+
+
+def _resolve_expensive_models(expensive_models: list[str] | None) -> _ExpensiveModelConfig:
+    """Resolve the ``expensive_models`` factory argument into matching config.
+
+    Shared by :func:`cost_budget` and :func:`user_daily_cost_budget` so
+    both treat the argument identically:
+
+    - ``None`` → the built-in default set
+      (:data:`_DEFAULT_EXPENSIVE_MODELS`) with the cheap-variant
+      exclusions (:data:`_DEFAULT_EXPENSIVE_EXCLUDES`) applied; hard gate
+      on.
+    - a non-empty list → those tokens (lowercased), matched literally
+      with NO exclusions (the caller controls the set exactly); hard gate
+      on.
+    - ``[]`` → no expensive tokens; hard gate off (soft thresholds only).
+
+    :param expensive_models: The factory argument, e.g.
+        ``["opus", "gpt-5"]``, ``None``, or ``[]``.
+    :returns: The resolved :class:`_ExpensiveModelConfig`.
+    :raises ValueError: If any entry is not a non-empty string.
+    """
+    if expensive_models is None:
+        return _ExpensiveModelConfig(
+            expensive_tokens=_DEFAULT_EXPENSIVE_MODELS,
+            exclude_tokens=_DEFAULT_EXPENSIVE_EXCLUDES,
+            hard_cap_enabled=True,
+        )
+    for m in expensive_models:
+        if not isinstance(m, str) or not m:
+            raise ValueError(f"each expensive_models value must be a non-empty string, got {m!r}")
+    expensive_tokens = tuple(m.lower() for m in expensive_models)
+    return _ExpensiveModelConfig(
+        expensive_tokens=expensive_tokens,
+        exclude_tokens=(),
+        hard_cap_enabled=len(expensive_tokens) > 0,
+    )
 
 
 def cost_budget(
@@ -229,14 +345,17 @@ def cost_budget(
     ask_thresholds_usd: list[float] | None = None,
     expensive_models: list[str] | None = None,
 ) -> PolicyCallable:
-    """Factory: gate a session on cumulative LLM spend (USD) at tool-call.
+    """Factory: gate a session on cumulative LLM spend (USD).
 
-    Gates the ``tool_call`` phase only: ASK at each soft warning
-    checkpoint ("continue?"; recorded on approve so it doesn't re-prompt,
-    re-asked after a decline) and, once the hard limit is reached, DENY
-    every tool call while the session is still on an expensive model —
-    telling the user to ``/model`` to a cheaper one. Abstains (ALLOW) on
-    every other phase and whenever cost is unpriced (``0.0``).
+    The hard limit gates BOTH the ``request`` phase (blocking the whole
+    turn before the LLM runs, so text-only turns are budgeted too) and
+    the ``tool_call`` phase: once the limit is reached, DENY while the
+    session is still on an expensive model — telling the user to
+    ``/model`` to a cheaper one. The soft warning checkpoints (ASK
+    "continue?"; recorded on approve so they don't re-prompt, re-asked
+    after a decline) fire on ``tool_call`` ONLY, because the request
+    phase has no approval round-trip (see ``evaluate``). Abstains (ALLOW)
+    on every other phase and whenever cost is unpriced (``0.0``).
 
     :param max_cost_usd: Hard limit in USD. Once cumulative session cost
         reaches this, tool calls are DENYed while the session is on an
@@ -251,12 +370,14 @@ def cost_budget(
         matter — they are sorted internally.
     :param expensive_models: Optional case-insensitive substring tokens
         identifying the model tiers blocked once over *max_cost_usd*,
-        e.g. ``["opus", "gpt-5.5"]``. A token matches when it is a
+        e.g. ``["opus", "gpt-5"]``. A token matches when it is a
         substring of the active model id (so ``"opus"`` matches both
         ``"databricks-claude-opus-4-8"`` and the alias ``"opus"``).
-        ``None`` uses the built-in default (Opus + GPT-5.5). ``[]``
-        disables the hard gate entirely (soft thresholds only, no
-        budget block). Each value must be a non-empty string.
+        ``None`` uses the built-in default (Fable + Opus + GPT-5,
+        excluding the cheap ``-mini`` / ``-nano`` variants). An explicit
+        list is matched literally with no exclusions. ``[]`` disables the
+        hard gate entirely (soft thresholds only, no budget block). Each
+        value must be a non-empty string.
     :returns: A policy callable implementing the budget gate.
     :raises ValueError: If *max_cost_usd* is not positive, any
         *ask_thresholds_usd* value is not in ``(0, max_cost_usd)``, or
@@ -271,52 +392,56 @@ def cost_budget(
                 f"each ask_thresholds_usd value must be in "
                 f"(0, max_cost_usd={max_cost_usd}), got {t!r}"
             )
-    # ``None`` → default tokens, hard gate on. ``[]`` → hard gate off
-    # (soft thresholds only). A non-empty list replaces the default.
-    if expensive_models is None:
-        expensive_tokens = _DEFAULT_EXPENSIVE_MODELS
-        hard_cap_enabled = True
-    else:
-        for m in expensive_models:
-            if not isinstance(m, str) or not m:
-                raise ValueError(
-                    f"each expensive_models value must be a non-empty string, got {m!r}"
-                )
-        expensive_tokens = tuple(m.lower() for m in expensive_models)
-        hard_cap_enabled = len(expensive_tokens) > 0
+    cfg = _resolve_expensive_models(expensive_models)
 
     def evaluate(event: PolicyEvent) -> PolicyResponse:
-        """Evaluate the session cost budget for a tool call.
+        """Evaluate the session cost budget for a request or tool call.
 
-        Gates only the ``tool_call`` phase — abstains on every other
-        phase.
+        Gates the ``request`` phase (before the LLM turn, so text-only
+        turns are budgeted too) and the ``tool_call`` phase (the native
+        ``PreToolUse`` block) — abstains on every other phase.
 
         - ``cost >= max_cost_usd`` and the active model is expensive
           (or undeterminable) → DENY (switch to a cheaper model);
-          ``cost >= max_cost_usd`` on a cheaper model → ALLOW.
+          ``cost >= max_cost_usd`` on a cheaper model → ALLOW. This hard
+          gate runs on BOTH gated phases.
         - the highest soft checkpoint newly crossed and not yet
           approved → ASK ("continue?") carrying a ``state_updates``
           write of the crossed value, applied only on approve so the
           checkpoint (and lower ones) won't re-prompt once approved.
+          This soft gate runs on ``tool_call`` ONLY: the request-phase
+          (input) policy path surfaces an ASK as a plain denial with no
+          approval round-trip and no ``state_updates`` persistence, so a
+          "Continue?" there would just block the turn and re-prompt every
+          turn. Soft warnings therefore fire at the first tool call of an
+          over-threshold turn instead.
 
         :param event: Policy event dict.
         :returns: DENY when over budget on an expensive model; ASK when
-            a new soft checkpoint is crossed; ALLOW otherwise.
+            a new soft checkpoint is crossed on ``tool_call``; ALLOW
+            otherwise.
         """
-        if event.get("type") != "tool_call":
+        phase = event.get("type")
+        if phase not in _GATED_PHASES:
             return _ALLOW
         cost = _session_cost_usd(event)
-        if hard_cap_enabled and cost >= max_cost_usd:
-            if _model_blocked_over_budget(_current_model(event), expensive_tokens):
+        if cfg.hard_cap_enabled and cost >= max_cost_usd:
+            if _model_blocked_over_budget(
+                _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
+            ):
                 return {
                     "result": "DENY",
                     "reason": _over_budget_deny_reason(
-                        cost, max_cost_usd, expensive_tokens, _current_harness(event)
+                        cost,
+                        max_cost_usd,
+                        cfg.expensive_tokens,
+                        _current_harness(event),
+                        phase=phase,
                     ),
                 }
             # Already on a cheaper model — the downgrade gate is satisfied.
             return _ALLOW
-        if thresholds:
+        if phase == "tool_call" and thresholds:
             # Highest checkpoint the cost has crossed so far.
             crossed = max((t for t in thresholds if cost >= t), default=None)
             if crossed is not None:
@@ -404,13 +529,15 @@ def user_daily_cost_budget(
     ``event["context"]["user_daily_cost"]`` (``cost_usd`` /
     ``ask_approved_usd``), which the policy engine injects — at
     engine-build time — only when this policy is configured (from the
-    ``user_daily_cost`` store, attributed to the session owner). Gates
-    the ``tool_call`` phase only.
+    ``user_daily_cost`` store, attributed to the session owner). The hard
+    limit gates the ``request`` phase (before the LLM turn) and the
+    ``tool_call`` phase; the soft warning checkpoints gate ``tool_call``
+    only (see :func:`cost_budget`).
 
     - **Soft (`ask_thresholds_usd`)**: the first time the owner's daily
       spend crosses a checkpoint, the tool call is parked for approval
-      (ASK). The approval is recorded **per user+day** (in
-      ``user_daily_cost.ask_approved_usd`` via a reserved
+      (ASK; ``tool_call`` phase only). The approval is recorded **per
+      user+day** (in ``user_daily_cost.ask_approved_usd`` via a reserved
       ``state_updates`` key the engine routes to that store), so an
       approved checkpoint won't re-prompt the user again that day —
       including from a different session. A decline blocks that one
@@ -429,8 +556,10 @@ def user_daily_cost_budget(
         ``< max_cost_usd``. ``None`` / ``[]`` disables the soft gate.
     :param expensive_models: Optional case-insensitive substring tokens
         for the model tiers blocked once over the daily limit. ``None``
-        uses the built-in default (Opus + GPT-5.5); ``[]`` disables the
-        hard gate (soft thresholds only).
+        uses the built-in default (Fable + Opus + GPT-5, excluding the
+        cheap ``-mini`` / ``-nano`` variants); an explicit list is
+        matched literally with no exclusions; ``[]`` disables the hard
+        gate (soft thresholds only).
     :returns: A policy callable implementing the per-user daily budget.
     :raises ValueError: Same validation as :func:`cost_budget`.
     """
@@ -443,20 +572,10 @@ def user_daily_cost_budget(
                 f"each ask_thresholds_usd value must be in "
                 f"(0, max_cost_usd={max_cost_usd}), got {t!r}"
             )
-    if expensive_models is None:
-        expensive_tokens = _DEFAULT_EXPENSIVE_MODELS
-        hard_cap_enabled = True
-    else:
-        for m in expensive_models:
-            if not isinstance(m, str) or not m:
-                raise ValueError(
-                    f"each expensive_models value must be a non-empty string, got {m!r}"
-                )
-        expensive_tokens = tuple(m.lower() for m in expensive_models)
-        hard_cap_enabled = len(expensive_tokens) > 0
+    cfg = _resolve_expensive_models(expensive_models)
 
     def evaluate(event: PolicyEvent) -> PolicyResponse:
-        """Evaluate the per-user daily cost budget for a tool call.
+        """Evaluate the per-user daily cost budget for a request or tool call.
 
         Mirrors :func:`cost_budget`'s ``evaluate`` exactly, reading the
         owner's daily spend / approval instead of the session totals,
@@ -465,29 +584,35 @@ def user_daily_cost_budget(
 
         :param event: Policy event dict.
         :returns: DENY when over the daily budget on an expensive model;
-            ASK when a new daily soft checkpoint is crossed; ALLOW
-            otherwise.
+            ASK when a new daily soft checkpoint is crossed on
+            ``tool_call``; ALLOW otherwise.
         """
-        if event.get("type") != "tool_call":
+        phase = event.get("type")
+        if phase not in _GATED_PHASES:
             return _ALLOW
         cost = _user_daily_cost_usd(event)
         owner = _user_daily_owner(event)
-        if hard_cap_enabled and cost >= max_cost_usd:
-            if _model_blocked_over_budget(_current_model(event), expensive_tokens):
+        if cfg.hard_cap_enabled and cost >= max_cost_usd:
+            if _model_blocked_over_budget(
+                _current_model(event), cfg.expensive_tokens, cfg.exclude_tokens
+            ):
                 return {
                     "result": "DENY",
                     "reason": _over_budget_deny_reason(
                         cost,
                         max_cost_usd,
-                        expensive_tokens,
+                        cfg.expensive_tokens,
                         _current_harness(event),
+                        phase=phase,
                         policy_label="per-user daily cost-budget",
                         budget_label="daily cost budget",
                         subject_user=owner,
                     ),
                 }
             return _ALLOW
-        if thresholds:
+        # Soft ASK is tool_call-only — see cost_budget.evaluate for why the
+        # request phase cannot carry an approvable checkpoint.
+        if phase == "tool_call" and thresholds:
             crossed = max((t for t in thresholds if cost >= t), default=None)
             if crossed is not None:
                 approved_up_to = _user_daily_ask_approved_usd(event)
@@ -524,10 +649,11 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
         "handler": "omnigent.policies.builtins.cost.cost_budget",
         "kind": "factory",
         "name": "Session Cost Budget",
-        "description": "Gates a session on cumulative LLM spend (USD) at tool-call: ASK for "
-        "approval at each soft warning checkpoint, and once a hard limit is reached DENY tool "
-        "calls while still on an expensive model (prompting a /model downgrade). Reads "
-        "event.context.usage.total_cost_usd and event.context.model.",
+        "description": "Gates a session on cumulative LLM spend (USD): once a hard limit is "
+        "reached DENY (the whole turn at the request phase, or each tool call) while still on "
+        "an expensive model (prompting a /model downgrade), and ASK for approval at each soft "
+        "warning checkpoint (tool-call phase only). Reads event.context.usage.total_cost_usd "
+        "and event.context.model.",
         "params_schema": {
             "type": "object",
             "properties": {
@@ -547,8 +673,9 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Optional case-insensitive substring tokens for the model "
-                    "tiers blocked once over budget (default: Opus + GPT-5.5). An empty list "
-                    "disables the hard limit, leaving only the soft thresholds.",
+                    "tiers blocked once over budget (default: Fable + Opus + GPT-5, excluding "
+                    "the cheap -mini/-nano variants). An empty list disables the hard limit, "
+                    "leaving only the soft thresholds.",
                 },
             },
             "required": ["max_cost_usd"],
@@ -559,10 +686,11 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
         "kind": "factory",
         "name": "Per-User Daily Cost Budget",
         "description": "Gates the session OWNER's cumulative LLM spend across all their "
-        "sessions for the current UTC day, at tool-call: ASK for approval at each soft "
-        "warning checkpoint (remembered per user+day), and once a hard daily limit is "
-        "reached DENY tool calls while still on an expensive model (prompting a /model "
-        "downgrade). Reads event.context.user_daily_cost and event.context.model.",
+        "sessions for the current UTC day: once a hard daily limit is reached DENY (the whole "
+        "turn at the request phase, or each tool call) while still on an expensive model "
+        "(prompting a /model downgrade), and ASK for approval at each soft warning checkpoint "
+        "(tool-call phase only, remembered per user+day). Reads event.context.user_daily_cost "
+        "and event.context.model.",
         "params_schema": {
             "type": "object",
             "properties": {
@@ -582,8 +710,9 @@ POLICY_REGISTRY: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Optional case-insensitive substring tokens for the model "
-                    "tiers blocked once over the daily budget (default: Opus + GPT-5.5). An "
-                    "empty list disables the hard limit, leaving only the soft thresholds.",
+                    "tiers blocked once over the daily budget (default: Fable + Opus + GPT-5, "
+                    "excluding the cheap -mini/-nano variants). An empty list disables the hard "
+                    "limit, leaving only the soft thresholds.",
                 },
             },
             "required": ["max_cost_usd"],

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -19,6 +19,15 @@ RUNNER_ADOPT_SIGNAL = signal.SIGUSR1
 RUNNER_WORKSPACE_ENV_VAR = "OMNIGENT_RUNNER_WORKSPACE"
 RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR = "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN"
 RUNNER_TUNNEL_TOKEN_HEADER = "X-Omnigent-Runner-Tunnel-Token"
+# Sentinel ``Origin`` header that the project's own non-browser WebSocket
+# clients (runner -> server tunnel, host/daemon -> server tunnel,
+# terminal-attach) set on their handshakes so the server's CSWSH origin
+# guard allows them. Lives here, alongside the tunnel token header,
+# because it is part of the same client/server handshake contract and the
+# server imports it from this module (server -> runner, not the reverse).
+# The non-HTTP scheme is deliberate: a browser computes ``Origin`` from
+# the page URL and can never emit this value.
+OMNIGENT_INTERNAL_WS_ORIGIN = "omnigent://internal"
 # "1" enables per-session workspace isolation so each session
 # gets its own subdirectory. Set by shared-host servers; single-user
 # CLI flows leave it unset (agent sees the project root directly).

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -24,7 +24,10 @@ from urllib.parse import quote, urlsplit, urlunsplit
 
 from websockets.exceptions import InvalidURI, WebSocketException
 
-from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER
+from omnigent.runner.identity import (
+    OMNIGENT_INTERNAL_WS_ORIGIN,
+    RUNNER_TUNNEL_TOKEN_HEADER,
+)
 from omnigent.runner.transports.ws_tunnel.frames import (
     HelloFrame,
     PingFrame,
@@ -518,7 +521,11 @@ async def _serve_tunnel_once(
 
     dispatch_tasks: dict[str, asyncio.Task[None]] = {}
     ws_channels: dict[str, _RunnerWSChannel] = {}
-    headers: dict[str, str] = {}
+    # Identify as a first-party client so the server's WebSocket origin
+    # guard (CSWSH protection) allows the handshake — this runner is not a
+    # browser and would otherwise rely on the permissive missing-origin
+    # branch.
+    headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
     if auth_token:
         headers["Authorization"] = f"Bearer {auth_token}"
     if tunnel_token:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -49,6 +49,7 @@ from omnigent.server.routes.sessions import (
     set_server_runner_router,
 )
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
+from omnigent.server.ws_origin import WebSocketOriginMiddleware
 from omnigent.stores import (
     AgentStore,
     ArtifactStore,
@@ -925,6 +926,11 @@ def create_app(
     app.state.server_metrics = server_metrics
     app.state.server_metrics_otel = server_metrics_otel
     app.add_middleware(_WebSocketMetricsMiddleware, metrics=server_metrics)
+    # CSWSH guard: reject cross-origin WebSocket handshakes before any
+    # route accepts them. Added after the metrics middleware so it is the
+    # outermost WS middleware — a forbidden origin is closed without even
+    # reaching the metrics counter (which only counts on accept anyway).
+    app.add_middleware(WebSocketOriginMiddleware)
     # Give the tool-policy ASK gate (which forwards the native-terminal
     # approval popup from a parked-gate background task, off any
     # request/route closure) the runner router so it can reach the bound

--- a/omnigent/server/routes/_content_type.py
+++ b/omnigent/server/routes/_content_type.py
@@ -1,0 +1,116 @@
+"""Content-Type preconditions for JSON-bodied POST routes.
+
+Several session POST handlers parse their request body with Starlette's
+``await request.json()``, which decodes the body as JSON regardless of
+the declared ``Content-Type``. That makes them reachable by a cross-site
+*simple* request (one that carries ``Content-Type: text/plain`` so the
+browser skips the CORS preflight) whose plain-text payload is in fact
+valid JSON — a CSRF vector, since the handler happily processes it.
+
+The dependencies here close that gap by requiring an explicit JSON
+``Content-Type`` (or, for the bundled-create route, ``multipart/form-data``)
+*before* the handler runs. They inspect only :attr:`Request.headers` and
+never touch the body, so the handler's existing ``await request.json()``
+and the verbatim runner pass-throughs keep working unchanged.
+
+These are FastAPI dependencies (attached via ``dependencies=[Depends(...)]``
+on the route decorator) rather than per-handler inline checks so the rule
+lives in exactly one place and reads identically across every route.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+
+def _request_media_type(request: Request) -> str:
+    """Return the lowercased media type of the request's Content-Type.
+
+    Strips any parameters (e.g. ``; charset=utf-8``) and surrounding
+    whitespace, yielding just the ``type/subtype`` token. Returns the
+    empty string when the header is absent, so a missing Content-Type
+    is treated as "no acceptable type" by the callers below.
+
+    :param request: The incoming FastAPI request.
+    :returns: The lowercased media type, e.g. ``"application/json"``,
+        or ``""`` when no ``Content-Type`` header is present.
+    """
+    raw = request.headers.get("content-type")
+    if raw is None:
+        return ""
+    return raw.split(";", 1)[0].strip().lower()
+
+
+def _is_json_media_type(media_type: str) -> bool:
+    """Return whether a media type denotes JSON.
+
+    Accepts the canonical ``application/json`` as well as any structured
+    JSON suffix type ``application/<subtype>+json`` (RFC 6839), e.g.
+    ``application/ld+json`` or ``application/vnd.api+json``.
+
+    :param media_type: An already-normalized (lowercased, parameter-stripped)
+        media type, e.g. ``"application/json"`` or ``"text/plain"``.
+    :returns: ``True`` if the type is JSON, ``False`` otherwise.
+    """
+    if media_type == "application/json":
+        return True
+    return media_type.startswith("application/") and media_type.endswith("+json")
+
+
+def require_json_content_type(request: Request) -> None:
+    """Reject any request that does not declare a JSON ``Content-Type``.
+
+    Use as a FastAPI dependency on POST routes whose body is parsed with
+    ``await request.json()``. Accepts ``application/json`` and
+    ``application/<subtype>+json``; rejects a missing header and every
+    other media type (``text/plain``, form-encoded, multipart,
+    octet-stream, ...) with ``415 Unsupported Media Type``.
+
+    Only the request headers are inspected — the body is never read — so
+    the downstream handler's own body parsing is unaffected.
+
+    :param request: The incoming FastAPI request.
+    :raises HTTPException: ``415`` when the ``Content-Type`` is missing or
+        is not a JSON media type.
+    """
+    media_type = _request_media_type(request)
+    if _is_json_media_type(media_type):
+        return
+    raise HTTPException(
+        status_code=415,
+        detail=(
+            "Unsupported Media Type: this endpoint requires a JSON request "
+            "body with Content-Type 'application/json' (or 'application/*+json')."
+        ),
+    )
+
+
+def require_json_or_multipart_content_type(request: Request) -> None:
+    """Reject requests that are neither JSON nor ``multipart/form-data``.
+
+    The bundled-create variant of :func:`require_json_content_type`, for
+    the one route (``POST /v1/sessions``) that legitimately accepts both a
+    JSON body and a ``multipart/form-data`` upload (the bundled-create
+    form path). Accepts ``application/json`` /
+    ``application/<subtype>+json`` and ``multipart/form-data``; rejects a
+    missing header and every other media type (``text/plain``,
+    form-encoded, octet-stream, ...) with ``415`` *before* the handler's
+    content-type dispatch runs.
+
+    Only the request headers are inspected — the body is never read.
+
+    :param request: The incoming FastAPI request.
+    :raises HTTPException: ``415`` when the ``Content-Type`` is missing or
+        is neither a JSON media type nor ``multipart/form-data``.
+    """
+    media_type = _request_media_type(request)
+    if _is_json_media_type(media_type) or media_type == "multipart/form-data":
+        return
+    raise HTTPException(
+        status_code=415,
+        detail=(
+            "Unsupported Media Type: this endpoint requires Content-Type "
+            "'application/json' (or 'application/*+json') for a JSON body, or "
+            "'multipart/form-data' for a bundled create."
+        ),
+    )

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -894,6 +894,28 @@ async def _poll_request_disconnect(request: Request) -> None:
             return
 
 
+def _attachment_disposition(filename: str) -> str:
+    """Build a safe ``Content-Disposition: attachment`` header value.
+
+    The filename is user-controlled, so it cannot be interpolated
+    into the header verbatim — a quote or newline would let the
+    uploader inject header content or break parsing. We emit an
+    ASCII-only ``filename`` fallback (with quotes/backslashes/control
+    characters stripped) plus an RFC 5987 ``filename*`` parameter that
+    percent-encodes the full UTF-8 name for modern browsers.
+
+    :param filename: The stored, user-supplied filename.
+    :returns: A ``Content-Disposition`` header value forcing download.
+    """
+    # ASCII fallback: drop anything outside printable ASCII and the
+    # characters that are structurally significant in the header.
+    ascii_name = "".join(ch for ch in filename if 0x20 <= ord(ch) < 0x7F and ch not in '"\\')
+    if not ascii_name:
+        ascii_name = "download"
+    encoded = urllib.parse.quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{encoded}"
+
+
 def _stored_file_to_resource(
     session_id: str,
     stored: StoredFile,
@@ -14680,7 +14702,22 @@ def create_sessions_router(
             )
         content = artifact_store.get(stored.id)
         media_type = mimetypes.guess_type(stored.filename)[0] or "application/octet-stream"
-        return Response(content=content, media_type=media_type)
+        # The filename and bytes are fully user-controlled. Serving the
+        # content inline lets a browser navigating directly to this URL
+        # render an uploaded ``evil.html`` as ``text/html`` and execute
+        # its script in the server's own origin (stored XSS — acute on
+        # the OSS/local server, which has no CSRF/apiproxy boundary).
+        # Force a download with ``Content-Disposition: attachment`` and
+        # disable MIME sniffing so the response cannot be reinterpreted
+        # as an active type.
+        return Response(
+            content=content,
+            media_type=media_type,
+            headers={
+                "Content-Disposition": _attachment_disposition(stored.filename),
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
 
     @router.delete(
         "/sessions/{session_id}/resources/files/{file_id}",

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -41,6 +41,7 @@ import httpx
 from fastapi import (
     APIRouter,
     BackgroundTasks,
+    Depends,
     File,
     HTTPException,
     Query,
@@ -174,6 +175,10 @@ from omnigent.server.routes._auth_helpers import (
     require_user as _require_user,
 )
 from omnigent.server.routes._codex_elicitation import parse_codex_elicitation_request
+from omnigent.server.routes._content_type import (
+    require_json_content_type,
+    require_json_or_multipart_content_type,
+)
 from omnigent.server.routes._host_worktree import CreatedWorktree
 from omnigent.server.schemas import (
     AgentObject,
@@ -11521,6 +11526,10 @@ def create_sessions_router(
         "/sessions",
         status_code=201,
         response_model=None,
+        # CSRF hardening: this route dispatches on Content-Type (JSON vs
+        # multipart bundled-create), so reject text/plain and other simple
+        # types up front while still allowing both legitimate body shapes.
+        dependencies=[Depends(require_json_or_multipart_content_type)],
     )
     async def create_session(
         request: Request,
@@ -13212,6 +13221,9 @@ def create_sessions_router(
     @router.post(
         "/sessions/{session_id}/hooks/permission-request",
         response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def claude_permission_request_hook(
         request: Request,
@@ -13484,6 +13496,9 @@ def create_sessions_router(
         # Returns EvaluationResponse JSON; no Pydantic model since the
         # proto-style schema is validated manually.
         response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def evaluate_policy(
         request: Request,
@@ -13673,6 +13688,9 @@ def create_sessions_router(
     @router.post(
         "/sessions/{session_id}/hooks/codex-elicitation-request",
         response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def codex_elicitation_request_hook(
         request: Request,
@@ -14268,6 +14286,9 @@ def create_sessions_router(
     @router.post(
         "/sessions/{session_id}/resources/terminals",
         response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def create_session_terminal(
         session_id: str,
@@ -14368,6 +14389,9 @@ def create_sessions_router(
     @router.post(
         "/sessions/{session_id}/resources/terminals/{terminal_id}/transfer",
         response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def transfer_session_terminal(
         request: Request,
@@ -15054,6 +15078,9 @@ def create_sessions_router(
     @router.post(
         "/sessions/{session_id}/resources/environments/{environment_id}/shell",
         response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def run_environment_shell(
         session_id: str,
@@ -16990,6 +17017,10 @@ def create_sessions_router(
     @router.post(
         "/sessions/{session_id}/mcp",
         response_model=None,  # Returns a raw Response with application/json
+        # CSRF hardening: the MCP Streamable HTTP contract already mandates
+        # an application/json request body; enforce it so a cross-site
+        # text/plain request can't drive JSON-RPC against this proxy.
+        dependencies=[Depends(require_json_content_type)],
     )
     async def mcp_proxy(
         session_id: str,

--- a/omnigent/server/ws_origin.py
+++ b/omnigent/server/ws_origin.py
@@ -1,0 +1,229 @@
+"""WebSocket ``Origin`` enforcement for the Omnigent server.
+
+Cross-Site WebSocket Hijacking (CSWSH) protection. FastAPI/Starlette do
+not validate the WebSocket ``Origin`` header by default, so any web page
+the user visits in their browser can open a WebSocket to a running
+Omnigent server and drive the agent, read session updates, or attach to a
+terminal. In single-user **local mode** there is no cookie / proxy auth to
+stop it — the server falls back to the reserved ``"local"`` user — so the
+``Origin`` header is the only signal that distinguishes the user's own UI
+from a hostile cross-origin page.
+
+This module provides:
+
+- :func:`websocket_origin_allowed` — the pure policy function deciding
+  whether a handshake's ``Origin`` is acceptable for the current mode;
+- :class:`WebSocketOriginMiddleware` — an ASGI middleware that applies the
+  policy to every WebSocket handshake *before* it reaches a route handler,
+  so the check runs before any ``websocket.accept()`` (per the rule in
+  ``.claude/skills/code-review/security-guidelines.md`` W1/W4);
+- :data:`OMNIGENT_INTERNAL_WS_ORIGIN` — the sentinel ``Origin`` the
+  project's own non-browser clients (runner, host/daemon, terminal-attach)
+  set so the middleware allows them unambiguously.
+
+Other auth modes (``oidc`` / ``accounts`` / multi-user ``header``)
+authenticate every connection with a signed ``__Host-ap_session`` cookie
+or a trusted-proxy header, so a cross-origin page cannot ride the user's
+credentials. The middleware leaves those modes as passthrough unless the
+deployment opts into an explicit allowlist via
+``OMNIGENT_WS_ALLOWED_ORIGINS``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from ipaddress import ip_address
+from urllib.parse import urlsplit
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from omnigent.server.auth import local_single_user_enabled
+
+_logger = logging.getLogger(__name__)
+
+# The sentinel ``Origin`` the project's own non-browser clients set is
+# defined alongside the tunnel handshake constants in
+# ``omnigent.runner.identity`` and re-exported here for the server-side
+# policy. See :data:`OMNIGENT_INTERNAL_WS_ORIGIN` there for rationale.
+__all__ = [
+    "FORBIDDEN_ORIGIN_CLOSE_CODE",
+    "OMNIGENT_INTERNAL_WS_ORIGIN",
+    "WebSocketOriginMiddleware",
+    "origin_hostname_is_loopback",
+    "parse_allowed_origins",
+    "websocket_origin_allowed",
+]
+
+# Optional comma-separated allowlist of additional permitted origins. When
+# set it is honored in every mode (defense-in-depth for deployments); in
+# non-local modes a non-empty allowlist also flips the default from
+# passthrough to deny-by-default.
+_ALLOWED_ORIGINS_ENV = "OMNIGENT_WS_ALLOWED_ORIGINS"
+
+# Private-use WebSocket close code (4000-4999) for a rejected origin.
+# Distinct from the auth-failure ``1008`` and the tunnel-mismatch ``4004``
+# already used elsewhere so a forbidden-origin rejection is diagnosable.
+FORBIDDEN_ORIGIN_CLOSE_CODE = 4403
+
+
+def origin_hostname_is_loopback(origin: str) -> bool:
+    """Return whether an ``Origin`` header points at a loopback host.
+
+    Parses the ``Origin`` URL and inspects its hostname. ``localhost``,
+    IPv4/IPv6 loopback addresses (``127.0.0.0/8``, ``::1``) and
+    IPv4-mapped loopback (``::ffff:127.0.0.1``) all count as loopback;
+    everything else (including a missing or unparseable host) does not.
+
+    :param origin: The raw ``Origin`` header value, e.g.
+        ``"http://localhost:8000"`` or ``"https://app.example.com"``.
+    :returns: ``True`` when the origin's hostname is a loopback host.
+    """
+    try:
+        host = urlsplit(origin).hostname
+    except ValueError:
+        return False
+    if host is None:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        addr = ip_address(host)
+    except ValueError:
+        return False
+    mapped_ipv4 = getattr(addr, "ipv4_mapped", None)
+    return addr.is_loopback or (mapped_ipv4 is not None and mapped_ipv4.is_loopback)
+
+
+def parse_allowed_origins() -> frozenset[str]:
+    """Read the optional explicit origin allowlist from the environment.
+
+    Reads ``OMNIGENT_WS_ALLOWED_ORIGINS`` (comma-separated). Whitespace
+    around each entry is stripped and empty entries are dropped.
+
+    :returns: The set of explicitly allowed origins, e.g.
+        ``frozenset({"https://app.example.com"})``; empty when the env
+        var is unset or blank.
+    """
+    raw = os.environ.get(_ALLOWED_ORIGINS_ENV, "")
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def websocket_origin_allowed(
+    origin: str | None,
+    *,
+    local_mode: bool,
+    extra_allowed: frozenset[str],
+) -> bool:
+    """Decide whether a WebSocket handshake's ``Origin`` is acceptable.
+
+    Policy:
+
+    - The first-party sentinel (:data:`OMNIGENT_INTERNAL_WS_ORIGIN`) and
+      any origin in ``extra_allowed`` are always allowed.
+    - A missing ``Origin`` is allowed: non-browser clients never send one,
+      and browsers always do, so its absence is not a browser CSWSH
+      vector.
+    - In ``local_mode`` an ``Origin`` is allowed only when its hostname is
+      a loopback host — this is the CSWSH guard for the unauthenticated
+      single-user local server.
+    - In non-local modes the connection is authenticated by cookie / proxy
+      header, so any ``Origin`` is allowed unless ``extra_allowed`` is
+      non-empty, in which case only the allowlist (matched above) passes.
+
+    :param origin: The handshake ``Origin`` header, or ``None`` when the
+        client sent none, e.g. ``"http://localhost:8000"``.
+    :param local_mode: Whether the server is a single-user local runtime
+        (``OMNIGENT_LOCAL_SINGLE_USER`` truthy).
+    :param extra_allowed: Explicitly allowlisted origins from
+        :func:`parse_allowed_origins`.
+    :returns: ``True`` when the handshake may proceed.
+    """
+    if origin == OMNIGENT_INTERNAL_WS_ORIGIN:
+        return True
+    if origin is not None and origin in extra_allowed:
+        return True
+    if origin is None:
+        return True
+    if local_mode:
+        return origin_hostname_is_loopback(origin)
+    # Non-local modes rely on cookie / proxy auth. Passthrough by default;
+    # if a deployment configured an allowlist, anything not matched above
+    # is denied.
+    return not extra_allowed
+
+
+def _origin_from_scope(scope: Scope) -> str | None:
+    """Extract the ``Origin`` header from an ASGI connection scope.
+
+    ASGI lowercases header names, so a byte-string match on ``b"origin"``
+    is sufficient.
+
+    :param scope: ASGI connection scope, e.g. one with
+        ``type == "websocket"``.
+    :returns: The decoded ``Origin`` value, or ``None`` when absent.
+    """
+    for key, value in scope.get("headers", []):
+        if key == b"origin":
+            return value.decode("latin-1")
+    return None
+
+
+class WebSocketOriginMiddleware:
+    """ASGI middleware enforcing the WebSocket ``Origin`` policy.
+
+    Wraps the downstream app and, for ``websocket``-typed scopes only,
+    rejects handshakes whose ``Origin`` is not permitted by
+    :func:`websocket_origin_allowed` — closing the connection before it
+    reaches a route handler (and thus before any ``websocket.accept()``).
+    Non-WebSocket scopes and permitted handshakes pass through untouched.
+
+    The server mode (``local_mode``) and the allowlist are read per
+    connection from the environment, so behavior tracks the runtime
+    configuration rather than being frozen at construction time.
+
+    :param app: Downstream ASGI app.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Initialize the middleware.
+
+        :param app: Downstream ASGI app.
+        :returns: None.
+        """
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Enforce the origin policy for WebSocket handshakes.
+
+        :param scope: ASGI connection scope, e.g. type ``"websocket"``.
+        :param receive: ASGI receive callable.
+        :param send: ASGI send callable.
+        :returns: None.
+        """
+        if scope["type"] != "websocket":
+            await self._app(scope, receive, send)
+            return
+
+        origin = _origin_from_scope(scope)
+        if websocket_origin_allowed(
+            origin,
+            local_mode=local_single_user_enabled(),
+            extra_allowed=parse_allowed_origins(),
+        ):
+            await self._app(scope, receive, send)
+            return
+
+        # Reject before the route runs: consume the initial
+        # ``websocket.connect`` then close without accepting. The client
+        # observes a failed handshake (close code, never an open socket).
+        await receive()
+        await send(
+            {
+                "type": "websocket.close",
+                "code": FORBIDDEN_ORIGIN_CLOSE_CODE,
+                "reason": "forbidden origin",
+            }
+        )
+        _logger.warning("Rejected WebSocket handshake: forbidden origin %r", origin)

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,8 @@ from omnigent.cli import (
     _discover_local_server_url,
     _ensure_backend,
     _ensure_host_daemon,
+    _resolve_attach_server,
+    _resolve_host_server,
 )
 from omnigent.cli import (
     cli as cli_group,
@@ -1425,3 +1428,168 @@ def test_ensure_backend_databricks_preflight_skips_when_authenticated(
 
     assert login_calls == []
     assert result == "https://myapp-1234.aws.databricksapps.com"
+
+
+# ── Workspace-URL expansion for attach / resume / host ──────────────
+#
+# ``run`` / ``claude`` / ``codex`` expand a bare Databricks workspace URL to
+# its ``/api/2.0/omnigent`` mount via ``_ensure_backend`` (covered above);
+# ``attach``, ``resume``, and the ``host`` subcommands resolve ``--server``
+# on their own paths and must route through the same expansion. The
+# expansion itself probes the network and is tested in
+# ``test_login_databricks.py`` — here we stub it to a recognizable
+# transform and assert each resolver actually calls it.
+
+
+def _expand_marker(server: str) -> str:
+    """Stand in for ``_workspace_api_server_url`` with a visible transform.
+
+    :param server: The URL the resolver hands to the expansion.
+    :returns: ``server`` with the API mount appended, so a test can tell
+        an expanded result apart from a passed-through one.
+    """
+    return f"{server.rstrip('/')}/api/2.0/omnigent"
+
+
+def _recording_expander(seen: list[str]) -> Callable[[str], str]:
+    """Build a ``_workspace_api_server_url`` stub that records its input.
+
+    :param seen: List the stub appends each received URL to, so a test
+        can assert the resolver expanded the bare URL (not a pre-pathed one).
+    :returns: Callable that records ``server`` then returns its expansion.
+    """
+
+    def _expand(server: str) -> str:
+        seen.append(server)
+        return _expand_marker(server)
+
+    return _expand
+
+
+def test_resolve_attach_server_expands_explicit_workspace_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``--server`` workspace URL is expanded to its API mount.
+
+    Regression: ``attach`` returned the bare URL, so ``/v1/sessions/{id}``
+    hit the workspace web app and 404'd instead of the omnigent API.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr(cli, "_workspace_api_server_url", _recording_expander(seen))
+
+    result = _resolve_attach_server("https://ws.example.net/", configured_server=None)
+
+    assert result == "https://ws.example.net/api/2.0/omnigent"
+    assert seen == ["https://ws.example.net"]
+
+
+def test_resolve_attach_server_expands_configured_workspace_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The configured ``server`` default is expanded just like ``--server``."""
+    monkeypatch.setattr(cli, "_workspace_api_server_url", _expand_marker)
+
+    result = _resolve_attach_server(None, configured_server="https://ws.example.net")
+
+    assert result == "https://ws.example.net/api/2.0/omnigent"
+
+
+def test_resolve_attach_server_local_fallback_not_expanded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The local-server fallback returns a concrete URL without expansion.
+
+    The background server already publishes a loopback URL; routing it
+    through the network probe would be pointless work.
+    """
+    monkeypatch.setattr(
+        cli,
+        "_workspace_api_server_url",
+        lambda s: pytest.fail("local fallback must not be expanded"),
+    )
+    monkeypatch.setattr(cli, "local_server_url_if_healthy", lambda: "http://127.0.0.1:8123/")
+
+    assert _resolve_attach_server(None, configured_server=None) == "http://127.0.0.1:8123"
+
+
+def test_resolve_host_server_expands_explicit_workspace_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``host`` subcommands expand a bare ``--server`` workspace URL.
+
+    The daemon is registered under the expanded ``/api/2.0/omnigent`` URL,
+    so the registry lookup must expand too or it never matches a daemon
+    that ``run`` / ``host`` started.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr(cli, "_workspace_api_server_url", _recording_expander(seen))
+
+    result = _resolve_host_server("https://ws.example.net/")
+
+    assert result == "https://ws.example.net/api/2.0/omnigent"
+    assert seen == ["https://ws.example.net"]
+
+
+def test_resolve_host_server_reads_config_and_expands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no ``--server``, the configured default is read and expanded."""
+    monkeypatch.setattr(
+        cli, "_load_effective_config", lambda: {"server": "https://ws.example.net"}
+    )
+    monkeypatch.setattr(cli, "_workspace_api_server_url", _expand_marker)
+
+    assert _resolve_host_server(None) == "https://ws.example.net/api/2.0/omnigent"
+
+
+def test_resolve_host_server_none_stays_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No CLI value and no configured default stays local (``None``)."""
+    monkeypatch.setattr(cli, "_load_effective_config", dict)
+    monkeypatch.setattr(
+        cli, "_workspace_api_server_url", lambda s: pytest.fail("nothing to expand")
+    )
+
+    assert _resolve_host_server(None) is None
+
+
+def test_resume_command_expands_server_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``omnigent resume <id> --server <workspace>`` expands before dispatch.
+
+    Regression: ``resume`` forwarded the bare URL, so its remote picker
+    and wrapper-label lookups 404'd against the workspace web app.
+    """
+    monkeypatch.setattr(cli, "_workspace_api_server_url", _expand_marker)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "omnigent.resume_dispatch.run_resume",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    result = CliRunner().invoke(
+        cli_group, ["resume", "conv_abc123", "--server", "https://ws.example.net"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "target": "conv_abc123",
+        "server": "https://ws.example.net/api/2.0/omnigent",
+    }
+
+
+def test_resume_command_without_server_skips_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``--server``, resume forwards ``None`` and never probes."""
+    monkeypatch.setattr(
+        cli, "_workspace_api_server_url", lambda s: pytest.fail("nothing to expand")
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "omnigent.resume_dispatch.run_resume",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    result = CliRunner().invoke(cli_group, ["resume", "conv_abc123"])
+
+    assert result.exit_code == 0, result.output
+    assert captured == {"target": "conv_abc123", "server": None}

--- a/tests/policies/builtins/test_cost.py
+++ b/tests/policies/builtins/test_cost.py
@@ -2,18 +2,21 @@
 Tests for the built-in cost-budget policy
 (:mod:`omnigent.policies.builtins.cost`) — the ``cost_budget`` factory.
 
-The policy gates the ``tool_call`` phase: ASK at each soft warning
-checkpoint, and once the hard limit is reached DENY tool calls while the
-session is still on an expensive model (forcing a ``/model`` downgrade),
-ALLOW once it has switched to a cheaper one.
+The policy's hard limit gates both the ``request`` and ``tool_call``
+phases: once reached, DENY (the whole turn on ``request``, or each tool
+call on ``tool_call``) while the session is still on an expensive model
+(forcing a ``/model`` downgrade), ALLOW once it has switched to a cheaper
+one. The soft warning checkpoints ASK on ``tool_call`` only (the
+request-phase path has no approval round-trip).
 
 Layers:
 
-- **Layer 1** — direct callable on the ``tool_call`` phase: ALLOW below
-  the soft checkpoints, ASK (recorded via ``session_state`` so an
-  approved checkpoint doesn't re-prompt) when one is crossed, DENY over
-  the hard limit on an expensive/unknown model, ALLOW over the limit on
-  a cheaper model, abstain on every other phase, and factory validation.
+- **Layer 1** — direct callable on the ``request`` / ``tool_call``
+  phases: ALLOW below the soft checkpoints, ASK (recorded via
+  ``session_state`` so an approved checkpoint doesn't re-prompt) when one
+  is crossed, DENY over the hard limit on an expensive/unknown model,
+  ALLOW over the limit on a cheaper model, abstain on every non-gated
+  phase, and factory validation.
 - **Layer 2** — spec resolution through :func:`resolve_function_policy`,
   proving DENY and ASK thread through the engine boundary with the cost
   on ``EvaluationContext.usage`` and the active model on
@@ -73,15 +76,52 @@ def _tool(
     }
 
 
+def _request(
+    cost: float | None,
+    *,
+    model: str | None = "databricks-claude-opus-4-8",
+    session_state: dict[str, Any] | None = None,
+    harness: str | None = None,
+) -> PolicyEvent:
+    """
+    Build a ``request`` :class:`PolicyEvent` with a cost + active model.
+
+    The request phase fires before the LLM turn; its ``data`` is the user
+    message string and there is no tool ``target``. Used to prove the
+    budget now gates whole turns (including text-only ones), not just
+    tool calls.
+
+    :param cost: ``total_cost_usd`` under ``context.usage``, e.g. ``6.0``.
+        ``None`` omits the field (unpriced-session case).
+    :param model: Active model under ``context.model``, e.g.
+        ``"databricks-claude-opus-4-8"`` or the alias ``"opus"``; ``None``
+        for the undeterminable-model case.
+    :param session_state: Optional persisted state, e.g.
+        ``{_ASK_APPROVED_KEY: 2.0}``. ``None`` means empty.
+    :param harness: Harness under ``context.harness``; ``None`` is the
+        web / API path (the request phase is not natively stamped).
+    :returns: A ``request`` event dict.
+    """
+    usage: dict[str, Any] = {} if cost is None else {"total_cost_usd": cost}
+    return {
+        "type": "request",
+        "target": None,
+        "data": "please run the build",
+        "context": {"actor": {}, "usage": usage, "model": model, "harness": harness},
+        "session_state": session_state or {},
+    }
+
+
 def _event(phase: str, cost: float) -> PolicyEvent:
     """
-    Build a non-tool-call :class:`PolicyEvent` carrying a session cost.
+    Build a non-gated-phase :class:`PolicyEvent` carrying a session cost.
 
-    :param phase: Event type, e.g. ``"request"`` / ``"response"`` /
-        ``"tool_result"``.
+    :param phase: Event type, e.g. ``"response"`` / ``"tool_result"`` /
+        ``"llm_request"`` / ``"llm_response"`` (NOT ``"request"`` or
+        ``"tool_call"``, which are gated).
     :param cost: ``total_cost_usd`` under ``context.usage``, e.g. ``9.99``.
     :returns: An event dict of the given phase (over budget, to prove the
-        non-tool-call phases are not gated).
+        non-gated phases are not gated).
     """
     return {
         "type": phase,
@@ -168,7 +208,7 @@ def test_over_budget_on_expensive_model_denies() -> None:
     assert "6.00" in result["reason"]  # current cost surfaced
     # The high-cost tokens are listed so the user knows which to avoid.
     assert "opus" in result["reason"]
-    assert "gpt-5.5" in result["reason"]
+    assert "gpt-5" in result["reason"]
 
 
 def test_deny_reason_for_codex_points_to_terminal() -> None:
@@ -239,24 +279,48 @@ def test_hard_limit_wins_over_checkpoint_approval() -> None:
     assert result["result"] == "DENY"
 
 
-def test_default_expensive_set_matches_opus_and_gpt55() -> None:
-    """The default expensive set blocks Fable, Opus, and GPT-5.5 spellings.
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        # Opus — concrete deployment id and the bare picker alias.
+        ("databricks-claude-opus-4-8", "DENY"),
+        ("opus", "DENY"),
+        # GPT-5 family: the broad "gpt-5" token covers bare gpt-5, the
+        # dot-spelled 5.5, and the dash-spelled deployment id.
+        ("gpt-5", "DENY"),
+        ("gpt-5.5", "DENY"),
+        ("databricks-gpt-5-5", "DENY"),
+        # Fable is the costliest tier (above Opus at 2x its price); both the
+        # concrete id and the bare picker alias must be gated, or switching to
+        # Fable becomes a budget bypass for a session downgraded off Opus.
+        ("claude-fable-5", "DENY"),
+        ("fable", "DENY"),
+        # Cheap GPT-5 variants are carved out by the -mini / -nano excludes,
+        # even though they contain the "gpt-5" substring → ALLOW over budget.
+        ("gpt-5-mini", "ALLOW"),
+        ("gpt-5-nano", "ALLOW"),
+        ("databricks-gpt-5-mini", "ALLOW"),
+        # A non-listed model is treated as cheap → allowed over budget.
+        ("databricks-claude-haiku-4-5", "ALLOW"),
+        # "gemini" contains the substring "mini" but NOT "-mini"; the
+        # leading dash in the exclude token keeps it from being wrongly
+        # carved out (it's simply not an expensive token either) → ALLOW.
+        ("databricks-gemini-2-5-pro", "ALLOW"),
+    ],
+)
+def test_default_expensive_set_matches_and_excludes(model: str, expected: str) -> None:
+    """The default set blocks Fable/Opus/GPT-5 but exempts -mini/-nano.
 
     Substring + case-insensitive matching must hit the deployment ids in
-    this stack: ``databricks-claude-opus-4-8`` and ``databricks-gpt-5-5``
-    (dashes). A miss would let the costliest models run past budget under
-    the zero-config default.
+    this stack (``databricks-claude-opus-4-8``, ``databricks-gpt-5-5``)
+    while the cheap ``gpt-5-mini`` / ``gpt-5-nano`` variants — which share
+    the ``gpt-5`` substring — are carved back out so they are NOT blocked.
+    A miss either way would mis-budget the zero-config default: blocking a
+    cheap variant traps users needlessly; letting Opus/GPT-5 through lets
+    the costliest models run past budget.
     """
     policy = cost_budget(max_cost_usd=5.0)
-    assert policy(_tool(6.0, model="databricks-claude-opus-4-8"))["result"] == "DENY"
-    assert policy(_tool(6.0, model="databricks-gpt-5-5"))["result"] == "DENY"
-    # Fable is the costliest tier (above Opus at 2x its price); both the
-    # concrete id and the bare picker alias must be gated, or switching to
-    # Fable becomes a budget bypass for a session downgraded off Opus.
-    assert policy(_tool(6.0, model="claude-fable-5"))["result"] == "DENY"
-    assert policy(_tool(6.0, model="fable"))["result"] == "DENY"
-    # A non-listed model is treated as cheap → allowed over budget.
-    assert policy(_tool(6.0, model="databricks-claude-haiku-4-5")) == {"result": "ALLOW"}
+    assert policy(_tool(6.0, model=model))["result"] == expected
 
 
 def test_custom_expensive_models_substring_case_insensitive() -> None:
@@ -269,6 +333,20 @@ def test_custom_expensive_models_substring_case_insensitive() -> None:
     policy = cost_budget(max_cost_usd=5.0, expensive_models=["FoO"])
     assert policy(_tool(6.0, model="x-foo-bar"))["result"] == "DENY"
     assert policy(_tool(6.0, model="claude-sonnet-4-6")) == {"result": "ALLOW"}
+
+
+def test_explicit_expensive_models_apply_no_mini_nano_exclusion() -> None:
+    """An explicit ``expensive_models`` list is matched literally — no excludes.
+
+    The ``-mini`` / ``-nano`` carve-out applies ONLY to the built-in
+    default set. When the author spells the tokens themselves, the set is
+    matched exactly: ``["gpt-5"]`` then blocks ``gpt-5-mini`` too. If the
+    exclusion leaked into explicit lists, an author who deliberately
+    listed a cheap-variant-inclusive token could not enforce it.
+    """
+    policy = cost_budget(max_cost_usd=5.0, expensive_models=["gpt-5"])
+    assert policy(_tool(6.0, model="gpt-5-mini"))["result"] == "DENY"
+    assert policy(_tool(6.0, model="gpt-5-nano"))["result"] == "DENY"
 
 
 def test_empty_expensive_models_disables_hard_gate() -> None:
@@ -288,17 +366,88 @@ def test_empty_expensive_models_disables_hard_gate() -> None:
     assert policy(_tool(2.0, model="opus"))["result"] == "ASK"
 
 
-def test_abstains_on_non_tool_call_phases() -> None:
-    """Only ``tool_call`` is gated — request/response/tool_result abstain.
+@pytest.mark.parametrize("phase", ["response", "tool_result", "llm_request", "llm_response"])
+def test_abstains_on_non_gated_phases(phase: str) -> None:
+    """Only ``request`` / ``tool_call`` are gated — other phases abstain.
 
-    The cost gate runs at ``tool_call`` (the one phase a PreToolUse hook
-    can block); an over-budget event of any other phase must ALLOW so the
-    policy does not block text-only turns or post-hoc results.
+    The cost gate runs at ``request`` (before the turn) and ``tool_call``
+    (the PreToolUse hook); an over-budget event of any other phase must
+    ALLOW so the policy does not block post-hoc results or per-round-trip
+    LLM events. (``request`` is covered by its own gating tests below.)
     """
     policy = cost_budget(max_cost_usd=1.0, ask_thresholds_usd=[0.5])
-    assert policy(_event("request", 9.99)) == {"result": "ALLOW"}
-    assert policy(_event("response", 9.99)) == {"result": "ALLOW"}
-    assert policy(_event("tool_result", 9.99)) == {"result": "ALLOW"}
+    assert policy(_event(phase, 9.99)) == {"result": "ALLOW"}
+
+
+def test_request_phase_over_budget_on_expensive_model_denies() -> None:
+    """Over the hard limit on an expensive model DENYs at the request phase.
+
+    The request phase fires before the LLM turn, so a text-only turn (no
+    tool call) is now budgeted: an over-budget request on Opus must be
+    blocked. The reason must be the USER-FACING variant (the turn never
+    reaches the model), so it must NOT carry the tool-call directive
+    ("re-issue the tool call" / "Relay this to the user verbatim"). If
+    this regressed, text-only turns would bypass the budget entirely, or
+    the user would see model-directed instructions meant for the agent.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    result = policy(_request(6.0, model="databricks-claude-opus-4-8"))
+    assert result["result"] == "DENY"
+    assert "6.00" in result["reason"]  # current cost surfaced to the user
+    # User-facing phrasing only — no tool-call directive leaks through.
+    assert "re-issue the tool call" not in result["reason"]
+    assert "Relay this to the user verbatim" not in result["reason"]
+    # Still names the limit + how to recover so the user can act.
+    assert "switch to a cheaper model" in result["reason"]
+
+
+def test_request_phase_over_budget_on_cheaper_model_allows() -> None:
+    """Over the hard limit on a cheaper model ALLOWs at the request phase.
+
+    Mirrors the tool-call downgrade gate: once the session is off an
+    expensive model, an over-budget request must proceed. A DENY here
+    would trap a downgraded user out of starting any new turn.
+    """
+    policy = cost_budget(max_cost_usd=5.0)
+    assert policy(_request(6.0, model="claude-sonnet-4-6")) == {"result": "ALLOW"}
+
+
+def test_request_phase_soft_checkpoint_does_not_ask() -> None:
+    """A crossed soft checkpoint does NOT ASK at the request phase → ALLOW.
+
+    The soft gate is tool-call only: the request-phase (input) policy path
+    surfaces an ASK as a plain denial with no approval round-trip and no
+    ``state_updates`` persistence, so emitting "Continue?" there would
+    just block the turn and re-prompt forever. Below the hard cap, an
+    over-threshold request must therefore ALLOW (the warning fires at the
+    first tool call instead). A regression to ASK here would wedge every
+    text-only turn once spend passes the first checkpoint.
+    """
+    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
+    # $2 is over the soft checkpoint but under the $5 hard cap.
+    assert policy(_request(2.0, model="opus")) == {"result": "ALLOW"}
+
+
+def test_request_phase_below_threshold_allows() -> None:
+    """Spend under the lowest checkpoint abstains (ALLOW) at the request phase."""
+    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
+    assert policy(_request(1.0, model="opus")) == {"result": "ALLOW"}
+
+
+def test_tool_call_still_asks_for_soft_checkpoint_after_request_allows() -> None:
+    """The soft warning still fires — at the first tool call, not the request.
+
+    Pairs with :func:`test_request_phase_soft_checkpoint_does_not_ask`:
+    the same over-threshold spend that ALLOWs on ``request`` must ASK on
+    ``tool_call`` (where approval + state persistence work). This proves
+    the warning was relocated, not lost.
+    """
+    policy = cost_budget(max_cost_usd=5.0, ask_thresholds_usd=[2.0])
+    result = policy(_tool(2.0, model="opus"))
+    assert result["result"] == "ASK"
+    assert result["state_updates"] == [
+        {"key": _ASK_APPROVED_KEY, "action": "set", "value": 2.0},
+    ]
 
 
 def test_unpriced_session_never_trips() -> None:
@@ -414,6 +563,34 @@ async def test_resolve_from_spec_asks_in_soft_zone() -> None:
     policy: FunctionPolicy = resolve_function_policy(spec)
     result = await policy.evaluate(_tool_ctx(3.0, "opus"), {})
     assert result.action == PolicyAction.ASK
+
+
+@pytest.mark.asyncio
+async def test_resolve_from_spec_denies_over_budget_on_request_phase() -> None:
+    """Over-budget on an expensive model DENYs at the REQUEST phase too.
+
+    The request phase is the path :func:`_evaluate_request_policy` in the
+    server uses (it builds a ``Phase.REQUEST`` ``EvaluationContext`` with
+    ``usage`` + ``model``). This proves the cost + model thread through the
+    engine boundary on that phase and the DENY comes back as a
+    :class:`PolicyAction`, so a text-only over-budget turn is blocked
+    before the LLM runs.
+    """
+    spec = FunctionPolicySpec(
+        name="cost",
+        on=None,
+        function=FunctionRef(path=_HANDLER, arguments={"max_cost_usd": 5.0}),
+    )
+    policy: FunctionPolicy = resolve_function_policy(spec)
+    ctx = EvaluationContext(
+        phase=Phase.REQUEST,
+        content="please run the build",
+        tool_name=None,
+        usage={"total_cost_usd": 6.0},
+        model="databricks-claude-opus-4-8",
+    )
+    result = await policy.evaluate(ctx, {})
+    assert result.action == PolicyAction.DENY
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/tests/policies/builtins/test_user_daily_cost.py
+++ b/tests/policies/builtins/test_user_daily_cost.py
@@ -1,7 +1,7 @@
 """Tests for the per-user daily cost-budget policy.
 
-``user_daily_cost_budget`` gates the ``tool_call`` phase on the session
-OWNER's cumulative spend for the current UTC day, read from
+``user_daily_cost_budget`` gates the ``request`` and ``tool_call`` phases
+on the session OWNER's cumulative spend for the current UTC day, read from
 ``event["context"]["user_daily_cost"]`` (injected by the engine). Same
 ASK/DENY/downgrade logic as ``cost_budget``, but:
 
@@ -72,17 +72,46 @@ def test_below_ask_threshold_allows() -> None:
     assert policy(_tool(1.0)) == {"result": "ALLOW"}
 
 
-def test_non_tool_call_phase_allows() -> None:
-    """Only the tool_call phase is gated; other phases abstain even over budget."""
+@pytest.mark.parametrize("phase", ["response", "tool_result", "llm_request", "llm_response"])
+def test_non_gated_phase_allows(phase: str) -> None:
+    """Non-gated phases abstain even over budget (request/tool_call ARE gated)."""
     policy = user_daily_cost_budget(max_cost_usd=5.0)
     event: PolicyEvent = {
-        "type": "request",
+        "type": phase,
         "target": None,
         "data": "x",
         "context": {"user_daily_cost": {"cost_usd": 9.99}, "model": "opus"},
         "session_state": {},
     }
     assert policy(event) == {"result": "ALLOW"}
+
+
+def test_request_phase_over_budget_on_expensive_model_denies() -> None:
+    """Over the hard daily limit on an expensive model DENYs at the request phase.
+
+    The daily gate now also fires before the LLM turn, so a text-only turn
+    counts against the daily budget. The reason must be the user-facing
+    variant (no tool-call directive), since a request-phase DENY is shown
+    straight to the user.
+    """
+    policy = user_daily_cost_budget(max_cost_usd=5.0)
+    event: PolicyEvent = {
+        "type": "request",
+        "target": None,
+        "data": "please run the build",
+        "context": {
+            "actor": {},
+            "user_daily_cost": {"cost_usd": 6.0, "ask_approved_usd": 0.0},
+            "model": "databricks-claude-opus-4-8",
+        },
+        "session_state": {},
+    }
+    result = policy(event)
+    assert result["result"] == "DENY"
+    assert "6.00" in result["reason"]
+    assert "daily" in result["reason"].lower()
+    # User-facing phrasing only — no tool-call directive leaks through.
+    assert "re-issue the tool call" not in result["reason"]
 
 
 def test_zero_or_missing_daily_cost_allows() -> None:
@@ -176,9 +205,15 @@ def test_deny_message_names_the_owner_when_present() -> None:
 
 
 def test_over_daily_budget_on_cheaper_model_allows() -> None:
-    """Over the daily limit but already on a cheaper model → ALLOW (downgrade satisfied)."""
+    """Over the daily limit but already on a cheaper model → ALLOW (downgrade satisfied).
+
+    Sonnet is outside the default expensive set, so a downgraded session
+    proceeds even over the daily limit. (Note: ``gpt-5-4`` is NOT a cheap
+    model under the broad ``gpt-5`` default token — only the ``-mini`` /
+    ``-nano`` variants are carved out.)
+    """
     policy = user_daily_cost_budget(max_cost_usd=5.0)
-    assert policy(_tool(6.0, model="databricks-gpt-5-4")) == {"result": "ALLOW"}
+    assert policy(_tool(6.0, model="databricks-claude-sonnet-4-6")) == {"result": "ALLOW"}
 
 
 @pytest.mark.parametrize(

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -12,7 +12,10 @@ from typing_extensions import Unpack
 from websockets.exceptions import InvalidStatus, InvalidURI, WebSocketException
 from websockets.http11 import Response
 
-from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER
+from omnigent.runner.identity import (
+    OMNIGENT_INTERNAL_WS_ORIGIN,
+    RUNNER_TUNNEL_TOKEN_HEADER,
+)
 from omnigent.runner.transports.ws_tunnel import serve as serve_module
 from omnigent.runner.transports.ws_tunnel.frames import (
     PingFrame,
@@ -545,8 +548,12 @@ async def test_serve_tunnel_once_sends_bearer_header(
     )
 
     assert captured["url"] == "wss://example.databricksapps.com/v1/runners/runner_auth/tunnel"
+    # The runner also sends the first-party Origin sentinel so the server's
+    # CSWSH origin guard admits the tunnel (a non-browser client), in
+    # addition to the bearer and tunnel-binding token.
     assert captured["kwargs"] == {
         "additional_headers": {
+            "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
             "Authorization": "Bearer tok-auth",
             RUNNER_TUNNEL_TOKEN_HEADER: "bind-token",
         },

--- a/tests/server/integration/test_sessions_content_type_csrf.py
+++ b/tests/server/integration/test_sessions_content_type_csrf.py
@@ -1,0 +1,347 @@
+"""
+Integration tests for the JSON Content-Type CSRF guard on session POSTs.
+
+Eight session POST handlers parse their body with Starlette's
+``await request.json()``, which decodes any body as JSON regardless of
+the declared ``Content-Type``. That left them reachable by a cross-site
+*simple* request — one carrying ``Content-Type: text/plain`` (so the
+browser skips the CORS preflight) whose plain-text payload is actually
+valid JSON. The ``require_json_content_type`` /
+``require_json_or_multipart_content_type`` dependencies close that gap by
+requiring an explicit JSON (or, for the bundled-create route, multipart)
+Content-Type before the handler runs.
+
+These tests drive the real routes through the shared ``client`` fixture
+(real stores + mock LLM, permissions disabled) and assert:
+
+- a ``text/plain`` body of valid JSON now returns 415 (was accepted),
+- a request with no ``Content-Type`` returns 415,
+- a correct ``application/json`` request still reaches the handler
+  (status is whatever the handler returns — crucially NOT 415),
+- ``POST /v1/sessions`` still accepts both JSON and ``multipart/form-data``
+  while rejecting ``text/plain``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from tests.server.helpers import build_agent_bundle, create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+# A body that is valid JSON but is sent with the wrong Content-Type. The
+# point of the guard is that the *content* parses fine — only the declared
+# media type makes it a cross-site CSRF vector — so the rejection must be
+# driven by the header, not by the payload being unparseable.
+_VALID_JSON_BODY = {"hello": "world"}
+
+
+# All seven handlers guarded by ``require_json_content_type``. A fake
+# session id is sufficient: the content-type dependency runs before any
+# session lookup, so the 415 fires regardless of whether the session
+# exists. ``term_x`` / ``env_x`` are likewise never resolved.
+_JSON_ONLY_ENDPOINTS = [
+    pytest.param(
+        "/v1/sessions/conv_missing/hooks/permission-request",
+        id="claude_permission_request_hook",
+    ),
+    pytest.param(
+        "/v1/sessions/conv_missing/hooks/codex-elicitation-request",
+        id="codex_elicitation_request_hook",
+    ),
+    pytest.param(
+        "/v1/sessions/conv_missing/policies/evaluate",
+        id="evaluate_policy",
+    ),
+    pytest.param(
+        "/v1/sessions/conv_missing/resources/terminals",
+        id="create_session_terminal",
+    ),
+    pytest.param(
+        "/v1/sessions/conv_missing/resources/terminals/term_x/transfer",
+        id="transfer_session_terminal",
+    ),
+    pytest.param(
+        "/v1/sessions/conv_missing/resources/environments/env_x/shell",
+        id="run_environment_shell",
+    ),
+    pytest.param(
+        "/v1/sessions/conv_missing/mcp",
+        id="mcp_proxy",
+    ),
+]
+
+
+async def _post_text_plain(
+    client: httpx.AsyncClient,
+    url: str,
+    payload: dict[str, object],
+) -> httpx.Response:
+    """
+    POST a valid-JSON payload with a ``text/plain`` Content-Type.
+
+    Sends the bytes explicitly so httpx does not set ``application/json``
+    for us — the whole point is that the declared type is ``text/plain``
+    while the body is parseable JSON (the CSRF simple-request shape).
+
+    :param client: The test HTTP client.
+    :param url: The route path to POST to.
+    :param payload: A JSON-serializable body, e.g. ``{"hello": "world"}``.
+    :returns: The HTTP response.
+    """
+    return await client.post(
+        url,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "text/plain"},
+    )
+
+
+async def _post_without_content_type(
+    client: httpx.AsyncClient,
+    url: str,
+    payload: dict[str, object],
+) -> httpx.Response:
+    """
+    POST a valid-JSON payload with no ``Content-Type`` header at all.
+
+    Passing raw ``bytes`` (not ``json=`` / ``str``) means httpx attaches
+    no ``Content-Type``, modelling a request that omits the header.
+
+    :param client: The test HTTP client.
+    :param url: The route path to POST to.
+    :param payload: A JSON-serializable body.
+    :returns: The HTTP response.
+    """
+    return await client.post(url, content=json.dumps(payload).encode("utf-8"))
+
+
+# ── JSON-only handlers: text/plain and missing header are rejected ──
+
+
+@pytest.mark.parametrize("url", _JSON_ONLY_ENDPOINTS)
+async def test_json_only_endpoint_rejects_text_plain(
+    client: httpx.AsyncClient,
+    url: str,
+) -> None:
+    """
+    A ``text/plain`` body of valid JSON now returns 415 on every guarded route.
+
+    Before the guard, ``await request.json()`` decoded this body and the
+    handler ran — the CSRF vector. A non-415 status here would mean the
+    cross-site simple request still reaches the handler.
+    """
+    resp = await _post_text_plain(client, url, _VALID_JSON_BODY)
+    assert resp.status_code == 415, (
+        f"{url} accepted a text/plain JSON body (status {resp.status_code}); "
+        "the CSRF content-type guard did not fire."
+    )
+
+
+@pytest.mark.parametrize("url", _JSON_ONLY_ENDPOINTS)
+async def test_json_only_endpoint_rejects_missing_content_type(
+    client: httpx.AsyncClient,
+    url: str,
+) -> None:
+    """
+    A request with no ``Content-Type`` returns 415 on every guarded route.
+
+    A missing header is treated as "no acceptable type"; if it slipped
+    through, a client could omit the header to dodge the guard.
+    """
+    resp = await _post_without_content_type(client, url, _VALID_JSON_BODY)
+    assert resp.status_code == 415, (
+        f"{url} accepted a body with no Content-Type (status {resp.status_code}); "
+        "a missing header must be rejected."
+    )
+
+
+# ── JSON-only handlers: application/json still reaches the handler ──
+#
+# Each positive case asserts the SPECIFIC status the handler returns for
+# the chosen input, which is never 415. That proves the guard let the
+# request through (the gate passed) AND the handler behaves exactly as it
+# did before this change.
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(
+            "/v1/sessions/conv_missing/hooks/permission-request",
+            id="claude_permission_request_hook",
+        ),
+        pytest.param(
+            "/v1/sessions/conv_missing/hooks/codex-elicitation-request",
+            id="codex_elicitation_request_hook",
+        ),
+    ],
+)
+async def test_hook_handlers_reached_with_application_json(
+    client: httpx.AsyncClient,
+    url: str,
+) -> None:
+    """
+    ``application/json`` reaches the hook handlers (400, not 415).
+
+    A JSON array body passes the content-type guard, then the handler's
+    own "body must be a JSON object" validation rejects it with 400 —
+    before any elicitation publish or long-poll. A 415 here would mean a
+    valid JSON request was wrongly blocked at the gate.
+    """
+    # ``json=[]`` sends a valid application/json body that is a JSON array,
+    # which both hook handlers reject as "not a JSON object" with 400.
+    resp = await client.post(url, json=[])
+    assert resp.status_code == 400, (
+        f"{url} returned {resp.status_code} for an application/json array body; "
+        "expected the handler's own 400 (proves the guard passed it through)."
+    )
+
+
+async def test_evaluate_policy_reached_with_application_json(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``application/json`` reaches ``evaluate_policy`` and returns its verdict.
+
+    With a real session and a valid ``PHASE_TOOL_CALL`` envelope, the
+    endpoint evaluates policies and returns 200 with an ALLOW verdict (no
+    policies configured) — exactly as before the guard. Proves the guard
+    is transparent to a correct JSON request.
+    """
+    agent = await create_test_agent(client)
+    create = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert create.status_code == 201, create.text
+    session_id = create.json()["id"]
+
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json={
+            "event": {
+                "type": "PHASE_TOOL_CALL",
+                "data": {"name": "Read", "arguments": {}},
+                "context": {},
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    # No policies configured → ALLOW. Confirms the body traversed the full
+    # handler pipeline, not just the content-type gate.
+    assert resp.json()["result"] == "POLICY_ACTION_ALLOW"
+
+
+async def test_create_terminal_reached_with_application_json(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``application/json`` reaches ``create_session_terminal`` (404, not 415).
+
+    A valid JSON body against a non-existent session passes the
+    content-type guard, then the handler's session lookup returns 404. A
+    415 would mean the guard wrongly blocked a correct JSON request.
+    """
+    resp = await client.post(
+        "/v1/sessions/conv_missing/resources/terminals",
+        json={"terminal": "shell", "session_key": "main"},
+    )
+    assert resp.status_code == 404, (
+        f"expected 404 (missing session) once the guard passed the JSON body "
+        f"through, got {resp.status_code}."
+    )
+
+
+async def test_mcp_proxy_reached_with_application_json(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``application/json`` reaches ``mcp_proxy`` and handles ``initialize`` (200).
+
+    A JSON-RPC ``initialize`` request passes the guard and is answered
+    locally with a 200 capability response (no runner round-trip). A 415
+    here would mean the guard blocked a valid MCP request.
+    """
+    resp = await client.post(
+        "/v1/sessions/conv_missing/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # JSON-RPC envelope echoed back → the handler ran, not the gate.
+    assert body["id"] == 1
+    assert body["result"]["serverInfo"]["name"] == "omnigent-mcp-proxy"
+
+
+# ── create_session: JSON and multipart both work; text/plain is 415 ──
+
+
+async def test_create_session_rejects_text_plain(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``POST /v1/sessions`` with a ``text/plain`` JSON body returns 415.
+
+    The bundled-create route dispatches on Content-Type, so the guard must
+    reject simple types up front while still allowing JSON and multipart
+    (covered below). Before the guard this text/plain body would have been
+    decoded by ``request.json()`` and a session created.
+    """
+    resp = await _post_text_plain(client, "/v1/sessions", {"agent_id": "agent_x"})
+    assert resp.status_code == 415, (
+        f"create_session accepted a text/plain JSON body (status {resp.status_code})."
+    )
+
+
+async def test_create_session_rejects_missing_content_type(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``POST /v1/sessions`` with no ``Content-Type`` returns 415.
+    """
+    resp = await _post_without_content_type(client, "/v1/sessions", {"agent_id": "agent_x"})
+    assert resp.status_code == 415, (
+        f"create_session accepted a body with no Content-Type (status {resp.status_code})."
+    )
+
+
+async def test_create_session_accepts_application_json(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``POST /v1/sessions`` with ``application/json`` still creates a session.
+
+    Binding to an existing agent by ``agent_id`` over JSON returns 201 —
+    the JSON-create contract is unchanged by the guard.
+    """
+    agent = await create_test_agent(client)
+    resp = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert resp.status_code == 201, resp.text
+    # Real session id returned → JSON create reached the handler and succeeded.
+    assert resp.json()["id"].startswith("conv_")
+
+
+async def test_create_session_accepts_multipart_bundled_create(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    ``POST /v1/sessions`` with ``multipart/form-data`` still bundled-creates.
+
+    The multipart upload path (JSON ``metadata`` part + ``bundle`` file
+    part) must remain reachable: the json-or-multipart guard accepts
+    ``multipart/form-data`` and the handler's content-type dispatch routes
+    it to the bundled-create form path, returning 201. A 415 here would
+    mean the guard broke the runner-state create path.
+    """
+    bundle = build_agent_bundle(name="csrf-multipart-agent")
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code == 201, resp.text
+    # The bundled-create response carries the new session id → multipart
+    # routed to the bundled-create branch, not rejected at the gate.
+    assert "session_id" in resp.json()

--- a/tests/server/routes/test_content_type.py
+++ b/tests/server/routes/test_content_type.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for the JSON Content-Type guard dependencies.
+
+Covers :func:`require_json_content_type` and
+:func:`require_json_or_multipart_content_type` from
+``omnigent.server.routes._content_type`` across the full matrix of
+Content-Type values: canonical JSON, the ``application/*+json``
+structured suffix, charset parameters, case insensitivity, a missing
+header, and the non-JSON / multipart types that must (or must not) be
+rejected.
+
+The dependencies only read ``request.headers``, so each case is driven
+by a real :class:`starlette.requests.Request` built from a minimal ASGI
+scope carrying just the header under test — no body, transport, or mock
+is involved.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from omnigent.server.routes._content_type import (
+    require_json_content_type,
+    require_json_or_multipart_content_type,
+)
+
+
+def _request_with_content_type(content_type: str | None) -> Request:
+    """
+    Build a real Starlette ``Request`` carrying (or omitting) a Content-Type.
+
+    :param content_type: The ``Content-Type`` header value to set, e.g.
+        ``"application/json"``. ``None`` omits the header entirely,
+        modelling a request with no declared content type.
+    :returns: A real :class:`starlette.requests.Request` whose only
+        meaningful state is its header set.
+    """
+    raw_headers: list[tuple[bytes, bytes]] = []
+    if content_type is not None:
+        raw_headers.append((b"content-type", content_type.encode("latin-1")))
+    return Request({"type": "http", "method": "POST", "headers": raw_headers})
+
+
+# Content-Type values both dependencies must accept as JSON: canonical,
+# charset parameter, structured +json suffix, and an uppercased variant
+# (the media type compare is case-insensitive).
+_JSON_ACCEPTED = [
+    "application/json",
+    "application/json; charset=utf-8",
+    "application/ld+json",
+    "application/vnd.api+json",
+    "APPLICATION/JSON",
+    "Application/JSON; charset=UTF-8",
+]
+
+# Content-Type values that are neither JSON nor multipart — both
+# dependencies must reject these with 415. ``None`` is the missing-header
+# case; "" is a present-but-empty header.
+_NON_JSON_NON_MULTIPART = [
+    None,
+    "",
+    "text/plain",
+    "text/plain; charset=utf-8",
+    "application/x-www-form-urlencoded",
+    "application/octet-stream",
+    "text/json",  # not application/* — must NOT be treated as JSON
+]
+
+# Multipart variants: rejected by the json-only dependency, accepted by
+# the json-or-multipart dependency.
+_MULTIPART = [
+    "multipart/form-data",
+    "multipart/form-data; boundary=----WebKitFormBoundaryabc123",
+]
+
+
+@pytest.mark.parametrize("content_type", _JSON_ACCEPTED)
+def test_require_json_accepts_json_media_types(content_type: str) -> None:
+    """
+    ``require_json_content_type`` returns ``None`` for every JSON type.
+
+    Accepting these proves the guard does not regress the legitimate JSON
+    clients: a raise here would turn a real ``application/json`` (or
+    ``application/ld+json``, or charset-suffixed, or uppercased) request
+    into a spurious 415.
+    """
+    # Returns None (no exception) → the request is allowed through to the handler.
+    assert require_json_content_type(_request_with_content_type(content_type)) is None
+
+
+@pytest.mark.parametrize("content_type", _NON_JSON_NON_MULTIPART + _MULTIPART)
+def test_require_json_rejects_non_json(content_type: str | None) -> None:
+    """
+    ``require_json_content_type`` raises 415 for non-JSON types.
+
+    This is the CSRF guard itself: a missing header, ``text/plain`` (the
+    cross-site simple-request vector), form/octet types, and even
+    ``multipart/form-data`` must all be rejected by the json-only
+    dependency. If any of these did NOT raise, a cross-site request could
+    smuggle a JSON body past ``request.json()``.
+    """
+    with pytest.raises(HTTPException) as exc_info:
+        require_json_content_type(_request_with_content_type(content_type))
+    # 415 Unsupported Media Type is the documented rejection status; any
+    # other code (or no raise) would mean the guard let a non-JSON type in.
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.parametrize("content_type", _JSON_ACCEPTED + _MULTIPART)
+def test_require_json_or_multipart_accepts_json_and_multipart(content_type: str) -> None:
+    """
+    ``require_json_or_multipart_content_type`` accepts JSON and multipart.
+
+    The bundled-create route legitimately serves both a JSON body and a
+    ``multipart/form-data`` upload, so this dependency must let both
+    through (including a multipart type carrying a ``boundary`` parameter).
+    A raise here would break either the JSON create or the bundled
+    multipart create path.
+    """
+    # Returns None for every JSON type AND every multipart variant.
+    assert require_json_or_multipart_content_type(_request_with_content_type(content_type)) is None
+
+
+@pytest.mark.parametrize("content_type", _NON_JSON_NON_MULTIPART)
+def test_require_json_or_multipart_rejects_other_types(content_type: str | None) -> None:
+    """
+    ``require_json_or_multipart_content_type`` still rejects simple types.
+
+    The multipart-allowing variant must keep rejecting ``text/plain``, a
+    missing header, and other non-JSON / non-multipart types with 415 —
+    otherwise the bundled-create route would inherit the same CSRF gap the
+    guard exists to close.
+    """
+    with pytest.raises(HTTPException) as exc_info:
+        require_json_or_multipart_content_type(_request_with_content_type(content_type))
+    assert exc_info.value.status_code == 415

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1555,6 +1555,52 @@ async def test_download_session_file_content(
     )
     assert resp.status_code == 200
     assert resp.content == b"hello world"
+    # The content route must force a download and forbid MIME sniffing
+    # so a browser never renders user-uploaded bytes as an active type
+    # in the server's origin. A failure here means the stored-XSS
+    # hardening was dropped and the response is renderable inline again.
+    assert resp.headers["content-disposition"] == (
+        "attachment; filename=\"hello.txt\"; filename*=UTF-8''hello.txt"
+    )
+    assert resp.headers["x-content-type-options"] == "nosniff"
+
+
+@pytest.mark.asyncio
+async def test_download_session_file_html_is_attachment_not_inline(
+    file_client: httpx.AsyncClient,
+) -> None:
+    """An uploaded .html must be served as a download, not rendered inline.
+
+    Reproduces the stored-XSS vector: a user uploads ``evil.html``
+    with a ``<script>`` body. Without the hardening the route would
+    return ``Content-Type: text/html`` with no disposition, letting a
+    browser execute the script in the server origin. The disposition +
+    nosniff headers neutralize that.
+    """
+    upload = await file_client.post(
+        "/v1/sessions/conv_proxy/resources/files",
+        files={
+            "file": (
+                "evil.html",
+                b"<script>alert(document.domain)</script>",
+                "text/html",
+            ),
+        },
+    )
+    file_id = upload.json()["id"]
+
+    resp = await file_client.get(
+        f"/v1/sessions/conv_proxy/resources/files/{file_id}/content",
+    )
+    assert resp.status_code == 200
+    # The bytes are still served verbatim — we don't mangle content,
+    # we only change how the browser is told to handle them.
+    assert resp.content == b"<script>alert(document.domain)</script>"
+    # attachment => browser downloads instead of rendering the script.
+    assert resp.headers["content-disposition"].startswith("attachment;")
+    assert 'filename="evil.html"' in resp.headers["content-disposition"]
+    # nosniff => the browser won't second-guess the declared type.
+    assert resp.headers["x-content-type-options"] == "nosniff"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_ws_origin.py
+++ b/tests/server/test_ws_origin.py
@@ -1,0 +1,501 @@
+"""Tests for WebSocket ``Origin`` enforcement (CSWSH protection).
+
+Three layers, each catching a distinct breakage:
+
+- pure-policy tests for :func:`websocket_origin_allowed` and
+  :func:`origin_hostname_is_loopback` (the decision table);
+- ASGI-level tests of :class:`WebSocketOriginMiddleware` that prove a
+  rejected handshake is closed with the forbidden-origin code and the
+  downstream app is never invoked;
+- end-to-end tests through Starlette's ``TestClient`` against a real
+  FastAPI app, proving the handshake is refused *before* the route's
+  ``websocket.accept()`` runs and that allowed origins round-trip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from omnigent.server.ws_origin import (
+    FORBIDDEN_ORIGIN_CLOSE_CODE,
+    WebSocketOriginMiddleware,
+    origin_hostname_is_loopback,
+    parse_allowed_origins,
+    websocket_origin_allowed,
+)
+
+_LOCAL_ENV = "OMNIGENT_LOCAL_SINGLE_USER"
+_ALLOWLIST_ENV = "OMNIGENT_WS_ALLOWED_ORIGINS"
+
+
+@pytest.fixture(autouse=True)
+def _clean_origin_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from a known WS-origin env baseline.
+
+    The middleware reads ``OMNIGENT_LOCAL_SINGLE_USER`` and
+    ``OMNIGENT_WS_ALLOWED_ORIGINS`` per connection; a value inherited
+    from the developer's shell would flip the policy and make these
+    tests pass or fail for the wrong reason. Each test sets only what it
+    needs on top of this cleared baseline.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.delenv(_LOCAL_ENV, raising=False)
+    monkeypatch.delenv(_ALLOWLIST_ENV, raising=False)
+
+
+# --------------------------------------------------------------------------
+# origin_hostname_is_loopback
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "origin,expected",
+    [
+        ("http://localhost", True),
+        ("http://localhost:8000", True),
+        ("https://localhost:443", True),
+        ("http://127.0.0.1:6767", True),
+        ("http://127.5.5.5:1", True),  # all of 127.0.0.0/8 is loopback
+        ("http://[::1]:8000", True),
+        ("http://[::ffff:127.0.0.1]:8000", True),  # IPv4-mapped loopback
+        ("https://app.example.com", False),
+        ("https://localhost.evil.com", False),  # not a loopback host
+        ("http://10.0.0.5:8000", False),
+        ("http://169.254.0.1", False),  # link-local, not loopback
+        ("", False),  # no host
+        ("not-a-url", False),  # unparseable host
+    ],
+)
+def test_origin_hostname_is_loopback(origin: str, expected: bool) -> None:
+    """The loopback check accepts only genuine loopback hosts.
+
+    A failure here means a non-loopback origin (a CSWSH attacker) was
+    classified as loopback, or a real local UI origin was rejected.
+
+    :param origin: The ``Origin`` header under test.
+    :param expected: Whether it should be classified as loopback.
+    :returns: None.
+    """
+    assert origin_hostname_is_loopback(origin) is expected
+
+
+# --------------------------------------------------------------------------
+# websocket_origin_allowed (the decision table)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "origin,local_mode,allowed",
+    [
+        # Missing Origin (non-browser client) is allowed in any mode.
+        (None, True, True),
+        (None, False, True),
+        # The first-party sentinel is always allowed.
+        (OMNIGENT_INTERNAL_WS_ORIGIN, True, True),
+        (OMNIGENT_INTERNAL_WS_ORIGIN, False, True),
+        # Local mode: only loopback browser origins pass.
+        ("http://localhost:8000", True, True),
+        ("http://127.0.0.1:6767", True, True),
+        ("https://evil.example.com", True, False),
+        # Non-local mode: cookie/proxy auth guards, so any origin passes
+        # when no allowlist is configured.
+        ("https://evil.example.com", False, True),
+    ],
+)
+def test_websocket_origin_allowed_no_allowlist(
+    origin: str | None, local_mode: bool, allowed: bool
+) -> None:
+    """Policy decisions with no explicit allowlist configured.
+
+    A failure means the core CSWSH guard is wrong: e.g. a cross-origin
+    browser handshake admitted in local mode (the attack), or the local
+    UI / runner sentinel wrongly refused (breaking the product).
+
+    :param origin: The handshake ``Origin``, or ``None``.
+    :param local_mode: Whether the single-user local marker is set.
+    :param allowed: Expected policy decision.
+    :returns: None.
+    """
+    assert (
+        websocket_origin_allowed(origin, local_mode=local_mode, extra_allowed=frozenset())
+        is allowed
+    )
+
+
+@pytest.mark.parametrize(
+    "origin,local_mode,allowed",
+    [
+        # Allowlisted origin passes in either mode.
+        ("https://ui.example.com", False, True),
+        ("https://ui.example.com", True, True),
+        # In non-local mode a configured allowlist flips the default to
+        # deny: an origin not on the list is refused even though cookies
+        # would otherwise guard it.
+        ("https://evil.example.com", False, False),
+        # Local mode still admits loopback even alongside an allowlist.
+        ("http://localhost:3000", True, True),
+        # Missing Origin still passes (non-browser clients) despite the
+        # allowlist.
+        (None, False, True),
+    ],
+)
+def test_websocket_origin_allowed_with_allowlist(
+    origin: str | None, local_mode: bool, allowed: bool
+) -> None:
+    """Policy decisions when ``OMNIGENT_WS_ALLOWED_ORIGINS`` is set.
+
+    A failure means the deployment allowlist either failed to admit a
+    configured origin or failed to deny an unlisted one in non-local
+    mode.
+
+    :param origin: The handshake ``Origin``, or ``None``.
+    :param local_mode: Whether the single-user local marker is set.
+    :param allowed: Expected policy decision.
+    :returns: None.
+    """
+    extra = frozenset({"https://ui.example.com"})
+    assert websocket_origin_allowed(origin, local_mode=local_mode, extra_allowed=extra) is allowed
+
+
+def test_parse_allowed_origins_splits_and_strips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The allowlist env is split on commas with whitespace stripped.
+
+    A failure would mean origins are parsed with stray whitespace (never
+    matching a real ``Origin`` header) or that blank entries leak in.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_ALLOWLIST_ENV, " https://a.example.com , ,https://b.example.com ")
+    assert parse_allowed_origins() == frozenset({"https://a.example.com", "https://b.example.com"})
+
+
+def test_parse_allowed_origins_unset_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unset allowlist env yields an empty set (passthrough default).
+
+    A failure would change the non-local default away from passthrough.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.delenv(_ALLOWLIST_ENV, raising=False)
+    assert parse_allowed_origins() == frozenset()
+
+
+# --------------------------------------------------------------------------
+# WebSocketOriginMiddleware — ASGI level
+# --------------------------------------------------------------------------
+
+
+class _RecordingASGIApp:
+    """Downstream ASGI app that records whether it was invoked.
+
+    Stands in for the real route stack so a middleware test can prove
+    whether a handshake reached the route (was admitted) or was rejected
+    by the middleware before reaching it.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with no invocations recorded.
+
+        :returns: None.
+        """
+        self.called = False
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        """Record the call and accept the (websocket) handshake.
+
+        :param scope: ASGI connection scope.
+        :param receive: ASGI receive callable.
+        :param send: ASGI send callable.
+        :returns: None.
+        """
+        self.called = True
+        await send({"type": "websocket.accept"})
+
+
+def _ws_scope(origin: str | None) -> dict[str, Any]:
+    """Build a minimal ASGI websocket scope with an optional ``Origin``.
+
+    :param origin: Origin header value to include, or ``None`` to omit.
+    :returns: An ASGI scope dict with ``type == "websocket"``.
+    """
+    headers: list[tuple[bytes, bytes]] = []
+    if origin is not None:
+        headers.append((b"origin", origin.encode("latin-1")))
+    return {"type": "websocket", "headers": headers}
+
+
+async def _drive_middleware(
+    middleware: WebSocketOriginMiddleware, scope: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Run the middleware against a scope, capturing sent ASGI messages.
+
+    :param middleware: The middleware instance under test.
+    :param scope: ASGI scope to dispatch.
+    :returns: The list of ASGI messages the middleware sent downstream.
+    """
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, str]:
+        """Yield the initial websocket connect event.
+
+        :returns: A ``websocket.connect`` ASGI event.
+        """
+        return {"type": "websocket.connect"}
+
+    async def send(message: dict[str, Any]) -> None:
+        """Capture an ASGI message emitted upstream.
+
+        :param message: The ASGI message to record.
+        :returns: None.
+        """
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+async def test_middleware_rejects_forbidden_origin_without_calling_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forbidden origin is closed and the downstream app never runs.
+
+    Proves the two security guarantees at once: the connection is closed
+    with :data:`FORBIDDEN_ORIGIN_CLOSE_CODE`, and the route (which would
+    otherwise ``accept()`` and bridge I/O) is never invoked. If the
+    middleware accepted-then-checked, ``downstream.called`` would be
+    ``True``.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    downstream = _RecordingASGIApp()
+    middleware = WebSocketOriginMiddleware(downstream)
+
+    sent = await _drive_middleware(middleware, _ws_scope("https://evil.example.com"))
+
+    assert downstream.called is False  # route never reached → rejected pre-accept
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": FORBIDDEN_ORIGIN_CLOSE_CODE,
+            "reason": "forbidden origin",
+        }
+    ]
+
+
+async def test_middleware_admits_loopback_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A loopback origin in local mode reaches the downstream app.
+
+    A failure (downstream not called) would mean the guard rejects the
+    user's own local UI.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    downstream = _RecordingASGIApp()
+    middleware = WebSocketOriginMiddleware(downstream)
+
+    sent = await _drive_middleware(middleware, _ws_scope("http://localhost:8000"))
+
+    assert downstream.called is True  # admitted → route handled the handshake
+    assert sent == [{"type": "websocket.accept"}]
+
+
+async def test_middleware_ignores_non_websocket_scope() -> None:
+    """Non-websocket scopes pass straight through, untouched.
+
+    A failure would mean the WS guard interferes with ordinary HTTP
+    traffic.
+
+    :returns: None.
+    """
+    downstream = _RecordingASGIApp()
+    middleware = WebSocketOriginMiddleware(downstream)
+
+    await _drive_middleware(middleware, {"type": "http", "headers": []})
+
+    assert downstream.called is True  # HTTP scope delegated unconditionally
+
+
+# --------------------------------------------------------------------------
+# End-to-end through Starlette TestClient + a real FastAPI route
+# --------------------------------------------------------------------------
+
+
+def _make_app() -> FastAPI:
+    """Build a FastAPI app guarded by the origin middleware.
+
+    The single websocket route appends to ``app.state.accepted`` *before*
+    accepting, so a test can prove whether the route ran at all — the
+    list stays empty when the middleware rejects pre-accept.
+
+    :returns: The configured FastAPI app.
+    """
+    app = FastAPI()
+    app.state.accepted = []
+
+    @app.websocket("/ws")
+    async def echo(websocket: WebSocket) -> None:
+        """Echo one text frame back to the client, prefixed.
+
+        :param websocket: The incoming connection.
+        :returns: None.
+        """
+        websocket.app.state.accepted.append(True)
+        await websocket.accept()
+        msg = await websocket.receive_text()
+        await websocket.send_text(f"echo:{msg}")
+        await websocket.close()
+
+    app.add_middleware(WebSocketOriginMiddleware)
+    return app
+
+
+def test_e2e_local_mode_rejects_cross_origin_before_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cross-origin browser handshake is refused before the route runs.
+
+    This is the core CSWSH defense end-to-end: with the local marker set,
+    a connection carrying a hostile ``Origin`` is closed at the handshake
+    with code 4403, and the route's pre-accept marker is never appended —
+    proving the rejection happened before ``websocket.accept()``.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    app = _make_app()
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws", headers={"origin": "https://evil.example.com"}):
+            pass
+
+    # 4403 = forbidden origin (our private close code), distinct from the
+    # 1008 auth-failure code used elsewhere.
+    assert exc_info.value.code == FORBIDDEN_ORIGIN_CLOSE_CODE
+    # The route never ran: rejection happened before websocket.accept().
+    assert app.state.accepted == []
+
+
+def test_e2e_local_mode_admits_loopback_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A loopback-origin handshake connects and round-trips a message.
+
+    Proves the user's own local UI (which sends a loopback ``Origin``)
+    still works under the guard.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    app = _make_app()
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws", headers={"origin": "http://localhost:5173"}) as ws:
+        ws.send_text("hi")
+        # The echo proves the route accepted and processed the frame.
+        assert ws.receive_text() == "echo:hi"
+    assert app.state.accepted == [True]
+
+
+def test_e2e_local_mode_admits_missing_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A handshake with no ``Origin`` connects (non-browser client path).
+
+    The CLI runner / host clients send no ``Origin``; rejecting them
+    would break local operation. TestClient sends no ``Origin`` unless
+    asked, so this mirrors that path.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    app = _make_app()
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("hi")
+        assert ws.receive_text() == "echo:hi"
+    assert app.state.accepted == [True]
+
+
+def test_e2e_local_mode_admits_internal_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A handshake bearing the first-party sentinel origin connects.
+
+    This mirrors what the runner / host / terminal-attach clients send;
+    a failure would mean our own tunnels are rejected in local mode.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    app = _make_app()
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws", headers={"origin": OMNIGENT_INTERNAL_WS_ORIGIN}) as ws:
+        ws.send_text("hi")
+        assert ws.receive_text() == "echo:hi"
+    assert app.state.accepted == [True]
+
+
+def test_e2e_non_local_mode_admits_cross_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the local marker, cross-origin handshakes pass through.
+
+    Non-local modes authenticate via cookie/proxy, so the middleware
+    must not block them. A failure would break deployed multi-user
+    servers.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.delenv(_LOCAL_ENV, raising=False)
+    app = _make_app()
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws", headers={"origin": "https://app.example.com"}) as ws:
+        ws.send_text("hi")
+        assert ws.receive_text() == "echo:hi"
+    assert app.state.accepted == [True]
+
+
+def test_e2e_allowlist_denies_unlisted_origin_in_non_local_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured allowlist denies unlisted origins even in non-local mode.
+
+    Proves the opt-in defense-in-depth knob: setting
+    ``OMNIGENT_WS_ALLOWED_ORIGINS`` flips the non-local default from
+    passthrough to deny-by-default, rejecting an unlisted origin with the
+    forbidden-origin code while the listed origin still connects.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.delenv(_LOCAL_ENV, raising=False)
+    monkeypatch.setenv(_ALLOWLIST_ENV, "https://ui.example.com")
+    app = _make_app()
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws", headers={"origin": "https://other.example.com"}):
+            pass
+    assert exc_info.value.code == FORBIDDEN_ORIGIN_CLOSE_CODE
+    assert app.state.accepted == []
+
+    with client.websocket_connect("/ws", headers={"origin": "https://ui.example.com"}) as ws:
+        ws.send_text("hi")
+        assert ws.receive_text() == "echo:hi"
+    # Only the allowlisted connection reached the route.
+    assert app.state.accepted == [True]

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -24,6 +24,7 @@ from omnigent import claude_native
 from omnigent._runner_startup import RunnerStartupProgress
 from omnigent._startup_profile import StartupProfiler
 from omnigent._terminal_picker_theme import PICKER_ACCENT, PICKER_MUTED
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from omnigent.spec import load_omnigent_yaml
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_DETACHED,
@@ -3494,9 +3495,15 @@ def test_websocket_connect_sets_short_close_timeout(monkeypatch: pytest.MonkeyPa
     )
 
     assert result is sentinel
+    # The wrapper adds the first-party Origin sentinel alongside the
+    # caller's auth header so the server's CSWSH origin guard admits this
+    # non-browser attach client; the caller's bearer is preserved.
     assert captured == {
         "url": "wss://example.com/attach",
-        "additional_headers": {"Authorization": "Bearer tok"},
+        "additional_headers": {
+            "Authorization": "Bearer tok",
+            "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
+        },
         "close_timeout": claude_native._CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
     }
 

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -177,7 +177,7 @@ def test_conversation_url_maps_workspace_hosted_server_to_ui_mount(tmp_path, mon
 
     The server base is the API proxy (``/api/2.0/omnigent``) — linking
     there returns JSON, not the web UI. The browser URL must land on
-    ``/ml/omnigent`` and carry ``?o=<org>`` recorded by ``omnigent
+    ``/omnigent`` and carry ``?o=<org>`` recorded by ``omnigent
     login`` so multi-org workspaces open in the right one.
     """
     from omnigent.cli_auth import store_databricks_auth
@@ -196,7 +196,7 @@ def test_conversation_url_maps_workspace_hosted_server_to_ui_mount(tmp_path, mon
 
     url = conversation_url(server, "conv_abc123")
 
-    assert url == ("https://example.databricks.com/ml/omnigent/c/conv_abc123?o=2850744067564480")
+    assert url == ("https://example.databricks.com/omnigent/c/conv_abc123?o=2850744067564480")
 
 
 def test_conversation_url_workspace_hosted_without_org_record(tmp_path, monkeypatch) -> None:
@@ -214,7 +214,7 @@ def test_conversation_url_workspace_hosted_without_org_record(tmp_path, monkeypa
 
     url = conversation_url("https://example.databricks.com/api/2.0/omnigent", "conv_abc123")
 
-    assert url == "https://example.databricks.com/ml/omnigent/c/conv_abc123"
+    assert url == "https://example.databricks.com/omnigent/c/conv_abc123"
 
 
 def test_conversation_url_plain_server_unchanged(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Land server/web hardening, policy, and quality fixes that aren't yet on `main`:

- **WebSocket Origin enforcement (CSWSH):** a `WebSocketOriginMiddleware` rejects cross-origin WebSocket handshakes in local mode before any route accepts them. Loopback, the `omnigent://` sentinel origin, and no-origin clients are still admitted.
- **CSRF hardening:** JSON POST session routes now require an `application/json` content-type (or multipart, where a route legitimately accepts both), so a cross-site `text/plain` form post can't reach them.
- **Stored-XSS hardening:** the session file content route forces `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff`, with a safe RFC 5987 filename encoding for user-supplied names.
- **Policy params:** object-typed policy parameters are JSON-parsed/coerced in the add-policy dialogs via a new `policyParams` helper wired into `AgentInfo` and `PoliciesPage`.
- **Cost-budget policy:** the cost budget now fires on the request phase, and the default expensive-model set uses gpt-5 (excluding `-mini`/`-nano`).

Smaller fixes also included: CLI bare-workspace-URL expansion for `attach` / `resume` / `host --server`; point workspace UI links at `/omnigent`; drag-and-drop files onto the new-session composer; per-conversation scoping of the composer's ArrowUp history; and a model-switcher tweak.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran the affected suites against this branch. Backend: `pytest tests/server/test_ws_origin.py tests/server/routes/test_content_type.py tests/server/integration/test_sessions_content_type_csrf.py tests/server/routes/test_session_resources.py tests/test_claude_native.py tests/runner/transports/ws_tunnel/test_serve.py tests/cli/test_backend.py` -> 376 passed; `pytest tests/policies/builtins/test_cost.py tests/policies/builtins/test_user_daily_cost.py` -> 70 passed. Web: `vitest run` over the changed tests (policyParams, usePromptHistory, modelPicker, NewChatDialog) -> 149 passed, and `npm run type-check` is clean. New tests cover the Origin guard, the content-type rejection matrix, the attachment/nosniff download behavior, the policy-param coercion, and the request-phase cost-budget logic.
