### PR TITLE
chore: gitignore ap-web SPA build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ artifacts/
 # Playwright test run output (screenshots, traces, videos).
 test-results/
 
+# ap-web SPA build output, emitted into the server's static dir by
+# `npm run build` / the e2e_ui test fixture. Regenerated on demand;
+# never committed.
+omnigent/server/static/web-ui/
+
 # macOS Finder metadata — never useful to commit.
 .DS_Store
 **/.DS_Store


### PR DESCRIPTION
## What

Adds `omnigent/server/static/web-ui/` to `.gitignore`.

## Why

The ap-web SPA build (`npm run build`, also triggered by the `tests/e2e_ui` test fixture's first run) emits its output into `omnigent/server/static/web-ui/`. These are regenerated on demand and should never be committed; ignoring them keeps `git status` clean after building or running the UI e2e suite.

## Notes

Scoped to the build output directory only — no other paths affected. Verified with `git check-ignore` that artifacts under that path now match.