### PR TITLE
test(db): add unit tests for ORM models, converters, and utilities

### DIFF
--- a/tests/db/test_converters.py
+++ b/tests/db/test_converters.py
@@ -1,0 +1,195 @@
+"""Tests for entity <-> ORM row converters (omnigent/db/converters.py).
+
+The converter layer currently provides ``sql_agent_to_entity``.
+Tests verify round-trip fidelity: entity -> ORM row -> entity, and
+edge cases (None values, special characters).
+"""
+
+from __future__ import annotations
+
+import time
+
+from omnigent.db.converters import sql_agent_to_entity
+from omnigent.db.db_models import SqlAgent
+from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
+from omnigent.entities import Agent
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class TestSqlAgentToEntity:
+    """Tests for sql_agent_to_entity."""
+
+    def test_basic_conversion(self) -> None:
+        """All fields on the ORM row map to the corresponding entity fields."""
+        row = SqlAgent(
+            id="ag_abc123",
+            created_at=1700000000,
+            name="research-agent",
+            bundle_location="ag_abc123/sha256hash",
+            version=3,
+            description="Does research",
+            updated_at=1700001000,
+            session_id="conv_xyz",
+        )
+        entity = sql_agent_to_entity(row)
+
+        assert isinstance(entity, Agent)
+        assert entity.id == "ag_abc123"
+        assert entity.created_at == 1700000000
+        assert entity.name == "research-agent"
+        assert entity.bundle_location == "ag_abc123/sha256hash"
+        assert entity.version == 3
+        assert entity.description == "Does research"
+        assert entity.updated_at == 1700001000
+        assert entity.session_id == "conv_xyz"
+
+    def test_nullable_fields_as_none(self) -> None:
+        """Optional fields convert cleanly when they are None."""
+        row = SqlAgent(
+            id="ag_minimal",
+            created_at=1700000000,
+            name="minimal-agent",
+            bundle_location="ag_minimal/hash",
+            version=1,
+            description=None,
+            updated_at=None,
+            session_id=None,
+        )
+        entity = sql_agent_to_entity(row)
+
+        assert entity.description is None
+        assert entity.updated_at is None
+        assert entity.session_id is None
+
+    def test_special_characters_in_fields(self) -> None:
+        """Names and descriptions with unicode / special chars survive conversion."""
+        row = SqlAgent(
+            id="ag_unicode",
+            created_at=1700000000,
+            name="agent-with-emoji-\u2603",
+            bundle_location="ag_unicode/hash",
+            version=1,
+            description="Handles \u00e9\u00e0\u00fc and newlines\nand tabs\t",
+        )
+        entity = sql_agent_to_entity(row)
+
+        assert entity.name == "agent-with-emoji-\u2603"
+        assert "\u00e9" in entity.description  # type: ignore[operator]
+        assert "\n" in entity.description  # type: ignore[operator]
+
+    def test_round_trip_entity_to_orm_to_entity(self) -> None:
+        """Create an Agent entity, build an ORM row from it, convert back, and
+        verify all fields match the original."""
+        original = Agent(
+            id="ag_roundtrip",
+            created_at=1700000000,
+            name="round-trip-agent",
+            bundle_location="ag_roundtrip/abc123def456",
+            version=5,
+            description="A test agent for round-trip verification",
+            updated_at=1700005000,
+            session_id="conv_rt1",
+        )
+
+        # Entity -> ORM row (manual construction, mirroring what a store would do)
+        row = SqlAgent(
+            id=original.id,
+            created_at=original.created_at,
+            name=original.name,
+            bundle_location=original.bundle_location,
+            version=original.version,
+            description=original.description,
+            updated_at=original.updated_at,
+            session_id=original.session_id,
+        )
+
+        # ORM row -> Entity (via the converter)
+        result = sql_agent_to_entity(row)
+
+        assert result.id == original.id
+        assert result.created_at == original.created_at
+        assert result.name == original.name
+        assert result.bundle_location == original.bundle_location
+        assert result.version == original.version
+        assert result.description == original.description
+        assert result.updated_at == original.updated_at
+        assert result.session_id == original.session_id
+
+    def test_round_trip_persisted_through_db(self, db_uri: str) -> None:
+        """Full round-trip: entity -> ORM row -> persist -> load -> convert -> entity."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        original = Agent(
+            id="ag_dbrt",
+            created_at=_now(),
+            name="db-round-trip",
+            bundle_location="ag_dbrt/hash",
+            version=2,
+            description="Persisted and loaded back",
+            updated_at=_now(),
+            session_id=None,
+        )
+
+        row = SqlAgent(
+            id=original.id,
+            created_at=original.created_at,
+            name=original.name,
+            bundle_location=original.bundle_location,
+            version=original.version,
+            description=original.description,
+            updated_at=original.updated_at,
+            session_id=original.session_id,
+        )
+        with managed() as session:
+            session.add(row)
+
+        with managed() as session:
+            loaded = session.get(SqlAgent, "ag_dbrt")
+            assert loaded is not None
+            result = sql_agent_to_entity(loaded)
+
+        assert result.id == original.id
+        assert result.created_at == original.created_at
+        assert result.name == original.name
+        assert result.bundle_location == original.bundle_location
+        assert result.version == original.version
+        assert result.description == original.description
+        assert result.updated_at == original.updated_at
+        assert result.session_id == original.session_id
+
+    def test_version_default_after_persist(self, db_uri: str) -> None:
+        """Version defaults to 1 when not explicitly set, after DB persistence."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        row = SqlAgent(
+            id="ag_defver",
+            created_at=1700000000,
+            name="default-version",
+            bundle_location="ag_defver/hash",
+        )
+        with managed() as session:
+            session.add(row)
+
+        with managed() as session:
+            loaded = session.get(SqlAgent, "ag_defver")
+            assert loaded is not None
+            entity = sql_agent_to_entity(loaded)
+            assert entity.version == 1
+
+    def test_empty_string_description(self) -> None:
+        """An empty-string description is preserved (not coerced to None)."""
+        row = SqlAgent(
+            id="ag_empty",
+            created_at=1700000000,
+            name="empty-desc",
+            bundle_location="ag_empty/hash",
+            version=1,
+            description="",
+        )
+        entity = sql_agent_to_entity(row)
+        assert entity.description == ""

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -1,0 +1,830 @@
+"""Tests for SQLAlchemy ORM models (omnigent/db/db_models.py).
+
+Verifies that each ORM model can be instantiated, persisted, read back,
+and that relationships, defaults, nullable columns, and constraints
+behave as expected.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from omnigent.db.db_models import (
+    SqlAccountToken,
+    SqlAgent,
+    SqlComment,
+    SqlConversation,
+    SqlConversationItem,
+    SqlConversationLabel,
+    SqlFile,
+    SqlHost,
+    SqlPolicy,
+    SqlSessionPermission,
+    SqlUser,
+    SqlUserDailyCost,
+)
+from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
+
+
+# ── helpers ───────────────────────────────────────────
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _make_agent(
+    id: str = "ag_test1",
+    name: str = "test-agent",
+    session_id: str | None = None,
+) -> SqlAgent:
+    return SqlAgent(
+        id=id,
+        created_at=_now(),
+        name=name,
+        bundle_location="ag_test1/abc123",
+        version=1,
+        session_id=session_id,
+    )
+
+
+def _make_conversation(
+    id: str = "conv_test1",
+    agent_id: str | None = None,
+    parent_conversation_id: str | None = None,
+    root_conversation_id: str | None = None,
+    kind: str = "default",
+    title: str | None = None,
+) -> SqlConversation:
+    return SqlConversation(
+        id=id,
+        created_at=_now(),
+        updated_at=_now(),
+        kind=kind,
+        agent_id=agent_id,
+        parent_conversation_id=parent_conversation_id,
+        root_conversation_id=root_conversation_id or id,
+        title=title,
+    )
+
+
+def _make_item(
+    id: str = "msg_test1",
+    conversation_id: str = "conv_test1",
+    position: int = 0,
+) -> SqlConversationItem:
+    return SqlConversationItem(
+        id=id,
+        conversation_id=conversation_id,
+        response_id="resp_test1",
+        created_at=_now(),
+        status="completed",
+        position=position,
+        type="message",
+        data='{"content": [{"type": "text", "text": "hello"}]}',
+        search_text="hello",
+    )
+
+
+def _session(db_uri: str) -> Session:
+    """Create a raw SQLAlchemy session from the db_uri fixture."""
+    engine = get_or_create_engine(db_uri)
+    managed = make_managed_session_maker(engine)
+    return managed
+
+
+# ── SqlAgent ──────────────────────────────────────────
+
+
+class TestSqlAgent:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        agent = _make_agent()
+        with managed() as session:
+            session.add(agent)
+
+        with managed() as session:
+            loaded = session.get(SqlAgent, "ag_test1")
+            assert loaded is not None
+            assert loaded.name == "test-agent"
+            assert loaded.version == 1
+            assert loaded.description is None
+            assert loaded.updated_at is None
+            assert loaded.session_id is None
+
+    def test_nullable_columns(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        agent = _make_agent()
+        agent.description = "A test agent"
+        agent.updated_at = _now()
+        with managed() as session:
+            session.add(agent)
+
+        with managed() as session:
+            loaded = session.get(SqlAgent, "ag_test1")
+            assert loaded is not None
+            assert loaded.description == "A test agent"
+            assert loaded.updated_at is not None
+
+    def test_session_scoped_agent_fk(self, db_uri: str) -> None:
+        """session_id FK to conversations must be valid."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        with managed() as session:
+            session.add(conv)
+
+        agent = _make_agent(session_id="conv_test1")
+        with managed() as session:
+            session.add(agent)
+
+        with managed() as session:
+            loaded = session.get(SqlAgent, "ag_test1")
+            assert loaded is not None
+            assert loaded.session_id == "conv_test1"
+
+    def test_unique_session_id_index(self, db_uri: str) -> None:
+        """ix_agents_session_id is unique -- two agents cannot share the same session_id."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        a1 = _make_agent(id="ag_1", name="agent-1", session_id="conv_test1")
+        a2 = _make_agent(id="ag_2", name="agent-2", session_id="conv_test1")
+
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(conv)
+                session.add(a1)
+                session.add(a2)
+
+
+# ── SqlFile ───────────────────────────────────────────
+
+
+class TestSqlFile:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        f = SqlFile(
+            id="file_test1",
+            created_at=_now(),
+            filename="report.pdf",
+            bytes=12345,
+            content_type="application/pdf",
+        )
+        with managed() as session:
+            session.add(f)
+
+        with managed() as session:
+            loaded = session.get(SqlFile, "file_test1")
+            assert loaded is not None
+            assert loaded.filename == "report.pdf"
+            assert loaded.bytes == 12345
+            assert loaded.content_type == "application/pdf"
+
+    def test_nullable_content_type(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        f = SqlFile(
+            id="file_test2",
+            created_at=_now(),
+            filename="data.bin",
+            bytes=100,
+        )
+        with managed() as session:
+            session.add(f)
+
+        with managed() as session:
+            loaded = session.get(SqlFile, "file_test2")
+            assert loaded is not None
+            assert loaded.content_type is None
+
+
+# ── SqlUser ───────────────────────────────────────────
+
+
+class TestSqlUser:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        user = SqlUser(id="alice@example.com", is_admin=False)
+        with managed() as session:
+            session.add(user)
+
+        with managed() as session:
+            loaded = session.get(SqlUser, "alice@example.com")
+            assert loaded is not None
+            assert loaded.is_admin is False
+            assert loaded.password_hash is None
+            assert loaded.created_at is None
+
+    def test_admin_user(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        user = SqlUser(
+            id="admin@example.com",
+            is_admin=True,
+            password_hash="$argon2id$hash",
+            created_at=_now(),
+        )
+        with managed() as session:
+            session.add(user)
+
+        with managed() as session:
+            loaded = session.get(SqlUser, "admin@example.com")
+            assert loaded is not None
+            assert loaded.is_admin is True
+            assert loaded.password_hash == "$argon2id$hash"
+
+    def test_duplicate_id_raises(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            session.add(SqlUser(id="dup@example.com", is_admin=False))
+
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(SqlUser(id="dup@example.com", is_admin=True))
+
+
+# ── SqlAccountToken ───────────────────────────────────
+
+
+class TestSqlAccountToken:
+    def test_persist_invite_token(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        token = SqlAccountToken(
+            id="tok_invite_abc",
+            kind="invite",
+            created_at=now,
+            expires_at=now + 3600,
+            created_by="admin@example.com",
+            invited_is_admin=True,
+        )
+        with managed() as session:
+            session.add(token)
+
+        with managed() as session:
+            loaded = session.get(SqlAccountToken, "tok_invite_abc")
+            assert loaded is not None
+            assert loaded.kind == "invite"
+            assert loaded.user_id is None
+            assert loaded.redeemed_at is None
+            assert loaded.invited_is_admin is True
+
+    def test_persist_magic_token(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        token = SqlAccountToken(
+            id="tok_magic_xyz",
+            kind="magic",
+            user_id="alice@example.com",
+            created_at=now,
+            expires_at=now + 300,
+        )
+        with managed() as session:
+            session.add(token)
+
+        with managed() as session:
+            loaded = session.get(SqlAccountToken, "tok_magic_xyz")
+            assert loaded is not None
+            assert loaded.kind == "magic"
+            assert loaded.user_id == "alice@example.com"
+
+    def test_check_constraint_rejects_invalid_kind(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        token = SqlAccountToken(
+            id="tok_bad",
+            kind="invalid",
+            created_at=now,
+            expires_at=now + 3600,
+        )
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(token)
+
+
+# ── SqlConversation ───────────────────────────────────
+
+
+class TestSqlConversation:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation(title="Hello World")
+        with managed() as session:
+            session.add(conv)
+
+        with managed() as session:
+            loaded = session.get(SqlConversation, "conv_test1")
+            assert loaded is not None
+            assert loaded.title == "Hello World"
+            assert loaded.kind == "default"
+            assert loaded.archived is False
+
+    def test_defaults(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        with managed() as session:
+            session.add(conv)
+
+        with managed() as session:
+            loaded = session.get(SqlConversation, "conv_test1")
+            assert loaded is not None
+            assert loaded.runner_id is None
+            assert loaded.host_id is None
+            assert loaded.reasoning_effort is None
+            assert loaded.model_override is None
+            assert loaded.external_session_id is None
+            assert loaded.workspace is None
+            assert loaded.git_branch is None
+            assert loaded.session_state is None
+            assert loaded.session_usage is None
+
+    def test_check_constraint_rejects_invalid_kind(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        conv.kind = "invalid_kind"
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(conv)
+
+    def test_sub_agent_kind(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        parent = _make_conversation(id="conv_parent")
+        child = _make_conversation(
+            id="conv_child",
+            kind="sub_agent",
+            parent_conversation_id="conv_parent",
+            root_conversation_id="conv_parent",
+            title="summarizer",
+        )
+        with managed() as session:
+            session.add(parent)
+            session.add(child)
+
+        with managed() as session:
+            loaded = session.get(SqlConversation, "conv_child")
+            assert loaded is not None
+            assert loaded.kind == "sub_agent"
+            assert loaded.parent_conversation_id == "conv_parent"
+            assert loaded.root_conversation_id == "conv_parent"
+
+    def test_cascade_delete_removes_children(self, db_uri: str) -> None:
+        """Deleting a parent conversation cascades to child conversations."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        parent = _make_conversation(id="conv_parent2")
+        child = _make_conversation(
+            id="conv_child2",
+            kind="sub_agent",
+            parent_conversation_id="conv_parent2",
+            root_conversation_id="conv_parent2",
+            title="child",
+        )
+        with managed() as session:
+            session.add(parent)
+            session.add(child)
+
+        with managed() as session:
+            p = session.get(SqlConversation, "conv_parent2")
+            assert p is not None
+            session.delete(p)
+
+        with managed() as session:
+            assert session.get(SqlConversation, "conv_child2") is None
+
+
+# ── SqlConversationItem ───────────────────────────────
+
+
+class TestSqlConversationItem:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        item = _make_item()
+        with managed() as session:
+            session.add(conv)
+            session.add(item)
+
+        with managed() as session:
+            loaded = session.get(SqlConversationItem, "msg_test1")
+            assert loaded is not None
+            assert loaded.conversation_id == "conv_test1"
+            assert loaded.type == "message"
+            assert loaded.position == 0
+            assert loaded.status == "completed"
+            assert loaded.created_by is None
+
+    def test_unique_position_per_conversation(self, db_uri: str) -> None:
+        """Two items in the same conversation cannot share the same position."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        item1 = _make_item(id="msg_1", position=0)
+        item2 = _make_item(id="msg_2", position=0)
+
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(conv)
+                session.add(item1)
+                session.add(item2)
+
+    def test_cascade_delete_with_conversation(self, db_uri: str) -> None:
+        """Deleting a conversation cascades to its items."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation(id="conv_del")
+        item = _make_item(id="msg_del", conversation_id="conv_del")
+        with managed() as session:
+            session.add(conv)
+            session.add(item)
+
+        with managed() as session:
+            c = session.get(SqlConversation, "conv_del")
+            assert c is not None
+            session.delete(c)
+
+        with managed() as session:
+            assert session.get(SqlConversationItem, "msg_del") is None
+
+    def test_multiple_items_ordered_by_position(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        with managed() as session:
+            session.add(conv)
+            for i in range(5):
+                session.add(_make_item(id=f"msg_{i}", position=i))
+
+        with managed() as session:
+            items = (
+                session.query(SqlConversationItem)
+                .filter_by(conversation_id="conv_test1")
+                .order_by(SqlConversationItem.position)
+                .all()
+            )
+            assert len(items) == 5
+            assert [it.position for it in items] == [0, 1, 2, 3, 4]
+
+
+# ── SqlConversationLabel ──────────────────────────────
+
+
+class TestSqlConversationLabel:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        label = SqlConversationLabel(
+            conversation_id="conv_test1",
+            key="sensitivity",
+            value="confidential",
+            updated_at=_now(),
+        )
+        with managed() as session:
+            session.add(conv)
+            session.add(label)
+
+        with managed() as session:
+            loaded = (
+                session.query(SqlConversationLabel)
+                .filter_by(conversation_id="conv_test1", key="sensitivity")
+                .one()
+            )
+            assert loaded.value == "confidential"
+
+    def test_composite_pk_allows_different_keys(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        with managed() as session:
+            session.add(conv)
+            session.add(
+                SqlConversationLabel(
+                    conversation_id="conv_test1", key="k1", value="v1", updated_at=_now()
+                )
+            )
+            session.add(
+                SqlConversationLabel(
+                    conversation_id="conv_test1", key="k2", value="v2", updated_at=_now()
+                )
+            )
+
+        with managed() as session:
+            labels = (
+                session.query(SqlConversationLabel)
+                .filter_by(conversation_id="conv_test1")
+                .all()
+            )
+            assert len(labels) == 2
+
+
+# ── SqlSessionPermission ─────────────────────────────
+
+
+class TestSqlSessionPermission:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            session.add(SqlUser(id="alice@example.com", is_admin=False))
+            session.add(_make_conversation())
+
+        perm = SqlSessionPermission(
+            user_id="alice@example.com",
+            conversation_id="conv_test1",
+            level=2,
+        )
+        with managed() as session:
+            session.add(perm)
+
+        with managed() as session:
+            loaded = session.get(
+                SqlSessionPermission, ("alice@example.com", "conv_test1")
+            )
+            assert loaded is not None
+            assert loaded.level == 2
+
+    def test_check_constraint_rejects_invalid_level(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            session.add(SqlUser(id="bob@example.com", is_admin=False))
+            session.add(_make_conversation())
+
+        perm = SqlSessionPermission(
+            user_id="bob@example.com",
+            conversation_id="conv_test1",
+            level=99,
+        )
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(perm)
+
+
+# ── SqlComment ────────────────────────────────────────
+
+
+class TestSqlComment:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        comment = SqlComment(
+            id="cmt_test1",
+            conversation_id="conv_test1",
+            path="src/App.tsx",
+            start_index=10,
+            end_index=20,
+            body="Looks good!",
+            status="draft",
+            created_at=now,
+            updated_at=now * 1_000_000,
+            anchor_content="selected text",
+            created_by="alice@example.com",
+        )
+        conv = _make_conversation()
+        with managed() as session:
+            session.add(conv)
+            session.add(comment)
+
+        with managed() as session:
+            loaded = session.get(SqlComment, "cmt_test1")
+            assert loaded is not None
+            assert loaded.path == "src/App.tsx"
+            assert loaded.body == "Looks good!"
+            assert loaded.status == "draft"
+            assert loaded.anchor_content == "selected text"
+            assert loaded.created_by == "alice@example.com"
+
+    def test_nullable_anchor_and_created_by(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        comment = SqlComment(
+            id="cmt_test2",
+            conversation_id="conv_test1",
+            path="README.md",
+            start_index=0,
+            end_index=5,
+            body="Legacy comment",
+            status="addressed",
+            created_at=now,
+            updated_at=now * 1_000_000,
+        )
+        conv = _make_conversation()
+        with managed() as session:
+            session.add(conv)
+            session.add(comment)
+
+        with managed() as session:
+            loaded = session.get(SqlComment, "cmt_test2")
+            assert loaded is not None
+            assert loaded.anchor_content is None
+            assert loaded.created_by is None
+
+
+# ── SqlPolicy ─────────────────────────────────────────
+
+
+class TestSqlPolicy:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        policy = SqlPolicy(
+            id="pol_test1",
+            name="cost-guard",
+            created_at=_now(),
+            type="python",
+            handler="omnigent.policies.cost_guard:handler",
+            enabled=True,
+        )
+        with managed() as session:
+            session.add(policy)
+
+        with managed() as session:
+            loaded = session.get(SqlPolicy, "pol_test1")
+            assert loaded is not None
+            assert loaded.name == "cost-guard"
+            assert loaded.type == "python"
+            assert loaded.enabled is True
+            assert loaded.session_id is None
+
+    def test_unique_constraint_session_name(self, db_uri: str) -> None:
+        """Two policies in the same session cannot share the same name."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        conv = _make_conversation()
+        p1 = SqlPolicy(
+            id="pol_1",
+            name="guard",
+            session_id="conv_test1",
+            created_at=_now(),
+            type="python",
+            handler="mod:fn",
+        )
+        p2 = SqlPolicy(
+            id="pol_2",
+            name="guard",
+            session_id="conv_test1",
+            created_at=_now(),
+            type="python",
+            handler="mod:fn2",
+        )
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(conv)
+                session.add(p1)
+                session.add(p2)
+
+
+# ── SqlHost ───────────────────────────────────────────
+
+
+class TestSqlHost:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        host = SqlHost(
+            owner="corey@example.com",
+            name="corey-laptop",
+            host_id="host_abc123",
+            status="online",
+            created_at=now,
+            updated_at=now,
+        )
+        with managed() as session:
+            session.add(host)
+
+        with managed() as session:
+            loaded = session.get(SqlHost, ("corey@example.com", "corey-laptop"))
+            assert loaded is not None
+            assert loaded.host_id == "host_abc123"
+            assert loaded.status == "online"
+            assert loaded.token_hash is None
+            assert loaded.sandbox_provider is None
+
+    def test_check_constraint_rejects_invalid_status(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        host = SqlHost(
+            owner="owner",
+            name="host",
+            host_id="host_bad",
+            status="unknown",
+            created_at=now,
+            updated_at=now,
+        )
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(host)
+
+    def test_unique_host_id(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        now = _now()
+        h1 = SqlHost(
+            owner="a@x.com", name="h1", host_id="host_dup", status="online",
+            created_at=now, updated_at=now,
+        )
+        h2 = SqlHost(
+            owner="b@x.com", name="h2", host_id="host_dup", status="offline",
+            created_at=now, updated_at=now,
+        )
+        with pytest.raises(IntegrityError):
+            with managed() as session:
+                session.add(h1)
+                session.add(h2)
+
+
+# ── SqlUserDailyCost ──────────────────────────────────
+
+
+class TestSqlUserDailyCost:
+    def test_persist_and_read(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        row = SqlUserDailyCost(
+            user_id="alice@example.com",
+            day_utc="2026-06-16",
+            cost_usd=1.23,
+            ask_approved_usd=0.0,
+            updated_at=_now(),
+        )
+        with managed() as session:
+            session.add(row)
+
+        with managed() as session:
+            loaded = session.get(SqlUserDailyCost, ("alice@example.com", "2026-06-16"))
+            assert loaded is not None
+            assert loaded.cost_usd == pytest.approx(1.23)
+            assert loaded.ask_approved_usd == pytest.approx(0.0)
+
+    def test_composite_pk_multiple_days(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            session.add(SqlUserDailyCost(
+                user_id="u1", day_utc="2026-06-15", cost_usd=1.0,
+                ask_approved_usd=0.0, updated_at=_now(),
+            ))
+            session.add(SqlUserDailyCost(
+                user_id="u1", day_utc="2026-06-16", cost_usd=2.0,
+                ask_approved_usd=0.0, updated_at=_now(),
+            ))
+
+        with managed() as session:
+            rows = session.query(SqlUserDailyCost).filter_by(user_id="u1").all()
+            assert len(rows) == 2

--- a/tests/db/test_db_models.py
+++ b/tests/db/test_db_models.py
@@ -11,7 +11,6 @@ import time
 
 import pytest
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import (
     SqlAccountToken,
@@ -28,7 +27,6 @@ from omnigent.db.db_models import (
     SqlUserDailyCost,
 )
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
-
 
 # ── helpers ───────────────────────────────────────────
 
@@ -88,13 +86,6 @@ def _make_item(
         data='{"content": [{"type": "text", "text": "hello"}]}',
         search_text="hello",
     )
-
-
-def _session(db_uri: str) -> Session:
-    """Create a raw SQLAlchemy session from the db_uri fixture."""
-    engine = get_or_create_engine(db_uri)
-    managed = make_managed_session_maker(engine)
-    return managed
 
 
 # ── SqlAgent ──────────────────────────────────────────
@@ -551,9 +542,7 @@ class TestSqlConversationLabel:
 
         with managed() as session:
             labels = (
-                session.query(SqlConversationLabel)
-                .filter_by(conversation_id="conv_test1")
-                .all()
+                session.query(SqlConversationLabel).filter_by(conversation_id="conv_test1").all()
             )
             assert len(labels) == 2
 
@@ -579,9 +568,7 @@ class TestSqlSessionPermission:
             session.add(perm)
 
         with managed() as session:
-            loaded = session.get(
-                SqlSessionPermission, ("alice@example.com", "conv_test1")
-            )
+            loaded = session.get(SqlSessionPermission, ("alice@example.com", "conv_test1"))
             assert loaded is not None
             assert loaded.level == 2
 
@@ -774,12 +761,20 @@ class TestSqlHost:
 
         now = _now()
         h1 = SqlHost(
-            owner="a@x.com", name="h1", host_id="host_dup", status="online",
-            created_at=now, updated_at=now,
+            owner="a@x.com",
+            name="h1",
+            host_id="host_dup",
+            status="online",
+            created_at=now,
+            updated_at=now,
         )
         h2 = SqlHost(
-            owner="b@x.com", name="h2", host_id="host_dup", status="offline",
-            created_at=now, updated_at=now,
+            owner="b@x.com",
+            name="h2",
+            host_id="host_dup",
+            status="offline",
+            created_at=now,
+            updated_at=now,
         )
         with pytest.raises(IntegrityError):
             with managed() as session:
@@ -816,14 +811,24 @@ class TestSqlUserDailyCost:
         managed = make_managed_session_maker(engine)
 
         with managed() as session:
-            session.add(SqlUserDailyCost(
-                user_id="u1", day_utc="2026-06-15", cost_usd=1.0,
-                ask_approved_usd=0.0, updated_at=_now(),
-            ))
-            session.add(SqlUserDailyCost(
-                user_id="u1", day_utc="2026-06-16", cost_usd=2.0,
-                ask_approved_usd=0.0, updated_at=_now(),
-            ))
+            session.add(
+                SqlUserDailyCost(
+                    user_id="u1",
+                    day_utc="2026-06-15",
+                    cost_usd=1.0,
+                    ask_approved_usd=0.0,
+                    updated_at=_now(),
+                )
+            )
+            session.add(
+                SqlUserDailyCost(
+                    user_id="u1",
+                    day_utc="2026-06-16",
+                    cost_usd=2.0,
+                    ask_approved_usd=0.0,
+                    updated_at=_now(),
+                )
+            )
 
         with managed() as session:
             rows = session.query(SqlUserDailyCost).filter_by(user_id="u1").all()

--- a/tests/db/test_utils_extended.py
+++ b/tests/db/test_utils_extended.py
@@ -1,0 +1,277 @@
+"""Extended tests for database utilities (omnigent/db/utils.py).
+
+Covers public utilities NOT already tested in test_utils.py:
+- normalize_database_url
+- engine caching (get_or_create_engine returns same engine for same URI)
+- make_managed_session_maker (commit/rollback semantics)
+- ID generators (generate_file_id, generate_conversation_id, generate_task_id,
+  generate_item_id for all types)
+- FTS helpers (ensure_fts_table, insert_fts, delete_fts_by_conversation)
+- Timestamp helpers (now_epoch, now_epoch_us, utc_day)
+- clear_engine_cache
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from omnigent.db.db_models import SqlConversation, SqlUser
+from omnigent.db.utils import (
+    _ITEM_TYPE_PREFIX,
+    clear_engine_cache,
+    delete_fts_by_conversation,
+    ensure_fts_table,
+    generate_conversation_id,
+    generate_file_id,
+    generate_item_id,
+    generate_task_id,
+    get_or_create_engine,
+    insert_fts,
+    make_managed_session_maker,
+    normalize_database_url,
+    now_epoch,
+    now_epoch_us,
+    utc_day,
+)
+
+
+# ── normalize_database_url ────────────────────────────
+
+
+class TestNormalizeDatabaseUrl:
+    def test_postgres_prefix(self) -> None:
+        url = "postgres://user:pass@host/db"
+        assert normalize_database_url(url) == "postgresql+psycopg://user:pass@host/db"
+
+    def test_postgresql_prefix(self) -> None:
+        url = "postgresql://user:pass@host/db"
+        assert normalize_database_url(url) == "postgresql+psycopg://user:pass@host/db"
+
+    def test_sqlite_passthrough(self) -> None:
+        url = "sqlite:///path/to/db.sqlite"
+        assert normalize_database_url(url) == url
+
+    def test_already_psycopg_passthrough(self) -> None:
+        url = "postgresql+psycopg://user:pass@host/db"
+        assert normalize_database_url(url) == url
+
+    def test_empty_string(self) -> None:
+        assert normalize_database_url("") == ""
+
+    def test_mysql_passthrough(self) -> None:
+        url = "mysql://user:pass@host/db"
+        assert normalize_database_url(url) == url
+
+
+# ── Engine caching ────────────────────────────────────
+
+
+class TestEngineCaching:
+    @pytest.fixture(autouse=True)
+    def _clean_cache(self) -> None:
+        clear_engine_cache()
+
+    def test_same_uri_returns_same_engine(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "cache_test.db"
+        uri = f"sqlite:///{db_path}"
+        e1 = get_or_create_engine(uri)
+        e2 = get_or_create_engine(uri)
+        assert e1 is e2
+
+    def test_different_uri_returns_different_engine(self, tmp_path: Path) -> None:
+        uri1 = f"sqlite:///{tmp_path / 'a.db'}"
+        uri2 = f"sqlite:///{tmp_path / 'b.db'}"
+        e1 = get_or_create_engine(uri1)
+        e2 = get_or_create_engine(uri2)
+        assert e1 is not e2
+
+    def test_clear_engine_cache_removes_engines(self, tmp_path: Path) -> None:
+        uri = f"sqlite:///{tmp_path / 'clear.db'}"
+        e1 = get_or_create_engine(uri)
+        clear_engine_cache()
+        e2 = get_or_create_engine(uri)
+        assert e1 is not e2
+
+
+# ── make_managed_session_maker ────────────────────────
+
+
+class TestManagedSessionMaker:
+    def test_auto_commit_on_success(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            session.add(SqlUser(id="commit_test", is_admin=False))
+
+        # Data should be visible in a new session
+        with managed() as session:
+            loaded = session.get(SqlUser, "commit_test")
+            assert loaded is not None
+
+    def test_auto_rollback_on_exception(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with pytest.raises(ValueError):
+            with managed() as session:
+                session.add(SqlUser(id="rollback_test", is_admin=False))
+                raise ValueError("simulated error")
+
+        # Data should NOT be visible
+        with managed() as session:
+            loaded = session.get(SqlUser, "rollback_test")
+            assert loaded is None
+
+    def test_sqlite_foreign_keys_enabled(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            result = session.execute(text("PRAGMA foreign_keys")).scalar()
+            assert result == 1
+
+    def test_immediate_mode(self, db_uri: str) -> None:
+        """immediate=True should not raise and still commit."""
+        engine = get_or_create_engine(db_uri)
+        managed = make_managed_session_maker(engine, immediate=True)
+
+        with managed() as session:
+            session.add(SqlUser(id="immediate_test", is_admin=False))
+
+        with managed() as session:
+            loaded = session.get(SqlUser, "immediate_test")
+            assert loaded is not None
+
+
+# ── ID generators ─────────────────────────────────────
+
+
+class TestIdGenerators:
+    def test_generate_file_id_format(self) -> None:
+        fid = generate_file_id()
+        assert re.fullmatch(r"file_[0-9a-f]{32}", fid)
+
+    def test_generate_conversation_id_format(self) -> None:
+        cid = generate_conversation_id()
+        assert re.fullmatch(r"conv_[0-9a-f]{32}", cid)
+
+    def test_generate_task_id_format(self) -> None:
+        tid = generate_task_id()
+        assert re.fullmatch(r"resp_[0-9a-f]{32}", tid)
+
+    def test_generate_item_id_all_types(self) -> None:
+        for item_type, prefix in _ITEM_TYPE_PREFIX.items():
+            item_id = generate_item_id(item_type)
+            assert item_id.startswith(prefix), f"{item_type} should start with {prefix}"
+            assert len(item_id) == len(prefix) + 32
+
+    def test_generate_item_id_unknown_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown item type"):
+            generate_item_id("nonexistent_type")
+
+    def test_ids_are_unique(self) -> None:
+        ids = {generate_file_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+# ── FTS helpers ───────────────────────────────────────
+
+
+class TestFtsHelpers:
+    def test_ensure_fts_table_idempotent(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        # Should not raise when called twice
+        ensure_fts_table(engine)
+        ensure_fts_table(engine)
+
+    def test_insert_and_search_fts(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        ensure_fts_table(engine)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            insert_fts(session, "msg_1", "conv_1", "hello world")
+            insert_fts(session, "msg_2", "conv_1", "goodbye world")
+
+        with managed() as session:
+            rows = session.execute(
+                text(
+                    "SELECT item_id FROM conversation_items_fts "
+                    "WHERE conversation_items_fts MATCH 'hello'"
+                )
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "msg_1"
+
+    def test_delete_fts_by_conversation(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        ensure_fts_table(engine)
+        managed = make_managed_session_maker(engine)
+
+        with managed() as session:
+            insert_fts(session, "msg_a", "conv_del", "searchable text")
+            insert_fts(session, "msg_b", "conv_keep", "also searchable")
+
+        with managed() as session:
+            delete_fts_by_conversation(session, "conv_del")
+
+        with managed() as session:
+            deleted = session.execute(
+                text(
+                    "SELECT item_id FROM conversation_items_fts "
+                    "WHERE conversation_id = 'conv_del'"
+                )
+            ).fetchall()
+            assert len(deleted) == 0
+
+            kept = session.execute(
+                text(
+                    "SELECT item_id FROM conversation_items_fts "
+                    "WHERE conversation_id = 'conv_keep'"
+                )
+            ).fetchall()
+            assert len(kept) == 1
+
+
+# ── Timestamp helpers ─────────────────────────────────
+
+
+class TestTimestampHelpers:
+    def test_now_epoch_is_close_to_time(self) -> None:
+        before = int(time.time())
+        result = now_epoch()
+        after = int(time.time())
+        assert before <= result <= after
+
+    def test_now_epoch_us_is_microseconds(self) -> None:
+        result = now_epoch_us()
+        # Should be roughly time.time() * 1_000_000
+        expected = int(time.time() * 1_000_000)
+        assert abs(result - expected) < 1_000_000  # within 1 second
+
+    def test_now_epoch_us_is_monotonically_increasing(self) -> None:
+        """Two consecutive calls should produce non-decreasing values."""
+        a = now_epoch_us()
+        b = now_epoch_us()
+        assert b >= a
+
+    def test_utc_day_known_value(self) -> None:
+        # 2026-06-16 00:00:00 UTC = 1781568000
+        assert utc_day(1781568000) == "2026-06-16"
+
+    def test_utc_day_midnight_boundary(self) -> None:
+        # 1 second before midnight vs midnight
+        day_before = utc_day(1781568000 - 1)
+        day_at = utc_day(1781568000)
+        assert day_before == "2026-06-15"
+        assert day_at == "2026-06-16"
+
+    def test_utc_day_format(self) -> None:
+        result = utc_day(now_epoch())
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", result)

--- a/tests/db/test_utils_extended.py
+++ b/tests/db/test_utils_extended.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 import re
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from sqlalchemy import text
 
-from omnigent.db.db_models import SqlConversation, SqlUser
+from omnigent.db.db_models import SqlUser
 from omnigent.db.utils import (
     _ITEM_TYPE_PREFIX,
     clear_engine_cache,
@@ -38,7 +39,6 @@ from omnigent.db.utils import (
     now_epoch_us,
     utc_day,
 )
-
 
 # ── normalize_database_url ────────────────────────────
 
@@ -73,7 +73,9 @@ class TestNormalizeDatabaseUrl:
 
 class TestEngineCaching:
     @pytest.fixture(autouse=True)
-    def _clean_cache(self) -> None:
+    def _clean_cache(self) -> Iterator[None]:
+        clear_engine_cache()
+        yield
         clear_engine_cache()
 
     def test_same_uri_returns_same_engine(self, tmp_path: Path) -> None:
@@ -224,8 +226,7 @@ class TestFtsHelpers:
         with managed() as session:
             deleted = session.execute(
                 text(
-                    "SELECT item_id FROM conversation_items_fts "
-                    "WHERE conversation_id = 'conv_del'"
+                    "SELECT item_id FROM conversation_items_fts WHERE conversation_id = 'conv_del'"
                 )
             ).fetchall()
             assert len(deleted) == 0


### PR DESCRIPTION
## Summary
- Add 69 unit tests covering the DB layer across three new test files
- `test_db_models.py`: Tests all 11 ORM models (SqlAgent, SqlFile, SqlUser, SqlAccountToken, SqlConversation, SqlConversationItem, SqlConversationLabel, SqlSessionPermission, SqlComment, SqlPolicy, SqlHost, SqlUserDailyCost) for persistence, defaults, nullable columns, FK relationships, cascade deletes, and constraint enforcement (CHECK, UNIQUE)
- `test_converters.py`: Tests `sql_agent_to_entity` round-trip conversion including edge cases (None values, special characters, empty strings, DB-persisted round-trip)
- `test_utils_extended.py`: Tests `normalize_database_url`, engine caching, `make_managed_session_maker` commit/rollback semantics, all ID generators, FTS helpers (ensure/insert/delete), and timestamp utilities

## Test plan
- [x] All 69 new tests pass locally (`pytest tests/db/test_db_models.py tests/db/test_converters.py tests/db/test_utils_extended.py -v --timeout=30`)
- [ ] CI passes on this branch

This pull request and its description were written by Isaac.