### PR TITLE
test(e2e): session labels/owner and utility endpoint tests

### DIFF
--- a/tests/server/integration/test_sessions_labels_owner.py
+++ b/tests/server/integration/test_sessions_labels_owner.py
@@ -1,0 +1,155 @@
+"""Integration tests for session labels and owner endpoints.
+
+Covers ``GET /v1/sessions/{id}/labels`` and
+``GET /v1/sessions/{id}/owner``.
+
+Uses the shared ``client`` fixture from ``tests/server/conftest.py``
+(real stores + mock LLM) so the tests hit the real route-to-store
+pipeline without subprocesses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+async def _create_session(
+    client: httpx.AsyncClient,
+    agent_id: str,
+    *,
+    title: str | None = None,
+    labels: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Create a session and return the response JSON."""
+    payload: dict[str, Any] = {"agent_id": agent_id}
+    if title is not None:
+        payload["title"] = title
+    if labels is not None:
+        payload["labels"] = labels
+    resp = await client.post("/v1/sessions", json=payload)
+    assert resp.status_code == 201, f"session create failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+# ── GET /v1/sessions/{id}/labels ─────────────────────────
+
+
+async def test_labels_empty_on_new_session(
+    client: httpx.AsyncClient,
+) -> None:
+    """A freshly created session with no labels returns an empty dict."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    resp = await client.get(f"/v1/sessions/{session['id']}/labels")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == session["id"]
+    # Labels may contain auto-injected keys (e.g. closed status);
+    # at minimum no user-supplied labels are present.
+    assert isinstance(data["labels"], dict)
+
+
+async def test_labels_set_via_create(
+    client: httpx.AsyncClient,
+) -> None:
+    """Labels passed at session creation are returned by GET labels."""
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        labels={"env": "staging", "team": "platform"},
+    )
+    resp = await client.get(f"/v1/sessions/{session['id']}/labels")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["labels"]["env"] == "staging"
+    assert data["labels"]["team"] == "platform"
+
+
+async def test_labels_updated_via_patch(
+    client: httpx.AsyncClient,
+) -> None:
+    """Labels updated via PATCH are reflected by a subsequent GET labels."""
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        labels={"env": "dev"},
+    )
+    sid = session["id"]
+
+    # Update labels via PATCH
+    patch_resp = await client.patch(
+        f"/v1/sessions/{sid}",
+        json={"labels": {"env": "prod", "region": "us-east"}},
+    )
+    assert patch_resp.status_code == 200
+
+    # Verify GET labels reflects the update
+    resp = await client.get(f"/v1/sessions/{sid}/labels")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["labels"]["env"] == "prod"
+    assert data["labels"]["region"] == "us-east"
+
+
+async def test_labels_persist_across_updates(
+    client: httpx.AsyncClient,
+) -> None:
+    """Successive PATCH updates overwrite labels correctly."""
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        labels={"version": "1"},
+    )
+    sid = session["id"]
+
+    # First update
+    await client.patch(
+        f"/v1/sessions/{sid}",
+        json={"labels": {"version": "2", "extra": "yes"}},
+    )
+
+    # Second update
+    await client.patch(
+        f"/v1/sessions/{sid}",
+        json={"labels": {"version": "3"}},
+    )
+
+    resp = await client.get(f"/v1/sessions/{sid}/labels")
+    assert resp.status_code == 200
+    assert resp.json()["labels"]["version"] == "3"
+
+
+# ── GET /v1/sessions/{id}/owner ──────────────────────────
+
+
+async def test_owner_returns_none_without_auth(
+    client: httpx.AsyncClient,
+) -> None:
+    """Without an auth provider the owner is null."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    resp = await client.get(f"/v1/sessions/{session['id']}/owner")
+    assert resp.status_code == 200
+    assert resp.json()["owner"] is None
+
+
+async def test_owner_null_for_nonexistent_session(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET owner for a nonexistent session returns null owner (no auth)."""
+    resp = await client.get("/v1/sessions/conv_nonexistent_abc123/owner")
+    assert resp.status_code == 200
+    assert resp.json()["owner"] is None

--- a/tests/server/integration/test_utility_endpoints.py
+++ b/tests/server/integration/test_utility_endpoints.py
@@ -1,0 +1,91 @@
+"""Integration tests for utility endpoints.
+
+Covers ``GET /health``, ``GET /api/version``, ``GET /v1/info``,
+and ``GET /v1/me``.
+
+Uses the shared ``client`` fixture from ``tests/server/conftest.py``
+(real stores + mock LLM) so the tests hit the real route-to-store
+pipeline without subprocesses.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── GET /health ──────────────────────────────────────────
+
+
+async def test_health_returns_ok(client: httpx.AsyncClient) -> None:
+    """Bare liveness probe returns 200 with status ok."""
+    resp = await client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+
+
+async def test_health_with_session_id(client: httpx.AsyncClient) -> None:
+    """Health with a session_id query param includes a session object."""
+    resp = await client.get("/health", params={"session_id": "conv_fake"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert "session" in data
+    assert data["session"]["id"] == "conv_fake"
+    assert "runner_online" in data["session"]
+
+
+async def test_health_with_batch_session_ids(client: httpx.AsyncClient) -> None:
+    """Health with comma-separated session_ids returns a sessions dict."""
+    resp = await client.get(
+        "/health",
+        params={"session_ids": "conv_a,conv_b"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "sessions" in data
+    assert "conv_a" in data["sessions"]
+    assert "conv_b" in data["sessions"]
+
+
+# ── GET /api/version ─────────────────────────────────────
+
+
+async def test_version_returns_string(client: httpx.AsyncClient) -> None:
+    """Version endpoint returns a version string."""
+    resp = await client.get("/api/version")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "version" in data
+    assert isinstance(data["version"], str)
+    assert len(data["version"]) > 0
+
+
+# ── GET /v1/info ─────────────────────────────────────────
+
+
+async def test_info_returns_expected_fields(client: httpx.AsyncClient) -> None:
+    """Info endpoint returns auth mode and feature flags."""
+    resp = await client.get("/v1/info")
+    assert resp.status_code == 200
+    data = resp.json()
+    # The test app has no auth provider, so accounts are disabled.
+    assert data["accounts_enabled"] is False
+    assert data["login_url"] is None
+    assert data["needs_setup"] is False
+    assert isinstance(data["databricks_features"], bool)
+    assert isinstance(data["managed_sandboxes_enabled"], bool)
+
+
+# ── GET /v1/me ───────────────────────────────────────────
+
+
+async def test_me_returns_null_user_without_auth(client: httpx.AsyncClient) -> None:
+    """Without auth, /v1/me returns user_id null."""
+    resp = await client.get("/v1/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user_id"] is None


### PR DESCRIPTION
## Summary
- Add integration tests for `GET /v1/sessions/{id}/labels` (empty on create, set via create, updated via PATCH, persist across updates)
- Add integration tests for `GET /v1/sessions/{id}/owner` (null without auth, null for nonexistent session)
- Add integration tests for utility endpoints: `GET /health`, `GET /api/version`, `GET /v1/info`, `GET /v1/me`

## Test plan
- [x] All 12 new tests pass locally (`pytest tests/server/integration/test_sessions_labels_owner.py tests/server/integration/test_utility_endpoints.py`)
- [ ] CI passes

This pull request and its description were written by Isaac.