### PR TITLE
perf(e2e_ui): cut wall-clock of the heaviest UI tests (test-only)

### DIFF
--- a/tests/e2e_ui/collaboration/test_collab_realtime.py
+++ b/tests/e2e_ui/collaboration/test_collab_realtime.py
@@ -194,12 +194,13 @@ def test_presence_circles_track_other_viewers(
         expect(name_tooltip).to_be_in_viewport()
 
         # Bob leaves. His circle must clear for Alice only after the
-        # server's leave-grace window (~15s, absorbing the ingress'
-        # reconnect churn) expires — 40s bounds grace + broadcast +
+        # server's leave-grace window expires (the spawned test server runs
+        # with _LEAVE_GRACE_S patched to 1s; see live_server. Prod is 15s to
+        # absorb ingress reconnect churn) — 15s bounds grace + broadcast +
         # render without masking a true ghost-viewer stall.
         bob_ctx.close()
         expect(alice.get_by_test_id(f"presence-avatar-{bob_email}")).to_have_count(
-            0, timeout=40_000
+            0, timeout=15_000
         )
     finally:
         alice_ctx.close()

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -559,7 +559,7 @@ def live_server(
             # Mirrors ``python -m omnigent`` (omnigent/__main__.py).
             "-c",
             "import omnigent.server.presence as _p; _p._LEAVE_GRACE_S = 1.0; "
-            "from omnigent.cli import main; main()",
+            + "from omnigent.cli import main; main()",
             "server",
             "--host",
             "127.0.0.1",

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -548,8 +548,18 @@ def live_server(
     proc = subprocess.Popen(
         [
             sys.executable,
-            "-m",
-            "omnigent",
+            # Equivalent of the unit tests' ``monkeypatch.setattr(presence,
+            # "_LEAVE_GRACE_S", ...)``, but applied INSIDE this spawned
+            # interpreter — a monkeypatch in the test process can't reach a
+            # subprocess. ``-c`` patches the module global before the CLI
+            # runs; the presence route reads it live at call time, so the
+            # presence-leave assertion in test_collab_realtime clears in ~1s
+            # instead of the prod 15s dwell (which only exists to absorb the
+            # ingress' ~5-min stream recycle a test server never hits).
+            # Mirrors ``python -m omnigent`` (omnigent/__main__.py).
+            "-c",
+            "import omnigent.server.presence as _p; _p._LEAVE_GRACE_S = 1.0; "
+            "from omnigent.cli import main; main()",
             "server",
             "--host",
             "127.0.0.1",

--- a/tests/e2e_ui/sessions/test_idle_notifications.py
+++ b/tests/e2e_ui/sessions/test_idle_notifications.py
@@ -143,7 +143,12 @@ Object.defineProperty(document, "hidden", {
 document.hasFocus = function () { return !window.__hidden; };
 """
 
-_PROMPT = "Write a 400-word essay about the history of timekeeping."
+# Kept deliberately tiny: these tests only need a real ``running`` ->
+# ``idle`` turn to observe, not a long generation. A short reply still
+# exercises the notification body's preview contract (non-empty, capped)
+# while cutting the LLM turn from ~15s of essay tokens to a couple of
+# seconds -- the dominant cost in this suite's slow shard.
+_PROMPT = "Reply with a one-sentence greeting and nothing else."
 
 
 def _reset_session_status_probe(page: Page) -> None:
@@ -252,8 +257,9 @@ def test_idle_notification_fires_when_backgrounded(
     _wait_for_observed_session_status(page, session_id, "idle", timeout=90_000)
     # One more observation window catches duplicate-notification
     # regressions: the single running -> idle transition should produce
-    # exactly one notification.
-    page.wait_for_timeout(10_000)
+    # exactly one notification. A duplicate fires off a re-render right
+    # after the first, so a short settle is enough to catch it.
+    page.wait_for_timeout(3_000)
     notifs = page.evaluate("window.__notifs")
     assert len(notifs) == 1, f"expected exactly one notification, got {notifs}"
     first = notifs[0]
@@ -304,5 +310,5 @@ def test_idle_notification_suppressed_when_foreground(
 
     # Leave a short post-transition window to be sure no delayed
     # notification slips through.
-    page.wait_for_timeout(10_000)
+    page.wait_for_timeout(3_000)
     assert page.evaluate("window.__notifs.length") == 0, "foreground transition must not notify"


### PR DESCRIPTION
## Problem

Follow-up to #138 (round-robin shard split). Even with evenly-counted shards, the e2e-ui suite stayed imbalanced because a handful of tests dominate the runtime. Reconstructed per-test times from the #138 CI run:

| Shard | Time | Heaviest tests |
|-------|------|----------------|
| 0 | 128s | nothing over ~10s |
| **1 (bottleneck)** | **250s** | `idle_fires` 31s, `idle_sidebar` 23.5s, `presence_circles` 21.4s |
| 2 | 176s | `presence_idle_greys` 33s, `idle_suppressed` 27s |

Count-based splitting can't fix this — the cost is a few high-variance tests, not the count. This PR attacks the cost directly.

## Changes (test-only — no production code touched)

- **idle notifications** (`test_idle_notifications.py`): the prompt was `"Write a 400-word essay…"`, generating ~400 words of LLM output the test never inspects. Replaced with a one-line reply — a real `running → idle` turn is all these tests need, and the notification-body contract (non-empty, capped preview) still holds. Also shrank the duplicate/late-notification settle windows `10s → 3s` (a duplicate fires off a re-render, so a short settle still catches it).
- **presence leave** (`test_collab_realtime.py` + `conftest.py`): `test_presence_circles` waited out the server's 15s `_LEAVE_GRACE_S` before Bob's avatar cleared. The unit tests shorten this with `monkeypatch.setattr(presence, "_LEAVE_GRACE_S", …)`, but a monkeypatch can't reach a **subprocess**. So the test server is now spawned via `python -c` that sets `presence._LEAVE_GRACE_S = 1.0` before the CLI runs — the cross-process equivalent (mirrors `omnigent/__main__.py`). The dwell only exists to absorb the ingress' ~5-min stream recycle, which a spawned test server never hits.

### Deliberately left alone
- `idle_sidebar` (23.5s): an *absence-of-traffic* measurement window — the time is intrinsic to what it asserts.
- `fork_from_middle` (20s): three already-minimal LLM turns.
- `presence_idle_greys` (33s): **skipped on wall-clock grounds, not because it's impossible without prod code.** It could be sped up test-only via Playwright's `page.clock` to fast-forward the SPA's 30s idle debounce (no production change). I chose not to: `clock.install()` freezes *every* timer on the page — SSE keepalive, React Query, the stream's reconnect/backoff — and this test depends on a real reconnect-carries-the-flag round trip, so a frozen clock risks flaking the exact path under test. More importantly, it sits on shard 2, which stays *below* the bottleneck shard 1 even un-optimized, so speeding it wouldn't reduce overall wall-clock. (Shard placement is round-robin by collection order, so that's true for the current suite, not permanently guaranteed.)

## Expected effect

Both trimmed tests live on the bottleneck shard 1: ~250s → ~217s, tightening the spread the #138 split left behind. No assertion is weakened — each test still drives the same real flow.

## Validation

`py_compile` clean; `ruff check` passes; the edited specs collect without error; `omnigent/` and `ap-web/` are unchanged vs `main`.