### PR TITLE
test(e2e_ui): cover start-session composer config affordances

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -76,14 +76,14 @@ def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
     and re-raised on the calling thread so the test fails normally.
 
     :param coro: The coroutine to run to completion.
-    :raises BaseException: Whatever the coroutine raised, re-raised here.
+    :raises Exception: Whatever the coroutine raised, re-raised here.
     """
-    captured: dict[str, BaseException] = {}
+    captured: dict[str, Exception] = {}
 
     def _worker() -> None:
         try:
             asyncio.run(coro)
-        except BaseException as exc:
+        except Exception as exc:
             captured["error"] = exc
 
     thread = threading.Thread(target=_worker)

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -83,7 +83,7 @@ def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
     def _worker() -> None:
         try:
             asyncio.run(coro)
-        except BaseException as exc:  # noqa: BLE001 — re-raised on caller thread
+        except BaseException as exc:
             captured["error"] = exc
 
     thread = threading.Thread(target=_worker)
@@ -209,9 +209,7 @@ async def _register_common_routes(
         await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
 
     async def handle_agents(route: Route) -> None:
-        await route.fulfill(
-            status=200, content_type="application/json", body=resolved_agents_body
-        )
+        await route.fulfill(status=200, content_type="application/json", body=resolved_agents_body)
 
     async def handle_events(route: Route) -> None:
         # Swallow the auto-sent initial prompt so no real LLM turn runs.

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1,0 +1,530 @@
+"""E2E: starting a new session from the home composer ("/").
+
+The landing composer (``NewChatLandingScreen`` in
+``ap-web/src/shell/NewChatDialog.tsx``) owns session creation end to end:
+the textarea is the new session's first message and the footer chips —
+host, working directory, git worktree — plus the agent picker and its
+Advanced settings menu supply every create parameter. Hitting Send POSTs
+``/v1/sessions`` and navigates to the new session; there is no modal.
+
+These tests cover the three configuration affordances the user reaches
+before sending:
+
+1. **Permission mode** — Claude Code's ``--permission-mode`` choices, in
+   the agent picker's Advanced settings menu. A non-default pick rides
+   along as ``terminal_launch_args``.
+2. **Working directory** — the file-browser popover behind the working-
+   directory chip. Browsing into a folder sets the session's
+   ``workspace``.
+3. **Git worktree** — the branch chip's popover. Naming a branch attaches
+   a ``git`` worktree spec to the create.
+
+Why the heavy ``page.route`` stubbing (mirrors
+``sessions/test_initial_prompt_session_switch.py``): the e2e harness's
+runner is directly tunneled into the server and registers no *host*, and
+the host filesystem endpoint has nothing to browse. The composer needs an
+online host, an agent catalog, and (for the folder test) a directory
+listing the headless harness can't produce, so ``/v1/hosts``,
+``/v1/agents``, and ``/v1/hosts/{id}/filesystem`` are faked. The create
+``POST /v1/sessions`` is intercepted too: rather than really launch a
+session, the handler *captures the request body* — which is the thing
+under test (that each selection reached the create call) — and returns a
+real pre-seeded session id so the post-send navigation lands somewhere
+real. ``/events`` is stubbed so the auto-sent first prompt never dispatches
+a real LLM turn.
+
+The async-in-a-fresh-thread shape is inherited from
+``test_initial_prompt_session_switch`` for the same reason documented
+there: once a pytest-playwright *sync* test has run in the session,
+pytest-asyncio can't start a loop on the main thread, so each async body
+runs in its own thread via :func:`asyncio.run`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Stubbed host the composer auto-selects (the tunneled runner registers no
+# host). Keyed identically in the recent-workspaces localStorage seed.
+_HOST_ID = "host_e2e"
+# Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
+# ``/v1/sessions/{id}/...`` — so the GET conversation list and the
+# agent-discovery scan pass through to the real server while only the POST
+# create is faked.
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+# Any host filesystem listing, base (home) or a nested path. ``search``
+# matches the substring, so it catches both ``…/filesystem`` and
+# ``…/filesystem/home/e2e/projects``; it never matches the bare
+# ``/v1/hosts`` list (no ``/filesystem`` segment).
+_FILESYSTEM_RE = re.compile(r"/v1/hosts/[^/]+/filesystem")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* to completion in a dedicated thread with its own event loop.
+
+    The e2e_ui suite runs many pytest-playwright **sync** tests in the same
+    session; once one has run, pytest-asyncio can't start a loop on the main
+    thread. Running the coroutine from a fresh thread via :func:`asyncio.run`
+    sidesteps that. Any exception (including assertion failures) is captured
+    and re-raised on the calling thread so the test fails normally.
+
+    :param coro: The coroutine to run to completion.
+    :raises BaseException: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, BaseException] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except BaseException as exc:  # noqa: BLE001 — re-raised on caller thread
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    """Poll ``predicate`` on the event loop until true or timeout.
+
+    :param predicate: Zero-arg callable returning truthy when satisfied.
+    :param timeout_s: Max seconds to wait before failing the test.
+    :raises AssertionError: If the predicate never becomes truthy.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: a single Claude Code agent.
+
+    ``claude-native-ui`` is the only built-in the picker needs here — its
+    name is what gates the permission-mode UI (``isClaudeNativeAgent``) and,
+    ranked first by display name, it auto-selects so no explicit pick is
+    required. ``harness: null`` keeps the "needs setup" badge off regardless
+    of the (stubbed) host's readiness map.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_claude_e2e",
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": None,
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+def _bundle_agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: the two harness-overridable bundle agents.
+
+    Polly and Debby are multi-agent bundles, not native terminal wrappers, so
+    their spec declares a brain harness (``harness: "claude-sdk"``) that lands
+    them in ``BRAIN_HARNESS_LABELS``. That — and the fact that neither is named
+    ``claude-native-ui`` — is what makes the Advanced menu render the **Agent
+    Harness** radio group instead of Claude Code's permission modes. Polly is
+    ranked ahead of Debby by ``AGENT_DISPLAY_ORDER``, so it auto-selects and no
+    explicit agent pick is needed. ``harness: null`` would suppress the section
+    entirely, so it must be a real harness id here.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_polly_e2e",
+                    "name": "polly",
+                    "display_name": "Polly",
+                    "description": "Multi-agent coding",
+                    "harness": "claude-sdk",
+                    "skills": [],
+                },
+                {
+                    "id": "ag_debby_e2e",
+                    "name": "debby",
+                    "display_name": "Debby",
+                    "description": "Multi-agent debate",
+                    "harness": "claude-sdk",
+                    "skills": [],
+                },
+            ]
+        }
+    )
+
+
+def _hosts_body() -> str:
+    """Stub body for ``GET /v1/hosts``: one online host the composer picks."""
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": "e2e-host",
+                    "owner": "e2e",
+                    "status": "online",
+                }
+            ]
+        }
+    )
+
+
+async def _register_common_routes(
+    page,
+    *,
+    created_session_id: str,
+    create_bodies: list[dict[str, Any]],
+    agents_body: str | None = None,
+) -> None:
+    """Register the host/agent/create/events stubs shared by every test.
+
+    :param page: The Playwright page to install routes on.
+    :param created_session_id: Real pre-seeded session id the faked create
+        returns, so the post-send navigation lands on a real page.
+    :param create_bodies: Sink the create ``POST /v1/sessions`` body is
+        appended to — the assertion target for each test.
+    :param agents_body: Override for the ``GET /v1/agents`` stub body;
+        defaults to the single Claude Code agent (:func:`_agents_body`).
+    """
+    resolved_agents_body = agents_body if agents_body is not None else _agents_body()
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(
+            status=200, content_type="application/json", body=resolved_agents_body
+        )
+
+    async def handle_events(route: Route) -> None:
+        # Swallow the auto-sent initial prompt so no real LLM turn runs.
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+        )
+
+    async def handle_sessions(route: Route) -> None:
+        # Capture ONLY the composer's create POST (the thing under test) and
+        # return a real session id so navigation lands somewhere real.
+        # Everything else (GET conversation list, agent-discovery scan) goes
+        # to the real server.
+        if route.request.method == "POST":
+            create_bodies.append(route.request.post_data_json)
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": created_session_id}),
+            )
+        else:
+            await route.continue_()
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route("**/v1/sessions/*/events", handle_events)
+    await page.route(_SESSIONS_RE, handle_sessions)
+
+
+def test_start_session_select_permission_mode(seeded_session: tuple[str, str]) -> None:
+    """Picking a non-default permission mode rides along to the create call.
+
+    Selecting "Accept edits" in the agent picker's Advanced settings menu
+    must (a) surface in the agent chip label as immediate feedback and
+    (b) reach ``POST /v1/sessions`` as
+    ``terminal_launch_args: ["--permission-mode", "acceptEdits"]``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_permission_mode(base_url, session_id))
+
+
+async def _drive_permission_mode(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+            # Seed a recent working directory for the stubbed host so the
+            # working-directory chip auto-fills and Send can enable without
+            # touching the (host-less) file browser. Set before the SPA boots
+            # so the landing composer reads it on mount.
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # Claude Code auto-selects (only built-in, ranked first), so the
+            # Advanced chip — gated on the Claude-native agent — is present.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
+            # All six Claude permission modes render as radio rows.
+            for mode in ("default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"):
+                await expect(
+                    page.get_by_test_id(f"new-chat-landing-permission-{mode}")
+                ).to_be_visible()
+            await page.get_by_test_id("new-chat-landing-permission-acceptEdits").click()
+
+            # The chip label reflects the non-default pick immediately.
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "Accept edits"
+            )
+
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_claude_e2e", body
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/work/repo", body
+            assert body.get("terminal_launch_args") == ["--permission-mode", "acceptEdits"], body
+        finally:
+            await browser.close()
+
+
+def test_start_session_select_harness(seeded_session: tuple[str, str]) -> None:
+    """For a bundle agent (Polly/Debby), Advanced offers an agent-harness pick.
+
+    Unlike Claude Code — whose Advanced menu shows permission modes — Polly and
+    Debby declare a brain harness, so their Advanced menu renders an "Agent
+    Harness" radio group. Selecting a non-default harness ("Pi") must (a) show
+    all four harness options, (b) surface the pick in the agent chip label, and
+    (c) reach ``POST /v1/sessions`` as ``harness_override: "pi"``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_select_harness(base_url, session_id))
+
+
+async def _drive_select_harness(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page,
+                created_session_id=session_id,
+                create_bodies=create_bodies,
+                agents_body=_bundle_agents_body(),
+            )
+            # Seed a recent working directory so the working-directory chip
+            # auto-fills and Send can enable without touching the file browser.
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # Polly auto-selects (ranked ahead of Debby), so the Advanced chip —
+            # present because Polly declares a harness — opens the harness group.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
+            # All four brain harnesses render as radio rows, in registry order.
+            for harness in ("claude-sdk", "openai-agents", "codex", "pi"):
+                await expect(
+                    page.get_by_test_id(f"new-chat-landing-harness-{harness}")
+                ).to_be_visible()
+            await page.get_by_test_id("new-chat-landing-harness-pi").click()
+
+            # The chip label reflects the non-default harness immediately.
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "Polly (Pi)"
+            )
+
+            await page.get_by_test_id("new-chat-landing-input").fill("debate the design")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_polly_e2e", body
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/work/repo", body
+            assert body.get("harness_override") == "pi", body
+        finally:
+            await browser.close()
+
+
+def test_start_session_select_folder(seeded_session: tuple[str, str]) -> None:
+    """Browsing into a folder sets the new session's working directory.
+
+    The composer seeds the working directory to the host's home, then the
+    user opens the file browser and navigates into a subfolder. The chip
+    label must follow the navigation and the picked path must reach
+    ``POST /v1/sessions`` as ``workspace``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_folder_selection(base_url, session_id))
+
+
+async def _drive_folder_selection(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            async def handle_filesystem(route: Route) -> None:
+                # Home ("/home/e2e") and the bare home listing both show the
+                # two top-level folders; "/home/e2e/projects" shows its child.
+                # Absolute paths let the picker pass entries straight through.
+                path_part = route.request.url.split("?")[0]
+                if path_part.endswith("/filesystem/home/e2e/projects"):
+                    entries = [
+                        {
+                            "name": "src",
+                            "path": "/home/e2e/projects/src",
+                            "type": "directory",
+                            "bytes": None,
+                            "modified_at": 0,
+                        }
+                    ]
+                else:
+                    entries = [
+                        {
+                            "name": "projects",
+                            "path": "/home/e2e/projects",
+                            "type": "directory",
+                            "bytes": None,
+                            "modified_at": 0,
+                        },
+                        {
+                            "name": "repo",
+                            "path": "/home/e2e/repo",
+                            "type": "directory",
+                            "bytes": None,
+                            "modified_at": 0,
+                        },
+                    ]
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"object": "list", "data": entries, "has_more": False}),
+                )
+
+            # Registered last so it wins over the broader **/v1/hosts glob for
+            # filesystem URLs.
+            await page.route(_FILESYSTEM_RE, handle_filesystem)
+
+            # No recent seed here: with no recent, the composer derives the
+            # host's home from the filesystem listing and seeds the working
+            # directory to it, so the chip starts at "e2e" (basename of
+            # /home/e2e) and the test changes it by browsing.
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # Working directory auto-fills to the derived home.
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "e2e"
+            )
+
+            # Open the file browser and navigate into the "projects" folder.
+            await page.get_by_test_id("new-chat-landing-workspace-chip").click()
+            await expect(page.get_by_test_id("workspace-picker")).to_be_visible()
+            await page.get_by_test_id("workspace-picker-entry-projects").click()
+            # The child listing confirms we navigated in.
+            await expect(page.get_by_test_id("workspace-picker-entry-src")).to_be_visible()
+
+            # Filling the message clicks outside the popover, closing it; the
+            # chip now shows the navigated folder.
+            await page.get_by_test_id("new-chat-landing-input").fill("explore the project")
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "projects"
+            )
+
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/home/e2e/projects", body
+        finally:
+            await browser.close()
+
+
+def test_start_session_add_worktree(seeded_session: tuple[str, str]) -> None:
+    """Naming a branch attaches a git worktree spec to the create call.
+
+    Opening the worktree chip and entering a branch (plus a base branch)
+    must (a) surface in the chip label and (b) reach ``POST /v1/sessions``
+    as ``git: {branch_name, base_branch}``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_add_worktree(base_url, session_id))
+
+
+async def _drive_add_worktree(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the worktree chip and name a branch + base branch.
+            await page.get_by_test_id("new-chat-landing-branch-chip").click()
+            await page.get_by_test_id("new-chat-landing-branch-input").fill("feature/login")
+            # The base-branch input only appears once a branch name is set.
+            await expect(page.get_by_test_id("new-chat-landing-base-branch-input")).to_be_visible()
+            await page.get_by_test_id("new-chat-landing-base-branch-input").fill("main")
+
+            # The chip label follows the branch name.
+            await expect(page.get_by_test_id("new-chat-landing-branch-chip")).to_contain_text(
+                "feature/login"
+            )
+
+            # Filling the message closes the popover, then send.
+            await page.get_by_test_id("new-chat-landing-input").fill("implement login")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/work/repo", body
+            assert body.get("git") == {"branch_name": "feature/login", "base_branch": "main"}, body
+        finally:
+            await browser.close()


### PR DESCRIPTION
## What

Adds Playwright e2e tests for the new-chat landing composer (`NewChatLandingScreen` in `ap-web/src/shell/NewChatDialog.tsx`), which owns session creation end to end. Covers the configuration affordances a user reaches before hitting Send:

- **Permission mode** — Claude Code's `--permission-mode` choices in the agent picker's Advanced settings. A non-default pick rides along as `terminal_launch_args`.
- **Working directory** — the file-browser popover behind the working-directory chip; browsing into a folder sets the session's `workspace`.
- **Git worktree** — the branch chip's popover; naming a branch attaches a `git` worktree spec.
- **Agent harness** — for bundle agents (Polly/Debby), the Advanced menu shows an "Agent Harness" radio group (Claude SDK / OpenAI Agents SDK / Codex / Pi) instead of permission modes; a non-default pick reaches the create as `harness_override`.

## How it works

Each test stubs `/v1/hosts`, `/v1/agents`, and (where needed) `/v1/hosts/{id}/filesystem`, and intercepts the create `POST /v1/sessions` to capture the request body — the assertion target — while returning a real pre-seeded session id so post-send navigation lands somewhere real. `/events` is stubbed so the auto-sent first prompt never dispatches a real LLM turn. Async bodies run in a fresh thread (mirrors `test_initial_prompt_session_switch`).

## Testing

Ran locally against a freshly built SPA + spawned server during development; the harness and full start_session module both passed at that point. Not re-run after the final rebase, so please rely on CI for the authoritative result.