### PR TITLE
Add community files: CODE_OF_CONDUCT, CHANGELOG, ARCHITECTURE, ISSUE_TEMPLATE, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS is a placeholder. Maintainers, please replace the
+# default owner below with your routing convention. GitHub uses
+# the LAST matching line wins, so order matters.
+#
+# Recommended grouping based on the repo layout the README describes:
+#
+#   omnigent/runner/**           -> the runner / harness team
+#   omnigent/server/**           -> the server / API team
+#   omnigent/runtime/harnesses/  -> per-harness owners (claude, codex, pi, ...)
+#   omnigent/llms/**             -> LLM client team
+#   omnigent/cli.py              -> the CLI / DX team
+#   sdks/python-client/**        -> SDK team
+#   sdks/ui/**                   -> UI SDK team
+#   ap-web/**                    -> frontend team
+#   deploy/**                    -> infra / deploy
+#   docs/**                      -> docs / DX
+#   .github/workflows/**         -> CI / build
+#
+# Until that's filled in, fall back to a single owner so no PR routes
+# to nobody.
+
+* @omnigent-ai/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Something's broken or misbehaving in omnigent
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+<!-- One or two sentences. What's broken, when, where. -->
+
+## Repro
+
+```bash
+# The smallest sequence of commands that reproduces the issue.
+# Include the agent YAML or repo path if relevant.
+```
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happens. Paste the error message, stack trace, or
+     unexpected output. If there's a server log under
+     ~/.omnigent/logs/server/, include the last ~30 lines. It's
+     usually where the root cause shows up. -->
+
+## Versions
+
+- omnigent: `omni --version`
+- Python: `python --version`
+- OS:
+- Provider (Claude / OpenAI / Databricks / etc.):
+
+## Anything else
+
+<!-- Workarounds you've tried, related PRs or issues, screenshots if
+     it's a UI bug. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security disclosure
+    url: https://github.com/omnigent-ai/omnigent/security/advisories/new
+    about: Report a security vulnerability privately via GitHub Security Advisories.
+  - name: Discussions
+    url: https://github.com/omnigent-ai/omnigent/discussions
+    about: Open-ended conversations, "how do I" questions, or feedback that does not fit the bug / feature / question templates.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Propose new functionality or a non-trivial change
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+<!-- One paragraph: what you'd like omnigent to do, and the use case
+     that's driving the ask. -->
+
+## Why this is worth doing
+
+<!-- The problem the feature solves. Concrete examples beat abstract
+     descriptions. If it's a workflow that's painful today, walk
+     through what you do now. -->
+
+## Proposed shape
+
+<!-- A sketch of the API, the YAML field, the CLI flag, or whatever
+     the user-facing surface would be. Pseudocode is fine. -->
+
+## Alternatives considered
+
+<!-- One or two other shapes you thought about and why this one wins.
+     If you didn't consider alternatives, that's OK. Say so. -->
+
+## Happy to send a PR?
+
+<!-- Optional. If you're up for implementing it once direction is
+     agreed, say so here. Otherwise the maintainers will pick it up
+     based on roadmap priority. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,27 @@
+---
+name: Question
+about: Ask about how to do something with omnigent
+title: ''
+labels: question
+assignees: ''
+---
+
+<!-- Before filing: check the README, docs/, and the closed issues for
+     a similar question. If you've found a related issue but it didn't
+     answer yours, link it below and explain what's different. -->
+
+## What you're trying to do
+
+<!-- The end goal, not just the immediate stuck point. -->
+
+## What you've tried
+
+<!-- Commands, code snippets, links to docs you've read. Including
+     what didn't work is more useful than just describing the goal. -->
+
+## Environment
+
+- omnigent: `omni --version`
+- Python: `python --version`
+- OS:
+- Provider (Claude / OpenAI / Databricks / etc.):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project should be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project will follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once it's out of alpha. While the project is in alpha (current state per
+the README badge and `pyproject.toml` Development Status), breaking
+changes can land on `main` and they're called out here under
+`### Changed (breaking)`.
+
+## [Unreleased]
+
+### Added
+- `SessionsChat(hooks=...)` and `OmnigentClient.sessions_chat(hooks=...)`
+  now accept a `StreamHooks` instance and fire response, reasoning,
+  message, tool-call, file-output, and elicitation callbacks from the
+  sessions-first event stream. See PR #43.
+
+### Fixed
+- Circular import between `omnigent.llms` and `omnigent.reasoning_effort`
+  that blocked server startup on a fresh install. See PR #149.
+
+### Notes for maintainers filling this in retroactively
+
+This file is a scaffold proposed in PR #<this-pr>. Please backfill
+prior released versions (or the most recent ~10 PRs if there aren't
+any tags yet) in the format below. Future merged PRs should add a
+one-line bullet under the appropriate `### Added / Changed /
+Deprecated / Removed / Fixed / Security` heading under
+`## [Unreleased]`, and the release workflow
+(`.github/workflows/release-omnigent.yml`) should promote the
+`## [Unreleased]` section to a versioned heading at tag time. That
+way a release tag automatically captures what's changed since the
+last one.
+
+Example shape once tags start landing:
+
+```markdown
+## [0.2.0] - 2026-07-15
+
+### Added
+- ...
+
+### Changed (breaking)
+- ...
+
+### Fixed
+- ...
+
+[0.2.0]: https://github.com/omnigent-ai/omnigent/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/omnigent-ai/omnigent/compare/v0.2.0...HEAD
+```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via a private GitHub security advisory at <https://github.com/omnigent-ai/omnigent/security/advisories/new> (same channel as security disclosures, since that's the inbox the project guarantees a maintainer reads). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,143 @@
+# Architecture
+
+This is a high-level map of how omnigent's pieces fit together, aimed
+at new contributors who'd like to find their way around before opening
+their first PR. It's intentionally short. Deep dives belong in the
+per-subsystem docs (`POLICIES.md`, `AGENT_YAML_SPEC.md`, the SDK README,
+etc.).
+
+> **Status:** scaffold. Sections marked `[maintainer fill]` are stubs
+> waiting for ground-truth wording from someone with the full design
+> context. The shape is meant to be edited freely.
+
+## 30-second pitch
+
+omnigent is a runtime for declarative agents. You write an agent as a
+short YAML file (a prompt, an executor, an optional list of sub-agents
+the supervisor can delegate to) and omnigent runs it across terminal,
+web, native app, mobile, and a REST API. The bundled `debby` example
+fans out to a Claude and a GPT sub-agent in parallel; `polly` is a
+multi-agent coding orchestrator.
+
+## The four roles
+
+```
+┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
+│   Client (UI)    │ ─► │     Server       │ ◄─ │     Runner       │
+│ CLI / web / app  │SSE │  /v1/sessions    │WS  │ executes agent   │
+│ mobile / SDK     │    │  /v1/responses*  │    │ talks to LLMs    │
+└──────────────────┘    └──────────────────┘    └──────────────────┘
+                                ▲
+                                │ HTTPS
+                        ┌───────┴─────────┐
+                        │  Harness (LLM)  │
+                        │ claude / codex  │
+                        │ openai-agents…  │
+                        └─────────────────┘
+*legacy, being phased out in favor of sessions-first
+```
+
+- **Client.** UI surfaces that talk to the server. Terminal REPL, web
+  UI (`ap-web/`), native desktop wrapper, mobile, and the Python SDK
+  (`sdks/python-client/`).
+- **Server** (`omnigent/server/`). Holds session state, brokers
+  events between client and runner over SSE, runs guardrails and
+  policy enforcement, exposes the REST + SSE surface (see
+  `openapi.json`).
+- **Runner** (`omnigent/runner/`). Executes the agent on the
+  user's machine (or a sandbox). Owns the harness subprocess and
+  the local filesystem.
+- **Harness.** The actual LLM integration: Claude Code, Codex, Pi,
+  the OpenAI Agents SDK, the Open Responses protocol, or custom
+  ones declared via the `executor.harness` field in an agent's
+  YAML. See `omnigent/runtime/harnesses/`.
+
+`omnigent/cli.py` is the glue that starts the server + runner pair
+locally and connects the REPL to it. `omni run AGENT` is the canonical
+entry point.
+
+## Repository layout
+
+| Path | What's there |
+| --- | --- |
+| `omnigent/` | The Python package. CLI, server, runner, harnesses. |
+| `omnigent/cli.py` | The `omni` command surface. It's 9KLOC today; see issue #147 for the gradual decomposition tracking. |
+| `omnigent/server/` | FastAPI app, routes, schemas, websocket tunnel. |
+| `omnigent/runner/` | Local agent execution, policy evaluation, tool dispatch. |
+| `omnigent/runtime/` | Harness adapters and the shared scaffold. |
+| `omnigent/llms/` | Multi-provider LLM client (OpenAI Responses-shaped). |
+| `sdks/python-client/` | `omnigent_client` package - HTTP/SSE client for headless use. |
+| `sdks/ui/` | `omnigent_ui_sdk` - shared terminal-rendering helpers. |
+| `ap-web/` | Vue SPA for the web UI. Independent build chain. |
+| `examples/` | `debby` and `polly` bundled reference agents. |
+| `deploy/` | Per-target deploy configs (modal, fly, railway, render, daytona, docker, hf-spaces). |
+| `tests/` | Pytest suite. Split into unit / integration / e2e / runner / server / inner / frontends. |
+| `docs/` | Spec docs (`AGENT_YAML_SPEC.md`, `POLICIES.md`, and this file). |
+| `openapi.json` | Generated OpenAPI spec, committed for drift detection. |
+
+## Request flow: an agent turn
+
+```
+1. User types question in REPL / web UI / mobile
+2. Client POSTs to /v1/sessions/{id}/events with the user message
+3. Server validates against agent guardrails (POLICIES.md §...)
+4. Server emits SSE: SessionStatusEvent (queued -> in_progress)
+5. Runner picks up the turn via WS tunnel
+6. Runner invokes the harness with prompt + tool schemas
+7. Harness streams LLM events back to runner
+8. Runner emits ServerStreamEvent SSE for each delta
+9. Client renders (and observability hooks, if attached, fire)
+10. Turn ends with CompletedEvent / FailedEvent / IncompleteEvent / CancelledEvent
+```
+
+The SDK's `BlockStream` consumes the SSE stream and emits semantic
+"blocks" (text, reasoning, tool call, tool result). The SDK's
+`StreamHooks` dataclass exposes per-lifecycle callbacks that third-
+party tools (tracers, metrics collectors) can register against.
+
+## Two extension surfaces worth knowing
+
+- **Adding a harness.** Create a new module under
+  `omnigent/runtime/harnesses/<your-harness>/`. Register the
+  executor type. Implement the streaming protocol. `[maintainer
+  fill: pointer to a worked harness PR or template]`.
+- **Adding a tool.** Tools come in three flavors: MCP, Python
+  function tools (decorated with `@omnigent_client.tool`), and
+  sub-agent delegations. The agent's YAML declares which it uses.
+  See `AGENT_YAML_SPEC.md` for the schema.
+
+## Observability surfaces
+
+- **`StreamHooks` callbacks.** Client-side. Fires per lifecycle
+  event (response start/end, tool call start/end, reasoning start/end,
+  message start/end, compaction start/end, retry, server error,
+  elicitation). Sessions-first path picked up hook support in PR #43.
+  Adapter example: [omnigent-mlflow-quickstart](https://github.com/debu-sinha/omnigent-mlflow-quickstart).
+- **Server logs.** `~/.omnigent/logs/server/` for server-process
+  logs, `~/.omnigent/logs/host-daemon/` for the host daemon.
+- **`SubAgentSummary` read model.** Surfaced via
+  `/v1/sessions/{id}/sub-agents` for REPL / web UI. See issue
+  #146 for the open question on whether sub-agent lifecycle
+  should also surface as an event.
+
+## What to read next
+
+| If you're working on… | Start here |
+| --- | --- |
+| The CLI | `omnigent/cli.py`, `CONTRIBUTING.md` |
+| The server | `omnigent/server/app.py`, `openapi.json`, `omnigent/server/routes/sessions.py` |
+| A harness adapter | `omnigent/runtime/harnesses/_scaffold.py` |
+| Agent YAML | `docs/AGENT_YAML_SPEC.md` |
+| Policies / guardrails | `docs/POLICIES.md` |
+| Web UI | `ap-web/README.md` (if present, else `ap-web/package.json`) |
+| The Python SDK | `sdks/python-client/omnigent_client/__init__.py`, `sdks/python-client/README.md` |
+| Deployment | `deploy/README.md` and the per-target subdirectories |
+
+## Open questions for maintainers
+
+- `[maintainer fill]` Canonical name for the host-daemon vs runner
+  distinction. The code uses both; readers get confused.
+- `[maintainer fill]` Pointer to the design doc for the sessions-
+  first migration (the legacy `/v1/responses` story).
+- `[maintainer fill]` Where do ADRs (architectural decision records)
+  live, or is this file the closest thing today?


### PR DESCRIPTION
## Summary

Adds the community files an external evaluator scans for in the first
minute on the repo: `CODE_OF_CONDUCT.md`, `CHANGELOG.md`,
`docs/ARCHITECTURE.md`, `.github/CODEOWNERS`, and
`.github/ISSUE_TEMPLATE/` with bug / feature / question templates plus
a `config.yml` linking the security advisory and discussions surfaces.

None of these change runtime behavior. They lower the friction for
outside contributors to land their first PR.

## Why open this

A repo this size (1,889 tracked files, 16 CI workflows, OpenAPI
checked in, OSS Scorecard already running) clearly is set up for
external contribution, but the community-files surface is still thin
enough that an external maintainer evaluating "should I invest in
this project" lands and bounces. The five files above are the ones
GitHub itself surfaces in the Community Standards check.

Each one is independently editable, so feel free to take pieces of
this PR and leave the rest if a different shape would fit your
process better.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Docs-only PR. Manual verification: `git status` shows only the new
files, no source modifications. `git diff --check` clean.

## File-by-file rationale

- **`CODE_OF_CONDUCT.md`** is Contributor Covenant 2.1 verbatim
  (preserving the recognizability that's the whole point of adopting
  it), with the contact field pointing at the existing GitHub Security
  Advisory channel rather than a new email, so there's no inbox to
  set up.
- **`CHANGELOG.md`** is a Keep-a-Changelog 1.1 scaffold seeded with
  the two recent PRs (#43, #149) under `## [Unreleased]`. There's an
  explicit "Notes for maintainers" block at the bottom asking the
  team to fill in prior tags (or the last ~10 PRs) and to wire the
  release workflow to promote `## [Unreleased]` at tag time.
- **`docs/ARCHITECTURE.md`** is a one-page overview of the four roles
  (client / server / runner / harness), the repository layout, a
  request-flow walkthrough, and pointers into per-subsystem deeper
  docs. Sections marked `[maintainer fill]` are stubs intentionally
  waiting for ground-truth wording from someone with full design
  context.
- **`.github/CODEOWNERS`** is a placeholder with the recommended
  routing grouping commented out for maintainers to fill in. The only
  active line is a fallback `* @omnigent-ai/maintainers` so no PR
  routes to nobody.
- **`.github/ISSUE_TEMPLATE/`** ships bug / feature / question
  markdown templates and a `config.yml` that links the security
  advisory and discussions surfaces.

## What's NOT in this PR

I considered also adding `.github/FUNDING.yml`, `CITATION.cff`, and a
deeper `SECURITY.md`. Left those out so this stays a single reviewable
docs PR. Happy to send those as small follow-ups if any of them are
wanted.

I noticed open issues #146 and #147 from earlier today are observations
about the codebase, not PRs. This PR closes none of them; it sits next
to them.
