### PR TITLE
fix: remove startup update check that nags on every CLI invocation

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1146,7 +1146,6 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
 )
 
 
-
 def main() -> None:
     """
     Console-script entry point for ``omnigent``.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1146,22 +1146,6 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
 )
 
 
-def _should_skip_update_check(argv: list[str]) -> bool:
-    """Decide whether the update check should be skipped for *argv*.
-
-    Skipped for help / version requests and internal subcommands
-    (``pane-split``, ``pane-picker``) that are invoked by the TUI,
-    not by the user directly.
-
-    :param argv: CLI arguments without the program name, e.g.
-        ``["run", "agent.yaml"]``.
-    :returns: ``True`` when the update check should be suppressed.
-    """
-    if not argv:
-        return True
-    first = argv[0]
-    return first in {"--help", "-h", "--version", "version", "pane-split", "pane-picker"}
-
 
 def main() -> None:
     """
@@ -1193,11 +1177,6 @@ def main() -> None:
     _migrate_legacy_state_dir()
 
     argv = sys.argv[1:]
-
-    if not _should_skip_update_check(argv):
-        from omnigent.update_check import maybe_show_update_notice
-
-        maybe_show_update_notice()
 
     # Bare ``omnigent`` with no args behaves like ``omnigent run`` on an
     # interactive terminal: ``run`` resolves the configured default agent /

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3582,7 +3582,6 @@ def test_bare_omnigent_tty_dispatches_to_run(
     monkeypatch.setattr(sys, "argv", ["omnigent"])
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
-
     dispatched: dict[str, list[str]] = {}
 
     def fake_cli(*, args: list[str], standalone_mode: bool = True) -> None:
@@ -3601,7 +3600,6 @@ def test_bare_omnigent_rejects_positional_server_url(
 ) -> None:
     """Top-level server URLs must use ``run --server`` explicitly."""
     from omnigent.cli import main
-
 
     monkeypatch.setattr(sys, "argv", ["omnigent", "http://localhost:8000"])
 
@@ -3626,7 +3624,6 @@ def test_unknown_command_reports_no_such_command(
     that previously swallowed every non-subcommand invocation.
     """
     from omnigent.cli import main
-
 
     monkeypatch.setattr(sys, "argv", ["omnigent", "blah"])
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3581,7 +3581,7 @@ def test_bare_omnigent_tty_dispatches_to_run(
 
     monkeypatch.setattr(sys, "argv", ["omnigent"])
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-    monkeypatch.setattr("omnigent.update_check.maybe_show_update_notice", Mock())
+
 
     dispatched: dict[str, list[str]] = {}
 
@@ -3602,7 +3602,7 @@ def test_bare_omnigent_rejects_positional_server_url(
     """Top-level server URLs must use ``run --server`` explicitly."""
     from omnigent.cli import main
 
-    monkeypatch.setattr("omnigent.update_check.maybe_show_update_notice", Mock())
+
     monkeypatch.setattr(sys, "argv", ["omnigent", "http://localhost:8000"])
 
     with pytest.raises(SystemExit) as exc_info:
@@ -3627,7 +3627,7 @@ def test_unknown_command_reports_no_such_command(
     """
     from omnigent.cli import main
 
-    monkeypatch.setattr("omnigent.update_check.maybe_show_update_notice", Mock())
+
     monkeypatch.setattr(sys, "argv", ["omnigent", "blah"])
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/cli/test_cli_diagnostics.py
+++ b/tests/cli/test_cli_diagnostics.py
@@ -363,21 +363,11 @@ def test_main_logs_click_exceptions(
     del isolated_cli_diagnostics
     from omnigent import cli as cli_module
 
-    def _skip_update_check(_argv: list[str]) -> bool:
-        """
-        Disable update checking so the test exercises only CLI error handling.
-
-        :param _argv: CLI argv passed by :func:`omnigent.cli.main`.
-        :returns: Always ``True``.
-        """
-        return True
-
     # An unsupported --harness is a deterministic ClickException trigger that
     # raises before any daemon/network work. (A bare `omnigent run` no longer
     # errors — it drops into first-run `configure harnesses` — so it can't be
     # the trigger here.)
     monkeypatch.setattr(sys, "argv", ["omnigent", "run", "--harness", "not-a-real-harness"])
-    monkeypatch.setattr(cli_module, "_should_skip_update_check", _skip_update_check)
     # Isolate from any real ~/.omnigent/config.yaml on the developer's machine.
     monkeypatch.setattr(cli_module, "_load_global_config", dict)
 

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -486,45 +486,6 @@ def test_check_failure_caches_zero(
 
 
 # ------------------------------------------------------------------
-# _should_skip_update_check (in cli.py)
-# ------------------------------------------------------------------
-
-
-def test_should_skip_help_flags() -> None:
-    """Skip for ``--help``, ``-h``, ``--version``, ``version``."""
-    from omnigent.cli import _should_skip_update_check
-
-    assert _should_skip_update_check(["--help"])
-    assert _should_skip_update_check(["-h"])
-    assert _should_skip_update_check(["--version"])
-    assert _should_skip_update_check(["version"])
-
-
-def test_should_skip_internal_subcommands() -> None:
-    """Skip for TUI-internal subcommands."""
-    from omnigent.cli import _should_skip_update_check
-
-    assert _should_skip_update_check(["pane-split"])
-    assert _should_skip_update_check(["pane-picker"])
-
-
-def test_should_skip_empty_argv() -> None:
-    """Skip when argv is empty (bare ``omnigent``)."""
-    from omnigent.cli import _should_skip_update_check
-
-    assert _should_skip_update_check([])
-
-
-def test_should_not_skip_run() -> None:
-    """Do NOT skip for normal subcommands like ``run``."""
-    from omnigent.cli import _should_skip_update_check
-
-    assert not _should_skip_update_check(["run", "agent.yaml"])
-    assert not _should_skip_update_check(["server"])
-    assert not _should_skip_update_check(["attach"])
-
-
-# ------------------------------------------------------------------
 # Installed-wheel path
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

Remove the `maybe_show_update_notice()` call from the CLI entry point that printed "Update check — installed build is  N day(s) old" on every invocation. Fixes https://github.com/omnigent-ai/omnigent/issues/101. 


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
All 15 affected tests pass