### PR TITLE
fix(merge-ready): require write access for /merge comment command

### DIFF
--- a/.github/scripts/merge-ready/authorize-merge-comment.sh
+++ b/.github/scripts/merge-ready/authorize-merge-comment.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Authorizes a `/merge` slash command by the commenter's repo access.
+#
+# `/merge` only enables auto-merge / direct-merges an already-mergeable
+# PR -- branch protection still blocks red or unreviewed PRs -- so the
+# bar is repo write access, not the stricter MAINTAINER set that gates
+# `force-merge`. This keeps `/merge` usable by the whole team while
+# blocking outside contributors and drive-by accounts.
+#
+# The job-level `if` already pre-filters on author_association as a
+# cheap first pass; this is the authoritative check, because an org
+# MEMBER does not necessarily have write on this specific repo. The
+# permission API resolves effective access (team grants, etc.).
+#
+# Env in: GH_TOKEN, REPO, AUTHOR, PR
+# Out:    authorized=true|false on $GITHUB_OUTPUT. On false, posts a
+#         reply comment explaining the rejection.
+
+set -euo pipefail
+
+# Effective permission for the commenter: admin|maintain|write|triage|read|none
+set +e
+PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null)
+RC=$?
+set -e
+
+if [[ $RC -ne 0 ]]; then
+  # 403/404 => not a collaborator with resolvable permission.
+  PERM="none"
+fi
+
+case "$PERM" in
+  admin|maintain|write)
+    echo "authorized=true" >> "$GITHUB_OUTPUT"
+    echo "Authorized: @$AUTHOR has '$PERM' access."
+    ;;
+  *)
+    echo "authorized=false" >> "$GITHUB_OUTPUT"
+    echo "::notice::@$AUTHOR has '$PERM' access; /merge requires write."
+    gh pr comment "$PR" --repo "$REPO" \
+      --body ":no_entry: \`/merge\` from @$AUTHOR ignored -- it requires write access to this repository."
+    ;;
+esac

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -5,8 +5,12 @@ name: Merge Ready
 # inside this workflow defines what backs it.
 #
 # Per trigger:
-#   /merge comment   always evaluate, post green or red, enable GitHub
-#                    auto-merge, drop a sticky comment.
+#   /merge comment   from a commenter with write access only: evaluate,
+#                    post green or red, enable GitHub auto-merge, drop a
+#                    sticky comment. Comments from users without write
+#                    access are ignored (author_association pre-filter
+#                    on the job, authoritative permission-API check
+#                    before any merge action).
 #   pull_request     skipped unless PR has `automerge` label. With
 #                    label, evaluate and post green or red. When the
 #                    `automerge` label was just added (action=labeled),
@@ -101,7 +105,12 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         contains(github.event.comment.body, '/merge') &&
-        !endsWith(github.actor, '[bot]')
+        !endsWith(github.actor, '[bot]') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -252,10 +261,27 @@ jobs:
             -f description="$DESC" >/dev/null
           echo "Posted Merge Ready=$STATE on $SHA ($DESC)"
 
-      - name: Enable auto-merge on /merge
+      # Authoritative authorization for /merge: the job `if` pre-filters
+      # on author_association, but an org MEMBER may lack write on this
+      # repo, so confirm effective write access via the permission API
+      # before any merge action runs.
+      - name: Authorize /merge commenter
+        id: authz
         if: >-
           github.event_name == 'issue_comment' &&
           steps.ctx.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.comment.user.login }}
+          PR: ${{ steps.ctx.outputs.pr }}
+        run: bash .github/scripts/merge-ready/authorize-merge-comment.sh
+
+      - name: Enable auto-merge on /merge
+        if: >-
+          github.event_name == 'issue_comment' &&
+          steps.ctx.outputs.skip != 'true' &&
+          steps.authz.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem

The `issue_comment` path in `merge-ready.yml` admitted **any** non-`[bot]` commenter whose body contained `/merge`, with no authorization check — while running in base context with `contents:write` / `pull-requests:write`. Any GitHub user could comment `/merge` on a PR to:

- enable GitHub auto-merge,
- trigger the **direct-merge fallback** on an already-mergeable PR, and
- delete the branch (`--delete-branch`).

Branch protection caps the worst case (can't merge red/unreviewed PRs), but enabling auto-merge, force-merging an already-green PR on someone else's behalf, and branch deletion are privileged actions that were reachable by anyone who could comment.

## Fix

Gate the `/merge` comment path on **repo write access**. That's the right bar for `/merge` — it only *enables* auto-merge and branch protection still blocks red/unreviewed PRs — as opposed to the stricter `MAINTAINER` set used by `force-merge`. This keeps `/merge` usable by the whole team while shutting out outside contributors and drive-by accounts.

Two layers of defense:
1. **`author_association` pre-filter** on the job `if` (`OWNER`/`MEMBER`/`COLLABORATOR`) so unauthorized comments don't even spin up a runner.
2. **Authoritative permission-API check** (`authorize-merge-comment.sh`) before any merge action — an org `MEMBER` may lack write on this specific repo, so we confirm effective access via `GET repos/{repo}/collaborators/{user}/permission` and require `admin`/`maintain`/`write`. On rejection it posts a `:no_entry:` reply and the merge step is skipped.

## Verification

Suggested live smoke test once merged: comment `/merge` from a non-write account on a test PR and confirm the `:no_entry:` reply appears and no merge is attempted.