### PR TITLE
fix(ci): push fork-e2e mirror ref with a GitHub App token

### DIFF
--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -10,6 +10,12 @@ name: Fork e2e mirror
 # untrusted code with secrets in scope. The fork code only runs on the
 # downstream `push` to fork-e2e/** (see e2e.yml), which is a trusted event.
 #
+# The ref is pushed with a GitHub App token, NOT the default GITHUB_TOKEN:
+# refs created/updated by GITHUB_TOKEN do not trigger workflows (GitHub
+# recursion-prevention), so the e2e `push` would never fire. Requires repo
+# variable FORK_E2E_APP_ID and secret FORK_E2E_APP_PRIVATE_KEY for an App
+# installed on this repo with contents:write.
+#
 # Gate -- .github/scripts/fork-e2e/should-mirror.sh opens when any holds:
 #   maintainer-approved  ||  returning-contributor  ||  fork-e2e/pr-N exists.
 # Once the branch exists, every later push re-mirrors (re-runs e2e on the new
@@ -42,7 +48,7 @@ jobs:
     # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`.
     if: ${{ github.event.pull_request.head.repo.fork }}
     permissions:
-      contents: write       # create / update / delete the fork-e2e/pr-N ref
+      contents: read        # reads only; the App token below does the ref writes
       pull-requests: read   # read author + reviews for the gate
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -61,8 +67,21 @@ jobs:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
+      - name: Mint mirror App token
+        id: app-token
+        # A ref created/updated with the default GITHUB_TOKEN does NOT trigger
+        # workflows (GitHub recursion-prevention), so e2e.yml's `push` would
+        # never fire. Push the ref with a GitHub App token instead: it carries
+        # contents:write and its pushes DO trigger downstream workflows.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.FORK_E2E_APP_ID }}
+          private-key: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY }}
+
       - name: Delete mirror branch on PR close
         if: ${{ github.event.action == 'closed' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api -X DELETE "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1 \
             && echo "Deleted $MIRROR_BRANCH" \
@@ -82,6 +101,8 @@ jobs:
 
       - name: Mirror head SHA onto trusted branch
         if: ${{ github.event.action != 'closed' && steps.gate.outputs.mirror == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if gh api "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1; then
             gh api -X PATCH "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" \


### PR DESCRIPTION
## Summary

Follow-up fix to the fork-e2e mirror. The mirror created the `fork-e2e/pr-N` branch with the default `GITHUB_TOKEN`, but **refs pushed by `GITHUB_TOKEN` do not trigger workflows** (GitHub's recursion-prevention), so `e2e.yml`'s `push` trigger never fired and fork PRs ended up running no e2e at all (correctly skipped on `pull_request`, never triggered on `push`). The `GITHUB_TOKEN` ref write also returned HTTP 403 on the `pull_request_review` (approval) event.

This switches the ref create/update/delete to a **GitHub App token** (`actions/create-github-app-token`). App-token pushes *do* trigger downstream workflows, and the token is reliably writable across the trigger events. The job's own `GITHUB_TOKEN` drops to read-only (it only performs gate reads).

## Required setup (before this works)

A GitHub App must exist and be installed on this repo:

1. Create a GitHub App (org-owned), repository permission **Contents: Read and write**, no webhook needed.
2. Install it on `omnigent-ai/omnigent`.
3. Add repo **variable** `FORK_E2E_APP_ID` = the App's ID.
4. Add repo **secret** `FORK_E2E_APP_PRIVATE_KEY` = the App's generated private key (PEM).

Until those exist, the mirror's token-mint step fails loudly (no silent fallback).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

The bug is a CI-credential/triggering issue not reachable by unit tests (the gate logic is already covered by `tests/scripts/test_fork_e2e_should_mirror.py`, unchanged here). Verified the workflow YAML parses, the write steps reference the App-token output, and the job token is read-only. The end-to-end fix (App-token push triggers e2e on `fork-e2e/**`) is validated live on the next fork PR once the App and its secret/variable are provisioned. Root cause was confirmed on a real fork PR: the mirror created `fork-e2e/pr-N` but zero workflow runs fired on that branch, the documented `GITHUB_TOKEN` behavior.
