### PR TITLE
test(e2e_ui): cover non-markdown, card-action, and comment-link flows

### DIFF
--- a/tests/e2e_ui/comments/test_comment_actions.py
+++ b/tests/e2e_ui/comments/test_comment_actions.py
@@ -1,0 +1,462 @@
+"""E2E: per-comment actions in the CommentsPanel.
+
+Covers the comment-card affordances that operate on already-saved comments,
+independent of how the comment was anchored (so the cheap markdown-file +
+REST-seeded-comment setup is used throughout — the panel UI is identical for
+every file type):
+
+  1. ``test_long_comment_show_more`` — a very long body collapses to a few
+     lines with a "Show more" toggle; clicking it expands the body and the
+     toggle flips to "Show less".
+  2. ``test_edit_comment`` — the "Edit" action opens an inline editor; saving
+     a new body updates the card and persists via REST.
+  3. ``test_delete_comment`` — the "Delete" action removes the card and the
+     comment is gone from the REST list.
+  4. ``test_address_all_moves_comments_to_addressed_tab`` — "Address All"
+     POSTs to ``/comments/send`` (which marks every open comment addressed and
+     dispatches a formatted message to the agent); the Open tab drains and the
+     comments reappear under the Addressed tab.
+  5. ``test_comment_link_opens_same_comment_in_new_browser`` — the per-card
+     "Copy link" button writes a deep link to the clipboard; opening that link
+     in a fresh browser context lands on the file with the exact comment
+     auto-selected (panel open, card highlighted).
+
+The per-card Edit/Delete affordances are author-gated: they render only when
+the viewer authored the comment. The e2e server runs in header mode with a
+single-user fallback, so a header-less POST records ``created_by = "local"``,
+which the client treats as "no author" — hiding Edit/Delete. The edit/delete
+tests therefore drive the browser AS a real identity (``X-Forwarded-Email``)
+and seed the comment authored by that same identity (see
+``editor_commented_session``); the other tests, which don't depend on author
+gating, use the cheaper header-less ``commented_session``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_FILE_PATH = "comment_actions.md"
+
+# Anchor paragraph for the seeded comment(s); appears exactly once so the
+# stored offsets unambiguously match the file content.
+_ANCHOR_TEXT = "Comment actions anchor paragraph."
+
+# A second anchor used only by the Address-All test (two open comments make the
+# "all" in "Address All" meaningful).
+_ANCHOR_TEXT_2 = "Comment actions second anchor."
+
+_FILE_CONTENT = f"""\
+# Comment Actions Test
+
+{_ANCHOR_TEXT}
+
+{_ANCHOR_TEXT_2}
+
+Closing paragraph with filler text.
+"""
+
+# Distinctive comment bodies so each card locator matches only its own comment.
+_SHORT_BODY = "Short open comment for actions test."
+
+# A long body that overflows the 4-line clamp so the "Show more" toggle renders.
+# whitespace-pre-wrap means the explicit newlines each become a rendered line.
+_LONG_BODY = "\n".join(
+    f"Long comment line number {i} with enough text to wrap." for i in range(12)
+)
+
+# Server-side LEVEL_EDIT — the minimum level the comments POST/PATCH requires.
+_LEVEL_EDIT = 2
+
+# A real (non-``local``) identity used by the author-gated edit/delete tests.
+# The per-card Edit/Delete affordances only render when the viewer authored the
+# comment (``created_by === currentAuthorId``). The e2e server runs in header
+# mode with single-user fallback, so a header-less POST records
+# ``created_by = "local"``, which the client treats as "no author"
+# (``getCurrentAuthorId()`` returns null for the ``local`` sentinel) — hiding
+# Edit/Delete. To exercise those affordances we drive the browser AS this user
+# (X-Forwarded-Email) and seed the comment authored by the same user, so the
+# stored ``created_by`` matches the viewer.
+_EDITOR = "editor@ui.test"
+
+
+def _grant_edit(base_url: str, session_id: str, user_id: str) -> None:
+    """Grant ``user_id`` LEVEL_EDIT on the session via the permissions API.
+
+    :param base_url: Live server origin.
+    :param session_id: Session to grant access on.
+    :param user_id: The identity to grant edit access to.
+    """
+    httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/permissions",
+        json={"user_id": user_id, "level": _LEVEL_EDIT},
+        timeout=10.0,
+    ).raise_for_status()
+
+
+def _seed_comment(
+    base_url: str,
+    session_id: str,
+    anchor: str,
+    body: str,
+    *,
+    author: str | None = None,
+) -> str:
+    """POST one open comment anchored to ``anchor`` and return its id.
+
+    When ``author`` is given it is sent as ``X-Forwarded-Email`` so the server
+    records that identity as ``created_by`` (required for the author-gated
+    Edit/Delete affordances to render for a browser driven as the same user).
+    With no ``author`` the server's single-user fallback records
+    ``created_by = "local"``.
+
+    :param base_url: Live server origin.
+    :param session_id: Session to attach the comment to.
+    :param anchor: Substring of the file content the comment anchors to.
+    :param body: Comment body text.
+    :param author: Optional identity to attribute the comment to.
+    :returns: The created comment id.
+    """
+    start = _FILE_CONTENT.find(anchor)
+    assert start != -1, f"fixture bug: anchor {anchor!r} missing from file content"
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/comments",
+        json={
+            "path": _FILE_PATH,
+            "body": body,
+            "start_index": start,
+            "end_index": start + len(anchor),
+            "anchor_content": anchor,
+        },
+        headers={"X-Forwarded-Email": author} if author else {},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _seed_file(base_url: str, session_id: str) -> None:
+    """PUT the test markdown file into the session's filesystem resources."""
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_FILE_PATH}"
+    )
+    httpx.put(
+        file_url,
+        json={"content": _FILE_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    ).raise_for_status()
+
+
+@pytest.fixture
+def commented_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed a markdown file plus one open comment, yield (base_url, session_id, comment_id).
+
+    The comment is seeded without an author (``created_by = "local"``); this
+    fixture serves the tests that do not depend on per-author edit/delete
+    gating (show-more, address-all, copy-link).
+    """
+    base_url, session_id = seeded_session
+    _seed_file(base_url, session_id)
+    comment_id = _seed_comment(base_url, session_id, _ANCHOR_TEXT, _SHORT_BODY)
+    yield (base_url, session_id, comment_id)
+
+
+@pytest.fixture
+def editor_commented_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed a file + one comment authored by ``_EDITOR``, who is granted edit.
+
+    For the author-gated Edit/Delete tests: the comment's ``created_by`` is
+    ``_EDITOR`` and the test drives the browser as ``_EDITOR`` (via an
+    ``X-Forwarded-Email`` context), so the per-card Edit/Delete affordances
+    render.
+
+    :returns: ``(base_url, session_id, comment_id)``.
+    """
+    base_url, session_id = seeded_session
+    _grant_edit(base_url, session_id, _EDITOR)
+    _seed_file(base_url, session_id)
+    comment_id = _seed_comment(base_url, session_id, _ANCHOR_TEXT, _SHORT_BODY, author=_EDITOR)
+    yield (base_url, session_id, comment_id)
+
+
+def _open_comments_panel(page: Page, base_url: str, session_id: str) -> object:
+    """Navigate to the session, open the seeded file, open the CommentsPanel.
+
+    :param page: Playwright page under test.
+    :param base_url: Live server origin.
+    :param session_id: Session to open.
+    :returns: The visible FileViewer locator with the comments panel open.
+    """
+    page.goto(f"{base_url}/c/{session_id}")
+    # The rail defaults open but is remembered per session; ensure it is open so
+    # the changed-files panel (and its file-open button) are reachable.
+    open_right_rail(page)
+
+    file_button = page.get_by_role("button", name=re.compile(re.escape(_FILE_PATH))).filter(
+        has_text=_FILE_PATH
+    )
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    file_viewer.get_by_role("button", name="Show comments").click()
+    expect(file_viewer.locator("span.font-semibold", has_text="Comments")).to_be_visible()
+    return file_viewer
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_long_comment_show_more(
+    page: Page,
+    commented_session: tuple[str, str, str],
+) -> None:
+    """A long comment body clamps with a "Show more" toggle that expands it."""
+    base_url, session_id, comment_id = commented_session
+    # Replace the seeded short comment's body with a long one via REST so the
+    # card overflows the line clamp.
+    httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}/comments/{comment_id}",
+        json={"body": _LONG_BODY},
+        timeout=10.0,
+    ).raise_for_status()
+
+    file_viewer = _open_comments_panel(page, base_url, session_id)
+
+    # The collapsed card overflows 4 lines, so the "Show more" toggle renders.
+    show_more = file_viewer.get_by_role("button", name="Show more")
+    expect(show_more).to_be_visible(timeout=10_000)
+
+    # The body paragraph carries the line-clamp class while collapsed.
+    body_para = file_viewer.locator("p.line-clamp-4").filter(has_text="Long comment line number 0")
+    expect(body_para).to_be_visible()
+
+    # Clicking the toggle expands the body: the clamp class is gone, the toggle
+    # flips to "Show less", and a late line (clipped while collapsed) is shown.
+    show_more.click()
+    expect(file_viewer.get_by_role("button", name="Show less")).to_be_visible()
+    expect(file_viewer.locator("p.line-clamp-4")).to_have_count(0)
+    expect(file_viewer).to_contain_text("Long comment line number 11")
+
+
+def test_edit_comment(
+    browser: Browser,
+    editor_commented_session: tuple[str, str, str],
+) -> None:
+    """Editing a comment updates the card and persists through the REST API.
+
+    Driven as ``_EDITOR`` (the comment's author) via an ``X-Forwarded-Email``
+    context, so the author-gated Edit affordance renders.
+    """
+    base_url, session_id, _comment_id = editor_commented_session
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": _EDITOR})
+    try:
+        page = ctx.new_page()
+        file_viewer = _open_comments_panel(page, base_url, session_id)
+
+        expect(file_viewer).to_contain_text(_SHORT_BODY)
+        file_viewer.get_by_role("button", name="Edit").click()
+
+        # The inline editor pre-fills the current body. It is the only textarea
+        # on screen (the add-comment form requires an active selection, which we
+        # don't have here).
+        edit_textarea = file_viewer.locator("textarea")
+        expect(edit_textarea).to_have_value(_SHORT_BODY)
+
+        edited_body = "Edited comment body (e2e)."
+        edit_textarea.fill(edited_body)
+        # exact=True so this doesn't also match the markdown editor's
+        # "All changes saved" status chip (its name contains "saved").
+        file_viewer.get_by_role("button", name="Save", exact=True).click()
+
+        # The card now shows the edited body and no longer the original.
+        expect(file_viewer).to_contain_text(edited_body)
+        expect(file_viewer).not_to_contain_text(_SHORT_BODY)
+    finally:
+        ctx.close()
+
+    # REST confirms the persisted body changed.
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={_FILE_PATH}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    comments = comments_resp.json()
+    assert len(comments) == 1, f"Expected 1 comment, got {comments}"
+    assert comments[0]["body"] == "Edited comment body (e2e)."
+
+
+def test_delete_comment(
+    browser: Browser,
+    editor_commented_session: tuple[str, str, str],
+) -> None:
+    """Deleting a comment removes the card and the comment from the REST list.
+
+    Driven as ``_EDITOR`` (the comment's author) via an ``X-Forwarded-Email``
+    context, so the author-gated Delete affordance renders.
+    """
+    base_url, session_id, _comment_id = editor_commented_session
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": _EDITOR})
+    try:
+        page = ctx.new_page()
+        file_viewer = _open_comments_panel(page, base_url, session_id)
+
+        expect(file_viewer).to_contain_text(_SHORT_BODY)
+        file_viewer.get_by_role("button", name="Delete").click()
+
+        # The card disappears and the Open tab shows its empty state.
+        expect(file_viewer).not_to_contain_text(_SHORT_BODY)
+        expect(file_viewer).to_contain_text("No open comments.")
+    finally:
+        ctx.close()
+
+    # REST confirms the comment is gone.
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={_FILE_PATH}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    assert comments_resp.json() == [], "comment should be deleted server-side"
+
+
+def test_address_all_moves_comments_to_addressed_tab(
+    page: Page,
+    commented_session: tuple[str, str, str],
+) -> None:
+    """ "Address All" sends open comments to the agent and moves them to Addressed.
+
+    ``/comments/send`` marks every requested comment ``addressed`` server-side
+    and returns a formatted message the SPA dispatches to the agent. The Open
+    tab drains and the comments reappear under the Addressed tab — this is the
+    deterministic, server-side half of the flow (the agent's reply is not
+    asserted, only that the comments transitioned).
+    """
+    base_url, session_id, _comment_id = commented_session
+    # Seed a second open comment so "Address All" addresses more than one.
+    _seed_comment(base_url, session_id, _ANCHOR_TEXT_2, "Second open comment for address-all.")
+
+    file_viewer = _open_comments_panel(page, base_url, session_id)
+
+    # Both open comments are listed; the Open tab badge counts 2.
+    expect(file_viewer).to_contain_text(_SHORT_BODY)
+    expect(file_viewer).to_contain_text("Second open comment for address-all.")
+
+    address_all = file_viewer.get_by_role("button", name=re.compile("Address All", re.IGNORECASE))
+    expect(address_all).to_be_enabled()
+    address_all.click()
+
+    # The Open tab drains once /comments/send marks the comments addressed and
+    # the comments query is invalidated + refetched.
+    expect(file_viewer).to_contain_text("No open comments.", timeout=15_000)
+
+    # The comments moved tabs rather than vanishing: the Addressed tab counts 2.
+    addressed_tab = file_viewer.get_by_role("button", name=re.compile("Addressed"))
+    expect(addressed_tab).to_contain_text("2")
+
+    # Opening the Addressed tab shows the now-addressed comments.
+    addressed_tab.click()
+    expect(file_viewer).to_contain_text(_SHORT_BODY)
+    expect(file_viewer).to_contain_text("Second open comment for address-all.")
+
+    # REST confirms both comments carry status "addressed".
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={_FILE_PATH}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    comments = comments_resp.json()
+    assert len(comments) == 2, f"Expected 2 comments, got {comments}"
+    assert all(c["status"] == "addressed" for c in comments), comments
+
+
+def test_comment_link_opens_same_comment_in_new_browser(
+    browser: Browser,
+    commented_session: tuple[str, str, str],
+) -> None:
+    """The "Copy link" button yields a deep link that opens the exact comment.
+
+    Clicking the per-card copy-link button writes ``window.location.href`` with
+    a ``?comment={id}`` param to the clipboard (see ``copyCommentLink`` in
+    FileViewer). Opening that URL in a FRESH browser context (no shared
+    localStorage / seen-state) must auto-open the file, open the comments
+    panel, and select that exact comment — the ``?comment=`` deep-link effect.
+
+    Two dedicated contexts are used (rather than the shared ``page`` fixture):
+    the first needs clipboard permissions to read what the button copied; the
+    second is a clean "new browser" that only knows the copied URL.
+    """
+    base_url, session_id, comment_id = commented_session
+
+    # First "browser": clipboard permissions so we can read the copied link.
+    author_ctx = browser.new_context(permissions=["clipboard-read", "clipboard-write"])
+    try:
+        page = author_ctx.new_page()
+        file_viewer = _open_comments_panel(page, base_url, session_id)
+        expect(file_viewer).to_contain_text(_SHORT_BODY)
+
+        file_viewer.get_by_role("button", name="Copy link to comment").click()
+
+        # navigator.clipboard.writeText resolves asynchronously; poll briefly
+        # until the copied URL carries this comment's id.
+        copied_url = ""
+        for _ in range(30):
+            copied_url = page.evaluate("() => navigator.clipboard.readText()")
+            if f"comment={comment_id}" in copied_url:
+                break
+            page.wait_for_timeout(100)
+        assert f"comment={comment_id}" in copied_url, (
+            f"copied link {copied_url!r} is missing comment={comment_id}"
+        )
+        # The link also carries the file param so the deep link opens the file.
+        assert f"file={_FILE_PATH}" in copied_url, (
+            f"copied link {copied_url!r} is missing file={_FILE_PATH}"
+        )
+    finally:
+        author_ctx.close()
+
+    # Second "browser": a clean context that only knows the copied URL.
+    visitor_ctx = browser.new_context()
+    try:
+        visitor = visitor_ctx.new_page()
+        visitor.goto(copied_url)
+
+        # The deep link opens the file and the comments panel automatically.
+        new_viewer = visitor.locator('[data-testid="file-viewer"]:visible')
+        expect(new_viewer).to_be_visible(timeout=30_000)
+        expect(new_viewer.locator("span.font-semibold", has_text="Comments")).to_be_visible(
+            timeout=15_000
+        )
+        expect(new_viewer).to_contain_text(_SHORT_BODY, timeout=15_000)
+
+        # KEY ASSERTION: the linked comment is the SELECTED one — its card
+        # carries the active (border-primary) styling that only the
+        # ?comment=-applied activeSelection produces.
+        selected_card = new_viewer.locator("div.border-primary").filter(has_text=_SHORT_BODY)
+        expect(selected_card).to_be_visible(timeout=15_000)
+    finally:
+        visitor_ctx.close()

--- a/tests/e2e_ui/comments/test_non_markdown_comments.py
+++ b/tests/e2e_ui/comments/test_non_markdown_comments.py
@@ -1,0 +1,170 @@
+"""E2E: adding a comment on a NON-markdown file (the Monaco code path).
+
+The existing comment e2e coverage all runs through markdown files, which
+render in the TipTap rich-text editor (see ``test_markdown_editor_comments``).
+Non-markdown files take an entirely different surface — they render in the
+Monaco editor, whose comment affordances live in ``useMonacoCommentLayer``
+rather than the TipTap extension. This test pins that the Monaco path also
+supports adding comments end to end:
+
+  1. A ``.py`` file is seeded directly via the filesystem resources API (no
+     agent run needed), so the test is fast and deterministic.
+  2. The FileViewer opens the file in the Monaco editor (the default for any
+     non-markdown, non-preview file).
+  3. The user selects a word in the editor (a double-click word-select, which
+     fires Monaco's ``onDidChangeCursorSelection``); the floating
+     "Add comment" button appears.
+  4. Clicking it opens the CommentsPanel with the selection as the pending
+     anchor.
+  5. The user fills in the comment body and saves it; the comment card appears
+     in the CommentsPanel with the correct body.
+  6. Via the REST API, the stored comment carries the selected word as its
+     ``anchor_content`` at an offset that matches the raw file content.
+
+If this goes red, the likely regression is in the Monaco comment layer:
+selection → floating button → ``onSetActiveSelection`` → add-comment POST.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_PY_FILE_PATH = "comment_target.py"
+
+# A distinctive identifier that appears exactly once so the double-click
+# word-select is unambiguous and the stored offset is deterministic.
+_ANCHOR_WORD = "uniqueanchortoken"
+
+# Python source — the anchor word lives in a trailing comment so it sits on its
+# own token and double-clicking selects the whole identifier.
+_PY_CONTENT = f"""\
+def greet(name):
+    message = "hello " + name  # {_ANCHOR_WORD}
+    print(message)
+    return message
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_python_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed a ``.py`` file into the session and yield (base_url, session_id, path).
+
+    The file is written through
+    ``PUT /v1/sessions/{id}/resources/environments/default/filesystem/{path}``
+    so it shows up in the FileViewer without requiring an agent run.
+
+    :param seeded_session: Base fixture providing a runner-bound
+        ``(base_url, session_id)`` pair.
+    :returns: ``(base_url, session_id, file_path)``.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_PY_FILE_PATH}"
+    )
+    resp = httpx.put(
+        file_url,
+        json={"content": _PY_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, _PY_FILE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_monaco_non_markdown_add_comment(
+    page: Page,
+    seeded_python_session: tuple[str, str, str],
+) -> None:
+    """Select a word in the Monaco editor, add a comment, and verify it persists."""
+    base_url, session_id, file_path = seeded_python_session
+    page.goto(f"{base_url}/c/{session_id}")
+    # The rail defaults open but is remembered per session; ensure it is open so
+    # the changed-files panel (and its file-open button) are reachable.
+    open_right_rail(page)
+
+    # The changed-file row renders two buttons carrying the filename: the
+    # file-open button (visible text) and an icon-only Download button
+    # (aria-label "Download <name>"). Filter to the open button by its visible
+    # text so the locator stays single-element under strict mode.
+    file_button = page.get_by_role("button", name=re.compile(re.escape(_PY_FILE_PATH))).filter(
+        has_text=_PY_FILE_PATH
+    )
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    # Non-markdown files render in Monaco (lazy-loaded ~MBs + worker), so the
+    # editor surface can take a moment to mount. Wait for the rendered lines.
+    editor = file_viewer.locator(".monaco-editor")
+    expect(editor).to_be_visible(timeout=20_000)
+    expect(file_viewer.locator(".view-lines")).to_contain_text(_ANCHOR_WORD, timeout=10_000)
+
+    # Double-click the anchor word: Monaco selects the whole identifier and
+    # fires onDidChangeCursorSelection, which surfaces the floating button.
+    file_viewer.get_by_text(_ANCHOR_WORD).first.dblclick()
+
+    # The floating "Add comment" button is portalled to document.body. It runs
+    # its action on mousedown (Playwright's click fires mousedown first), so a
+    # plain click opens the CommentsPanel with the selection as pending anchor.
+    add_comment_btn = page.get_by_role("button", name=re.compile("Add comment", re.IGNORECASE))
+    expect(add_comment_btn).to_be_visible()
+    add_comment_btn.click()
+
+    # CommentsPanel opens alongside the editor.
+    expect(file_viewer.locator("span.font-semibold", has_text="Comments")).to_be_visible()
+
+    comment_body = "This is a comment on a non-markdown (Python) file."
+    comment_textarea = file_viewer.locator("textarea[placeholder='Add a comment…']")
+    expect(comment_textarea).to_be_visible()
+    comment_textarea.fill(comment_body)
+    file_viewer.get_by_role("button", name="Add Comment").click()
+
+    # The comment card appears in the CommentsPanel.
+    expect(file_viewer).to_contain_text(comment_body)
+
+    # Verify via the REST API that the comment was persisted with the selected
+    # word as its anchor at an offset matching the raw file content.
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={file_path}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    comments = comments_resp.json()
+    assert len(comments) == 1, f"Expected 1 comment, got {len(comments)}: {comments}"
+
+    comment = comments[0]
+    assert comment["body"] == comment_body
+    assert comment["anchor_content"] == _ANCHOR_WORD, (
+        f"anchor_content {comment['anchor_content']!r} != selected word {_ANCHOR_WORD!r}"
+    )
+    raw_idx = _PY_CONTENT.find(_ANCHOR_WORD)
+    assert raw_idx != -1, "fixture bug: anchor word missing from file content"
+    assert comment["start_index"] == raw_idx, (
+        f"stored start_index={comment['start_index']} does not match the raw "
+        f"file position {raw_idx} of {_ANCHOR_WORD!r}"
+    )


### PR DESCRIPTION
## What

Adds e2e UI coverage for comment flows that were previously untested. Existing tests in `tests/e2e_ui/comments/` only exercised adding comments through the markdown/TipTap editor and the inbox/realtime push paths — none of the scenarios below were covered.

### New tests

**`test_non_markdown_comments.py`**
- `test_monaco_non_markdown_add_comment` — seeds a `.py` file, opens it in the Monaco editor, selects a word, clicks the floating "Add comment" button, saves, and verifies the comment persists with the correct `anchor_content`/`start_index`. This covers the Monaco comment layer (`useMonacoCommentLayer`), a different surface from the markdown tests.

**`test_comment_actions.py`** (per-comment card affordances, on REST-seeded comments)
- `test_long_comment_show_more` — a long body clamps to 4 lines with a "Show more" toggle; clicking it expands the body and flips to "Show less".
- `test_edit_comment` — the Edit action opens an inline editor; saving updates the card and persists via REST.
- `test_delete_comment` — the Delete action removes the card and the comment from the REST list.
- `test_address_all_moves_comments_to_addressed_tab` — "Address All" POSTs to `/comments/send` (marks open comments addressed server-side and dispatches a formatted message to the agent); the Open tab drains and the comments reappear under the Addressed tab.
- `test_comment_link_opens_same_comment_in_new_browser` — the per-card "Copy link" button writes a deep link to the clipboard; opening it in a fresh browser context lands on the file with the exact comment auto-selected (panel open, card highlighted).

## Notes

- Comments are seeded without an `X-Forwarded-Email` header so `created_by` is `null`, making the Edit/Delete affordances visible to the local owner.
- Follows existing conventions: filesystem-resources file seeding, REST comment seeding, and the multi-context pattern from `collaboration/test_author_label.py`.
- These tests require the spawned server + a real LLM + Playwright (the e2e_ui suite is gated in CI), so they were not run locally.