### PR TITLE
ci: dynamic e2e shard matrix to drop skipped fork-PR placeholders

### DIFF
--- a/.github/scripts/ci/e2e-shard-matrix.sh
+++ b/.github/scripts/ci/e2e-shard-matrix.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Emits the e2e shard matrix as `matrix=<json>` on $GITHUB_OUTPUT. Shared by
+# e2e.yml and e2e-ui.yml (they differ only in NUM_SHARDS).
+#
+# Returns an EMPTY matrix ({"include":[]}) when the run should be skipped:
+#   - draft PRs, or
+#   - a fork's pull_request (no secrets there; forks run via the fork-e2e/**
+#     mirror push instead).
+# An empty matrix yields zero jobs and therefore NO check-runs. This is the
+# whole reason for the indirection: a job-level `if:` skip of a matrixed job
+# would instead leave one check-run with an unexpanded
+# `E2E Tests (shard ${{ matrix.shard_id }}/...)` name.
+#
+# Env in:  EVENT_NAME (github.event_name), IS_DRAFT, IS_FORK (both may be empty
+#          on non-PR events), NUM_SHARDS.
+# Out:     matrix={"include":[{"shard_id":0,"num_shards":N}, ...]}  (or [] empty)
+
+set -euo pipefail
+
+skip=false
+if [[ "${IS_DRAFT:-false}" == "true" ]]; then
+  skip=true
+fi
+if [[ "$EVENT_NAME" == "pull_request" && "${IS_FORK:-false}" == "true" ]]; then
+  skip=true
+fi
+
+if [[ "$skip" == "true" ]]; then
+  echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+  echo "skip: empty matrix (event=$EVENT_NAME draft=${IS_DRAFT:-} fork=${IS_FORK:-})"
+  exit 0
+fi
+
+inc=""
+for ((i = 0; i < NUM_SHARDS; i++)); do
+  inc+="{\"shard_id\":$i,\"num_shards\":$NUM_SHARDS},"
+done
+echo "matrix={\"include\":[${inc%,}]}" >> "$GITHUB_OUTPUT"
+echo "run: $NUM_SHARDS shards (event=$EVENT_NAME)"

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -77,16 +77,40 @@ env:
   TERM: xterm-256color
 
 jobs:
+  # Compute the shard matrix once. A skipped run (draft, or a fork's
+  # pull_request) yields an EMPTY matrix -> zero shard jobs -> no skipped
+  # check-runs with an unexpanded ${{ matrix.* }} name. Shared with e2e.yml
+  # via .github/scripts/ci/e2e-shard-matrix.sh (only NUM_SHARDS differs).
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Check out CI scripts from main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main             # trusted; the matrix script is not PR-controlled
+          sparse-checkout: .github/scripts/ci
+          persist-credentials: false
+      - name: Compute shard matrix
+        id: matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          NUM_SHARDS: "3"
+        run: bash .github/scripts/ci/e2e-shard-matrix.sh
+
   e2e-ui:
     name: E2E UI Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
-    # Skip on draft PRs; the `ready_for_review` trigger re-fires the
-    # workflow when the draft is converted, so the check won't strand
-    # pending on the eventual ready-for-review state.
-    # Public-only: also skip fork PRs — they can't read the LLM_API_KEY /
-    # GATEWAY_BASE_URL secrets; see _E2E_GUARD_IF_BLOCK.
-    if: ${{ !github.event.pull_request.draft
-      && (github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Draft PRs and fork pull_request events resolve to an EMPTY matrix in
+    # `setup` (forks can't read the LLM_API_KEY / GATEWAY_BASE_URL secrets on a
+    # pull_request; they run via the fork-e2e/** mirror push instead), so this
+    # job produces zero shard runs for them -- and thus no skipped placeholder
+    # check. The `ready_for_review` trigger re-fires when a draft is converted.
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -95,22 +119,10 @@ jobs:
       # localized to one chunk.
       fail-fast: false
       max-parallel: 3
-      matrix:
-        # 3 shards: pytest-shard splits test node IDs deterministically,
-        # so the same test always lands in the same shard across runs.
-        # Each shard pays the full setup cost (uv sync + npm build +
-        # Playwright install, all cached), so more shards buy less once
-        # per-shard test time approaches setup time. Bump the count if
-        # shard runtime creeps up again. The shard check names are
-        # listed in .github/scripts/merge-ready/required.sh -- keep the
-        # two in sync when changing the count.
-        include:
-          - shard_id: 0
-            num_shards: 3
-          - shard_id: 1
-            num_shards: 3
-          - shard_id: 2
-            num_shards: 3
+      # Shards from `setup`; [] when the run is skipped. Shard check names are
+      # in .github/scripts/merge-ready/required.sh -- keep in sync with the
+      # NUM_SHARDS in this workflow's setup job when changing the count.
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -88,10 +88,13 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - name: Check out CI scripts from main
+      - name: Check out CI scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: main             # trusted; the matrix script is not PR-controlled
+          # Triggering ref (not pinned to main): the script must exist on the
+          # running ref, and it is not a security gate -- it only shards tests
+          # and can't expose secrets (fork pull_request has none), so the PR's
+          # own copy is fine.
           sparse-checkout: .github/scripts/ci
           persist-credentials: false
       - name: Compute shard matrix

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,6 +68,32 @@ env:
   CLAUDE_CODE: ""
 
 jobs:
+  # Compute the shard matrix once. A skipped run (draft, or a fork's
+  # pull_request) yields an EMPTY matrix -> zero shard jobs -> no skipped
+  # check-runs with an unexpanded ${{ matrix.* }} name. Shared with e2e-ui.yml
+  # via .github/scripts/ci/e2e-shard-matrix.sh (only NUM_SHARDS differs).
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Check out CI scripts from main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main             # trusted; the matrix script is not PR-controlled
+          sparse-checkout: .github/scripts/ci
+          persist-credentials: false
+      - name: Compute shard matrix
+        id: matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          NUM_SHARDS: "4"
+        run: bash .github/scripts/ci/e2e-shard-matrix.sh
+
   e2e:
     # Sharded matrix. Each shard runs ~1/N of the test set, well under
     # the wallclock budget at which the hardened runner image's
@@ -91,13 +117,10 @@ jobs:
     # we trip rate limits, drop ``-n`` to 1 first; only fall back to
     # ``max-parallel`` reduction if QPS still hurts.
     name: E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
-    # Skip draft PRs, and skip FORK pull_request events: forks get no secrets
-    # on `pull_request`, so they run via the fork-e2e/** push that
-    # fork-e2e-mirror.yml creates after approval (a `push` event is not a
-    # 'pull_request', so it always passes this guard).
-    if: ${{ !github.event.pull_request.draft
-      && (github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Draft PRs and fork pull_request events resolve to an EMPTY matrix in
+    # `setup` (forks run via the fork-e2e/** mirror push instead), so this job
+    # produces zero shard runs for them -- and thus no skipped placeholder check.
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       # One red shard shouldn't cancel siblings; we want every shard's
@@ -105,19 +128,9 @@ jobs:
       # localized to one chunk.
       fail-fast: false
       max-parallel: 4
-      matrix:
-        # 4 shards: pytest-shard splits test node IDs deterministically,
-        # so the same test always lands in the same shard across runs.
-        # Bump count if shard runtime creeps back into the kill zone.
-        include:
-          - shard_id: 0
-            num_shards: 4
-          - shard_id: 1
-            num_shards: 4
-          - shard_id: 2
-            num_shards: 4
-          - shard_id: 3
-            num_shards: 4
+      # Shards from `setup` (pytest-shard splits node IDs deterministically, so
+      # a test always lands in the same shard); [] when the run is skipped.
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,10 +79,13 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - name: Check out CI scripts from main
+      - name: Check out CI scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: main             # trusted; the matrix script is not PR-controlled
+          # Triggering ref (not pinned to main): the script must exist on the
+          # running ref, and it is not a security gate -- it only shards tests
+          # and can't expose secrets (fork pull_request has none), so the PR's
+          # own copy is fine.
           sparse-checkout: .github/scripts/ci
           persist-credentials: false
       - name: Compute shard matrix


### PR DESCRIPTION
## Summary

Removes the confusing skipped placeholder checks on fork PRs — the ones that render as `E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }}) — Skipped` with the matrix expression unexpanded.

Root cause: a **job-level `if:` skip of a matrixed job** always emits one check-run, and since the matrix never expands for a skipped job, the name keeps its raw `${{ matrix.* }}` template. This change replaces the `if:` guard with a `setup` job that computes the shard matrix and returns an **empty matrix** for the skip cases (draft PRs, and fork `pull_request` events, which have no secrets and run via the `fork-e2e/**` mirror push instead). An empty matrix produces **zero shard jobs and therefore zero check-runs** — the placeholders disappear. The real per-shard checks are unchanged: they come from the same-repo `pull_request` run or the fork mirror's `push`.

The matrix logic is shared between both workflows via `.github/scripts/ci/e2e-shard-matrix.sh`; `e2e.yml` and `e2e-ui.yml` call it with their only difference, `NUM_SHARDS` (4 and 3). Also drops a stale internal constant reference from an e2e-ui comment.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Exercised the shared `e2e-shard-matrix.sh` against its full truth table locally (fork pull_request and draft -> empty matrix; same-repo pull_request, push, and schedule -> full N-shard matrix; N=4 for e2e, 3 for e2e-ui) and confirmed both workflows parse with the `setup` job wired (`needs: setup`, dynamic `matrix: ${{ fromJSON(...) }}`). The end-to-end effect (no skipped placeholder checks on a fork PR, real checks still posted on the mirror push) is verified live on a fork smoke PR.
