### PR TITLE
test(e2e_ui): add fork_session browser tests

### DIFF
--- a/tests/e2e_ui/fork_session/test_fork_from_middle.py
+++ b/tests/e2e_ui/fork_session/test_fork_from_middle.py
@@ -1,0 +1,140 @@
+"""Browser e2e: forking from the MIDDLE of a conversation truncates history.
+
+The "Fork from here" per-message action passes that response's id as
+``up_to_response_id``, so the server deep-copies the transcript only up to
+and including the selected turn. This test drives the real chain — two
+marked turns → fork from the FIRST assistant's action → navigate into the
+clone — and asserts truncation two independent ways:
+
+1. The rendered fork transcript shows the pre-fork (kept) user turn and
+   NOT the post-fork (dropped) one — the DOM proves the server copied a
+   truncated item list, not the whole conversation.
+2. Asking the clone "what did I ask you" surfaces only the kept code word.
+   The SDK harness replays the copied Omnigent transcript as context, so a
+   reply that recalls the dropped word would mean the truncation point was
+   ignored and the full history leaked into the fork.
+
+Both source and fork run the seeded ``hello_world`` (openai-agents SDK)
+agent, so this is fully runnable in the e2e_ui harness (no host / native
+CLI needed).
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+from playwright.sync_api import Page, expect
+
+# Two distinct code words with no shared substring, so the kept/dropped
+# assertions can't satisfy each other. Only the KEPT word is part of the
+# turn the fork copies; the DROPPED word lives in the turn after the fork
+# point and must never reach the clone.
+_KEPT_MARKER = "zephyr-keepsake"
+_DROPPED_MARKER = "quasar-castoff"
+
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_USER = '[data-testid="message-bubble"][data-role="user"]'
+
+
+def test_fork_from_middle_truncates_history(
+    page: Page,
+    seeded_session: tuple[str, str],
+    runner_id: str,
+) -> None:
+    """Fork from the first turn — the clone carries only history up to it.
+
+    Failure modes this catches:
+
+    - ``up_to_response_id`` is dropped on the wire or ignored server-side
+      (the clone renders the dropped turn too — full-history copy).
+    - The fork action on a non-last message forks the WHOLE session (the
+      per-message action wires the wrong response id).
+    - The truncated transcript hydrates but the SDK replay still feeds the
+      dropped turn to the model (recall surfaces the dropped word).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound ``hello_world`` session.
+    :param runner_id: The shared spawned runner's id — the fork is bound to
+        it before the recall turn (the non-coding fork flow creates the
+        clone unbound, so a message would otherwise have no runner).
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(composer).to_be_visible()
+
+    # Turn 1 (KEPT): plant the first code word and wait for its reply so the
+    # fork has a committed assistant response to anchor the action on.
+    composer.fill(f"Remember this code word and reply with just OK: {_KEPT_MARKER}")
+    page.get_by_role("button", name="Send", exact=True).click()
+    assistant = page.locator(_ASSISTANT)
+    expect(assistant).to_have_count(1, timeout=60_000)
+
+    # Turn 2 (DROPPED): plant the second code word AFTER the fork point.
+    # Forking from turn 1's response must exclude this turn entirely.
+    composer.fill(f"Now also remember this code word and reply with just OK: {_DROPPED_MARKER}")
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(assistant).to_have_count(2, timeout=60_000)
+
+    # Fork from the FIRST assistant response (the middle of the now
+    # two-turn conversation). The action lives inside that bubble's action
+    # bar (dimmed until hover but clickable); scoping the locator to the
+    # first bubble guarantees we pass turn 1's response id, not turn 2's.
+    first_assistant = assistant.nth(0)
+    first_assistant.hover()
+    first_assistant.get_by_test_id("fork-from-response").click()
+
+    dialog = page.get_by_test_id("fork-session-dialog")
+    expect(dialog).to_be_visible()
+    # The truncated-fork title (distinct from the full-clone "Clone session")
+    # confirms the dialog received an up_to_response_id.
+    expect(dialog.get_by_text("Fork from this response")).to_be_visible()
+    submit = page.get_by_test_id("fork-session-submit")
+    expect(submit).to_have_text("Clone")
+    submit.click()
+
+    # Land in a DIFFERENT session — a URL still on the source means
+    # navigation never fired; a visible dialog means the fork call failed.
+    expect(page).to_have_url(
+        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        timeout=30_000,
+    )
+    expect(dialog).not_to_be_visible()
+    fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
+    assert fork_id != session_id
+
+    # (1) DOM truncation: the kept user turn is present, the dropped one is
+    # absent. to_have_count(0) retries, so this holds even if the dropped
+    # bubble would only ever appear via a (buggy) full-history copy.
+    expect(page.locator(_USER).filter(has_text=_KEPT_MARKER).first).to_be_visible(timeout=30_000)
+    expect(page.locator(_USER).filter(has_text=_DROPPED_MARKER)).to_have_count(0)
+
+    # The non-coding fork is created UNBOUND (the dialog only launches a
+    # runner for a coding source), so a recall turn would have nothing to
+    # dispatch to. Bind it to the shared runner — same PATCH the
+    # ``seeded_session`` fixture uses — then reload so the client picks up
+    # the binding before sending.
+    bind = httpx.patch(
+        f"{base_url}/v1/sessions/{fork_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    bind.raise_for_status()
+    page.reload()
+
+    # (2) Recall: ask the clone what it was told to remember. The reply must
+    # echo the kept word and never the dropped one. The copied OK reply is
+    # the only assistant bubble so far; the recall answer is the second.
+    fork_composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(fork_composer).to_be_visible()
+    fork_composer.fill("What code word did I ask you to remember? Reply with the code word only.")
+    page.get_by_role("button", name="Send", exact=True).click()
+    fork_assistant = page.locator(_ASSISTANT)
+    expect(fork_assistant).to_have_count(2, timeout=60_000)
+
+    recall = fork_assistant.nth(1)
+    expect(recall).to_contain_text(_KEPT_MARKER, timeout=60_000)
+    expect(recall).not_to_contain_text(_DROPPED_MARKER)

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -1,0 +1,180 @@
+"""Browser e2e: forking while SWITCHING the agent carries history forward.
+
+The fork dialog's agent picker lets a fork bind a DIFFERENT built-in agent
+than the source — "fork this Claude-SDK chat into Claude Code". This drives
+that flow end-to-end (real per-message action → dialog → agent select →
+``POST /v1/sessions/{id}/fork`` with ``agent_id`` → navigate) for three
+targets whose SOURCE is the seeded ``hello_world`` openai-agents SDK agent:
+
+  - SDK → a DIFFERENT SDK agent (``files_probe_env``, openai-agents)
+  - SDK → Claude Code   (``claude-native-ui``,  anthropic native, X-family)
+  - SDK → Codex         (``codex-native-ui``,   openai native, same-family)
+
+Each case asserts what the server+UI can guarantee WITHOUT a host or a real
+native CLI: the fork is created on the TARGET agent, the copied transcript
+renders, and the fork's labels route the runner correctly —
+
+  - native targets stamp ``omnigent.fork.carry_history`` (the runner must
+    rebuild the native transcript; absent → the clone would launch fresh
+    and lose history) and the TARGET ``omnigent.wrapper`` (so the clone
+    opens in the right UI mode, not the source's chat mode);
+  - the SDK target stamps neither (an SDK target replays the transcript as
+    context, and plain chat has no wrapper).
+
+The full "the native clone actually recalls source history" recall path
+needs a host + a logged-in ``claude``/``codex`` CLI, which the e2e_ui
+harness doesn't spawn; that is covered at the API level by
+``tests/e2e/test_host_cross_family_fork_e2e.py``. Directions where the
+SOURCE is native (``claude code → *``, ``codex → *``) can't run here at all
+— producing the assistant bubble the fork action anchors on would require
+the native CLI to take a turn.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import _FILES_PROBE_ENV_AGENT_NAME
+
+# Unique marker so the copied-transcript assertion can't match UI chrome or
+# another test's message.
+_MARKER = "tangerine-switch-marker"
+
+_WRAPPER_LABEL_KEY = "omnigent.wrapper"
+_CARRY_HISTORY_LABEL_KEY = "omnigent.fork.carry_history"
+_SOURCE_EXTERNAL_SESSION_LABEL_KEY = "omnigent.fork.source_external_session_id"
+
+
+def _agent_id_by_name(base_url: str, name: str) -> str:
+    """Resolve a built-in agent's id by name from ``GET /v1/agents``.
+
+    :param base_url: Live server base URL, e.g. ``"http://127.0.0.1:51234"``.
+    :param name: Built-in agent name, e.g. ``"codex-native-ui"``.
+    :returns: The agent id.
+    """
+    resp = httpx.get(f"{base_url}/v1/agents", params={"limit": 100}, timeout=30.0)
+    resp.raise_for_status()
+    agent = next((a for a in resp.json()["data"] if a["name"] == name), None)
+    assert agent is not None, (
+        f"built-in agent {name!r} not registered on the test server — the SDK "
+        f"targets come from OMNIGENT_BUILTIN_AGENT_DIRS and the native targets "
+        f"are seeded unconditionally at startup, so absence is a server bug"
+    )
+    return str(agent["id"])
+
+
+@pytest.mark.parametrize(
+    ("target_name", "expected_wrapper", "expect_carry_history"),
+    [
+        # SDK → SDK: a different openai-agents built-in. The target replays
+        # the transcript as context, so no carry-history marker and no
+        # terminal wrapper — the clone stays in plain chat mode.
+        pytest.param(_FILES_PROBE_ENV_AGENT_NAME, None, False, id="sdk-to-sdk"),
+        # SDK → Claude Code: CROSS-family native target. The runner rebuilds
+        # the Claude transcript from the copied items, so carry-history is
+        # stamped and the wrapper flips to the claude-native terminal UI.
+        pytest.param("claude-native-ui", "claude-code-native-ui", True, id="sdk-to-claude-code"),
+        # SDK → Codex: SAME-family native target. Same carry-history rebuild
+        # path; the wrapper flips to the codex-native terminal UI.
+        pytest.param("codex-native-ui", "codex-native-ui", True, id="sdk-to-codex"),
+    ],
+)
+def test_fork_switch_agent_carries_history(
+    page: Page,
+    seeded_session: tuple[str, str],
+    target_name: str,
+    expected_wrapper: str | None,
+    expect_carry_history: bool,
+) -> None:
+    """Fork + switch agent: lands on the target agent with history copied.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound ``hello_world`` (openai-agents SDK) session.
+    :param target_name: Built-in agent name to switch the fork onto.
+    :param expected_wrapper: TARGET ``omnigent.wrapper`` value, or ``None``
+        when the target runs as plain chat (SDK).
+    :param expect_carry_history: Whether the fork must stamp the
+        carry-history label (true only for native targets).
+    """
+    base_url, session_id = seeded_session
+    target_agent_id = _agent_id_by_name(base_url, target_name)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # One marked turn so the fork has content AND an assistant bubble to
+    # anchor the "Fork from here" action. Forking from the LAST response is
+    # a full clone (no truncation), isolating the agent-switch behavior.
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(composer).to_be_visible()
+    composer.fill(f"Reply with one short word. Marker: {_MARKER}")
+    page.get_by_role("button", name="Send", exact=True).click()
+    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    expect(assistant).to_be_visible(timeout=60_000)
+
+    assistant.hover()
+    page.get_by_test_id("fork-from-response").first.click()
+    dialog = page.get_by_test_id("fork-session-dialog")
+    expect(dialog).to_be_visible()
+
+    # Pick the cross-/same-family target. The option being present at all is
+    # itself under test: the picker hides targets it can't classify
+    # (``harness: null``) or that wouldn't preserve history.
+    page.get_by_test_id("fork-session-agent-select").click()
+    option = page.get_by_test_id(f"fork-session-agent-option-{target_agent_id}")
+    expect(option).to_be_visible()
+    option.click()
+    page.get_by_test_id("fork-session-submit").click()
+
+    # The switch fork succeeds and navigates to a NEW session id.
+    expect(page).to_have_url(
+        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        timeout=30_000,
+    )
+    expect(dialog).not_to_be_visible()
+    fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
+    assert fork_id != session_id
+
+    # The copied transcript carries the source's marked user turn (history
+    # was deep-copied into the fork). For native targets this also renders
+    # in the clone's chat surface before the runner ever rebuilds.
+    copied_user = page.locator('[data-testid="message-bubble"][data-role="user"]').filter(
+        has_text=_MARKER
+    )
+    expect(copied_user.first).to_be_visible(timeout=30_000)
+
+    # The fork is bound to the TARGET agent (its cloned name carries the
+    # base agent name, with the route's " (fork <id>)" suffix appended).
+    agent_resp = httpx.get(f"{base_url}/v1/sessions/{fork_id}/agent", timeout=30.0)
+    agent_resp.raise_for_status()
+    assert agent_resp.json()["name"].startswith(target_name), (
+        f"fork should bind the target agent {target_name!r}, got {agent_resp.json()['name']!r}"
+    )
+
+    # Server-side label gating made observable. The SDK source never has a
+    # native session id, so the source-external directive is always absent
+    # — what matters per target is the carry-history marker and the wrapper.
+    snap = httpx.get(f"{base_url}/v1/sessions/{fork_id}", timeout=30.0)
+    snap.raise_for_status()
+    labels: dict[str, str] = snap.json().get("labels") or {}
+    assert _SOURCE_EXTERNAL_SESSION_LABEL_KEY not in labels, (
+        f"fork of an SDK source must not stamp a source native session id, got {labels!r}"
+    )
+    if expect_carry_history:
+        assert labels.get(_CARRY_HISTORY_LABEL_KEY) == "1", (
+            f"native-target fork must stamp carry-history, got {labels!r}"
+        )
+        assert labels.get(_WRAPPER_LABEL_KEY) == expected_wrapper, (
+            f"native-target fork must present as {expected_wrapper!r}, got {labels!r}"
+        )
+    else:
+        assert _CARRY_HISTORY_LABEL_KEY not in labels, (
+            f"SDK-target fork must not stamp carry-history, got {labels!r}"
+        )
+        assert _WRAPPER_LABEL_KEY not in labels, (
+            f"SDK-target fork must stay in chat mode (no wrapper), got {labels!r}"
+        )


### PR DESCRIPTION
## What

Adds `tests/e2e_ui/fork_session/` — browser-driven e2e tests for the session **fork** flow, run against a spawned `omnigent server` + runner (real SDK LLM).

### `test_fork_from_middle.py`
Forks from the **first** of two marked turns via the per-message "Fork from here" action and verifies truncation two independent ways:
- **DOM**: the cloned transcript renders the pre-fork user turn and *not* the post-fork one.
- **Recall**: asking the clone "what code word did I ask you to remember" surfaces only the kept word — the dropped turn never entered the SDK replay.

The non-coding fork is created unbound, so the test binds it to the shared runner (same PATCH `seeded_session` uses) before the recall turn.

### `test_fork_switch_agent.py`
Forks **while switching agent**, parametrized over the SDK-source directions the browser harness can run without a host or native CLI:
- `sdk → a different sdk agent` (openai-agents)
- `sdk → Claude Code` (claude-native, cross-family)
- `sdk → Codex` (codex-native, same-family)

Each asserts the fork binds the target agent, the transcript is copied, and the labels route the runner correctly — native targets stamp `omnigent.fork.carry_history` + the target `omnigent.wrapper`; the SDK target stamps neither.

## Scope note
Directions where the **source** is native (`claude code → *`, `codex → *`, `claude code ↔ codex`) are intentionally out of this browser suite: producing the assistant bubble the fork action anchors on would require the native CLI to take a turn (host + logged-in `claude`/`codex`). Those are covered at the API level by `tests/e2e/test_host_cross_family_fork_e2e.py`. The module docstrings state this explicitly.

## Testing
Ran locally against a spawned server + runner: **4 passed**.