### PR TITLE
test(e2e_ui): add message render-parity suite (custom openai-agents)

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -312,7 +312,18 @@ jobs:
           # on GitHub-hosted runners. The previous glob targeted
           # ``e2e_ui_logs*``, which never matched, so the artifact was
           # always empty.
-          path: /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
+          #
+          # The sibling runner subprocess writes ``runner.log`` next to it,
+          # and respawned / external runners under ``e2e_ui_*runner*/``. The
+          # native-CLI harness (claude/codex) routing decisions and the vendor
+          # CLI's own output land there, NOT in server.log (which only carries
+          # HTTP access lines), so capture all of them — a native-turn failure
+          # (e.g. a provider that resolves to no credential) is otherwise
+          # undiagnosable from the artifacts alone.
+          path: |
+            /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
+            /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
+            /tmp/pytest-of-runner/**/e2e_ui_*runner*/runner.log
           retention-days: 3
           if-no-files-found: ignore
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -174,6 +174,33 @@ jobs:
           # PAT passthrough for the codex / claude-native auth commands.
           echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
 
+      - name: Pre-seed Claude Code first-run state (~/.claude.json)
+        # The claude-native render-parity test drives the real Claude Code TUI
+        # in a PTY. On a fresh CI $HOME, Claude's first-run theme picker + the
+        # workspace-trust dialog block the TUI before it renders its prompt, so
+        # the process exits ("[server exited]") and the turn never completes —
+        # the only thing that differs from a developer's machine, where
+        # ~/.claude.json already records onboarding + a trusted workspace. Seed
+        # "already onboarded" + trust the workspace (the runner's cwd = Claude's
+        # cwd = $GITHUB_WORKSPACE) to clear both gates, mirroring the native e2e
+        # suite's _seed_onboarded_claude_home. Auth is separate (the gateway
+        # profile above + the conftest's provider config). CI-only: a workflow
+        # step, so a dev's real ~/.claude.json is never touched.
+        run: |
+          cat > "$HOME/.claude.json" <<EOF
+          {
+            "hasCompletedOnboarding": true,
+            "theme": "dark",
+            "lastOnboardingVersion": "2.0.0",
+            "projects": {
+              "${GITHUB_WORKSPACE}": {
+                "hasTrustDialogAccepted": true,
+                "hasCompletedProjectOnboarding": true
+              }
+            }
+          }
+          EOF
+
       - name: Install project + dev extras
         run: uv sync --extra all --extra dev
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -63,16 +63,8 @@ env:
   # expected the agent to fall back to ~/.databrickscfg, but the SDK's
   # default-profile lookup didn't resolve our OAuth M2M config in CI,
   # which is what was failing the LLM calls.
-  #
-  # ANTHROPIC_API_KEY / CODEX / CLAUDE_CODE stay scrubbed (matching
-  # e2e.yml): the native claude-native harness routes through the Databricks
-  # gateway's anthropic surface via the ~/.databrickscfg profile +
-  # DATABRICKS_BEARER written below, NOT a vendor API key. DATABRICKS_TOKEN
-  # is intentionally NOT scrubbed here (it was, before): the message
-  # render-parity suite's claude-native agent needs the Databricks profile to
-  # resolve, and an empty DATABRICKS_TOKEN in the env would shadow the profile
-  # and break that auth.
   ANTHROPIC_API_KEY: ""
+  DATABRICKS_TOKEN: ""
   CODEX: ""
   CLAUDE_CODE: ""
   # Match e2e.yml's proxy choice.
@@ -151,87 +143,23 @@ jobs:
       - name: Set LLM credentials
         run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
 
-      - name: Write gateway profile (~/.databrickscfg)
-        # The message render-parity suite spins up claude-native ("Claude
-        # Code") and codex-native ("Codex") sessions. Both resolve their
-        # model provider from the Databricks gateway profile (the gateway
-        # serves the OpenAI surface for codex AND the anthropic surface for
-        # claude-native), exactly like e2e.yml's native rows. The
-        # openai-agents hello_world agent the other UI tests use is
-        # unaffected — it authenticates via OPENAI_API_KEY / OPENAI_BASE_URL
-        # set in the "Run UI e2e tests" step.
-        env:
-          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-        run: |
-          # Strip the /serving-endpoints suffix the conftest re-appends.
-          host="${GATEWAY_BASE_URL%/serving-endpoints}"
-          cat > "$HOME/.databrickscfg" <<EOF
-          [default]
-          host  = $host
-          token = $LLM_API_KEY
-          EOF
-          # PAT passthrough for the codex / claude-native auth commands.
-          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
-
-      - name: Pre-seed Claude Code first-run state (~/.claude.json)
-        # The claude-native render-parity test drives the real Claude Code TUI
-        # in a PTY. On a fresh CI $HOME, Claude's first-run theme picker + the
-        # workspace-trust dialog block the TUI before it renders its prompt, so
-        # the process exits ("[server exited]") and the turn never completes —
-        # the only thing that differs from a developer's machine, where
-        # ~/.claude.json already records onboarding + a trusted workspace. Seed
-        # "already onboarded" + trust the workspace (the runner's cwd = Claude's
-        # cwd = $GITHUB_WORKSPACE) to clear both gates, mirroring the native e2e
-        # suite's _seed_onboarded_claude_home. Auth is separate (the gateway
-        # profile above + the conftest's provider config). CI-only: a workflow
-        # step, so a dev's real ~/.claude.json is never touched.
-        run: |
-          cat > "$HOME/.claude.json" <<EOF
-          {
-            "hasCompletedOnboarding": true,
-            "theme": "dark",
-            "lastOnboardingVersion": "2.0.0",
-            "projects": {
-              "${GITHUB_WORKSPACE}": {
-                "hasTrustDialogAccepted": true,
-                "hasCompletedProjectOnboarding": true
-              }
-            }
-          }
-          EOF
-
       - name: Install project + dev extras
         run: uv sync --extra all --extra dev
 
-      - name: Install binary dependencies
-        # bubblewrap: the UI tests boot a real server and open terminals,
-        # which run under os_env. An agent/terminal that omits
-        # `os_env.sandbox.type` defaults to `linux_bwrap` on Linux and fails
-        # loud at runtime if `bwrap` is missing (rather than silently running
-        # unsandboxed). The apparmor sysctl mirrors ci.yml: Ubuntu 24.04
-        # blocks unprivileged user namespaces by default, which `bwrap`'s
-        # `unshare(CLONE_NEWUSER)` needs.
-        #
-        # tmux + claude/codex CLIs: the render-parity suite drives the
-        # claude-native / codex-native harnesses, which launch the vendor
-        # CLI in a tmux-backed terminal. `npm install` against
-        # `.github/ci-deps/package.json` pins the CLI versions;
-        # `--ignore-scripts` blocks arbitrary postinstall across every
-        # package. `@anthropic-ai/claude-code` ships a stub at
-        # `bin/claude.exe`; its `install.cjs` only does platform detection
-        # plus a same-tree copy of the native binary from
-        # `optionalDependencies` (no network, no external execution), so we
-        # run it explicitly while `--ignore-scripts` still gates the rest.
-        # `@openai/codex` has `scripts: null`. Mirrors e2e.yml exactly.
+      - name: Install bubblewrap
+        # The UI tests boot a real server and open terminals, which run
+        # under os_env. An agent/terminal that omits `os_env.sandbox.type`
+        # defaults to `linux_bwrap` on Linux and fails loud at runtime if
+        # `bwrap` is missing (rather than silently running unsandboxed), so
+        # the terminal never launches and the right-panel terminal assertion
+        # fails. Install `bubblewrap` like ci.yml / e2e.yml. The apparmor
+        # sysctl mirrors ci.yml: Ubuntu 24.04 blocks unprivileged user
+        # namespaces by default, which `bwrap`'s `unshare(CLONE_NEWUSER)`
+        # needs.
         run: |
           sudo apt-get update
-          sudo apt-get install -y tmux bubblewrap
+          sudo apt-get install -y bubblewrap
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          cd .github/ci-deps
-          npm install --ignore-scripts
-          node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.github/ci-deps/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
@@ -339,18 +267,7 @@ jobs:
           # on GitHub-hosted runners. The previous glob targeted
           # ``e2e_ui_logs*``, which never matched, so the artifact was
           # always empty.
-          #
-          # The sibling runner subprocess writes ``runner.log`` next to it,
-          # and respawned / external runners under ``e2e_ui_*runner*/``. The
-          # native-CLI harness (claude/codex) routing decisions and the vendor
-          # CLI's own output land there, NOT in server.log (which only carries
-          # HTTP access lines), so capture all of them — a native-turn failure
-          # (e.g. a provider that resolves to no credential) is otherwise
-          # undiagnosable from the artifacts alone.
-          path: |
-            /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
-            /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
-            /tmp/pytest-of-runner/**/e2e_ui_*runner*/runner.log
+          path: /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
           retention-days: 3
           if-no-files-found: ignore
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -63,8 +63,16 @@ env:
   # expected the agent to fall back to ~/.databrickscfg, but the SDK's
   # default-profile lookup didn't resolve our OAuth M2M config in CI,
   # which is what was failing the LLM calls.
+  #
+  # ANTHROPIC_API_KEY / CODEX / CLAUDE_CODE stay scrubbed (matching
+  # e2e.yml): the native claude-native harness routes through the Databricks
+  # gateway's anthropic surface via the ~/.databrickscfg profile +
+  # DATABRICKS_BEARER written below, NOT a vendor API key. DATABRICKS_TOKEN
+  # is intentionally NOT scrubbed here (it was, before): the message
+  # render-parity suite's claude-native agent needs the Databricks profile to
+  # resolve, and an empty DATABRICKS_TOKEN in the env would shadow the profile
+  # and break that auth.
   ANTHROPIC_API_KEY: ""
-  DATABRICKS_TOKEN: ""
   CODEX: ""
   CLAUDE_CODE: ""
   # Match e2e.yml's proxy choice.
@@ -143,23 +151,60 @@ jobs:
       - name: Set LLM credentials
         run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
 
+      - name: Write gateway profile (~/.databrickscfg)
+        # The message render-parity suite spins up claude-native ("Claude
+        # Code") and codex-native ("Codex") sessions. Both resolve their
+        # model provider from the Databricks gateway profile (the gateway
+        # serves the OpenAI surface for codex AND the anthropic surface for
+        # claude-native), exactly like e2e.yml's native rows. The
+        # openai-agents hello_world agent the other UI tests use is
+        # unaffected — it authenticates via OPENAI_API_KEY / OPENAI_BASE_URL
+        # set in the "Run UI e2e tests" step.
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          # Strip the /serving-endpoints suffix the conftest re-appends.
+          host="${GATEWAY_BASE_URL%/serving-endpoints}"
+          cat > "$HOME/.databrickscfg" <<EOF
+          [default]
+          host  = $host
+          token = $LLM_API_KEY
+          EOF
+          # PAT passthrough for the codex / claude-native auth commands.
+          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
+
       - name: Install project + dev extras
         run: uv sync --extra all --extra dev
 
-      - name: Install bubblewrap
-        # The UI tests boot a real server and open terminals, which run
-        # under os_env. An agent/terminal that omits `os_env.sandbox.type`
-        # defaults to `linux_bwrap` on Linux and fails loud at runtime if
-        # `bwrap` is missing (rather than silently running unsandboxed), so
-        # the terminal never launches and the right-panel terminal assertion
-        # fails. Install `bubblewrap` like ci.yml / e2e.yml. The apparmor
-        # sysctl mirrors ci.yml: Ubuntu 24.04 blocks unprivileged user
-        # namespaces by default, which `bwrap`'s `unshare(CLONE_NEWUSER)`
-        # needs.
+      - name: Install binary dependencies
+        # bubblewrap: the UI tests boot a real server and open terminals,
+        # which run under os_env. An agent/terminal that omits
+        # `os_env.sandbox.type` defaults to `linux_bwrap` on Linux and fails
+        # loud at runtime if `bwrap` is missing (rather than silently running
+        # unsandboxed). The apparmor sysctl mirrors ci.yml: Ubuntu 24.04
+        # blocks unprivileged user namespaces by default, which `bwrap`'s
+        # `unshare(CLONE_NEWUSER)` needs.
+        #
+        # tmux + claude/codex CLIs: the render-parity suite drives the
+        # claude-native / codex-native harnesses, which launch the vendor
+        # CLI in a tmux-backed terminal. `npm install` against
+        # `.github/ci-deps/package.json` pins the CLI versions;
+        # `--ignore-scripts` blocks arbitrary postinstall across every
+        # package. `@anthropic-ai/claude-code` ships a stub at
+        # `bin/claude.exe`; its `install.cjs` only does platform detection
+        # plus a same-tree copy of the native binary from
+        # `optionalDependencies` (no network, no external execution), so we
+        # run it explicitly while `--ignore-scripts` still gates the rest.
+        # `@openai/codex` has `scripts: null`. Mirrors e2e.yml exactly.
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap
+          sudo apt-get install -y tmux bubblewrap
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          cd .github/ci-deps
+          npm install --ignore-scripts
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          echo "${GITHUB_WORKSPACE}/.github/ci-deps/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -274,74 +274,6 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
-def _maybe_isolate_gateway_config(mp: pytest.MonkeyPatch, config_home: Path) -> bool:
-    """Point native-claude at a gateway provider config when CI gateway creds exist.
-
-    The packaged ``claude-native-ui`` built-in spec declares no auth, so the
-    native-claude harness resolves its model provider from
-    ``~/.omnigent/config.yaml`` (``resolve_native_claude_config`` →
-    ``default_provider_for_harness``). On a developer machine that resolves to a
-    logged-in ``claude`` CLI (a subscription login); CI has no such login AND
-    scrubs ``ANTHROPIC_API_KEY``, so without an explicit provider the harness
-    launches Claude Code with no credentials and the turn never produces output
-    — the render-parity suite then times out waiting for the first reply (the
-    failure this guards against).
-
-    When the gateway creds the workflow already exports for the openai-agents
-    agents are present (``OPENAI_BASE_URL`` + ``OPENAI_API_KEY``), write a
-    ``gateway`` provider that serves the Databricks anthropic surface
-    (``<host>/ai-gateway/anthropic`` — see
-    ``omnigent/inner/claude_sdk_executor.py``) and point ``OMNIGENT_CONFIG_HOME``
-    at it via *mp* (mirroring ``test_model_catalog._isolate_config``), so
-    native-claude routes through the same gateway. The token is referenced
-    lazily as ``env:OPENAI_API_KEY`` so it reaches the runner (which resolves
-    the config) without baking the secret into a file. Only the ``anthropic``
-    family is declared, so openai family resolution (openai-agents / codex) is
-    untouched.
-
-    ``OMNIGENT_CONFIG_HOME`` is set only on the in-process ``os.environ`` (which
-    the spawned server + runner copy), and *mp* restores it on teardown — a
-    developer's real ``~/.omnigent/config.yaml`` is never read or written.
-    Locally (no gateway creds) this is a no-op and the subscription-login path
-    is preserved.
-
-    :param mp: A session-scoped :class:`pytest.MonkeyPatch` whose ``undo`` the
-        caller invokes on teardown.
-    :param config_home: Directory to write ``config.yaml`` into.
-    :returns: ``True`` when a config was written + the env pointed at it,
-        ``False`` when gateway creds were absent (the local no-op path).
-    """
-    import yaml
-
-    openai_base = os.environ.get("OPENAI_BASE_URL")
-    token = os.environ.get("OPENAI_API_KEY")
-    if not openai_base or not token:
-        return False
-    # The Databricks anthropic surface lives at ``<host>/ai-gateway/anthropic``;
-    # ``host`` is the gateway base minus the openai ``/serving-endpoints`` suffix.
-    host = openai_base.rstrip("/")
-    suffix = "/serving-endpoints"
-    if host.endswith(suffix):
-        host = host[: -len(suffix)]
-    config = {
-        "providers": {
-            "e2e-gateway": {
-                "kind": "gateway",
-                "default": True,
-                "anthropic": {
-                    "base_url": f"{host}/ai-gateway/anthropic",
-                    "api_key_ref": "env:OPENAI_API_KEY",
-                    "models": {"default": "databricks-claude-opus-4-8"},
-                },
-            }
-        }
-    }
-    config_home.mkdir(parents=True, exist_ok=True)
-    (config_home / "config.yaml").write_text(yaml.safe_dump(config, sort_keys=False))
-    mp.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
-    return True
-
-
 @pytest.fixture(scope="session")
 def built_spa(request: pytest.FixtureRequest) -> None:
     """
@@ -550,18 +482,6 @@ def live_server(
 
     binding_token = _secrets.token_urlsafe(32)
     runner_id = token_bound_runner_id(binding_token)
-    # Provision a native-claude gateway provider (CI only) so the
-    # ``claude-native-ui`` built-in authenticates through the Databricks gateway
-    # instead of a (CI-absent) Claude CLI login. The helper points
-    # ``OMNIGENT_CONFIG_HOME`` at an isolated dir via this MonkeyPatch BEFORE the
-    # server/runner env dicts are built below (they copy ``os.environ``), so
-    # every spawned process — including any runner respawn — resolves the same
-    # config. A session-scoped ``pytest.MonkeyPatch`` (the function-scoped
-    # fixture can't be used here) restores the env on teardown. A developer's
-    # real ``~/.omnigent/config.yaml`` is never touched; no-op locally (no
-    # gateway creds), preserving the subscription-login path.
-    _config_mp = pytest.MonkeyPatch()
-    _maybe_isolate_gateway_config(_config_mp, server_tmp / "omnigent_config")
     # PYTHONPATH forces the subprocess to import omnigent from
     # the worktree, not whatever's pip-installed in .venv —
     # otherwise a branch with code changes would silently run
@@ -667,7 +587,6 @@ def live_server(
                 proc.kill()
                 proc.wait(timeout=5)
         log_handle.close()
-        _config_mp.undo()
         log_text = log_path.read_text() if log_path.exists() else ""
         raise RuntimeError(
             f"`omnigent server` did not become healthy within "
@@ -687,7 +606,6 @@ def live_server(
         yield base_url
     finally:
         _server_state.clear()
-        _config_mp.undo()
         if runner_proc.poll() is None:
             runner_proc.send_signal(signal.SIGTERM)
             try:
@@ -1307,38 +1225,18 @@ def server_pid(live_server: str) -> int:
 # ---------------------------------------------------------------------------
 # Per-agent chat sessions (message render-parity suite, and reusable beyond it)
 #
-# Each fixture below yields ``(base_url, session_id)`` for a session bound to
-# the shared ``live_server`` runner, ready to chat at ``/c/<session_id>``,
-# across three agent shapes whose transcript-rendering paths differ:
+# ``custom_agent_session`` yields ``(base_url, session_id)`` for a session bound
+# to the shared ``live_server`` runner, ready to chat at ``/c/<session_id>``. It
+# registers a plain ``openai-agents`` agent (the ``echo_probe`` spec below) —
+# the same harness family as ``hello_world`` — fresh, so it stands in for "spin
+# up a different agent" without the multi-provider sprawl of the packaged
+# ``polly`` / ``debby`` examples.
 #
-# * ``custom_agent_session`` — a plain ``openai-agents`` agent (the
-#   ``echo_probe`` spec below), the same harness family as ``hello_world``,
-#   registered fresh so it stands in for "spin up a different agent" without
-#   the multi-provider sprawl of the packaged ``polly`` / ``debby`` examples.
-# * ``claude_code_session`` — the auto-registered ``claude-native-ui`` built-in
-#   (the ``claude-native`` CLI harness, "Claude Code").
-# * ``codex_session`` — the auto-registered ``codex-native-ui`` built-in (the
-#   ``codex-native`` CLI harness, "Codex").
-#
-# The two native built-ins are registered by ``_ensure_default_agents`` at
-# server startup (omnigent/server/app.py), so they exist on any ``omnigent
-# server`` without extra wiring — the fixtures just create a session bound to
-# them by durable agent id and PATCH it onto the runner, the same bind the
-# ``seeded_session`` fixture does for the bundled agent.
+# Native CLI built-ins (``claude-native-ui`` / ``codex-native-ui``) are not
+# wired up here yet: driving the real vendor TUI in a PTY needs CI-side setup
+# (gateway auth + Claude Code first-run state) owned by the native-harness CI
+# enablement work. Add those fixtures back alongside that effort.
 # ---------------------------------------------------------------------------
-
-# Names the server auto-registers for the two native CLI harnesses
-# (omnigent/server/app.py: _ensure_default_claude_agent /
-# _ensure_default_codex_agent). The matching CLI binary must be on PATH for
-# the harness to launch — callers skip when it is absent.
-CLAUDE_NATIVE_AGENT_NAME = "claude-native-ui"
-CODEX_NATIVE_AGENT_NAME = "codex-native-ui"
-
-# Model pinned on codex-native sessions — matches omnigent's own codex default
-# (omnigent/codex_native_app_server.py ``_DATABRICKS_CODEX_DEFAULT_MODEL``) and
-# is served by the Databricks gateway used in CI. See ``model_override`` on
-# :func:`_create_native_session` for why pinning is required.
-_NATIVE_CODEX_MODEL = "databricks-gpt-5-5"
 
 # A precise-echo agent on the openai-agents harness (same provider family as
 # hello_world, so it authenticates against the same gateway in CI). spec_version
@@ -1373,80 +1271,6 @@ def _bind_session_runner(base_url: str, session_id: str, runner_id: str) -> None
         timeout=10.0,
     )
     patch.raise_for_status()
-
-
-def _find_builtin_agent_id(base_url: str, name: str) -> str | None:
-    """Return the durable id of a built-in agent by name, or ``None``.
-
-    :param base_url: Spawned server base URL.
-    :param name: Registered agent name, e.g. ``"claude-native-ui"``.
-    :returns: The ``"ag_..."`` id, or ``None`` when the server did not
-        register it (e.g. the harness's CLI is unavailable).
-    """
-    resp = httpx.get(f"{base_url}/v1/agents", timeout=10.0)
-    resp.raise_for_status()
-    for agent in resp.json().get("data", []):
-        if agent.get("name") == name:
-            return str(agent["id"])
-    return None
-
-
-def _create_native_session(
-    base_url: str,
-    runner_id: str,
-    agent_name: str,
-    *,
-    workspace: str | None = None,
-    model_override: str | None = None,
-) -> str:
-    """Create a runner-bound session against a native built-in agent.
-
-    Native built-ins have ``session_id IS NULL``, so the JSON create body
-    (``{"agent_id": ...}``) is accepted and returns a ``SessionResponse``
-    whose ``id`` is the new session — unlike the multipart bundle create
-    (used for session-scoped agents) which returns ``session_id``.
-
-    :param base_url: Spawned server base URL.
-    :param runner_id: The token-bound runner id to bind.
-    :param agent_name: The native built-in name, e.g. ``"codex-native-ui"``.
-    :param workspace: Optional absolute path stored as the session's
-        workspace. Required for ``codex-native``: the runner refuses to
-        auto-launch the Codex terminal without a session workspace or
-        ``OMNIGENT_RUNNER_WORKSPACE`` (omnigent/runner/app.py
-        ``_codex_session_workspace``). With ``host_id`` unset the server
-        stores the path verbatim (no os_env boundary validation), so it
-        must already exist. ``claude-native`` does not need it.
-    :param model_override: Optional model id pinned on the session, passed
-        to the native CLI as ``--model`` at terminal launch. Required for
-        ``codex-native`` here: when an ``OPENAI_API_KEY`` is present (the
-        e2e_ui server sets one for the openai-agents agents) Codex resolves
-        the generic ``openai`` provider with no default model and launches
-        against a model the gateway doesn't serve, so the turn completes
-        with no output. Pinning a gateway-served model makes Codex reach a
-        real endpoint regardless of which provider it resolves.
-    :returns: The new session/conversation id.
-    :raises pytest.skip.Exception: When the built-in is not registered.
-    """
-    agent_id = _find_builtin_agent_id(base_url, agent_name)
-    if agent_id is None:
-        pytest.skip(
-            f"{agent_name!r} is not registered on the server — its CLI harness "
-            "is likely unavailable in this environment."
-        )
-    body: dict[str, object] = {"agent_id": agent_id}
-    if workspace is not None:
-        body["workspace"] = workspace
-    if model_override is not None:
-        body["model_override"] = model_override
-    create = httpx.post(
-        f"{base_url}/v1/sessions",
-        json=body,
-        timeout=30.0,
-    )
-    create.raise_for_status()
-    session_id = str(create.json()["id"])
-    _bind_session_runner(base_url, session_id, runner_id)
-    return session_id
 
 
 def _create_bundled_session(base_url: str, runner_id: str, yaml_text: str) -> str:
@@ -1496,61 +1320,6 @@ def custom_agent_session(
     respawned = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
     session_id = _create_bundled_session(live_server, runner_id, _CUSTOM_AGENT_YAML)
-    try:
-        yield (live_server, session_id)
-    finally:
-        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
-        if respawned is not None:
-            respawned.terminate()
-            respawned.wait(timeout=5)
-
-
-@pytest.fixture
-def claude_code_session(
-    live_server: str,
-    tmp_path_factory: pytest.TempPathFactory,
-) -> Iterator[tuple[str, str]]:
-    """A runner-bound session on the ``claude-native-ui`` ("Claude Code") agent.
-
-    :param live_server: Spawned server fixture; its runner is reused.
-    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
-    :returns: ``(base_url, session_id)``.
-    """
-    respawned = _ensure_runner_online(live_server, tmp_path_factory)
-    runner_id = str(_server_state["runner_id"])
-    session_id = _create_native_session(live_server, runner_id, CLAUDE_NATIVE_AGENT_NAME)
-    try:
-        yield (live_server, session_id)
-    finally:
-        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
-        if respawned is not None:
-            respawned.terminate()
-            respawned.wait(timeout=5)
-
-
-@pytest.fixture
-def codex_session(
-    live_server: str,
-    tmp_path_factory: pytest.TempPathFactory,
-) -> Iterator[tuple[str, str]]:
-    """A runner-bound session on the ``codex-native-ui`` ("Codex") agent.
-
-    :param live_server: Spawned server fixture; its runner is reused.
-    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
-    :returns: ``(base_url, session_id)``.
-    """
-    respawned = _ensure_runner_online(live_server, tmp_path_factory)
-    runner_id = str(_server_state["runner_id"])
-    # Codex refuses to auto-launch its terminal without a workspace; give it
-    # a real (empty) dir to run in. claude-native needs no such thing.
-    workspace = tmp_path_factory.mktemp("codex_workspace")
-    session_id = _create_native_session(
-        live_server,
-        runner_id,
-        CODEX_NATIVE_AGENT_NAME,
-        workspace=str(workspace),
-        model_override=_NATIVE_CODEX_MODEL,
-    )
     try:
         yield (live_server, session_id)
     finally:

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -274,6 +274,74 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
+def _maybe_isolate_gateway_config(mp: pytest.MonkeyPatch, config_home: Path) -> bool:
+    """Point native-claude at a gateway provider config when CI gateway creds exist.
+
+    The packaged ``claude-native-ui`` built-in spec declares no auth, so the
+    native-claude harness resolves its model provider from
+    ``~/.omnigent/config.yaml`` (``resolve_native_claude_config`` →
+    ``default_provider_for_harness``). On a developer machine that resolves to a
+    logged-in ``claude`` CLI (a subscription login); CI has no such login AND
+    scrubs ``ANTHROPIC_API_KEY``, so without an explicit provider the harness
+    launches Claude Code with no credentials and the turn never produces output
+    — the render-parity suite then times out waiting for the first reply (the
+    failure this guards against).
+
+    When the gateway creds the workflow already exports for the openai-agents
+    agents are present (``OPENAI_BASE_URL`` + ``OPENAI_API_KEY``), write a
+    ``gateway`` provider that serves the Databricks anthropic surface
+    (``<host>/ai-gateway/anthropic`` — see
+    ``omnigent/inner/claude_sdk_executor.py``) and point ``OMNIGENT_CONFIG_HOME``
+    at it via *mp* (mirroring ``test_model_catalog._isolate_config``), so
+    native-claude routes through the same gateway. The token is referenced
+    lazily as ``env:OPENAI_API_KEY`` so it reaches the runner (which resolves
+    the config) without baking the secret into a file. Only the ``anthropic``
+    family is declared, so openai family resolution (openai-agents / codex) is
+    untouched.
+
+    ``OMNIGENT_CONFIG_HOME`` is set only on the in-process ``os.environ`` (which
+    the spawned server + runner copy), and *mp* restores it on teardown — a
+    developer's real ``~/.omnigent/config.yaml`` is never read or written.
+    Locally (no gateway creds) this is a no-op and the subscription-login path
+    is preserved.
+
+    :param mp: A session-scoped :class:`pytest.MonkeyPatch` whose ``undo`` the
+        caller invokes on teardown.
+    :param config_home: Directory to write ``config.yaml`` into.
+    :returns: ``True`` when a config was written + the env pointed at it,
+        ``False`` when gateway creds were absent (the local no-op path).
+    """
+    import yaml
+
+    openai_base = os.environ.get("OPENAI_BASE_URL")
+    token = os.environ.get("OPENAI_API_KEY")
+    if not openai_base or not token:
+        return False
+    # The Databricks anthropic surface lives at ``<host>/ai-gateway/anthropic``;
+    # ``host`` is the gateway base minus the openai ``/serving-endpoints`` suffix.
+    host = openai_base.rstrip("/")
+    suffix = "/serving-endpoints"
+    if host.endswith(suffix):
+        host = host[: -len(suffix)]
+    config = {
+        "providers": {
+            "e2e-gateway": {
+                "kind": "gateway",
+                "default": True,
+                "anthropic": {
+                    "base_url": f"{host}/ai-gateway/anthropic",
+                    "api_key_ref": "env:OPENAI_API_KEY",
+                    "models": {"default": "databricks-claude-opus-4-8"},
+                },
+            }
+        }
+    }
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "config.yaml").write_text(yaml.safe_dump(config, sort_keys=False))
+    mp.setenv("OMNIGENT_CONFIG_HOME", str(config_home))
+    return True
+
+
 @pytest.fixture(scope="session")
 def built_spa(request: pytest.FixtureRequest) -> None:
     """
@@ -482,6 +550,18 @@ def live_server(
 
     binding_token = _secrets.token_urlsafe(32)
     runner_id = token_bound_runner_id(binding_token)
+    # Provision a native-claude gateway provider (CI only) so the
+    # ``claude-native-ui`` built-in authenticates through the Databricks gateway
+    # instead of a (CI-absent) Claude CLI login. The helper points
+    # ``OMNIGENT_CONFIG_HOME`` at an isolated dir via this MonkeyPatch BEFORE the
+    # server/runner env dicts are built below (they copy ``os.environ``), so
+    # every spawned process — including any runner respawn — resolves the same
+    # config. A session-scoped ``pytest.MonkeyPatch`` (the function-scoped
+    # fixture can't be used here) restores the env on teardown. A developer's
+    # real ``~/.omnigent/config.yaml`` is never touched; no-op locally (no
+    # gateway creds), preserving the subscription-login path.
+    _config_mp = pytest.MonkeyPatch()
+    _maybe_isolate_gateway_config(_config_mp, server_tmp / "omnigent_config")
     # PYTHONPATH forces the subprocess to import omnigent from
     # the worktree, not whatever's pip-installed in .venv —
     # otherwise a branch with code changes would silently run
@@ -587,6 +667,7 @@ def live_server(
                 proc.kill()
                 proc.wait(timeout=5)
         log_handle.close()
+        _config_mp.undo()
         log_text = log_path.read_text() if log_path.exists() else ""
         raise RuntimeError(
             f"`omnigent server` did not become healthy within "
@@ -606,6 +687,7 @@ def live_server(
         yield base_url
     finally:
         _server_state.clear()
+        _config_mp.undo()
         if runner_proc.poll() is None:
             runner_proc.send_signal(signal.SIGTERM)
             try:

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1220,3 +1220,259 @@ def server_pid(live_server: str) -> int:
     :returns: OS process id.
     """
     return int(_server_state["pid"])
+
+
+# ---------------------------------------------------------------------------
+# Per-agent chat sessions (message render-parity suite, and reusable beyond it)
+#
+# Each fixture below yields ``(base_url, session_id)`` for a session bound to
+# the shared ``live_server`` runner, ready to chat at ``/c/<session_id>``,
+# across three agent shapes whose transcript-rendering paths differ:
+#
+# * ``custom_agent_session`` — a plain ``openai-agents`` agent (the
+#   ``echo_probe`` spec below), the same harness family as ``hello_world``,
+#   registered fresh so it stands in for "spin up a different agent" without
+#   the multi-provider sprawl of the packaged ``polly`` / ``debby`` examples.
+# * ``claude_code_session`` — the auto-registered ``claude-native-ui`` built-in
+#   (the ``claude-native`` CLI harness, "Claude Code").
+# * ``codex_session`` — the auto-registered ``codex-native-ui`` built-in (the
+#   ``codex-native`` CLI harness, "Codex").
+#
+# The two native built-ins are registered by ``_ensure_default_agents`` at
+# server startup (omnigent/server/app.py), so they exist on any ``omnigent
+# server`` without extra wiring — the fixtures just create a session bound to
+# them by durable agent id and PATCH it onto the runner, the same bind the
+# ``seeded_session`` fixture does for the bundled agent.
+# ---------------------------------------------------------------------------
+
+# Names the server auto-registers for the two native CLI harnesses
+# (omnigent/server/app.py: _ensure_default_claude_agent /
+# _ensure_default_codex_agent). The matching CLI binary must be on PATH for
+# the harness to launch — callers skip when it is absent.
+CLAUDE_NATIVE_AGENT_NAME = "claude-native-ui"
+CODEX_NATIVE_AGENT_NAME = "codex-native-ui"
+
+# Model pinned on codex-native sessions — matches omnigent's own codex default
+# (omnigent/codex_native_app_server.py ``_DATABRICKS_CODEX_DEFAULT_MODEL``) and
+# is served by the Databricks gateway used in CI. See ``model_override`` on
+# :func:`_create_native_session` for why pinning is required.
+_NATIVE_CODEX_MODEL = "databricks-gpt-5-5"
+
+# A precise-echo agent on the openai-agents harness (same provider family as
+# hello_world, so it authenticates against the same gateway in CI). spec_version
+# 1 + executor.config.harness routes through the strict parser; arcname
+# config.yaml keeps it on that path.
+_CUSTOM_AGENT_NAME = "echo_probe"
+_CUSTOM_AGENT_YAML = f"""\
+spec_version: 1
+name: {_CUSTOM_AGENT_NAME}
+prompt: |
+  You are a precise echo assistant. The user sends a turn that ends with an
+  instruction to reply with one exact token. Reply with that token verbatim
+  and nothing else — no preamble, no quotes, no trailing punctuation.
+
+executor:
+  model: databricks-gpt-5-4
+  config:
+    harness: openai-agents
+"""
+
+
+def _bind_session_runner(base_url: str, session_id: str, runner_id: str) -> None:
+    """PATCH *session_id* onto *runner_id* so ``POST /v1/responses`` dispatches.
+
+    :param base_url: Spawned server base URL, e.g. ``"http://127.0.0.1:51234"``.
+    :param session_id: The session/conversation id to bind.
+    :param runner_id: The token-bound runner id the session dispatches to.
+    """
+    patch = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    patch.raise_for_status()
+
+
+def _find_builtin_agent_id(base_url: str, name: str) -> str | None:
+    """Return the durable id of a built-in agent by name, or ``None``.
+
+    :param base_url: Spawned server base URL.
+    :param name: Registered agent name, e.g. ``"claude-native-ui"``.
+    :returns: The ``"ag_..."`` id, or ``None`` when the server did not
+        register it (e.g. the harness's CLI is unavailable).
+    """
+    resp = httpx.get(f"{base_url}/v1/agents", timeout=10.0)
+    resp.raise_for_status()
+    for agent in resp.json().get("data", []):
+        if agent.get("name") == name:
+            return str(agent["id"])
+    return None
+
+
+def _create_native_session(
+    base_url: str,
+    runner_id: str,
+    agent_name: str,
+    *,
+    workspace: str | None = None,
+    model_override: str | None = None,
+) -> str:
+    """Create a runner-bound session against a native built-in agent.
+
+    Native built-ins have ``session_id IS NULL``, so the JSON create body
+    (``{"agent_id": ...}``) is accepted and returns a ``SessionResponse``
+    whose ``id`` is the new session — unlike the multipart bundle create
+    (used for session-scoped agents) which returns ``session_id``.
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: The token-bound runner id to bind.
+    :param agent_name: The native built-in name, e.g. ``"codex-native-ui"``.
+    :param workspace: Optional absolute path stored as the session's
+        workspace. Required for ``codex-native``: the runner refuses to
+        auto-launch the Codex terminal without a session workspace or
+        ``OMNIGENT_RUNNER_WORKSPACE`` (omnigent/runner/app.py
+        ``_codex_session_workspace``). With ``host_id`` unset the server
+        stores the path verbatim (no os_env boundary validation), so it
+        must already exist. ``claude-native`` does not need it.
+    :param model_override: Optional model id pinned on the session, passed
+        to the native CLI as ``--model`` at terminal launch. Required for
+        ``codex-native`` here: when an ``OPENAI_API_KEY`` is present (the
+        e2e_ui server sets one for the openai-agents agents) Codex resolves
+        the generic ``openai`` provider with no default model and launches
+        against a model the gateway doesn't serve, so the turn completes
+        with no output. Pinning a gateway-served model makes Codex reach a
+        real endpoint regardless of which provider it resolves.
+    :returns: The new session/conversation id.
+    :raises pytest.skip.Exception: When the built-in is not registered.
+    """
+    agent_id = _find_builtin_agent_id(base_url, agent_name)
+    if agent_id is None:
+        pytest.skip(
+            f"{agent_name!r} is not registered on the server — its CLI harness "
+            "is likely unavailable in this environment."
+        )
+    body: dict[str, object] = {"agent_id": agent_id}
+    if workspace is not None:
+        body["workspace"] = workspace
+    if model_override is not None:
+        body["model_override"] = model_override
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        json=body,
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+def _create_bundled_session(base_url: str, runner_id: str, yaml_text: str) -> str:
+    """Register a session-scoped agent from *yaml_text* and bind its session.
+
+    The multipart ``POST /v1/sessions`` both registers the agent and creates
+    the session it is scoped to, returning that ``session_id`` directly — so
+    no separate create call is needed.
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: The token-bound runner id to bind.
+    :param yaml_text: The agent spec body.
+    :returns: The new session/conversation id.
+    """
+    import json as _json
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+@pytest.fixture
+def custom_agent_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session on the custom ``echo_probe`` agent.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    session_id = _create_bundled_session(live_server, runner_id, _CUSTOM_AGENT_YAML)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)
+
+
+@pytest.fixture
+def claude_code_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session on the ``claude-native-ui`` ("Claude Code") agent.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    session_id = _create_native_session(live_server, runner_id, CLAUDE_NATIVE_AGENT_NAME)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)
+
+
+@pytest.fixture
+def codex_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session on the ``codex-native-ui`` ("Codex") agent.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    # Codex refuses to auto-launch its terminal without a workspace; give it
+    # a real (empty) dir to run in. claude-native needs no such thing.
+    workspace = tmp_path_factory.mktemp("codex_workspace")
+    session_id = _create_native_session(
+        live_server,
+        runner_id,
+        CODEX_NATIVE_AGENT_NAME,
+        workspace=str(workspace),
+        model_override=_NATIVE_CODEX_MODEL,
+    )
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -1,0 +1,308 @@
+r"""UI journey: messages render identically to the transcript, with no dupes.
+
+Across three agent shapes — a custom ``openai-agents`` agent ("echo_probe"),
+``claude-native-ui`` ("Claude Code"), and ``codex-native-ui`` ("Codex") — this
+drives five real chat turns through the web composer and asserts two
+properties that historically regressed on the native CLI harnesses:
+
+1. **Render parity with the TUI.** The terminal UI (``omnigent/chat.py``) and
+   the web SPA both render from the SAME canonical transcript,
+   ``GET /v1/sessions/{id}/items``. So "renders exactly the same as the TUI"
+   is checked by treating that transcript as ground truth: every per-turn
+   user marker and assistant token the SPA shows in a bubble must also be in
+   the transcript, in the same order, exactly once. If the SPA bubbles and the
+   transcript carry the same markers in the same order, the SPA renders what
+   the TUI renders.
+
+2. **No duplicate rendering.** Each turn embeds a unique user marker and asks
+   the agent to echo a unique assistant token. After the turn settles (working
+   shimmer gone) each marker must appear in EXACTLY ONE bubble — the classic
+   native-forwarder bug double-rendered a reply as both a streaming live
+   preview and the committed bubble, which would push a token's bubble count
+   to 2.
+
+Per-turn unique tokens (rather than fixed strings) are load-bearing: they make
+both the dedup count and the order check unambiguous even when an agent is
+chatty, and they survive any harness that splits a turn across multiple
+assistant blocks (the count is over bubbles containing the token, not over
+bubbles).
+
+The native ``claude-native`` agent requires the ``claude`` CLI on PATH; CI
+installs it (.github/workflows/e2e-ui.yml). The shared fixtures skip only when
+the server never registered the built-in.
+
+Only the custom and claude-native cases run here today. codex-native is not yet
+covered — see the note above ``custom``/``claude_code`` near the end of the
+module for the gateway-routing gap.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_USER = '[data-testid="message-bubble"][data-role="user"]'
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_WORKING = '[data-testid="working-indicator"]'
+
+_TURNS = 5
+
+# A custom openai-agents turn is a single LLM call; a native CLI turn pays
+# cold-launch + a real claude/codex round trip, so it gets a far larger budget.
+_CUSTOM_TURN_TIMEOUT_MS = 90_000
+_NATIVE_TURN_TIMEOUT_MS = 180_000
+
+
+def _send(page: Page, text: str) -> None:
+    """Type *text* into the composer and click Send.
+
+    :param page: The Playwright page, on the session's chat surface.
+    :param text: The message body to send.
+    """
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+def _ensure_chat_view(page: Page) -> None:
+    """Switch a terminal-first (native) session to its chat bubble view.
+
+    Native wrapper sessions default to the terminal view; the chat view
+    renders the same transcript as ``message-bubble``s. The toggle only
+    exists for terminal-capable sessions, so its absence (a plain SDK
+    agent) is a no-op.
+
+    :param page: The Playwright page, on the session's chat surface.
+    """
+    view_mode = page.get_by_role("group", name="View mode")
+    if view_mode.count() == 0:
+        return
+    chat_button = view_mode.get_by_role("button", name="Chat")
+    expect(chat_button).to_be_visible(timeout=30_000)
+    chat_button.click()
+
+
+def _turn_prompt(index: int, user_marker: str, assistant_token: str) -> str:
+    """Build turn *index*'s prompt: carry a marker, echo a token verbatim.
+
+    :param index: 1-based turn number, e.g. ``3``.
+    :param user_marker: Unique token embedded in the user message itself.
+    :param assistant_token: Unique token the agent must echo back exactly.
+    :returns: The composed prompt text.
+    """
+    return (
+        f"This is turn {index}. Context marker {user_marker}. "
+        f"Reply with exactly this token and nothing else: {assistant_token}"
+    )
+
+
+def _ordered_message_items(base_url: str, session_id: str) -> list[dict[str, object]]:
+    """Return the session's user/assistant message items in render order.
+
+    Filters ``GET /v1/sessions/{id}/items`` to ``type == "message"`` items
+    with a ``user`` / ``assistant`` role, preserving the server's position
+    order — which is exactly the order the SPA renders bubbles and the TUI
+    prints lines.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The session/conversation id.
+    :returns: Ordered message-item dicts (each with ``role`` + ``content``).
+    """
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/items",
+        params={"limit": 100, "order": "asc"},
+        timeout=15.0,
+    )
+    resp.raise_for_status()
+    return [
+        item
+        for item in resp.json().get("data", [])
+        if item.get("type") == "message" and item.get("role") in ("user", "assistant")
+    ]
+
+
+def _item_text(item: dict[str, object]) -> str:
+    """Join every string ``text`` field across a message item's content blocks.
+
+    Works for both user (``input_text``) and assistant (``output_text`` /
+    ``text``) blocks, so the same extractor serves both roles.
+
+    :param item: One element from the items API.
+    :returns: The concatenated text, or ``""``.
+    """
+    content = item.get("content")
+    if not isinstance(content, list):
+        return ""
+    return " ".join(
+        block["text"]
+        for block in content
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    )
+
+
+def _ordered_token_sequence(texts: list[str], tokens: list[str]) -> list[str]:
+    """Reduce *texts* to the order its members' tokens appear, one per text.
+
+    Each text is expected to carry at most one of *tokens*. A text carrying
+    none is skipped; a text carrying a token contributes that token. The
+    result is the observed order of tokens — directly comparable to the
+    expected per-turn order.
+
+    :param texts: Ordered message texts (e.g. transcript assistant texts).
+    :param tokens: The unique per-turn tokens to look for.
+    :returns: The tokens in the order they appear across *texts*.
+    """
+    token_set = set(tokens)
+    observed: list[str] = []
+    for text in texts:
+        hits = [tok for tok in token_set if tok in text]
+        observed.extend(hits)
+    return observed
+
+
+def _assert_no_duplicate_render(
+    page: Page,
+    user_markers: list[str],
+    assistant_tokens: list[str],
+) -> None:
+    """Assert each marker/token renders in exactly one bubble, in order.
+
+    :param page: The Playwright page, on the settled chat surface.
+    :param user_markers: Per-turn unique user markers, oldest first.
+    :param assistant_tokens: Per-turn unique assistant tokens, oldest first.
+    """
+    # Exactly one bubble per token — a second bubble means duplicate rendering
+    # (e.g. a native live-preview that was never reconciled away).
+    for marker in user_markers:
+        expect(page.locator(_USER, has_text=marker)).to_have_count(1)
+    for token in assistant_tokens:
+        expect(page.locator(_ASSISTANT, has_text=token)).to_have_count(1)
+    # One user bubble per turn — no phantom/duplicated user echoes.
+    expect(page.locator(_USER)).to_have_count(len(user_markers))
+
+    # DOM render order matches the turn order for both roles.
+    user_texts = page.locator(_USER).all_inner_texts()
+    assert _ordered_token_sequence(user_texts, user_markers) == user_markers, (
+        "user bubbles are out of order or a marker rendered more than once"
+    )
+    assistant_texts = page.locator(_ASSISTANT).all_inner_texts()
+    assert _ordered_token_sequence(assistant_texts, assistant_tokens) == assistant_tokens, (
+        "assistant bubbles are out of order or a token rendered more than once"
+    )
+
+
+def _assert_transcript_parity(
+    base_url: str,
+    session_id: str,
+    user_markers: list[str],
+    assistant_tokens: list[str],
+) -> None:
+    """Assert the canonical transcript carries the same markers, once, in order.
+
+    This is the "same as the TUI" half: the SPA bubbles (already asserted to
+    hold each marker exactly once, in order) match the transcript the TUI also
+    renders from.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The session/conversation id.
+    :param user_markers: Per-turn unique user markers, oldest first.
+    :param assistant_tokens: Per-turn unique assistant tokens, oldest first.
+    """
+    items = _ordered_message_items(base_url, session_id)
+    user_texts = [_item_text(it) for it in items if it.get("role") == "user"]
+    assistant_texts = [_item_text(it) for it in items if it.get("role") == "assistant"]
+
+    for marker in user_markers:
+        hits = sum(marker in t for t in user_texts)
+        assert hits == 1, f"user marker {marker!r} appears {hits}x in the transcript, expected 1"
+    for token in assistant_tokens:
+        hits = sum(token in t for t in assistant_texts)
+        assert hits == 1, (
+            f"assistant token {token!r} appears {hits}x in the transcript, expected 1"
+        )
+
+    assert _ordered_token_sequence(user_texts, user_markers) == user_markers, (
+        "transcript user messages are out of turn order"
+    )
+    assert _ordered_token_sequence(assistant_texts, assistant_tokens) == assistant_tokens, (
+        "transcript assistant messages are out of turn order"
+    )
+
+
+def _run_render_parity_journey(
+    page: Page,
+    base_url: str,
+    session_id: str,
+    *,
+    per_turn_timeout_ms: int,
+) -> None:
+    """Drive five turns, then assert no-duplicate render + transcript parity.
+
+    :param page: The Playwright page.
+    :param base_url: Spawned server base URL.
+    :param session_id: The session/conversation id to chat in.
+    :param per_turn_timeout_ms: How long to wait for each turn to land.
+    """
+    page.goto(f"{base_url}/c/{session_id}")
+    _ensure_chat_view(page)
+
+    user_markers: list[str] = []
+    assistant_tokens: list[str] = []
+    for index in range(1, _TURNS + 1):
+        nonce = uuid.uuid4().hex[:8]
+        user_marker = f"usr-{index}-{nonce}"
+        assistant_token = f"ast-{index}-{nonce}"
+        user_markers.append(user_marker)
+        assistant_tokens.append(assistant_token)
+
+        _send(page, _turn_prompt(index, user_marker, assistant_token))
+        # The echoed token in an assistant bubble = the turn produced its
+        # reply; only producible from this turn's prompt.
+        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+            timeout=per_turn_timeout_ms
+        )
+        # Turn fully settled before the next send, so any transient live
+        # preview has collapsed into the committed bubble (the dedup check
+        # below would otherwise race a mid-stream double).
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=per_turn_timeout_ms)
+        expect(page.locator(_USER)).to_have_count(index, timeout=15_000)
+
+    _assert_no_duplicate_render(page, user_markers, assistant_tokens)
+    _assert_transcript_parity(base_url, session_id, user_markers, assistant_tokens)
+
+
+@pytest.mark.timeout(300)
+def test_custom_agent_message_render_parity(
+    page: Page,
+    custom_agent_session: tuple[str, str],
+) -> None:
+    base_url, session_id = custom_agent_session
+    _run_render_parity_journey(
+        page, base_url, session_id, per_turn_timeout_ms=_CUSTOM_TURN_TIMEOUT_MS
+    )
+
+
+@pytest.mark.timeout(600)
+def test_claude_code_message_render_parity(
+    page: Page,
+    claude_code_session: tuple[str, str],
+) -> None:
+    base_url, session_id = claude_code_session
+    _run_render_parity_journey(
+        page, base_url, session_id, per_turn_timeout_ms=_NATIVE_TURN_TIMEOUT_MS
+    )
+
+
+# NOTE: codex-native ("Codex") is intentionally NOT covered here yet. In the
+# e2e_ui server's provider setup (OPENAI_API_KEY is set for the openai-agents
+# agents), Codex resolves the ambient `openai` provider and routes to the
+# gateway's generic openai surface rather than the `databricks` profile path
+# that e2e.yml's native-codex rows use, so its turns come back empty. The
+# reusable `codex_session` fixture (with the workspace + model_override fixes)
+# stays in the shared conftest for when that routing is sorted; re-add a
+# `test_codex_message_render_parity` then.

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -87,6 +87,35 @@ def _ensure_chat_view(page: Page) -> None:
     chat_button.click()
 
 
+def _reveal_terminal_view(page: Page) -> None:
+    """Best-effort switch to the Terminal view so the failure capture shows the CLI pane.
+
+    A native CLI turn that produces no chat output fails silently from the
+    Chat view's perspective — the real error (auth/model rejection, a crash)
+    is in the vendor CLI's terminal pane, which neither the server log nor a
+    Chat-view trace records. Flipping to the Terminal view before re-raising
+    lets Playwright's on-failure screenshot / video / trace capture that pane,
+    turning the black-box timeout into a diagnosable artifact.
+
+    Best-effort by design: it runs on an already-failing path, so any error
+    here (no toggle, pane not ready) is swallowed — it must never mask the
+    original assertion failure.
+
+    :param page: The Playwright page, on the session's chat surface.
+    """
+    try:
+        view_mode = page.get_by_role("group", name="View mode")
+        if view_mode.count() == 0:
+            return
+        terminal_button = view_mode.get_by_role("button", name="Terminal")
+        terminal_button.click(timeout=10_000)
+        # Give the PTY pane a moment to attach and paint before the harness
+        # grabs the on-failure screenshot.
+        page.wait_for_timeout(2_000)
+    except Exception:  # noqa: BLE001 — diagnostic only; never mask the real failure
+        pass
+
+
 def _turn_prompt(index: int, user_marker: str, assistant_token: str) -> str:
     """Build turn *index*'s prompt: carry a marker, echo a token verbatim.
 
@@ -262,10 +291,16 @@ def _run_render_parity_journey(
 
         _send(page, _turn_prompt(index, user_marker, assistant_token))
         # The echoed token in an assistant bubble = the turn produced its
-        # reply; only producible from this turn's prompt.
-        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
-            timeout=per_turn_timeout_ms
-        )
+        # reply; only producible from this turn's prompt. If it never lands
+        # (a native CLI turn that silently produced nothing), flip to the
+        # Terminal view first so the on-failure capture shows the CLI pane.
+        try:
+            expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+                timeout=per_turn_timeout_ms
+            )
+        except AssertionError:
+            _reveal_terminal_view(page)
+            raise
         # Turn fully settled before the next send, so any transient live
         # preview has collapsed into the committed bubble (the dedup check
         # below would otherwise race a mid-stream double).

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -1,9 +1,8 @@
 r"""UI journey: messages render identically to the transcript, with no dupes.
 
-Across three agent shapes — a custom ``openai-agents`` agent ("echo_probe"),
-``claude-native-ui`` ("Claude Code"), and ``codex-native-ui`` ("Codex") — this
-drives five real chat turns through the web composer and asserts two
-properties that historically regressed on the native CLI harnesses:
+Drives a custom ``openai-agents`` agent ("echo_probe") through five real chat
+turns via the web composer and asserts two properties that historically
+regressed on the native forwarder:
 
 1. **Render parity with the TUI.** The terminal UI (``omnigent/chat.py``) and
    the web SPA both render from the SAME canonical transcript,
@@ -27,13 +26,8 @@ chatty, and they survive any harness that splits a turn across multiple
 assistant blocks (the count is over bubbles containing the token, not over
 bubbles).
 
-The native ``claude-native`` agent requires the ``claude`` CLI on PATH; CI
-installs it (.github/workflows/e2e-ui.yml). The shared fixtures skip only when
-the server never registered the built-in.
-
-Only the custom and claude-native cases run here today. codex-native is not yet
-covered — see the note above ``custom``/``claude_code`` near the end of the
-module for the gateway-routing gap.
+The native CLI harnesses (claude-native, codex-native) are not covered here yet
+— see the note after ``test_custom_agent_message_render_parity``.
 """
 
 from __future__ import annotations
@@ -51,10 +45,8 @@ _WORKING = '[data-testid="working-indicator"]'
 
 _TURNS = 5
 
-# A custom openai-agents turn is a single LLM call; a native CLI turn pays
-# cold-launch + a real claude/codex round trip, so it gets a far larger budget.
+# A custom openai-agents turn is a single LLM call.
 _CUSTOM_TURN_TIMEOUT_MS = 90_000
-_NATIVE_TURN_TIMEOUT_MS = 180_000
 
 
 def _send(page: Page, text: str) -> None:
@@ -85,35 +77,6 @@ def _ensure_chat_view(page: Page) -> None:
     chat_button = view_mode.get_by_role("button", name="Chat")
     expect(chat_button).to_be_visible(timeout=30_000)
     chat_button.click()
-
-
-def _reveal_terminal_view(page: Page) -> None:
-    """Best-effort switch to the Terminal view so the failure capture shows the CLI pane.
-
-    A native CLI turn that produces no chat output fails silently from the
-    Chat view's perspective — the real error (auth/model rejection, a crash)
-    is in the vendor CLI's terminal pane, which neither the server log nor a
-    Chat-view trace records. Flipping to the Terminal view before re-raising
-    lets Playwright's on-failure screenshot / video / trace capture that pane,
-    turning the black-box timeout into a diagnosable artifact.
-
-    Best-effort by design: it runs on an already-failing path, so any error
-    here (no toggle, pane not ready) is swallowed — it must never mask the
-    original assertion failure.
-
-    :param page: The Playwright page, on the session's chat surface.
-    """
-    try:
-        view_mode = page.get_by_role("group", name="View mode")
-        if view_mode.count() == 0:
-            return
-        terminal_button = view_mode.get_by_role("button", name="Terminal")
-        terminal_button.click(timeout=10_000)
-        # Give the PTY pane a moment to attach and paint before the harness
-        # grabs the on-failure screenshot.
-        page.wait_for_timeout(2_000)
-    except Exception:  # noqa: BLE001 — diagnostic only; never mask the real failure
-        pass
 
 
 def _turn_prompt(index: int, user_marker: str, assistant_token: str) -> str:
@@ -291,16 +254,10 @@ def _run_render_parity_journey(
 
         _send(page, _turn_prompt(index, user_marker, assistant_token))
         # The echoed token in an assistant bubble = the turn produced its
-        # reply; only producible from this turn's prompt. If it never lands
-        # (a native CLI turn that silently produced nothing), flip to the
-        # Terminal view first so the on-failure capture shows the CLI pane.
-        try:
-            expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
-                timeout=per_turn_timeout_ms
-            )
-        except AssertionError:
-            _reveal_terminal_view(page)
-            raise
+        # reply; only producible from this turn's prompt.
+        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+            timeout=per_turn_timeout_ms
+        )
         # Turn fully settled before the next send, so any transient live
         # preview has collapsed into the committed bubble (the dedup check
         # below would otherwise race a mid-stream double).
@@ -322,22 +279,9 @@ def test_custom_agent_message_render_parity(
     )
 
 
-@pytest.mark.timeout(600)
-def test_claude_code_message_render_parity(
-    page: Page,
-    claude_code_session: tuple[str, str],
-) -> None:
-    base_url, session_id = claude_code_session
-    _run_render_parity_journey(
-        page, base_url, session_id, per_turn_timeout_ms=_NATIVE_TURN_TIMEOUT_MS
-    )
-
-
-# NOTE: codex-native ("Codex") is intentionally NOT covered here yet. In the
-# e2e_ui server's provider setup (OPENAI_API_KEY is set for the openai-agents
-# agents), Codex resolves the ambient `openai` provider and routes to the
-# gateway's generic openai surface rather than the `databricks` profile path
-# that e2e.yml's native-codex rows use, so its turns come back empty. The
-# reusable `codex_session` fixture (with the workspace + model_override fixes)
-# stays in the shared conftest for when that routing is sorted; re-add a
-# `test_codex_message_render_parity` then.
+# NOTE: the native CLI harnesses (claude-native "Claude Code", codex-native
+# "Codex") are intentionally NOT covered here yet. Driving the real vendor TUI
+# in a PTY needs CI-side setup (gateway auth + Claude Code first-run state) that
+# is owned by the native-harness CI enablement work; until that lands, this
+# suite covers the render-parity / no-duplicate logic via the custom
+# openai-agents agent above.


### PR DESCRIPTION
## What

Adds a browser-driven **message render-parity** suite under `tests/e2e_ui/messages/`, driving a custom `openai-agents` agent (`echo_probe`) through five real chat turns via the web composer and asserting two properties that historically regressed on the native forwarder:

1. **Render parity with the TUI.** The terminal UI and the web SPA both render from the same canonical transcript (`GET /v1/sessions/{id}/items`). The test treats that transcript as ground truth: every per-turn user marker and assistant token the SPA shows in a bubble must also appear in the transcript, in the same order, exactly once.
2. **No duplicate rendering.** Each turn embeds a unique user marker and asks the agent to echo a unique token; after the turn settles, each must appear in exactly one bubble — catching the classic double-render (live preview + committed bubble).

Per-turn unique tokens make both the dedup count and the order check unambiguous even when an agent is chatty or splits a turn across multiple assistant blocks.

## Scope

- `tests/e2e_ui/messages/test_message_render_parity.py` — `test_custom_agent_message_render_parity`.
- `tests/e2e_ui/conftest.py` — `custom_agent_session` fixture (a fresh `openai-agents` agent bound to the shared runner) + bundled-session helpers.

No product code changes.

## Native CLI harnesses (deferred)

The native render-parity rows (`claude-native-ui` / `codex-native-ui`) are **intentionally not included yet**. Driving the real vendor TUI in a PTY needs CI-side setup — gateway auth + Claude Code first-run state (onboarding/trust) — that is owned by the native-harness CI enablement work. Those rows will be added back alongside that effort; the module and conftest carry notes pointing there.

## Testing

Verified locally against a spawned server + runner: `test_custom_agent_message_render_parity` passes (real openai-agents LLM turns).