### PR TITLE
perf(e2e_ui): round-robin shard split to balance CI wall-clock

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -238,14 +238,19 @@ jobs:
           if [[ "$NIGHTLY_FULL" != "true" ]]; then
             EXTRA_ARGS+=(-m "not nightly")
           fi
-          # --shard-id/--num-shards (pytest-shard) split the test node
-          # IDs deterministically across the matrix entries; same set
-          # of tests overall, just chunked.
+          # --splits/--group partition the suite across the matrix entries
+          # via a round-robin strided slice (see pytest_collection_modifyitems
+          # in tests/e2e_ui/conftest.py). Unlike pytest-shard's hash-bucketing
+          # -- which was blind to runtime and left one shard ~5min while
+          # others ran ~2min -- striding scatters each heavy file's cases
+          # one-per-shard, evening out wall-clock with no extra dependency
+          # and no durations file to maintain. --group is 1-indexed, so we
+          # map the 0-indexed matrix shard_id with +1.
           uv run pytest tests/e2e_ui \
             -v --tb=long --showlocals --log-level=INFO -r a \
             --ui-skip-build \
-            --shard-id="$SHARD_ID" \
-            --num-shards="$NUM_SHARDS" \
+            --splits="$NUM_SHARDS" \
+            --group="$((SHARD_ID + 1))" \
             --tracing=retain-on-failure \
             --screenshot=only-on-failure \
             --video=retain-on-failure \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,9 @@ dev = [
     "pytest-cov>=5",
     "pytest-playwright>=0.5",
     # Hash-partition the test suite across N shards for the nightly
-    # matrix. Pinned to a known-stable older release.
+    # matrix. Pinned to a known-stable older release. Used by e2e.yml;
+    # the e2e-ui suite uses its own round-robin `--splits`/`--group`
+    # split (see tests/e2e_ui/conftest.py), so no extra dep there.
     "pytest-shard==0.1.2",
     # Per-test wallclock cap. Without this, a single hung test (e.g.
     # a pexpect REPL test waiting for a terminal pattern that never

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -205,6 +205,55 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "instead of rebuilding. Fails if no build is present."
         ),
     )
+    # Round-robin shard split for the e2e-ui CI matrix. We roll our own
+    # (rather than pull in pytest-shard / pytest-split) so the partition
+    # is a dependency-free strided slice -- see pytest_collection_modifyitems
+    # below for why striding beats hash-bucketing for wall-clock balance.
+    parser.addoption(
+        "--splits",
+        type=int,
+        default=None,
+        help="Total number of shards to split the UI suite into (CI matrix).",
+    )
+    parser.addoption(
+        "--group",
+        type=int,
+        default=None,
+        help="1-indexed shard this run executes (requires --splits).",
+    )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Round-robin the collected UI tests across the CI shard matrix.
+
+    pytest-shard hash-buckets node IDs, which is blind to per-test
+    wall-clock and left one shard at ~5min while siblings finished in
+    ~2min. A *strided* slice -- ``items[group-1::splits]`` -- deals tests
+    out like cards instead, so a heavy file (whose cases collect
+    adjacently) scatters one-per-shard rather than landing in a single
+    bucket. That averages cost across shards without maintaining a
+    durations file.
+
+    No-op unless both ``--splits`` and ``--group`` are passed, so local
+    runs and the non-sharded suites are unaffected. ``trylast`` lets the
+    repo-wide known-failures marking in ``tests/conftest.py`` tag items
+    first; markers travel with the items the slice keeps.
+    """
+    splits = config.getoption("--splits")
+    group = config.getoption("--group")
+    if splits is None and group is None:
+        return
+    if splits is None or group is None:
+        raise pytest.UsageError("--splits and --group must be passed together")
+    if splits < 1:
+        raise pytest.UsageError("--splits must be >= 1")
+    if not 1 <= group <= splits:
+        raise pytest.UsageError(f"--group must be between 1 and {splits}")
+    items[:] = items[group - 1 :: splits]
 
 
 def _register_agent_yaml(


### PR DESCRIPTION
## Problem

The `E2E UI Tests` matrix splits the suite across 3 shards with **pytest-shard**, which buckets tests by `hash(node_id) % num_shards`. That hashing is blind to both test count and per-test runtime. On a recent run ([example](https://github.com/omnigent-ai/omnigent/actions/runs/27544646513)) it produced a badly skewed split:

| Shard | Tests | Test step |
|-------|-------|-----------|
| **0** | **26** | **5m14s** |
| 1 | 19 | 2m05s |
| 2 | 21 | 2m09s |

Setup (checkout, uv, Playwright, SPA build) is identical across shards (~1m17s) — the entire gap is in test execution. Shard 0 drew both more tests and a cluster of the heavier multi-browser-context cases, so total wall-clock is gated at ~6m39s by one shard.

## Fix

Replace pytest-shard with a dependency-free **round-robin** split implemented directly in `tests/e2e_ui/conftest.py`:

```python
items[:] = items[group - 1 :: splits]
```

A *strided* slice deals tests out like cards instead of contiguous/hashed bucketing, so a heavy file (whose cases collect adjacently) scatters one-per-shard rather than landing in a single bucket. This is the same approach mlflow uses for its suite.

- Counts go from **26/19/21 → an even 22/22/22**, and per-shard wall-clock evens out.
- The workflow keeps the same matrix and just swaps the flags: `--shard-id/--num-shards` → `--splits/--group` (1-indexed, mapped from the 0-indexed `shard_id` with `+1`).
- No new dependency, no `uv.lock` change, and no `.test_durations` file to maintain.

## Notes

- `e2e.yml` still uses pytest-shard; this PR scopes the change to the UI suite only. (The same hook could later be shared to drop pytest-shard entirely.)
- The hook is a no-op unless both `--splits` and `--group` are passed, so local runs and other suites are unaffected. It uses `trylast=True` so the repo-wide known-failures marking in `tests/conftest.py` tags items before the slice.