### PR TITLE
test(e2e_ui): native Claude Code render-parity suite (CI validation)

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -252,7 +252,14 @@ jobs:
               anthropic:
                 base_url: "${GATEWAY_BASE_URL}"
                 api_key_ref: "env:LLM_API_KEY"
-                default_model: databricks-claude-sonnet-4-6
+                # The default model id is read from models.default (not a
+                # top-level default_model key). Without it the provider
+                # resolves model=None, Claude Code launches with no --model and
+                # falls back to its built-in 'claude-sonnet-4-6', which the
+                # Databricks gateway rejects (the endpoint name is the
+                # 'databricks-' prefixed id).
+                models:
+                  default: databricks-claude-sonnet-4-6
           EOF
           host="${GATEWAY_BASE_URL%/serving-endpoints}"
           cat > "$HOME/.databrickscfg" <<EOF

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -348,6 +348,28 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
+      - name: Dump ~/.claude state on failure (TEMP)
+        # The native-claude transcript + config live under ~/.claude (a hidden
+        # dir the absolute-path artifact glob missed). Copy them under /tmp so
+        # the server-logs upload captures the Claude transcript (API errors) and
+        # ~/.claude.json (first-run gate state). REVERT with the rest.
+        if: failure()
+        run: |
+          mkdir -p /tmp/claude-home-dump
+          cp -r "$HOME/.claude/projects" /tmp/claude-home-dump/ 2>/dev/null || true
+          cp "$HOME/.claude.json" /tmp/claude-home-dump/claude.json 2>/dev/null || true
+          # Redact the bearer token from the copied config before upload.
+          if [ -f /tmp/claude-home-dump/claude.json ]; then
+            python3 - <<'PY' || true
+          import json, pathlib, re
+          p = pathlib.Path("/tmp/claude-home-dump/claude.json")
+          txt = p.read_text()
+          # Scrub any apiKeyHelper printf token and obvious bearer-looking values.
+          txt = re.sub(r'(printf %s )\S+', r'\1<REDACTED>', txt)
+          p.write_text(txt)
+          PY
+          fi
+
       - name: Upload server logs on failure
         id: upload_server_logs
         if: failure()
@@ -369,7 +391,8 @@ jobs:
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
             /tmp/omnigent-*/claude-native/**
-            /home/runner/.claude/projects/**/*.jsonl
+            /tmp/claude-home-dump/**
+            /tmp/claude-tui-*.png
           retention-days: 3
           if-no-files-found: ignore
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -247,7 +247,11 @@ jobs:
         # provider: ANTHROPIC_BASE_URL := the gateway, the token reaches Claude
         # via a printf apiKeyHelper built from env:LLM_API_KEY (the runner env
         # allowlist excludes ANTHROPIC_API_KEY), model := the CI Claude model.
-        # ~/.databrickscfg mirrors e2e.yml for any ambient lookups.
+        # The config uses an env: ref (not the literal token), so no secret is
+        # written to disk here. ~/.databrickscfg / DATABRICKS_BEARER are
+        # intentionally NOT written: the native-claude path authenticates purely
+        # from this provider config, so there's no ambient Databricks lookup to
+        # satisfy — keeping the literal token off disk.
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
@@ -276,13 +280,6 @@ jobs:
                 models:
                   default: databricks-claude-sonnet-4-6
           EOF
-          host="${GATEWAY_BASE_URL%/serving-endpoints}"
-          cat > "$HOME/.databrickscfg" <<EOF
-          [default]
-          host  = $host
-          token = $LLM_API_KEY
-          EOF
-          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
 
       - name: Run UI e2e tests
         # --ui-skip-build: the SPA was already built in the previous

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Install project + dev extras
         run: uv sync --extra all --extra dev
 
-      - name: Install bubblewrap
+      - name: Install bubblewrap + tmux
         # The UI tests boot a real server and open terminals, which run
         # under os_env. An agent/terminal that omits `os_env.sandbox.type`
         # defaults to `linux_bwrap` on Linux and fails loud at runtime if
@@ -171,9 +171,13 @@ jobs:
         # sysctl mirrors ci.yml: Ubuntu 24.04 blocks unprivileged user
         # namespaces by default, which `bwrap`'s `unshare(CLONE_NEWUSER)`
         # needs.
+        #
+        # tmux (TEMP: native-claude validation): the claude-native harness
+        # drives Claude Code through a tmux pane (omnigent/claude_native_bridge),
+        # so the native render-parity test needs `tmux` on PATH like e2e.yml.
         run: |
           sudo apt-get update
-          sudo apt-get install -y bubblewrap
+          sudo apt-get install -y bubblewrap tmux
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Cache Playwright browsers
@@ -207,7 +211,56 @@ jobs:
           npm ci --legacy-peer-deps --no-audit --no-fund
           npm run build
 
+      # ----------------------------------------------------------------------
+      # TEMP (native-claude validation): the three steps below enable the
+      # claude-native ("Claude Code") harness so test_native_claude_render_parity
+      # can boot a real Claude Code CLI in CI. Mirrors how e2e.yml / integration.yml
+      # auth the Claude harnesses. REVERT this block before merge — the standard
+      # e2e-ui suite (openai-agents) does not need it.
+      # ----------------------------------------------------------------------
+      - name: Install Claude Code CLI (TEMP)
+        # Pinned @anthropic-ai/claude-code from .github/ci-deps, same as e2e.yml.
+        # --ignore-scripts blocks arbitrary postinstall; we then run claude-code's
+        # own install.cjs explicitly (audited: platform detect + same-tree hardlink
+        # of the native binary, no network/exec) and put its bin on PATH.
+        working-directory: .github/ci-deps
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          npm install --ignore-scripts
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          echo "${GITHUB_WORKSPACE}/.github/ci-deps/node_modules/.bin" >> "$GITHUB_PATH"
 
+      - name: Configure native-claude gateway provider (TEMP)
+        # The runner derives Claude Code's gateway auth from omnigent provider
+        # config (omnigent.claude_native.resolve_native_claude_config). Register
+        # the Databricks serving-endpoints gateway as the default anthropic
+        # provider: ANTHROPIC_BASE_URL := the gateway, the token reaches Claude
+        # via a printf apiKeyHelper built from env:LLM_API_KEY (the runner env
+        # allowlist excludes ANTHROPIC_API_KEY), model := the CI Claude model.
+        # ~/.databrickscfg mirrors e2e.yml for any ambient lookups.
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          mkdir -p "$HOME/.omnigent"
+          cat > "$HOME/.omnigent/config.yaml" <<EOF
+          providers:
+            databricks-gateway:
+              kind: gateway
+              default: anthropic
+              anthropic:
+                base_url: "${GATEWAY_BASE_URL}"
+                api_key_ref: "env:LLM_API_KEY"
+                default_model: databricks-claude-sonnet-4-6
+          EOF
+          host="${GATEWAY_BASE_URL%/serving-endpoints}"
+          cat > "$HOME/.databrickscfg" <<EOF
+          [default]
+          host  = $host
+          token = $LLM_API_KEY
+          EOF
+          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
 
       - name: Run UI e2e tests
         # --ui-skip-build: the SPA was already built in the previous
@@ -246,8 +299,15 @@ jobs:
           # one-per-shard, evening out wall-clock with no extra dependency
           # and no durations file to maintain. --group is 1-indexed, so we
           # map the 0-indexed matrix shard_id with +1.
-          uv run pytest tests/e2e_ui \
-            -v --tb=long --showlocals --log-level=INFO -r a \
+          # TEMP (native-claude validation): run ONLY the native render-parity
+          # test, not the whole e2e_ui suite. --splits/--group still assign the
+          # single collected test to exactly one shard (the others collect 0 ->
+          # exit 5 -> treated as a pass below), so the matrix stays intact while
+          # Claude Code boots just once. --log-cli-level streams the runner's
+          # claude-native auto-launch + auth-resolution logs live into the step.
+          # REVERT this target back to `tests/e2e_ui` before merge.
+          uv run pytest tests/e2e_ui/messages/test_native_claude_render_parity.py \
+            -v --tb=long --showlocals --log-level=INFO --log-cli-level=INFO -r a -s \
             --ui-skip-build \
             --splits="$NUM_SHARDS" \
             --group="$((SHARD_ID + 1))" \
@@ -287,7 +347,15 @@ jobs:
           # on GitHub-hosted runners. The previous glob targeted
           # ``e2e_ui_logs*``, which never matched, so the artifact was
           # always empty.
-          path: /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
+          #
+          # TEMP (native-claude validation): also grab runner.log (carries the
+          # claude-native auto-launch + auth-resolution + terminal-launch logs)
+          # and the native bridge dir (tmux target, transcript-forward deltas)
+          # under /tmp/omnigent-<uid>/claude-native. REVERT with the rest.
+          path: |
+            /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
+            /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
+            /tmp/omnigent-*/claude-native/**
           retention-days: 3
           if-no-files-found: ignore
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -219,17 +219,25 @@ jobs:
       # e2e-ui suite (openai-agents) does not need it.
       # ----------------------------------------------------------------------
       - name: Install Claude Code CLI (TEMP)
-        # Pinned @anthropic-ai/claude-code from .github/ci-deps, same as e2e.yml.
+        # Install claude-code 2.1.170, NOT the 2.1.124 pinned in
+        # .github/ci-deps. 2.1.124 does not recognise the hook events the
+        # native bridge configures (InstructionsLoaded / CwdChanged /
+        # FileChanged) and shows a blocking "settings values skipped" modal on
+        # startup; the injected first message lands on that modal and is lost,
+        # so no turn ever runs. 2.1.170 accepts those events and boots straight
+        # to the prompt. (The ci-deps pin drives e2e.yml's claude-sdk/codex
+        # legs; bumping it there is a separate change with wider blast radius —
+        # tracked for the permanent native-harness wiring.)
         # --ignore-scripts blocks arbitrary postinstall; we then run claude-code's
         # own install.cjs explicitly (audited: platform detect + same-tree hardlink
         # of the native binary, no network/exec) and put its bin on PATH.
-        working-directory: .github/ci-deps
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
-          npm install --ignore-scripts
+          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
           node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.github/ci-deps/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Configure native-claude gateway provider (TEMP)
         # The runner derives Claude Code's gateway auth from omnigent provider

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -172,9 +172,10 @@ jobs:
         # namespaces by default, which `bwrap`'s `unshare(CLONE_NEWUSER)`
         # needs.
         #
-        # tmux (TEMP: native-claude validation): the claude-native harness
-        # drives Claude Code through a tmux pane (omnigent/claude_native_bridge),
-        # so the native render-parity test needs `tmux` on PATH like e2e.yml.
+        # tmux: the claude-native harness drives Claude Code through a tmux
+        # pane (omnigent/claude_native_bridge), so the native render-parity
+        # test (test_native_claude_render_parity) needs `tmux` on PATH like
+        # e2e.yml.
         run: |
           sudo apt-get update
           sudo apt-get install -y bubblewrap tmux
@@ -212,13 +213,13 @@ jobs:
           npm run build
 
       # ----------------------------------------------------------------------
-      # TEMP (native-claude validation): the three steps below enable the
-      # claude-native ("Claude Code") harness so test_native_claude_render_parity
-      # can boot a real Claude Code CLI in CI. Mirrors how e2e.yml / integration.yml
-      # auth the Claude harnesses. REVERT this block before merge — the standard
-      # e2e-ui suite (openai-agents) does not need it.
+      # Native-claude ("Claude Code") harness enablement. The two steps below
+      # let test_native_claude_render_parity boot a real Claude Code CLI in CI,
+      # mirroring how e2e.yml / integration.yml auth the Claude harnesses. Only
+      # the native render-parity test depends on these; the rest of the e2e-ui
+      # suite (openai-agents) ignores them.
       # ----------------------------------------------------------------------
-      - name: Install Claude Code CLI (TEMP)
+      - name: Install Claude Code CLI
         # Install claude-code 2.1.170, NOT the 2.1.124 pinned in
         # .github/ci-deps. 2.1.124 does not recognise the hook events the
         # native bridge configures (InstructionsLoaded / CwdChanged /
@@ -239,7 +240,7 @@ jobs:
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
-      - name: Configure native-claude gateway provider (TEMP)
+      - name: Configure native-claude gateway provider
         # The runner derives Claude Code's gateway auth from omnigent provider
         # config (omnigent.claude_native.resolve_native_claude_config). Register
         # the Databricks serving-endpoints gateway as the default anthropic
@@ -320,15 +321,8 @@ jobs:
           # one-per-shard, evening out wall-clock with no extra dependency
           # and no durations file to maintain. --group is 1-indexed, so we
           # map the 0-indexed matrix shard_id with +1.
-          # TEMP (native-claude validation): run ONLY the native render-parity
-          # test, not the whole e2e_ui suite. --splits/--group still assign the
-          # single collected test to exactly one shard (the others collect 0 ->
-          # exit 5 -> treated as a pass below), so the matrix stays intact while
-          # Claude Code boots just once. --log-cli-level streams the runner's
-          # claude-native auto-launch + auth-resolution logs live into the step.
-          # REVERT this target back to `tests/e2e_ui` before merge.
-          uv run pytest tests/e2e_ui/messages/test_native_claude_render_parity.py \
-            -v --tb=long --showlocals --log-level=INFO --log-cli-level=INFO -r a -s \
+          uv run pytest tests/e2e_ui \
+            -v --tb=long --showlocals --log-level=INFO -r a \
             --ui-skip-build \
             --splits="$NUM_SHARDS" \
             --group="$((SHARD_ID + 1))" \
@@ -356,11 +350,11 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
-      - name: Dump ~/.claude state on failure (TEMP)
+      - name: Dump ~/.claude state on failure
         # The native-claude transcript + config live under ~/.claude (a hidden
-        # dir the absolute-path artifact glob missed). Copy them under /tmp so
+        # dir the absolute-path artifact glob misses). Copy them under /tmp so
         # the server-logs upload captures the Claude transcript (API errors) and
-        # ~/.claude.json (first-run gate state). REVERT with the rest.
+        # ~/.claude.json (first-run gate state) when the native test fails.
         if: failure()
         run: |
           mkdir -p /tmp/claude-home-dump
@@ -391,16 +385,16 @@ jobs:
           # ``e2e_ui_logs*``, which never matched, so the artifact was
           # always empty.
           #
-          # TEMP (native-claude validation): also grab runner.log (carries the
-          # claude-native auto-launch + auth-resolution + terminal-launch logs)
-          # and the native bridge dir (tmux target, transcript-forward deltas)
-          # under /tmp/omnigent-<uid>/claude-native. REVERT with the rest.
+          # Also grab runner.log (carries the claude-native auto-launch +
+          # auth-resolution + terminal-launch logs) and the native bridge dir
+          # (tmux target, transcript-forward deltas) under
+          # /tmp/omnigent-<uid>/claude-native, plus the ~/.claude dump above —
+          # all needed to triage a native render-parity failure.
           path: |
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
             /tmp/omnigent-*/claude-native/**
             /tmp/claude-home-dump/**
-            /tmp/claude-tui-*.png
           retention-days: 3
           if-no-files-found: ignore
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -350,27 +350,17 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
-      - name: Dump ~/.claude state on failure
-        # The native-claude transcript + config live under ~/.claude (a hidden
-        # dir the absolute-path artifact glob misses). Copy them under /tmp so
-        # the server-logs upload captures the Claude transcript (API errors) and
-        # ~/.claude.json (first-run gate state) when the native test fails.
+      - name: Dump Claude transcript on failure
+        # Claude Code's transcript (the JSONL with its actual API errors)
+        # lives under ~/.claude/projects, a hidden dir the absolute-path
+        # artifact glob misses. Copy it under /tmp so the server-logs upload
+        # captures it when the native test fails. Deliberately NOT copying
+        # ~/.claude.json: its apiKeyHelper embeds the gateway token, so it is
+        # never staged for upload — no credential leaves the runner.
         if: failure()
         run: |
           mkdir -p /tmp/claude-home-dump
           cp -r "$HOME/.claude/projects" /tmp/claude-home-dump/ 2>/dev/null || true
-          cp "$HOME/.claude.json" /tmp/claude-home-dump/claude.json 2>/dev/null || true
-          # Redact the bearer token from the copied config before upload.
-          if [ -f /tmp/claude-home-dump/claude.json ]; then
-            python3 - <<'PY' || true
-          import json, pathlib, re
-          p = pathlib.Path("/tmp/claude-home-dump/claude.json")
-          txt = p.read_text()
-          # Scrub any apiKeyHelper printf token and obvious bearer-looking values.
-          txt = re.sub(r'(printf %s )\S+', r'\1<REDACTED>', txt)
-          p.write_text(txt)
-          PY
-          fi
 
       - name: Upload server logs on failure
         id: upload_server_logs
@@ -388,8 +378,8 @@ jobs:
           # Also grab runner.log (carries the claude-native auto-launch +
           # auth-resolution + terminal-launch logs) and the native bridge dir
           # (tmux target, transcript-forward deltas) under
-          # /tmp/omnigent-<uid>/claude-native, plus the ~/.claude dump above —
-          # all needed to triage a native render-parity failure.
+          # /tmp/omnigent-<uid>/claude-native, plus the Claude transcript
+          # staged above — all needed to triage a native render-parity failure.
           path: |
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -250,7 +250,13 @@ jobs:
               kind: gateway
               default: anthropic
               anthropic:
-                base_url: "${GATEWAY_BASE_URL}"
+                # Databricks serves the Anthropic Messages surface at
+                # <host>/serving-endpoints/anthropic (see
+                # omnigent/inner/pi_executor.py: claude_base_url). GATEWAY_BASE_URL
+                # is <host>/serving-endpoints (the OpenAI-compatible surface), so
+                # the /anthropic suffix is required — without it Claude Code POSTs
+                # to .../serving-endpoints/v1/messages and gets no reply.
+                base_url: "${GATEWAY_BASE_URL}/anthropic"
                 api_key_ref: "env:LLM_API_KEY"
                 # The default model id is read from models.default (not a
                 # top-level default_model key). Without it the provider
@@ -363,6 +369,7 @@ jobs:
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
             /tmp/omnigent-*/claude-native/**
+            /home/runner/.claude/projects/**/*.jsonl
           retention-days: 3
           if-no-files-found: ignore
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1491,7 +1491,16 @@ def _provider_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcod
         family.default_model,
     )
     return ClaudeNativeUcodeConfig(
-        env={_UCODE_CLAUDE_BASE_URL_ENV: family.base_url},
+        env={
+            _UCODE_CLAUDE_BASE_URL_ENV: family.base_url,
+            # Disable Claude Code's experimental anthropic-beta flags. Gateways
+            # (Databricks serving-endpoints and the like) reject beta flags they
+            # don't implement with a 400 "invalid beta flag", which kills every
+            # turn. The ucode/databricks path already sets this; mirror it here
+            # so the generic key/gateway/local provider path is equally
+            # gateway-safe.
+            _CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS_ENV: "1",
+        },
         api_key_helper=api_key_helper,
         model=family.default_model,
     )

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1482,4 +1482,11 @@ def native_claude_session(
         httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
         if respawned is not None:
             respawned.terminate()
-            respawned.wait(timeout=5)
+            # Escalate to SIGKILL if the runner ignores SIGTERM, so a wedged
+            # process can't raise in teardown and leak / fail unrelated tests
+            # (matching terminal_session / seeded_session_pair).
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1291,10 +1291,18 @@ def server_pid(live_server: str) -> int:
 # up a different agent" without the multi-provider sprawl of the packaged
 # ``polly`` / ``debby`` examples.
 #
-# Native CLI built-ins (``claude-native-ui`` / ``codex-native-ui``) are not
-# wired up here yet: driving the real vendor TUI in a PTY needs CI-side setup
-# (gateway auth + Claude Code first-run state) owned by the native-harness CI
-# enablement work. Add those fixtures back alongside that effort.
+# ``native_claude_session`` is the native-CLI counterpart: it spins up a real
+# ``claude-native`` ("Claude Code") wrapper session — the same terminal-first
+# spec ``omnigent claude`` ships — and yields ``(base_url, session_id)``. The
+# runner auto-launches Claude Code in the session terminal on bind, including
+# the gateway auth it derives from the runner's own credentials and the
+# first-run trust/onboarding pre-accept, so no CLI client is needed. In CI the
+# workflow exchanges Databricks OAuth before pytest runs (the same gateway the
+# ``hello_world`` / ``echo_probe`` agents authenticate against), so Claude Code
+# boots non-interactively. The native render-parity suite drives this fixture.
+#
+# ``codex-native-ui`` is still not wired up here — add a sibling fixture
+# alongside that effort.
 # ---------------------------------------------------------------------------
 
 # A precise-echo agent on the openai-agents harness (same provider family as
@@ -1379,6 +1387,95 @@ def custom_agent_session(
     respawned = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
     session_id = _create_bundled_session(live_server, runner_id, _CUSTOM_AGENT_YAML)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)
+
+
+def _create_native_claude_session(base_url: str, runner_id: str) -> str:
+    """Register the ``claude-native`` wrapper agent and bind its session.
+
+    Reuses the exact terminal-first spec ``omnigent claude`` ships
+    (:func:`omnigent.claude_native._materialize_claude_agent_spec`) so the
+    fixture never drifts from production, and stamps the same wrapper /
+    terminal-first labels (``omnigent.wrapper`` + ``omnigent.ui = terminal``)
+    the CLI writes. The spec carries no ``spec_version``, so it is bundled
+    under a ``*.yaml`` arcname to route through the omnigent compat translator
+    (which preserves ``executor.harness`` + ``terminals:``); a ``config.yaml``
+    arcname would hit the strict parser and reject it.
+
+    Binding the session to the runner triggers the runner's claude-native
+    auto-bootstrap: it launches Claude Code in the session terminal, derives
+    the gateway auth from its own credentials, and pre-accepts the first-run
+    trust/onboarding prompts — no CLI client required.
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: The token-bound runner id to bind.
+    :returns: The new session/conversation id.
+    """
+    import json as _json
+    import tempfile
+
+    from omnigent._wrapper_labels import (
+        CLAUDE_NATIVE_WRAPPER_VALUE,
+        UI_MODE_LABEL_KEY,
+        UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY,
+    )
+    from omnigent.claude_native import _materialize_claude_agent_spec
+
+    with tempfile.TemporaryDirectory() as _tmp:
+        spec_path = _materialize_claude_agent_spec(Path(_tmp))
+        yaml_text = spec_path.read_text()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        # Non-config.yaml arcname → omnigent compat translator (the spec has
+        # no spec_version), matching the terminal_session fixture.
+        info = tarfile.TarInfo("claude-native-ui.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    labels = {
+        UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY: CLAUDE_NATIVE_WRAPPER_VALUE,
+    }
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": _json.dumps({"labels": labels})},
+        files={"bundle": ("claude-native-ui.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+@pytest.fixture
+def native_claude_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session on the real ``claude-native`` ("Claude Code") wrapper.
+
+    The runner auto-launches Claude Code in the session terminal on bind
+    (gateway auth + first-run pre-accept handled runner-side), so the SPA's
+    Terminal view attaches to a live Claude Code TUI and its Chat view renders
+    the same canonical transcript. Drives the native render-parity suite.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    session_id = _create_native_claude_session(live_server, runner_id)
     try:
         yield (live_server, session_id)
     finally:

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -41,7 +41,6 @@ OAuth before pytest. See ``native_claude_session`` in ``conftest.py``.
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 
 import pytest
@@ -120,29 +119,6 @@ def _type_into_tui(page: Page, text: str) -> None:
     page.keyboard.press("Enter")
 
 
-def _dump_tui_screenshot(page: Page, tag: str) -> None:
-    """TEMP diagnostic: screenshot the live Claude Code TUI pane.
-
-    On a CI failure the default page screenshot shows the Chat view; this
-    switches to the Terminal view and captures the xterm canvas so a
-    blocking first-run TUI screen (trust/login/theme/api-key prompt) is
-    visible in the uploaded artifact. Best-effort — never masks the real
-    failure. REMOVE with the rest of the native-claude CI validation TEMP.
-
-    :param page: The Playwright page.
-    :param tag: Short label for the screenshot filename.
-    """
-    out_dir = os.environ.get("OMNIGENT_TUI_DIAG_DIR", "/tmp")
-    try:
-        _open_terminal_view(page)
-        page.wait_for_timeout(1500)
-        page.locator(_TERMINAL_VIEW).last.screenshot(path=f"{out_dir}/claude-tui-{tag}.png")
-        _log.warning("captured Claude TUI screenshot: %s/claude-tui-%s.png", out_dir, tag)
-    except Exception as exc:
-        # Diagnostic must never mask the real failure.
-        _log.warning("failed to capture Claude TUI screenshot (%s): %s", tag, exc)
-
-
 @pytest.mark.timeout(900)
 def test_native_claude_message_render_parity(
     page: Page,
@@ -185,14 +161,9 @@ def test_native_claude_message_render_parity(
         )
         _send(page, _turn_prompt(index, user_marker, assistant_token))
         # The echoed token in an assistant bubble = this turn produced its reply.
-        try:
-            expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
-                timeout=_NATIVE_TURN_TIMEOUT_MS
-            )
-        except AssertionError:
-            # TEMP: capture the TUI pane so a blocking first-run screen is visible.
-            _dump_tui_screenshot(page, f"composer-turn-{index}")
-            raise
+        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+            timeout=_NATIVE_TURN_TIMEOUT_MS
+        )
         # Fully settle (working shimmer gone) before the next send, so any
         # transient native live-preview has collapsed into the committed bubble.
         expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -41,6 +41,7 @@ OAuth before pytest. See ``native_claude_session`` in ``conftest.py``.
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 
 import pytest
@@ -119,6 +120,29 @@ def _type_into_tui(page: Page, text: str) -> None:
     page.keyboard.press("Enter")
 
 
+def _dump_tui_screenshot(page: Page, tag: str) -> None:
+    """TEMP diagnostic: screenshot the live Claude Code TUI pane.
+
+    On a CI failure the default page screenshot shows the Chat view; this
+    switches to the Terminal view and captures the xterm canvas so a
+    blocking first-run TUI screen (trust/login/theme/api-key prompt) is
+    visible in the uploaded artifact. Best-effort — never masks the real
+    failure. REMOVE with the rest of the native-claude CI validation TEMP.
+
+    :param page: The Playwright page.
+    :param tag: Short label for the screenshot filename.
+    """
+    out_dir = os.environ.get("OMNIGENT_TUI_DIAG_DIR", "/tmp")
+    try:
+        _open_terminal_view(page)
+        page.wait_for_timeout(1500)
+        page.locator(_TERMINAL_VIEW).last.screenshot(path=f"{out_dir}/claude-tui-{tag}.png")
+        _log.warning("captured Claude TUI screenshot: %s/claude-tui-%s.png", out_dir, tag)
+    except Exception as exc:
+        # Diagnostic must never mask the real failure.
+        _log.warning("failed to capture Claude TUI screenshot (%s): %s", tag, exc)
+
+
 @pytest.mark.timeout(900)
 def test_native_claude_message_render_parity(
     page: Page,
@@ -161,9 +185,14 @@ def test_native_claude_message_render_parity(
         )
         _send(page, _turn_prompt(index, user_marker, assistant_token))
         # The echoed token in an assistant bubble = this turn produced its reply.
-        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
-            timeout=_NATIVE_TURN_TIMEOUT_MS
-        )
+        try:
+            expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+                timeout=_NATIVE_TURN_TIMEOUT_MS
+            )
+        except AssertionError:
+            # TEMP: capture the TUI pane so a blocking first-run screen is visible.
+            _dump_tui_screenshot(page, f"composer-turn-{index}")
+            raise
         # Fully settle (working shimmer gone) before the next send, so any
         # transient native live-preview has collapsed into the committed bubble.
         expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -110,7 +110,10 @@ def _type_into_tui(page: Page, text: str) -> None:
     :param page: The Playwright page, on the connected Terminal view.
     :param text: The single-line prompt to type into the TUI.
     """
-    xterm_input = page.locator(_XTERM_INPUT).last
+    # Scope to the active terminal-view (not page-level) so the lookup can't
+    # focus a stray textarea from another terminal widget — matches the shell
+    # E2E test pattern.
+    xterm_input = page.locator(_TERMINAL_VIEW).last.locator(_XTERM_INPUT)
     expect(xterm_input).to_be_attached(timeout=30_000)
     xterm_input.focus()
     # Type at a human-ish cadence: Claude Code's TUI composer can drop or

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -1,0 +1,197 @@
+r"""UI journey: a native Claude Code session renders parity with its TUI.
+
+The native ``claude-native`` ("Claude Code") wrapper is terminal-first: a real
+``claude`` CLI runs in the session terminal, the SPA's **Terminal** view
+attaches to that live TUI over a WebSocket, and the SPA's **Chat** view renders
+the SAME canonical transcript (``GET /v1/sessions/{id}/items``) the TUI prints.
+A native bridge forwards web-composer messages INTO the Claude process and
+forwards Claude's transcript back OUT as conversation items. This suite asserts
+that round-trips both ways and renders exactly once — the three properties the
+native forwarder has historically regressed on:
+
+1. **Render parity with the TUI.** Composer turns are sent through the web SPA;
+   each per-turn user marker and assistant token the SPA shows in a bubble must
+   also appear in the canonical transcript, in the same order, exactly once. The
+   transcript is what the TUI prints, so transcript parity == "renders the same
+   as the TUI".
+
+2. **A TUI-originated message surfaces in the web UI.** A turn is typed directly
+   into the Claude Code TUI (the embedded xterm in the Terminal view) — never
+   through the composer. The native bridge must forward it back out as a user
+   item + assistant reply, so switching to Chat shows both as bubbles and the
+   transcript carries them. This is the OUT direction the composer turns don't
+   exercise.
+
+3. **No duplicate rendering.** Every marker/token — composer- and TUI-originated
+   alike — must land in EXACTLY ONE bubble and one transcript entry. The classic
+   native-forwarder bug double-rendered a reply as both a streaming live preview
+   and the committed bubble; per-turn unique tokens make that count unambiguous.
+
+Per-turn unique markers/tokens are load-bearing for the same reasons as the
+custom-agent suite: they keep the dedup count and order checks unambiguous even
+though Claude Code is far chattier than the ``echo_probe`` agent (it may emit
+thinking, tool calls, and prose around the echoed token). Every assertion counts
+*bubbles/entries containing the token*, never bubbles, so chattiness is fine.
+
+Requires the native-harness gateway auth the runner derives from its own
+credentials (the same gateway ``hello_world`` uses); CI exchanges Databricks
+OAuth before pytest. See ``native_claude_session`` in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+from playwright.sync_api import Page, expect
+
+# Reuse the custom-agent suite's helpers — both surfaces render from the same
+# canonical transcript, so parity / dedup / ordering are asserted identically.
+from .test_message_render_parity import (
+    _ASSISTANT,
+    _USER,
+    _WORKING,
+    _assert_no_duplicate_render,
+    _assert_transcript_parity,
+    _ensure_chat_view,
+    _send,
+    _turn_prompt,
+)
+
+_log = logging.getLogger(__name__)
+
+_TERMINAL_VIEW = '[data-testid="terminal-view"]'
+# xterm.js routes all keystrokes through a hidden helper <textarea>; focusing it
+# and typing is how a user (and Playwright) drives the embedded TUI.
+_XTERM_INPUT = ".xterm-helper-textarea"
+
+# A native Claude Code turn is a full agent loop (real LLM, possible tool use),
+# so it is far slower than a single custom-agent LLM call.
+_NATIVE_TURN_TIMEOUT_MS = 180_000
+# Claude Code boots in the terminal on bind; the auto-launch + first-run
+# pre-accept + WS attach can take a while on a cold CI runner.
+_TERMINAL_READY_TIMEOUT_MS = 120_000
+
+# Two composer turns (the IN direction) + one TUI turn (the OUT direction).
+_COMPOSER_TURNS = 2
+
+
+def _open_terminal_view(page: Page) -> None:
+    """Switch a terminal-first session to its Terminal (TUI) view.
+
+    :param page: The Playwright page, on the session's chat surface.
+    """
+    view_mode = page.get_by_role("group", name="View mode")
+    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
+    terminal_button = view_mode.get_by_role("button", name="Terminal")
+    expect(terminal_button).to_be_visible(timeout=30_000)
+    terminal_button.click()
+
+
+def _wait_terminal_connected(page: Page) -> None:
+    """Wait until the embedded xterm has attached to the live Claude TUI.
+
+    :param page: The Playwright page, on the Terminal view.
+    """
+    terminal = page.locator(_TERMINAL_VIEW).last
+    expect(terminal).to_have_attribute(
+        "data-state", "connected", timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+
+
+def _type_into_tui(page: Page, text: str) -> None:
+    """Type *text* into the embedded Claude Code TUI and submit with Enter.
+
+    Drives the real TUI exactly as a user would: focus the xterm input,
+    type the prompt, press Enter. This is the OUT direction — the message
+    originates in the terminal, not the web composer.
+
+    :param page: The Playwright page, on the connected Terminal view.
+    :param text: The single-line prompt to type into the TUI.
+    """
+    xterm_input = page.locator(_XTERM_INPUT).last
+    expect(xterm_input).to_be_attached(timeout=30_000)
+    xterm_input.focus()
+    # Type at a human-ish cadence: Claude Code's TUI composer can drop or
+    # reorder characters injected faster than it repaints.
+    page.keyboard.type(text, delay=15)
+    page.keyboard.press("Enter")
+
+
+@pytest.mark.timeout(900)
+def test_native_claude_message_render_parity(
+    page: Page,
+    native_claude_session: tuple[str, str],
+) -> None:
+    """Native Claude Code renders parity with its TUI, both ways, with no dupes.
+
+    Covers all three properties on a single (expensive to spin up) native
+    session: composer parity (IN), a TUI-originated turn surfacing in the web UI
+    (OUT), and no duplicate rendering across every turn.
+    """
+    base_url, session_id = native_claude_session
+    _log.info("native-claude session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The Terminal view proves Claude Code actually booted in the session
+    # terminal (the runner's claude-native auto-launch) before we send anything.
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _log.info("Claude Code TUI attached (terminal-view connected)")
+
+    user_markers: list[str] = []
+    assistant_tokens: list[str] = []
+
+    def _new_turn(index: int) -> tuple[str, str]:
+        nonce = uuid.uuid4().hex[:8]
+        user_marker = f"usr-{index}-{nonce}"
+        assistant_token = f"ast-{index}-{nonce}"
+        user_markers.append(user_marker)
+        assistant_tokens.append(assistant_token)
+        return user_marker, assistant_token
+
+    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
+    _ensure_chat_view(page)
+    for index in range(1, _COMPOSER_TURNS + 1):
+        user_marker, assistant_token = _new_turn(index)
+        _log.info(
+            "composer turn %d: sending (marker=%s token=%s)", index, user_marker, assistant_token
+        )
+        _send(page, _turn_prompt(index, user_marker, assistant_token))
+        # The echoed token in an assistant bubble = this turn produced its reply.
+        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+            timeout=_NATIVE_TURN_TIMEOUT_MS
+        )
+        # Fully settle (working shimmer gone) before the next send, so any
+        # transient native live-preview has collapsed into the committed bubble.
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+        expect(page.locator(_USER)).to_have_count(index, timeout=30_000)
+        _log.info("composer turn %d: settled", index)
+
+    # --- Property 2 & 3: a TUI-originated turn (OUT) surfaces in the web UI. ---
+    tui_index = _COMPOSER_TURNS + 1
+    tui_marker, tui_token = _new_turn(tui_index)
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _log.info(
+        "TUI turn %d: typing into xterm (marker=%s token=%s)", tui_index, tui_marker, tui_token
+    )
+    _type_into_tui(page, _turn_prompt(tui_index, tui_marker, tui_token))
+
+    # Back in Chat, the bridge must have forwarded the TUI turn OUT as a user
+    # item + assistant reply — both render as bubbles, exactly once.
+    _ensure_chat_view(page)
+    expect(page.locator(_ASSISTANT, has_text=tui_token).first).to_be_visible(
+        timeout=_NATIVE_TURN_TIMEOUT_MS
+    )
+    expect(page.locator(_USER, has_text=tui_marker).first).to_be_visible(timeout=30_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(page.locator(_USER)).to_have_count(len(user_markers), timeout=30_000)
+    _log.info("TUI turn %d: surfaced in web UI (user + assistant bubbles present)", tui_index)
+
+    # --- Assert all three properties over every turn. ---
+    _assert_no_duplicate_render(page, user_markers, assistant_tokens)
+    _assert_transcript_parity(base_url, session_id, user_markers, assistant_tokens)
+    _log.info("all turns verified: render parity + no-duplicate-render + transcript parity")

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -5713,7 +5713,12 @@ def test_provider_config_for_native_claude_key_injects_base_url_and_helper() -> 
 
     cfg = claude_native._provider_config_for_native_claude(entry)
     assert cfg is not None
-    assert cfg.env == {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}
+    # ANTHROPIC_BASE_URL plus the gateway-safety beta-disable flag (gateways
+    # 400 on beta flags they don't implement; see _provider_config_for_native_claude).
+    assert cfg.env == {
+        "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    }
     # Static key delivered via the apiKeyHelper, never the env (allowlist).
     assert cfg.api_key_helper == "printf %s sk-ant-test"
     assert cfg.model == "claude-sonnet-4-6"
@@ -5740,7 +5745,10 @@ def test_provider_config_for_native_claude_uses_auth_command_verbatim() -> None:
     cfg = claude_native._provider_config_for_native_claude(entry)
     assert cfg is not None
     assert cfg.api_key_helper == "my-cli print-token"
-    assert cfg.env == {"ANTHROPIC_BASE_URL": "https://gw.example/v1"}
+    assert cfg.env == {
+        "ANTHROPIC_BASE_URL": "https://gw.example/v1",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    }
 
 
 def test_resolve_native_claude_config_spec_provider_default(


### PR DESCRIPTION
## What

Adds `tests/e2e_ui/messages/test_native_claude_render_parity.py` — the native-CLI counterpart to the custom-agent render-parity suite. It drives a **real `claude-native` ("Claude Code")** session through the web UI and asserts the three properties the native forwarder has historically regressed on:

1. **Render parity with the TUI** — composer turns; each marker/token the SPA shows in a bubble also appears in the canonical transcript (`GET /v1/sessions/{id}/items`, the same source the TUI prints from), in order, exactly once.
2. **TUI → web UI** — a turn typed directly into the embedded Claude Code TUI (the xterm Terminal view) surfaces back in Chat as user + assistant bubbles via the native bridge.
3. **No duplicate rendering** — every composer- and TUI-originated marker/token lands in exactly one bubble and one transcript entry.

New `native_claude_session` fixture reuses the exact terminal-first spec `omnigent claude` ships (`_materialize_claude_agent_spec`), so it never drifts from production. The runner auto-launches Claude Code in the session terminal on bind (gateway auth + first-run trust pre-accept handled runner-side). Passes locally in ~75s.

## TEMPORARY — for CI validation only (revert before merge)

This closes the native-harness CI-enablement gap the previous suite's NOTE referenced. `e2e-ui.yml` is temporarily:
- scoped to run **only** this test (kept `--splits/--group` so it lands on one shard; the others collect 0 -> pass);
- wired to enable the claude-native harness: install the pinned `@anthropic-ai/claude-code` CLI + `tmux`, register the Databricks serving-endpoints gateway as the default `anthropic` provider (token via a `printf` apiKeyHelper from `env:LLM_API_KEY`, model `databricks-claude-sonnet-4-6`);
- streaming runner logs (`--log-cli-level=INFO -s`) and uploading `runner.log` + the native bridge dir on failure.

All `e2e-ui.yml` changes are marked `TEMP` / "REVERT before merge". Once CI is green, the workflow should be reverted to run the full suite and the native-harness enablement moved into the proper permanent wiring.

## Open question being validated

Whether `GATEWAY_BASE_URL` (the OpenAI-compatible serving-endpoints URL) also serves the Anthropic Messages API that Claude Code requires. Used as the best hypothesis for `ANTHROPIC_BASE_URL`; the streamed runner logs will confirm or refute it.
