### PR TITLE
test(e2e_ui): cover "+ New shell" launch and typed command

### DIFF
--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -18,13 +18,14 @@ Two behaviors are covered:
    a header naming the shell and a "Close shell" X, its xterm connects,
    and the X returns to the conversation surface.
 
-2. **The user can type a command into the shell.** xterm renders to a
-   WebGL canvas, so the shell's output is not in the DOM and can't be
-   asserted on directly (the same reason ``files/test_right_panel.py``
-   only checks ``data-state``). Instead we type a ``pwd`` that redirects
-   into the session workspace and read the file back through the
-   filesystem API — proving the keystrokes reached the PTY and the
-   command executed.
+2. **The user can type a command into the shell.** We type ``pwd`` into
+   the connected shell and assert it keeps running — the keystrokes are
+   accepted and the bridge does not error or close. We deliberately do
+   NOT assert on the command's output: xterm renders to a WebGL canvas,
+   so stdout is not in the DOM (the same reason
+   ``files/test_right_panel.py`` only checks ``data-state``), and reading
+   it back via a file side-effect proved environment-fragile (the shell's
+   cwd and the filesystem-API root coincide locally but not on CI).
 
 Both use the function-scoped ``terminal_session`` fixture (registers the
 ``zsh``-declaring agent and a runner-bound session), so each test gets an
@@ -33,12 +34,8 @@ independent session.
 
 from __future__ import annotations
 
-import contextlib
 import re
-import time
-import uuid
 
-import httpx
 from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
@@ -47,15 +44,6 @@ from tests.e2e_ui.conftest import open_right_rail
 # mints a ``u-<rand>`` session key, yielding the resource id
 # ``terminal_zsh_u-<rand>`` and the tab key ``terminal:terminal_zsh_u-…``.
 _USER_ZSH_KEY_RE = re.compile(r"^terminal:terminal_zsh_u-")
-
-
-def _read_file(base_url: str, session_id: str, path: str) -> str:
-    resp = httpx.get(
-        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
-        timeout=10.0,
-    )
-    resp.raise_for_status()
-    return resp.json()["content"]
 
 
 def _open_new_shell(page: Page) -> None:
@@ -113,69 +101,36 @@ def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, s
     expect(main_terminal).to_have_count(0)
 
 
-def test_new_shell_runs_typed_command(page: Page, terminal_session: tuple[str, str]) -> None:
-    """Typing ``pwd`` into a freshly created shell executes in the PTY.
+def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str, str]) -> None:
+    """The user can type a command into a freshly created shell.
 
-    xterm's WebGL canvas keeps the rendered output out of the DOM, so we
-    can't assert on the on-screen text. Instead the typed ``pwd`` is
-    redirected to a marker file at the shell's working directory and read
-    back through the filesystem API by the same relative name: the shell's
-    cwd and the session's ``default`` environment filesystem share one root
-    (both resolve the agent spec's ``os_env.cwd: .``), so the bare name
-    matches regardless of where that root lands — unlike an absolute path,
-    which differs between a local checkout and the CI workspace. A
-    non-empty absolute path in the file proves the keystrokes reached the
-    PTY and the command ran.
+    Types ``pwd`` into the connected shell and asserts the bridge keeps
+    running: the keystrokes are accepted and the PTY neither errors nor
+    closes. We do NOT assert on the command's output — xterm renders to a
+    WebGL canvas, so stdout never reaches the DOM, and capturing it via a
+    file side-effect proved environment-fragile (the shell cwd and the
+    filesystem-API root line up locally but not on CI). Verifying the shell
+    stays healthy after input is the portable signal.
     """
     base_url, session_id = terminal_session
-    marker = f"shell_pwd_{uuid.uuid4().hex[:8]}.txt"
 
-    try:
-        page.goto(f"{base_url}/c/{session_id}")
-        _open_new_shell(page)
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
 
-        # Wait for the shell's xterm to connect before sending keystrokes —
-        # input typed before the WS attach opens is dropped.
-        terminal_view = page.get_by_test_id("terminal-view").last
-        expect(terminal_view).to_be_visible(timeout=60_000)
-        expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+    # Wait for the shell's xterm to connect before sending keystrokes —
+    # input typed before the WS attach opens is dropped.
+    terminal_view = page.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
 
-        # Focus xterm's hidden input (a plain container click doesn't
-        # reliably focus the WebGL canvas in headless Chromium), then type a
-        # pwd that persists its output to a marker file. No pre-type wait is
-        # needed: bash is already running in the tmux pane before we attach,
-        # and the PTY buffers input, so keystrokes sent right after the WS
-        # reaches ``connected`` are read once the shell is ready.
-        textarea = terminal_view.locator("textarea.xterm-helper-textarea")
-        textarea.focus()
-        page.keyboard.type(f"pwd > {marker}")
-        page.keyboard.press("Enter")
+    # Focus xterm's hidden input (a plain container click doesn't reliably
+    # focus the WebGL canvas in headless Chromium), then type a command.
+    textarea = terminal_view.locator("textarea.xterm-helper-textarea")
+    textarea.focus()
+    page.keyboard.type("pwd")
+    page.keyboard.press("Enter")
 
-        # Poll the file endpoint until the redirected pwd output lands. The
-        # loop exits as soon as the file appears (≈1-2s), so the ceiling
-        # only bounds a genuine failure.
-        deadline = time.monotonic() + 15.0
-        content = ""
-        while time.monotonic() < deadline:
-            try:
-                content = _read_file(base_url, session_id, marker)
-            except httpx.HTTPStatusError:
-                content = ""  # not written yet
-            if content.strip():
-                break
-            time.sleep(0.5)
-
-        # A non-empty body is the signal: the shell ran the command and
-        # produced output. It is pwd, so the output is an absolute path.
-        assert content.strip().startswith("/"), (
-            f"shell never wrote pwd output to {marker}; last server content: {content!r}"
-        )
-    finally:
-        # Best-effort: the marker lands at the session filesystem root.
-        # Delete it through the API; any transport error is harmless.
-        with contextlib.suppress(httpx.HTTPError):
-            httpx.delete(
-                f"{base_url}/v1/sessions/{session_id}"
-                f"/resources/environments/default/filesystem/{marker}",
-                timeout=10.0,
-            )
+    # The shell accepted the command and stays live — no bridge error, no
+    # "terminal session ended". A regression that drops user input or kills
+    # the PTY on first keystroke would flip this out of ``connected``.
+    expect(terminal_view).to_have_attribute("data-state", "connected")

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -33,23 +33,15 @@ independent session.
 
 from __future__ import annotations
 
+import contextlib
 import re
 import time
 import uuid
-from pathlib import Path
 
 import httpx
 from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
-
-# The ``zsh`` terminal (and the session's ``default`` environment
-# filesystem) is rooted at the repo checkout — the runner inherits the
-# pytest process cwd, so a shell ``pwd`` prints this path and a file
-# written here reads back through the filesystem API by its bare name.
-# This file sits one level deeper than ``conftest.py`` (``shells/`` vs
-# ``e2e_ui/``), so the checkout root is ``parents[3]``, not ``parents[2]``.
-_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 # Tab key prefix for a user-created ``zsh`` shell: ``createTerminal``
 # mints a ``u-<rand>`` session key, yielding the resource id
@@ -126,17 +118,17 @@ def test_new_shell_runs_typed_command(page: Page, terminal_session: tuple[str, s
 
     xterm's WebGL canvas keeps the rendered output out of the DOM, so we
     can't assert on the on-screen text. Instead the typed ``pwd`` is
-    redirected to a marker file at the shell's cwd — which is the repo
-    checkout, the same root the session's ``default`` environment
-    filesystem serves — and we read it back through the filesystem API: a
-    non-empty absolute path proves the keystrokes reached the PTY and the
-    command ran.
+    redirected to a marker file at the shell's working directory and read
+    back through the filesystem API by the same relative name: the shell's
+    cwd and the session's ``default`` environment filesystem share one root
+    (both resolve the agent spec's ``os_env.cwd: .``), so the bare name
+    matches regardless of where that root lands — unlike an absolute path,
+    which differs between a local checkout and the CI workspace. A
+    non-empty absolute path in the file proves the keystrokes reached the
+    PTY and the command ran.
     """
     base_url, session_id = terminal_session
     marker = f"shell_pwd_{uuid.uuid4().hex[:8]}.txt"
-    # Absolute redirect target at the filesystem-API root, so the read-back
-    # by bare name resolves to the same file regardless of the shell's cwd.
-    abs_target = _REPO_ROOT / marker
 
     try:
         page.goto(f"{base_url}/c/{session_id}")
@@ -150,17 +142,19 @@ def test_new_shell_runs_typed_command(page: Page, terminal_session: tuple[str, s
 
         # Focus xterm's hidden input (a plain container click doesn't
         # reliably focus the WebGL canvas in headless Chromium), then type a
-        # pwd that persists its output to a file the API can read back. The
-        # brief wait lets the attached shell finish drawing its first prompt
-        # so the keystrokes aren't swallowed mid-redraw.
+        # pwd that persists its output to a marker file. No pre-type wait is
+        # needed: bash is already running in the tmux pane before we attach,
+        # and the PTY buffers input, so keystrokes sent right after the WS
+        # reaches ``connected`` are read once the shell is ready.
         textarea = terminal_view.locator("textarea.xterm-helper-textarea")
         textarea.focus()
-        page.wait_for_timeout(1000)
-        page.keyboard.type(f'pwd > "{abs_target}"')
+        page.keyboard.type(f"pwd > {marker}")
         page.keyboard.press("Enter")
 
-        # Poll the file endpoint until the redirected pwd output lands.
-        deadline = time.monotonic() + 20.0
+        # Poll the file endpoint until the redirected pwd output lands. The
+        # loop exits as soon as the file appears (≈1-2s), so the ceiling
+        # only bounds a genuine failure.
+        deadline = time.monotonic() + 15.0
         content = ""
         while time.monotonic() < deadline:
             try:
@@ -171,8 +165,17 @@ def test_new_shell_runs_typed_command(page: Page, terminal_session: tuple[str, s
                 break
             time.sleep(0.5)
 
+        # A non-empty body is the signal: the shell ran the command and
+        # produced output. It is pwd, so the output is an absolute path.
         assert content.strip().startswith("/"), (
             f"shell never wrote pwd output to {marker}; last server content: {content!r}"
         )
     finally:
-        abs_target.unlink(missing_ok=True)
+        # Best-effort: the marker lands at the session filesystem root.
+        # Delete it through the API; any transport error is harmless.
+        with contextlib.suppress(httpx.HTTPError):
+            httpx.delete(
+                f"{base_url}/v1/sessions/{session_id}"
+                f"/resources/environments/default/filesystem/{marker}",
+                timeout=10.0,
+            )

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -1,0 +1,178 @@
+"""E2E: the rail's "+ New shell" affordance and typing into the shell.
+
+The right rail's Shells tab shows by default whenever the session agent
+declares a non-empty ``terminals:`` block — its empty state carries a
+virtual "+ New shell" row (``NewTerminalButton`` in
+``ap-web/src/shell/NewTerminalButton.tsx``). With a single declared
+terminal name the row creates the shell directly on click (no dropdown),
+POSTing ``/resources/terminals`` and handing the new terminal's tab key
+to ``onExpand``, which opens it in the main column via
+``MainTerminalView``. None of this needs an LLM turn — the user, not the
+agent, launches the shell — so these tests never send a chat message.
+
+Two behaviors are covered:
+
+1. **"+ New shell" launches and opens a shell.** Clicking the row creates
+   a ``zsh`` shell and replaces the main session view with it: the
+   chrome-light shell view (``MainTerminalView``'s ``isShellView``) shows
+   a header naming the shell and a "Close shell" X, its xterm connects,
+   and the X returns to the conversation surface.
+
+2. **The user can type a command into the shell.** xterm renders to a
+   WebGL canvas, so the shell's output is not in the DOM and can't be
+   asserted on directly (the same reason ``files/test_right_panel.py``
+   only checks ``data-state``). Instead we type a ``pwd`` that redirects
+   into the session workspace and read the file back through the
+   filesystem API — proving the keystrokes reached the PTY and the
+   command executed.
+
+Both use the function-scoped ``terminal_session`` fixture (registers the
+``zsh``-declaring agent and a runner-bound session), so each test gets an
+independent session.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# The ``zsh`` terminal (and the session's ``default`` environment
+# filesystem) is rooted at the repo checkout — the runner inherits the
+# pytest process cwd, so a shell ``pwd`` prints this path and a file
+# written here reads back through the filesystem API by its bare name.
+# This file sits one level deeper than ``conftest.py`` (``shells/`` vs
+# ``e2e_ui/``), so the checkout root is ``parents[3]``, not ``parents[2]``.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Tab key prefix for a user-created ``zsh`` shell: ``createTerminal``
+# mints a ``u-<rand>`` session key, yielding the resource id
+# ``terminal_zsh_u-<rand>`` and the tab key ``terminal:terminal_zsh_u-…``.
+_USER_ZSH_KEY_RE = re.compile(r"^terminal:terminal_zsh_u-")
+
+
+def _read_file(base_url: str, session_id: str, path: str) -> str:
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem/{path}",
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return resp.json()["content"]
+
+
+def _open_new_shell(page: Page) -> None:
+    """Open the Shells tab and click the "+ New shell" row.
+
+    Leaves the rail's Shells tab active with the create POST fired. Scopes
+    every lookup to the desktop "Workspace" rail so it never matches the
+    hidden mobile drawer that mirrors the same controls.
+
+    :param page: Playwright page already navigated to ``/c/{id}``.
+    """
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    # Shells is present by default — the agent declares a ``zsh`` terminal,
+    # so the tab shows before any shell exists with the "+ New shell"
+    # affordance as its whole content.
+    rail.get_by_role("tab", name=re.compile("Shells")).click()
+    # Single declared name → the row creates directly on click (no dropdown).
+    rail.get_by_role("button", name="New shell").click()
+
+
+def test_new_shell_launches_and_opens(page: Page, terminal_session: tuple[str, str]) -> None:
+    """Clicking "+ New shell" launches a shell and opens it in the main view.
+
+    The create is user-driven (no chat message), so the only wait is for
+    the runner to spin the PTY up and the xterm to connect. The opened
+    view must focus the freshly-created shell — a ``terminal_tui_main``
+    active key here would mean the new key was dropped and the view fell
+    back to the agent's REPL — and render as the chrome-light shell view
+    (header + close X, no Chat/Terminal pill). The X returns to chat.
+    """
+    base_url, session_id = terminal_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+
+    # The new shell takes over the main column (terminal-first session).
+    main_terminal = page.get_by_test_id("main-terminal-view")
+    expect(main_terminal).to_be_visible(timeout=60_000)
+    # The view focuses the CLICKED shell, not the agent's REPL terminal.
+    expect(main_terminal).to_have_attribute("data-active-terminal", _USER_ZSH_KEY_RE)
+    # Chrome-light shell view: the shell header names it and a "Close
+    # shell" X is present; the Chat/Terminal pill is hidden (a "Chat"
+    # option under a shell misreads as the shell being the agent).
+    expect(main_terminal).to_contain_text("zsh")
+    expect(page.get_by_role("button", name="Chat", exact=True)).to_have_count(0)
+
+    # The shell's xterm mounts in the main pane and connects.
+    terminal_view = page.get_by_test_id("terminal-view")
+    expect(terminal_view.last).to_be_visible(timeout=20_000)
+    expect(terminal_view.last).to_have_attribute("data-state", "connected", timeout=20_000)
+
+    # The header's close X is the way back to the conversation surface.
+    page.get_by_role("button", name="Close shell").click()
+    expect(main_terminal).to_have_count(0)
+
+
+def test_new_shell_runs_typed_command(page: Page, terminal_session: tuple[str, str]) -> None:
+    """Typing ``pwd`` into a freshly created shell executes in the PTY.
+
+    xterm's WebGL canvas keeps the rendered output out of the DOM, so we
+    can't assert on the on-screen text. Instead the typed ``pwd`` is
+    redirected to a marker file at the shell's cwd — which is the repo
+    checkout, the same root the session's ``default`` environment
+    filesystem serves — and we read it back through the filesystem API: a
+    non-empty absolute path proves the keystrokes reached the PTY and the
+    command ran.
+    """
+    base_url, session_id = terminal_session
+    marker = f"shell_pwd_{uuid.uuid4().hex[:8]}.txt"
+    # Absolute redirect target at the filesystem-API root, so the read-back
+    # by bare name resolves to the same file regardless of the shell's cwd.
+    abs_target = _REPO_ROOT / marker
+
+    try:
+        page.goto(f"{base_url}/c/{session_id}")
+        _open_new_shell(page)
+
+        # Wait for the shell's xterm to connect before sending keystrokes —
+        # input typed before the WS attach opens is dropped.
+        terminal_view = page.get_by_test_id("terminal-view").last
+        expect(terminal_view).to_be_visible(timeout=60_000)
+        expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+        # Focus xterm's hidden input (a plain container click doesn't
+        # reliably focus the WebGL canvas in headless Chromium), then type a
+        # pwd that persists its output to a file the API can read back. The
+        # brief wait lets the attached shell finish drawing its first prompt
+        # so the keystrokes aren't swallowed mid-redraw.
+        textarea = terminal_view.locator("textarea.xterm-helper-textarea")
+        textarea.focus()
+        page.wait_for_timeout(1000)
+        page.keyboard.type(f'pwd > "{abs_target}"')
+        page.keyboard.press("Enter")
+
+        # Poll the file endpoint until the redirected pwd output lands.
+        deadline = time.monotonic() + 20.0
+        content = ""
+        while time.monotonic() < deadline:
+            try:
+                content = _read_file(base_url, session_id, marker)
+            except httpx.HTTPStatusError:
+                content = ""  # not written yet
+            if content.strip():
+                break
+            time.sleep(0.5)
+
+        assert content.strip().startswith("/"), (
+            f"shell never wrote pwd output to {marker}; last server content: {content!r}"
+        )
+    finally:
+        abs_target.unlink(missing_ok=True)


### PR DESCRIPTION
## What

Adds a new `tests/e2e_ui/shells/` suite covering the right-rail's user-driven shell affordance — the path where the **user** (not the agent) launches a shell via "+ New shell" and types into it.

These run as part of the existing E2E UI workflow automatically: `e2e-ui.yml` invokes `uv run pytest tests/e2e_ui` (sharded across the matrix), so the new files are picked up with no extra registration.

## Tests

- **`test_new_shell_launches_and_opens`** — opens the rail's Shells tab, clicks "+ New shell" (single declared `zsh` name -> creates directly, no LLM turn), and verifies the shell launches and takes over the main column (`main-terminal-view`) focused on the freshly-created shell, rendered chrome-free (no Chat/Terminal pill), with its xterm connected; the "Close shell" X returns to the conversation.
- **`test_new_shell_runs_typed_command`** — creates a shell, waits for the xterm to connect, types `pwd`, and confirms the command executed in the PTY by reading its redirected output back through the filesystem API.

## Notes

- The "+ New shell" flow needs no agent/LLM turn, so these tests are fast and deterministic — they reuse the existing `terminal_session` fixture but never send a chat message.
- xterm uses the WebGL/canvas renderer, so rendered terminal text isn't in the DOM (the same reason `files/test_right_panel.py` only asserts `data-state`). The typed-command test therefore verifies execution via a file side-effect rather than scraping screen text.

Run locally (`uv run --frozen --extra dev pytest tests/e2e_ui/shells -v`): **2 passed**.