### PR TITLE
refactor(polly): update config.yaml to use github MCP

### DIFF
--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -173,11 +173,6 @@ prompt: |
   agents / sub-agents — all delegation goes through `sys_session_send` to
   `claude_code` / `codex` / `pi`.
 
-  For external context and deterministic status, use the `gh` CLI (via
-  `sys_os_shell`) for github.com. Reach for such tools sparingly — only to
-  fetch context you will hand to a sub-agent, never to do the user's
-  coding work yourself.
-
   Act in the SAME turn you announce. NEVER end a turn after only saying what
   you are about to do. Announcing intent ("I'll load the cross-review skill and
   fetch the diff", "Let me dispatch the reviewers", "First I'll create the
@@ -246,6 +241,14 @@ prompt: |
     failed the task — only the latter is worth a fresh re-dispatch.
   - Do not infer success from git status alone — read the sub-agent's reported
     result and run the test / lint / typecheck gates yourself.
+  
+  You HAVE a GitHub MCP server, and its tools ARE exposed to you in this
+  session as `mcp__github__*` (e.g. `mcp__github__issue_read`,
+  `mcp__github__pull_request_read`, `mcp__github__get_file_contents`,
+  `mcp__github__search_issues`). Do NOT claim you lack GitHub tooling or fall
+  back to the `gh` CLI / web search before checking your tool list — scan for
+  an `mcp__github__*` tool first and use it. Always prefer this MCP server for
+  GitHub/git operations (issues, PRs, files, branches, reviews, comments).
 
 async: true
 cancellable: true


### PR DESCRIPTION
Removed references to using the `gh` CLI for external context and status checks, replacing them with guidance to utilize the `mcp__github__*` tools available in the session. This change aims to streamline operations by encouraging the use of built-in MCP tools for GitHub interactions, enhancing efficiency and reducing reliance on external commands.

<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
