### PR TITLE
Add deploy/kubernetes/ (#39): server manifests + on-cluster host stopgap

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -64,6 +64,12 @@ deploy/
 │   ├── modal_app.py
 │   └── README.md
 │
+├── kubernetes/        ← Kubernetes manifests (server Deployment + on-cluster
+│   ├── server/           `omnigent host` stopgap for agent compute)
+│   ├── host/
+│   ├── README.md
+│   └── SKILL.md
+│
 ├── trycloudflare/     ← Cloudflare quick tunnel (public URL for a LOCAL server)
 │   └── README.md
 │
@@ -92,7 +98,8 @@ deploy/
 | Deploy to Modal (durable artifact Volume) | Modal | [`modal/README.md`](modal/README.md): `modal deploy`, BYO Neon Postgres |
 | Stand up a quick demo (no DB to provision) | HF Spaces | [`hf-spaces/README.md`](hf-spaces/README.md): Docker Space, SQLite |
 | Share a server running on your **laptop**: demo it to teammates, or let remote runners & cloud sandboxes connect back to it (nothing to deploy) | Cloudflare quick tunnel | `cloudflared tunnel --url http://localhost:6767` |
-| Cloud Run / Kubernetes / other | Docker image | [`docker/README.md`](docker/README.md), then point your platform at the image |
+| Deploy to Kubernetes (server + on-cluster host) | Kubernetes manifests | [`kubernetes/README.md`](kubernetes/README.md): `kubectl apply` the `server/` manifests (built-in accounts auth by default) |
+| Cloud Run / other | Docker image | [`docker/README.md`](docker/README.md), then point your platform at the image |
 
 All deploy paths share the same image (`docker/Dockerfile`): a slim Python
 container running the FastAPI / WebSocket coordinator, with Postgres or

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -13,50 +13,63 @@ A reference deployment for running Omnigent on a Kubernetes cluster, in two part
 
 > Extracted and generalized from a working homelab K3s deployment. Everything
 > here is environment-agnostic with placeholders — adapt the namespace, image
-> tag, domain, Postgres, OIDC, storage class, and Ingress to your cluster.
+> tag, domain, Postgres, auth, storage class, and Ingress to your cluster.
 
 ## The gap this addresses (`omnigent-ai/omnigent#39`)
 
-Omnigent does **not** auto-discover Kubernetes nodes as agent compute, and the
-server's managed-sandbox backends are lakebox / Modal / Daytona — **there is no
-Kubernetes backend yet**. So "run the agents on my K8s cluster" isn't a config
-flag today; it's the runner-on-K8s gap.
+Omnigent already has **managed sandboxes** with a pluggable `sandbox.provider`
+(see [`deploy/README.md`](../README.md#run-hosts-in-cloud-sandboxes)) — the
+server can provision a sandbox per session and run the agent there. The shipped
+providers are **lakebox / Modal / Daytona**. What's missing is a **Kubernetes
+sandbox provider**: there's no `sandbox.provider: kubernetes` that spawns runner
+Pods on your own cluster. So "run the agents as Pods on my K8s cluster" isn't a
+config flag today — that one provider is the gap.
 
-The proper fix is a **server-side Kubernetes sandbox launcher** that spawns
-runner Pods on demand (via the existing launch-token seam). Until that lands,
-`host/` is a pragmatic workaround: it runs the **`omnigent host` daemon** in a
-pod, which dials the server's `/v1/runner/tunnel` (**outbound only**) and spawns
-Claude Code / Codex runners locally on that node. One Deployment per node you
-want as compute.
+The proper fix is a **server-side Kubernetes sandbox provider** that spawns
+runner Pods on demand (via the existing launch-token seam, exactly like the
+Modal/Daytona providers do). Until that lands, `host/` is a pragmatic
+workaround: it runs the **`omnigent host` daemon** in a pod, which dials the
+server's `/v1/runner/tunnel` (**outbound only**) and spawns Claude Code / Codex
+runners locally on that node. One Deployment per node you want as compute.
 
 This deployment is offered as a starting point for that work — it proves the
 server runs cleanly on K8s and demonstrates the host-on-cluster pattern that a
-native launcher would replace.
+native Kubernetes provider would replace.
 
 ## Architecture
 
 ```
-  Browser ──OIDC──▶ omnigent server (Deployment, unprivileged)   ◀── host(s) dial in
-                       │   external-runners-only                     (/v1/runner/tunnel,
-                       │   /v1/runner/tunnel  ◀──────────────────┐    outbound only)
-                       ├─ Postgres (DATABASE_URL)                │
-                       └─ artifact PVC (/data)             omnigent host (Deployment, host/)
-                                                           runs the agentic-dev toolchain +
-                                                           spawns Claude/Codex runners locally
+  Browser ──HTTP──▶ omnigent server (Deployment, unprivileged)
+                       │   external-runners-only
+                       │   accepts host/runner WS at /v1/runner/tunnel ◀──┐
+                       ├─ Postgres (DATABASE_URL)                         │  outbound only
+                       └─ artifact PVC (/data)                           │
+                                                                          │
+                                            omnigent host (Deployment, host/)
+                                            runs the prebaked host image +
+                                            spawns Claude/Codex runners locally
 ```
 
 ## Quickstart
 
+Default auth is the built-in **`accounts`** provider (multi-user,
+username/password, no external IdP; first boot auto-creates an admin — password
+in the pod logs). Prefer your own IdP? See the opt-in OIDC block in
+`server/deployment.yaml`.
+
 ```bash
 # 1. Server
-kubectl create namespace omnigent
-# edit server/secret.example.yaml (DATABASE_URL + OIDC) -> apply as a real Secret
+kubectl apply -f server/namespace.yaml
+# edit server/secret.example.yaml (database-url + accounts-cookie-secret) -> apply as a real Secret
 kubectl apply -f server/secret.example.yaml      # or your sealed-secrets/SOPS/ESO equivalent
 kubectl apply -f server/configmap.yaml
 kubectl apply -f server/pvc.yaml
 kubectl apply -f server/deployment.yaml
 kubectl apply -f server/service.yaml
 kubectl apply -f server/ingress.example.yaml     # adapt to your ingress controller
+
+# first-boot admin password (accounts mode):
+kubectl -n omnigent logs deploy/omnigent | grep -A4 "Created initial admin"
 
 # 2. (optional, stopgap) agent compute on the cluster — see host/README.md
 kubectl apply -f host/secret.example.yaml        # the host's session + harness tokens
@@ -66,16 +79,22 @@ kubectl apply -f host/host.yaml
 ## Notes that bit us (worth knowing)
 
 - **Image is `linux/amd64`-only** → `nodeSelector: kubernetes.io/arch: amd64`.
-  The host bootstrap also can't run on arm64 (`omnigent==0.1.0` →
+  The host image can't run on arm64 either (`omnigent==0.1.0` →
   `cel-expr-python` has no aarch64-linux wheel).
 - **Alembic migrations run in the entrypoint** — no migration Job/initContainer.
 - **`DATABASE_URL`** can be any Postgres; the entrypoint normalizes
   `postgresql://` → `postgresql+psycopg://`.
-- **OIDC `email_verified`**: Omnigent rejects logins where `email_verified != true`.
+- **Auth (default = accounts):** set `OMNIGENT_AUTH_ENABLED=1` +
+  `OMNIGENT_ACCOUNTS_COOKIE_SECRET` + `OMNIGENT_ACCOUNTS_BASE_URL` (the public
+  URL). First boot creates an admin with a random password (in the logs + on the
+  PVC at `/data/admin-credentials`); pin it with
+  `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD` for headless deploys.
+- **OIDC (opt-in):** Omnigent rejects logins where `email_verified != true`.
   Some IdPs (e.g. Authentik's default OpenID `email` scope mapping) emit
   `email_verified: false` — make your IdP assert `true`.
 - **Session TTL**: a connecting *host* authenticates with the JWT from
   `omnigent login`; the default 8h expiry breaks a long-lived host on reconnect.
-  Raise `OMNIGENT_OIDC_SESSION_TTL_HOURS` (e.g. 720 = 30d) for unattended hosts.
+  Raise `OMNIGENT_ACCOUNTS_SESSION_TTL_HOURS` (or `OMNIGENT_OIDC_SESSION_TTL_HOURS`
+  under OIDC) — e.g. 720 = 30d — for unattended hosts.
 
 See `server/deployment.yaml` and `host/host.yaml` for inline detail.

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,81 @@
+# Omnigent on Kubernetes
+
+A reference deployment for running Omnigent on a Kubernetes cluster, in two parts:
+
+- **`server/`** — the Omnigent **server** (the meta-harness hub) as a `Deployment`.
+  This is straightforward: per the OSS entrypoint the server runs in
+  *external-runners-only* mode (it accepts runner connections at
+  `/v1/runner/tunnel` and never spawns harness subprocesses itself), so the pod
+  is **unprivileged**.
+- **`host/`** — a **stopgap** that runs the `omnigent host` daemon as a
+  `Deployment` *on the cluster*, so cluster nodes become agent compute. See the
+  gap below.
+
+> Extracted and generalized from a working homelab K3s deployment. Everything
+> here is environment-agnostic with placeholders — adapt the namespace, image
+> tag, domain, Postgres, OIDC, storage class, and Ingress to your cluster.
+
+## The gap this addresses (`omnigent-ai/omnigent#39`)
+
+Omnigent does **not** auto-discover Kubernetes nodes as agent compute, and the
+server's managed-sandbox backends are lakebox / Modal / Daytona — **there is no
+Kubernetes backend yet**. So "run the agents on my K8s cluster" isn't a config
+flag today; it's the runner-on-K8s gap.
+
+The proper fix is a **server-side Kubernetes sandbox launcher** that spawns
+runner Pods on demand (via the existing launch-token seam). Until that lands,
+`host/` is a pragmatic workaround: it runs the **`omnigent host` daemon** in a
+pod, which dials the server's `/v1/runner/tunnel` (**outbound only**) and spawns
+Claude Code / Codex runners locally on that node. One Deployment per node you
+want as compute.
+
+This deployment is offered as a starting point for that work — it proves the
+server runs cleanly on K8s and demonstrates the host-on-cluster pattern that a
+native launcher would replace.
+
+## Architecture
+
+```
+  Browser ──OIDC──▶ omnigent server (Deployment, unprivileged)   ◀── host(s) dial in
+                       │   external-runners-only                     (/v1/runner/tunnel,
+                       │   /v1/runner/tunnel  ◀──────────────────┐    outbound only)
+                       ├─ Postgres (DATABASE_URL)                │
+                       └─ artifact PVC (/data)             omnigent host (Deployment, host/)
+                                                           runs the agentic-dev toolchain +
+                                                           spawns Claude/Codex runners locally
+```
+
+## Quickstart
+
+```bash
+# 1. Server
+kubectl create namespace omnigent
+# edit server/secret.example.yaml (DATABASE_URL + OIDC) -> apply as a real Secret
+kubectl apply -f server/secret.example.yaml      # or your sealed-secrets/SOPS/ESO equivalent
+kubectl apply -f server/configmap.yaml
+kubectl apply -f server/pvc.yaml
+kubectl apply -f server/deployment.yaml
+kubectl apply -f server/service.yaml
+kubectl apply -f server/ingress.example.yaml     # adapt to your ingress controller
+
+# 2. (optional, stopgap) agent compute on the cluster — see host/README.md
+kubectl apply -f host/secret.example.yaml        # the host's session + harness tokens
+kubectl apply -f host/host.yaml
+```
+
+## Notes that bit us (worth knowing)
+
+- **Image is `linux/amd64`-only** → `nodeSelector: kubernetes.io/arch: amd64`.
+  The host bootstrap also can't run on arm64 (`omnigent==0.1.0` →
+  `cel-expr-python` has no aarch64-linux wheel).
+- **Alembic migrations run in the entrypoint** — no migration Job/initContainer.
+- **`DATABASE_URL`** can be any Postgres; the entrypoint normalizes
+  `postgresql://` → `postgresql+psycopg://`.
+- **OIDC `email_verified`**: Omnigent rejects logins where `email_verified != true`.
+  Some IdPs (e.g. Authentik's default OpenID `email` scope mapping) emit
+  `email_verified: false` — make your IdP assert `true`.
+- **Session TTL**: a connecting *host* authenticates with the JWT from
+  `omnigent login`; the default 8h expiry breaks a long-lived host on reconnect.
+  Raise `OMNIGENT_OIDC_SESSION_TTL_HOURS` (e.g. 720 = 30d) for unattended hosts.
+
+See `server/deployment.yaml` and `host/host.yaml` for inline detail.

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -6,7 +6,8 @@ A reference deployment for running Omnigent on a Kubernetes cluster, in two part
   This is straightforward: per the OSS entrypoint the server runs in
   *external-runners-only* mode (it accepts runner connections at
   `/v1/runner/tunnel` and never spawns harness subprocesses itself), so the pod
-  is **unprivileged**.
+  needs **no special privileges** — an ordinary container (no `privileged`, no
+  `CAP_SYS_ADMIN`, no host access), unlike the host daemon below.
 - **`host/`** — a **stopgap** that runs the `omnigent host` daemon as a
   `Deployment` *on the cluster*, so cluster nodes become agent compute. See the
   gap below.
@@ -39,7 +40,7 @@ native Kubernetes provider would replace.
 ## Architecture
 
 ```
-  Browser ──HTTP──▶ omnigent server (Deployment, unprivileged)
+  Browser ──HTTP──▶ omnigent server (Deployment, ordinary container)
                        │   external-runners-only
                        │   accepts host/runner WS at /v1/runner/tunnel ◀──┐
                        ├─ Postgres (DATABASE_URL)                         │  outbound only
@@ -53,26 +54,38 @@ native Kubernetes provider would replace.
 ## Quickstart
 
 Default auth is the built-in **`accounts`** provider (multi-user,
-username/password, no external IdP; first boot auto-creates an admin — password
-in the pod logs). Prefer your own IdP? See the opt-in OIDC block in
-`server/deployment.yaml`.
+username/password, no external IdP). Omnigent **never auto-generates** an admin
+password: for a headless deploy set `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD` in
+the Secret; otherwise create the first admin via the one-time web setup form on
+first visit (`/v1/info` reports `needs_setup` until then). Prefer your own IdP?
+See the opt-in OIDC block in `server/deployment.yaml`.
 
 ```bash
 # 1. Server
 kubectl apply -f server/namespace.yaml
-# edit server/secret.example.yaml (database-url + accounts-cookie-secret) -> apply as a real Secret
-kubectl apply -f server/secret.example.yaml      # or your sealed-secrets/SOPS/ESO equivalent
-kubectl apply -f server/configmap.yaml
+
+# Build the Secret from real values (do NOT apply the example as-is — it's
+# placeholders). See server/secret.example.yaml, or use sealed-secrets/SOPS/ESO.
+kubectl -n omnigent create secret generic omnigent-secrets \
+  --from-literal=database-url='postgresql://user:pass@host:5432/omnigent' \
+  --from-literal=accounts-cookie-secret="$(openssl rand -hex 32)"
+  # + --from-literal=accounts-admin-password='...'  for a headless first admin
+
+kubectl apply -f server/configmap.yaml           # edit admins/allowed_domains first
 kubectl apply -f server/pvc.yaml
 kubectl apply -f server/deployment.yaml
 kubectl apply -f server/service.yaml
 kubectl apply -f server/ingress.example.yaml     # adapt to your ingress controller
 
-# first-boot admin password (accounts mode):
-kubectl -n omnigent logs deploy/omnigent | grep -A4 "Created initial admin"
+# First admin (accounts mode): sign in with the accounts-admin-password you set
+# above. If you didn't set one, open the URL and use the one-time web setup form.
 
-# 2. (optional, stopgap) agent compute on the cluster — see host/README.md
-kubectl apply -f host/secret.example.yaml        # the host's session + harness tokens
+# 2. (optional, stopgap) agent compute on the cluster — see host/README.md.
+# Build the host Secret from real files (auth_tokens.json MUST come via
+# --from-file — a hand-written entry without expires_at reads as expired):
+kubectl -n omnigent create secret generic omnigent-host \
+  --from-file=auth_tokens.json="$HOME/.omnigent/auth_tokens.json" \
+  --from-literal=claude-oauth-token="$(claude setup-token)"
 kubectl apply -f host/host.yaml
 ```
 
@@ -86,9 +99,9 @@ kubectl apply -f host/host.yaml
   `postgresql://` → `postgresql+psycopg://`.
 - **Auth (default = accounts):** set `OMNIGENT_AUTH_ENABLED=1` +
   `OMNIGENT_ACCOUNTS_COOKIE_SECRET` + `OMNIGENT_ACCOUNTS_BASE_URL` (the public
-  URL). First boot creates an admin with a random password (in the logs + on the
-  PVC at `/data/admin-credentials`); pin it with
-  `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD` for headless deploys.
+  URL). Omnigent never auto-generates an admin password: set
+  `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD` (from the Secret) for a headless first
+  admin, or create it via the one-time web setup form on first visit.
 - **OIDC (opt-in):** Omnigent rejects logins where `email_verified != true`.
   Some IdPs (e.g. Authentik's default OpenID `email` scope mapping) emit
   `email_verified: false` — make your IdP assert `true`.

--- a/deploy/kubernetes/SKILL.md
+++ b/deploy/kubernetes/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: deploy-kubernetes
+description: Deploy the Omnigent server to a Kubernetes cluster (Deployment + Service + Ingress + PVC + Postgres-via-DATABASE_URL), and optionally run agent compute on the cluster via the `omnigent host` stopgap. Invoke when the user wants to apply the manifests, adapt them to their cluster (namespace, image tag, domain, auth, storage class, ingress controller), debug the server or host pod, or work on the Kubernetes-sandbox-provider gap (omnigent-ai/omnigent#39).
+---
+
+# Run Omnigent on Kubernetes
+
+The manifests here deploy the Omnigent **server** — the FastAPI / WebSocket
+coordinator from the shared `deploy/docker/Dockerfile` (`omnigent-server`
+image) — as a plain `Deployment`. The server runs "external-runner only": it
+accepts runner connections at `/v1/runner/tunnel` and never executes agent
+harnesses itself, so the pod is **unprivileged**. Runners live elsewhere — a
+laptop, a managed sandbox (Modal/Daytona), or the on-cluster `host/` stopgap.
+
+Auth defaults to the built-in **`accounts`** provider (multi-user
+username/password, first-boot admin, no external IdP), matching the deploy
+default everywhere else. OIDC is an opt-in block in `server/deployment.yaml`.
+
+`host/` is a **stopgap** for the missing piece: Omnigent has managed sandboxes
+with a pluggable `sandbox.provider` (lakebox/Modal/Daytona) but **no
+`kubernetes` provider** — that gap is `omnigent-ai/omnigent#39`. Until a
+server-side Kubernetes sandbox provider lands, `host/` runs the `omnigent host`
+daemon in a pod (booting the prebaked `omnigent-host` image) so a cluster node
+becomes agent compute.
+
+## TL;DR — bring it up
+
+```bash
+cd deploy/kubernetes
+kubectl apply -f server/namespace.yaml
+# edit server/secret.example.yaml (database-url + accounts-cookie-secret), then:
+kubectl apply -f server/secret.example.yaml      # or sealed-secrets / SOPS / ESO
+kubectl apply -f server/configmap.yaml server/pvc.yaml \
+               server/deployment.yaml server/service.yaml \
+               server/ingress.example.yaml       # adapt the Ingress to your controller
+kubectl -n omnigent rollout status deploy/omnigent
+kubectl -n omnigent logs deploy/omnigent | grep -A4 "Created initial admin"   # admin password
+```
+
+Server answers on the Service (`omnigent:8000`) and at your Ingress host
+(`OMNIGENT_ACCOUNTS_BASE_URL`). Sign in with the admin password from the logs.
+
+## Files
+
+| | |
+|---|---|
+| `server/namespace.yaml` | The `omnigent` Namespace. Apply first. |
+| `server/deployment.yaml` | The server `Deployment`. amd64 nodeSelector (image is linux/amd64-only), accounts auth env by default (OIDC block commented in-line), `DATABASE_URL` from the Secret, `/health` readiness+liveness probes, artifact PVC at `/data`, config ConfigMap at `/etc/omnigent`. The single source for which env vars the server reads — mirrors `deploy/docker/.env.example`. |
+| `server/secret.example.yaml` | EXAMPLE Secret template (`omnigent-secrets`): `database-url` + `accounts-cookie-secret` (default), `oidc-client-secret` / `oidc-cookie-secret` (opt-in, commented). DO NOT commit real values — manage with sealed-secrets/SOPS/ESO/Vault. |
+| `server/configmap.yaml` | Non-secret server config (`config.yaml`: `admins`, `allowed_domains`) — the same YAML `omnigent server -c` reads, loaded via `OMNIGENT_CONFIG`. Gates *authorization* (the IdP/accounts flow gates *authentication*). |
+| `server/service.yaml` | ClusterIP `Service` → port 8000. |
+| `server/ingress.example.yaml` | Generic `networking.k8s.io/v1` Ingress (host → `omnigent:8000`, TLS). Adapt to your controller (or use a controller CRD: Traefik IngressRoute, Contour HTTPProxy, …). Host must match `OMNIGENT_ACCOUNTS_BASE_URL` (and the OIDC redirect URI if you opt into OIDC). |
+| `server/pvc.yaml` | `ReadWriteOnce` PVC for the artifact store at `/data`. Set your `storageClassName`. |
+| `host/host.yaml` | The on-cluster `omnigent host` stopgap (#39): a Deployment + PVC running the prebaked `omnigent-host` image. One per node you want as compute (distinct `metadata.name` + `spec.hostname` + `nodeSelector`). |
+| `host/secret.example.yaml` | EXAMPLE Secret (`omnigent-host`): the `omnigent login` `auth_tokens.json` (via `--from-file`, NOT inline — it must carry `expires_at`) + harness tokens (`CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_ACCESS_TOKEN`). |
+| `host/README.md` | The host stopgap walkthrough: prebaked image, token minting, and the security trust-boundary note. |
+
+## Iterating on the deploy
+
+```bash
+# Re-apply after editing a manifest
+kubectl apply -f server/deployment.yaml
+
+# Roll the server (e.g. after a Secret/ConfigMap change it doesn't auto-watch)
+kubectl -n omnigent rollout restart deploy/omnigent
+kubectl -n omnigent rollout status  deploy/omnigent
+
+# Tear down (PVC retains the artifact store + accounts DB unless you delete it)
+kubectl delete -f server/ -f host/        # then: kubectl delete pvc -n omnigent --all
+```
+
+## Common debugging
+
+| Symptom | Likely cause | First check |
+|---|---|---|
+| Pod `Pending`, never schedules | No amd64 node, or the PVC can't bind | `kubectl -n omnigent describe pod -l app=omnigent` — look for the nodeSelector or `FailedScheduling`/`unbound PersistentVolumeClaim` event; set a real `storageClassName` in `pvc.yaml`. |
+| `CrashLoopBackOff` at startup, accounts error | Missing/short cookie secret or bad base URL | Logs show `OMNIGENT_ACCOUNTS_COOKIE_SECRET must be …` (needs 64 hex chars — `openssl rand -hex 32`) or `OMNIGENT_ACCOUNTS_BASE_URL must start with http:// or https://`. |
+| `CrashLoopBackOff`, `psycopg.OperationalError` | `DATABASE_URL` wrong/unreachable | `kubectl -n omnigent get secret omnigent-secrets -o jsonpath='{.data.database-url}' | base64 -d` and verify the Postgres host/creds; first boot over a remote DB is slow (migrations). |
+| Can't find the admin password | Random password only printed once | `kubectl -n omnigent logs deploy/omnigent | grep -A4 "Created initial admin"`, or read `/data/admin-credentials` on the PVC; pre-seed with `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD`. |
+| OIDC login bounces / "email present but email_verified is not true" | IdP asserts `email_verified: false` | Make the IdP emit `email_verified: true` (e.g. override Authentik's default `email` scope mapping). |
+| Web UI loads but new chats hang forever | Expected — runners are external | Launch a runner (`omnigent run … --server <url>`) or bring up `host/`. |
+| On-cluster host never connects | `auth_tokens.json` missing `expires_at` (treated as expired) | `--from-file` the real `~/.omnigent/auth_tokens.json`; don't hand-write a `{"token": …}`-only body. See `host/secret.example.yaml`. |
+
+## Extending / the #39 gap
+
+The right long-term fix is a **`sandbox.provider: kubernetes`** that the server
+uses to spawn runner Pods on demand — the same launch-token seam the Modal and
+Daytona providers already use — replacing the `host/` stopgap. Until then,
+replicate `host/host.yaml` (Deployment + PVC, distinct `spec.hostname` +
+`nodeSelector`) per node you want as compute.
+
+## Related skills + docs
+
+- [`deploy/README.md`](../README.md) — the deploy-options menu.
+- [`deploy/docker/SKILL.md`](../docker/SKILL.md) — the shared image both the
+  server and host targets are built from.
+- `host/README.md` — the on-cluster host stopgap (security note included).

--- a/deploy/kubernetes/SKILL.md
+++ b/deploy/kubernetes/SKILL.md
@@ -9,8 +9,9 @@ The manifests here deploy the Omnigent **server** — the FastAPI / WebSocket
 coordinator from the shared `deploy/docker/Dockerfile` (`omnigent-server`
 image) — as a plain `Deployment`. The server runs "external-runner only": it
 accepts runner connections at `/v1/runner/tunnel` and never executes agent
-harnesses itself, so the pod is **unprivileged**. Runners live elsewhere — a
-laptop, a managed sandbox (Modal/Daytona), or the on-cluster `host/` stopgap.
+harnesses itself, so the pod needs **no special privileges** (an ordinary
+container). Runners live elsewhere — a laptop, a managed sandbox
+(Modal/Daytona), or the on-cluster `host/` stopgap.
 
 Auth defaults to the built-in **`accounts`** provider (multi-user
 username/password, first-boot admin, no external IdP), matching the deploy
@@ -28,17 +29,22 @@ becomes agent compute.
 ```bash
 cd deploy/kubernetes
 kubectl apply -f server/namespace.yaml
-# edit server/secret.example.yaml (database-url + accounts-cookie-secret), then:
-kubectl apply -f server/secret.example.yaml      # or sealed-secrets / SOPS / ESO
+# Build the Secret (don't apply the example as-is — it's placeholders). See
+# server/secret.example.yaml, or use sealed-secrets / SOPS / ESO:
+kubectl -n omnigent create secret generic omnigent-secrets \
+  --from-literal=database-url='postgresql://user:pass@host:5432/omnigent' \
+  --from-literal=accounts-cookie-secret="$(openssl rand -hex 32)"
 kubectl apply -f server/configmap.yaml server/pvc.yaml \
                server/deployment.yaml server/service.yaml \
                server/ingress.example.yaml       # adapt the Ingress to your controller
 kubectl -n omnigent rollout status deploy/omnigent
-kubectl -n omnigent logs deploy/omnigent | grep -A4 "Created initial admin"   # admin password
+# First admin: set accounts-admin-password in the Secret, or use the one-time web
+# setup form on first visit (omnigent never auto-generates a password).
 ```
 
 Server answers on the Service (`omnigent:8000`) and at your Ingress host
-(`OMNIGENT_ACCOUNTS_BASE_URL`). Sign in with the admin password from the logs.
+(`OMNIGENT_ACCOUNTS_BASE_URL`). Sign in as the admin you set via
+`accounts-admin-password` (or created in the web setup form).
 
 ## Files
 
@@ -47,7 +53,7 @@ Server answers on the Service (`omnigent:8000`) and at your Ingress host
 | `server/namespace.yaml` | The `omnigent` Namespace. Apply first. |
 | `server/deployment.yaml` | The server `Deployment`. amd64 nodeSelector (image is linux/amd64-only), accounts auth env by default (OIDC block commented in-line), `DATABASE_URL` from the Secret, `/health` readiness+liveness probes, artifact PVC at `/data`, config ConfigMap at `/etc/omnigent`. The single source for which env vars the server reads — mirrors `deploy/docker/.env.example`. |
 | `server/secret.example.yaml` | EXAMPLE Secret template (`omnigent-secrets`): `database-url` + `accounts-cookie-secret` (default), `oidc-client-secret` / `oidc-cookie-secret` (opt-in, commented). DO NOT commit real values — manage with sealed-secrets/SOPS/ESO/Vault. |
-| `server/configmap.yaml` | Non-secret server config (`config.yaml`: `admins`, `allowed_domains`) — the same YAML `omnigent server -c` reads, loaded via `OMNIGENT_CONFIG`. Gates *authorization* (the IdP/accounts flow gates *authentication*). |
+| `server/configmap.yaml` | Non-secret server config (`config.yaml`: `admins`, `allowed_domains`) — the same YAML `omnigent server -c` reads, loaded via `OMNIGENT_CONFIG`. `admins` promotes operators; `allowed_domains` is an **OIDC-only** email gate (accounts mode keys admins by username and doesn't enforce it). |
 | `server/service.yaml` | ClusterIP `Service` → port 8000. |
 | `server/ingress.example.yaml` | Generic `networking.k8s.io/v1` Ingress (host → `omnigent:8000`, TLS). Adapt to your controller (or use a controller CRD: Traefik IngressRoute, Contour HTTPProxy, …). Host must match `OMNIGENT_ACCOUNTS_BASE_URL` (and the OIDC redirect URI if you opt into OIDC). |
 | `server/pvc.yaml` | `ReadWriteOnce` PVC for the artifact store at `/data`. Set your `storageClassName`. |
@@ -76,7 +82,7 @@ kubectl delete -f server/ -f host/        # then: kubectl delete pvc -n omnigent
 | Pod `Pending`, never schedules | No amd64 node, or the PVC can't bind | `kubectl -n omnigent describe pod -l app=omnigent` — look for the nodeSelector or `FailedScheduling`/`unbound PersistentVolumeClaim` event; set a real `storageClassName` in `pvc.yaml`. |
 | `CrashLoopBackOff` at startup, accounts error | Missing/short cookie secret or bad base URL | Logs show `OMNIGENT_ACCOUNTS_COOKIE_SECRET must be …` (needs 64 hex chars — `openssl rand -hex 32`) or `OMNIGENT_ACCOUNTS_BASE_URL must start with http:// or https://`. |
 | `CrashLoopBackOff`, `psycopg.OperationalError` | `DATABASE_URL` wrong/unreachable | `kubectl -n omnigent get secret omnigent-secrets -o jsonpath='{.data.database-url}' | base64 -d` and verify the Postgres host/creds; first boot over a remote DB is slow (migrations). |
-| Can't find the admin password | Random password only printed once | `kubectl -n omnigent logs deploy/omnigent | grep -A4 "Created initial admin"`, or read `/data/admin-credentials` on the PVC; pre-seed with `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD`. |
+| No admin / can't sign in (accounts mode) | accounts mode never auto-generates a password | Set `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD` (Secret key `accounts-admin-password`) for a headless admin, or open the URL and use the one-time web setup form (`/v1/info` reports `needs_setup`). |
 | OIDC login bounces / "email present but email_verified is not true" | IdP asserts `email_verified: false` | Make the IdP emit `email_verified: true` (e.g. override Authentik's default `email` scope mapping). |
 | Web UI loads but new chats hang forever | Expected — runners are external | Launch a runner (`omnigent run … --server <url>`) or bring up `host/`. |
 | On-cluster host never connects | `auth_tokens.json` missing `expires_at` (treated as expired) | `--from-file` the real `~/.omnigent/auth_tokens.json`; don't hand-write a `{"token": …}`-only body. See `host/secret.example.yaml`. |

--- a/deploy/kubernetes/host/README.md
+++ b/deploy/kubernetes/host/README.md
@@ -6,63 +6,90 @@ Deployment on the cluster** so a cluster node becomes agent compute. The daemon
 dials the server's `/v1/runner/tunnel` (**outbound only** — no inbound port) and
 spawns Claude Code / Codex runners locally on that node.
 
-This is a hand-built workaround, not the end state. The proper fix is a
+This is a pragmatic workaround, not the end state. The proper fix is a
 server-side launcher that spawns runner Pods on demand (no per-host seeded
 token). `host.yaml` is offered as a working reference for that design.
 
 ## How `host.yaml` works
 
-A stock `node:22` pod **runtime-bootstraps** on first start (no baked image —
-deliberate for a stopgap; cached on the PVC across restarts):
+It runs the **official prebaked host image**,
+`ghcr.io/omnigent-ai/omnigent-host:latest` — the same image the Modal/Daytona
+managed-sandbox providers boot from, published by CI from the `host` target of
+[`../../docker/Dockerfile`](../../docker/Dockerfile). The image already bakes
+everything a host needs:
 
-1. installs an **agentic-dev toolchain** (see below) via `micromamba` +
-   conda-forge into the PVC (no root — the pod runs as uid 1000);
-2. installs the `omnigent` CLI (via `uv`) + the `claude` / `codex` CLIs (npm);
-3. seeds the session + harness tokens from a mounted Secret;
-4. runs `omnigent host --server <SERVER_URL>`.
+- the full `omnigent` install (+ `git` and `tmux`), and
+- the coding-harness CLIs — `claude`, `codex`, `pi` — with the Node runtime,
 
-### The toolchain matters (hard-won)
+so there is **no runtime bootstrap** and no in-pod toolchain install: the pod
+seeds its tokens from the mounted Secret and execs `omnigent host` directly.
 
-- **`tmux` is required** — Omnigent's terminal / "new shell" feature
-  (`inner/terminal.py`) hard-fails `RuntimeError: tmux is not installed or not on
-  PATH` without it.
-- **`bubblewrap` (`bwrap`)** — the `claude-native` / `codex-native` harnesses
-  wrap the CLI in a bwrap sandbox; without it they fail at
-  `terminal.py` `linux_bwrap sandbox requires the 'bwrap' binary on PATH`.
-  Rootless bwrap works in-pod via Omnigent's `--unshare-user-try` profile.
-- **ffmpeg + language servers** (ts/bash/yaml/json/pyright/gopls/rust-analyzer +
-  ripgrep/fd/jq) — so agents have a real dev environment.
+### Two things the image already handles for you
 
-A baked CI image would remove the runtime install; it's left runtime for the
-stopgap.
+- **`tmux` is present.** Omnigent's terminal / "new shell" feature
+  (`omnigent/inner/terminal.py`) hard-fails `RuntimeError: tmux is not installed
+  or not on PATH` without it; the image bakes it in.
+- **`IS_SANDBOX=1` is baked in**, so the native harnesses skip their own
+  in-sandbox sandboxing. Claude Code refuses `--dangerously-skip-permissions`
+  under root unless `IS_SANDBOX` is set (and sandbox containers run as root), and
+  it short-circuits the `bwrap` wrap. So you do **not** need `bubblewrap` in the
+  pod. (Without `IS_SANDBOX`, the `claude-native` / `codex-native` harnesses try
+  to wrap the CLI in a bwrap sandbox and fail at
+  `omnigent/inner/bwrap_sandbox.py`:
+  `linux_bwrap sandbox requires the 'bwrap' binary on PATH`.)
 
 ## Activate
 
-The host authenticates to the server with **your `omnigent login` session JWT**,
-and to the harnesses with **your Claude/Codex subscription or API keys**. Mint
-them on a machine where you're logged into the web UI, then put them in the
-`omnigent-host` Secret (see `secret.example.yaml`):
+The host authenticates to the **server** with your `omnigent login` session JWT,
+and to the **harnesses** with your Claude/Codex subscription tokens (or API
+keys). Mint them on a machine where you're logged into the web UI, then put them
+in the `omnigent-host` Secret (see `secret.example.yaml`):
 
 ```bash
 omnigent login https://omnigent.example.com   # browser -> ~/.omnigent/auth_tokens.json
 claude setup-token                             # long-lived CLAUDE_CODE_OAUTH_TOKEN
-# codex: read the access token from ~/.codex/auth.json
+# codex: a Codex access token -> CODEX_ACCESS_TOKEN (ChatGPT Business/Enterprise)
 ```
 
-Because the host's session token must outlive the default 8h, raise
-`OMNIGENT_OIDC_SESSION_TTL_HOURS` on the server (e.g. 720 = 30d).
+Copy `~/.omnigent/auth_tokens.json` into the Secret **verbatim** with
+`--from-file` — it carries the token's `user_id` and `expires_at`, and a
+hand-written entry that omits `expires_at` is treated as already-expired (the
+host then never authenticates). See `secret.example.yaml` for the gotcha.
+
+Because the host's session token must outlive the default 8h, raise the
+session TTL on the server (`OMNIGENT_ACCOUNTS_SESSION_TTL_HOURS`, or
+`OMNIGENT_OIDC_SESSION_TTL_HOURS` if you opted into OIDC) — e.g. 720 = 30d.
+
+## Security
+
+This pod **runs untrusted, LLM-driven agent code with your credentials mounted**
+— the `omnigent login` session JWT, your Claude/Codex tokens, and any `git`/`gh`
+token you add. An agent (or a prompt-injection in its context) executes shell
+commands and reads/writes the workspace inside this pod. Treat it as a trust
+boundary and contain the blast radius:
+
+- **Scope the tokens.** Use a dedicated, least-privilege GitHub token; prefer a
+  short-lived/rotatable harness credential over a long-lived API key.
+- **Isolate the workload.** Run it in a **dedicated namespace** on a **dedicated
+  node**, separate from anything sensitive on the cluster.
+- **Restrict egress.** Add a `NetworkPolicy` that permits only what the host
+  needs (DNS, the Omnigent server, your model/gateway endpoints, package and git
+  registries) and denies the rest of the cluster — the daemon is outbound-only,
+  so nothing needs to reach *in*.
 
 ## Per-machine
 
 One Deployment per node you want as compute — set `spec.hostname` (the host
 registers under it; the CLI has no `--name` flag) and a `nodeSelector` to pin it.
-Select compute with `POST /v1/hosts/{host_id}/runners`.
+Select compute with `POST /v1/hosts/{host_id}/runners`. See `host.yaml` for the
+concrete pod (image, Secret mounts, optional git/gh wiring, and the workspace
+volume).
 
 ## Caveats
 
 - **amd64 only** — `omnigent==0.1.0` depends on `cel-expr-python`, which has no
-  aarch64-linux wheel, so arm64 nodes can't run the host.
-- **`git`/`gh` for agents** is optional and graceful: mount an SSH key +
-  `gh` token in the Secret and the bootstrap wires them (incl. routing
-  `git@github.com:` remotes through HTTPS so a separate GitHub SSH key isn't
-  needed). Omit them and the bootstrap simply skips that step.
+  aarch64-linux wheel, so arm64 nodes can't run the host. (The prebaked host
+  image is `linux/amd64` for the same reason.)
+- **`git`/`gh` for agents** is optional: mount an SSH key + `gh` token in the
+  Secret (the image's git credential helper picks up `GIT_TOKEN`/`GIT_USERNAME`
+  for HTTPS). Omit them for anonymous clones of public repos. See `host.yaml`.

--- a/deploy/kubernetes/host/README.md
+++ b/deploy/kubernetes/host/README.md
@@ -90,9 +90,10 @@ volume).
 - **Terminal / `native-ui` agents don't run in an unprivileged pod.**
   `claude-sdk` and `codex` agents work; `claude-native-ui` / `codex-native-ui`
   open an interactive shell via Omnigent's terminal feature
-  (`omnigent/inner/terminal.py`), whose sandbox defaults to `linux_bwrap`
-  **regardless of `IS_SANDBOX`** (that flag only relaxes the harness CLI, not the
-  terminal). `bwrap` isn't baked into the image, and even with it present, bwrap
+  (`omnigent/inner/terminal.py`), which for native-ui agents runs under a
+  `linux_bwrap` sandbox **regardless of `IS_SANDBOX`** (that flag only relaxes
+  the harness CLI, not the terminal). `bwrap` isn't baked into the image, and
+  even with it present, bwrap
   needs unprivileged user namespaces — denied in an unprivileged pod. So those
   agents fail (`omnigent/inner/bwrap_sandbox.py`:
   `linux_bwrap sandbox requires the 'bwrap' binary on PATH`). Use `claude-sdk` /

--- a/deploy/kubernetes/host/README.md
+++ b/deploy/kubernetes/host/README.md
@@ -29,14 +29,11 @@ seeds its tokens from the mounted Secret and execs `omnigent host` directly.
 - **`tmux` is present.** Omnigent's terminal / "new shell" feature
   (`omnigent/inner/terminal.py`) hard-fails `RuntimeError: tmux is not installed
   or not on PATH` without it; the image bakes it in.
-- **`IS_SANDBOX=1` is baked in**, so the native harnesses skip their own
-  in-sandbox sandboxing. Claude Code refuses `--dangerously-skip-permissions`
-  under root unless `IS_SANDBOX` is set (and sandbox containers run as root), and
-  it short-circuits the `bwrap` wrap. So you do **not** need `bubblewrap` in the
-  pod. (Without `IS_SANDBOX`, the `claude-native` / `codex-native` harnesses try
-  to wrap the CLI in a bwrap sandbox and fail at
-  `omnigent/inner/bwrap_sandbox.py`:
-  `linux_bwrap sandbox requires the 'bwrap' binary on PATH`.)
+- **`IS_SANDBOX=1` is baked in.** Claude Code refuses
+  `--dangerously-skip-permissions` as root unless `IS_SANDBOX` is set, and the
+  flag makes the `claude` / `codex` CLIs run without wrapping *themselves* in
+  `bwrap`. So **`claude-sdk` and `codex` agents need no `bubblewrap` in the
+  pod**. (This does *not* extend to terminal/`native-ui` agents — see Caveats.)
 
 ## Activate
 
@@ -90,6 +87,19 @@ volume).
 - **amd64 only** — `omnigent==0.1.0` depends on `cel-expr-python`, which has no
   aarch64-linux wheel, so arm64 nodes can't run the host. (The prebaked host
   image is `linux/amd64` for the same reason.)
-- **`git`/`gh` for agents** is optional: mount an SSH key + `gh` token in the
-  Secret (the image's git credential helper picks up `GIT_TOKEN`/`GIT_USERNAME`
-  for HTTPS). Omit them for anonymous clones of public repos. See `host.yaml`.
+- **Terminal / `native-ui` agents don't run in an unprivileged pod.**
+  `claude-sdk` and `codex` agents work; `claude-native-ui` / `codex-native-ui`
+  open an interactive shell via Omnigent's terminal feature
+  (`omnigent/inner/terminal.py`), whose sandbox defaults to `linux_bwrap`
+  **regardless of `IS_SANDBOX`** (that flag only relaxes the harness CLI, not the
+  terminal). `bwrap` isn't baked into the image, and even with it present, bwrap
+  needs unprivileged user namespaces — denied in an unprivileged pod. So those
+  agents fail (`omnigent/inner/bwrap_sandbox.py`:
+  `linux_bwrap sandbox requires the 'bwrap' binary on PATH`). Use `claude-sdk` /
+  `codex` agents, or grant the pod the needed privilege (CAP_SYS_ADMIN / a userns
+  policy) or set the agent's server-side `os_env.sandbox.type=none`.
+- **`git` for agents is HTTPS-only** (the image bakes no ssh client). Add a `gh`
+  token to the Secret; the baked credential helper picks up
+  `GIT_TOKEN`/`GIT_USERNAME` for HTTPS, and `host.yaml` rewrites `git@github.com:`
+  SSH remotes to HTTPS so they're covered too. Omit it for anonymous clones of
+  public repos. See `host.yaml`.

--- a/deploy/kubernetes/host/README.md
+++ b/deploy/kubernetes/host/README.md
@@ -1,0 +1,68 @@
+# Agent compute on the cluster — the `omnigent host` stopgap
+
+Until Omnigent has a native Kubernetes sandbox launcher
+(**`omnigent-ai/omnigent#39`**), this runs the **`omnigent host` daemon as a
+Deployment on the cluster** so a cluster node becomes agent compute. The daemon
+dials the server's `/v1/runner/tunnel` (**outbound only** — no inbound port) and
+spawns Claude Code / Codex runners locally on that node.
+
+This is a hand-built workaround, not the end state. The proper fix is a
+server-side launcher that spawns runner Pods on demand (no per-host seeded
+token). `host.yaml` is offered as a working reference for that design.
+
+## How `host.yaml` works
+
+A stock `node:22` pod **runtime-bootstraps** on first start (no baked image —
+deliberate for a stopgap; cached on the PVC across restarts):
+
+1. installs an **agentic-dev toolchain** (see below) via `micromamba` +
+   conda-forge into the PVC (no root — the pod runs as uid 1000);
+2. installs the `omnigent` CLI (via `uv`) + the `claude` / `codex` CLIs (npm);
+3. seeds the session + harness tokens from a mounted Secret;
+4. runs `omnigent host --server <SERVER_URL>`.
+
+### The toolchain matters (hard-won)
+
+- **`tmux` is required** — Omnigent's terminal / "new shell" feature
+  (`inner/terminal.py`) hard-fails `RuntimeError: tmux is not installed or not on
+  PATH` without it.
+- **`bubblewrap` (`bwrap`)** — the `claude-native` / `codex-native` harnesses
+  wrap the CLI in a bwrap sandbox; without it they fail at
+  `terminal.py` `linux_bwrap sandbox requires the 'bwrap' binary on PATH`.
+  Rootless bwrap works in-pod via Omnigent's `--unshare-user-try` profile.
+- **ffmpeg + language servers** (ts/bash/yaml/json/pyright/gopls/rust-analyzer +
+  ripgrep/fd/jq) — so agents have a real dev environment.
+
+A baked CI image would remove the runtime install; it's left runtime for the
+stopgap.
+
+## Activate
+
+The host authenticates to the server with **your `omnigent login` session JWT**,
+and to the harnesses with **your Claude/Codex subscription or API keys**. Mint
+them on a machine where you're logged into the web UI, then put them in the
+`omnigent-host` Secret (see `secret.example.yaml`):
+
+```bash
+omnigent login https://omnigent.example.com   # browser -> ~/.omnigent/auth_tokens.json
+claude setup-token                             # long-lived CLAUDE_CODE_OAUTH_TOKEN
+# codex: read the access token from ~/.codex/auth.json
+```
+
+Because the host's session token must outlive the default 8h, raise
+`OMNIGENT_OIDC_SESSION_TTL_HOURS` on the server (e.g. 720 = 30d).
+
+## Per-machine
+
+One Deployment per node you want as compute — set `spec.hostname` (the host
+registers under it; the CLI has no `--name` flag) and a `nodeSelector` to pin it.
+Select compute with `POST /v1/hosts/{host_id}/runners`.
+
+## Caveats
+
+- **amd64 only** — `omnigent==0.1.0` depends on `cel-expr-python`, which has no
+  aarch64-linux wheel, so arm64 nodes can't run the host.
+- **`git`/`gh` for agents** is optional and graceful: mount an SSH key +
+  `gh` token in the Secret and the bootstrap wires them (incl. routing
+  `git@github.com:` remotes through HTTPS so a separate GitHub SSH key isn't
+  needed). Omit them and the bootstrap simply skips that step.

--- a/deploy/kubernetes/host/host.yaml
+++ b/deploy/kubernetes/host/host.yaml
@@ -1,12 +1,22 @@
 # On-cluster `omnigent host` daemon — the K8s agent-compute stopgap (#39).
 #
-# A stock node:22 pod runtime-bootstraps a dev toolchain + the omnigent/claude/
-# codex CLIs onto its PVC, seeds tokens from the omnigent-host Secret, and runs
-# `omnigent host`, which dials the server (outbound only) and spawns runners
-# locally. Replicate this (Deployment + PVC) per node you want as compute; set
-# a distinct metadata.name + spec.hostname + nodeSelector for each.
+# Runs the OFFICIAL prebaked host image `ghcr.io/omnigent-ai/omnigent-host:latest`
+# (CI-built from the `host` target of ../../docker/Dockerfile; linux/amd64). It
+# bakes the omnigent install + git + tmux + the claude/codex/pi CLIs and sets
+# IS_SANDBOX=1 — so there is NO runtime bootstrap: the pod seeds its tokens from
+# the mounted Secret and execs `omnigent host`, which dials the server (outbound
+# only) and spawns runners locally on the node.
 #
-# amd64 only (omnigent 0.1.0 -> cel-expr-python has no aarch64-linux wheel).
+# Replicate this (Deployment + PVC) per node you want as compute; give each a
+# distinct metadata.name + spec.hostname + nodeSelector.
+#
+# amd64 only — the image is linux/amd64 (omnigent 0.1.0 -> cel-expr-python has no
+# aarch64-linux wheel).
+#
+# AGENT CLASSES: `claude-sdk` / `codex` agents (no interactive terminal) run here.
+# Terminal "native-ui" agents (`claude-native-ui` / `codex-native-ui`) do NOT —
+# they need a bwrap sandbox the unprivileged pod can't provide. See README.md
+# ("Caveats").
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -38,72 +48,62 @@ spec:
         kubernetes.io/arch: amd64
         # kubernetes.io/hostname: <pin to a specific node>
       securityContext:
+        # The image is built to run as root (WORKDIR /root). We run it
+        # UNPRIVILEGED and point HOME at the writable PVC instead (see the
+        # `cd "$HOME"` note in the command). fsGroup lets the pod own the volume
+        # even if the storage backend squashes root.
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: host
-          image: node:22-bookworm
+          image: ghcr.io/omnigent-ai/omnigent-host:latest
           env:
             - { name: HOME, value: /data }
             - { name: OMNIGENT_SERVER, value: https://omnigent.example.com }
             - { name: GIT_USER_NAME, value: "Omnigent Agent" }
             - { name: GIT_USER_EMAIL, value: "agent@example.com" }
-            # Harness auth via env (cleaner than mounting ~/.claude). Optional.
+            # github (and any HTTPS git host): the image's baked credential helper
+            # sends GIT_TOKEN as the password. Optional.
+            - { name: GIT_USERNAME, value: "x-access-token" }
+            - name: GIT_TOKEN
+              valueFrom: { secretKeyRef: { name: omnigent-host, key: gh-token, optional: true } }
+            # Harness auth via env (cleaner than mounting ~/.claude). Provide at
+            # least one. Optional secret keys -> host boots without them.
             - name: CLAUDE_CODE_OAUTH_TOKEN
               valueFrom: { secretKeyRef: { name: omnigent-host, key: claude-oauth-token, optional: true } }
-          command: ["/bin/bash", "-c"]
+            - name: CODEX_ACCESS_TOKEN
+              valueFrom: { secretKeyRef: { name: omnigent-host, key: codex-access-token, optional: true } }
+          command: ["bash", "-lc"]
           args:
             - |
               set -euo pipefail
-              export MAMBA_ROOT_PREFIX=/data/.mamba
-              export PATH="/data/.toolchain/bin:/data/.local/bin:/data/.npm-global/bin:$PATH"
-
-              # --- agentic-dev toolchain on the PVC (no root; persisted + sentinel-gated) ---
-              # tmux is REQUIRED (omnigent terminal feature); bubblewrap for native-claude
-              # sandboxing; plus ffmpeg + language servers for real agent work.
-              command -v micromamba >/dev/null 2>&1 || { mkdir -p /tmp/mm && curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xj -C /tmp/mm bin/micromamba && install -m 755 /tmp/mm/bin/micromamba /data/.local/bin/micromamba && rm -rf /tmp/mm; }
-              [ -x /data/.toolchain/bin/tmux ] || micromamba create -y -q -p /data/.toolchain -c conda-forge tmux ffmpeg ripgrep fd-find jq git git-delta bat gh openssh less unzip gopls rust-analyzer bubblewrap
-              [ -x /data/.toolchain/bin/bwrap ] || micromamba install -y -q -p /data/.toolchain -c conda-forge bubblewrap
-              npm config set prefix /data/.npm-global
-              [ -f /data/.npm-global/.lsp-installed ] || { npm install -g typescript typescript-language-server bash-language-server yaml-language-server vscode-langservers-extracted pyright prettier eslint && touch /data/.npm-global/.lsp-installed; }
-
-              # --- omnigent + harness CLIs ---
-              command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/data/.local/bin sh
-              command -v omnigent >/dev/null 2>&1 || uv tool install "omnigent==0.1.0"
-              command -v claude   >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code
-              command -v codex    >/dev/null 2>&1 || npm install -g @openai/codex
-              command -v ruff     >/dev/null 2>&1 || uv tool install ruff || true
-
-              # --- tokens (the whole Secret is mounted at /secrets) ---
-              mkdir -p /data/.omnigent && install -m 600 /secrets/auth_tokens.json /data/.omnigent/auth_tokens.json
-              mkdir -p /data/.codex && { [ -f /data/.codex/auth.json ] || { [ -s /secrets/codex_auth.json ] && install -m 600 /secrets/codex_auth.json /data/.codex/auth.json; }; } || true
-
-              # --- optional git/gh auth for agents (graceful: skipped if keys absent) ---
-              git config --global user.name "${GIT_USER_NAME}"
+              echo "omnigent host ($(hostname)) -> $OMNIGENT_SERVER | uid=$(id -u) omnigent=$(command -v omnigent) tmux=$(tmux -V 2>/dev/null || echo NONE)"
+              # --- seed the omnigent login session into HOME (=/data); the image's
+              #     /root is root-owned, so we keep all state on the writable PVC ---
+              mkdir -p "$HOME/.omnigent"
+              install -m 600 /secrets/auth_tokens.json "$HOME/.omnigent/auth_tokens.json"
+              # --- git config for agents (HTTPS; the image bakes no ssh client) ---
+              git config --global user.name  "${GIT_USER_NAME}"
               git config --global user.email "${GIT_USER_EMAIL}"
               git config --global --add safe.directory '*'
-              if [ -s /secrets/ssh-key ]; then
-                mkdir -p /data/.ssh && chmod 700 /data/.ssh
-                install -m 600 /secrets/ssh-key /data/.ssh/id_ed25519
-                printf 'Host github.com\n  User git\n  IdentityFile /data/.ssh/id_ed25519\n  StrictHostKeyChecking accept-new\n' > /data/.ssh/config
-                chmod 600 /data/.ssh/config
-                # conda-forge ssh doesn't auto-read ~/.ssh/config -> point git's ssh at it
-                git config --global core.sshCommand 'ssh -F /data/.ssh/config -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'
-              fi
-              # gh token -> github over HTTPS; route github SSH remotes to HTTPS so a
-              # separate github SSH key isn't needed.
-              [ -s /secrets/gh-token ] && { gh auth login --with-token < /secrets/gh-token && gh auth setup-git && git config --global url."https://github.com/".insteadOf "git@github.com:" && git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"; } || true
-
-              echo "omnigent host -> $OMNIGENT_SERVER  tmux=$(tmux -V 2>/dev/null || echo NONE) bwrap=$(command -v bwrap >/dev/null && echo yes || echo no)"
+              # Rewrite github SSH remotes -> HTTPS so GIT_TOKEN covers them (no ssh
+              # key needed). A self-hosted forge over HTTPS works the same way: add a
+              # scoped `~/.git-credentials` entry + a matching `insteadOf` for its host.
+              git config --global url."https://github.com/".insteadOf "git@github.com:"
+              git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+              # THE uid-1000 FIX: omnigent stats <cwd>/.omnigent/config.yaml; the image
+              # WORKDIR is /root (root-owned) -> EACCES as uid 1000 -> CrashLoop. cd
+              # into HOME (writable) first so the probe reads $HOME/.omnigent.
+              cd "$HOME"
               exec omnigent host --server "$OMNIGENT_SERVER"
           volumeMounts:
             - { name: data, mountPath: /data }
             - { name: secrets, mountPath: /secrets, readOnly: true }
-            # Mount your code/workspaces here so agents have real repos to work in,
-            # e.g. an NFS PVC of your projects at /data/projects (runner workspace
-            # dirs must already exist on the host).
+            # Mount your code/workspaces so agents have real repos to work in
+            # (runner workspace dirs must already exist on the host), e.g. an NFS
+            # PVC of your projects at /data/projects:
             # - { name: projects, mountPath: /data/projects }
           resources:
             requests: { cpu: 200m, memory: 512Mi }

--- a/deploy/kubernetes/host/host.yaml
+++ b/deploy/kubernetes/host/host.yaml
@@ -1,0 +1,115 @@
+# On-cluster `omnigent host` daemon — the K8s agent-compute stopgap (#39).
+#
+# A stock node:22 pod runtime-bootstraps a dev toolchain + the omnigent/claude/
+# codex CLIs onto its PVC, seeds tokens from the omnigent-host Secret, and runs
+# `omnigent host`, which dials the server (outbound only) and spawns runners
+# locally. Replicate this (Deployment + PVC) per node you want as compute; set
+# a distinct metadata.name + spec.hostname + nodeSelector for each.
+#
+# amd64 only (omnigent 0.1.0 -> cel-expr-python has no aarch64-linux wheel).
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: omnigent-host-data
+  namespace: omnigent
+  labels: { app: omnigent-host }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  # storageClassName: your-storage-class
+  resources: { requests: { storage: 20Gi } }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omnigent-host
+  namespace: omnigent
+  labels: { app: omnigent-host }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }   # one stable host identity per PVC
+  selector: { matchLabels: { app: omnigent-host } }
+  template:
+    metadata:
+      labels: { app: omnigent-host }
+    spec:
+      hostname: omnigent-host-1          # the host registers under this name
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        # kubernetes.io/hostname: <pin to a specific node>
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: host
+          image: node:22-bookworm
+          env:
+            - { name: HOME, value: /data }
+            - { name: OMNIGENT_SERVER, value: https://omnigent.example.com }
+            - { name: GIT_USER_NAME, value: "Omnigent Agent" }
+            - { name: GIT_USER_EMAIL, value: "agent@example.com" }
+            # Harness auth via env (cleaner than mounting ~/.claude). Optional.
+            - name: CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom: { secretKeyRef: { name: omnigent-host, key: claude-oauth-token, optional: true } }
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              export MAMBA_ROOT_PREFIX=/data/.mamba
+              export PATH="/data/.toolchain/bin:/data/.local/bin:/data/.npm-global/bin:$PATH"
+
+              # --- agentic-dev toolchain on the PVC (no root; persisted + sentinel-gated) ---
+              # tmux is REQUIRED (omnigent terminal feature); bubblewrap for native-claude
+              # sandboxing; plus ffmpeg + language servers for real agent work.
+              command -v micromamba >/dev/null 2>&1 || { mkdir -p /tmp/mm && curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xj -C /tmp/mm bin/micromamba && install -m 755 /tmp/mm/bin/micromamba /data/.local/bin/micromamba && rm -rf /tmp/mm; }
+              [ -x /data/.toolchain/bin/tmux ] || micromamba create -y -q -p /data/.toolchain -c conda-forge tmux ffmpeg ripgrep fd-find jq git git-delta bat gh openssh less unzip gopls rust-analyzer bubblewrap
+              [ -x /data/.toolchain/bin/bwrap ] || micromamba install -y -q -p /data/.toolchain -c conda-forge bubblewrap
+              npm config set prefix /data/.npm-global
+              [ -f /data/.npm-global/.lsp-installed ] || { npm install -g typescript typescript-language-server bash-language-server yaml-language-server vscode-langservers-extracted pyright prettier eslint && touch /data/.npm-global/.lsp-installed; }
+
+              # --- omnigent + harness CLIs ---
+              command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/data/.local/bin sh
+              command -v omnigent >/dev/null 2>&1 || uv tool install "omnigent==0.1.0"
+              command -v claude   >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code
+              command -v codex    >/dev/null 2>&1 || npm install -g @openai/codex
+              command -v ruff     >/dev/null 2>&1 || uv tool install ruff || true
+
+              # --- tokens (the whole Secret is mounted at /secrets) ---
+              mkdir -p /data/.omnigent && install -m 600 /secrets/auth_tokens.json /data/.omnigent/auth_tokens.json
+              mkdir -p /data/.codex && { [ -f /data/.codex/auth.json ] || { [ -s /secrets/codex_auth.json ] && install -m 600 /secrets/codex_auth.json /data/.codex/auth.json; }; } || true
+
+              # --- optional git/gh auth for agents (graceful: skipped if keys absent) ---
+              git config --global user.name "${GIT_USER_NAME}"
+              git config --global user.email "${GIT_USER_EMAIL}"
+              git config --global --add safe.directory '*'
+              if [ -s /secrets/ssh-key ]; then
+                mkdir -p /data/.ssh && chmod 700 /data/.ssh
+                install -m 600 /secrets/ssh-key /data/.ssh/id_ed25519
+                printf 'Host github.com\n  User git\n  IdentityFile /data/.ssh/id_ed25519\n  StrictHostKeyChecking accept-new\n' > /data/.ssh/config
+                chmod 600 /data/.ssh/config
+                # conda-forge ssh doesn't auto-read ~/.ssh/config -> point git's ssh at it
+                git config --global core.sshCommand 'ssh -F /data/.ssh/config -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'
+              fi
+              # gh token -> github over HTTPS; route github SSH remotes to HTTPS so a
+              # separate github SSH key isn't needed.
+              [ -s /secrets/gh-token ] && { gh auth login --with-token < /secrets/gh-token && gh auth setup-git && git config --global url."https://github.com/".insteadOf "git@github.com:" && git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"; } || true
+
+              echo "omnigent host -> $OMNIGENT_SERVER  tmux=$(tmux -V 2>/dev/null || echo NONE) bwrap=$(command -v bwrap >/dev/null && echo yes || echo no)"
+              exec omnigent host --server "$OMNIGENT_SERVER"
+          volumeMounts:
+            - { name: data, mountPath: /data }
+            - { name: secrets, mountPath: /secrets, readOnly: true }
+            # Mount your code/workspaces here so agents have real repos to work in,
+            # e.g. an NFS PVC of your projects at /data/projects (runner workspace
+            # dirs must already exist on the host).
+            # - { name: projects, mountPath: /data/projects }
+          resources:
+            requests: { cpu: 200m, memory: 512Mi }
+            limits:   { cpu: "4", memory: 6Gi }
+      volumes:
+        - { name: data, persistentVolumeClaim: { claimName: omnigent-host-data } }
+        - { name: secrets, secret: { secretName: omnigent-host } }
+        # - name: projects
+        #   nfs: { server: nfs.example.com, path: /export/projects }

--- a/deploy/kubernetes/host/host.yaml
+++ b/deploy/kubernetes/host/host.yaml
@@ -91,7 +91,11 @@ spec:
               # Rewrite github SSH remotes -> HTTPS so GIT_TOKEN covers them (no ssh
               # key needed). A self-hosted forge over HTTPS works the same way: add a
               # scoped `~/.git-credentials` entry + a matching `insteadOf` for its host.
-              git config --global url."https://github.com/".insteadOf "git@github.com:"
+              # --unset-all first so this is idempotent across restarts on the persistent
+              # PVC — a non---add set over an existing multi-value insteadOf errors under
+              # set -e ("cannot overwrite multiple values with a single value") -> CrashLoop.
+              git config --global --unset-all url."https://github.com/".insteadOf 2>/dev/null || true
+              git config --global --add url."https://github.com/".insteadOf "git@github.com:"
               git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
               # THE uid-1000 FIX: omnigent stats <cwd>/.omnigent/config.yaml; the image
               # WORKDIR is /root (root-owned) -> EACCES as uid 1000 -> CrashLoop. cd

--- a/deploy/kubernetes/host/host.yaml
+++ b/deploy/kubernetes/host/host.yaml
@@ -87,7 +87,7 @@ spec:
               # --- git config for agents (HTTPS; the image bakes no ssh client) ---
               git config --global user.name  "${GIT_USER_NAME}"
               git config --global user.email "${GIT_USER_EMAIL}"
-              git config --global --add safe.directory '*'
+              git config --global --replace-all safe.directory '*'   # idempotent across restarts
               # Rewrite github SSH remotes -> HTTPS so GIT_TOKEN covers them (no ssh
               # key needed). A self-hosted forge over HTTPS works the same way: add a
               # scoped `~/.git-credentials` entry + a matching `insteadOf` for its host.

--- a/deploy/kubernetes/host/host.yaml
+++ b/deploy/kubernetes/host/host.yaml
@@ -89,8 +89,14 @@ spec:
               git config --global user.email "${GIT_USER_EMAIL}"
               git config --global --replace-all safe.directory '*'   # idempotent across restarts
               # Rewrite github SSH remotes -> HTTPS so GIT_TOKEN covers them (no ssh
-              # key needed). A self-hosted forge over HTTPS works the same way: add a
-              # scoped `~/.git-credentials` entry + a matching `insteadOf` for its host.
+              # key needed). NOTE: the image's baked GIT_TOKEN credential helper matches
+              # ANY https host, so for a SELF-HOSTED forge, empty-reset that host's helper
+              # chain before adding a scoped store helper, e.g.:
+              #   git config --global --add credential."https://forge.example".helper ""
+              #   git config --global --add credential."https://forge.example".helper \
+              #     "store --file=$HOME/.git-credentials"
+              # (the empty "" first, or the baked helper shadows yours and sends your
+              # GitHub token to the forge) + a matching `insteadOf` for its host.
               # --unset-all first so this is idempotent across restarts on the persistent
               # PVC — a non---add set over an existing multi-value insteadOf errors under
               # set -e ("cannot overwrite multiple values with a single value") -> CrashLoop.

--- a/deploy/kubernetes/host/secret.example.yaml
+++ b/deploy/kubernetes/host/secret.example.yaml
@@ -11,8 +11,7 @@
 #     --from-file=auth_tokens.json="$HOME/.omnigent/auth_tokens.json" \
 #     --from-literal=claude-oauth-token='<from `claude setup-token`>' \
 #     --from-literal=codex-access-token='<a Codex access token>' \  # optional (codex)
-#     --from-file=ssh-key="$HOME/.ssh/id_ed25519" \                 # optional (git over SSH)
-#     --from-literal=gh-token='<a GitHub token>'                    # optional (gh / HTTPS)
+#     --from-literal=gh-token='<a GitHub token>'                    # optional (git over HTTPS)
 #
 # ── auth_tokens.json — COPY THE FILE VERBATIM, never hand-construct it ──
 # `omnigent login https://omnigent.example.com` writes
@@ -45,10 +44,8 @@ stringData:
   # for agents to run; both shown for completeness.
   claude-oauth-token: "REPLACE_WITH_claude_setup_token_or_unused"
   codex-access-token: "REPLACE_WITH_codex_access_token_or_unused"
-  # Optional: git over SSH + gh over HTTPS for agents. Omit to skip.
-  # ssh-key: |
-  #   -----BEGIN OPENSSH PRIVATE KEY-----
-  #   ...
+  # Optional: a GitHub token so agents can clone/push over HTTPS (the image
+  # bakes no ssh client, so git is HTTPS-only). Omit for anonymous public clones.
   # gh-token: "REPLACE_WITH_github_token"
 #
 # NOTE: `auth_tokens.json` is intentionally NOT defined as stringData here.

--- a/deploy/kubernetes/host/secret.example.yaml
+++ b/deploy/kubernetes/host/secret.example.yaml
@@ -1,0 +1,31 @@
+---
+# EXAMPLE secret for an on-cluster host. DO NOT commit real values — use
+# sealed-secrets / SOPS / External Secrets / Vault, or `kubectl create secret`.
+# The whole secret is mounted read-only at /secrets in the host pod.
+#
+#   kubectl -n omnigent create secret generic omnigent-host \
+#     --from-file=auth_tokens.json="$HOME/.omnigent/auth_tokens.json" \
+#     --from-literal=claude-oauth-token='<from `claude setup-token`>' \
+#     --from-file=codex_auth.json="$HOME/.codex/auth.json" \
+#     --from-file=ssh-key="$HOME/.ssh/id_ed25519" \       # optional (git over SSH)
+#     --from-literal=gh-token='<a GitHub token>'          # optional (gh / HTTPS)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnigent-host
+  namespace: omnigent
+  labels:
+    app: omnigent-host
+type: Opaque
+stringData:
+  # The `omnigent login` session, keyed by server URL. Required.
+  auth_tokens.json: |
+    { "https://omnigent.example.com": { "token": "REPLACE_WITH_omnigent_login_session_jwt" } }
+  # Harness auth (one of token / api-key / gateway). Required for agents to run.
+  claude-oauth-token: "REPLACE_WITH_claude_setup_token_or_unused"
+  codex_auth.json: "REPLACE_WITH_codex_auth_json_or_unused"
+  # Optional: git over SSH + gh over HTTPS for agents. Omit to skip.
+  # ssh-key: |
+  #   -----BEGIN OPENSSH PRIVATE KEY-----
+  #   ...
+  # gh-token: "REPLACE_WITH_github_token"

--- a/deploy/kubernetes/host/secret.example.yaml
+++ b/deploy/kubernetes/host/secret.example.yaml
@@ -1,14 +1,37 @@
 ---
 # EXAMPLE secret for an on-cluster host. DO NOT commit real values — use
 # sealed-secrets / SOPS / External Secrets / Vault, or `kubectl create secret`.
-# The whole secret is mounted read-only at /secrets in the host pod.
+# The whole secret is mounted read-only in the host pod (see host.yaml).
+#
+# Build it from files/literals on a machine where you're logged into the web UI
+# and the harness CLIs — do NOT hand-write the YAML below for auth_tokens.json
+# (see the note):
 #
 #   kubectl -n omnigent create secret generic omnigent-host \
 #     --from-file=auth_tokens.json="$HOME/.omnigent/auth_tokens.json" \
 #     --from-literal=claude-oauth-token='<from `claude setup-token`>' \
-#     --from-file=codex_auth.json="$HOME/.codex/auth.json" \
-#     --from-file=ssh-key="$HOME/.ssh/id_ed25519" \       # optional (git over SSH)
-#     --from-literal=gh-token='<a GitHub token>'          # optional (gh / HTTPS)
+#     --from-literal=codex-access-token='<a Codex access token>' \  # optional (codex)
+#     --from-file=ssh-key="$HOME/.ssh/id_ed25519" \                 # optional (git over SSH)
+#     --from-literal=gh-token='<a GitHub token>'                    # optional (gh / HTTPS)
+#
+# ── auth_tokens.json — COPY THE FILE VERBATIM, never hand-construct it ──
+# `omnigent login https://omnigent.example.com` writes
+# ~/.omnigent/auth_tokens.json with a per-server entry that carries the
+# session token, `user_id`, AND `expires_at`. The host loader treats a MISSING
+# `expires_at` as 0 — i.e. ALREADY EXPIRED — so the host would silently never
+# authenticate (omnigent/cli_auth.py: `entry.get("expires_at", 0)`). Always
+# `--from-file` the real file; do not retype a `{"token": ...}`-only body.
+# (The host's session must outlive the default 8h — raise the server's
+# OMNIGENT_ACCOUNTS_SESSION_TTL_HOURS, e.g. 720 = 30d, before minting it.)
+#
+# ── Codex / Claude harness auth (env, not files) ──
+# claude-oauth-token  -> CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
+# codex-access-token  -> CODEX_ACCESS_TOKEN (the codex CLI's headless
+#                        ChatGPT-workspace credential; Business/Enterprise plans)
+# These are the upstream harness credential env vars the host forwards to its
+# runners (omnigent/host/connect.py HARNESS_CREDENTIAL_ENV_VARS). Provide at
+# least one harness credential (token, API key, or a gateway base URL) for
+# agents to run.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,14 +41,17 @@ metadata:
     app: omnigent-host
 type: Opaque
 stringData:
-  # The `omnigent login` session, keyed by server URL. Required.
-  auth_tokens.json: |
-    { "https://omnigent.example.com": { "token": "REPLACE_WITH_omnigent_login_session_jwt" } }
-  # Harness auth (one of token / api-key / gateway). Required for agents to run.
+  # Harness auth (one of token / api-key / gateway). At least one is required
+  # for agents to run; both shown for completeness.
   claude-oauth-token: "REPLACE_WITH_claude_setup_token_or_unused"
-  codex_auth.json: "REPLACE_WITH_codex_auth_json_or_unused"
+  codex-access-token: "REPLACE_WITH_codex_access_token_or_unused"
   # Optional: git over SSH + gh over HTTPS for agents. Omit to skip.
   # ssh-key: |
   #   -----BEGIN OPENSSH PRIVATE KEY-----
   #   ...
   # gh-token: "REPLACE_WITH_github_token"
+#
+# NOTE: `auth_tokens.json` is intentionally NOT defined as stringData here.
+# Add it with `--from-file=auth_tokens.json="$HOME/.omnigent/auth_tokens.json"`
+# (see the create-secret command above) so it carries `user_id` + `expires_at`
+# verbatim. A hand-written entry without `expires_at` is treated as expired.

--- a/deploy/kubernetes/server/configmap.yaml
+++ b/deploy/kubernetes/server/configmap.yaml
@@ -1,0 +1,22 @@
+---
+# Non-secret Omnigent server settings (the same YAML `omnigent server -c` reads;
+# the entrypoint loads it via OMNIGENT_CONFIG). The IdP gates *authentication*;
+# this gates *authorization*:
+#   admins          — promoted to operator on login, keyed by the OIDC email
+#                     claim. Additive (removing an entry never demotes). Make
+#                     sure these match your IdP's email claim.
+#   allowed_domains — non-admin logins must match one of these. Drop it to allow
+#                     any authenticated user.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: omnigent-config
+  namespace: omnigent
+  labels:
+    app: omnigent
+data:
+  config.yaml: |
+    admins:
+      - you@example.com
+    allowed_domains:
+      - example.com

--- a/deploy/kubernetes/server/configmap.yaml
+++ b/deploy/kubernetes/server/configmap.yaml
@@ -2,11 +2,13 @@
 # Non-secret Omnigent server settings (the same YAML `omnigent server -c` reads;
 # the entrypoint loads it via OMNIGENT_CONFIG). The IdP gates *authentication*;
 # this gates *authorization*:
-#   admins          — promoted to operator on login, keyed by the OIDC email
-#                     claim. Additive (removing an entry never demotes). Make
-#                     sure these match your IdP's email claim.
-#   allowed_domains — non-admin logins must match one of these. Drop it to allow
-#                     any authenticated user.
+#   admins          — promoted to operator on login. Additive (removing an entry
+#                     never demotes). In OIDC mode keyed by the email claim
+#                     (match your IdP's claim); in accounts mode keyed by the
+#                     account username — so list usernames, not emails, there.
+#   allowed_domains — OIDC-ONLY email-domain gate: non-admin OIDC logins must
+#                     match one of these. NOT enforced in accounts mode. Drop it
+#                     to allow any authenticated user.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/kubernetes/server/deployment.yaml
+++ b/deploy/kubernetes/server/deployment.yaml
@@ -4,7 +4,10 @@
 # Deploys the SERVER ONLY. Per the OSS entrypoint the server runs in
 # "external-runners-only" mode: it accepts runner WebSocket connections at
 # /v1/runner/tunnel and NEVER spawns harness subprocesses itself — so this pod
-# is unprivileged. Agents run in RUNNERS launched elsewhere: a laptop
+# needs no special privileges (an ordinary container: no privileged, no
+# CAP_SYS_ADMIN, no host access). It does run as root by default (the image sets
+# no USER); the securityContext below drops caps + blocks privilege escalation.
+# Agents run in RUNNERS launched elsewhere: a laptop
 # (`omnigent run agent.yaml --server https://omnigent.example.com`), a managed
 # sandbox (Modal/Daytona), or the on-cluster host daemon in ../host/.
 #
@@ -13,12 +16,12 @@
 # - Alembic migrations run automatically in the entrypoint (no migration Job).
 # - AUTH (default = built-in `accounts`): with OMNIGENT_AUTH_ENABLED=1 and no
 #   OMNIGENT_OIDC_ISSUER set, the server selects its built-in multi-user
-#   `accounts` provider — username/password, no external IdP, first boot
-#   auto-creates an admin (random password in the pod logs + on the artifact
-#   PVC at /data/admin-credentials), and the admin invites teammates from the
-#   web UI. This matches the deploy default everywhere else (see deploy/README.md
-#   "Auth"). To pin the admin password for a headless bring-up, set
-#   OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD.
+#   `accounts` provider — username/password, no external IdP. Omnigent NEVER
+#   auto-generates an admin password: set OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
+#   (below) to create the first admin headlessly, or create it via the one-time
+#   web setup form on first visit (/v1/info reports needs_setup until then); the
+#   admin then invites teammates from the web UI. Matches the deploy default
+#   everywhere else (see deploy/README.md "Auth").
 #   Prefer your own IdP? See the "opt-in: OIDC instead of accounts" block below.
 #   For a no-auth dev/test bring-up, set OMNIGENT_AUTH_ENABLED=0 (single shared
 #   "local" user — local dev only, never a network-exposed deploy).
@@ -45,11 +48,20 @@ spec:
         # Group-own the artifact volume so the server can write it even if the
         # storage backend squashes root. Drop if your storage perms don't need it.
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        # To run fully non-root, add: runAsNonRoot: true / runAsUser: 1000
+        # (confirm the image writes only to /data — fsGroup-owned — and the DB).
       nodeSelector:
         kubernetes.io/arch: amd64
       containers:
         - name: omnigent
           image: ghcr.io/omnigent-ai/omnigent-server:v0.1.0
+          securityContext:
+            # A web server needs no Linux capabilities or privilege escalation.
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: DATABASE_URL
               valueFrom:
@@ -84,10 +96,10 @@ spec:
             # URL (behind your Ingress/LB), NOT the in-cluster Service address.
             - name: OMNIGENT_ACCOUNTS_BASE_URL
               value: "https://omnigent.example.com"
-            # Optional: pin the first-boot admin password for a headless deploy
-            # where you can't read the pod logs. Otherwise a random password is
-            # generated and printed to the logs + written to
-            # /data/admin-credentials on the artifact PVC.
+            # Creates the first admin headlessly. Omnigent never auto-generates a
+            # password — without this (and with no TTY) first boot reports
+            # needs_setup and waits for the one-time web setup form. Set this to
+            # provision the admin non-interactively.
             # - name: OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
             #   valueFrom:
             #     secretKeyRef: { name: omnigent-secrets, key: accounts-admin-password }

--- a/deploy/kubernetes/server/deployment.yaml
+++ b/deploy/kubernetes/server/deployment.yaml
@@ -96,13 +96,16 @@ spec:
             # URL (behind your Ingress/LB), NOT the in-cluster Service address.
             - name: OMNIGENT_ACCOUNTS_BASE_URL
               value: "https://omnigent.example.com"
-            # Creates the first admin headlessly. Omnigent never auto-generates a
-            # password — without this (and with no TTY) first boot reports
-            # needs_setup and waits for the one-time web setup form. Set this to
-            # provision the admin non-interactively.
-            # - name: OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
-            #   valueFrom:
-            #     secretKeyRef: { name: omnigent-secrets, key: accounts-admin-password }
+            # Creates the first admin headlessly when accounts-admin-password is
+            # present in the Secret (Omnigent never auto-generates a password).
+            # optional:true → if the key is absent the pod still boots and first
+            # boot reports needs_setup, waiting for the one-time web setup form.
+            - name: OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: omnigent-secrets
+                  key: accounts-admin-password
+                  optional: true
             # A connecting HOST authenticates with the session JWT from
             # `omnigent login`; the default 8h expiry breaks a long-lived host
             # on reconnect. Raise it for unattended hosts (720 = 30d).

--- a/deploy/kubernetes/server/deployment.yaml
+++ b/deploy/kubernetes/server/deployment.yaml
@@ -1,0 +1,117 @@
+---
+# Omnigent server — the meta-harness hub.
+#
+# Deploys the SERVER ONLY. Per the OSS entrypoint the server runs in
+# "external-runners-only" mode: it accepts runner WebSocket connections at
+# /v1/runner/tunnel and NEVER spawns harness subprocesses itself — so this pod
+# is unprivileged. Agents run in RUNNERS launched elsewhere: a laptop
+# (`omnigent run agent.yaml --server https://omnigent.example.com`), a managed
+# sandbox (Modal/Daytona), or the on-cluster host daemon in ../host/.
+#
+# - Image is linux/amd64-only -> amd64 nodeSelector. GHCR package is public
+#   (no imagePullSecret).
+# - Alembic migrations run automatically in the entrypoint (no migration Job).
+# - AUTH: setting OMNIGENT_OIDC_ISSUER with OMNIGENT_AUTH_ENABLED=1 selects OIDC
+#   mode; the server runs its own /auth/login + /auth/callback. Works with any
+#   OIDC IdP (Authentik, Keycloak, Auth0, Okta, ...). GOTCHA: Omnigent rejects
+#   logins where email_verified != true — make your IdP assert it.
+#   For a no-auth dev/test bring-up, set OMNIGENT_AUTH_ENABLED=0 and drop the
+#   OMNIGENT_OIDC_* / OMNIGENT_DOMAIN env below.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omnigent
+  namespace: omnigent
+  labels:
+    app: omnigent
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate            # single writer to the artifact PVC
+  selector:
+    matchLabels:
+      app: omnigent
+  template:
+    metadata:
+      labels:
+        app: omnigent
+    spec:
+      securityContext:
+        # Group-own the artifact volume so the server can write it even if the
+        # storage backend squashes root. Drop if your storage perms don't need it.
+        fsGroup: 1000
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: omnigent
+          image: ghcr.io/omnigent-ai/omnigent-server:v0.1.0
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: omnigent-secrets
+                  key: database-url
+            - name: ARTIFACT_DIR
+              value: /data/artifacts
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "8000"
+            # ---- auth (OIDC). For no-auth dev: set to "0" and delete the rest. ----
+            - name: OMNIGENT_AUTH_ENABLED
+              value: "1"
+            - name: OMNIGENT_CONFIG
+              value: /etc/omnigent/config.yaml
+            # Browser-facing host. The server derives the OIDC redirect URI
+            # https://<domain>/auth/callback (must match your IdP client's
+            # allowed redirect URIs) and the cookie scope.
+            - name: OMNIGENT_DOMAIN
+              value: omnigent.example.com
+            # Your IdP issuer; the server appends /.well-known/openid-configuration.
+            - name: OMNIGENT_OIDC_ISSUER
+              value: https://YOUR_IDP/application/o/omnigent/
+            - name: OMNIGENT_OIDC_CLIENT_ID
+              value: YOUR_OIDC_CLIENT_ID
+            - name: OMNIGENT_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: omnigent-secrets
+                  key: oidc-client-secret
+            - name: OMNIGENT_OIDC_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: omnigent-secrets
+                  key: oidc-cookie-secret
+            # A connecting HOST authenticates with the session JWT from
+            # `omnigent login`; the default 8h expiry breaks a long-lived host
+            # on reconnect. Raise it for unattended hosts (720 = 30d).
+            - name: OMNIGENT_OIDC_SESSION_TTL_HOURS
+              value: "720"
+          ports:
+            - name: http
+              containerPort: 8000
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /etc/omnigent
+              readOnly: true
+          readinessProbe:
+            httpGet: { path: /health, port: 8000 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: 8000 }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits: { cpu: "1", memory: 1Gi }
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: omnigent-artifacts
+        - name: config
+          configMap:
+            name: omnigent-config

--- a/deploy/kubernetes/server/deployment.yaml
+++ b/deploy/kubernetes/server/deployment.yaml
@@ -11,12 +11,17 @@
 # - Image is linux/amd64-only -> amd64 nodeSelector. GHCR package is public
 #   (no imagePullSecret).
 # - Alembic migrations run automatically in the entrypoint (no migration Job).
-# - AUTH: setting OMNIGENT_OIDC_ISSUER with OMNIGENT_AUTH_ENABLED=1 selects OIDC
-#   mode; the server runs its own /auth/login + /auth/callback. Works with any
-#   OIDC IdP (Authentik, Keycloak, Auth0, Okta, ...). GOTCHA: Omnigent rejects
-#   logins where email_verified != true — make your IdP assert it.
-#   For a no-auth dev/test bring-up, set OMNIGENT_AUTH_ENABLED=0 and drop the
-#   OMNIGENT_OIDC_* / OMNIGENT_DOMAIN env below.
+# - AUTH (default = built-in `accounts`): with OMNIGENT_AUTH_ENABLED=1 and no
+#   OMNIGENT_OIDC_ISSUER set, the server selects its built-in multi-user
+#   `accounts` provider — username/password, no external IdP, first boot
+#   auto-creates an admin (random password in the pod logs + on the artifact
+#   PVC at /data/admin-credentials), and the admin invites teammates from the
+#   web UI. This matches the deploy default everywhere else (see deploy/README.md
+#   "Auth"). To pin the admin password for a headless bring-up, set
+#   OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD.
+#   Prefer your own IdP? See the "opt-in: OIDC instead of accounts" block below.
+#   For a no-auth dev/test bring-up, set OMNIGENT_AUTH_ENABLED=0 (single shared
+#   "local" user — local dev only, never a network-exposed deploy).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,36 +62,72 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: "8000"
-            # ---- auth (OIDC). For no-auth dev: set to "0" and delete the rest. ----
-            - name: OMNIGENT_AUTH_ENABLED
-              value: "1"
             - name: OMNIGENT_CONFIG
               value: /etc/omnigent/config.yaml
-            # Browser-facing host. The server derives the OIDC redirect URI
-            # https://<domain>/auth/callback (must match your IdP client's
-            # allowed redirect URIs) and the cookie scope.
-            - name: OMNIGENT_DOMAIN
-              value: omnigent.example.com
-            # Your IdP issuer; the server appends /.well-known/openid-configuration.
-            - name: OMNIGENT_OIDC_ISSUER
-              value: https://YOUR_IDP/application/o/omnigent/
-            - name: OMNIGENT_OIDC_CLIENT_ID
-              value: YOUR_OIDC_CLIENT_ID
-            - name: OMNIGENT_OIDC_CLIENT_SECRET
+            # ---- auth: built-in `accounts` (DEFAULT — multi-user, no IdP) ----
+            # With AUTH_ENABLED=1 and no OIDC issuer, the server runs its
+            # built-in username/password flow with a first-boot admin. For
+            # no-auth dev/test set OMNIGENT_AUTH_ENABLED=0 (and the cookie
+            # secret / base URL below are then unused).
+            - name: OMNIGENT_AUTH_ENABLED
+              value: "1"
+            # 32-byte hex cookie secret that signs the session cookie. REQUIRED
+            # in accounts mode. Generate with `openssl rand -hex 32`.
+            - name: OMNIGENT_ACCOUNTS_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
                   name: omnigent-secrets
-                  key: oidc-client-secret
-            - name: OMNIGENT_OIDC_COOKIE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: omnigent-secrets
-                  key: oidc-cookie-secret
+                  key: accounts-cookie-secret
+            # Public URL the browser uses. REQUIRED: it builds the single-use
+            # invite-redeem links and decides whether the session cookie gets
+            # the secure __Host- prefix (HTTPS). Must be the externally-reachable
+            # URL (behind your Ingress/LB), NOT the in-cluster Service address.
+            - name: OMNIGENT_ACCOUNTS_BASE_URL
+              value: "https://omnigent.example.com"
+            # Optional: pin the first-boot admin password for a headless deploy
+            # where you can't read the pod logs. Otherwise a random password is
+            # generated and printed to the logs + written to
+            # /data/admin-credentials on the artifact PVC.
+            # - name: OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef: { name: omnigent-secrets, key: accounts-admin-password }
             # A connecting HOST authenticates with the session JWT from
             # `omnigent login`; the default 8h expiry breaks a long-lived host
             # on reconnect. Raise it for unattended hosts (720 = 30d).
-            - name: OMNIGENT_OIDC_SESSION_TTL_HOURS
+            - name: OMNIGENT_ACCOUNTS_SESSION_TTL_HOURS
               value: "720"
+            # ============================================================
+            # OPT-IN: OIDC instead of accounts (bring your own IdP)
+            # ------------------------------------------------------------
+            # To use single sign-on (Authentik, Keycloak, Auth0, Okta, Entra,
+            # Google, GitHub) INSTEAD of the built-in accounts flow, UNCOMMENT
+            # the block below. Setting OMNIGENT_OIDC_ISSUER (with auth enabled)
+            # is what flips the mode to OIDC — the accounts vars above then go
+            # unused, so you can leave them or drop them. The server runs its
+            # own /auth/login + /auth/callback. OIDC requires HTTPS (the session
+            # cookie uses the __Host- prefix). Also switch the Secret over to
+            # its oidc-client-secret / oidc-cookie-secret keys (see
+            # secret.example.yaml).
+            #
+            # GOTCHA: Omnigent rejects logins where email_verified != true —
+            # make your IdP assert it (e.g. Authentik's default OpenID `email`
+            # scope mapping emits false; override it).
+            #
+            # - name: OMNIGENT_DOMAIN          # browser-facing host; the server
+            #   value: omnigent.example.com    #   derives https://<domain>/auth/callback
+            # - name: OMNIGENT_OIDC_ISSUER     # your IdP base URL; the server appends
+            #   value: "https://idp.example.com/"  #   /.well-known/openid-configuration
+            # - name: OMNIGENT_OIDC_CLIENT_ID
+            #   value: YOUR_OIDC_CLIENT_ID
+            # - name: OMNIGENT_OIDC_CLIENT_SECRET
+            #   valueFrom:
+            #     secretKeyRef: { name: omnigent-secrets, key: oidc-client-secret }
+            # - name: OMNIGENT_OIDC_COOKIE_SECRET
+            #   valueFrom:
+            #     secretKeyRef: { name: omnigent-secrets, key: oidc-cookie-secret }
+            # - name: OMNIGENT_OIDC_SESSION_TTL_HOURS   # raise for unattended hosts
+            #   value: "720"                            #   (OIDC equivalent of the accounts TTL above)
+            # ============================================================
           ports:
             - name: http
               containerPort: 8000

--- a/deploy/kubernetes/server/ingress.example.yaml
+++ b/deploy/kubernetes/server/ingress.example.yaml
@@ -1,8 +1,9 @@
 ---
 # Generic Ingress (networking.k8s.io/v1). Adapt to your ingress controller and
-# TLS setup. The host must match OMNIGENT_DOMAIN in the Deployment so the OIDC
-# redirect URI lines up. WebSockets (the live session stream + /v1/runner/tunnel)
-# ride normal HTTP upgrade — most controllers pass them through by default.
+# TLS setup. The host must match the server's public URL — OMNIGENT_ACCOUNTS_BASE_URL
+# in accounts mode (the default), or OMNIGENT_DOMAIN / the OIDC redirect URI if you
+# opt into OIDC. WebSockets (the live session stream + /v1/runner/tunnel) ride
+# normal HTTP upgrade — most controllers pass them through by default.
 #
 # Using a controller CRD instead (Traefik IngressRoute, Contour HTTPProxy, ...)?
 # Route host omnigent.example.com -> service omnigent:8000 there instead.

--- a/deploy/kubernetes/server/ingress.example.yaml
+++ b/deploy/kubernetes/server/ingress.example.yaml
@@ -1,0 +1,33 @@
+---
+# Generic Ingress (networking.k8s.io/v1). Adapt to your ingress controller and
+# TLS setup. The host must match OMNIGENT_DOMAIN in the Deployment so the OIDC
+# redirect URI lines up. WebSockets (the live session stream + /v1/runner/tunnel)
+# ride normal HTTP upgrade — most controllers pass them through by default.
+#
+# Using a controller CRD instead (Traefik IngressRoute, Contour HTTPProxy, ...)?
+# Route host omnigent.example.com -> service omnigent:8000 there instead.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: omnigent
+  namespace: omnigent
+  labels:
+    app: omnigent
+  # annotations:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  # ingressClassName: nginx
+  tls:
+    - hosts: [omnigent.example.com]
+      secretName: omnigent-tls
+  rules:
+    - host: omnigent.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: omnigent
+                port:
+                  number: 8000

--- a/deploy/kubernetes/server/namespace.yaml
+++ b/deploy/kubernetes/server/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: omnigent

--- a/deploy/kubernetes/server/pvc.yaml
+++ b/deploy/kubernetes/server/pvc.yaml
@@ -1,0 +1,17 @@
+---
+# Artifact storage for the server (mounted at /data, ARTIFACT_DIR=/data/artifacts).
+# The Deployment is single-writer (strategy: Recreate), so RWO is fine. Set
+# storageClassName to one your cluster provides (omit to use the default class).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: omnigent-artifacts
+  namespace: omnigent
+  labels:
+    app: omnigent
+spec:
+  accessModes: ["ReadWriteOnce"]
+  # storageClassName: your-storage-class
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/kubernetes/server/secret.example.yaml
+++ b/deploy/kubernetes/server/secret.example.yaml
@@ -3,8 +3,15 @@
 # (sealed-secrets, SOPS, External Secrets, Vault, or a plain `kubectl create
 # secret`). Shown here as a stringData template for clarity.
 #
+# Default (built-in accounts auth):
 #   kubectl -n omnigent create secret generic omnigent-secrets \
-#     --from-literal=database-url='postgresql://omnigent:CHANGE_ME@postgres:5432/omnigent' \
+#     --from-literal=database-url='postgresql://omnigent:CHANGE_ME@postgres.omnigent.svc:5432/omnigent' \
+#     --from-literal=accounts-cookie-secret="$(openssl rand -hex 32)"
+#
+# Opt-in (OIDC instead of accounts) — swap the cookie-secret key and add the
+# client secret (see the OIDC block in deployment.yaml):
+#   kubectl -n omnigent create secret generic omnigent-secrets \
+#     --from-literal=database-url='postgresql://omnigent:CHANGE_ME@postgres.omnigent.svc:5432/omnigent' \
 #     --from-literal=oidc-client-secret='CHANGE_ME' \
 #     --from-literal=oidc-cookie-secret="$(openssl rand -hex 32)"
 apiVersion: v1
@@ -18,7 +25,12 @@ type: Opaque
 stringData:
   # Any reachable Postgres. The entrypoint normalizes postgresql:// -> postgresql+psycopg://.
   database-url: "postgresql://omnigent:CHANGE_ME@postgres.omnigent.svc:5432/omnigent"
+  # Signs the accounts session cookie (default auth mode). Random 32-byte hex:
+  #   openssl rand -hex 32
+  accounts-cookie-secret: "CHANGE_ME"
+  # ---- opt-in: OIDC instead of accounts (uncomment the OIDC block in
+  # deployment.yaml and these keys together) ----
   # From your OIDC provider's client registration.
-  oidc-client-secret: "CHANGE_ME"
-  # Random 32+ byte secret for the session cookie: openssl rand -hex 32
-  oidc-cookie-secret: "CHANGE_ME"
+  # oidc-client-secret: "CHANGE_ME"
+  # Random 32-byte secret for the OIDC session cookie: openssl rand -hex 32
+  # oidc-cookie-secret: "CHANGE_ME"

--- a/deploy/kubernetes/server/secret.example.yaml
+++ b/deploy/kubernetes/server/secret.example.yaml
@@ -6,7 +6,8 @@
 # Default (built-in accounts auth):
 #   kubectl -n omnigent create secret generic omnigent-secrets \
 #     --from-literal=database-url='postgresql://omnigent:CHANGE_ME@postgres.omnigent.svc:5432/omnigent' \
-#     --from-literal=accounts-cookie-secret="$(openssl rand -hex 32)"
+#     --from-literal=accounts-cookie-secret="$(openssl rand -hex 32)" \
+#     --from-literal=accounts-admin-password='CHANGE_ME'   # optional: headless first admin
 #
 # Opt-in (OIDC instead of accounts) — swap the cookie-secret key and add the
 # client secret (see the OIDC block in deployment.yaml):
@@ -28,6 +29,10 @@ stringData:
   # Signs the accounts session cookie (default auth mode). Random 32-byte hex:
   #   openssl rand -hex 32
   accounts-cookie-secret: "CHANGE_ME"
+  # Optional: creates the first admin headlessly (accounts mode never
+  # auto-generates one). Uncomment OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD in
+  # deployment.yaml to consume it; omit to use the one-time web setup form.
+  # accounts-admin-password: "CHANGE_ME"
   # ---- opt-in: OIDC instead of accounts (uncomment the OIDC block in
   # deployment.yaml and these keys together) ----
   # From your OIDC provider's client registration.

--- a/deploy/kubernetes/server/secret.example.yaml
+++ b/deploy/kubernetes/server/secret.example.yaml
@@ -30,8 +30,9 @@ stringData:
   #   openssl rand -hex 32
   accounts-cookie-secret: "CHANGE_ME"
   # Optional: creates the first admin headlessly (accounts mode never
-  # auto-generates one). Uncomment OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD in
-  # deployment.yaml to consume it; omit to use the one-time web setup form.
+  # auto-generates one). deployment.yaml consumes it automatically via an
+  # optional secretKeyRef — just set this key. Omit it to use the one-time web
+  # setup form instead.
   # accounts-admin-password: "CHANGE_ME"
   # ---- opt-in: OIDC instead of accounts (uncomment the OIDC block in
   # deployment.yaml and these keys together) ----

--- a/deploy/kubernetes/server/secret.example.yaml
+++ b/deploy/kubernetes/server/secret.example.yaml
@@ -1,0 +1,24 @@
+---
+# EXAMPLE secret — DO NOT commit real values. Manage it with whatever you use
+# (sealed-secrets, SOPS, External Secrets, Vault, or a plain `kubectl create
+# secret`). Shown here as a stringData template for clarity.
+#
+#   kubectl -n omnigent create secret generic omnigent-secrets \
+#     --from-literal=database-url='postgresql://omnigent:CHANGE_ME@postgres:5432/omnigent' \
+#     --from-literal=oidc-client-secret='CHANGE_ME' \
+#     --from-literal=oidc-cookie-secret="$(openssl rand -hex 32)"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnigent-secrets
+  namespace: omnigent
+  labels:
+    app: omnigent
+type: Opaque
+stringData:
+  # Any reachable Postgres. The entrypoint normalizes postgresql:// -> postgresql+psycopg://.
+  database-url: "postgresql://omnigent:CHANGE_ME@postgres.omnigent.svc:5432/omnigent"
+  # From your OIDC provider's client registration.
+  oidc-client-secret: "CHANGE_ME"
+  # Random 32+ byte secret for the session cookie: openssl rand -hex 32
+  oidc-cookie-secret: "CHANGE_ME"

--- a/deploy/kubernetes/server/service.yaml
+++ b/deploy/kubernetes/server/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: omnigent
+  namespace: omnigent
+  labels:
+    app: omnigent
+spec:
+  selector:
+    app: omnigent
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
Addresses #39 — a Kubernetes way to run Omnigent.

## What this adds

A new `deploy/kubernetes/` reference (alongside the existing `deploy/docker/` and
`deploy/hf-spaces/`), in two parts:

- **`server/`** — the Omnigent server as a `Deployment` + `Service` + `Ingress` +
  `PVC`, Postgres via `DATABASE_URL`. Built-in **`accounts`** auth by default
  (OIDC opt-in). The server runs external-runners-only, so it's an ordinary,
  hardened container (drops all caps, no priv-escalation, seccomp RuntimeDefault).
- **`host/`** — a **stopgap** that runs the `omnigent host` daemon as a
  `Deployment` on the cluster, so a node becomes agent compute: it dials
  `/v1/runner/tunnel` (outbound only) and spawns Claude/Codex runners locally.
  Boots the prebaked `ghcr.io/omnigent-ai/omnigent-host:latest` image.

Plus `README.md` + a `SKILL.md` matching the `deploy/docker` conventions.

## On #39 (the gap)

Omnigent already has managed sandboxes with a pluggable `sandbox.provider`
(lakebox / Modal / Daytona). What's missing is a **`kubernetes` provider** that
spawns runner Pods on demand — so "run the agents as Pods on my cluster" isn't a
config flag today. The right long-term fix is that server-side provider (the same
launch-token seam Modal/Daytona use); `host/` is the pragmatic workaround until it
lands, and demonstrates the host-on-cluster pattern such a provider would replace.

## Validation

- Extracted + generalized from a working K3s deployment, then **re-tested
  end-to-end in that cluster**: the server runs cleanly, and a `claude-sdk` agent
  on an on-cluster host replied to a live request as an unprivileged (uid 1000) pod.
- All manifests pass `kubectl apply --dry-run=client` (`deployment.yaml` also
  `--dry-run=server`).
- Reviewed adversarially against the source. Corrections baked in: accounts mode
  **never auto-generates** an admin password (set
  `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD` or use the one-time web setup form);
  `allowed_domains` is OIDC-only; the `email_verified != true` gotcha; and the
  uid-1000 (`cd $HOME`) + persistent-PVC git-config idempotency details for the host.

## Scope / notes

- Image is `linux/amd64`-only (`cel-expr-python` has no aarch64 wheel) → amd64
  `nodeSelector`.
- Everything is placeholder-driven (namespace, image tag, domain, Postgres, auth,
  storage class, Ingress) — adapt to your cluster.
- Terminal / `native-ui` agents need a `bwrap` sandbox an unprivileged pod can't
  provide; `claude-sdk` / `codex` agents are the supported class on the host
  (documented in `host/README.md`).

Happy to iterate on shape or scope — including folding this toward the eventual
`kubernetes` sandbox provider if you'd prefer that direction over a host stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
