### PR TITLE
test(e2e_ui): cover sidebar pin/unpin, search, rename, stop, delete

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_delete.py
+++ b/tests/e2e_ui/sessions/test_sidebar_delete.py
@@ -1,0 +1,97 @@
+"""Browser e2e for deleting a session from the sidebar.
+
+The row kebab's "Delete" item opens a confirmation dialog; confirming it
+fires the stop→``DELETE /v1/sessions/{id}`` chain
+(``useStopAndDeleteConversation``). Delete is fire-and-forget: the dialog
+closes immediately, the row shows a transient "Deleting…" status, then
+drops out of the list, and if the deleted session is the active one the
+SPA bounces back to ``/``.
+
+This asserts both halves of a real delete:
+
+  - The row is removed from the sidebar (client list converges).
+  - The session is gone from the conversation store —
+    ``GET /v1/sessions/{id}`` returns 404 — so the removal is durable,
+    not just a cache splice the next refetch would resurrect.
+
+The runner-kill half of "delete stops its runner" isn't asserted here:
+the e2e harness binds a tunneled, non-host runner, and the stop forwarded
+ahead of the delete is a no-op for the openai-agents harness (no external
+process to kill, and only host-spawned sessions stop their runner). The
+store-removal contract above is the part observable in this harness.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def test_delete_session_removes_row_and_from_store(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Deleting a session removes its row and the store row (404).
+
+    Failure modes this catches:
+
+    - The DELETE never fires (or 4xxs) so the row lingers.
+    - The row is spliced from the client cache but the server keeps the
+      conversation, so a refetch/reload would bring it back.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-delete-{uuid.uuid4().hex[:8]}"
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Open the kebab → Delete → confirm in the dialog. Hover first so the
+    # desktop hover-revealed kebab trigger is interactable.
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("delete-conversation").click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+    dialog.get_by_role("button", name="Delete", exact=True).click()
+
+    # The row drops out of the sidebar: it first swaps to a transient
+    # "Deleting…" status (no href) while the stop→DELETE chain is in
+    # flight, then unmounts entirely on success.
+    expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+    # And the deletion is durable: the conversation is gone from the
+    # store, not just spliced from the client cache. The href vanishes
+    # the moment the mutation starts (the "Deleting…" state), and the
+    # mutation runs ``stopSession`` ahead of the DELETE, so the
+    # server-side row removal lands slightly after the UI does — poll
+    # until ``GET /v1/sessions/{id}`` reports 404.
+    deadline = time.monotonic() + 15.0
+    last_status = None
+    while time.monotonic() < deadline:
+        last_status = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0).status_code
+        if last_status == 404:
+            break
+        time.sleep(0.25)
+    assert last_status == 404, (
+        f"deleted session should be gone from the store (404), got {last_status}"
+    )

--- a/tests/e2e_ui/sessions/test_sidebar_pin_unpin.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pin_unpin.py
@@ -1,0 +1,160 @@
+"""Browser e2e for the sidebar's pin / unpin quick action.
+
+Pinning is a client-side navigation preference (persisted to
+``localStorage`` under ``omnigent:pinned-conversation-ids`` — see
+``sidebarNav.ts``), surfaced as a hover/focus-revealed button on every
+conversation row (``data-testid="quick-pin-conversation"``). Toggling it
+moves the row between the sidebar's grouped sections:
+
+  - **Pin** lifts the row out of "Recent" and into a "Pinned" section
+    rendered above it (``ConversationList`` peels pinned, non-archived
+    rows into their own group — Sidebar.tsx).
+  - **Unpin** drops it back under "Recent".
+
+These drive the real chain the ``Sidebar`` unit tests mock out: the live
+``GET /v1/sessions`` list feeding ``useConversations`` → the section
+split → the row landing under the right header. The unit tests render
+the sidebar with a hand-mocked list; here the rows come from a real
+server so a regression in the list shape, the owner-vs-shared split, or
+the pinned peel would surface end-to-end.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Give a session a title via ``PATCH /v1/sessions/{id}``.
+
+    The seeded session has no title (renders as "New session"), which is
+    ambiguous when other tests' sessions accumulate in the shared server.
+    A unique title makes the row trivially identifiable in assertions
+    even though these tests locate it by its stable ``/c/{id}`` href.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The session/conversation id to rename.
+    :param title: The new title to set.
+    """
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _section(page: Page, title: str) -> Locator:
+    """Locate the sidebar ``<section>`` whose header reads *title*.
+
+    Each ``ConversationSection`` renders an ``<h2>`` with a collapse
+    button whose accessible name is the section title (e.g. "Pinned",
+    "Recent"). Scoping row assertions to the matching section is how we
+    prove a row is grouped under the right header.
+
+    :param page: Playwright page with the sidebar open.
+    :param title: Section header text, e.g. ``"Pinned"``.
+    :returns: A locator for the section element.
+    """
+    return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def test_pin_moves_session_to_pinned_section(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Pinning a Recent session lifts its row into the Pinned section.
+
+    Failure modes this catches that the mocked unit test can't:
+
+    - The live ``GET /v1/sessions`` row shape drifts so the owner split
+      drops the session out of "Recent" (it would never be pinnable).
+    - The pin toggle persists but the section peel regresses, leaving the
+      row under "Recent" after a pin.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-pin-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    # Owned, non-archived, unpinned → starts under "Recent", never
+    # "Pinned" (no Pinned section exists yet).
+    expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+    # Pin via the row's quick action. Hover first so the desktop
+    # hover-revealed control is interactable.
+    row.hover()
+    pin_button = row.get_by_test_id("quick-pin-conversation")
+    expect(pin_button).to_have_attribute("aria-label", "Pin conversation")
+    pin_button.click()
+
+    # The row now lives under "Pinned" and out of "Recent", and the
+    # quick action flips to its unpin affordance — both prove the toggle
+    # ran through the sidebar's pin state, not a local no-op.
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    expect(_row(page, session_id).get_by_test_id("quick-pin-conversation")).to_have_attribute(
+        "aria-label", "Unpin conversation"
+    )
+
+
+def test_unpin_moves_session_back_to_recent(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Unpinning a pinned session drops its row back under Recent.
+
+    Pins first (so there's something to unpin), confirms the row is under
+    "Pinned", then unpins and asserts it returns to "Recent" and the
+    "Pinned" section no longer holds it. Catches a regression where the
+    toggle is one-way (pin sticks, unpin no-ops) or the section peel
+    fails to re-home the row.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-unpin-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Pin it.
+    row.hover()
+    row.get_by_test_id("quick-pin-conversation").click()
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+
+    # Now unpin from under the Pinned header.
+    pinned_row = (
+        _section(page, "Pinned")
+        .locator("li")
+        .filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+    )
+    pinned_row.hover()
+    unpin_button = pinned_row.get_by_test_id("quick-pin-conversation")
+    expect(unpin_button).to_have_attribute("aria-label", "Unpin conversation")
+    unpin_button.click()
+
+    # Back under "Recent", and no longer in "Pinned".
+    expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)

--- a/tests/e2e_ui/sessions/test_sidebar_rename.py
+++ b/tests/e2e_ui/sessions/test_sidebar_rename.py
@@ -1,0 +1,79 @@
+"""Browser e2e for renaming a session from the sidebar.
+
+The row kebab's "Rename" item swaps the row for an inline edit field
+(``data-testid="rename-conversation-input"``); committing it (Enter)
+fires ``PATCH /v1/sessions/{id}`` with the new title. The rename is
+persisted server-side, so it must survive a full page reload — that's
+the regression this guards: a rename that only patches the in-memory
+TanStack cache (and is lost on reload) would pass the ``Sidebar`` unit
+tests, which mock the mutation, but fail here.
+
+We assert persistence two ways after a reload: the row re-renders with
+the new title from a fresh ``GET /v1/sessions``, and the server's
+own ``GET /v1/sessions/{id}`` snapshot returns it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def test_rename_session_is_preserved(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Renaming via the kebab persists across a reload and on the server.
+
+    Failure modes this catches that the mocked unit test can't:
+
+    - The PATCH never fires (or 4xxs on wire drift) so the title reverts
+      on reload.
+    - The rename only patches the client cache and is lost once the
+      sidebar refetches ``GET /v1/sessions`` after a reload.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    new_title = f"e2e-renamed-{uuid.uuid4().hex[:8]}"
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Open the row kebab and pick Rename. Hover first so the desktop
+    # hover-revealed kebab trigger is interactable.
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("rename-conversation").click()
+
+    # The inline edit field replaces the row; type the new title + Enter.
+    edit = page.get_by_test_id("rename-conversation-input")
+    expect(edit).to_be_visible()
+    edit.fill(new_title)
+    edit.press("Enter")
+
+    # The row reflects the new title immediately (optimistic cache patch).
+    expect(page.locator(f'a[href="/c/{session_id}"]')).to_contain_text(new_title)
+
+    # Reload: the sidebar refetches GET /v1/sessions from scratch. A
+    # rename that only lived in the client cache would revert here.
+    page.reload()
+    expect(page.locator(f'a[href="/c/{session_id}"]')).to_contain_text(new_title)
+
+    # And the server agrees — the rename was persisted, not just rendered.
+    snap = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    snap.raise_for_status()
+    assert snap.json().get("title") == new_title, (
+        f"server should persist the renamed title {new_title!r}, got {snap.json().get('title')!r}"
+    )

--- a/tests/e2e_ui/sessions/test_sidebar_search.py
+++ b/tests/e2e_ui/sessions/test_sidebar_search.py
@@ -1,0 +1,72 @@
+"""Browser e2e for the sidebar's session search box.
+
+The search input (``aria-label="Search sessions"``) debounces keystrokes
+(~300 ms) and forwards the query to the server as
+``GET /v1/sessions?search_query=…`` — filtering is server-side, a
+case-insensitive substring match on the session title or conversation
+content (see ``list_sessions`` in ``routes/sessions.py``). A matching
+query keeps the row; a non-matching one drops it and the list falls to
+its "No matching conversations" empty state.
+
+This drives the full chain the ``useConversations`` unit test can't: the
+debounce → the ``?search_query=`` round trip → the re-rendered list. A
+regression in the query param wiring, the debounce, or the empty-state
+copy would surface here.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from playwright.sync_api import Page, expect
+
+
+def test_search_filters_sessions(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Typing a query narrows the list to matching sessions and back.
+
+    Sets a unique title on the seeded session, then asserts the
+    round-trip both ways:
+
+    - A query matching the title keeps the row visible.
+    - A query that matches nothing drops the row and surfaces the
+      "No matching conversations" empty state.
+
+    The unique marker (a uuid) can't collide with other tests' sessions
+    in the shared server, so the non-matching assertion is deterministic.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    marker = uuid.uuid4().hex[:12]
+    title = f"e2e-search-{marker}"
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = page.locator(f'a[href="/c/{session_id}"]')
+    search = page.get_by_role("searchbox", name="Search sessions")
+    # Baseline: with no query the row is listed.
+    expect(row).to_be_visible()
+
+    # A query that matches nothing empties the list (debounce + server
+    # round trip resolve within the default expect timeout).
+    no_match = f"zzz-no-match-{uuid.uuid4().hex[:12]}"
+    search.fill(no_match)
+    expect(row).to_have_count(0)
+    expect(page.get_by_text("No matching conversations")).to_be_visible()
+
+    # A query matching the title brings the row back — proving the box
+    # filters server-side on the title, not just hides everything.
+    search.fill(marker)
+    expect(row).to_be_visible()

--- a/tests/e2e_ui/sessions/test_sidebar_stop.py
+++ b/tests/e2e_ui/sessions/test_sidebar_stop.py
@@ -1,0 +1,112 @@
+"""Browser e2e: a stopped session surfaces the reconnect affordance.
+
+What "stop session" looks like to the user is the agent going away: the
+runner tunnel drops, the open chat flips to ``local_stranded`` liveness
+(not host-bound → no host to relaunch it), and the composer area swaps in
+the "Agent disconnected — click to reconnect" banner
+(``data-testid="disconnected-indicator"``). Clicking it opens the
+reconnect dialog with the exact ``omnigent run … --resume <id>`` command
+to bring the session back from the user's own machine.
+
+The e2e harness binds a tunneled, non-host runner, so the sidebar kebab's
+"Stop session" item — gated to host-spawned / claude-native sessions by
+``isSessionStoppable`` — isn't offered, and a forwarded ``stop_session``
+is a no-op for the openai-agents harness (no external process, and only
+host-spawned sessions stop their runner). The observable that the same
+liveness chain produces is reproduced here by dropping the runner
+directly, then asserting the disconnected → click → reconnect-dialog flow
+(the dialog half is not covered by ``test_stale_stream``, which kills the
+runner mid-stream and only checks the banner text).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+
+import httpx
+from playwright.sync_api import Page, expect
+
+
+def _find_runner_pids() -> list[int]:
+    """Find PIDs of the runner entry point (``omnigent.runner._entry``).
+
+    The runner is a sibling subprocess of the server (both spawned by the
+    fixture), so we match on the command line rather than the parent PID.
+
+    :returns: List of runner PIDs (may be empty).
+    """
+    result = subprocess.run(
+        ["pgrep", "-f", "omnigent.runner._entry"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [int(line.strip()) for line in result.stdout.strip().splitlines() if line.strip()]
+
+
+def test_stopped_session_shows_reconnect_affordance(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A dropped runner flips the open chat to the reconnect banner + dialog.
+
+    Waits for the frontend's ``/health`` poll to observe the runner online
+    first (so the ``starting`` cold-boot grace can't mask the drop — once a
+    runner has been seen online, a later offline is a real disconnect),
+    kills the runner, then asserts:
+
+    - the "Agent disconnected — click to reconnect" banner appears, and
+    - clicking it opens the reconnect dialog carrying the session's
+      ``--resume`` command.
+
+    Killing the shared runner is order-independent: the ``seeded_session``
+    fixture respawns it for the next test (same contract as
+    ``test_stale_stream``).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+
+    # Confirm the frontend observed the runner ONLINE via a successful
+    # /health poll before we kill it. Without this the freshly created
+    # session could still be inside its 45s cold-boot grace, which would
+    # render "Connecting…" instead of the reconnect banner. The health
+    # poller fires on mount and reschedules every ~10s; capturing one
+    # successful poll proves the frontend saw runner_online=true.
+    with page.expect_response(
+        lambda r: "/health" in r.url and "session_id" in r.url and r.status == 200,
+        timeout=15_000,
+    ):
+        page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(composer).to_be_visible()
+
+    health = httpx.get(f"{base_url}/health?session_id={session_id}", timeout=5).json()
+    assert health.get("session", {}).get("runner_online") is True, (
+        f"runner should be online before the kill, got: {health}"
+    )
+
+    runner_pids = _find_runner_pids()
+    assert runner_pids, "no runner processes found to stop"
+    for pid in runner_pids:
+        os.kill(pid, signal.SIGKILL)
+
+    # The health poll fires every 10s; the banner flips on the next poll
+    # that reads runner_online=false. Budget generously past one interval.
+    indicator = page.get_by_test_id("disconnected-indicator")
+    expect(indicator).to_be_visible(timeout=30_000)
+    expect(indicator).to_contain_text(re.compile("disconnected", re.IGNORECASE))
+
+    # Clicking it opens the reconnect dialog with the resume command the
+    # user runs to bring the stopped session back.
+    indicator.click()
+    dialog = page.get_by_test_id("reconnect-session-dialog")
+    expect(dialog).to_be_visible()
+    expect(dialog).to_contain_text(session_id)


### PR DESCRIPTION
## Summary

Adds browser e2e coverage under `tests/e2e_ui/sessions/` for the left sidebar's conversation-row flows. Each test drives the real server chain (spawned `omnigent server` + runner + built SPA) that the mocked `Sidebar` unit tests can't exercise.

| Test | File | What it drives |
|------|------|----------------|
| pin → **Pinned** section | `test_sidebar_pin_unpin.py` | quick-pin button moves a row out of **Recent** into **Pinned**; aria-label flips to "Unpin" |
| unpin → back to **Recent** | `test_sidebar_pin_unpin.py` | pin then unpin returns the row to **Recent**, gone from **Pinned** |
| search filters sessions | `test_sidebar_search.py` | `?search_query=` round-trips both ways (no-match → empty state; match → row restored) |
| rename preserved | `test_sidebar_rename.py` | kebab → Rename → Enter, then **reload** + a `GET /v1/sessions/{id}` check prove it's persisted server-side |
| delete | `test_sidebar_delete.py` | row removed **and** session gone from the store (polled to **404**) |
| stop → reconnect | `test_sidebar_stop.py` | a dropped runner surfaces "Agent disconnected — click to reconnect" and opens the reconnect dialog with the `--resume` command |

## Note on stop / delete scope

The e2e harness binds a **tunneled, non-host** runner, so the "Stop session" kebab item (gated to host-spawned/claude-native sessions) and the runner-kill side effects aren't reachable as-is:

- **Stop:** asserts the harness-observable behavior — dropping the runner produces the same `local_stranded` liveness a real stop yields, surfacing the "click to reconnect" banner + dialog.
- **Delete:** asserts the verifiable half — row removed + store returns 404. The runner-kill half isn't observable (non-host runner stays online); documented in the test docstring rather than asserted.

## Verification

Ran locally with `uv run --frozen` (builds the SPA, spawns the server + runner): **6/6 passed**. `ruff check` + `ruff format` clean.