### PR TITLE
fix(e2e_ui): --argjson is a jq flag, not a gh api flag

### DIFF
--- a/.github/scripts/e2e-ui-required/check.sh
+++ b/.github/scripts/e2e-ui-required/check.sh
@@ -90,9 +90,10 @@ fi
 # the others, keeping the prompt representative across many-file PRs. A final
 # head -c is an overall backstop for PRs with very many files.
 MAX_PATCH_LINES=400
+# `gh api --paginate` (no --jq) merges all pages into one JSON array; pipe that
+# to jq so --argjson reaches jq (gh api itself has no --argjson flag).
 DIFF_BLOB=$(gh api "repos/$REPO/pulls/$PR/files" --paginate \
-  --argjson max "$MAX_PATCH_LINES" \
-  --jq '.[]
+  | jq -r --argjson max "$MAX_PATCH_LINES" '.[]
     | select(.filename | startswith("ap-web/") or startswith("tests/e2e_ui/"))
     | (.patch // "(no textual patch -- binary or too large)") as $p
     | ($p | split("\n")) as $lines


### PR DESCRIPTION
## Problem

The per-file patch truncation added in #128 passed `--argjson` to `gh api`:

```
gh api ... --paginate --argjson max "$MAX_PATCH_LINES" --jq '...'
```

`gh api` has no `--argjson` flag (that's a **jq** flag), so the step errored with `unknown flag: --argjson`, exited 1, and the gate **hard-failed before ever reaching the judge** — breaking `E2E UI Required` on every `ap-web/**` PR.

Caught by the test PR #133, where the check failed with an infra error instead of the expected observe-only warning.

## Fix

`gh api --paginate` (without `--jq`) already merges all pages into a single JSON array. Pipe that to a real `jq --argjson` instead:

```
gh api ... --paginate | jq -r --argjson max "$MAX_PATCH_LINES" '...'
```

Verified the jq pipeline locally: long patches truncate with a marker, short patches pass through, non-UI files are filtered out.