### PR TITLE
chore: keep uv.lock pinned to public PyPI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      # Must run BEFORE any `uv` command: `uv sync` / `uv run` re-resolve
+      # the working tree against CI's own index (pypi.org) and would
+      # rewrite a committed proxy URL to canonical, masking it from the
+      # pre-commit hook below. This checks the committed file as-is
+      # (stdlib only, no venv needed).
+      - name: Check uv.lock uses the public PyPI index
+        run: python scripts/normalize_uv_lock_registry.py --check uv.lock
+
       - name: Set up uv
         uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,17 @@ repos:
         files: ^ap-web/.*\.(css|html|js|jsx|json|md|mdx|ts|tsx|yaml|yml)$
         exclude: ^omnigent/server/static/web-ui/assets/
 
+      # Local `uv` runs rewrite uv.lock's registry to whatever index is
+      # configured on the developer's machine (e.g. the Databricks PyPI
+      # proxy). This OSS repo must always commit the public PyPI URL, so
+      # normalize it back before it lands. Fixer: re-stage if it changes.
+      - id: normalize-uv-lock-registry
+        name: normalize uv.lock registry to pypi.org
+        language: system
+        entry: .venv/bin/python scripts/normalize_uv_lock_registry.py
+        files: ^uv\.lock$
+        pass_filenames: true
+
   # ── File hygiene ────────────────────────────────────────────────
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/scripts/normalize_uv_lock_registry.py
+++ b/scripts/normalize_uv_lock_registry.py
@@ -1,0 +1,113 @@
+"""Normalize the package index in ``uv.lock`` to the public PyPI URL.
+
+Local ``uv`` runs resolve against whatever index is configured on the
+developer's machine (e.g. the Databricks PyPI proxy via ``UV_INDEX_URL``
+or ``~/.config/uv``), and ``uv`` rewrites every
+``source = { registry = "<url>" }`` entry in ``uv.lock`` to that index.
+For this OSS repo the committed lockfile must always point at public
+PyPI (``https://pypi.org/simple``) so the lock is reproducible for
+contributors who don't have the proxy — CI already pins
+``UV_INDEX_URL: https://pypi.org/simple`` for the same reason.
+
+This is a pre-commit *fixer*: it rewrites the registry URL in place and
+exits non-zero when it changed anything, so the commit aborts and the
+developer re-stages the normalized lockfile (mirroring
+``end-of-file-fixer`` and friends). Only ``registry`` sources are
+touched; ``git`` / ``path`` / ``editable`` sources are left alone.
+
+Pass ``--check`` to validate without writing: it exits non-zero (and
+names the offending URLs) when a file is *not* already canonical, but
+leaves it untouched. CI runs this mode against the committed lockfile
+*before* any ``uv`` command — a plain ``uv run pre-commit`` can't catch a
+committed proxy URL, because ``uv`` re-syncs the working tree to CI's
+own index (``pypi.org``) first and masks it.
+
+Usage::
+
+    python scripts/normalize_uv_lock_registry.py uv.lock           # fix
+    python scripts/normalize_uv_lock_registry.py --check uv.lock   # verify
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The canonical public index the committed lockfile must always use.
+_CANONICAL_INDEX = "https://pypi.org/simple"
+
+# Matches a uv.lock registry source, capturing the surrounding literal so
+# only the URL between the quotes is replaced, e.g.
+#   source = { registry = "https://pypi-proxy.example.com/simple" }
+_REGISTRY_RE = re.compile(r'(registry = ")[^"]*(")')
+
+
+def non_canonical_registries(text: str) -> list[str]:
+    """Return the registry URLs in *text* that are not public PyPI.
+
+    :param text: Full contents of a ``uv.lock`` file.
+    :returns: Each non-canonical ``registry`` URL, in order, with
+        duplicates preserved (one per offending entry).
+    """
+    return [
+        m.group(1)
+        for m in re.finditer(r'registry = "([^"]*)"', text)
+        if m.group(1) != _CANONICAL_INDEX
+    ]
+
+
+def normalize_text(text: str) -> str:
+    """Return *text* with every registry URL rewritten to public PyPI.
+
+    :param text: Full contents of a ``uv.lock`` file.
+    :returns: The same text with each ``registry = "<url>"`` URL replaced
+        by :data:`_CANONICAL_INDEX`.
+    """
+    return _REGISTRY_RE.sub(rf"\g<1>{_CANONICAL_INDEX}\g<2>", text)
+
+
+def main(argv: list[str]) -> int:
+    """Normalize (or, with ``--check``, validate) each given lockfile.
+
+    :param argv: Filenames to process, optionally preceded/followed by the
+        ``--check`` flag (passed by pre-commit or CI).
+    :returns: In fix mode, ``1`` when a file was modified (so the commit
+        aborts and the change is re-staged) else ``0``. In ``--check``
+        mode, ``1`` when any file is not already canonical (printing the
+        offending URLs) else ``0``; no file is written.
+    """
+    check = "--check" in argv
+    files = [a for a in argv if a != "--check"]
+
+    if check:
+        ok = True
+        for name in files:
+            offenders = non_canonical_registries(Path(name).read_text())
+            if offenders:
+                ok = False
+                unique = sorted(set(offenders))
+                print(
+                    f"{name}: {len(offenders)} non-canonical registry "
+                    f"source(s) (expected {_CANONICAL_INDEX}): {', '.join(unique)}"
+                )
+                print(
+                    "Fix with: python scripts/normalize_uv_lock_registry.py "
+                    f"{name} && git add {name}"
+                )
+        return 0 if ok else 1
+
+    changed = False
+    for name in files:
+        path = Path(name)
+        original = path.read_text()
+        normalized = normalize_text(original)
+        if normalized != original:
+            path.write_text(normalized)
+            print(f"{name}: normalized package index to {_CANONICAL_INDEX}")
+            changed = True
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_normalize_uv_lock_registry.py
+++ b/tests/test_normalize_uv_lock_registry.py
@@ -1,0 +1,168 @@
+"""Unit tests for ``scripts/normalize_uv_lock_registry.py``.
+
+The pre-commit fixer rewrites every ``source = { registry = "<url>" }``
+in ``uv.lock`` to public PyPI so a developer's local index/proxy never
+leaks into the committed lockfile. These tests pin that contract:
+arbitrary registry URLs are normalized, non-registry sources are left
+alone, the fixer is idempotent, and ``main`` signals modifications via
+its exit code (1 = changed → commit aborts and re-stages; 0 = clean).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "normalize_uv_lock_registry.py"
+
+# The canonical index the fixer must always produce — kept in the test as
+# an independent literal so a change to the script's constant is caught.
+_CANONICAL = "https://pypi.org/simple"
+
+
+def _load_module() -> Any:
+    """Import ``scripts/normalize_uv_lock_registry.py`` from its file path.
+
+    ``scripts/`` is not a package on ``sys.path`` (mirrors
+    ``tests/server/test_openapi_drift.py``'s loader), so load it directly.
+
+    :returns: The imported module, exposing ``normalize_text`` and ``main``.
+    """
+    spec = importlib.util.spec_from_file_location("scripts_normalize_uv_lock", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not locate the script at {_SCRIPT_PATH}."
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MOD = _load_module()
+
+
+def test_normalize_text_rewrites_proxy_registry() -> None:
+    """A Databricks-proxy registry URL is rewritten to public PyPI."""
+    text = 'source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }\n'
+    assert _MOD.normalize_text(text) == f'source = {{ registry = "{_CANONICAL}" }}\n'
+
+
+def test_normalize_text_rewrites_any_index() -> None:
+    """Normalization is proxy-agnostic — any registry URL collapses to PyPI."""
+    text = 'source = { registry = "https://nexus.internal.example.com/repository/pypi/simple" }'
+    assert _MOD.normalize_text(text) == f'source = {{ registry = "{_CANONICAL}" }}'
+
+
+def test_normalize_text_rewrites_every_occurrence() -> None:
+    """Multiple package entries are all normalized in one pass."""
+    proxy = "https://pypi-proxy.cloud.databricks.com/simple"
+    text = (
+        f'source = {{ registry = "{proxy}" }}\n'
+        f'source = {{ registry = "{proxy}" }}\n'
+        f'source = {{ registry = "{proxy}" }}\n'
+    )
+    result = _MOD.normalize_text(text)
+    assert proxy not in result
+    assert result.count(f'registry = "{_CANONICAL}"') == 3
+
+
+def test_normalize_text_leaves_non_registry_sources_untouched() -> None:
+    """``git`` / ``path`` / ``editable`` sources and other content survive."""
+    text = (
+        'source = { git = "https://github.com/org/repo.git" }\n'
+        'source = { editable = "." }\n'
+        'source = { path = "sdks/python-client" }\n'
+        'name = "some-package"\n'
+        'sdist = { url = "https://files.pythonhosted.org/packages/ab/cd/pkg.tar.gz" }\n'
+    )
+    assert _MOD.normalize_text(text) == text
+
+
+def test_normalize_text_already_canonical_is_noop() -> None:
+    """Text already pointing at public PyPI is returned unchanged."""
+    text = f'source = {{ registry = "{_CANONICAL}" }}\n'
+    assert _MOD.normalize_text(text) == text
+
+
+def test_main_rewrites_file_and_returns_one_when_changed(tmp_path: Path) -> None:
+    """``main`` rewrites a proxy lockfile in place and returns 1 (changed)."""
+    lock = tmp_path / "uv.lock"
+    lock.write_text('source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }\n')
+    rc = _MOD.main([str(lock)])
+    assert rc == 1
+    assert lock.read_text() == f'source = {{ registry = "{_CANONICAL}" }}\n'
+
+
+def test_main_returns_zero_when_already_canonical(tmp_path: Path) -> None:
+    """``main`` leaves a canonical lockfile untouched and returns 0 (clean)."""
+    lock = tmp_path / "uv.lock"
+    original = f'source = {{ registry = "{_CANONICAL}" }}\n'
+    lock.write_text(original)
+    rc = _MOD.main([str(lock)])
+    assert rc == 0
+    assert lock.read_text() == original
+
+
+def test_main_is_idempotent(tmp_path: Path) -> None:
+    """A second run after normalization is a no-op returning 0."""
+    lock = tmp_path / "uv.lock"
+    lock.write_text('source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }\n')
+    assert _MOD.main([str(lock)]) == 1
+    assert _MOD.main([str(lock)]) == 0
+
+
+def test_main_handles_multiple_files(tmp_path: Path) -> None:
+    """Given several files, any change yields exit 1 and each is normalized."""
+    proxy = 'source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }\n'
+    canonical = f'source = {{ registry = "{_CANONICAL}" }}\n'
+    a = tmp_path / "a.lock"
+    b = tmp_path / "b.lock"
+    a.write_text(proxy)
+    b.write_text(canonical)
+    rc = _MOD.main([str(a), str(b)])
+    assert rc == 1
+    assert a.read_text() == canonical
+    assert b.read_text() == canonical
+
+
+def test_non_canonical_registries_lists_offenders() -> None:
+    """The check helper reports each non-canonical registry URL, in order."""
+    proxy = "https://pypi-proxy.cloud.databricks.com/simple"
+    text = (
+        f'source = {{ registry = "{proxy}" }}\n'
+        f'source = {{ registry = "{_CANONICAL}" }}\n'
+        f'source = {{ registry = "{proxy}" }}\n'
+    )
+    assert _MOD.non_canonical_registries(text) == [proxy, proxy]
+
+
+def test_non_canonical_registries_empty_when_canonical() -> None:
+    """A fully-canonical lockfile reports no offenders."""
+    text = f'source = {{ registry = "{_CANONICAL}" }}\n'
+    assert _MOD.non_canonical_registries(text) == []
+
+
+def test_main_check_fails_without_writing(tmp_path: Path) -> None:
+    """``--check`` returns 1 for a proxy lockfile and does NOT modify it."""
+    lock = tmp_path / "uv.lock"
+    original = 'source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }\n'
+    lock.write_text(original)
+    rc = _MOD.main(["--check", str(lock)])
+    assert rc == 1
+    # Check mode must be read-only — the file is left exactly as-is.
+    assert lock.read_text() == original
+
+
+def test_main_check_passes_when_canonical(tmp_path: Path) -> None:
+    """``--check`` returns 0 for an already-canonical lockfile."""
+    lock = tmp_path / "uv.lock"
+    lock.write_text(f'source = {{ registry = "{_CANONICAL}" }}\n')
+    assert _MOD.main(["--check", str(lock)]) == 0
+
+
+def test_main_check_flag_position_independent(tmp_path: Path) -> None:
+    """``--check`` is recognized whether it precedes or follows the file."""
+    lock = tmp_path / "uv.lock"
+    lock.write_text(f'source = {{ registry = "{_CANONICAL}" }}\n')
+    assert _MOD.main([str(lock), "--check"]) == 0


### PR DESCRIPTION
## Problem

Local `uv` runs (including `uv run`) re-resolve the working tree against whatever index is configured on the developer's machine — e.g. the Databricks PyPI proxy — and rewrite every `source = { registry = "..." }` in `uv.lock` to that index. For this OSS repo the committed lockfile must always point at public PyPI (`https://pypi.org/simple`) so the lock is reproducible for contributors who don't have the proxy. CI already pins `UV_INDEX_URL: https://pypi.org/simple` for the same reason.

## Changes

**Pre-commit fixer** — `scripts/normalize_uv_lock_registry.py` normalizes every `registry` source back to `https://pypi.org/simple`. It's proxy-agnostic (rewrites *any* non-canonical registry URL), only touches `registry` sources (leaves `git`/`path`/`editable` alone), and exits non-zero when it changes anything so the commit aborts and the file is re-staged. Wired up as a `local` hook in `.pre-commit-config.yaml` scoped to `^uv\.lock$`.

**CI guard** — a new step in `lint.yml` runs the script's `--check` (read-only) mode against the committed `uv.lock` **before any `uv` command**. This is the key ordering detail: a bare `uv run pre-commit` can't catch a committed proxy URL, because `uv` re-syncs the working tree to CI's own index (pypi.org) first and rewrites the bad URL to canonical, masking it. Checking the committed file up front closes that hole, and the step is stdlib-only (no venv needed).

**Tests** — `tests/test_normalize_uv_lock_registry.py` (14 tests) covers normalization (proxy + arbitrary indexes, multiple occurrences, non-registry sources untouched, idempotency), the fixer's exit codes / in-place writes, and `--check` mode (read-only, fails on proxy, passes when canonical, flag position-independent).

## Notes for reviewers

- Run hooks without dirtying `uv.lock` locally via `uv run --no-sync pre-commit ...` (or call `pre-commit` directly) — `uv run` otherwise re-syncs against your proxy.