### PR TITLE
ci(e2e): gate fork-PR e2e behind a maintainer-approved mirror

### DIFF
--- a/.github/scripts/fork-e2e/should-mirror.sh
+++ b/.github/scripts/fork-e2e/should-mirror.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Decides whether a fork PR's head commit should be mirrored onto the trusted
+# fork-e2e/pr-N branch (which lets e2e run as a `push` with the test-gateway
+# secrets). Called by .github/workflows/fork-e2e-mirror.yml.
+#
+# Gate (any one opens it):
+#   1. The fork-e2e/pr-N branch already exists -> always re-mirror, so new
+#      commits on an already-opened PR re-run e2e.
+#   2. Returning contributor -- author_association is OWNER / MEMBER /
+#      COLLABORATOR / CONTRIBUTOR (GitHub's own "has contributed before"
+#      signal; first-timers are FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / NONE).
+#   3. Maintainer-approved -- the author is in .github/MAINTAINER, or a
+#      maintainer's latest non-COMMENTED review is APPROVED.
+#
+# Case 3 deliberately mirrors maintainer-approval.yml's computation (same
+# MAINTAINER list via load-maintainers.sh, same review semantics). Keep the two
+# in sync; a drift only over-/under-opens the mirror gate (bounded by the
+# rate-limited, revocable test token), it can't bypass the merge gate.
+#
+# Env in:  GH_TOKEN, REPO, PR, AUTHOR_ASSOCIATION, MAINTAINERS (space-separated,
+#          from load-maintainers.sh), MIRROR_BRANCH (e.g. fork-e2e/pr-123).
+# Out:     `mirror=true|false` and `reason=<text>` on $GITHUB_OUTPUT.
+
+set -euo pipefail
+
+emit() {
+  echo "mirror=$1" >> "$GITHUB_OUTPUT"
+  echo "reason=$2" >> "$GITHUB_OUTPUT"
+  echo "mirror=$1 ($2)"
+}
+
+# 1. Already opened: re-mirror every subsequent push.
+if gh api "repos/$REPO/branches/$MIRROR_BRANCH" >/dev/null 2>&1; then
+  emit true "re-mirror: $MIRROR_BRANCH already exists"
+  exit 0
+fi
+
+# 2. Returning contributor (GitHub's native author_association signal).
+case "$AUTHOR_ASSOCIATION" in
+  OWNER | MEMBER | COLLABORATOR | CONTRIBUTOR)
+    emit true "returning contributor (author_association=$AUTHOR_ASSOCIATION)"
+    exit 0
+    ;;
+esac
+
+# 3. Maintainer-approved (mirrors maintainer-approval.yml; see header note).
+MAINTAINERS_LC=$(echo "${MAINTAINERS:-}" | tr '[:upper:]' '[:lower:]')
+if [[ -n "${MAINTAINERS_LC// /}" ]]; then
+  AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login')
+  AUTHOR_LC=$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')
+
+  for m in $MAINTAINERS_LC; do
+    if [[ "$m" == "$AUTHOR_LC" ]]; then
+      emit true "author @$AUTHOR is a maintainer"
+      exit 0
+    fi
+  done
+
+  # Latest non-COMMENTED review per reviewer; APPROVED by a maintainer opens it.
+  APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+    --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login')
+  for u in $APPROVERS; do
+    u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
+    for m in $MAINTAINERS_LC; do
+      if [[ "$m" == "$u_lc" ]]; then
+        emit true "approved by maintainer @$u"
+        exit 0
+      fi
+    done
+  done
+fi
+
+emit false "awaiting maintainer approval (first-time contributor)"

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -11,8 +11,12 @@ name: E2E UI Tests
 #
 # Triggers:
 #   pull_request        opened / synchronize / reopened /
-#                       ready_for_review. Draft PRs are skipped.
-#   push (main)         post-merge run on the default branch.
+#                       ready_for_review. SAME-REPO PRs only; draft
+#                       PRs and fork PRs skip the job (forks run via
+#                       the fork-e2e/** push after approval, mirrored
+#                       by fork-e2e-mirror.yml).
+#   push (fork-e2e/**)  the UI suite for mirrored fork PRs -- a trusted
+#                       base-repo branch, so secrets flow.
 #   schedule            09:00 UTC daily, alongside nightly.yml.
 #   workflow_dispatch   manual run. Input `branch` selects a non-main
 #                       ref.
@@ -20,6 +24,9 @@ name: E2E UI Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - 'fork-e2e/**'
   schedule:
     - cron: "0 9 * * *"
   workflow_dispatch:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,25 +11,27 @@ name: E2E Tests
 #   workflow_dispatch   manual run. Inputs: `branch` to target a
 #                       non-main ref; `parallelism` to override the
 #                       pytest `-n` worker count (default 8).
-#   pull_request        PR-gate entry point. The four shard check
-#                       names are listed in merge-ready.yml's
-#                       REQUIRED array so merge is blocked until
-#                       all four go green. Full suite runs ~3-4
-#                       minutes wall-clock with all four shards in
-#                       parallel; leans heavily on
-#                       ``tests/known_failures.yaml`` quarantines
-#                       (~290 entries today) tracked under #532.
+#   pull_request        PR-gate entry point for SAME-REPO PRs (secrets
+#                       flow). FORK PRs skip the job here (no secrets on
+#                       fork pull_request runs) and instead run via the
+#                       fork-e2e/** push below, after fork-e2e-mirror.yml
+#                       mirrors an approved / returning-contributor PR.
+#                       The four shard check names are in merge-ready.yml's
+#                       REQUIRED array so merge is blocked until all four
+#                       go green. Leans heavily on
+#                       ``tests/known_failures.yaml`` quarantines (#532).
+#   push (fork-e2e/**)  The e2e run for mirrored fork PRs -- a trusted
+#                       base-repo branch, so secrets flow.
 
 on:
   schedule:
     - cron: "0 9 * * *"
-  # pull_request_target (not pull_request) so fork PRs run in the base-repo
-  # context with the test-gateway secrets. Ungated by design: those creds are
-  # rate-limited + revocable, so auto-run on fork PRs is an accepted risk (no
-  # environment -> no approval prompt, no per-shard deployment records).
-  # leak-scan-allow: pull_request_target
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore: ['ap-web/**']
+  push:
+    branches:
+      - 'fork-e2e/**'
     paths-ignore: ['ap-web/**']
   workflow_dispatch:
     inputs:
@@ -89,9 +91,13 @@ jobs:
     # we trip rate limits, drop ``-n`` to 1 first; only fall back to
     # ``max-parallel`` reduction if QPS still hurts.
     name: E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
-    # Draft PRs skip. Fork PRs run ungated -- see the leak-scan-allow note on
-    # the pull_request_target trigger above.
-    if: ${{ !github.event.pull_request.draft }}
+    # Skip draft PRs, and skip FORK pull_request events: forks get no secrets
+    # on `pull_request`, so they run via the fork-e2e/** push that
+    # fork-e2e-mirror.yml creates after approval (a `push` event is not a
+    # 'pull_request', so it always passes this guard).
+    if: ${{ !github.event.pull_request.draft
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     strategy:
       # One red shard shouldn't cancel siblings; we want every shard's
@@ -117,11 +123,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # Test the merge result: refs/pull/N/merge is the PR head merged into
-          # the base by GitHub. It is absent when the PR conflicts, so a
-          # conflicted PR fails checkout here by design (resolve conflicts
-          # first). Fork code still runs only after the env gate above. Non-PR
-          # events fall back to the dispatch branch / ref.
+          # Same-repo PRs: test the merge result. refs/pull/N/merge is the PR
+          # head merged into the base by GitHub; it is absent when the PR
+          # conflicts, so a conflicted PR fails checkout here by design
+          # (resolve conflicts first). Push events (the mirrored fork-e2e/**
+          # branches) and dispatch fall back to the branch / ref -- for
+          # fork-e2e/** that is the contributor's head commit on a trusted
+          # base-repo branch.
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
 
       - name: Set up Python

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -1,0 +1,94 @@
+name: Fork e2e mirror
+
+# Mirrors an approved (or returning-contributor) fork PR's head commit onto a
+# trusted base-repo branch, fork-e2e/pr-N, so the e2e suite runs there as a
+# `push` event. A fork's own `pull_request` run gets no secrets; a `push` to a
+# base-repo branch does -- that's how fork e2e reaches the test gateway.
+#
+# The mirror is a pure git-ref update via the API: it never checks out or runs
+# the fork's code, so this privileged (secret-eligible) workflow never executes
+# untrusted code with secrets in scope. The fork code only runs on the
+# downstream `push` to fork-e2e/** (see e2e.yml), which is a trusted event.
+#
+# Gate -- .github/scripts/fork-e2e/should-mirror.sh opens when any holds:
+#   maintainer-approved  ||  returning-contributor  ||  fork-e2e/pr-N exists.
+# Once the branch exists, every later push re-mirrors (re-runs e2e on the new
+# commits). Accepted risk: an approved first-timer's later pushes then run with
+# the secret unreviewed -- bounded by the rate-limited, revocable test token.
+#
+# pull_request_target / pull_request_review run the workflow + scripts from the
+# base (default branch), never the PR head, so a PR cannot alter the gate; the
+# script checkout is additionally pinned to main.
+#
+# leak-scan-allow: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+  pull_request_review:
+    types: [submitted]
+
+# Read-only at the top level (Scorecard Token-Permissions); write scope is on
+# the job.
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-e2e-mirror-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: mirror
+    # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`.
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: write       # create / update / delete the fork-e2e/pr-N ref
+      pull-requests: read   # read author + reviews for the gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+      MIRROR_BRANCH: fork-e2e/pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Check out gate scripts from main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main             # trusted base; never the PR head
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Delete mirror branch on PR close
+        if: ${{ github.event.action == 'closed' }}
+        run: |
+          gh api -X DELETE "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1 \
+            && echo "Deleted $MIRROR_BRANCH" \
+            || echo "No $MIRROR_BRANCH to delete"
+
+      - name: Load maintainers
+        id: maintainers
+        if: ${{ github.event.action != 'closed' }}
+        run: bash .github/scripts/merge-ready/load-maintainers.sh
+
+      - name: Evaluate mirror gate
+        id: gate
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          MAINTAINERS: ${{ steps.maintainers.outputs.list }}
+        run: bash .github/scripts/fork-e2e/should-mirror.sh
+
+      - name: Mirror head SHA onto trusted branch
+        if: ${{ github.event.action != 'closed' && steps.gate.outputs.mirror == 'true' }}
+        run: |
+          if gh api "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" \
+              -f sha="$HEAD_SHA" -F force=true >/dev/null
+            echo "Updated $MIRROR_BRANCH -> $HEAD_SHA"
+          else
+            gh api -X POST "repos/$REPO/git/refs" \
+              -f ref="refs/heads/$MIRROR_BRANCH" -f sha="$HEAD_SHA" >/dev/null
+            echo "Created $MIRROR_BRANCH -> $HEAD_SHA"
+          fi

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -71,14 +71,14 @@ jobs:
     # workflow_run completions, or `/merge` comments. Other label
     # adds no longer skip-run here.
     #
-    # workflow_run is filtered to PR-originated runs. Post-merge
-    # runs on `main` (workflow_run.event == 'push') and nightlies
-    # / manual dispatches (schedule / workflow_dispatch) have no
-    # PR to post a status on -- the context-resolution step below
-    # would skip them anyway, but we'd still spend ~15 s spinning
-    # up a runner. Filter at the job-`if:` level so push:main
-    # completions of the watched workflows don't spawn wasteful
-    # merge-ready runs per merge.
+    # workflow_run is filtered to PR-originated runs: the watched
+    # workflows' `pull_request` completions, plus the fork-e2e run
+    # which arrives as a `push` on a `fork-e2e/**` branch (the e2e
+    # suite for a mirrored fork PR -- see fork-e2e-mirror.yml). The
+    # context-resolution step below maps that branch's head SHA back
+    # to its PR. Post-merge runs on `main` (push), nightlies, and
+    # manual dispatches have no PR to post on, so they're excluded
+    # here to avoid spinning up a wasteful runner per merge.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -91,7 +91,10 @@ jobs:
         github.event_name == 'workflow_run' &&
         (
           github.event.workflow_run.event == 'pull_request' ||
-          github.event.workflow_run.event == 'pull_request_target'
+          (
+            github.event.workflow_run.event == 'push' &&
+            startsWith(github.event.workflow_run.head_branch, 'fork-e2e/')
+          )
         )
       ) ||
       (

--- a/tests/scripts/test_fork_e2e_should_mirror.py
+++ b/tests/scripts/test_fork_e2e_should_mirror.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github/scripts/fork-e2e/should-mirror.sh"
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    author_association: str,
+    maintainers: str = "",
+    branch_exists: bool = False,
+    author: str = "octocat",
+    approvers: str = "",
+) -> dict[str, str]:
+    """
+    Run should-mirror.sh against a mocked ``gh`` and return its outputs.
+
+    The mock answers the three calls the script can make:
+
+    - ``api repos/{repo}/branches/{mirror_branch}`` -> exit 0 if
+      *branch_exists* else exit 1 (the existence probe).
+    - ``pr view {pr} ...`` -> *author* (the PR author login).
+    - ``api repos/{repo}/pulls/{pr}/reviews ...`` -> *approvers*, a
+      space-separated login list printed one per line (post-``--jq``
+      shape the script iterates).
+
+    :param tmp_path: Pytest tmp dir for the mock + output file.
+    :param author_association: GitHub ``author_association`` value,
+        e.g. ``"FIRST_TIME_CONTRIBUTOR"`` or ``"CONTRIBUTOR"``.
+    :param maintainers: Space-separated maintainer logins (as
+        load-maintainers.sh would emit); empty means none.
+    :param branch_exists: Whether fork-e2e/pr-N already exists.
+    :param author: PR author login the ``gh pr view`` mock returns.
+    :param approvers: Space-separated logins whose latest review is
+        APPROVED, as the reviews ``--jq`` would yield.
+    :returns: Parsed ``key=value`` GITHUB_OUTPUT lines, e.g.
+        ``{"mirror": "true", "reason": "..."}``.
+    """
+    gh = tmp_path / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -uo pipefail\n"
+        'if [[ "$1" == "pr" ]]; then echo "$MOCK_AUTHOR"; exit 0; fi\n'
+        'if [[ "$1" == "api" ]]; then\n'
+        '  case "$2" in\n'
+        '    *branches/*) [[ "$BRANCH_EXISTS" == "1" ]] && exit 0 || exit 1 ;;\n'
+        # shellcheck-style: unquoted expansion intentionally splits logins.
+        '    *reviews*) [[ -n "$MOCK_APPROVERS" ]] && printf "%s\\n" $MOCK_APPROVERS; exit 0 ;;\n'
+        "  esac\n"
+        "fi\n"
+        'echo "unexpected gh invocation: $*" >&2\n'
+        "exit 1\n"
+    )
+    gh.chmod(0o755)
+
+    out_file = tmp_path / "gh_output"
+    out_file.touch()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "GH_TOKEN": "unused",
+            "REPO": "test/repo",
+            "PR": "7",
+            "MIRROR_BRANCH": "fork-e2e/pr-7",
+            "AUTHOR_ASSOCIATION": author_association,
+            "MAINTAINERS": maintainers,
+            "GITHUB_OUTPUT": str(out_file),
+            "BRANCH_EXISTS": "1" if branch_exists else "0",
+            "MOCK_AUTHOR": author,
+            "MOCK_APPROVERS": approvers,
+        }
+    )
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"script failed: {proc.stderr}"
+    outputs: dict[str, str] = {}
+    for line in out_file.read_text().splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return outputs
+
+
+def test_first_time_contributor_without_approval_does_not_mirror(tmp_path: Path) -> None:
+    """A first-timer with no maintainer approval must NOT open the gate.
+
+    This is the whole point of the gate: brand-new contributors don't get a
+    secret-bearing e2e run on first push. Asserts ``mirror=false`` (the e2e
+    suite stays unmirrored until a maintainer reviews).
+    """
+    out = _run(tmp_path, author_association="FIRST_TIME_CONTRIBUTOR")
+    assert out["mirror"] == "false"
+
+
+def test_returning_contributor_mirrors(tmp_path: Path) -> None:
+    """A returning contributor (author_association=CONTRIBUTOR) auto-mirrors.
+
+    Matches GitHub's own "has contributed before" relaxation. Asserts
+    ``mirror=true`` with no maintainer list needed.
+    """
+    out = _run(tmp_path, author_association="CONTRIBUTOR")
+    assert out["mirror"] == "true"
+    assert "returning contributor" in out["reason"]
+
+
+def test_member_association_mirrors(tmp_path: Path) -> None:
+    """An org MEMBER's fork PR auto-mirrors (also a returning-type association)."""
+    out = _run(tmp_path, author_association="MEMBER")
+    assert out["mirror"] == "true"
+
+
+def test_maintainer_author_mirrors(tmp_path: Path) -> None:
+    """A first-timer whose login is in MAINTAINER opens the gate.
+
+    Covers the author-is-maintainer branch even when author_association is not
+    a returning value. Asserts ``mirror=true`` and that the reason names the
+    author.
+    """
+    out = _run(
+        tmp_path,
+        author_association="NONE",
+        maintainers="alice bob",
+        author="bob",
+    )
+    assert out["mirror"] == "true"
+    assert "maintainer" in out["reason"]
+
+
+def test_maintainer_approved_review_mirrors(tmp_path: Path) -> None:
+    """A first-timer whose PR a maintainer APPROVED opens the gate.
+
+    Covers the review-approval branch: the author isn't a maintainer, but a
+    maintainer (``bob``) approved. Asserts ``mirror=true``.
+    """
+    out = _run(
+        tmp_path,
+        author_association="FIRST_TIME_CONTRIBUTOR",
+        maintainers="alice bob",
+        author="newcomer",
+        approvers="bob",
+    )
+    assert out["mirror"] == "true"
+    assert "approved by maintainer" in out["reason"]
+
+
+def test_non_maintainer_approval_does_not_mirror(tmp_path: Path) -> None:
+    """An APPROVED review from a NON-maintainer must not open the gate.
+
+    Guards against treating any approval as sufficient: only a maintainer's
+    approval counts. ``eve`` approves but isn't in MAINTAINER, so
+    ``mirror=false``.
+    """
+    out = _run(
+        tmp_path,
+        author_association="FIRST_TIME_CONTRIBUTOR",
+        maintainers="alice bob",
+        author="newcomer",
+        approvers="eve",
+    )
+    assert out["mirror"] == "false"
+
+
+def test_existing_branch_always_remirrors(tmp_path: Path) -> None:
+    """Once fork-e2e/pr-N exists, a first-timer's new push re-mirrors.
+
+    The accepted always-re-mirror behavior: a first-timer with no approval
+    whose branch already exists still mirrors (new commits re-run e2e).
+    Asserts ``mirror=true`` despite the otherwise-closed gate.
+    """
+    out = _run(
+        tmp_path,
+        author_association="FIRST_TIME_CONTRIBUTOR",
+        branch_exists=True,
+    )
+    assert out["mirror"] == "true"
+    assert "re-mirror" in out["reason"]


### PR DESCRIPTION
## Summary

Fork/community PRs no longer auto-run the e2e suite with the test-gateway secret. Previously e2e ran via `pull_request_target`, which executes a contributor's code with secrets in scope on their very first push, with no human gate (GitHub's "require approval for first-time contributors" button does not apply to `pull_request_target`).

This change introduces a maintainer-approved **mirror**: a new `fork-e2e-mirror.yml` mirrors a fork PR's head commit onto a trusted `fork-e2e/pr-N` branch only when the gate opens (a maintainer approved the PR, OR the author is a returning contributor, OR the branch already exists for re-runs). e2e then runs on that trusted branch as a `push`, which legitimately receives secrets. The mirror step is a pure git-ref update via the API, so the privileged workflow never checks out or executes fork code with secrets in scope.

- `e2e.yml`: `pull_request_target` becomes `pull_request` (same-repo PRs run with secrets) plus a `push` trigger on `fork-e2e/**`; fork `pull_request` events skip the job.
- `fork-e2e-mirror.yml` (new): the approval-gated ref mirror.
- `.github/scripts/fork-e2e/should-mirror.sh` (new): the gate logic, reusing the existing `load-maintainers.sh`.
- `merge-ready.yml`: accept the fork-e2e/** `push` completion and resolve its PR from the head SHA.

## ELI5

The e2e tests need a secret key to talk to our test AI gateway. GitHub has a safety rule: when a stranger opens a PR from their own fork, their code never gets our secret keys. That is good. The problem is our old setup used a special trigger (`pull_request_target`) that *bypassed* that rule and handed the key to a stranger's code automatically, the first time they pushed, with nobody checking first.

New setup: a stranger's PR does **not** run the real e2e tests until either a maintainer approves it, or the author is someone who has contributed before. When that happens, a small robot copies the contributor's commit onto a branch in **our** repo (`fork-e2e/pr-N`). Code sitting on a branch in our own repo is trusted, so the tests run there with the key.

The important trick: the robot only moves a *pointer* to the commit (a git ref). It never runs the stranger's code itself. So the secret is only ever near code that a human (or our "has contributed before" rule) already vouched for.

## How it works

```
                       Fork PR opened / updated
            (or: a maintainer approves it later on)
                                |
                                v
        +-----------------------------------------------------+
        |  Gate open?   should-mirror.sh                      |
        |    - maintainer approved the PR, OR                 |
        |    - returning contributor, OR                      |
        |    - fork-e2e/pr-N already exists (re-run)          |
        +-----------------------------------------------------+
                  |                              |
               no |                              | yes
                  v                              v
        e2e does NOT run            fork-e2e-mirror.yml points
        (no secret exposed;         refs/heads/fork-e2e/pr-N -> PR head SHA
         waits for approval)        (pure git-ref update; no fork code runs)
                                                 |
                                                 v
                                     push event on fork-e2e/**
                                     (a trusted base-repo branch)
                                                 |
                                                 v
                                     e2e.yml runs WITH secrets
                                     (checks land on the PR head SHA)
                                                 |
                                                 v
                                     merge-ready resolves the PR
                                     from the head SHA -> Merge Ready

        PR closed / merged  ----->  mirror deletes fork-e2e/pr-N
```

Same-repo PRs are unaffected: they run e2e directly via `pull_request` (secrets flow normally), and only fork `pull_request` events are skipped (they take the mirror path instead).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `tests/scripts/test_fork_e2e_should_mirror.py`, a truth-table unit test for the gate script that mocks `gh` and asserts: a first-time contributor without approval does not mirror; a returning contributor and an org member do; an author listed as a maintainer does; a maintainer's APPROVED review does, but a non-maintainer's approval does not; and an already-existing mirror branch always re-mirrors. Manual verification: parsed all three workflows with PyYAML and confirmed the trigger sets, and ran the gate test suite (7 passed). The same-repo `pull_request` path is additionally confirmed green by this PR's own e2e run; the fork mirror path is exercised live once the first fork PR flows through after merge.
