### PR TITLE
test: add two test-quality lint hooks (no-skipped-tests, no-global-asyncio-patch)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,22 @@ repos:
         entry: .venv/bin/python -m ruff check --fix --force-exclude
         types: [python]
 
+      # Project-specific test-quality lint rules (dev/lint/). Run on test
+      # files only — the patterns never occur in production code.
+      - id: no-global-asyncio-patch
+        name: no globally-clobbering asyncio monkeypatch
+        language: system
+        entry: .venv/bin/python dev/lint/lint_no_global_asyncio_patch.py
+        types: [python]
+        files: ^tests/
+
+      - id: no-skipped-tests
+        name: no unconditional `@pytest.mark.skip`
+        language: system
+        entry: .venv/bin/python dev/lint/lint_no_skipped_tests.py
+        types: [python]
+        files: ^tests/
+
       - id: ap-web-prettier
         name: ap-web prettier
         language: system

--- a/dev/__init__.py
+++ b/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Project development tooling (lint hooks run from .pre-commit-config.yaml)."""

--- a/dev/lint/__init__.py
+++ b/dev/lint/__init__.py
@@ -1,0 +1,1 @@
+"""Project-specific lint hooks run from .pre-commit-config.yaml."""

--- a/dev/lint/lint_no_global_asyncio_patch.py
+++ b/dev/lint/lint_no_global_asyncio_patch.py
@@ -1,0 +1,262 @@
+"""Flag patches that globally clobber ``asyncio`` module attributes.
+
+What goes wrong
+---------------
+
+When test code writes::
+
+    with patch("omnigent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
+        ...
+
+``unittest.mock``'s dotted-path resolver walks:
+
+1. ``import omnigent.tools.mcp``
+2. ``getattr(omnigent.tools.mcp, "asyncio")`` -> returns the
+   ``asyncio`` module singleton (because production code did
+   ``import asyncio`` at module top).
+3. ``setattr(asyncio_module, "sleep", mock)`` -> globally clobbers
+   ``asyncio.sleep`` for the entire process for the patch's lifetime.
+
+Under ``pytest-xdist``, concurrent tests in other workers that touch
+``asyncio.sleep`` (directly or via any of the many helpers built on
+top of it) silently get the mock, causing hard-to-debug cross-test
+flakiness.
+
+The same bug shape applies to:
+
+- ``monkeypatch.setattr("...asyncio.sleep", ...)`` (pytest)
+- ``patch.object(mod.asyncio, "sleep", ...)``
+
+What this catches
+-----------------
+
+1. ``patch("...asyncio.<name>", ...)`` / ``mock.patch(...)`` where the
+   first positional arg is a string literal containing ``.asyncio.``
+   or ending in ``.asyncio``.
+2. ``monkeypatch.setattr("...asyncio.<name>", ...)`` with the same
+   string-literal shape.
+3. ``patch.object(<expr>, "<name>", ...)`` where ``<expr>`` is an
+   attribute access whose leaf attribute is ``asyncio``
+   (e.g. ``patch.object(mcp_mod.asyncio, "sleep", ...)``).
+
+Correct shapes
+--------------
+
+Option A (preferred, when production has few sleep sites): add a
+thin ``_sleep`` indirection in the production module and patch
+``module._sleep`` from tests. The real ``asyncio.sleep`` is never
+touched.
+
+Option B (when A is too invasive): replace the ``asyncio`` binding
+in the target module's namespace with a ``SimpleNamespace`` that
+mirrors the real module but with the desired attribute swapped.
+The real ``asyncio`` module is left alone.
+
+Exit code 1 if any hits are found.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _is_global_asyncio_literal(value: str) -> bool:
+    """Return True if ``value`` is a one-segment getattr off the
+    stdlib ``asyncio`` module name (the shape that clobbers the
+    singleton).
+
+    The dangerous shape is::
+
+        patch("<pkg>.<mod>.asyncio.<leaf>", ...)
+
+    where ``<leaf>`` is exactly one segment. The dotted-path resolver
+    imports ``<pkg>.<mod>``, calls ``getattr(_, "asyncio")`` -- which
+    returns the stdlib ``asyncio`` module singleton because the
+    consumer did ``import asyncio`` -- then sets ``<leaf>`` on it.
+
+    NOT flagged:
+
+    * ``"<pkg>.asyncio.<sub>.<leaf>"`` -- here ``asyncio`` is a
+      subpackage name (e.g. ``websockets.asyncio.client``) and the
+      resolver descends *through* a package directory, not through
+      a getattr on the stdlib module.
+    * ``"<pkg>.asyncio"`` -- the bare module path is used to *replace*
+      the binding (the safe Option B pattern), not to clobber an
+      attribute inside it.
+
+    :param value: The dotted-path string passed to ``patch`` /
+        ``monkeypatch.setattr``.
+    :returns: ``True`` if the path has exactly one segment after the
+        last ``.asyncio.``.
+    """
+    marker = ".asyncio."
+    idx = value.rfind(marker)
+    if idx == -1:
+        return False
+    tail = value[idx + len(marker) :]
+    # Exactly one segment after `.asyncio.` -> getattr on the stdlib
+    # module singleton. Two or more segments -> the path descends
+    # through a subpackage named `asyncio`.
+    return bool(tail) and "." not in tail
+
+
+def _is_patch_func(func: ast.expr) -> bool:
+    """Return True if ``func`` spells ``patch`` or ``mock.patch``.
+
+    Plain ``patch.object`` is handled separately -- this only matches
+    the dotted-path form ``patch("...")`` / ``mock.patch("...")``.
+    """
+    if isinstance(func, ast.Name) and func.id == "patch":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "patch":
+        return True
+    return False
+
+
+def _is_patch_object(func: ast.expr) -> bool:
+    """Return True if ``func`` spells ``patch.object`` or ``mock.patch.object``."""
+    if not isinstance(func, ast.Attribute) or func.attr != "object":
+        return False
+    inner = func.value
+    if isinstance(inner, ast.Name) and inner.id == "patch":
+        return True
+    if isinstance(inner, ast.Attribute) and inner.attr == "patch":
+        return True
+    return False
+
+
+def _is_monkeypatch_setattr(func: ast.expr) -> bool:
+    """Return True if ``func`` spells ``<monkeypatch>.setattr``.
+
+    Conservative: matches any attribute access where the leaf is
+    ``setattr`` and the receiver is a ``Name`` containing
+    ``monkeypatch`` (case-insensitive). This covers the common
+    ``monkeypatch.setattr(...)`` and ``m.setattr(...)`` (from
+    ``with monkeypatch.context() as m:``).
+
+    :param func: The function-position expression of a ``Call``.
+    :returns: ``True`` if this looks like ``monkeypatch.setattr``.
+    """
+    if not isinstance(func, ast.Attribute) or func.attr != "setattr":
+        return False
+    base = func.value
+    if isinstance(base, ast.Name):
+        return "monkeypatch" in base.id.lower() or base.id == "m"
+    return False
+
+
+def _attribute_ends_in_asyncio(node: ast.expr) -> bool:
+    """Return True if ``node`` is an attribute access ending in ``.asyncio``.
+
+    e.g. matches ``mcp_mod.asyncio`` and ``omnigent.tools.mcp.asyncio``.
+    """
+    return isinstance(node, ast.Attribute) and node.attr == "asyncio"
+
+
+def _check_string_literal_first_arg(node: ast.Call) -> bool:
+    """Return True if ``node.args[0]`` is a string literal flagged by
+    :func:`_is_global_asyncio_literal`."""
+    if not node.args:
+        return False
+    first = node.args[0]
+    if not isinstance(first, ast.Constant) or not isinstance(first.value, str):
+        return False
+    return _is_global_asyncio_literal(first.value)
+
+
+def scan(path: Path) -> list[tuple[int, str]]:
+    """
+    Return ``[(lineno, snippet), ...]`` for each violation in ``path``.
+
+    :param path: File to scan.
+    :returns: One entry per flagged call site.
+    """
+    try:
+        source = path.read_text()
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    source_lines = source.splitlines()
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_flagged_call(node):
+            continue
+        line = node.lineno
+        snippet = source_lines[line - 1].strip() if 0 < line <= len(source_lines) else ""
+        hits.append((line, snippet))
+    return hits
+
+
+def _is_flagged_call(node: ast.Call) -> bool:
+    """Return True if ``node`` is one of the banned patch shapes.
+
+    Covers three call shapes:
+
+    1. ``patch("...asyncio.<name>", ...)`` / ``mock.patch(...)``.
+    2. ``monkeypatch.setattr("...asyncio.<name>", ...)``.
+    3. ``patch.object(<expr ending in .asyncio>, "<name>", ...)``.
+
+    :param node: A ``Call`` node from the AST.
+    :returns: ``True`` if the call matches a banned shape.
+    """
+    # patch("...asyncio.<name>", ...) / mock.patch("...asyncio.<name>", ...)
+    if _is_patch_func(node.func) and _check_string_literal_first_arg(node):
+        return True
+    # monkeypatch.setattr("...asyncio.<name>", ...)
+    if _is_monkeypatch_setattr(node.func) and _check_string_literal_first_arg(node):
+        return True
+    # patch.object(<...>.asyncio, "<name>", ...)
+    if (
+        _is_patch_object(node.func)
+        and len(node.args) >= 1
+        and _attribute_ends_in_asyncio(node.args[0])
+    ):
+        return True
+    return False
+
+
+def main(argv: list[str]) -> int:
+    """
+    Scan every file in ``argv[1:]`` and report violations.
+
+    :param argv: Command-line args (``argv[0]`` is the script name).
+    :returns: Exit code -- 0 on clean scan, 1 if any hits.
+    """
+    failed = False
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.is_file():
+            continue
+        hits = scan(path)
+        if hits:
+            failed = True
+            for line, snippet in hits:
+                sys.stdout.write(
+                    f"{path}:{line}: globally-clobbering asyncio patch detected: {snippet}\n"
+                )
+                sys.stdout.write(
+                    "   hint: see dev/lint/lint_no_global_asyncio_patch.py "
+                    "docstring for correct shapes.\n"
+                )
+    if failed:
+        sys.stdout.write(
+            "\nPatching ``module.asyncio.sleep`` (or any other asyncio "
+            "attribute via a dotted path that walks through the asyncio "
+            "module) mutates the real asyncio module singleton, which "
+            "leaks into every other test running in the same process "
+            "(critical under pytest-xdist). Prefer adding a thin "
+            "``_sleep`` indirection in the production module and "
+            "patching that, or replace the module's ``asyncio`` binding "
+            "wholesale with a ``SimpleNamespace`` -- see the script "
+            "docstring for Option A / Option B examples.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/dev/lint/lint_no_skipped_tests.py
+++ b/dev/lint/lint_no_skipped_tests.py
@@ -1,0 +1,185 @@
+"""Flag unconditional ``pytest.mark.skip`` on tests.
+
+Per CLAUDE.md and the omnigent-testing skill, skipped tests are
+invisible coverage loss — they silently rot and nobody remembers to
+unskip them. If a test can't pass, rewrite it or delete it. Never
+defer broken tests behind ``@pytest.mark.skip``.
+
+What this catches
+-----------------
+
+- ``@pytest.mark.skip`` as a decorator (with or without args)
+- ``pytestmark = pytest.mark.skip(...)`` as module-level skip
+- ``pytest.skip(...)`` called as a statement at module scope
+- ``pytest.mark.skip`` imported under an alias (e.g. ``from pytest
+  import mark; @mark.skip``) — detected conservatively when the
+  attribute chain resolves to ``skip``.
+
+What this does NOT catch
+------------------------
+
+- ``@pytest.mark.skipif(condition, reason=...)``. Conditional skip
+  is legitimate when the condition tests an environmental
+  precondition (missing binary, wrong platform, missing optional
+  dep). Flagging it uniformly would produce too many false
+  positives; reviewers judge each ``skipif`` on whether the
+  condition is a real precondition or a hack to hide a broken
+  test.
+
+Exit code 1 if any hits are found.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _is_skip_attribute(node: ast.expr) -> bool:
+    """Return True if ``node`` spells ``pytest.mark.skip`` (or ``mark.skip``).
+
+    Conservative: follows the ``.skip`` attribute access. Any chain
+    whose leaf attribute is ``skip`` and whose root resolves to
+    ``pytest`` or ``mark`` is flagged.
+    """
+    if not isinstance(node, ast.Attribute):
+        return False
+    if node.attr != "skip":
+        return False
+    # Walk back up the chain.
+    base = node.value
+    while isinstance(base, ast.Attribute):
+        if base.attr == "mark":
+            return True
+        base = base.value
+    if isinstance(base, ast.Name) and base.id in ("pytest", "mark"):
+        return True
+    return False
+
+
+def _decorator_calls_skip(decorator: ast.expr) -> bool:
+    """Return True if ``decorator`` is ``@pytest.mark.skip`` or ``@...skip(...)``."""
+    if _is_skip_attribute(decorator):
+        return True
+    if isinstance(decorator, ast.Call) and _is_skip_attribute(decorator.func):
+        return True
+    return False
+
+
+def _is_module_level_skip_assignment(node: ast.stmt) -> bool:
+    """Return True if ``node`` is ``pytestmark = pytest.mark.skip(...)``.
+
+    Assigning to ``pytestmark`` at module scope applies the mark to
+    every test collected from the file — the nuclear option for
+    skipping.
+    """
+    if not isinstance(node, ast.Assign):
+        return False
+    if not any(isinstance(t, ast.Name) and t.id == "pytestmark" for t in node.targets):
+        return False
+    return _decorator_calls_skip(node.value)
+
+
+def _is_module_level_skip_call(node: ast.stmt) -> bool:
+    """Return True if ``node`` is a bare ``pytest.skip(...)`` call.
+
+    A ``pytest.skip()`` call at module scope during collection skips
+    the entire module. (Inside a test body it's a conditional skip
+    expression — not what we flag; we only care about module-level
+    or top-of-class uses.)
+    """
+    if not isinstance(node, ast.Expr):
+        return False
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr == "skip":
+        base = func.value
+        if isinstance(base, ast.Name) and base.id == "pytest":
+            return True
+    return False
+
+
+def scan(path: Path) -> list[tuple[int, str]]:
+    """
+    Return ``[(lineno, message), ...]`` for each skip site in ``path``.
+
+    :param path: File to scan.
+    :returns: Hits with line numbers and descriptive messages.
+    """
+    try:
+        source = path.read_text()
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    hits: list[tuple[int, str]] = []
+
+    # Decorator-level skips on test functions / classes.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for decorator in node.decorator_list:
+                if _decorator_calls_skip(decorator):
+                    hits.append(
+                        (
+                            decorator.lineno,
+                            f"`@pytest.mark.skip` on `{node.name}`: skipped tests "
+                            "rot invisibly; rewrite or delete",
+                        ),
+                    )
+
+    # Module-level `pytestmark = pytest.mark.skip(...)` and bare
+    # `pytest.skip(...)` calls at module scope.
+    for stmt in tree.body:
+        if _is_module_level_skip_assignment(stmt):
+            hits.append(
+                (
+                    stmt.lineno,
+                    "`pytestmark = pytest.mark.skip(...)` at module scope skips "
+                    "every test in the file",
+                ),
+            )
+        elif _is_module_level_skip_call(stmt):
+            hits.append(
+                (
+                    stmt.lineno,
+                    "`pytest.skip(...)` at module scope skips the entire module during collection",
+                ),
+            )
+
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    """
+    Scan every file in ``argv[1:]`` and report unconditional skips.
+
+    :param argv: Command-line args (``argv[0]`` is the script name).
+    :returns: Exit code — 0 on clean scan, 1 if any hits.
+    """
+    failed = False
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.is_file():
+            continue
+        hits = scan(path)
+        if hits:
+            failed = True
+            for line, msg in hits:
+                sys.stdout.write(f"{path}:{line}: {msg}\n")
+    if failed:
+        sys.stdout.write(
+            "\nSkipped tests are invisible coverage loss. If a test can't "
+            "pass, rewrite it for the current architecture or delete it. "
+            "For genuine environmental gates (missing binary, platform), "
+            "use ``@pytest.mark.skipif`` with a clear reason — this rule "
+            "only flags unconditional ``skip``.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/dev/__init__.py
+++ b/tests/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the project-specific lint hooks."""

--- a/tests/dev/lint/__init__.py
+++ b/tests/dev/lint/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the project-specific lint hooks."""

--- a/tests/dev/lint/test_lint_no_global_asyncio_patch.py
+++ b/tests/dev/lint/test_lint_no_global_asyncio_patch.py
@@ -1,0 +1,57 @@
+"""Tests for the no-global-asyncio-patch hook (``dev/lint/lint_no_global_asyncio_patch.py``).
+
+Patching ``asyncio.<name>`` via a dotted-path string (or ``patch.object``
+on a module's ``asyncio`` attribute) clobbers the process-wide singleton
+and leaks the mock across pytest-xdist workers. The guard exempts paths
+with 2+ segments after ``.asyncio.`` (e.g. ``websockets.asyncio.client``,
+a subpackage, not the stdlib module).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dev.lint.lint_no_global_asyncio_patch import main, scan
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        'patch("omnigent.tools.mcp.asyncio.sleep")',
+        'mock.patch("omnigent.tools.mcp.asyncio.sleep", new_callable=AsyncMock)',
+        'monkeypatch.setattr("omnigent.llms.client.asyncio.sleep", _fake)',
+    ],
+)
+def test_scan_flags_global_asyncio_patch(tmp_path: Path, line: str) -> None:
+    """Each banned patch shape that targets the asyncio singleton trips the hook."""
+    f = tmp_path / "test_sample.py"
+    f.write_text(f"{line}\n")
+    assert scan(f) == [(1, line)], f"Expected {line!r} flagged on line 1."
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Thin-helper indirection — the sanctioned alternative.
+        'patch("omnigent.tools.mcp._sleep", new_callable=AsyncMock)',
+        # 2+ segments after .asyncio. → a subpackage, not the stdlib module.
+        'patch("websockets.asyncio.client.connect")',
+    ],
+)
+def test_scan_ignores_helper_and_subpackage(tmp_path: Path, line: str) -> None:
+    """The helper indirection and asyncio-subpackage paths must stay green."""
+    f = tmp_path / "test_sample.py"
+    f.write_text(f"{line}\n")
+    assert scan(f) == [], f"{line!r} must not be flagged but was."
+
+
+def test_main_exit_codes(tmp_path: Path) -> None:
+    """``main`` returns 1 on a global asyncio patch, 0 on the helper form."""
+    dirty = tmp_path / "test_dirty.py"
+    dirty.write_text('patch("omnigent.x.asyncio.sleep")\n')
+    clean = tmp_path / "test_clean.py"
+    clean.write_text('patch("omnigent.x._sleep")\n')
+    assert main(["lint_no_global_asyncio_patch.py", str(dirty)]) == 1
+    assert main(["lint_no_global_asyncio_patch.py", str(clean)]) == 0

--- a/tests/dev/lint/test_lint_no_skipped_tests.py
+++ b/tests/dev/lint/test_lint_no_skipped_tests.py
@@ -1,0 +1,62 @@
+"""Tests for the no-skipped-tests hook (``dev/lint/lint_no_skipped_tests.py``).
+
+Unconditional ``@pytest.mark.skip``, module-level
+``pytestmark = pytest.mark.skip(...)``, and bare module-scope
+``pytest.skip(...)`` are invisible coverage loss. ``@pytest.mark.skipif``
+(a genuine environmental gate) is exempt. The scanner returns
+``(line, message)`` pairs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev.lint.lint_no_skipped_tests import main, scan
+
+
+def test_scan_flags_decorator_skip(tmp_path: Path) -> None:
+    """``@pytest.mark.skip`` on a test trips the hook, naming the function."""
+    f = tmp_path / "test_sample.py"
+    f.write_text(
+        'import pytest\n@pytest.mark.skip(reason="later")\ndef test_thing() -> None: ...\n'
+    )
+    hits = scan(f)
+    # The decorator line (2) is flagged; the message names the function so
+    # the CI failure is actionable.
+    assert len(hits) == 1, f"Expected exactly one skip flagged, got {hits!r}."
+    assert hits[0][0] == 2, f"Skip should be flagged on the decorator line 2, got {hits[0][0]}."
+    assert "test_thing" in hits[0][1], f"Message should name the function, got {hits[0][1]!r}."
+
+
+def test_scan_flags_module_level_pytestmark_skip(tmp_path: Path) -> None:
+    """A module-level ``pytestmark = pytest.mark.skip(...)`` trips the hook."""
+    f = tmp_path / "test_sample.py"
+    f.write_text("import pytest\npytestmark = pytest.mark.skip(reason='wip')\n")
+    hits = scan(f)
+    assert len(hits) == 1, f"Expected one module-level skip flagged, got {hits!r}."
+    assert hits[0][0] == 2  # the pytestmark assignment line
+
+
+def test_scan_ignores_skipif(tmp_path: Path) -> None:
+    """``@pytest.mark.skipif`` is a real environmental gate and must stay green."""
+    f = tmp_path / "test_sample.py"
+    f.write_text(
+        "import pytest, sys\n"
+        '@pytest.mark.skipif(sys.platform == "win32", reason="posix only")\n'
+        "def test_thing() -> None: ...\n"
+    )
+    assert scan(f) == [], "skipif must not be flagged — it is a conditional gate, not a skip."
+
+
+def test_main_exit_codes(tmp_path: Path) -> None:
+    """``main`` returns 1 on an unconditional skip, 0 on a skipif."""
+    dirty = tmp_path / "test_dirty.py"
+    dirty.write_text("import pytest\n@pytest.mark.skip\ndef test_x() -> None: ...\n")
+    clean = tmp_path / "test_clean.py"
+    clean.write_text(
+        "import pytest, sys\n"
+        '@pytest.mark.skipif(sys.platform == "win32", reason="x")\n'
+        "def test_x() -> None: ...\n"
+    )
+    assert main(["lint_no_skipped_tests.py", str(dirty)]) == 1
+    assert main(["lint_no_skipped_tests.py", str(clean)]) == 0


### PR DESCRIPTION
## Summary

Adds two project-specific, AST-based lint rules under `dev/lint/`, wired into `.pre-commit-config.yaml` to run on test files:

- **no-skipped-tests** — flags unconditional `@pytest.mark.skip` and module-level `pytestmark = pytest.mark.skip(...)`, which silently rot. `@pytest.mark.skipif` stays allowed as a genuine environmental gate.
- **no-global-asyncio-patch** — flags patches that clobber the process-wide `asyncio` module singleton via a dotted path (e.g. `patch("pkg.mod.asyncio.sleep")`), which leaks the mock across `pytest-xdist` workers. Patching a thin in-module helper, and `asyncio` subpackage paths (e.g. `websockets.asyncio.client`), stay allowed.

Both report zero violations on the current test suite, so they are safe to enable on `pre-commit run --all-files`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Adds `tests/dev/lint/test_lint_no_skipped_tests.py` and `tests/dev/lint/test_lint_no_global_asyncio_patch.py` (10 tests). Each pins the flagged shapes, the documented exemptions (skipif; the helper-indirection and asyncio-subpackage paths), and the `main()` exit-code contract. Ran both test files (pass) and ran both scripts over the whole `tests/` tree (zero violations) so the new hooks are green on `--all-files`.