### PR TITLE
docs: point Pi docstrings at maintained @earendil-works/pi-coding-agent

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1186,7 +1186,7 @@ def _extract_pi_turn_usage(
     that :class:`TurnComplete` consumes, so pi sub-agent cost is priced
     the same way as ``claude-sdk`` and ``codex`` turns.
 
-    Pi (``@mariozechner/pi-coding-agent``) forwards assistant messages
+    Pi (``@earendil-works/pi-coding-agent``) forwards assistant messages
     whose ``usage`` dict carries ``input`` / ``output`` / ``cacheRead`` /
     ``cacheWrite`` / ``totalTokens`` token counts, and the message itself
     carries the resolved ``model``. This translates those into omnigent's

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -345,9 +345,9 @@ class _PiRetryAdapter:
         before subprocess spawn.
 
         Schema audited from
-        ``@mariozechner/pi-coding-agent@0.68.1/docs/settings.md``
-        (the package now ships as ``@earendil-works/pi-coding-agent``
-        — github.com/earendil-works/pi — with the same settings
+        ``@earendil-works/pi-coding-agent/docs/settings.md``
+        (github.com/earendil-works/pi; formerly published as
+        ``@mariozechner/pi-coding-agent@0.68.1``, same settings
         schema). Pi natively implements exponential backoff with
         jitter and ``Retry-After`` honoring; we configure the budget
         and shape.


### PR DESCRIPTION
## What

Two docstrings still reference the **deprecated** npm package `@mariozechner/pi-coding-agent`; this updates them to the maintained `@earendil-works/pi-coding-agent` that Omnigent's functional code already uses.

- `omnigent/inner/pi_executor.py` — `Pi (@mariozechner/pi-coding-agent) forwards …`
- `omnigent/spec/types.py` — the audited-from `@mariozechner/pi-coding-agent@0.68.1/docs/settings.md` URL

## Why

`@mariozechner/pi-coding-agent` is deprecated on npm — its notice reads *"please use @earendil-works/pi-coding-agent instead going forward."* The installer (`onboarding/harness_install.py:100`), `deploy/docker/Dockerfile`, and the install hint in `inner/pi_executor.py:1367` already use `@earendil-works/…`; only these two docstrings lagged. Aligning them keeps the audited-from `settings.md` URL live and avoids pointing readers at a deprecated package.

Docs-only — no functional change.

Closes #117
