### PR TITLE
feat(deploy): add UBI9-based Dockerfile for RHEL/OpenShift compliance

### DIFF
--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -82,7 +82,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER 0
 
-RUN dnf install -y --nodocs git tmux curl ca-certificates \
+# curl-minimal and ca-certificates are preinstalled in UBI9.
+RUN dnf install -y --nodocs git tmux \
  && dnf clean all
 
 RUN git config --system credential.helper \
@@ -117,8 +118,9 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER 0
 
-RUN dnf install -y --nodocs curl ca-certificates \
- && dnf clean all
+# curl-minimal and ca-certificates are preinstalled in UBI9;
+# installing full curl would conflict with curl-minimal.
+
 
 COPY --from=server-builder /opt/venv /opt/venv
 COPY --from=server-builder /build /build

--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -1,0 +1,144 @@
+# Omnigent UBI images: server (default target) + host (`--target host`).
+#
+# Red Hat Universal Base Image (UBI 9) variant of the standard Dockerfile,
+# for RHEL/OpenShift environments that require UBI-compliant containers.
+# Same two-target structure: `runtime` (server) and `host` (sandbox).
+#
+# Build (from repo root):
+#
+#   docker build -t omnigent-server:ubi \
+#                -f deploy/docker/Dockerfile.ubi .
+#
+#   docker build -t omnigent-host:ubi --target host \
+#                -f deploy/docker/Dockerfile.ubi .
+
+ARG PYTHON_VERSION=3.12
+ARG NODE_VERSION=20
+
+# ── Web UI builder ──────────────────────────────────────
+FROM registry.access.redhat.com/ubi9/nodejs-${NODE_VERSION} AS web-builder
+ARG NPM_CONFIG_REGISTRY=
+ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY}
+
+USER 0
+WORKDIR /web/ap-web
+COPY ap-web/package.json ap-web/package-lock.json ./
+RUN npm install --no-audit --no-fund
+COPY ap-web/ ./
+RUN npm run build
+
+# ── Python builder (shared: server + host) ──────────────
+FROM registry.access.redhat.com/ubi9/python-312 AS builder
+
+ARG PYPI_INDEX_URL=https://pypi.org/simple
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+USER 0
+
+RUN microdnf install -y --nodocs gcc gcc-c++ make python3-devel \
+ && microdnf clean all
+
+RUN pip install --index-url ${PYPI_INDEX_URL} --no-cache-dir uv
+
+WORKDIR /build
+
+COPY pyproject.toml setup.py ./
+COPY LICENSE NOTICE ./
+COPY sdks/ ./sdks/
+COPY omnigent/ ./omnigent/
+COPY examples/ ./examples/
+
+RUN python -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:${PATH}"
+
+RUN uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} -e .
+
+# ── Server builder ──────────────────────────────────────
+FROM builder AS server-builder
+
+ARG PYPI_INDEX_URL=https://pypi.org/simple
+
+COPY --from=web-builder /web/omnigent/server/static/web-ui ./omnigent/server/static/web-ui
+RUN test -f ./omnigent/server/static/web-ui/index.html \
+    || (echo "ERROR: SPA bundle missing after web-builder stage — check the ap-web build." && exit 1)
+
+RUN uv pip install --no-cache-dir --index-url ${PYPI_INDEX_URL} 'psycopg[binary]>=3.1,<4'
+
+# ── Node alias stage ─────────────────────────────────────
+FROM registry.access.redhat.com/ubi9/nodejs-${NODE_VERSION} AS node-runtime
+
+# ── Host runtime (`--target host`) ──────────────────────
+FROM registry.access.redhat.com/ubi9/python-312 AS host
+ARG NPM_CONFIG_REGISTRY=
+ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY}
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/opt/venv/bin:${PATH}" \
+    IS_SANDBOX=1
+
+USER 0
+
+RUN microdnf install -y --nodocs git tmux curl ca-certificates \
+ && microdnf clean all
+
+RUN git config --system credential.helper \
+      '!f() { [ "$1" = get ] || return 0; [ -n "$GIT_TOKEN" ] || return 0; printf "username=%s\npassword=%s\n" "${GIT_USERNAME:-x-access-token}" "$GIT_TOKEN"; }; f'
+
+# Node runtime from the UBI Node image.
+COPY --from=node-runtime /usr/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+RUN npm install -g --no-audit --no-fund \
+      @anthropic-ai/claude-code \
+      @openai/codex \
+      @earendil-works/pi-coding-agent \
+ && npm cache clean --force
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /build /build
+
+RUN echo 'export PATH="/opt/venv/bin:${PATH}"' > /etc/profile.d/omnigent-venv.sh
+
+WORKDIR /root
+CMD ["sleep", "infinity"]
+
+# ── Server runtime (default target) ─────────────────────
+FROM registry.access.redhat.com/ubi9/python-312 AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/opt/venv/bin:${PATH}"
+
+USER 0
+
+RUN microdnf install -y --nodocs curl ca-certificates \
+ && microdnf clean all
+
+COPY --from=server-builder /opt/venv /opt/venv
+COPY --from=server-builder /build /build
+COPY deploy/docker/entrypoint.py /app/entrypoint.py
+
+WORKDIR /app
+
+RUN mkdir -p /data/artifacts \
+ && chown -R 1001:0 /data \
+ && chmod -R g=u /data
+
+ENV PORT=8000 \
+    HOST=0.0.0.0 \
+    ARTIFACT_DIR=/data/artifacts
+
+EXPOSE 8000
+
+USER 1001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1
+
+CMD ["python", "/app/entrypoint.py"]

--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -37,8 +37,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 USER 0
 
-RUN microdnf install -y --nodocs gcc gcc-c++ make python3-devel \
- && microdnf clean all
+RUN dnf install -y --nodocs gcc gcc-c++ make python3-devel \
+ && dnf clean all
 
 RUN pip install --index-url ${PYPI_INDEX_URL} --no-cache-dir uv
 
@@ -82,8 +82,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER 0
 
-RUN microdnf install -y --nodocs git tmux curl ca-certificates \
- && microdnf clean all
+RUN dnf install -y --nodocs git tmux curl ca-certificates \
+ && dnf clean all
 
 RUN git config --system credential.helper \
       '!f() { [ "$1" = get ] || return 0; [ -n "$GIT_TOKEN" ] || return 0; printf "username=%s\npassword=%s\n" "${GIT_USERNAME:-x-access-token}" "$GIT_TOKEN"; }; f'
@@ -117,8 +117,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER 0
 
-RUN microdnf install -y --nodocs curl ca-certificates \
- && microdnf clean all
+RUN dnf install -y --nodocs curl ca-certificates \
+ && dnf clean all
 
 COPY --from=server-builder /opt/venv /opt/venv
 COPY --from=server-builder /build /build

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -146,6 +146,21 @@ with its own 10 Gi PVC. Good for dev/testing clusters.
    kubectl kustomize deploy/kubernetes/overlays/postgres/ | kubectl apply -f -
    ```
 
+## Building a UBI image (Red Hat / OpenShift)
+
+For RHEL and OpenShift environments that require UBI-compliant containers, use
+the UBI variant of the Dockerfile. It uses Red Hat Universal Base Image 9
+(`ubi9/python-312`, `ubi9/nodejs-20`) and runs the server as non-root (UID 1001)
+by default — compatible with OpenShift's `restricted-v2` SCC out of the box.
+
+```bash
+# from the repo root
+docker build -t omnigent-server:ubi -f deploy/docker/Dockerfile.ubi .
+```
+
+Then reference the image in the OpenShift overlay by patching the Deployment
+or pointing your image stream at it.
+
 ## Deploy on Red Hat OpenShift
 
 The `overlays/openshift/` overlay replaces the Ingress with an OpenShift Route


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Add `deploy/docker/Dockerfile.ubi` using Red Hat UBI 9 base images (`ubi9/python-312`, `ubi9/nodejs-20`) for  enterprise environments requiring UBI-compliant containers
- Same multi-stage structure as the Debian Dockerfile: `runtime` (server) and `host` (sandbox) targets
- Server runtime runs as non-root (UID 1001) with group-writable `/data`, compatible with OpenShift's `restricted-v2`  SCC out of the box
- Add "Building a UBI image" section to the Kubernetes README


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->

Successfully built the image locally.