### PR TITLE
test(e2e_ui): cover file-panel markdown alerts, autosave, link sharing, and search

### DIFF
--- a/tests/e2e_ui/files/test_all_filter.py
+++ b/tests/e2e_ui/files/test_all_filter.py
@@ -1,0 +1,95 @@
+"""E2E: the All-mode "files to include / exclude" glob filters narrow search.
+
+In the All (folder-tree) scope the search bar has a filters toggle that
+reveals VSCode-style "files to include" / "files to exclude" glob inputs
+(see ``SearchFilterInput`` in ``FilesPanel.tsx``). Per
+``useWorkspaceFileSearch`` the globs only *narrow an active text query* —
+they don't search on their own — so the test always types a query first,
+then applies a glob and asserts the results shrink accordingly.
+
+Files sharing a "report" fragment but split across ``.py`` / ``.txt``
+extensions are seeded so an include/exclude glob isolates one extension.
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PY_A = "report_alpha.py"
+_PY_B = "report_beta.py"
+_TXT_C = "report_gamma.txt"
+_ALL_FILES = (_PY_A, _PY_B, _TXT_C)
+
+
+def _seed_file(base_url: str, session_id: str, path: str) -> None:
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        json={"content": f"contents of {path}\n", "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+@pytest.fixture
+def seeded_filter_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    for path in _ALL_FILES:
+        _seed_file(base_url, session_id, path)
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def _row(rail: Locator, name: str) -> Locator:
+    return rail.get_by_role("button", name=re.compile(re.escape(name))).filter(has_text=name)
+
+
+def test_all_mode_include_exclude_filters_narrow_search(
+    page: Page,
+    seeded_filter_session: tuple[str, str],
+) -> None:
+    """An include glob then an exclude glob narrow the All-mode search results."""
+    base_url, session_id = seeded_filter_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    search = rail.get_by_role("searchbox", name="Search all files")
+    expect(search).to_be_visible(timeout=30_000)
+
+    # Unfiltered query matches all three "report*" files.
+    search.fill("report")
+    for path in _ALL_FILES:
+        expect(_row(rail, path)).to_be_visible(timeout=15_000)
+
+    # Reveal the glob filter inputs.
+    rail.get_by_role("button", name="Show search filters").click()
+    include = rail.get_by_role("textbox", name="files to include")
+    exclude = rail.get_by_role("textbox", name="files to exclude")
+    expect(include).to_be_visible()
+    expect(exclude).to_be_visible()
+
+    # Include only *.py → the .txt file drops out (globs are debounced ~300ms).
+    include.fill("*.py")
+    expect(_row(rail, _PY_A)).to_be_visible(timeout=15_000)
+    expect(_row(rail, _PY_B)).to_be_visible()
+    expect(_row(rail, _TXT_C)).to_have_count(0)
+
+    # Clear include, switch to excluding *.py → now only the .txt remains.
+    include.fill("")
+    exclude.fill("*.py")
+    expect(_row(rail, _TXT_C)).to_be_visible(timeout=15_000)
+    expect(_row(rail, _PY_A)).to_have_count(0)
+    expect(_row(rail, _PY_B)).to_have_count(0)

--- a/tests/e2e_ui/files/test_file_autosave.py
+++ b/tests/e2e_ui/files/test_file_autosave.py
@@ -1,0 +1,164 @@
+"""E2E: file edits auto-save without an explicit Save action.
+
+The FileViewer has no Save button — both editor surfaces (TipTap for
+markdown, Monaco for everything else) debounce edits and write them back
+through ``PUT .../filesystem/{path}`` automatically (see
+``useEditorAutoSave``). These tests drive a real edit in each surface and
+prove the change reaches the server:
+
+  1. A status indicator returns to "Saved" after the edit settles
+     (the markdown toolbar pill / the Monaco toolbar chip).
+  2. A fresh ``GET .../filesystem/{path}`` returns the edited content.
+
+Both are seeded via the filesystem PUT endpoint (no agent run), so the
+tests are deterministic.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# Files land in ``<repo-root>/<session_id>/`` (the agent spec uses
+# ``os_env.cwd: .``), so clean that per-session dir up in teardown.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _cleanup_session_workdir(session_id: str) -> None:
+    shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def _seed_file(base_url: str, session_id: str, path: str, content: str) -> None:
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        json={"content": content, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _read_file(base_url: str, session_id: str, path: str) -> str:
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return resp.json()["content"]
+
+
+def _wait_for_persisted(
+    base_url: str,
+    session_id: str,
+    path: str,
+    needle: str,
+    timeout_s: float = 15.0,
+) -> str:
+    """Poll the file-content endpoint until ``needle`` lands (auto-save)."""
+    deadline = time.monotonic() + timeout_s
+    last = ""
+    while time.monotonic() < deadline:
+        last = _read_file(base_url, session_id, path)
+        if needle in last:
+            return last
+        time.sleep(0.5)
+    raise AssertionError(
+        f"auto-save never persisted {needle!r} to {path}; last server content:\n{last}"
+    )
+
+
+_MARKDOWN_PATH = "autosave_doc.md"
+_MARKDOWN_CONTENT = """\
+# Auto Save Doc
+
+A paragraph that will be edited in the rich-text editor.
+"""
+
+_PY_PATH = "autosave_module.py"
+_PY_CONTENT = """\
+def greet(name):
+    return "hello " + name
+"""
+
+
+@pytest.fixture
+def seeded_markdown(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    _seed_file(base_url, session_id, _MARKDOWN_PATH, _MARKDOWN_CONTENT)
+    try:
+        yield (base_url, session_id)
+    finally:
+        _cleanup_session_workdir(session_id)
+
+
+@pytest.fixture
+def seeded_python(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    _seed_file(base_url, session_id, _PY_PATH, _PY_CONTENT)
+    try:
+        yield (base_url, session_id)
+    finally:
+        _cleanup_session_workdir(session_id)
+
+
+def test_markdown_edit_autosaves(page: Page, seeded_markdown: tuple[str, str]) -> None:
+    """Typing in the markdown rich-text editor auto-saves back to the server."""
+    base_url, session_id = seeded_markdown
+    page.goto(f"{base_url}/c/{session_id}?file={_MARKDOWN_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    editor = file_viewer.locator("[contenteditable='true']")
+    expect(editor).to_be_visible(timeout=10_000)
+    expect(editor).to_contain_text("A paragraph that will be edited")
+
+    # The save pill starts at "Saved" (clean). Type a unique sentinel at the
+    # end of the document; the pill must transition through dirty back to
+    # "Saved" and the edited markdown must reach the server.
+    sentinel = "autosaved-md-sentinel-7f3a"
+    editor.click()
+    page.keyboard.press("Control+End")
+    page.keyboard.type(f" {sentinel}")
+
+    # The markdown editor toolbar's auto-save pill settles back to the saved
+    # state. Its accessible name is the button's title ("All changes saved"),
+    # not the short visible label.
+    expect(file_viewer.get_by_role("button", name="All changes saved")).to_be_visible(
+        timeout=15_000
+    )
+
+    persisted = _wait_for_persisted(base_url, session_id, _MARKDOWN_PATH, sentinel)
+    assert sentinel in persisted
+
+
+def test_non_markdown_edit_autosaves(page: Page, seeded_python: tuple[str, str]) -> None:
+    """Typing in the Monaco code editor auto-saves back to the server."""
+    base_url, session_id = seeded_python
+    page.goto(f"{base_url}/c/{session_id}?file={_PY_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    # Non-markdown files render in Monaco (lazy-loaded). Wait for the editor.
+    monaco = file_viewer.locator(".monaco-editor")
+    expect(monaco).to_be_visible(timeout=20_000)
+    expect(file_viewer.locator(".view-lines")).to_contain_text("greet", timeout=10_000)
+
+    # Place the cursor at the start of the buffer and type a comment line. A
+    # leading edit is unambiguous and easy to assert in the persisted file.
+    sentinel = "autosaved_py_sentinel_9c2b"
+    file_viewer.locator(".view-lines").click()
+    page.keyboard.press("Control+Home")
+    page.keyboard.type(f"# {sentinel}\n")
+
+    # The FileViewer toolbar shows the Monaco auto-save status chip; it
+    # settles back to "Saved" once the debounced write lands.
+    expect(file_viewer.get_by_text("Saved", exact=True)).to_be_visible(timeout=15_000)
+
+    persisted = _wait_for_persisted(base_url, session_id, _PY_PATH, sentinel)
+    assert sentinel in persisted

--- a/tests/e2e_ui/files/test_file_link_sharing.py
+++ b/tests/e2e_ui/files/test_file_link_sharing.py
@@ -1,0 +1,98 @@
+"""E2E: the FileViewer "Copy link to file" button yields a shareable URL.
+
+The toolbar's copy-link action writes ``window.location.href`` (carrying
+``?file=<path>``) to the clipboard and flashes a "Copied!" confirmation
+(see ``copyFileLink`` in ``FileViewer.tsx``). A shared link is only useful
+if a *fresh* browser session that opens it lands on the same file, so this
+test:
+
+  1. Opens a seeded file, clicks Copy link, and asserts the clipboard holds
+     a URL with the file's ``?file=`` param.
+  2. Opens that exact URL in a brand-new browser context (no shared storage
+     — i.e. "open in a new browser") and asserts the file viewer rehydrates
+     with the real file content.
+
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FILE_PATH = "shareable_note.md"
+_FILE_BODY = "Unique shareable body that proves a fresh session fetched the file."
+_FILE_CONTENT = f"""\
+# Shareable Note
+
+{_FILE_BODY}
+"""
+
+
+@pytest.fixture
+def seeded_shareable_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_FILE_PATH}",
+        json={"content": _FILE_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def test_copy_link_is_shareable_in_a_new_browser(
+    page: Page,
+    browser: Browser,
+    seeded_shareable_session: tuple[str, str],
+) -> None:
+    """Copy link → clipboard URL → opens the file in a fresh browser context."""
+    base_url, session_id = seeded_shareable_session
+    # Clipboard read/write needs explicit permission in headless Chromium.
+    page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+    page.goto(f"{base_url}/c/{session_id}?file={_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    expect(file_viewer.get_by_text(_FILE_BODY).first).to_be_visible(timeout=20_000)
+
+    # Click the copy-link toolbar action and confirm the "Copied!" feedback
+    # (the button swaps to a check icon; its tooltip becomes "Copied!").
+    copy_btn = file_viewer.get_by_role("button", name="Copy link to file")
+    expect(copy_btn).to_be_visible()
+    copy_btn.click()
+
+    clipboard = page.evaluate("() => navigator.clipboard.readText()")
+    assert re.search(rf"[?&]file={re.escape(_FILE_PATH)}", clipboard), (
+        f"clipboard URL {clipboard!r} does not carry ?file={_FILE_PATH}"
+    )
+    assert session_id in clipboard, f"clipboard URL {clipboard!r} missing session id"
+
+    # Open the copied link in a brand-new context — no cookies, no localStorage,
+    # i.e. a different browser. The file must rehydrate purely from the URL.
+    fresh_context = browser.new_context()
+    try:
+        fresh_page = fresh_context.new_page()
+        fresh_page.goto(clipboard)
+        fresh_viewer = fresh_page.locator('[data-testid="file-viewer"]:visible')
+        expect(fresh_viewer).to_be_visible(timeout=20_000)
+        expect(
+            fresh_page.get_by_role("button", name=f"Close {_FILE_PATH}", exact=True).first
+        ).to_be_visible()
+        expect(fresh_viewer.get_by_text(_FILE_BODY).first).to_be_visible(timeout=20_000)
+    finally:
+        fresh_context.close()

--- a/tests/e2e_ui/files/test_file_search.py
+++ b/tests/e2e_ui/files/test_file_search.py
@@ -1,0 +1,83 @@
+"""E2E: the Files-panel search box filters the All-files tree.
+
+In the All (folder-tree) scope the search field runs a server-side recursive
+``/search`` call and renders the matches as a flat list (``useWorkspaceFileSearch``
+→ ``FolderTree`` search mode). Three files with distinguishing name fragments are
+seeded so a query can isolate a subset and exclude the rest.
+
+Note on scope: the *Changed* scope's search filters the changed-files list, which
+in this e2e harness can only be populated by a git workspace or the agent's
+``sys_os_write`` tool — neither is reachable deterministically here (the seeded
+temp workspace is non-git, and the openai-agents harness writes outside the
+web-visible ``default`` environment). The Changed-list filter is covered by the
+``FlatFileList`` component test instead. This e2e pins the server-backed All search.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Two share the "alpha" fragment; one is "beta" — a query is unambiguous.
+_ALPHA_ONE = "alpha_one.py"
+_ALPHA_TWO = "alpha_two.py"
+_BETA = "beta_three.txt"
+_ALL_FILES = (_ALPHA_ONE, _ALPHA_TWO, _BETA)
+
+
+def _put_file(base_url: str, session_id: str, path: str) -> None:
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        json={"content": f"contents of {path}\n", "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+@pytest.fixture
+def all_search_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Three files PUT to the workspace so they populate the All tree listing."""
+    base_url, session_id = seeded_session
+    for path in _ALL_FILES:
+        _put_file(base_url, session_id, path)
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def _row(rail: Locator, name: str) -> Locator:
+    return rail.get_by_role("button", name=re.compile(re.escape(name))).filter(has_text=name)
+
+
+def test_search_filters_all_files(
+    page: Page,
+    all_search_session: tuple[str, str],
+) -> None:
+    """Typing in the All search box runs the server search and lists matches."""
+    base_url, session_id = all_search_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    search = rail.get_by_role("searchbox", name="Search all files")
+    expect(search).to_be_visible(timeout=30_000)
+
+    # Server-side recursive search (debounced ~300ms): only beta matches.
+    search.fill("beta_three")
+    expect(_row(rail, _BETA)).to_be_visible(timeout=15_000)
+    expect(_row(rail, _ALPHA_ONE)).to_have_count(0)
+    expect(_row(rail, _ALPHA_TWO)).to_have_count(0)
+
+    # Re-querying for the shared fragment surfaces both alpha files.
+    search.fill("alpha_")
+    expect(_row(rail, _ALPHA_ONE)).to_be_visible(timeout=15_000)
+    expect(_row(rail, _ALPHA_TWO)).to_be_visible()
+    expect(_row(rail, _BETA)).to_have_count(0)

--- a/tests/e2e_ui/files/test_markdown_github_alerts.py
+++ b/tests/e2e_ui/files/test_markdown_github_alerts.py
@@ -1,0 +1,113 @@
+"""E2E: GitHub alert callouts render in the markdown rich-text editor.
+
+Counterpart to ``test_markdown_rich_rendering.py`` (which covers headings,
+lists, code blocks, tables, links and plain blockquotes): this pins the
+GitHub-flavored *alert* construct — a blockquote whose first line is a
+``[!NOTE]`` / ``[!TIP]`` / ``[!IMPORTANT]`` / ``[!WARNING]`` / ``[!CAUTION]``
+marker. The ``GitHubAlertBlockquote`` TipTap extension turns those into
+typed callouts carrying ``data-alert-type`` / ``data-alert-label`` attrs
+(see ``TipTapGitHubAlert.ts``), distinct from a plain blockquote.
+
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_MARKDOWN_FILE_PATH = "alerts.md"
+
+# One blockquote per GitHub alert type, plus a plain blockquote that must
+# stay un-typed (no data-alert-type), so the test proves the marker — not
+# blockquotes in general — is what produces the callout.
+_MARKDOWN_CONTENT = """\
+# Alert Gallery
+
+> [!NOTE]
+> Highlights information that users should take into account.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention.
+
+> [!CAUTION]
+> Negative potential consequences of an action.
+
+> A plain blockquote with no alert marker.
+"""
+
+
+@pytest.fixture
+def seeded_alerts_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_MARKDOWN_FILE_PATH}",
+        json={"content": _MARKDOWN_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def test_github_alerts_render_as_typed_callouts(
+    page: Page,
+    seeded_alerts_session: tuple[str, str],
+) -> None:
+    """Each ``[!TYPE]`` blockquote renders as a typed alert; plain quotes don't."""
+    base_url, session_id = seeded_alerts_session
+    page.goto(f"{base_url}/c/{session_id}?file={_MARKDOWN_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    editor = file_viewer.locator("[contenteditable='true']")
+    expect(editor).to_be_visible(timeout=10_000)
+
+    # Every alert type renders as a blockquote tagged with its lowercase
+    # data-alert-type and human-readable data-alert-label.
+    expected = {
+        "note": "Note",
+        "tip": "Tip",
+        "important": "Important",
+        "warning": "Warning",
+        "caution": "Caution",
+    }
+    for alert_type, label in expected.items():
+        callout = editor.locator(f'blockquote[data-alert-type="{alert_type}"]')
+        expect(callout).to_have_count(1)
+        expect(callout).to_have_attribute("data-alert-label", label)
+
+    # The marker text itself is consumed — the rendered callout shows the body,
+    # never the raw "[!NOTE]" syntax.
+    note = editor.locator('blockquote[data-alert-type="note"]')
+    expect(note).to_contain_text("Highlights information")
+    expect(note).not_to_contain_text("[!NOTE]")
+
+    # The plain blockquote stays an ordinary blockquote — no alert typing.
+    plain = editor.locator("blockquote:not([data-alert-type])").filter(
+        has_text="A plain blockquote"
+    )
+    expect(plain).to_have_count(1)
+
+    # Source toggle: the raw markers are visible verbatim in the source view.
+    file_viewer.get_by_role("button", name="Source view").click()
+    expect(file_viewer.locator("[contenteditable='true']")).to_have_count(0)
+    expect(file_viewer.get_by_text("[!WARNING]", exact=False)).to_be_visible(timeout=10_000)


### PR DESCRIPTION
## What

Adds browser e2e coverage in `tests/e2e_ui/files/` for FileViewer / Files-panel surfaces that previously had no end-to-end test. All five tests pass locally against a spawned server + built SPA.

| Test | Covers |
|------|--------|
| `test_markdown_github_alerts.py` | `[!NOTE]/[!TIP]/[!IMPORTANT]/[!WARNING]/[!CAUTION]` render as typed alert callouts in the rich-text editor; a plain blockquote stays untyped; raw markers show verbatim in source view. (Tables / code blocks / bullets already covered by `test_markdown_rich_rendering.py`.) |
| `test_file_autosave.py` | Edits in the TipTap markdown editor **and** the Monaco code editor auto-save with no Save button — asserted via the saved-state indicator and a server-side content poll. |
| `test_file_link_sharing.py` | "Copy link to file" writes a shareable URL to the clipboard, which opens the same file in a **fresh browser context**. |
| `test_file_search.py` | All-mode search runs the server-side recursive `/search` and narrows the result list. |
| `test_all_filter.py` | All-mode "files to include / exclude" glob filters narrow an active search (`*.py` include, then exclude). |

All seed via the filesystem `PUT` endpoint (no LLM run) except where noted, matching the existing `files/` test style.

## Not covered here (and why)

The **Changed-mode search**, **Changed-mode sort**, and **changed-files diff** were requested but are not feasible as e2e tests in this harness:

- The e2e_ui session workspace is a **non-git temp dir**, so its changed-files registry is the snapshot-backed (non-git) variant, created/cached at session setup.
- `PUT` seeding lands in the All-files listing but is **not** attributed to the changed-files registry (the `changes` endpoint returns `[]`).
- The agent's `sys_os_write` *does* attribute writes, but the `openai-agents` harness runs the agent in a TUI terminal that writes **outside** the web-visible `default` environment — so agent writes also never reach the web Changed list.

These surfaces stay covered by the `FlatFileList` / `MonacoDiffViewer` component tests and the backend `test_filesystem_changed_files_e2e.py`.

> Side note from the investigation: the `PUT .../filesystem` handler records changes on the **shared** runner registry while the `changes` endpoint reads the **per-session** registry, so user PUT writes never surface in a non-git session's Changed list. May be an unintended product gap worth a separate look.

## Test plan

```
uv run --frozen pytest tests/e2e_ui/files/test_markdown_github_alerts.py \
  tests/e2e_ui/files/test_file_autosave.py \
  tests/e2e_ui/files/test_file_link_sharing.py \
  tests/e2e_ui/files/test_file_search.py \
  tests/e2e_ui/files/test_all_filter.py
# 6 passed
```