### PR TITLE
feat(claude-sdk): gate connector-native MCP tools through TOOL_CALL policy

### DIFF
--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -115,7 +115,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     hook_event = payload.get("hook_event_name", "")
     eval_request = hook_payload_to_evaluation_request(hook_event, payload)
     if eval_request is None:
-        # Unrecognized hook event or an mcp__* tool (relay-enforced).
+        # Unrecognized hook event or an mcp__omnigent__* tool (relay-enforced).
         return 0
 
     # Stamp the live model from this session's config.toml (what an in-TUI

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1648,13 +1648,18 @@ class ClaudeSDKExecutor(Executor):
             ``"mcp__github__issue_write"``.
         :param tool_input: Arguments dict for the tool call.
         :returns: :class:`claude_agent_sdk.PermissionResultDeny` when a
-            policy denies the call (the server collapses TOOL_CALL ASK to a
-            hard ALLOW/DENY, so only the hard verdict reaches us), or
-            ``None`` when the call should be allowed to proceed (no policy
-            evaluator wired, an ``mcp__omnigent__*`` tool already gated on
-            the dispatch path, or an ALLOW / no-match verdict). Returning
-            ``None`` lets the caller fall through to its remaining gate
-            logic (elicitation) without forcing an allow.
+            policy denies the call. ``POLICY_ACTION_ASK`` is normally
+            collapsed to a hard ALLOW/DENY by the server-side
+            ``/policies/evaluate`` route. If a raw ASK reaches this callback
+            (for example from a read-only evaluation path), this hook runs the
+            existing Omnigent elicitation handler before returning
+            :class:`claude_agent_sdk.PermissionResultAllow` or DENY; without
+            a handler it fails closed. Returns ``None`` when the call should
+            be allowed to proceed (no policy evaluator wired, an
+            ``mcp__omnigent__*`` tool already gated on the dispatch path, or
+            an ALLOW / no-match verdict). Returning ``None`` lets the caller
+            fall through to its remaining gate logic (elicitation) without
+            forcing an allow.
         """
         _policy_eval = getattr(self, "_policy_evaluator", None)
         if _policy_eval is None:
@@ -1667,15 +1672,37 @@ class ClaudeSDKExecutor(Executor):
             "PHASE_TOOL_CALL",
             {"name": tool_name, "arguments": tool_input},
         )
-        if _verdict.action == "POLICY_ACTION_DENY":
+        _action = getattr(_verdict, "action", None)
+        if _action in ("POLICY_ACTION_ALLOW", "POLICY_ACTION_UNSPECIFIED"):
+            # ALLOW / no-match — fall through (caller decides whether to also
+            # run the human-consent elicitation gate).
+            return None
+        if _action == "POLICY_ACTION_ASK":
+            from claude_agent_sdk import PermissionResultAllow, PermissionResultDeny
+
+            reason = _verdict.reason or "Approval required by Omnigent TOOL_CALL policy"
+            if self._elicitation_handler is None:
+                logger.warning(
+                    "TOOL_CALL policy ASK had no elicitation handler; denying tool=%s reason=%s",
+                    tool_name,
+                    reason,
+                )
+                return PermissionResultDeny(message=reason)
+            logger.info("TOOL_CALL policy requested approval tool=%s reason=%s", tool_name, reason)
+            if await self._elicitation_handler(tool_name, tool_input):
+                return PermissionResultAllow()
+            return PermissionResultDeny(message=reason)
+        if _action == "POLICY_ACTION_DENY":
             from claude_agent_sdk import PermissionResultDeny
 
             reason = _verdict.reason or "Denied by Omnigent TOOL_CALL policy"
             logger.info("TOOL_CALL policy denied tool=%s reason=%s", tool_name, reason)
             return PermissionResultDeny(message=reason)
-        # ALLOW / no-match — fall through (caller decides whether to also
-        # run the human-consent elicitation gate).
-        return None
+        from claude_agent_sdk import PermissionResultDeny
+
+        reason = f"Unexpected Omnigent TOOL_CALL policy verdict: {_action!r}"
+        logger.warning("TOOL_CALL policy failed closed tool=%s reason=%s", tool_name, reason)
+        return PermissionResultDeny(message=reason)
 
     async def _can_use_tool_gate(
         self,

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1609,6 +1609,116 @@ class ClaudeSDKExecutor(Executor):
             return PermissionResultAllow()
         return PermissionResultDeny(message="Denied via Omnigent elicitation")
 
+    async def _evaluate_tool_call_policy(
+        self,
+        tool_name: str,
+        tool_input: ToolArgs,
+    ) -> Any:  # type: ignore[explicit-any]  # PermissionResult | None
+        """
+        Run a pre-execution TOOL_CALL policy evaluation for one tool call.
+
+        This is the policy half of the ``can_use_tool`` gate. It exists
+        so connector-native MCP tools — ones injected by the Claude Agent
+        SDK / claude.ai connector layer (e.g. ``mcp__github__*``,
+        ``mcp__atlassian__*``) that are NOT part of the agent spec's
+        ``mcp_servers`` and execute INSIDE the CLI subprocess — get
+        evaluated against Omnigent TOOL_CALL-phase policies BEFORE they
+        run. Without this gate those calls bypass policy entirely (the
+        executor only OBSERVES them in the message stream, which posts no
+        policy event).
+
+        Double-evaluation guard: Omnigent's OWN tools are exposed as the
+        single ``omnigent`` SDK MCP server (the model sees
+        ``mcp__omnigent__*``). When the model calls one, the SDK wrapper
+        routes it back through Omnigent's dispatch bridge
+        (``_stable_tool_executor`` -> ``TurnContext.dispatch_tool`` ->
+        ``action_required``), and the runner re-dispatches it via
+        ``ProxyMcpManager``, which enforces TOOL_CALL + TOOL_RESULT
+        policies server-side before forwarding to ``/mcp/execute``
+        (see ``omnigent/runner/app.py`` "All tool calls go through AP:/mcp
+        ... which enforces TOOL_CALL + TOOL_RESULT policies server-side").
+        Spec-declared MCP tools are surfaced through that same
+        ``mcp__omnigent__*`` server, so they are covered there too.
+        Evaluating ``mcp__omnigent__*`` here as well would double-count
+        the same call (and could double-charge a cost-budget checkpoint),
+        so we SKIP that prefix and only gate the connector-native /
+        out-of-band tools the dispatch path never sees.
+
+        :param tool_name: Full SDK tool name, e.g.
+            ``"mcp__github__issue_write"``.
+        :param tool_input: Arguments dict for the tool call.
+        :returns: :class:`claude_agent_sdk.PermissionResultDeny` when a
+            policy denies the call (the server collapses TOOL_CALL ASK to a
+            hard ALLOW/DENY, so only the hard verdict reaches us), or
+            ``None`` when the call should be allowed to proceed (no policy
+            evaluator wired, an ``mcp__omnigent__*`` tool already gated on
+            the dispatch path, or an ALLOW / no-match verdict). Returning
+            ``None`` lets the caller fall through to its remaining gate
+            logic (elicitation) without forcing an allow.
+        """
+        _policy_eval = getattr(self, "_policy_evaluator", None)
+        if _policy_eval is None:
+            return None
+        # Omnigent's own tools are already TOOL_CALL-gated server-side via
+        # the dispatch bridge / ProxyMcpManager — don't evaluate them twice.
+        if tool_name.startswith("mcp__omnigent__"):
+            return None
+        _verdict = await _policy_eval(
+            "PHASE_TOOL_CALL",
+            {"name": tool_name, "arguments": tool_input},
+        )
+        if _verdict.action == "POLICY_ACTION_DENY":
+            from claude_agent_sdk import PermissionResultDeny
+
+            reason = _verdict.reason or "Denied by Omnigent TOOL_CALL policy"
+            logger.info("TOOL_CALL policy denied tool=%s reason=%s", tool_name, reason)
+            return PermissionResultDeny(message=reason)
+        # ALLOW / no-match — fall through (caller decides whether to also
+        # run the human-consent elicitation gate).
+        return None
+
+    async def _can_use_tool_gate(
+        self,
+        tool_name: str,
+        tool_input: ToolArgs,
+        perm_ctx: Any,  # type: ignore[explicit-any]  # ToolPermissionContext
+    ) -> Any:  # type: ignore[explicit-any]  # PermissionResult
+        """
+        Unified ``options.can_use_tool`` callback for the claude-sdk path.
+
+        Composes two independent gates, in order:
+
+        1. **TOOL_CALL policy** (always, when a ``_policy_evaluator`` is
+           wired): a hard DENY short-circuits to
+           :class:`~claude_agent_sdk.PermissionResultDeny`. This runs in
+           EVERY permission mode — including ``bypassPermissions`` — so
+           connector-native MCP tools can't slip past policy. ALLOW /
+           no-match falls through with no human interaction, preserving
+           ``bypassPermissions`` ergonomics for un-gated tools.
+        2. **Human-consent elicitation** (only when the permission mode is
+           NOT ``bypassPermissions`` and an elicitation handler is wired):
+           the pre-existing per-tool approval prompt. Under
+           ``bypassPermissions`` this step is skipped entirely, so the
+           model still acts autonomously for anything policy allows.
+
+        :param tool_name: Full SDK tool name, e.g. ``"Bash"`` or
+            ``"mcp__github__issue_write"``.
+        :param tool_input: Arguments dict for the tool call.
+        :param perm_ctx: :class:`claude_agent_sdk.ToolPermissionContext`.
+        :returns: A :class:`~claude_agent_sdk.PermissionResult`.
+        """
+        from claude_agent_sdk import PermissionResultAllow
+
+        policy_result = await self._evaluate_tool_call_policy(tool_name, tool_input)
+        if policy_result is not None:
+            # Hard DENY from policy — block before execution.
+            return policy_result
+        # Policy allowed (or no policy gate). Under bypassPermissions we
+        # never prompt; otherwise defer to the elicitation gate.
+        if self._permission_mode == "bypassPermissions" or self._elicitation_handler is None:
+            return PermissionResultAllow()
+        return await self._can_use_tool_for_permission(tool_name, tool_input, perm_ctx)
+
     async def run_turn(
         self,
         messages: list[Message],
@@ -1826,16 +1936,28 @@ class ClaudeSDKExecutor(Executor):
             options.model = model
         if self._cwd:
             options.cwd = self._cwd
-        # When an elicitation handler is installed (by ExecutorAdapter)
-        # and the permission mode is not unconditional bypass, gate every
-        # tool call through a can_use_tool callback that surfaces an AP
-        # elicitation request to the UI and parks until the user responds.
+        # Install the unified can_use_tool gate. It runs the TOOL_CALL
+        # policy evaluation in EVERY permission mode — including
+        # ``bypassPermissions`` — so connector-native MCP tools
+        # (``mcp__github__*``, ``mcp__atlassian__*``) that execute inside
+        # the CLI subprocess are evaluated against Omnigent TOOL_CALL
+        # policy before they run, instead of bypassing policy entirely.
         #
-        # ``bypassPermissions`` tells the CLI to skip all permission
-        # checks before can_use_tool is ever called, so there is nothing
-        # to intercept in that mode — only install for other modes.
-        if self._elicitation_handler is not None and self._permission_mode != "bypassPermissions":
-            options.can_use_tool = self._can_use_tool_for_permission
+        # The gate is no-friction when nothing matches: a policy ALLOW /
+        # no-match returns allow with no human prompt, so
+        # ``bypassPermissions`` ergonomics are preserved for un-gated
+        # tools. The human-consent elicitation half of the gate still only
+        # fires for non-bypass modes (see ``_can_use_tool_gate``).
+        #
+        # Install whenever EITHER a policy evaluator OR an elicitation
+        # handler is wired. Previously this only installed for non-bypass
+        # modes, which is why default ``claude-sdk`` sessions (which
+        # default to ``bypassPermissions``) had no per-tool TOOL_CALL gate.
+        if (
+            getattr(self, "_policy_evaluator", None) is not None
+            or self._elicitation_handler is not None
+        ):
+            options.can_use_tool = self._can_use_tool_gate
 
         # Log the full configuration for debugging
         logger.info(

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -29,11 +29,12 @@ def hook_payload_to_evaluation_request(
     Convert a native-harness tool-hook payload into a proto ``EvaluationRequest``.
 
     Maps ``PreToolUse`` to a ``PHASE_TOOL_CALL`` event and
-    ``PostToolUse`` to a ``PHASE_TOOL_RESULT`` event. MCP tools
-    (``mcp__*``) are skipped because they are already policy-checked by
-    the relay path (``ProxyMcpManager`` → Omnigent ``/mcp`` endpoint →
-    ``_evaluate_tool_call_policy``); evaluating them here would
-    double-count.
+    ``PostToolUse`` to a ``PHASE_TOOL_RESULT`` event. Omnigent MCP tools
+    (``mcp__omnigent__*``) are skipped because they are already
+    policy-checked by the relay path (``ProxyMcpManager`` → Omnigent
+    ``/mcp`` endpoint → ``_evaluate_tool_call_policy``); evaluating
+    them here would double-count. Connector-native MCP tools
+    (for example ``mcp__github__*``) still need this pre-call gate.
 
     :param hook_event: Hook event name from the payload's
         ``hook_event_name`` field, e.g. ``"PreToolUse"`` or
@@ -43,13 +44,14 @@ def hook_payload_to_evaluation_request(
         "tool_input": {"command": "rm -rf /"}}``.
     :returns: An ``EvaluationRequest`` dict suitable for POSTing to
         ``/policies/evaluate``, or ``None`` when the event is not
-        policy-relevant (unknown event or an ``mcp__*`` tool).
+        policy-relevant (unknown event or an ``mcp__omnigent__*`` tool).
     """
     tool_name = payload.get("tool_name", "")
-    # MCP tools (mcp__*) are already policy-checked by the relay path
+    # Omnigent MCP tools are already policy-checked by the relay path
     # (ProxyMcpManager → Omnigent /mcp endpoint → _evaluate_tool_call_policy).
-    # Skip them here to avoid double evaluation.
-    if isinstance(tool_name, str) and tool_name.startswith("mcp__"):
+    # Skip only those here to avoid double evaluation; connector-native MCP
+    # tools such as mcp__github__* must still go through this hook.
+    if isinstance(tool_name, str) and tool_name.startswith("mcp__omnigent__"):
         return None
     tool_input = payload.get("tool_input") or {}
     if hook_event == _PRE_TOOL_USE:

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -3078,6 +3078,113 @@ class TestToolCallPolicyGate(unittest.TestCase):
 
         _run(_t())
 
+    def test_ask_verdict_prompts_even_under_bypass(self):
+        """A raw ASK verdict is supported by routing to Omnigent
+        elicitation, even under bypassPermissions."""
+        from claude_agent_sdk import PermissionResultAllow
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_ASK", reason="approval required")
+            )
+            elicit = AsyncMock(return_value=True)
+            executor._elicitation_handler = elicit
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_write",
+                {"title": "bug"},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultAllow)
+            elicit.assert_awaited_once_with("mcp__github__issue_write", {"title": "bug"})
+
+        _run(_t())
+
+    def test_ask_verdict_denies_when_user_declines(self):
+        """A declined raw ASK blocks execution with the policy reason."""
+        from claude_agent_sdk import PermissionResultDeny
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_ASK", reason="approval required")
+            )
+            executor._elicitation_handler = AsyncMock(return_value=False)
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_write",
+                {"title": "bug"},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultDeny)
+            self.assertEqual(result.message, "approval required")
+
+        _run(_t())
+
+    def test_ask_verdict_without_elicitation_handler_fails_closed(self):
+        """If raw ASK reaches the callback but no handler is available,
+        the tool must not run."""
+        from claude_agent_sdk import PermissionResultDeny
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_ASK", reason="approval required")
+            )
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_write",
+                {"title": "bug"},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultDeny)
+            self.assertEqual(result.message, "approval required")
+
+        _run(_t())
+
+    def test_unspecified_verdict_falls_through(self):
+        """UNSPECIFIED is a proto no-op verdict and should behave like no match."""
+        from claude_agent_sdk import PermissionResultAllow
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_UNSPECIFIED")
+            )
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_read",
+                {"number": 1},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultAllow)
+
+        _run(_t())
+
+    def test_unexpected_verdict_fails_closed(self):
+        """Unknown policy actions should not silently allow a tool call."""
+        from claude_agent_sdk import PermissionResultDeny
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(return_value=self._verdict("BOGUS"))
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_write",
+                {"title": "bug"},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultDeny)
+            self.assertIn("Unexpected Omnigent TOOL_CALL policy verdict", result.message)
+
+        _run(_t())
+
     def test_allow_verdict_no_human_prompt_under_bypass(self):
         """ALLOW under bypassPermissions allows the call with no human
         prompt, preserving bypass ergonomics."""

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2995,3 +2995,234 @@ async def test_result_message_usage_none_yields_turn_complete_without_usage() ->
         f"TurnComplete.usage should be None when ResultMessage.usage is None, "
         f"got {turn.usage!r}. An empty dict would display 0 tokens in the ring."
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests: pre-execution TOOL_CALL policy gate (can_use_tool)
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallPolicyGate(unittest.TestCase):
+    """The ``can_use_tool`` gate that enforces TOOL_CALL policy on
+    connector-native MCP tools (``mcp__github__*`` etc.) before they run.
+    """
+
+    def _make_executor(self, permission_mode="bypassPermissions"):
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        return ClaudeSDKExecutor(permission_mode=permission_mode)
+
+    @staticmethod
+    def _verdict(action, reason=None):
+        from omnigent.runtime.harnesses._scaffold import PolicyVerdictPayload
+
+        return PolicyVerdictPayload(action=action, reason=reason)
+
+    @staticmethod
+    def _perm_ctx():
+        return SimpleNamespace(tool_use_id="tu_1", agent_id=None, suggestions=[])
+
+    def test_connector_native_tool_triggers_tool_call_eval(self):
+        """A connector-native tool name drives a PHASE_TOOL_CALL evaluation
+        with the SDK-native tool name and arguments."""
+        from claude_agent_sdk import PermissionResultAllow
+
+        async def _t():
+            executor = self._make_executor()
+            evaluator = AsyncMock(return_value=self._verdict("POLICY_ACTION_ALLOW"))
+            executor._policy_evaluator = evaluator
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_write",
+                {"title": "bug", "body": "x"},
+                self._perm_ctx(),
+            )
+
+            evaluator.assert_awaited_once()
+            phase, data = evaluator.await_args.args
+            self.assertEqual(phase, "PHASE_TOOL_CALL")
+            self.assertEqual(
+                data,
+                {
+                    "name": "mcp__github__issue_write",
+                    "arguments": {"title": "bug", "body": "x"},
+                },
+            )
+            self.assertIsInstance(result, PermissionResultAllow)
+
+        _run(_t())
+
+    def test_deny_verdict_blocks_execution(self):
+        """A DENY verdict returns PermissionResultDeny carrying the
+        policy's reason and never reaches the elicitation handler."""
+        from claude_agent_sdk import PermissionResultDeny
+
+        async def _t():
+            executor = self._make_executor(permission_mode="default")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_DENY", reason="no writes to github")
+            )
+            elicit = AsyncMock(return_value=True)
+            executor._elicitation_handler = elicit
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_write",
+                {"title": "bug"},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultDeny)
+            self.assertEqual(result.message, "no writes to github")
+            # DENY short-circuits — no human prompt.
+            elicit.assert_not_awaited()
+
+        _run(_t())
+
+    def test_allow_verdict_no_human_prompt_under_bypass(self):
+        """ALLOW under bypassPermissions allows the call with no human
+        prompt, preserving bypass ergonomics."""
+        from claude_agent_sdk import PermissionResultAllow
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_ALLOW")
+            )
+            elicit = AsyncMock(return_value=True)
+            executor._elicitation_handler = elicit
+
+            result = await executor._can_use_tool_gate(
+                "mcp__github__issue_read",
+                {"number": 1},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultAllow)
+            elicit.assert_not_awaited()
+
+        _run(_t())
+
+    def test_no_policy_evaluator_no_match_allows_silently(self):
+        """With no policy evaluator wired (default ALLOW), the gate allows
+        with no evaluation and no human prompt under bypassPermissions."""
+        from claude_agent_sdk import PermissionResultAllow
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            # No _policy_evaluator set, no elicitation handler.
+            result = await executor._can_use_tool_gate(
+                "mcp__atlassian__createJiraIssue",
+                {"summary": "x"},
+                self._perm_ctx(),
+            )
+            self.assertIsInstance(result, PermissionResultAllow)
+
+        _run(_t())
+
+    def test_omnigent_own_tool_skips_evaluation(self):
+        """``mcp__omnigent__*`` tools are already TOOL_CALL-gated server-side
+        via the dispatch bridge / ProxyMcpManager, so the gate must NOT
+        evaluate them again (avoids double-evaluation)."""
+        from claude_agent_sdk import PermissionResultAllow
+
+        async def _t():
+            executor = self._make_executor(permission_mode="bypassPermissions")
+            evaluator = AsyncMock(return_value=self._verdict("POLICY_ACTION_ALLOW"))
+            executor._policy_evaluator = evaluator
+
+            result = await executor._can_use_tool_gate(
+                "mcp__omnigent__sys_os_read",
+                {"path": "/tmp/x"},
+                self._perm_ctx(),
+            )
+
+            self.assertIsInstance(result, PermissionResultAllow)
+            evaluator.assert_not_awaited()
+
+        _run(_t())
+
+    def test_non_bypass_runs_elicitation_after_policy_allow(self):
+        """In a non-bypass mode, a policy ALLOW falls through to the
+        human-consent elicitation gate (pre-existing behavior)."""
+        from claude_agent_sdk import PermissionResultAllow, PermissionResultDeny
+
+        async def _t():
+            executor = self._make_executor(permission_mode="default")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_ALLOW")
+            )
+
+            # Human approves.
+            executor._elicitation_handler = AsyncMock(return_value=True)
+            approved = await executor._can_use_tool_gate(
+                "mcp__github__issue_read", {}, self._perm_ctx()
+            )
+            self.assertIsInstance(approved, PermissionResultAllow)
+
+            # Human denies.
+            executor._elicitation_handler = AsyncMock(return_value=False)
+            denied = await executor._can_use_tool_gate(
+                "mcp__github__issue_read", {}, self._perm_ctx()
+            )
+            self.assertIsInstance(denied, PermissionResultDeny)
+
+        _run(_t())
+
+    def test_gate_installed_under_bypass_permissions(self):
+        """run_turn installs the can_use_tool gate even under
+        bypassPermissions when a policy evaluator is wired — the
+        regression this feature fixes."""
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        async def _t():
+            executor = ClaudeSDKExecutor(permission_mode="bypassPermissions")
+            executor._policy_evaluator = AsyncMock(
+                return_value=self._verdict("POLICY_ACTION_ALLOW")
+            )
+
+            captured = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["can_use_tool"] = options.can_use_tool
+                raise RuntimeError("stop after options build")
+
+            with patch.object(
+                executor,
+                "_get_or_create_client",
+                side_effect=fake_get_or_create_client,
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            # Bound-method identity differs per access; compare equality.
+            self.assertEqual(captured["can_use_tool"], executor._can_use_tool_gate)
+            self.assertIsNotNone(captured["can_use_tool"])
+
+        _run(_t())
+
+    def test_gate_not_installed_without_evaluator_or_handler(self):
+        """With neither a policy evaluator nor an elicitation handler, no
+        can_use_tool callback is installed (unchanged baseline)."""
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        async def _t():
+            executor = ClaudeSDKExecutor(permission_mode="bypassPermissions")
+            captured = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["can_use_tool"] = options.can_use_tool
+                raise RuntimeError("stop after options build")
+
+            with patch.object(
+                executor,
+                "_get_or_create_client",
+                side_effect=fake_get_or_create_client,
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            self.assertIsNone(captured["can_use_tool"])
+
+        _run(_t())

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -60,11 +60,11 @@ def test_post_tool_use_maps_to_phase_tool_result() -> None:
 
 
 @pytest.mark.parametrize("hook_event", ["PreToolUse", "PostToolUse"])
-def test_mcp_tools_are_skipped(hook_event: str) -> None:
+def test_omnigent_mcp_tools_are_skipped(hook_event: str) -> None:
     """
-    MCP tools (``mcp__*``) return None and are never sent to /policies/evaluate.
+    Omnigent MCP tools return None and are never sent to /policies/evaluate.
 
-    MCP tool calls are already policy-checked by the relay path
+    Omnigent MCP tool calls are already policy-checked by the relay path
     (ProxyMcpManager → Omnigent /mcp endpoint → _evaluate_tool_call_policy).
     If this guard regressed, every MCP tool call would be evaluated
     twice — once via the relay, once via this hook.
@@ -75,6 +75,41 @@ def test_mcp_tools_are_skipped(hook_event: str) -> None:
     )
     # None signals the caller to skip the POST entirely.
     assert result is None
+
+
+@pytest.mark.parametrize(
+    "hook_event,expected_type",
+    [("PreToolUse", "PHASE_TOOL_CALL"), ("PostToolUse", "PHASE_TOOL_RESULT")],
+)
+def test_connector_native_mcp_tools_are_evaluated(hook_event: str, expected_type: str) -> None:
+    """
+    Connector-native MCP tools must not be skipped by the native pre-call hook.
+
+    Tools such as ``mcp__github__*`` are injected by the connector layer and
+    do not round-trip through Omnigent's MCP proxy, so this hook is their
+    TOOL_CALL/TOOL_RESULT policy enforcement site.
+    """
+    result = hook_payload_to_evaluation_request(
+        hook_event,
+        {
+            "tool_name": "mcp__github__create_issue",
+            "tool_input": {"title": "blocked?"},
+            "tool_output": "created",
+        },
+    )
+    assert result is not None
+    event = result["event"]
+    assert event["type"] == expected_type
+    if hook_event == "PreToolUse":
+        assert event["data"] == {
+            "name": "mcp__github__create_issue",
+            "arguments": {"title": "blocked?"},
+        }
+    else:
+        assert event["request_data"] == {
+            "name": "mcp__github__create_issue",
+            "arguments": {"title": "blocked?"},
+        }
 
 
 def test_unknown_hook_event_returns_none() -> None:


### PR DESCRIPTION
## Summary

Adds a policy-aware, **pre-execution TOOL_CALL gate** to the `claude-sdk` harness so that connector-native MCP tools — ones injected by the Claude Agent SDK / claude.ai connector layer (e.g. `mcp__github__*`, `mcp__atlassian__*`) that are **not** in the agent spec's `mcp_servers` and execute *inside* the CLI subprocess — are evaluated against Omnigent `TOOL_CALL`-phase policies **before** they run.

Previously the executor only *observed* these calls in the SDK stream (`ToolUseBlock` → `ToolCallRequest`), which posts no policy event, so they bypassed policy entirely. There was no per-tool TOOL_CALL gate in the claude-sdk path at all, because the only `can_use_tool` callback was installed solely for non-`bypassPermissions` modes — and the claude-sdk harness defaults to `bypassPermissions`.

## Where the gate lives

`omnigent/inner/claude_sdk_executor.py`:

- **`_evaluate_tool_call_policy(tool_name, tool_input)`** — the policy half. Builds `{"name": <full SDK tool name>, "arguments": <tool_input>}` and runs it through the existing `_policy_evaluator` bridge (`TurnContext.evaluate_policy("PHASE_TOOL_CALL", ...)`). Honors the hard verdict: `POLICY_ACTION_DENY` → `PermissionResultDeny(reason)`; otherwise returns `None` (fall through / allow). Since the server collapses a TOOL_CALL `ASK` to a hard `ALLOW`/`DENY` (`/policies/evaluate`), the callback only handles the hard verdict.
- **`_can_use_tool_gate(...)`** — the unified `options.can_use_tool` callback. Runs the TOOL_CALL policy gate in **every** permission mode (including `bypassPermissions`); a DENY short-circuits. ALLOW / no-match falls through with **no human interaction**. The pre-existing human-consent elicitation step still only runs in non-`bypassPermissions` modes.
- **Wiring** in `run_turn`: the gate is now installed whenever *either* a `_policy_evaluator` *or* an elicitation handler is wired — instead of only for non-bypass modes. This is the line that makes default (bypass) sessions gate connector-native calls.

## Double-evaluation decision

`mcp__omnigent__*` tools (Omnigent's own tools + spec-declared MCP tools, both surfaced through the single `omnigent` SDK MCP server) are **explicitly skipped** in the gate. When the model calls one, it round-trips through the dispatch bridge (`_stable_tool_executor` → `TurnContext.dispatch_tool` → `action_required`) and the runner re-dispatches it via `ProxyMcpManager`, which **already enforces `TOOL_CALL` + `TOOL_RESULT` policy server-side** before forwarding to `/mcp/execute` (see `omnigent/runner/app.py`: *"All tool calls go through AP:/mcp … which enforces TOOL_CALL + TOOL_RESULT policies server-side"*). Gating them here too would double-count the same call (and could double-charge a cost-budget checkpoint). The skip and rationale are documented in code comments on `_evaluate_tool_call_policy`. Only the connector-native / out-of-band tools the dispatch path never sees are gated here.

## Tests

Added `TestToolCallPolicyGate` in `tests/inner/test_claude_sdk_executor.py` (8 tests):

- (a) a connector-native name (`mcp__github__issue_write`) triggers a `PHASE_TOOL_CALL` evaluation with the SDK-native name + arguments;
- (b) a `DENY` verdict returns `PermissionResultDeny` with the policy reason and never reaches elicitation;
- (c) an `ALLOW` verdict (and the no-policy-evaluator/no-match case) allows the call with **no human prompt** under `bypassPermissions`;
- (d) `mcp__omnigent__*` is skipped (no double-evaluation);
- non-bypass mode still defers to the human-consent elicitation after a policy ALLOW;
- the gate **is** installed under `bypassPermissions` when a policy evaluator is wired, and is **not** installed when neither evaluator nor handler is present.

## Gates run (touched files)

```
.venv/bin/python -m pytest tests/inner/test_claude_sdk_executor.py
  → 92 passed
.venv/bin/python -m pytest tests/runtime/harnesses/
  → 95 passed
.venv/bin/python -m ruff check omnigent/inner/claude_sdk_executor.py tests/inner/test_claude_sdk_executor.py
  → All checks passed!
.venv/bin/python -m ruff format --check <same files>
  → 2 files already formatted
```

Typecheck: mypy is configured in `pyproject.toml` but is **not** an enforced CI gate (it is absent from `.pre-commit-config.yaml`; only referenced in a stale comment in `lint.yml`). Running mypy on the file reports `explicit-any` / `unused-ignore` on the new `Any`-typed SDK-boundary annotations — but the **pre-existing** analogous method `_can_use_tool_for_permission` produces the identical pattern (`# type: ignore[explicit-any]` on the opaque `ToolPermissionContext` / `PermissionResult` boundaries). The new code mirrors that established convention exactly, adding no net-new error class.

## Note on end-to-end behavior

This installs `options.can_use_tool` under `bypassPermissions` per the requirement. Whether the bundled CLI actually delivers `can_use_tool` control requests to the SDK under `bypassPermissions` for connector-native tools should be confirmed with a live session — the unit tests prove the callback logic and that it is wired, not the CLI's delivery behavior.
