### PR TITLE
test(e2e_ui): cover Agents tab and sub-agent navigation

### DIFF
--- a/tests/e2e_ui/agents/conftest.py
+++ b/tests/e2e_ui/agents/conftest.py
@@ -1,0 +1,183 @@
+"""Fixtures for the Agents-rail / sub-agent e2e UI journeys.
+
+Reuses the session-scoped ``live_server`` (and its runner) from the
+parent ``tests/e2e_ui/conftest.py``; this module only adds the
+sub-agent spec fixtures the ``agents/`` tests need.
+
+The parent agent here (a "joke director") is forbidden from telling
+jokes itself: each joke lives ONLY in one of its two inline
+``type: agent`` comedian sub-agents, tagged with a per-run nonce. A
+joke's nonce reaching the parent's bubbles can therefore only have
+traveled through a real ``sys_session_send`` round trip (dispatch,
+sub-agent turn, inbox auto-wake) — never from the parent's own world
+knowledge. Two distinct comedians means two distinct child sessions,
+which is what the Agents-rail tests assert on.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import tarfile
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+
+# Private helpers from the parent conftest — same import pattern the
+# sibling chat tests use for ``open_right_rail`` / ``TwoAgentChatSession``.
+from tests.e2e_ui.conftest import _ensure_runner_online, _server_state
+
+_JOKE_DIRECTOR_NAME = "joke_director"
+
+
+@dataclass(frozen=True)
+class JokeSubagentsSession:
+    """Handle for the two-comedian "joke director" session fixture.
+
+    :param base_url: Spawned server base URL, e.g. ``"http://127.0.0.1:51234"``.
+    :param session_id: The runner-bound parent session id, e.g. ``"conv_abc123"``.
+    :param code_one: Per-run nonce only ``comic_one``'s joke carries,
+        e.g. ``"scarecrow-3a7f9c2e1b"``.
+    :param code_two: Per-run nonce only ``comic_two``'s joke carries,
+        e.g. ``"sleepmode-9c2e1b3a7f"``.
+    """
+
+    base_url: str
+    session_id: str
+    code_one: str
+    code_two: str
+
+
+def _joke_director_yaml(code_one: str, code_two: str) -> str:
+    """Build the joke-director spec (parent + two comedian sub-agents).
+
+    Mirrors the omnigent-flavored inline ``type: agent`` shape parsed by
+    ``omnigent/inner/loader.py:_parse_tool`` (same as the Hitchhiker's
+    fixture in the parent conftest). The parent must dispatch to BOTH
+    comedians and relay their jokes verbatim; each joke's nonce appears
+    only in that comedian's prompt, so a nonce in the parent's reply
+    proves a real two-agent round trip rather than a model-invented joke.
+
+    :param code_one: Per-run nonce in ``comic_one``'s canned joke and nowhere else.
+    :param code_two: Per-run nonce in ``comic_two``'s canned joke and nowhere else.
+    :returns: YAML text ready for bundle upload.
+    """
+    return f"""\
+name: {_JOKE_DIRECTOR_NAME}
+prompt: |
+  You are a joke director coordinating two stand-up comedian sub-agents:
+  `comic_one` and `comic_two`. You are NOT funny and you must NEVER write
+  or guess a joke yourself — only your comedians tell jokes.
+
+  When the user asks you to get some jokes, you MUST do exactly this:
+
+  1. Call `sys_session_send` to ask your `comic_one` sub-agent to tell a joke.
+  2. Call `sys_session_send` to ask your `comic_two` sub-agent to tell a joke.
+
+  Then end your turn and wait; do not poll. When the comedians' replies
+  arrive in your inbox, relay BOTH jokes to the user VERBATIM — repeat
+  every word and every code exactly as written, without omitting or
+  altering anything.
+
+  You have exactly ONE of each comedian. If a comedian sub-agent already
+  exists, send any follow-up to that SAME sub-agent session — NEVER spawn
+  a second `comic_one` or `comic_two`.
+
+executor:
+  model: databricks-gpt-5-4
+  harness: openai-agents
+
+tools:
+  comic_one:
+    type: agent
+    description: First stand-up comedian. Tells exactly one joke when asked.
+    executor:
+      model: databricks-gpt-5-4
+      harness: openai-agents
+    prompt: |
+      You are a stand-up comedian. When asked for a joke, reply with
+      exactly this and nothing else:
+
+      Why did the scarecrow win an award? Because he was outstanding in
+      his field. Joke code: {code_one}.
+  comic_two:
+    type: agent
+    description: Second stand-up comedian. Tells exactly one joke when asked.
+    executor:
+      model: databricks-gpt-5-4
+      harness: openai-agents
+    prompt: |
+      You are a stand-up comedian. When asked for a joke, reply with
+      exactly this and nothing else:
+
+      I told my computer I needed a break, and now it will not stop
+      sending me KitKats. Joke code: {code_two}.
+"""
+
+
+@pytest.fixture
+def joke_subagents_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[JokeSubagentsSession]:
+    """Create a runner-bound session for the two-comedian joke director.
+
+    Same runner-respawn + bind contract as ``two_agent_chat_session`` in
+    the parent conftest. Yields the per-run nonces so a test can assert
+    that the sub-agents' jokes (and only the sub-agents') reached the UI.
+
+    :param live_server: Spawned server fixture from the parent conftest.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: A :class:`JokeSubagentsSession` handle.
+    """
+    code_one = f"scarecrow-{uuid.uuid4().hex[:10]}"
+    code_two = f"kitkat-{uuid.uuid4().hex[:10]}"
+    yaml_text = _joke_director_yaml(code_one, code_two)
+    respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+
+    yaml_bytes = yaml_text.encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        # Non-config.yaml arcname routes the bundle through the omnigent
+        # compat adapter, whose loader parses the inline `type: agent`
+        # tools. The spec_version:1 parser does not accept this shorthand.
+        info = tarfile.TarInfo(name=f"{_JOKE_DIRECTOR_NAME}.yaml")
+        info.size = len(yaml_bytes)
+        tar.addfile(info, io.BytesIO(yaml_bytes))
+    create_resp = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+
+    patch_resp = httpx.patch(
+        f"{live_server}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    patch_resp.raise_for_status()
+
+    try:
+        yield JokeSubagentsSession(
+            base_url=live_server,
+            session_id=session_id,
+            code_one=code_one,
+            code_two=code_two,
+        )
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned_runner is not None:
+            respawned_runner.terminate()
+            try:
+                respawned_runner.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned_runner.kill()
+                respawned_runner.wait(timeout=5)

--- a/tests/e2e_ui/agents/test_agents_tab.py
+++ b/tests/e2e_ui/agents/test_agents_tab.py
@@ -1,0 +1,54 @@
+"""UI journey: the right-rail Agents tab and its agent-count badge.
+
+The Agents tab is an unconditional rail tab (AppShell: "the tab is
+ALWAYS shown" — its panel always lists at least the "main" row, so an
+empty tree is a one-entry list, not a dead end). Its count badge is the
+real signal of how many agents are in the session tree:
+``agentCount = childSessions.length + 1`` (WorkspacePanel.tsx), i.e. it
+reads ``1`` for a lone agent and grows as sub-agents spawn.
+
+This test pins the lone-agent baseline: the tab is present, its badge
+reads ``1``, the panel shows the single "main" row, and there are no
+sub-agent rows. The companion ``test_subagent_navigation.py`` covers the
+multi-agent case where the badge and rows grow once sub-agents exist.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+_SUBAGENT_MAIN_ROW = '[data-testid="subagent-main-row"]'
+_SUBAGENT_ROW = '[data-testid="subagent-row"]'
+
+
+def test_agents_tab_lists_lone_agent(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A single-agent session shows the Agents tab with a count of 1.
+
+    No message is sent — the tab and its baseline count are rail state,
+    not a function of any turn — so this stays a fast, LLM-free check.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Scope every lookup to the desktop "Workspace" rail so it never
+    # matches the hidden mobile drawer that mirrors the same testids.
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    agents_tab = rail.get_by_role("tab", name=re.compile("^Agents"))
+    expect(agents_tab).to_be_visible(timeout=30_000)
+    # Badge starts at 1 for a lone agent (childSessions.length + 1).
+    expect(agents_tab).to_contain_text("1")
+
+    agents_tab.click()
+    # The panel always renders the "main" row linking back to the root,
+    # and a lone agent has no sub-agent rows beneath it.
+    expect(rail.locator(_SUBAGENT_MAIN_ROW)).to_be_visible(timeout=30_000)
+    expect(rail.locator(_SUBAGENT_ROW)).to_have_count(0)

--- a/tests/e2e_ui/agents/test_subagent_navigation.py
+++ b/tests/e2e_ui/agents/test_subagent_navigation.py
@@ -1,0 +1,123 @@
+"""UI journey: spin up two sub-agents, see them in the Agents tab, and
+navigate into one and back to the parent.
+
+The user asks the joke director (the session's top-level agent) to get a
+joke from each of its two comedian sub-agents. The director's prompt
+forbids telling jokes itself; it must `sys_session_send` to `comic_one`
+and `comic_two`, which run as two separate child sessions and auto-wake
+the director to relay their jokes back into the SPA.
+
+This single journey covers two requested behaviors, kept together so the
+heavy multi-agent spin-up (one dispatch turn + two sub-agent turns + the
+auto-wake continuation) runs only once:
+
+1. After the relay, the right-rail Agents tab lists BOTH comedians as
+   sub-agent rows and its count badge grows past the lone-agent ``1``.
+2. Clicking a sub-agent row swaps the chat page to that child's own
+   conversation (``/c/<child-id>``), and the header carries a
+   "Back to parent session" affordance that returns to the parent.
+
+The load-bearing assertions are the per-run nonces, which exist ONLY in
+each comedian's prompt (embedded at registration by the
+`joke_subagents_session` fixture): a nonce in the director's bubble can
+only have reached it via the real parent -> sub-agent -> inbox -> parent
+-> SSE -> UI pipeline, never from a model-invented joke.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.agents.conftest import JokeSubagentsSession
+from tests.e2e_ui.conftest import open_right_rail
+
+_COMPOSER = "Ask the agent anything…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_SUBAGENT_ROW = '[data-testid="subagent-row"]'
+_SUBAGENT_STATUS_DOT = '[data-testid="subagent-status-dot"]'
+
+# One relay = dispatch turn + two sub-agent turns + the auto-wake
+# continuation, several serial real-LLM calls, so the nonce assertions
+# get a generous budget (matches test_two_agent_chat.py).
+_RELAY_TIMEOUT_MS = 240_000
+
+
+def _send(page: Page, text: str) -> None:
+    """Type *text* into the composer and click Send."""
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+# Nightly: several serial real-LLM turns (dispatch + two sub-agents +
+# auto-wake continuation), too heavy and 429-sensitive for the PR gate.
+# The 600s budget overrides the suite-wide 300s default for the same
+# reason test_two_agent_chat.py uses it: FMAPI backoff stacks
+# multiplicatively across the serial turns.
+@pytest.mark.nightly
+@pytest.mark.timeout(600)
+def test_two_joke_subagents_appear_and_navigate(
+    page: Page,
+    joke_subagents_session: JokeSubagentsSession,
+) -> None:
+    chat = joke_subagents_session
+    parent_url = f"{chat.base_url}/c/{chat.session_id}"
+    page.goto(parent_url)
+
+    # Ask the director to gather a joke from each comedian sub-agent.
+    _send(
+        page,
+        "Please get one joke from comic_one and one joke from comic_two, "
+        "then tell me both jokes exactly as they said them, including each "
+        "joke code.",
+    )
+
+    # Both comedians' jokes (identified by their nonces) reached the
+    # parent transcript — proof that both sub-agents really ran and
+    # relayed back, not that the director invented jokes.
+    expect(page.locator(_ASSISTANT, has_text=chat.code_one).first).to_be_visible(
+        timeout=_RELAY_TIMEOUT_MS
+    )
+    expect(page.locator(_ASSISTANT, has_text=chat.code_two).first).to_be_visible(
+        timeout=_RELAY_TIMEOUT_MS
+    )
+
+    # (1) The Agents tab lists BOTH comedians as sub-agent rows. The rail
+    # defaults closed per session, so it is expanded first; lookups are
+    # scoped to the desktop "Workspace" rail so they don't match the
+    # hidden mobile drawer that mirrors the same testids.
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    agents_tab = rail.get_by_role("tab", name=re.compile("^Agents"))
+    agents_tab.click()
+    rows = rail.locator(_SUBAGENT_ROW)
+    expect(rows).to_have_count(2, timeout=30_000)
+    expect(rail).to_contain_text("comic_one")
+    expect(rail).to_contain_text("comic_two")
+    # Each row carries a status dot and its own child session id.
+    expect(rows.first.locator(_SUBAGENT_STATUS_DOT)).to_be_visible()
+    # The count badge grew past the lone-agent baseline of 1 (main + 2).
+    expect(agents_tab).to_contain_text("3")
+
+    # (2) Clicking a sub-agent row swaps the chat to that child's session.
+    target_row = rows.first
+    child_session_id = target_row.get_attribute("data-child-session-id")
+    assert child_session_id, "subagent row is missing data-child-session-id"
+    target_row.click()
+    page.wait_for_url(re.compile(re.escape(f"/c/{child_session_id}")))
+
+    # The header carries the back-to-parent affordance: a "Back to parent
+    # session" link pointing at the parent conversation, beside the
+    # "Sub-agent" identity caption.
+    back_link = page.get_by_role("link", name="Back to parent session")
+    expect(back_link).to_be_visible(timeout=30_000)
+    expect(back_link).to_have_attribute("href", re.compile(re.escape(f"/c/{chat.session_id}")))
+    expect(page.get_by_text("Sub-agent", exact=True)).to_be_visible()
+
+    # Following it returns to the parent session.
+    back_link.click()
+    page.wait_for_url(re.compile(re.escape(f"/c/{chat.session_id}")))


### PR DESCRIPTION
## What

Adds a new `tests/e2e_ui/agents/` package covering the right-rail **Agents** tab and sub-agent navigation — flows no existing UI test exercised end to end:

- **`test_agents_tab_lists_lone_agent`** — the Agents tab is present with a count badge of `1` for a lone agent, a single "main" row, and no sub-agent rows. No LLM turn, so it's fast.
- **`test_two_joke_subagents_appear_and_navigate`** (`@nightly`) — a "joke director" parent dispatches to two inline `type: agent` comedian sub-agents. Both jokes relay back (asserted via per-run nonces embedded only in each comedian's prompt), both surface as sub-agent rows in the Agents tab with the count badge growing to `3`, then clicking a row swaps the chat to the child's `/c/<child-id>` and verifies the header's **"Back to parent session"** link points at — and returns to — the parent.

The `joke_subagents_session` fixture mirrors the existing `two_agent_chat_session` contract (runner respawn/bind, per-run nonces).

## Notes

- Tests #2/#3 are combined into one nightly journey so the heavy multi-agent spin-up runs only once.
- The Agents tab is rendered **unconditionally** (AppShell: "the tab is ALWAYS shown"); the real per-agent signal is the count badge, so test #1 asserts the tab + baseline count of 1 rather than conditional visibility.

## Test plan

Both pass locally against a real server + LLM:

```
uv run --frozen pytest tests/e2e_ui/agents -v                 # #1  (55s)
uv run --frozen pytest tests/e2e_ui/agents -v -m nightly      # #2/#3  (2m13s)
```