### PR TITLE
fix(runner): handle required terminal lifecycle failures

### DIFF
--- a/ap-web/src/components/blocks/BlockRenderer.test.tsx
+++ b/ap-web/src/components/blocks/BlockRenderer.test.tsx
@@ -89,6 +89,49 @@ describe("BlockRenderer dispatch", () => {
     expect(card.getAttribute("data-terminal-kind")).toBe("output");
   });
 
+  it("renders error diagnostics with local wrapping and preserved line breaks", () => {
+    const message = [
+      "Required terminal exited unexpectedly; the session runtime is no longer available.",
+      "Lifecycle diagnostics:",
+      "terminal: required-runtime:main",
+      "command: runtime-worker (10 args; argv omitted because terminal args may contain secrets)",
+      "cwd: /workspace/project",
+      "last captured output:",
+      "  - first diagnostic line",
+      "  - second diagnostic line",
+    ].join("\n");
+    const items: RenderItem[] = [
+      {
+        kind: "error",
+        itemId: null,
+        source: "",
+        code: "required_terminal_exited",
+        message,
+      },
+    ];
+
+    const { container } = render(<BlockRenderer items={items} sessionStatus="idle" />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveClass("min-w-0");
+    expect(alert).toHaveClass("overflow-hidden");
+
+    const description = container.querySelector('[data-slot="alert-description"]');
+    expect(description).not.toBeNull();
+    expect(description).toHaveClass("min-w-0");
+    expect(description).toHaveClass("overflow-hidden");
+
+    const messageNode = screen.getByText(/Required terminal exited unexpectedly/);
+    expect(messageNode).toHaveClass("whitespace-pre-wrap");
+    expect(messageNode).toHaveClass("break-words");
+    expect(messageNode.textContent).toContain(
+      "Lifecycle diagnostics:\nterminal: required-runtime:main",
+    );
+    expect(messageNode.textContent).toContain(
+      "  - first diagnostic line\n  - second diagnostic line",
+    );
+  });
+
   it("treats a trailing reasoning item as streaming when sessionStatus is running", () => {
     const items: RenderItem[] = [
       { kind: "reasoning", itemId: null, text: "thinking", duration: undefined },

--- a/ap-web/src/components/blocks/StatusBlocks.tsx
+++ b/ap-web/src/components/blocks/StatusBlocks.tsx
@@ -24,13 +24,20 @@ interface ErrorBannerProps {
 export function ErrorBanner({ message, source, code }: ErrorBannerProps) {
   const display = message || code || "Unknown error";
   return (
-    <Alert variant="destructive">
+    <Alert
+      variant="destructive"
+      className="min-w-0 max-w-full overflow-hidden has-[>svg]:grid-cols-[auto_minmax(0,1fr)]"
+    >
       <AlertCircleIcon />
-      <AlertTitle>
+      <AlertTitle className="min-w-0 break-words [overflow-wrap:anywhere]">
         Error{source ? ` · ${source}` : ""}
         {code && message ? ` · ${code}` : ""}
       </AlertTitle>
-      <AlertDescription>{display}</AlertDescription>
+      <AlertDescription className="min-w-0 max-w-full overflow-hidden">
+        <span className="block max-w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] [text-wrap:wrap]">
+          {display}
+        </span>
+      </AlertDescription>
     </Alert>
   );
 }

--- a/ap-web/src/hooks/useChildSessions.ts
+++ b/ap-web/src/hooks/useChildSessions.ts
@@ -9,6 +9,11 @@ import { authenticatedFetch } from "@/lib/identity";
  */
 export const MAX_TREE_DEPTH = 3;
 
+export interface ChildSessionError {
+  code: string;
+  message: string;
+}
+
 /**
  * UI-facing child (sub-agent) session record.
  *
@@ -30,6 +35,8 @@ export interface ChildSessionInfo {
   labels?: Record<string, string>;
   /** Status of the latest task, e.g. ``"completed"``. */
   current_task_status: string | null;
+  /** Durable error details from the latest failed child run. */
+  last_task_error?: ChildSessionError | null;
   /** True when the latest task is in an active (queued/in_progress) state. */
   busy: boolean;
   /**
@@ -58,6 +65,7 @@ interface ChildSessionWire {
   session_name: string | null;
   labels?: Record<string, string>;
   current_task_status: string | null;
+  last_task_error?: ChildSessionError | null;
   busy: boolean;
   last_message_preview?: string | null;
   pending_elicitations_count?: number;
@@ -135,6 +143,14 @@ export function executionLogTabKey(idOrMain: string): string {
   return `executionLog:${idOrMain}`;
 }
 
+function parseChildSessionError(value: unknown): ChildSessionError | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.code !== "string" || typeof record.message !== "string") return null;
+  if (!record.code || !record.message) return null;
+  return { code: record.code, message: record.message };
+}
+
 interface UseChildSessionsResult {
   children: ChildSessionInfo[];
   isLoading: boolean;
@@ -160,6 +176,7 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
     session_name: row.session_name,
     labels: row.labels ?? {},
     current_task_status: row.current_task_status,
+    last_task_error: parseChildSessionError(row.last_task_error),
     busy: row.busy,
     last_message_preview: row.last_message_preview ?? null,
     pending_elicitations_count: row.pending_elicitations_count ?? 0,

--- a/ap-web/src/shell/SubagentsPanel.test.tsx
+++ b/ap-web/src/shell/SubagentsPanel.test.tsx
@@ -704,8 +704,8 @@ describe("SubagentsPanel", () => {
   });
 
   it("renders 'Failed' for a child whose latest task ended in failure", () => {
-    // Matches MainStatusBadge's red-dot + "Failed" treatment, so the
-    // two surfaces read consistently when something goes wrong.
+    // Failed keeps the label in destructive text, with a trailing dot
+    // matching the rest of the rail's compact status markers.
     mockChildTree({
       conv_parent: [
         {
@@ -727,6 +727,34 @@ describe("SubagentsPanel", () => {
     expect(row).toHaveTextContent(/Failed/);
     // Should not lowercase-bleed the raw status into the label.
     expect(row.textContent).not.toMatch(/failed[^F]/);
+  });
+
+  it("renders a child with last_task_error as failed and exposes the error detail", () => {
+    mockChildTree({
+      conv_parent: [
+        childInfo({
+          id: "conv_child",
+          title: "researcher:auth",
+          tool: "researcher",
+          session_name: "auth",
+          last_task_error: {
+            code: "required_terminal_exited",
+            message:
+              "\nRequired terminal exited unexpectedly; the session runtime is no longer available.\ncommand: worker-cli",
+          },
+        }),
+      ],
+    });
+
+    const { container } = renderPanel();
+
+    const row = childRow(container, "conv_child");
+    const indicator = within(row).getByTestId("subagent-status-dot");
+    expect(row).toHaveTextContent(/Failed/);
+    expect(indicator).toHaveAttribute(
+      "aria-label",
+      "Failed: Required terminal exited unexpectedly; the session runtime is no longer available.",
+    );
   });
 
   it("shows the pulsing working dot (no redundant 'Working' word) on the main row when the parent session is running", () => {
@@ -811,9 +839,14 @@ describe("SubagentsPanel", () => {
     ).not.toBeNull();
     // Terminal states use design tokens, not raw 500-weight Tailwind. "done"
     // is a quiet, expected outcome, so it reads as a muted dot (not green);
-    // only failures keep a saturated tone.
+    // failures keep destructive text + a destructive dot.
     expect(childRow(container, "c_done").querySelector(".bg-muted-foreground\\/55")).not.toBeNull();
-    expect(childRow(container, "c_fail").querySelector(".bg-destructive")).not.toBeNull();
+    const failedIndicator = within(childRow(container, "c_fail")).getByTestId(
+      "subagent-status-dot",
+    );
+    expect(failedIndicator).toHaveClass("text-destructive");
+    expect(failedIndicator.querySelector(".bg-destructive")).not.toBeNull();
+    expect(failedIndicator.querySelector("svg")).toBeNull();
     // Regression guard: "done" must not regress to the loud green success tone.
     expect(childRow(container, "c_done").querySelector(".bg-success")).toBeNull();
     // Regression guard: the pre-polish stoplight classes must be gone.
@@ -888,11 +921,11 @@ describe("SubagentsPanel", () => {
     ).toHaveAttribute("aria-label", "Idle");
   });
 
-  it("renders the dot last so dots align across rows regardless of label width", () => {
-    // Alignment fix: the dot trails the label, so a wide label ("Failed")
-    // can't push its dot left of a bare "Idle" dot. If the dot ever renders
-    // before the label again, lastElementChild stops being the dot and the
-    // dots fall out of column.
+  it("renders the status marker last so markers align across rows regardless of label width", () => {
+    // Alignment fix: the marker trails the label, so a wide label ("Failed")
+    // can't push its marker left of a bare "Idle" dot. If the marker ever
+    // renders before the label again, lastElementChild stops being the marker
+    // and the markers fall out of column.
     mockChildTree({
       conv_parent: [
         childInfo({ id: "c_fail", tool: "researcher", current_task_status: "failed" }),
@@ -902,7 +935,7 @@ describe("SubagentsPanel", () => {
 
     const { container } = renderPanel();
 
-    // Failed row shows its label, with the colored dot trailing it.
+    // Failed row shows its label, with the destructive dot trailing it.
     const failIndicator = within(childRow(container, "c_fail")).getByTestId("subagent-status-dot");
     const failDot = failIndicator.querySelector("span.rounded-full");
     expect(failDot).not.toBeNull();

--- a/ap-web/src/shell/SubagentsPanel.tsx
+++ b/ap-web/src/shell/SubagentsPanel.tsx
@@ -149,6 +149,16 @@ interface AgentStatus {
   activity: AgentActivity;
   /** Human label, shown inline for notable states and always in the tooltip. */
   label: string;
+  /** Optional detail for the tooltip / accessible label. */
+  details?: string;
+}
+
+function firstErrorLine(message: string): string {
+  const first = message
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  return first ?? message;
 }
 
 /**
@@ -173,8 +183,15 @@ function childStatus(child: ChildSessionInfo): AgentStatus {
     return { activity: "launching", label: "Launching" };
   }
   if (child.busy) return { activity: "working", label: "Working" };
-  if (child.current_task_status === "completed") return { activity: "done", label: "Done" };
+  if (child.last_task_error) {
+    return {
+      activity: "failed",
+      label: "Failed",
+      details: firstErrorLine(child.last_task_error.message),
+    };
+  }
   if (child.current_task_status === "failed") return { activity: "failed", label: "Failed" };
+  if (child.current_task_status === "completed") return { activity: "done", label: "Done" };
   if (child.current_task_status) {
     return { activity: "other", label: child.current_task_status };
   }
@@ -198,8 +215,7 @@ function sessionStatus(status: string | undefined): AgentStatus {
 // Dot color per dot-rendered state. Working uses the animated RunningDot
 // and awaiting uses the "Needs response" tag, so both are excluded here.
 // "done" is a quiet, expected outcome, so it reads as a muted dot rather
-// than a loud green one — only failures keep a saturated (red) tone to draw
-// the eye.
+// than a loud green one.
 const DOT_TONE: Record<Exclude<AgentActivity, "working" | "awaiting">, string> = {
   done: "bg-muted-foreground/55",
   failed: "bg-destructive",
@@ -306,7 +322,8 @@ function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
  *
  * @param status - The resolved activity + label to render.
  */
-function StatusIndicator({ activity, label }: AgentStatus) {
+function StatusIndicator({ activity, label, details }: AgentStatus) {
+  const title = details ? `${label}: ${details}` : label;
   // Awaiting renders the exact same "Needs response" tag as the sidebar
   // (SessionStateBadge) so the approval affordance reads identically across
   // the app. The tag carries its own copy, so the row's separate label word
@@ -314,8 +331,8 @@ function StatusIndicator({ activity, label }: AgentStatus) {
   if (activity === "awaiting") {
     return (
       <span
-        aria-label={label}
-        title={label}
+        aria-label={title}
+        title={title}
         data-testid="subagent-status-dot"
         className="inline-flex shrink-0 items-center text-xs"
       >
@@ -323,10 +340,23 @@ function StatusIndicator({ activity, label }: AgentStatus) {
       </span>
     );
   }
+  if (activity === "failed") {
+    return (
+      <span
+        aria-label={title}
+        title={title}
+        data-testid="subagent-status-dot"
+        className="inline-flex shrink-0 items-center gap-1 text-destructive text-xs"
+      >
+        <span>{label}</span>
+        <span className={cn("inline-block size-2 shrink-0 rounded-full", DOT_TONE.failed)} />
+      </span>
+    );
+  }
   return (
     <span
-      aria-label={label}
-      title={label}
+      aria-label={title}
+      title={title}
       data-testid="subagent-status-dot"
       className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs"
     >

--- a/ap-web/src/store/chatStore.test.ts
+++ b/ap-web/src/store/chatStore.test.ts
@@ -3931,6 +3931,7 @@ describe("chatStore — handleSessionEvent (resource events)", () => {
       session_name: "auth",
       current_task_status: "in_progress",
       busy: true,
+      last_task_error: null,
       last_message_preview: "looking…",
       ...overrides,
     });
@@ -3952,6 +3953,7 @@ describe("chatStore — handleSessionEvent (resource events)", () => {
           session_name: "auth",
           labels: {},
           current_task_status: "in_progress",
+          last_task_error: null,
           busy: true,
           last_message_preview: "looking…",
           // Insert path defaults the count to 0 when the delta omits it.
@@ -4043,6 +4045,80 @@ describe("chatStore — handleSessionEvent (resource events)", () => {
       expect(row?.last_message_preview).toBe("found the bug"); // updated
       expect(row?.busy).toBe(true); // preserved
       expect(row?.current_task_status).toBe("in_progress"); // preserved
+    });
+
+    it("merges a failed status delta with a durable error", () => {
+      client.setQueryData<ChildSessionInfo[]>(childSessionsQueryKey("conv_parent"), [
+        {
+          id: "conv_child1",
+          title: "researcher:auth",
+          tool: "researcher",
+          session_name: "auth",
+          current_task_status: "in_progress",
+          busy: true,
+          last_message_preview: "booting worker",
+          pending_elicitations_count: 0,
+        },
+      ]);
+      handleSessionEvent({
+        type: "session_child_session_updated",
+        conversationId: "conv_parent",
+        childSessionId: "conv_child1",
+        child: {
+          id: "conv_child1",
+          busy: false,
+          current_task_status: "failed",
+          last_task_error: {
+            code: "required_terminal_exited",
+            message: "Required terminal exited unexpectedly",
+          },
+        },
+      });
+      const row = client.getQueryData<ChildSessionInfo[]>(
+        childSessionsQueryKey("conv_parent"),
+      )?.[0];
+      expect(row?.busy).toBe(false);
+      expect(row?.current_task_status).toBe("failed");
+      expect(row?.last_task_error).toEqual({
+        code: "required_terminal_exited",
+        message: "Required terminal exited unexpectedly",
+      });
+    });
+
+    it("clears a stale child error when the runner sends an active status", () => {
+      client.setQueryData<ChildSessionInfo[]>(childSessionsQueryKey("conv_parent"), [
+        {
+          id: "conv_child1",
+          title: "researcher:auth",
+          tool: "researcher",
+          session_name: "auth",
+          current_task_status: "failed",
+          busy: false,
+          last_task_error: {
+            code: "required_terminal_exited",
+            message: "Required terminal exited unexpectedly",
+          },
+          last_message_preview: "boot failed",
+          pending_elicitations_count: 0,
+        },
+      ]);
+      handleSessionEvent({
+        type: "session_child_session_updated",
+        conversationId: "conv_parent",
+        childSessionId: "conv_child1",
+        child: {
+          id: "conv_child1",
+          busy: true,
+          current_task_status: "in_progress",
+          last_task_error: null,
+        },
+      });
+      const row = client.getQueryData<ChildSessionInfo[]>(
+        childSessionsQueryKey("conv_parent"),
+      )?.[0];
+      expect(row?.busy).toBe(true);
+      expect(row?.current_task_status).toBe("in_progress");
+      expect(row?.last_task_error).toBeNull();
     });
 
     it("initializes a cold child-sessions cache from a full delta", () => {

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -3768,12 +3768,21 @@ function applyChildSessionUpdated(
           ),
         )
       : {};
+  const errorOrNull = (v: unknown): ChildSessionInfo["last_task_error"] => {
+    if (!v || typeof v !== "object") return null;
+    const record = v as Record<string, unknown>;
+    if (typeof record.code !== "string" || typeof record.message !== "string") return null;
+    if (!record.code || !record.message) return null;
+    return { code: record.code, message: record.message };
+  };
   if (child.title !== undefined) patch.title = strOrNull(child.title);
   if (child.tool !== undefined) patch.tool = strOrNull(child.tool);
   if (child.session_name !== undefined) patch.session_name = strOrNull(child.session_name);
   if (child.labels !== undefined) patch.labels = strRecordOrEmpty(child.labels);
   if (child.current_task_status !== undefined)
     patch.current_task_status = strOrNull(child.current_task_status);
+  if (child.last_task_error !== undefined)
+    patch.last_task_error = errorOrNull(child.last_task_error);
   if (child.busy !== undefined) patch.busy = child.busy === true;
   if (child.last_message_preview !== undefined)
     patch.last_message_preview = strOrNull(child.last_message_preview);
@@ -3792,6 +3801,7 @@ function applyChildSessionUpdated(
       session_name: patch.session_name ?? null,
       labels: patch.labels ?? {},
       current_task_status: patch.current_task_status ?? null,
+      last_task_error: patch.last_task_error ?? null,
       busy: patch.busy ?? false,
       last_message_preview: patch.last_message_preview ?? null,
       pending_elicitations_count: patch.pending_elicitations_count ?? 0,

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -722,6 +722,7 @@ class TerminalInstance:
     tmux_allow_passthrough: bool = False
     tmux_start_on_attach: bool = False
     running: bool = False
+    launch_cwd: str | None = None
     # Owned per-launch egress proxy. ``None`` when the sandbox
     # carries no ``egress_rules`` or the backend doesn't need a
     # spawn-time wrap (the ``none`` backend does nothing here). Cleaned
@@ -745,6 +746,7 @@ class TerminalInstance:
     # so a client attaching, detaching, focusing, clicking, or typing does
     # not read as agent activity. ``-inf`` until the first interaction.
     _last_client_interaction_at: float = field(default=float("-inf"), repr=False)
+    _last_pane_snapshot: str | None = field(default=None, repr=False)
 
     @property
     def tmux_target(self) -> str:
@@ -771,6 +773,23 @@ class TerminalInstance:
         :returns: None.
         """
         self._last_client_interaction_at = time.monotonic()
+
+    def last_pane_text(self) -> str | None:
+        """Return the last visible pane text captured for diagnostics.
+
+        The value is updated opportunistically by reads and watcher polls.
+        It is intentionally a snapshot, not a live tmux query, so callers can
+        still retrieve useful context after tmux has already disappeared.
+        """
+        snapshot = self._last_pane_snapshot
+        if snapshot is None:
+            return None
+        text = _strip_ansi(snapshot).strip()
+        return text or None
+
+    def _remember_pane_snapshot(self, snapshot: str) -> None:
+        """Store a pane capture for later exit diagnostics."""
+        self._last_pane_snapshot = snapshot
 
     def _tmux_base_cmd(self) -> list[str]:
         """
@@ -928,6 +947,7 @@ class TerminalInstance:
             )
 
         self.running = True
+        self.launch_cwd = effective_cwd
 
     async def send(
         self,
@@ -999,6 +1019,7 @@ class TerminalInstance:
                 )
             }
 
+        self._remember_pane_snapshot(result)
         return {
             "terminal": f"{self.name}:{self.session_key}",
             "screen": _strip_ansi(result),
@@ -1110,6 +1131,8 @@ class TerminalInstance:
     def start_idle_watcher(
         self,
         on_idle: Callable[[], None | Awaitable[None]],
+        *,
+        on_exit: Callable[[], None | Awaitable[None]] | None = None,
     ) -> None:
         """Start a background task that fires ``on_idle`` each time the pane
         becomes quiet (no change for ``_IDLE_THRESHOLD_SECONDS``).
@@ -1122,7 +1145,7 @@ class TerminalInstance:
             raise RuntimeError("Cannot start idle watcher before launch")
         if self._idle_task is not None and not self._idle_task.done():
             return
-        self._idle_task = asyncio.create_task(self._idle_watch_loop(on_idle))
+        self._idle_task = asyncio.create_task(self._idle_watch_loop(on_idle, on_exit=on_exit))
 
     async def _stop_idle_watcher(self) -> None:
         task = self._idle_task
@@ -1138,6 +1161,8 @@ class TerminalInstance:
     async def _idle_watch_loop(
         self,
         on_idle: Callable[[], None | Awaitable[None]],
+        *,
+        on_exit: Callable[[], None | Awaitable[None]] | None = None,
     ) -> None:
         """
         Asyncio polling loop driving an :class:`_IdleDetector`.
@@ -1148,15 +1173,16 @@ class TerminalInstance:
         """
         detector = _IdleDetector()
 
-        async def _fire() -> bool:
-            """Invoke on_idle. Returns False if the callback raised (watcher should exit)."""
+        async def _fire(callback: Callable[[], None | Awaitable[None]], kind: str) -> bool:
+            """Invoke a callback. Returns False if it raised and the watcher should exit."""
             try:
-                result = on_idle()
+                result = callback()
                 if asyncio.iscoroutine(result):
                     await result
             except Exception:
                 logger.exception(
-                    "idle-notification callback failed for terminal %s:%s",
+                    "%s-notification callback failed for terminal %s:%s",
+                    kind,
                     self.name,
                     self.session_key,
                 )
@@ -1176,10 +1202,14 @@ class TerminalInstance:
                     "-e",
                 )
             except RuntimeError:
-                # tmux server likely gone; stop watching quietly.
+                # tmux server likely gone.
+                self.running = False
+                if on_exit is not None:
+                    await _fire(on_exit, "exit")
                 return
 
-            if detector.tick(snapshot) and not await _fire():
+            self._remember_pane_snapshot(snapshot)
+            if detector.tick(snapshot) and not await _fire(on_idle, "idle"):
                 return
 
     def start_idle_watcher_thread(
@@ -1187,8 +1217,10 @@ class TerminalInstance:
         on_idle: Callable[[], None] | None = None,
         *,
         on_activity: Callable[[], None] | None = None,
+        on_exit: Callable[[], None] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
+        replace: bool = False,
     ) -> None:
         """
         Start a daemon thread driving idle/activity edges from the pane.
@@ -1208,10 +1240,11 @@ class TerminalInstance:
         fires on every poll tick where the pane content changed — so at
         most once per *poll_interval_s*, which for the fast claude-native
         watcher (200ms) is up to ~5/sec while a pane redraws continuously.
+        ``on_exit`` fires once when the tmux session disappears unexpectedly.
         Any further rate-limiting of activity (e.g. the runner's
         one-pulse-per-second ``session.terminal.activity`` throttle) is
         the caller's responsibility, not this watcher's. At least one
-        callback should be provided; passing both is fine.
+        callback should be provided; passing several is fine.
 
         :param on_idle: Optional sync callback invoked once per idle
             edge, or ``None`` to skip idle detection. Must not block the
@@ -1220,6 +1253,9 @@ class TerminalInstance:
         :param on_activity: Optional sync callback invoked on each tick
             the pane changed (the runner-determined "PTY had output"
             signal). Same non-blocking contract as *on_idle*.
+        :param on_exit: Optional sync callback invoked when the watcher
+            observes that tmux has disappeared. Same non-blocking contract
+            as *on_idle*.
         :param idle_threshold_s: Per-watcher diff-track idle threshold in
             seconds passed to :class:`_IdleDetector`, e.g. ``1.0`` for the
             claude-native status watcher. ``None`` uses the module
@@ -1228,19 +1264,23 @@ class TerminalInstance:
             ``0.2`` for the claude-native status watcher (snappier
             running/idle transitions). ``None`` uses the module default
             :data:`_IDLE_POLL_INTERVAL_SECONDS`.
+        :param replace: When ``True``, replace any existing threaded watcher
+            so callbacks can be rebound after terminal ownership transfer.
         :raises RuntimeError: When the instance is not currently
             running (caller forgot to ``await launch`` first).
         """
         if not self.running:
             raise RuntimeError("Cannot start idle watcher before launch")
-        if on_idle is None and on_activity is None:
+        if on_idle is None and on_activity is None and on_exit is None:
             raise ValueError(
                 "start_idle_watcher_thread requires at least one of "
-                "on_idle / on_activity — a watcher with neither would poll "
+                "on_idle / on_activity / on_exit — a watcher with none would poll "
                 "tmux forever with no effect."
             )
         if self._idle_thread is not None and self._idle_thread.is_alive():
-            return
+            if not replace:
+                return
+            self._stop_idle_watcher_thread()
         stop_event = threading.Event()
         self._idle_stop_event = stop_event
         self._idle_thread = threading.Thread(
@@ -1249,6 +1289,7 @@ class TerminalInstance:
             kwargs={
                 "on_idle": on_idle,
                 "on_activity": on_activity,
+                "on_exit": on_exit,
                 "idle_threshold_s": idle_threshold_s,
                 "poll_interval_s": poll_interval_s,
             },
@@ -1263,6 +1304,7 @@ class TerminalInstance:
         *,
         on_idle: Callable[[], None] | None = None,
         on_activity: Callable[[], None] | None = None,
+        on_exit: Callable[[], None] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
     ) -> None:
@@ -1283,6 +1325,8 @@ class TerminalInstance:
             :meth:`start_idle_watcher_thread`); skipped when ``None``.
         :param on_activity: Optional pane-changed callback; fired each
             tick the pane content changed. Skipped when ``None``.
+        :param on_exit: Optional callback fired when tmux disappears.
+            Skipped when ``None``.
         :param idle_threshold_s: Per-watcher diff-track idle threshold in
             seconds forwarded to :class:`_IdleDetector`, e.g. ``1.0``.
             ``None`` uses the module default.
@@ -1302,7 +1346,11 @@ class TerminalInstance:
                 return
             snapshot = self._capture_pane_for_idle_or_none()
             if snapshot is None:
+                self.running = False
+                if on_exit is not None:
+                    self._fire_watch_callback(on_exit, "exit")
                 return
+            self._remember_pane_snapshot(snapshot)
             # A pane change that lands within the recent-interaction window
             # is a client-driven repaint (attach/detach reflow, focus,
             # mouse, keystroke — stamped via note_client_interaction), not

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -793,7 +793,7 @@ async def _auto_create_pi_terminal(
             cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
             pi_env.update(cred_env)
             pi_args.extend(cred_args)
-    terminal_view = await resource_registry.launch_terminal(
+    terminal_view = await resource_registry.launch_required_terminal(
         session_id=session_id,
         terminal_name="pi",
         session_key="main",

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -57,6 +57,8 @@ from omnigent.runner.resource_registry import (
     OMNIGENT_REPL_TERMINAL_ROLE,
     PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
+    TerminalExitEvent,
+    TerminalLifecycle,
 )
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from omnigent.spec.parser import discover_host_skills
@@ -1161,7 +1163,7 @@ async def _auto_create_codex_terminal(
     # the listener and app-server here: the background forwarder task (which
     # otherwise owns their teardown) has not been created yet.
     try:
-        terminal_view = await resource_registry.launch_terminal(
+        terminal_view = await resource_registry.launch_auxiliary_terminal(
             session_id=session_id,
             terminal_name="codex",
             session_key="main",
@@ -2276,7 +2278,7 @@ async def _auto_create_claude_terminal(
         env_spec.scrollback,
     )
     try:
-        terminal_view = await resource_registry.launch_terminal(
+        terminal_view = await resource_registry.launch_required_terminal(
             session_id=session_id,
             terminal_name="claude",
             session_key="main",
@@ -2293,9 +2295,9 @@ async def _auto_create_claude_terminal(
         )
         raise
     # Surface the terminal on the live SSE stream so an already-connected
-    # web UI enables the Terminal toggle immediately. launch_terminal
-    # registers the resource and starts the activity watcher but does not
-    # publish; the tool / REST launch paths emit this same event via
+    # web UI enables the Terminal toggle immediately. The required-terminal
+    # launch helper registers the resource and starts the activity watcher but
+    # does not publish; the tool / REST launch paths emit this same event via
     # _emit_terminal_resource_event. Without it, this auto-created terminal
     # is only discovered on reconnect (snapshot-on-connect), so the toggle
     # stays gray until the user refreshes.
@@ -2447,7 +2449,7 @@ async def _auto_create_repl_terminal(
         # starts against the real attached terminal size.
         tmux_start_on_attach=True,
     )
-    terminal_view = await resource_registry.launch_terminal(
+    terminal_view = await resource_registry.launch_auxiliary_terminal(
         session_id=session_id,
         terminal_name=_REPL_TERMINAL_NAME,
         session_key=_REPL_TERMINAL_SESSION_KEY,
@@ -2476,8 +2478,8 @@ async def _auto_create_repl_terminal(
             session_id,
         )
     # Surface the terminal on the live SSE stream so an already-connected
-    # web UI enables the Terminal toggle immediately (launch_terminal
-    # registers the resource but does not publish — mirrors the
+    # web UI enables the Terminal toggle immediately (the auxiliary-terminal
+    # launch helper registers the resource but does not publish — mirrors the
     # claude-native auto-create path).
     from omnigent.entities.session_resources import session_resource_view_to_dict
 
@@ -3846,6 +3848,9 @@ class _ChildParentMeta:
     :param last_task_status: Last child-rail task status fanned out, e.g.
         ``"completed"``. Tracked separately so ``idle`` → ``failed`` emits
         even though both states are non-busy.
+    :param last_error: Last child failure detail fanned out, used to emit a
+        new parent update when only the error changes, and to clear stale
+        errors on a later running/waiting edge.
     """
 
     parent_id: str
@@ -3854,6 +3859,7 @@ class _ChildParentMeta:
     session_name: str
     last_busy: bool | None = None
     last_task_status: str | None = None
+    last_error: tuple[str, str] | None = None
 
 
 # child_session_id -> :class:`_ChildParentMeta`. Populated at spawn (see
@@ -4325,6 +4331,9 @@ def create_runner_app(
         session_id: str,
         meta: _ChildParentMeta,
         status: str | None,
+        *,
+        error: dict[str, str] | None = None,
+        include_error: bool = False,
     ) -> dict[str, Any]:
         """
         Build the ``child`` object for a parent-stream status update.
@@ -4332,10 +4341,14 @@ def create_runner_app(
         :param session_id: Child session id, e.g. ``"conv_child123"``.
         :param meta: Registered child-to-parent fan-out metadata.
         :param status: Child session status, e.g. ``"running"``.
+        :param error: Failure detail from the ``session.status`` event.
+        :param include_error: Whether to include ``last_task_error`` in the
+            partial payload. ``True`` for failed edges and for activity edges
+            that clear a stale failure.
         :returns: Child summary payload for ``session.child_session.updated``.
         """
         busy = status in ("running", "waiting")
-        return {
+        child = {
             "id": session_id,
             "title": meta.title,
             "tool": meta.tool,
@@ -4343,12 +4356,41 @@ def create_runner_app(
             "busy": busy,
             "current_task_status": _session_status_to_task_status(status),
         }
+        if include_error:
+            child["last_task_error"] = error
+        return child
+
+    def _child_error_from_status_event(
+        status: str | None,
+        event: dict[str, Any],
+    ) -> dict[str, str] | None:
+        """
+        Extract typed failure details from a generic ``session.status`` event.
+
+        :param status: Status value from the event, e.g. ``"failed"``.
+        :param event: Published status event.
+        :returns: ``{"code": "...", "message": "..."}`` for failed events
+            with a valid error payload, otherwise ``None``.
+        """
+        if status != "failed":
+            return None
+        raw_error = event.get("error")
+        if not isinstance(raw_error, dict):
+            return None
+        raw_code = raw_error.get("code")
+        raw_message = raw_error.get("message")
+        if not isinstance(raw_code, str) or not isinstance(raw_message, str):
+            return None
+        if not raw_code or not raw_message:
+            return None
+        return {"code": raw_code, "message": raw_message}
 
     def _build_child_status_update(
         session_id: str,
         meta: _ChildParentMeta,
         status: str | None,
         *,
+        error: dict[str, str] | None = None,
         latest_assistant_text: str | None = None,
         allow_history_preview_fallback: bool = True,
     ) -> dict[str, Any] | None:
@@ -4358,6 +4400,7 @@ def create_runner_app(
         :param session_id: Child session id, e.g. ``"conv_child123"``.
         :param meta: Registered child-to-parent fan-out metadata.
         :param status: Child session status, e.g. ``"running"``.
+        :param error: Failure detail from a failed ``session.status`` edge.
         :param latest_assistant_text: Explicit preview text, e.g. ``"done"``.
         :param allow_history_preview_fallback: Whether to read runner history.
         :returns: Update event, or ``None`` when busy/task status did not change.
@@ -4366,11 +4409,24 @@ def create_runner_app(
             mark_subagent_work_started(session_id)
         busy = status in ("running", "waiting")
         task_status = _session_status_to_task_status(status)
-        if meta.last_busy == busy and meta.last_task_status == task_status:
+        error_signature = (error["code"], error["message"]) if error is not None else None
+        include_error = status in ("running", "waiting") or error is not None
+        if (
+            meta.last_busy == busy
+            and meta.last_task_status == task_status
+            and meta.last_error == error_signature
+        ):
             return None
         meta.last_busy = busy
         meta.last_task_status = task_status
-        child = _child_status_body(session_id, meta, status)
+        meta.last_error = error_signature
+        child = _child_status_body(
+            session_id,
+            meta,
+            status,
+            error=error,
+            include_error=include_error,
+        )
         if not busy:
             preview = _child_preview_from_status(
                 session_id,
@@ -4418,6 +4474,7 @@ def create_runner_app(
                 session_id,
                 meta,
                 status,
+                error=_child_error_from_status_event(status, event),
                 latest_assistant_text=latest_assistant_text,
                 allow_history_preview_fallback=allow_history_preview_fallback,
             )
@@ -4474,6 +4531,99 @@ def create_runner_app(
         )
 
     resource_registry.set_session_status_publisher(_publish_session_status)
+
+    def _format_terminal_command_for_failure(event: TerminalExitEvent) -> str:
+        """Format a launch command without exposing possibly secret argv."""
+        if event.command is None:
+            return "unknown"
+        if event.args_count is None or event.args_count == 0:
+            return event.command
+        noun = "arg" if event.args_count == 1 else "args"
+        return (
+            f"{event.command} ({event.args_count} {noun}; "
+            "argv omitted because terminal args may contain secrets)"
+        )
+
+    def _format_required_terminal_exit_output(event: TerminalExitEvent) -> str:
+        """Build the sub-agent failure text for a required terminal exit."""
+        command = _format_terminal_command_for_failure(event)
+        cwd = event.cwd or "unknown"
+        parts = [
+            "Required terminal exited unexpectedly; the session runtime is no longer available.",
+            "",
+            "Terminal diagnostics:",
+            f"terminal: {event.terminal_name}:{event.session_key}",
+            f"command: {command}",
+            f"cwd: {cwd}",
+        ]
+        if event.last_output:
+            parts.extend(["", "Last captured terminal output:", event.last_output])
+        else:
+            parts.extend(
+                [
+                    "",
+                    "Last captured terminal output: unavailable. The process exited before "
+                    "Omnigent captured a pane snapshot.",
+                ]
+            )
+        return "\n".join(parts)
+
+    def _release_failed_required_terminal_session(session_id: str) -> None:
+        """Release the harness subprocess for a session whose runtime died."""
+        if process_manager is None:
+            return
+
+        async def _release() -> None:
+            try:
+                await process_manager.release(session_id)
+            except Exception:
+                _logger.exception(
+                    "Failed to release harness subprocess after required terminal exit: "
+                    "session=%s",
+                    session_id,
+                )
+
+        task = asyncio.create_task(
+            _release(),
+            name=f"required-terminal-release:{session_id}",
+        )
+        task.add_done_callback(_background_tasks.discard)
+        _background_tasks.add(task)
+
+    def _publish_terminal_exit(event: TerminalExitEvent) -> None:
+        """Publish terminal-exit lifecycle effects from the resource registry."""
+        _publish_event(
+            event.session_id,
+            {
+                "type": "session.resource.deleted",
+                "resource_id": event.terminal_id,
+                "resource_type": "terminal",
+                "session_id": event.session_id,
+            },
+        )
+        if event.lifecycle != TerminalLifecycle.REQUIRED:
+            return
+
+        output = _format_required_terminal_exit_output(event)
+        _publish_event(
+            event.session_id,
+            {
+                "type": "session.status",
+                "status": "failed",
+                "error": {
+                    "code": "required_terminal_exited",
+                    "message": output,
+                },
+            },
+        )
+        _mark_subagent_terminal_and_wake(
+            event.session_id,
+            status="failed",
+            output=output,
+        )
+        _release_failed_required_terminal_session(event.session_id)
+
+    resource_registry.set_terminal_exit_publisher(_publish_terminal_exit)
 
     # The runner owns a filesystem registry when it has a local workspace
     # (the CLI workspace path). In practice runner_workspace is always set
@@ -8960,6 +9110,7 @@ def create_runner_app(
                                                     harness_client=client,
                                                     server_client=server_client,
                                                     terminal_registry=terminal_registry,
+                                                    resource_registry=resource_registry,
                                                     agent_spec=_spec_for_dispatch,
                                                     conversation_id=conv_id,
                                                     task_id=_omnigent_task_id or _response_id,
@@ -10090,7 +10241,12 @@ def create_runner_app(
             await _ensure_comment_relay_started(session_id, bridge_id=bridge_id)
 
         try:
-            resource_view = await resource_registry.launch_terminal(
+            launch_method = (
+                resource_registry.launch_required_terminal
+                if bridge_inject
+                else resource_registry.launch_auxiliary_terminal
+            )
+            resource_view = await launch_method(
                 session_id=session_id,
                 terminal_name=terminal_name,
                 session_key=session_key,
@@ -11738,6 +11894,7 @@ def create_runner_app(
                         arguments=_json.dumps(arguments),
                         server_client=server_client,
                         terminal_registry=terminal_registry,
+                        resource_registry=resource_registry,
                         agent_spec=spec,
                         conversation_id=session_id,
                         task_id=session_id,

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -17,6 +17,8 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -85,6 +87,96 @@ _CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS = 0.2
 # at 1s, so this throttle is a no-op for them (their own poll spacing
 # already exceeds the threshold).
 _TERMINAL_ACTIVITY_EMIT_MIN_INTERVAL_SECONDS = 1.0
+_TERMINAL_EXIT_OUTPUT_MAX_LINES = 40
+_TERMINAL_EXIT_OUTPUT_MAX_CHARS = 4000
+
+
+class TerminalLifecycle(Enum):
+    """Session-lifecycle relationship for a terminal resource."""
+
+    REQUIRED = "required"
+    AUXILIARY = "auxiliary"
+
+
+@dataclass(frozen=True)
+class TerminalExitEvent:
+    """Terminal exit event emitted by :class:`SessionResourceRegistry`.
+
+    :param session_id: Owning session/conversation identifier.
+    :param terminal_id: Opaque terminal resource id.
+    :param terminal_name: Terminal spec/resource name.
+    :param session_key: Per-launch terminal key.
+    :param lifecycle: Required/auxiliary lifecycle relationship.
+    :param command: Executable launched in the terminal, if known.
+    :param args_count: Number of arguments passed to the executable, if known.
+        The event intentionally does not expose argv contents because terminal
+        specs may contain credentials or other launch-only secrets.
+    :param cwd: Working directory used to launch the terminal, if known.
+    :param last_output: Last visible pane text captured before exit, if any.
+    """
+
+    session_id: str
+    terminal_id: str
+    terminal_name: str
+    session_key: str
+    lifecycle: TerminalLifecycle
+    command: str | None = None
+    args_count: int | None = None
+    cwd: str | None = None
+    last_output: str | None = None
+
+
+def _trim_terminal_exit_output(text: str | None) -> str | None:
+    """Bound terminal-output diagnostics so a failure report stays compact."""
+    if text is None:
+        return None
+    stripped = text.strip()
+    if not stripped:
+        return None
+    lines = stripped.splitlines()
+    if len(lines) > _TERMINAL_EXIT_OUTPUT_MAX_LINES:
+        lines = [
+            f"... omitted {len(lines) - _TERMINAL_EXIT_OUTPUT_MAX_LINES} earlier line(s) ...",
+            *lines[-_TERMINAL_EXIT_OUTPUT_MAX_LINES:],
+        ]
+    clipped = "\n".join(lines)
+    if len(clipped) > _TERMINAL_EXIT_OUTPUT_MAX_CHARS:
+        clipped = (
+            f"... omitted {len(clipped) - _TERMINAL_EXIT_OUTPUT_MAX_CHARS} "
+            "earlier character(s) ...\n"
+            f"{clipped[-_TERMINAL_EXIT_OUTPUT_MAX_CHARS:]}"
+        )
+    return clipped
+
+
+def _terminal_exit_diagnostics(
+    instance: Any | None,
+) -> tuple[str | None, int | None, str | None, str | None]:
+    """Extract generic launch/output diagnostics from a terminal instance."""
+    if instance is None:
+        return None, None, None, None
+
+    raw_command = getattr(instance, "command", None)
+    command = raw_command if isinstance(raw_command, str) and raw_command else None
+
+    raw_args = getattr(instance, "args", None)
+    args_count = len(raw_args) if isinstance(raw_args, list) else None
+
+    raw_cwd = getattr(instance, "launch_cwd", None)
+    cwd = raw_cwd if isinstance(raw_cwd, str) and raw_cwd else None
+
+    last_output: str | None = None
+    read_last_output = getattr(instance, "last_pane_text", None)
+    if callable(read_last_output):
+        try:
+            raw_last_output = read_last_output()
+        except Exception:
+            _logger.exception("Failed to read terminal pane diagnostics")
+        else:
+            if isinstance(raw_last_output, str):
+                last_output = _trim_terminal_exit_output(raw_last_output)
+
+    return command, args_count, cwd, last_output
 
 
 def _monotonic() -> float:
@@ -159,6 +251,7 @@ class SessionResourceRegistry:
         self._per_session_workspace = per_session_workspace
         self._primary_envs: dict[str, OSEnvironment] = {}
         self._terminal_roles: dict[tuple[str, str], str] = {}
+        self._terminal_lifecycles: dict[tuple[str, str], TerminalLifecycle] = {}
         self._lock = threading.Lock()
         # Optional callback ``(session_id, terminal_id) -> None`` invoked
         # (on the event loop) when a terminal's pane produces output, so
@@ -173,6 +266,11 @@ class SessionResourceRegistry:
         # → running / ``Stop`` → idle bracketing. Set by the runner via
         # :meth:`set_session_status_publisher`.
         self._session_status_publisher: Callable[[str, str], None] | None = None
+        # Optional callback invoked on the event loop when a watched terminal
+        # disappears unexpectedly. The callback receives the terminal's
+        # lifecycle relationship so the runner can decide whether the owning
+        # session should fail.
+        self._terminal_exit_publisher: Callable[[TerminalExitEvent], None] | None = None
 
     def set_terminal_activity_publisher(
         self,
@@ -208,6 +306,27 @@ class SessionResourceRegistry:
             *status* is ``"running"`` or ``"idle"``.
         """
         self._session_status_publisher = publisher
+
+    def set_terminal_exit_publisher(
+        self,
+        publisher: Callable[[TerminalExitEvent], None],
+    ) -> None:
+        """Install the terminal-exit publisher.
+
+        The runner passes a callback that publishes resource/session lifecycle
+        events when a watched terminal disappears. It is invoked on the event
+        loop, not on the watcher thread.
+
+        Mental model:
+            required terminal:
+                If this terminal dies, the session is dead.
+
+            auxiliary terminal:
+                If this terminal dies, only this terminal resource is gone.
+
+        :param publisher: Callable receiving a :class:`TerminalExitEvent`.
+        """
+        self._terminal_exit_publisher = publisher
 
     @property
     def terminal_registry(self) -> TerminalRegistry | None:
@@ -535,7 +654,7 @@ class SessionResourceRegistry:
         default_cwd = _session_workspace(session_id)
         return str(Path(default_cwd).resolve())
 
-    async def launch_terminal(
+    async def launch_required_terminal(
         self,
         session_id: str,
         terminal_name: str,
@@ -547,35 +666,76 @@ class SessionResourceRegistry:
         parent_os_env: Any | None = None,
         resource_role: str | None = None,
     ) -> SessionResourceView:
-        """Launch or return an existing terminal resource.
+        """Launch a terminal required for the owning session to execute.
 
-        Delegates to ``TerminalRegistry.launch()`` and projects
-        the result into a :class:`SessionResourceView`.
+        Mental model:
+            If this terminal dies, the session is dead.
 
-        :param session_id: Session/conversation identifier.
-        :param terminal_name: Terminal name from the agent spec.
-        :param session_key: Per-launch session key.
-        :param spec: ``TerminalEnvSpec`` for the terminal.
-        :param cwd_override: Optional cwd override.
-        :param sandbox_override: Optional sandbox override.
-        :param parent_os_env: The agent's primary
-            :class:`OSEnvSpec`. Required for terminals whose spec
-            sets ``os_env: inherit`` or omits ``os_env`` (which is
-            how a REST-launched terminal picks up the agent's
-            sandbox / egress_rules / env_passthrough policy).
-        :param resource_role: Optional runner-private marker for the
-            resource, e.g. ``"codex-native"``.
-        :returns: The terminal resource view.
-        :raises RuntimeError: If the terminal registry is not
-            configured or launch fails.
+        Use this when the terminal process is the session runtime, or an
+        essential part of that runtime. This is agent-independent: callers
+        declare a lifecycle relationship, not a vendor or harness type.
         """
+        return await self._launch_terminal_with_lifecycle(
+            TerminalLifecycle.REQUIRED,
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            spec=spec,
+            cwd_override=cwd_override,
+            sandbox_override=sandbox_override,
+            parent_os_env=parent_os_env,
+            resource_role=resource_role,
+        )
+
+    async def launch_auxiliary_terminal(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: Any,
+        *,
+        cwd_override: str | None = None,
+        sandbox_override: str | None = None,
+        parent_os_env: Any | None = None,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Launch a terminal resource attached to the owning session.
+
+        Mental model:
+            If this terminal dies, only this terminal resource is gone.
+
+        Use this for terminals that provide UI access, logs, debugging, REPLs,
+        or optional interaction. This is agent-independent: callers declare a
+        lifecycle relationship, not a vendor or harness type.
+        """
+        return await self._launch_terminal_with_lifecycle(
+            TerminalLifecycle.AUXILIARY,
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            spec=spec,
+            cwd_override=cwd_override,
+            sandbox_override=sandbox_override,
+            parent_os_env=parent_os_env,
+            resource_role=resource_role,
+        )
+
+    async def _launch_terminal_with_lifecycle(
+        self,
+        lifecycle: TerminalLifecycle,
+        *,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: Any,
+        cwd_override: str | None = None,
+        sandbox_override: str | None = None,
+        parent_os_env: Any | None = None,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Launch a terminal, then observe it with the requested lifecycle."""
         if self._terminal_registry is None:
             raise RuntimeError("Terminal registry not configured")
-
-        from omnigent.entities.session_resources import (
-            terminal_resource_view,
-        )
-        from omnigent.terminals.registry import TerminalListEntry
 
         instance = await self._terminal_registry.launch(
             conversation_id=session_id,
@@ -586,19 +746,110 @@ class SessionResourceRegistry:
             cwd_override=cwd_override,
             sandbox_override=sandbox_override,
         )
-        entry = TerminalListEntry(
+        return await self._observe_terminal_with_lifecycle(
+            lifecycle,
+            session_id=session_id,
             terminal_name=terminal_name,
             session_key=session_key,
             instance=instance,
+            resource_role=resource_role,
         )
-        if resource_role is not None:
-            resource_id = terminal_resource_id(terminal_name, session_key)
-            with self._lock:
+
+    async def observe_required_terminal(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        instance: Any,
+        *,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Observe an existing terminal required for session execution.
+
+        Mental model:
+            If this terminal dies, the session is dead.
+        """
+        return await self._observe_terminal_with_lifecycle(
+            TerminalLifecycle.REQUIRED,
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            instance=instance,
+            resource_role=resource_role,
+        )
+
+    async def observe_auxiliary_terminal(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        instance: Any,
+        *,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Observe an existing terminal attached to the owning session.
+
+        Mental model:
+            If this terminal dies, only this terminal resource is gone.
+        """
+        return await self._observe_terminal_with_lifecycle(
+            TerminalLifecycle.AUXILIARY,
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            instance=instance,
+            resource_role=resource_role,
+        )
+
+    async def _observe_terminal_with_lifecycle(
+        self,
+        lifecycle: TerminalLifecycle,
+        *,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        instance: Any,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Project and observe an already-launched terminal instance."""
+        if self._terminal_registry is None:
+            raise RuntimeError("Terminal registry not configured")
+        if not getattr(instance, "running", False) or not await instance.is_alive():
+            await self._terminal_registry.close(session_id, terminal_name, session_key)
+            raise RuntimeError(
+                f"terminal {terminal_name}:{session_key} is not running for session {session_id}"
+            )
+
+        from omnigent.terminals.registry import TerminalListEntry
+
+        resource_id = terminal_resource_id(terminal_name, session_key)
+        with self._lock:
+            previous = self._terminal_lifecycles.get((session_id, resource_id))
+            if previous is not None and previous != lifecycle:
+                raise RuntimeError(
+                    f"terminal {terminal_name}:{session_key} for session {session_id} "
+                    f"is already observed as {previous.value}"
+                )
+            self._terminal_lifecycles[(session_id, resource_id)] = lifecycle
+            if resource_role is not None:
                 self._terminal_roles[(session_id, resource_id)] = resource_role
         self._start_terminal_activity_watcher(
-            session_id, terminal_name, session_key, instance, resource_role
+            session_id,
+            terminal_name,
+            session_key,
+            instance,
+            resource_role,
+            lifecycle,
+            replace=True,
         )
-        return terminal_resource_view(session_id, entry)
+        return terminal_resource_view(
+            session_id,
+            TerminalListEntry(
+                terminal_name=terminal_name,
+                session_key=session_key,
+                instance=instance,
+            ),
+        )
 
     def _start_terminal_activity_watcher(
         self,
@@ -607,15 +858,18 @@ class SessionResourceRegistry:
         session_key: str,
         instance: Any,
         resource_role: str | None,
+        lifecycle: TerminalLifecycle,
+        *,
+        replace: bool = False,
     ) -> None:
         """Start (idempotently) the per-terminal pane-activity watcher.
 
         Drives the runner-determined "PTY had output" signal that powers
         the web terminal-activity badge, replacing the removed
-        per-terminal client WS attach. No-op when no publisher is
-        installed (e.g. embedded/test runners). Idempotent re-launch is
-        safe — :meth:`TerminalInstance.start_idle_watcher_thread` no-ops
-        if a watcher is already running, and :meth:`close` stops it.
+        per-terminal client WS attach. The same watcher also reports
+        unexpected terminal exit so resource/session lifecycle stays
+        aligned with the underlying tmux process. No-op when no publisher
+        is installed (e.g. embedded/test runners).
 
         For the claude-native *agent* terminal (``resource_role`` ==
         :data:`CLAUDE_NATIVE_TERMINAL_ROLE` or
@@ -634,16 +888,21 @@ class SessionResourceRegistry:
         :param resource_role: Runner-private role marker for this
             terminal, e.g. :data:`CLAUDE_NATIVE_TERMINAL_ROLE`, or
             ``None`` for a generic terminal (activity badge only).
+        :param lifecycle: Required/auxiliary relationship between this
+            terminal and the owning session.
+        :param replace: Whether to replace an existing watcher so callbacks
+            can be rebound after terminal ownership transfer.
         """
         activity_publisher = self._terminal_activity_publisher
         status_publisher = self._session_status_publisher
+        exit_publisher = self._terminal_exit_publisher
         # Status edges are derived only from native agent terminals — a
         # generic shell's output must not move the session's working status.
         emit_status = status_publisher is not None and resource_role in {
             CLAUDE_NATIVE_TERMINAL_ROLE,
             PI_NATIVE_TERMINAL_ROLE,
         }
-        if activity_publisher is None and not emit_status:
+        if activity_publisher is None and not emit_status and exit_publisher is None:
             return
         resource_id = terminal_resource_id(terminal_name, session_key)
         loop = asyncio.get_running_loop()
@@ -686,8 +945,49 @@ class SessionResourceRegistry:
                 last_status["value"] = "running"
                 loop.call_soon_threadsafe(status_publisher, session_id, "running")
 
+        def _on_exit() -> None:
+            def _schedule() -> None:
+                task = asyncio.create_task(
+                    self._handle_terminal_exit(
+                        session_id=session_id,
+                        terminal_name=terminal_name,
+                        session_key=session_key,
+                        lifecycle=lifecycle,
+                        instance=instance,
+                    )
+                )
+                task.add_done_callback(_log_terminal_exit_task_result)
+
+            try:
+                loop.call_soon_threadsafe(_schedule)
+            except RuntimeError:
+                _logger.debug(
+                    "Event loop unavailable while handling terminal exit: "
+                    "session=%s terminal=%s:%s",
+                    session_id,
+                    terminal_name,
+                    session_key,
+                )
+
+        def _log_terminal_exit_task_result(task: asyncio.Task[None]) -> None:
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                _logger.exception(
+                    "Terminal exit cleanup failed: session=%s terminal=%s:%s",
+                    session_id,
+                    terminal_name,
+                    session_key,
+                )
+
         if not emit_status:
-            instance.start_idle_watcher_thread(on_activity=_on_activity)
+            instance.start_idle_watcher_thread(
+                on_activity=_on_activity if activity_publisher is not None else None,
+                on_exit=_on_exit,
+                replace=replace,
+            )
             return
 
         def _on_idle() -> None:
@@ -707,9 +1007,68 @@ class SessionResourceRegistry:
         instance.start_idle_watcher_thread(
             on_activity=_on_activity,
             on_idle=_on_idle,
+            on_exit=_on_exit,
             idle_threshold_s=_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
             poll_interval_s=_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
+            replace=replace,
         )
+
+    async def _handle_terminal_exit(
+        self,
+        *,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        lifecycle: TerminalLifecycle,
+        instance: Any | None = None,
+    ) -> None:
+        """Clean up and publish lifecycle events for an unexpected terminal exit."""
+        terminal_id = terminal_resource_id(terminal_name, session_key)
+        with self._lock:
+            observed = self._terminal_lifecycles.pop((session_id, terminal_id), None)
+            self._terminal_roles.pop((session_id, terminal_id), None)
+        if observed is None:
+            return
+        if observed != lifecycle:
+            _logger.warning(
+                "Terminal lifecycle changed before exit handling: session=%s terminal=%s:%s "
+                "observed=%s callback=%s",
+                session_id,
+                terminal_name,
+                session_key,
+                observed.value,
+                lifecycle.value,
+            )
+            lifecycle = observed
+
+        command, args_count, cwd, last_output = _terminal_exit_diagnostics(instance)
+
+        if self._terminal_registry is not None:
+            try:
+                await self._terminal_registry.close(session_id, terminal_name, session_key)
+            except Exception:
+                _logger.exception(
+                    "Error evicting exited terminal: session=%s terminal=%s:%s",
+                    session_id,
+                    terminal_name,
+                    session_key,
+                )
+
+        publisher = self._terminal_exit_publisher
+        if publisher is not None:
+            publisher(
+                TerminalExitEvent(
+                    session_id=session_id,
+                    terminal_id=terminal_id,
+                    terminal_name=terminal_name,
+                    session_key=session_key,
+                    lifecycle=lifecycle,
+                    command=command,
+                    args_count=args_count,
+                    cwd=cwd,
+                    last_output=last_output,
+                )
+            )
 
     async def close_terminal(
         self,
@@ -728,9 +1087,6 @@ class SessionResourceRegistry:
         for entry in self._terminal_registry.list_for_conversation(
             session_id,
         ):
-            if not entry.instance.running:
-                continue
-
             if terminal_resource_id(entry.terminal_name, entry.session_key) == terminal_id:
                 closed = await self._terminal_registry.close(
                     session_id,
@@ -740,6 +1096,7 @@ class SessionResourceRegistry:
                 if closed:
                     with self._lock:
                         self._terminal_roles.pop((session_id, terminal_id), None)
+                        self._terminal_lifecycles.pop((session_id, terminal_id), None)
                 return closed
         return False
 
@@ -791,6 +1148,9 @@ class SessionResourceRegistry:
                 role = self._terminal_roles.pop((source_session_id, terminal_id), None)
                 if role is not None:
                     self._terminal_roles[(target_session_id, terminal_id)] = role
+                lifecycle = self._terminal_lifecycles.pop((source_session_id, terminal_id), None)
+                if lifecycle is not None:
+                    self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
             try:
                 await entry.instance.set_conversation_link(
                     self._terminal_registry.conversation_link_for_id(target_session_id)
@@ -800,6 +1160,16 @@ class SessionResourceRegistry:
                     "Failed to update terminal status link after transfer to %s: %s",
                     target_session_id,
                     exc,
+                )
+            if lifecycle is not None:
+                self._start_terminal_activity_watcher(
+                    target_session_id,
+                    entry.terminal_name,
+                    entry.session_key,
+                    entry.instance,
+                    role,
+                    lifecycle,
+                    replace=True,
                 )
             return terminal_resource_view(
                 target_session_id,
@@ -825,6 +1195,11 @@ class SessionResourceRegistry:
             stale_role_keys = [key for key in self._terminal_roles if key[0] == session_id]
             for key in stale_role_keys:
                 self._terminal_roles.pop(key, None)
+            stale_lifecycle_keys = [
+                key for key in self._terminal_lifecycles if key[0] == session_id
+            ]
+            for key in stale_lifecycle_keys:
+                self._terminal_lifecycles.pop(key, None)
         if primary is not None:
             try:
                 primary.close()

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3359,6 +3359,7 @@ async def execute_tool(
     arguments: str,
     server_client: httpx.AsyncClient | None = None,
     terminal_registry: Any | None = None,
+    resource_registry: Any | None = None,
     agent_spec: Any | None = None,
     conversation_id: str | None = None,
     task_id: str | None = None,
@@ -3386,6 +3387,9 @@ async def execute_tool(
         runner's per-session outbound queue. ``None`` from
         dispatch sites that don't need event emission (e.g.
         async background tools).
+    :param resource_registry: Optional session-resource registry used to
+        observe tool-launched terminals through the same lifecycle path as
+        runner-launched terminals.
     :param filesystem_registry: Optional registry for tracking agent
         file modifications. Forwarded to ``_execute_os_env_tool``
         so that ``sys_os_write`` and ``sys_os_edit`` calls record changed
@@ -3436,6 +3440,7 @@ async def execute_tool(
                 tool_name,
                 args,
                 terminal_registry=terminal_registry,
+                resource_registry=resource_registry,
                 agent_spec=agent_spec,
                 conversation_id=conversation_id,
                 task_id=task_id,
@@ -3453,6 +3458,7 @@ async def execute_tool(
                 harness_client=harness_client or httpx.AsyncClient(),
                 server_client=server_client,
                 terminal_registry=terminal_registry,
+                resource_registry=resource_registry,
                 agent_spec=agent_spec,
                 conversation_id=conversation_id,
                 task_id=task_id,
@@ -3632,6 +3638,7 @@ async def dispatch_tool_locally(
     harness_client: httpx.AsyncClient,
     server_client: httpx.AsyncClient | None = None,
     terminal_registry: Any | None = None,
+    resource_registry: Any | None = None,
     agent_spec: Any | None = None,
     conversation_id: str | None = None,
     task_id: str | None = None,
@@ -3662,6 +3669,8 @@ async def dispatch_tool_locally(
         file modifications. Forwarded to ``execute_tool`` so that
         ``sys_os_write`` and ``sys_os_edit`` calls record changed paths
         for the ``GET …/changes`` endpoint.
+    :param resource_registry: Optional session-resource registry used to
+        observe tool-launched terminals.
     :returns: The tool output string.
     """
     output = await execute_tool(
@@ -3669,6 +3678,7 @@ async def dispatch_tool_locally(
         arguments=arguments,
         server_client=server_client,
         terminal_registry=terminal_registry,
+        resource_registry=resource_registry,
         agent_spec=agent_spec,
         conversation_id=conversation_id,
         task_id=task_id,
@@ -4179,6 +4189,7 @@ async def _execute_terminal_tool(
     args: dict[str, Any],
     *,
     terminal_registry: Any | None,
+    resource_registry: Any | None = None,
     agent_spec: Any | None,
     conversation_id: str | None,
     task_id: str | None,
@@ -4202,6 +4213,8 @@ async def _execute_terminal_tool(
         the web rail updates mid-turn instead of waiting for the
         response-end terminals-cache invalidation. ``None`` for
         in-process callers / tests that don't relay.
+    :param resource_registry: Optional session-resource registry used to
+        observe fresh launches as auxiliary terminal resources.
     """
     import asyncio
 
@@ -4255,24 +4268,26 @@ async def _execute_terminal_tool(
         SysTerminalLaunchTool.name(),
         SysTerminalCloseTool.name(),
     ):
-        _emit_terminal_resource_event(
+        await _emit_terminal_resource_event(
             tool_name=tool_name,
             output=output,
             args=args,
             conversation_id=conversation_id,
             terminal_registry=terminal_registry,
+            resource_registry=resource_registry,
             publish_event=publish_event,
         )
     return output
 
 
-def _emit_terminal_resource_event(
+async def _emit_terminal_resource_event(
     *,
     tool_name: str,
     output: str,
     args: dict[str, Any],
     conversation_id: str,
     terminal_registry: Any,
+    resource_registry: Any | None,
     publish_event: Callable[[str, dict[str, Any]], None],
 ) -> None:
     """Emit a ``session.resource.{created,deleted}`` event for a terminal tool.
@@ -4300,6 +4315,8 @@ def _emit_terminal_resource_event(
         ``"conv_abc123"``.
     :param terminal_registry: The runner's ``TerminalRegistry``,
         used to look up the live instance for a fresh launch.
+    :param resource_registry: Optional session-resource registry used to
+        observe fresh launches as auxiliary terminal resources.
     :param publish_event: The runner's per-session SSE emitter.
     """
     try:
@@ -4315,11 +4332,12 @@ def _emit_terminal_resource_event(
 
     status = envelope.get("status")
     if tool_name == SysTerminalLaunchTool.name() and status == "launched":
-        _publish_terminal_created_event(
+        await _publish_terminal_created_event(
             conversation_id=conversation_id,
             terminal_name=terminal_name,
             session_key=session_key,
             terminal_registry=terminal_registry,
+            resource_registry=resource_registry,
             publish_event=publish_event,
         )
     elif tool_name == SysTerminalCloseTool.name() and status == "closed":
@@ -4331,12 +4349,13 @@ def _emit_terminal_resource_event(
         )
 
 
-def _publish_terminal_created_event(
+async def _publish_terminal_created_event(
     *,
     conversation_id: str,
     terminal_name: str,
     session_key: str,
     terminal_registry: Any,
+    resource_registry: Any | None,
     publish_event: Callable[[str, dict[str, Any]], None],
 ) -> None:
     """Build and publish ``session.resource.created`` for a fresh launch.
@@ -4352,38 +4371,53 @@ def _publish_terminal_created_event(
     :param terminal_name: Terminal spec name, e.g. ``"bash"``.
     :param session_key: Per-launch session key, e.g. ``"s1"``.
     :param terminal_registry: The runner's ``TerminalRegistry``.
+    :param resource_registry: Optional session-resource registry used to
+        observe the launched terminal as auxiliary.
     :param publish_event: The runner's per-session SSE emitter.
     """
-    from omnigent.entities.session_resources import (
-        session_resource_view_to_dict,
-        terminal_resource_view,
-    )
-    from omnigent.terminals.registry import TerminalListEntry
+    from omnigent.entities.session_resources import session_resource_view_to_dict
 
     instance = terminal_registry.get(conversation_id, terminal_name, session_key)
     if instance is None:
         return
-    entry = TerminalListEntry(
-        terminal_name=terminal_name,
-        session_key=session_key,
-        instance=instance,
-    )
-    resource = session_resource_view_to_dict(terminal_resource_view(conversation_id, entry))
+    if resource_registry is not None:
+        try:
+            view = await resource_registry.observe_auxiliary_terminal(
+                conversation_id,
+                terminal_name,
+                session_key,
+                instance,
+            )
+        except Exception:
+            _logger.exception(
+                "Failed to observe tool-launched terminal: session=%s terminal=%s:%s",
+                conversation_id,
+                terminal_name,
+                session_key,
+            )
+            return
+        resource = session_resource_view_to_dict(view)
+    else:
+        from omnigent.entities.session_resources import terminal_resource_view
+        from omnigent.terminals.registry import TerminalListEntry
+
+        entry = TerminalListEntry(
+            terminal_name=terminal_name,
+            session_key=session_key,
+            instance=instance,
+        )
+        resource = session_resource_view_to_dict(terminal_resource_view(conversation_id, entry))
     publish_event(
         conversation_id,
         {"type": "session.resource.created", "resource": resource},
     )
 
-    # Start the runner-side pane-activity watcher for this tool-launched
-    # terminal so the web "active" badge works for it without a client
-    # attach. The agent-tool launch path uses ``terminal_registry``
-    # directly (not ``resource_registry.launch_terminal``), so this is the
-    # only hook that covers it. We run on the runner's MAIN event loop
-    # here (this fires after the launch ``to_thread`` returns), so capture
-    # it for the watcher daemon thread to hop onto via
-    # ``call_soon_threadsafe`` — the loop the tool's launch ran on is a
-    # throwaway per-call ``asyncio.run`` loop and would be dead. Idempotent
-    # (the watcher no-ops if already running) and stopped by ``close()``.
+    # Legacy fallback for callers that do not have a SessionResourceRegistry:
+    # start the runner-side pane-activity watcher here so the web "active"
+    # badge still works. Normal runner dispatch uses observe_auxiliary_terminal
+    # above, which owns the watcher and terminal-exit lifecycle semantics.
+    if resource_registry is not None:
+        return
     resource_id = resource["id"]
     if isinstance(resource_id, str) and resource_id:
         loop = asyncio.get_running_loop()
@@ -4445,6 +4479,7 @@ async def _execute_async_inbox_tool(
     session_async_tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] | None,
     server_client: httpx.AsyncClient | None,
     terminal_registry: Any | None,
+    resource_registry: Any | None,
     agent_spec: Any | None,
     conversation_id: str | None,
     task_id: str | None,
@@ -4470,6 +4505,8 @@ async def _execute_async_inbox_tool(
         changes made by tools spawned via ``sys_call_async``.
         Forwarded to ``_spawn_async_tool`` so that async OS-env tool
         calls record paths for the ``GET …/changes`` endpoint.
+    :param resource_registry: Optional session-resource registry used by
+        async terminal-tool launches.
     :param harness_client: Unused; kept for caller compatibility.
     :returns: Tool output string.
     """
@@ -4488,6 +4525,7 @@ async def _execute_async_inbox_tool(
             session_async_tasks=session_async_tasks,
             server_client=server_client,
             terminal_registry=terminal_registry,
+            resource_registry=resource_registry,
             agent_spec=agent_spec,
             conversation_id=conversation_id,
             task_id=task_id,
@@ -4871,6 +4909,7 @@ def _spawn_async_tool(
     session_async_tasks: dict[str, tuple[asyncio.Task[str], asyncio.Event]] | None,
     server_client: httpx.AsyncClient | None,
     terminal_registry: Any | None,
+    resource_registry: Any | None,
     agent_spec: Any | None,
     conversation_id: str | None,
     task_id: str | None,
@@ -4893,6 +4932,8 @@ def _spawn_async_tool(
         ``execute_tool`` so that OS-env tools invoked via
         ``sys_call_async`` record file changes for the
         ``GET …/changes`` endpoint.
+    :param resource_registry: Optional session-resource registry used by
+        async terminal-tool launches.
     :returns: JSON handle string with ``handle_id``, ``tool_name``,
         ``status``.
     """
@@ -4926,6 +4967,7 @@ def _spawn_async_tool(
                 arguments=target_args,
                 server_client=server_client,
                 terminal_registry=terminal_registry,
+                resource_registry=resource_registry,
                 agent_spec=agent_spec,
                 conversation_id=conversation_id,
                 task_id=task_id,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -32,7 +32,7 @@ import time
 import urllib.parse
 import weakref
 from collections import deque
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal, cast
 
@@ -418,6 +418,11 @@ _CODEX_NATIVE_SUBAGENT_DISPLAY_FALLBACK = "Codex"
 # reload for sessions where no Omnigent task carries usage (claude-native).
 _LAST_CONTEXT_TOKENS_LABEL_KEY: str = "omnigent.last_context_tokens"
 _LAST_CONTEXT_WINDOW_LABEL_KEY: str = "omnigent.last_context_window"
+# Labels read by ``_get_session_snapshot`` to surface the latest terminal /
+# runner task failure after the live ``session.status: failed`` SSE has gone
+# by. Empty string clears a stale value because labels are upsert-only.
+_LAST_TASK_ERROR_CODE_LABEL_KEY: str = "omnigent.last_task_error_code"
+_LAST_TASK_ERROR_MESSAGE_LABEL_KEY: str = "omnigent.last_task_error_message"
 
 # Todo-list update from the claude-native forwarder. Carries the raw
 # todo items captured from PostToolUse/TodoWrite hook events. Payload
@@ -4488,6 +4493,68 @@ def _publish_status(
     session_stream.publish(session_id, payload)
 
 
+async def _persist_session_status_error_labels(
+    session_id: str,
+    error: ErrorDetail | None,
+    conversation_store: ConversationStore,
+) -> None:
+    """
+    Persist or clear the reload-visible failure detail for a session status.
+
+    ``session.status`` is an SSE edge, so its ``error`` object disappears on
+    reload. Terminal-native sessions can fail before any transcript item is
+    written, so store the latest failure detail as runner-owned labels and let
+    snapshots project it as ``last_task_error``. Empty string clears stale
+    values because the label store is upsert-only.
+
+    :param session_id: Session/conversation identifier.
+    :param error: Failure detail from a ``session.status: failed`` edge, or
+        ``None`` to clear stale error labels on subsequent activity.
+    :param conversation_store: Store used to upsert labels.
+    """
+    updates = (
+        {
+            _LAST_TASK_ERROR_CODE_LABEL_KEY: error.code,
+            _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: error.message,
+        }
+        if error is not None
+        else {
+            _LAST_TASK_ERROR_CODE_LABEL_KEY: "",
+            _LAST_TASK_ERROR_MESSAGE_LABEL_KEY: "",
+        }
+    )
+    try:
+        await asyncio.to_thread(conversation_store.set_labels, session_id, updates)
+    except Exception:
+        _logger.exception(
+            "Failed to persist session status error labels for %s",
+            session_id,
+        )
+
+
+def _last_task_error_from_labels(labels: Mapping[str, str]) -> dict[str, str] | None:
+    """
+    Project runner-owned failure labels into the typed API error shape.
+
+    Terminal/native runtimes can fail before they write any transcript item,
+    so the session-status relay stores the latest failure as durable labels.
+    This helper is the single server-side boundary where those internal labels
+    become public ``last_task_error`` data for snapshots and child summaries.
+
+    :param labels: Conversation labels, usually after closed-status projection.
+    :returns: ``{"code": "...", "message": "..."}``, or ``None`` when either
+        value is absent/cleared.
+    """
+    raw_error_code = labels.get(_LAST_TASK_ERROR_CODE_LABEL_KEY)
+    raw_error_message = labels.get(_LAST_TASK_ERROR_MESSAGE_LABEL_KEY)
+    if raw_error_code and raw_error_message:
+        return {
+            "code": raw_error_code,
+            "message": raw_error_message,
+        }
+    return None
+
+
 def _publish_runner_recovered_status(session_id: str) -> None:
     """
     Clear a stale failed session status after runner recovery.
@@ -7978,6 +8045,18 @@ async def _relay_runner_stream(
                                 if isinstance(raw_err, dict)
                                 else None
                             )
+                            if status == "failed" and status_error is not None:
+                                await _persist_session_status_error_labels(
+                                    session_id,
+                                    status_error,
+                                    conversation_store,
+                                )
+                            elif status == "running":
+                                await _persist_session_status_error_labels(
+                                    session_id,
+                                    None,
+                                    conversation_store,
+                                )
                             # PTY-activity status is a UI signal only. Terminal
                             # sub-agent delivery rides the Stop/StopFailure hook
                             # via external_session_status (the codex-shared path)
@@ -10852,6 +10931,10 @@ def _child_session_summary_from_conversation(
         busy = True
     else:
         busy = False
+    last_task_error = _last_task_error_from_labels(labels)
+    current_task_status = (
+        "failed" if cached_status == "failed" or last_task_error is not None else None
+    )
 
     # For Codex children, fall back to the prompt label as preview when the
     # real transcript has not arrived yet — avoids synthesizing a user message
@@ -10875,9 +10958,10 @@ def _child_session_summary_from_conversation(
         agent_id=conv.agent_id,
         agent_name=None,
         current_task_id=None,
-        current_task_status=None,
+        current_task_status=current_task_status,
         busy=busy,
         labels=labels,
+        last_task_error=last_task_error,
         last_message_preview=last_message_preview,
         # Surface the sub-agent's parked-elicitation count from the same
         # in-memory index that feeds the sidebar badge, so the Agents
@@ -17442,6 +17526,7 @@ async def _get_session_snapshot(
     raw_label = conv.labels.get(_LAST_CONTEXT_TOKENS_LABEL_KEY)
     if isinstance(raw_label, str) and raw_label.isdigit():
         last_total_tokens = int(raw_label)
+    last_task_error = _last_task_error_from_labels(conv.labels)
     # Runner-crash durability: if the session's bound runner reported an
     # unexpected exit (host.runner_exited → RunnerExitReports), surface the
     # cause as last_task_error so a reload/late-open still renders the error

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -621,6 +621,12 @@ class ChildSessionSummary(BaseModel):
         consult is what keeps the rail's "Working" badge correct.
     :param labels: Session-scoped guardrails labels on the child
         conversation (mirrors :class:`ConversationObject.labels`).
+    :param last_task_error: Error details from the child's most recent
+        failed run, e.g.
+        ``{"code": "required_terminal_exited", "message": "..."}``.
+        ``None`` when the child has no durable failure detail. This is
+        the typed projection of runner-owned failure labels; clients
+        should not parse those labels directly.
     :param last_message_preview: Single-line preview of the most
         recent message item in the child's conversation, truncated
         to ~150 chars with a trailing ellipsis when longer. ``None``
@@ -653,6 +659,7 @@ class ChildSessionSummary(BaseModel):
     current_task_status: str | None = None
     busy: bool = False
     labels: dict[str, str] = Field(default_factory=dict)
+    last_task_error: dict[str, str] | None = None
     last_message_preview: str | None = None
     pending_elicitations_count: int = 0
 

--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -205,8 +205,12 @@ class TerminalRegistry:
         key = (terminal_name, session_key)
         with self._lock:
             existing = self._by_conversation.get(conversation_id, {}).get(key)
-            if existing is not None and existing.running:
+        if existing is not None and existing.running:
+            if await existing.is_alive():
                 return existing
+            await self.close(conversation_id, terminal_name, session_key)
+        elif existing is not None:
+            await self.close(conversation_id, terminal_name, session_key)
 
         # Lock-free section: ``create_terminal_instance`` and
         # ``launch`` may take real time (tmux spawn). Holding the
@@ -223,6 +227,19 @@ class TerminalRegistry:
             conversation_link=self.conversation_link_for_id(conversation_id),
         )
         await created.instance.launch(cwd=created.cwd)
+        if not await created.instance.is_alive():
+            try:
+                await asyncio.wait_for(created.instance.close(), timeout=_CLOSE_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Newly launched terminal close timed out for %s:%s in conv %s",
+                    terminal_name,
+                    session_key,
+                    conversation_id,
+                )
+            raise RuntimeError(
+                f"terminal {terminal_name}:{session_key} exited before it became available"
+            )
 
         with self._lock:
             slot = self._by_conversation.setdefault(conversation_id, {})

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -52,6 +53,59 @@ def contains_subsequence(values: list[str], expected: list[str]) -> bool:
     return any(
         values[index : index + len(expected)] == expected for index in range(last_start + 1)
     )
+
+
+def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
+    """
+    The threaded watcher reports tmux disappearance instead of exiting silently.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    exited = threading.Event()
+
+    instance._capture_pane_for_idle_or_none = lambda: None  # type: ignore[method-assign]
+
+    instance.start_idle_watcher_thread(
+        on_exit=exited.set,
+        poll_interval_s=0.01,
+    )
+
+    assert exited.wait(timeout=1.0)
+    assert instance.running is False
+
+
+def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> None:
+    """
+    The exit callback can still report the last pane text after tmux disappears.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    exited = threading.Event()
+    snapshots = iter(["\x1b[31mstartup failed\x1b[0m\ntry config", None])
+
+    instance._capture_pane_for_idle_or_none = lambda: next(snapshots)  # type: ignore[method-assign]
+
+    instance.start_idle_watcher_thread(
+        on_exit=exited.set,
+        poll_interval_s=0.01,
+    )
+
+    assert exited.wait(timeout=1.0)
+    assert instance.last_pane_text() == "startup failed\ntry config"
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -43,9 +43,11 @@ from omnigent.runner.app import (
     ResolvedSpec,
     _auto_create_claude_terminal,
     _auto_create_codex_terminal,
+    _auto_create_pi_terminal,
     _auto_create_repl_terminal,
     _deliver_subagent_wake_post,
     _log_terminal_lookup_miss,
+    _PiNativeLaunchConfig,
     _publish_native_terminal_start_error,
     _publish_terminal_pending,
     _session_labels_for_runner_spawn,
@@ -57,6 +59,7 @@ from omnigent.runner.resource_registry import (
     CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
     OMNIGENT_REPL_TERMINAL_ROLE,
+    PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
 )
 from omnigent.spec.types import AgentSpec, ExecutorSpec, LocalToolInfo, MCPServerConfig
@@ -9563,6 +9566,96 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
 
     await asyncio.sleep(0)
     assert isinstance(forwarder_kwargs.get("auth"), _RunnerDatabricksAuth)
+
+
+@pytest.mark.asyncio
+async def test_auto_create_pi_terminal_launches_required_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Pi-native auto-create must launch a *required* terminal.
+
+    Regression guard for a missed call site. The pi-native runtime *is* the
+    terminal process (parity with claude-native), so when the lifecycle-aware
+    launch API replaced ``launch_terminal`` with ``launch_required_terminal`` /
+    ``launch_auxiliary_terminal``, ``_auto_create_pi_terminal`` had to move to
+    ``launch_required_terminal``. The fake registry below exposes *only*
+    ``launch_required_terminal`` (no ``launch_terminal``), so a stale call site
+    raises ``AttributeError`` here in CI instead of crashing in production the
+    moment a real pi-native session boots.
+
+    :param tmp_path: Pytest-provided temporary directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    import omnigent.pi_native as pi_native
+    import omnigent.pi_native_bridge as pi_native_bridge
+    import omnigent.pi_native_credentials as pi_native_credentials
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
+    # The lifecycle of the launch — not the binary or credentials — is under
+    # test, so neither a real Pi install nor a configured provider is needed.
+    monkeypatch.setattr(pi_native, "resolve_pi_executable", lambda: "pi")
+    monkeypatch.setattr(pi_native_credentials, "resolve_pi_native_provider", lambda: None)
+
+    # Skip the GET /v1/sessions round-trip: hand the flow a ready launch
+    # config pointing at the tmp workspace.
+    async def _fake_launch_config(**_kwargs: Any) -> _PiNativeLaunchConfig:
+        return _PiNativeLaunchConfig(
+            workspace=tmp_path,
+            server_url="http://127.0.0.1:8000",
+            terminal_launch_args=None,
+            external_session_id=None,
+        )
+
+    monkeypatch.setattr("omnigent.runner.app._pi_native_launch_config", _fake_launch_config)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        """Records the launch; exposes ONLY the required-terminal launch API."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+        ) -> SessionResourceView:
+            """Record the launch and return a terminal resource view."""
+            captured["terminal_name"] = terminal_name
+            captured["session_key"] = session_key
+            captured["resource_role"] = resource_role
+            captured["spec"] = spec
+            return SessionResourceView(
+                id="terminal_pi_main",
+                type="terminal",
+                session_id=session_id,
+                name="pi:main",
+                metadata={"terminal_name": "pi", "session_key": "main", "running": True},
+            )
+
+    published: list[dict[str, Any]] = []
+
+    await _auto_create_pi_terminal(
+        "conv_pi",
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, evt: published.append(evt),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    # Required lifecycle (parity with claude-native), correct terminal identity.
+    assert captured["terminal_name"] == "pi"
+    assert captured["session_key"] == "main"
+    assert captured["resource_role"] == PI_NATIVE_TERMINAL_ROLE
+    assert captured["spec"].command == "pi"
+    # The fresh terminal is surfaced on the live stream for the Terminal toggle.
+    assert any(evt.get("type") == "session.resource.created" for evt in published)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -1001,7 +1001,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     class _FakeResourceRegistry:
         """Resource registry that records the launched terminal spec."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,
@@ -1290,7 +1290,7 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
     class _FakeResourceRegistry:
         """Resource registry that records the launched terminal spec."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,
@@ -1548,7 +1548,7 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
     class _FakeResourceRegistry:
         """Resource registry that records the launched terminal spec."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,
@@ -1792,7 +1792,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     class _FakeResourceRegistry:
         """Resource registry that records the launched terminal spec."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,
@@ -1958,7 +1958,7 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
     class _FakeResourceRegistry:
         """Resource registry returning a fixed terminal view."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,
@@ -5238,6 +5238,7 @@ async def test_external_session_status_running_fans_out_child_busy_to_parent() -
                 "session_name": "impl",
                 "busy": True,
                 "current_task_status": "in_progress",
+                "last_task_error": None,
             },
         }
     ]
@@ -5309,6 +5310,7 @@ async def test_external_status_sequence_coalesces_duplicates_but_emits_task_stat
                 "session_name": "impl",
                 "busy": True,
                 "current_task_status": "in_progress",
+                "last_task_error": None,
             },
         },
         {
@@ -8088,6 +8090,147 @@ async def test_events_stop_session_closes_terminal_and_publishes_deleted(
 
 
 @pytest.mark.asyncio
+async def test_required_terminal_exit_publishes_deleted_and_failed(tmp_path: Path) -> None:
+    """
+    A required terminal disappearing fails the owning session.
+
+    This uses a generic ``worker`` terminal name to pin the lifecycle rule,
+    not a Claude-specific branch: if the terminal was registered as required,
+    the runner must publish both resource deletion and ``session.status:
+    failed`` when its watcher reports that tmux disappeared.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.app import _session_event_queues_ref
+    from tests.runner.helpers import make_test_terminal_instance
+
+    parent_id = f"conv_parent_required_exit_{uuid.uuid4().hex[:12]}"
+    conv_id = f"conv_required_exit_{uuid.uuid4().hex[:12]}"
+    parent_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    terminal_registry = TerminalRegistry()
+    instance = make_test_terminal_instance("worker", "main", tmp_path)
+    instance.command = "worker-cli"
+    instance.args = ["--profile", "test"]
+    instance.launch_cwd = str(tmp_path)
+    instance._remember_pane_snapshot("startup failed\ncomplete setup first")
+    terminal_registry._by_conversation.setdefault(conv_id, {})[("worker", "main")] = instance
+    callbacks: dict[str, Any] = {}
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del on_idle, on_activity, idle_threshold_s, poll_interval_s
+        callbacks["on_exit"] = on_exit
+        callbacks["replace"] = replace
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    pm._sessions.add(conv_id)
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        terminal_registry=terminal_registry,
+    )
+    resource_registry = app.state.session_resource_registry
+    runner_app._session_inboxes_ref[parent_id] = parent_inbox
+    runner_app.register_child_session(
+        conv_id,
+        parent_session_id=parent_id,
+        title="worker:main",
+        tool="worker",
+        session_name="main",
+    )
+    runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=conv_id,
+        agent="worker",
+        title="main",
+    )
+
+    async def _collect_exit_events() -> list[dict[str, Any]]:
+        while True:
+            queue = _session_event_queues_ref.get(conv_id)
+            if queue is not None and queue.qsize() >= 2:
+                events: list[dict[str, Any]] = []
+                while not queue.empty():
+                    item = queue.get_nowait()
+                    if isinstance(item, dict):
+                        events.append(item)
+                return events
+            await asyncio.sleep(0)
+
+    try:
+        await resource_registry.observe_required_terminal(
+            conv_id,
+            "worker",
+            "main",
+            instance,
+        )
+        on_exit = callbacks.get("on_exit")
+        assert callable(on_exit)
+        on_exit()
+        queued_events = await asyncio.wait_for(_collect_exit_events(), timeout=1.0)
+        for _ in range(100):
+            if pm.released:
+                break
+            await asyncio.sleep(0)
+        parent_events = _drain_session_event_queue(_session_event_queues_ref.get(parent_id))
+    finally:
+        _session_event_queues_ref.pop(conv_id, None)
+        _session_event_queues_ref.pop(parent_id, None)
+        runner_app.unregister_subagent_work(conv_id)
+        runner_app.unregister_child_session(conv_id)
+        runner_app._session_inboxes_ref.pop(parent_id, None)
+
+    assert terminal_registry.get(conv_id, "worker", "main") is None
+    assert {
+        "type": "session.resource.deleted",
+        "resource_id": "terminal_worker_main",
+        "resource_type": "terminal",
+        "session_id": conv_id,
+    } in queued_events
+    failed_events = [
+        event
+        for event in queued_events
+        if event.get("type") == "session.status" and event.get("status") == "failed"
+    ]
+    assert len(failed_events) == 1, f"expected one failed status, got {queued_events!r}"
+    assert failed_events[0]["error"]["code"] == "required_terminal_exited"
+    assert "Required terminal exited unexpectedly" in failed_events[0]["error"]["message"]
+    assert parent_events == [
+        {
+            "type": "session.child_session.updated",
+            "conversation_id": parent_id,
+            "child_session_id": conv_id,
+            "child": {
+                "id": conv_id,
+                "title": "worker:main",
+                "tool": "worker",
+                "session_name": "main",
+                "busy": False,
+                "current_task_status": "failed",
+                "last_task_error": failed_events[0]["error"],
+            },
+        }
+    ]
+    assert pm.released == [conv_id]
+    inbox_item = parent_inbox.get_nowait()
+    assert inbox_item["status"] == "failed"
+    assert "Required terminal exited unexpectedly" in inbox_item["output"]
+    assert "command: worker-cli (2 args; argv omitted" in inbox_item["output"]
+    assert f"cwd: {tmp_path}" in inbox_item["output"]
+    assert "startup failed\ncomplete setup first" in inbox_item["output"]
+    assert "Suggested next checks" not in inbox_item["output"]
+
+
+@pytest.mark.asyncio
 async def test_events_effort_change_on_native_session_types_slash_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -9369,7 +9512,7 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
         # None, so the test doesn't need a real terminal instance.
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -9457,7 +9600,7 @@ async def test_auto_create_claude_terminal_passes_session_effort(
 
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -9568,7 +9711,7 @@ async def test_auto_create_claude_terminal_injects_ucode_gateway_config(
 
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -9729,7 +9872,7 @@ async def test_auto_create_claude_terminal_forwarder_skips_replayed_transcript_o
 
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -9852,7 +9995,7 @@ async def test_auto_create_claude_terminal_emits_resource_created_event(
         # ``_publish_tmux_target_for_bridge`` early-returns when this is None.
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -10075,7 +10218,7 @@ async def test_auto_create_claude_terminal_resets_stale_bridge_id_label(
 
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -10409,7 +10552,7 @@ class _EnsureTerminalCase:
     :param expect_auto_create: Whether the request must route to
         ``_auto_create_claude_terminal`` (the ensure path).
     :param expect_launch: Whether the request must route to the generic
-        ``launch_terminal`` path instead.
+        terminal launch path instead.
     :param expect_name: ``name`` of the resource the route must return —
         identifies which collaborator produced the response.
     """
@@ -10469,15 +10612,15 @@ async def test_create_session_terminal_ensure_routes_claude_native(
     no ``spec`` and no ``bridge_inject_dir`` must go to the full native
     ``_auto_create_claude_terminal`` (or return the live terminal if one
     exists), while a request carrying ``spec``/``bridge_inject_dir`` (the
-    fresh-launch wrapper path) must still use the generic ``launch_terminal``.
+    fresh-launch wrapper path) must still use the generic terminal launch.
 
     The three collaborators are stubbed so the routing decision is the only
     thing under test; each returns a distinctly-named real
     :class:`SessionResourceView`, so the response ``name`` proves which path
     handled the request. Remove the ensure branch and the auto-create cases
-    fall through to ``launch_terminal`` (wrong name, ``launched`` recorded);
-    drop the ``not spec`` guard and the explicit-spec case wrongly
-    auto-creates — either way this test fails.
+    fall through to the generic terminal launch path (wrong name,
+    ``launched`` recorded); drop the ``not spec`` guard and the explicit-spec
+    case wrongly auto-creates — either way this test fails.
 
     :param case: The parametrized routing scenario.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -10511,7 +10654,7 @@ async def test_create_session_terminal_ensure_routes_claude_native(
             )
         return None
 
-    async def _stub_launch_terminal(
+    async def _stub_launch_auxiliary_terminal(
         self: object, *, session_id: str, terminal_name: str, session_key: str, **_kwargs: object
     ) -> SessionResourceView:
         """Record the generic-launch call and return a tagged terminal view."""
@@ -10526,7 +10669,11 @@ async def test_create_session_terminal_ensure_routes_claude_native(
 
     monkeypatch.setattr("omnigent.runner.app._auto_create_claude_terminal", _stub_auto_create)
     monkeypatch.setattr(SessionResourceRegistry, "get_terminal_resource", _stub_get_terminal)
-    monkeypatch.setattr(SessionResourceRegistry, "launch_terminal", _stub_launch_terminal)
+    monkeypatch.setattr(
+        SessionResourceRegistry,
+        "launch_auxiliary_terminal",
+        _stub_launch_auxiliary_terminal,
+    )
 
     app = create_runner_app(
         process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
@@ -10821,7 +10968,7 @@ async def test_create_session_terminal_ensure_routes_codex_native(
         close_calls.append(f"{session_id}:{terminal_id}")
         return True
 
-    async def _stub_launch_terminal(
+    async def _stub_launch_auxiliary_terminal(
         self: object,
         *,
         session_id: str,
@@ -10857,7 +11004,11 @@ async def test_create_session_terminal_ensure_routes_codex_native(
         _stub_terminal_resource_role,
     )
     monkeypatch.setattr(SessionResourceRegistry, "close_terminal", _stub_close_terminal)
-    monkeypatch.setattr(SessionResourceRegistry, "launch_terminal", _stub_launch_terminal)
+    monkeypatch.setattr(
+        SessionResourceRegistry,
+        "launch_auxiliary_terminal",
+        _stub_launch_auxiliary_terminal,
+    )
 
     app = create_runner_app(
         process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
@@ -10984,7 +11135,7 @@ async def test_auto_create_repl_terminal_launches_attach_and_stamps_label(
     class _FakeResourceRegistry:
         """Resource registry that records the launched REPL terminal spec."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,
@@ -12223,7 +12374,7 @@ async def test_auto_create_claude_terminal_recreate_cancels_prior_forwarder(
 
         terminal_registry = None
 
-        async def launch_terminal(
+        async def launch_required_terminal(
             self,
             *,
             session_id: str,
@@ -12425,7 +12576,7 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
     class _FakeResourceRegistry:
         """Returns a terminal resource view without launching tmux."""
 
-        async def launch_terminal(
+        async def launch_auxiliary_terminal(
             self,
             *,
             session_id: str,

--- a/tests/runner/test_comment_relay.py
+++ b/tests/runner/test_comment_relay.py
@@ -90,6 +90,18 @@ class _StubResourceRegistry:
         """
         self._session_status_publisher = publisher
 
+    def set_terminal_exit_publisher(
+        self,
+        publisher: Callable[[Any], None],
+    ) -> None:
+        """
+        Accept the terminal-exit publisher installed by the runner app.
+
+        :param publisher: Callable receiving a terminal-exit event.
+        :returns: None.
+        """
+        self._terminal_exit_publisher = publisher
+
     def compute_default_env_root(self, session_id: str, agent_spec: Any) -> str:
         """
         Return a fixed env root for the launched terminal.
@@ -101,13 +113,59 @@ class _StubResourceRegistry:
         del session_id, agent_spec
         return str(self._tmp_path)
 
-    async def launch_terminal(
+    async def launch_required_terminal(
         self,
         session_id: str,
         terminal_name: str,
         session_key: str,
         spec: TerminalEnvSpec,
+        cwd_override: str | None = None,
+        sandbox_override: str | None = None,
+        parent_os_env: object | None = None,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Return a required terminal resource view for a fake instance."""
+        return await self._launch(
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            spec=spec,
+            cwd_override=cwd_override,
+            sandbox_override=sandbox_override,
+            parent_os_env=parent_os_env,
+            resource_role=resource_role,
+        )
+
+    async def launch_auxiliary_terminal(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: TerminalEnvSpec,
+        cwd_override: str | None = None,
+        sandbox_override: str | None = None,
+        parent_os_env: object | None = None,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Return an auxiliary terminal resource view for a fake instance."""
+        return await self._launch(
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            spec=spec,
+            cwd_override=cwd_override,
+            sandbox_override=sandbox_override,
+            parent_os_env=parent_os_env,
+            resource_role=resource_role,
+        )
+
+    async def _launch(
+        self,
         *,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: TerminalEnvSpec,
         cwd_override: str | None = None,
         sandbox_override: str | None = None,
         parent_os_env: object | None = None,
@@ -124,8 +182,7 @@ class _StubResourceRegistry:
         :param sandbox_override: Optional sandbox override (unused).
         :param parent_os_env: Agent's ``os_env`` threaded through by the
             runner so the launched terminal can inherit the sandbox
-            (unused in the stub — see real
-            :class:`SessionResourceRegistry.launch_terminal`).
+            (unused in the stub).
         :param resource_role: Runner-private role marker (e.g.
             ``"claude-native"``) for the bridge-inject path (unused in
             the stub).

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -17,8 +18,11 @@ from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner.resource_registry import (
     CODEX_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
+    TerminalExitEvent,
+    TerminalLifecycle,
 )
 from omnigent.terminals import TerminalRegistry
+from tests.runner.helpers import make_test_terminal_instance
 
 
 @dataclass
@@ -156,13 +160,7 @@ async def test_terminal_resource_role_is_private_and_cleared_on_close(
     """
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
-    instance = TerminalInstance(
-        name="codex",
-        session_key="main",
-        socket_path=tmp_path / "codex-main.sock",
-        private_dir=tmp_path / "codex-main",
-        running=True,
-    )
+    instance = make_test_terminal_instance("codex", "main", tmp_path)
 
     async def _fake_launch(
         conversation_id: str,
@@ -206,7 +204,7 @@ async def test_terminal_resource_role_is_private_and_cleared_on_close(
     monkeypatch.setattr(terminal_registry, "launch", _fake_launch)
     monkeypatch.setattr(terminal_registry, "close", _fake_close)
 
-    view = await registry.launch_terminal(
+    view = await registry.launch_auxiliary_terminal(
         "conv_codex",
         "codex",
         "main",
@@ -242,13 +240,7 @@ async def test_terminal_resource_role_moves_on_transfer(
     """
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
-    instance = TerminalInstance(
-        name="codex",
-        session_key="main",
-        socket_path=tmp_path / "codex-main.sock",
-        private_dir=tmp_path / "codex-main",
-        running=True,
-    )
+    instance = make_test_terminal_instance("codex", "main", tmp_path)
 
     async def _fake_launch(
         conversation_id: str,
@@ -284,7 +276,7 @@ async def test_terminal_resource_role_moves_on_transfer(
     monkeypatch.setattr(terminal_registry, "launch", _fake_launch)
     monkeypatch.setattr(instance, "set_conversation_link", _no_status_link)
 
-    view = await registry.launch_terminal(
+    view = await registry.launch_auxiliary_terminal(
         "conv_old",
         "codex",
         "main",
@@ -297,6 +289,69 @@ async def test_terminal_resource_role_moves_on_transfer(
     assert moved is not None
     assert registry.terminal_resource_role("conv_old", view.id) is None
     assert registry.terminal_resource_role("conv_new", view.id) == CODEX_NATIVE_TERMINAL_ROLE
+
+
+@pytest.mark.asyncio
+async def test_terminal_lifecycle_cannot_change_after_observe(tmp_path: Path) -> None:
+    """A terminal cannot silently switch between auxiliary and required lifecycle."""
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("worker", "main", tmp_path)
+
+    await registry.observe_auxiliary_terminal("conv_lifecycle", "worker", "main", instance)
+
+    with pytest.raises(RuntimeError, match="already observed as auxiliary"):
+        await registry.observe_required_terminal("conv_lifecycle", "worker", "main", instance)
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_terminal_exit_publishes_resource_exit_only(tmp_path: Path) -> None:
+    """Auxiliary terminal exit is reported with auxiliary lifecycle metadata."""
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("sidecar", "s1", tmp_path)
+    instance.command = "worker-cli"
+    instance.args = ["--verbose"]
+    instance.launch_cwd = str(tmp_path)
+    instance._remember_pane_snapshot("\x1b[31mstartup failed\x1b[0m\nretry login")
+    terminal_registry._by_conversation.setdefault("conv_exit", {})[("sidecar", "s1")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+    callbacks: dict[str, object] = {}
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del on_idle, on_activity, idle_threshold_s, poll_interval_s
+        callbacks["on_exit"] = on_exit
+        callbacks["replace"] = replace
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
+    registry.set_terminal_exit_publisher(_publish_exit)
+
+    await registry.observe_auxiliary_terminal("conv_exit", "sidecar", "s1", instance)
+    on_exit = callbacks["on_exit"]
+    assert callable(on_exit)
+    on_exit()
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert [event.lifecycle for event in exits] == [TerminalLifecycle.AUXILIARY]
+    assert exits[0].terminal_id == "terminal_sidecar_s1"
+    assert exits[0].command == "worker-cli"
+    assert exits[0].args_count == 1
+    assert exits[0].cwd == str(tmp_path)
+    assert exits[0].last_output == "startup failed\nretry login"
+    assert terminal_registry.get("conv_exit", "sidecar", "s1") is None
 
 
 def test_get_resource_finds_default() -> None:

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -132,6 +132,7 @@ class _CapturingResourceRegistry:
         self.launches: list[TerminalEnvSpec] = []
         self.parent_os_envs: list[Any | None] = []
         self.resource_roles: list[str | None] = []
+        self.launch_lifecycles: list[str] = []
 
     def set_terminal_activity_publisher(
         self,
@@ -163,6 +164,18 @@ class _CapturingResourceRegistry:
         """
         self._session_status_publisher = publisher
 
+    def set_terminal_exit_publisher(
+        self,
+        publisher: Callable[[Any], None],
+    ) -> None:
+        """
+        Accept the terminal-exit publisher installed by the runner app.
+
+        :param publisher: Callable receiving a terminal-exit event.
+        :returns: None.
+        """
+        self._terminal_exit_publisher = publisher
+
     def compute_default_env_root(self, session_id: str, agent_spec: Any) -> str | None:
         """Return the runner workspace as the default cwd, or None.
 
@@ -172,13 +185,62 @@ class _CapturingResourceRegistry:
         """
         return str(self._runner_workspace) if self._runner_workspace is not None else None
 
-    async def launch_terminal(
+    async def launch_required_terminal(
         self,
         session_id: str,
         terminal_name: str,
         session_key: str,
         spec: TerminalEnvSpec,
+        cwd_override: str | None = None,
+        sandbox_override: str | None = None,
+        parent_os_env: Any | None = None,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Capture a required terminal launch."""
+        return await self._launch(
+            "required",
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            spec=spec,
+            cwd_override=cwd_override,
+            sandbox_override=sandbox_override,
+            parent_os_env=parent_os_env,
+            resource_role=resource_role,
+        )
+
+    async def launch_auxiliary_terminal(
+        self,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: TerminalEnvSpec,
+        cwd_override: str | None = None,
+        sandbox_override: str | None = None,
+        parent_os_env: Any | None = None,
+        resource_role: str | None = None,
+    ) -> SessionResourceView:
+        """Capture an auxiliary terminal launch."""
+        return await self._launch(
+            "auxiliary",
+            session_id=session_id,
+            terminal_name=terminal_name,
+            session_key=session_key,
+            spec=spec,
+            cwd_override=cwd_override,
+            sandbox_override=sandbox_override,
+            parent_os_env=parent_os_env,
+            resource_role=resource_role,
+        )
+
+    async def _launch(
+        self,
+        lifecycle: str,
         *,
+        session_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: TerminalEnvSpec,
         cwd_override: str | None = None,
         sandbox_override: str | None = None,
         parent_os_env: Any | None = None,
@@ -187,6 +249,7 @@ class _CapturingResourceRegistry:
         """
         Capture the launch spec and return a terminal resource view.
 
+        :param lifecycle: ``"required"`` or ``"auxiliary"``.
         :param session_id: Session/conversation identifier.
         :param terminal_name: Terminal name from the request.
         :param session_key: Per-launch terminal key.
@@ -203,6 +266,7 @@ class _CapturingResourceRegistry:
         """
         assert cwd_override is None
         assert sandbox_override is None
+        self.launch_lifecycles.append(lifecycle)
         self.launches.append(spec)
         self.parent_os_envs.append(parent_os_env)
         self.resource_roles.append(resource_role)
@@ -1329,6 +1393,8 @@ class _WatcherCapture:
         or ``None`` if none was wired.
     :param on_idle: The idle-edge callback the registry passed, or
         ``None`` if none was wired.
+    :param on_exit: The exit callback the registry passed, or ``None`` if none
+        was wired.
     :param idle_threshold_s: The per-watcher idle threshold the registry
         passed, or ``None`` for the module default.
     :param poll_interval_s: The per-watcher poll interval the registry
@@ -1338,8 +1404,10 @@ class _WatcherCapture:
     started: bool = False
     on_activity: Callable[[], None] | None = None
     on_idle: Callable[[], None] | None = None
+    on_exit: Callable[[], None] | None = None
     idle_threshold_s: float | None = None
     poll_interval_s: float | None = None
+    replace: bool = False
 
 
 def _make_capturing_instance(
@@ -1370,14 +1438,18 @@ def _make_capturing_instance(
         on_idle: Callable[[], None] | None = None,
         *,
         on_activity: Callable[[], None] | None = None,
+        on_exit: Callable[[], None] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
+        replace: bool = False,
     ) -> None:
         capture.started = True
         capture.on_idle = on_idle
         capture.on_activity = on_activity
+        capture.on_exit = on_exit
         capture.idle_threshold_s = idle_threshold_s
         capture.poll_interval_s = poll_interval_s
+        capture.replace = replace
 
     # Instance attribute shadows the bound method, so the registry's call
     # lands on the recorder (no real daemon thread / tmux poll).
@@ -1388,7 +1460,7 @@ def _make_capturing_instance(
 class _LaunchReturningRegistry:
     """Terminal-registry stub whose ``launch`` returns a fixed instance.
 
-    The real :meth:`SessionResourceRegistry.launch_terminal` only calls
+    The real terminal launch helpers only call
     ``launch`` on its terminal registry; returning a prepared instance
     lets the test exercise the real ``_start_terminal_activity_watcher``
     wiring without spawning a terminal.
@@ -1474,7 +1546,7 @@ async def test_claude_native_terminal_drives_session_status_from_pane_activity(
         lambda sid, status: status_edges.append(_StatusEdge(session_id=sid, status=status))
     )
 
-    await registry.launch_terminal(
+    await registry.launch_required_terminal(
         session_id="conv_x",
         terminal_name="claude",
         session_key="main",
@@ -1537,7 +1609,7 @@ async def test_generic_terminal_does_not_drive_session_status(
         lambda sid, status: status_edges.append(_StatusEdge(session_id=sid, status=status))
     )
 
-    await registry.launch_terminal(
+    await registry.launch_auxiliary_terminal(
         session_id="conv_y",
         terminal_name="zsh",
         session_key="s1",
@@ -1601,7 +1673,7 @@ async def test_terminal_activity_pulses_throttled_to_one_per_second(
     # the status publisher must be installed to exercise on_idle.
     registry.set_session_status_publisher(lambda _sid, _status: None)
 
-    await registry.launch_terminal(
+    await registry.launch_required_terminal(
         session_id="conv_throttle",
         terminal_name="claude",
         session_key="main",

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -305,8 +305,8 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
     _seed_registry(registry, "conv_abc", stale)
 
     resource_registry = SessionResourceRegistry(terminal_registry=registry)
-    # Role stamped at auto-create time in production (launch_terminal's
-    # resource_role); seeded directly here to avoid spawning real tmux.
+    # Role stamped at auto-create time in production (resource_role);
+    # seeded directly here to avoid spawning real tmux.
     resource_registry._terminal_roles[("conv_abc", "terminal_tui_main")] = (
         OMNIGENT_REPL_TERMINAL_ROLE
     )

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -9,10 +9,11 @@ through the spawn workflow) — the route depends only on
 and the relay-fed ``_session_status_cache``, so direct seeding gives
 fast, deterministic coverage of every response field.
 
-The tasks table has been removed. ``current_task_id``, ``current_task_status``,
-and ``agent_name`` (previously derived from task rows) are now always
-``None``. ``agent_id`` is populated from the conversation row's
-``agent_id`` column.
+The tasks table has been removed. ``current_task_id`` and ``agent_name``
+(previously derived from task rows) are now always ``None``.
+``current_task_status`` is derived from session lifecycle state when
+available, and is otherwise ``None``. ``agent_id`` is populated from the
+conversation row's ``agent_id`` column.
 """
 
 from __future__ import annotations
@@ -206,6 +207,7 @@ async def test_child_sessions_returns_seeded_child_with_full_shape(
     assert row["agent_name"] is None
     assert row["current_task_id"] is None
     assert row["current_task_status"] is None
+    assert row["last_task_error"] is None
     # No cache entry → busy=False.
     assert row["busy"] is False
 
@@ -215,6 +217,51 @@ async def test_child_sessions_returns_seeded_child_with_full_shape(
     # No outstanding elicitations → 0 (the index is empty for a freshly
     # seeded child that never published an elicitation_request).
     assert row["pending_elicitations_count"] == 0
+
+
+async def test_child_sessions_surfaces_durable_failure_error(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    A child with runner-owned failure labels is visibly failed.
+
+    Terminal/native harnesses can fail before a transcript item exists. The
+    session-status relay persists that failure as labels; the child summary
+    must project them as typed ``last_task_error`` so clients do not parse
+    internal labels or render the row as idle.
+
+    :param client: The test HTTP client.
+    :param db_uri: Per-test SQLite database URI.
+    """
+    session = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    child = _seed_child(
+        conv_store=conv_store,
+        parent_id=session["id"],
+        title="researcher:auth",
+        agent_id=session["agent_id"],
+    )
+    conv_store.set_labels(
+        child.id,
+        {
+            sessions_module._LAST_TASK_ERROR_CODE_LABEL_KEY: "required_terminal_exited",
+            sessions_module._LAST_TASK_ERROR_MESSAGE_LABEL_KEY: (
+                "Required terminal exited unexpectedly"
+            ),
+        },
+    )
+
+    resp = await client.get(f"/v1/sessions/{session['id']}/child_sessions")
+
+    assert resp.status_code == 200
+    row = resp.json()["data"][0]
+    assert row["busy"] is False
+    assert row["current_task_status"] == "failed"
+    assert row["last_task_error"] == {
+        "code": "required_terminal_exited",
+        "message": "Required terminal exited unexpectedly",
+    }
 
 
 # ── Pending elicitation count ─────────────────────────────

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -127,6 +127,17 @@ class _ConversationStore:
         conv.title = title
         return conv
 
+    def set_labels(
+        self,
+        conversation_id: str,
+        updates: dict[str, str],
+        updated_at: int | None = None,
+    ) -> None:
+        """Merge label updates into an in-memory conversation."""
+        del updated_at
+        conv = self._conversations[conversation_id]
+        conv.labels.update(updates)
+
     def append(
         self,
         conversation_id: str,
@@ -2365,6 +2376,40 @@ async def test_relay_persists_terminal_resource_deleted_from_runner() -> None:
     assert events[0].data.resource_type == "terminal"
     # Delete carries no resource body.
     assert events[0].data.resource is None
+
+
+@pytest.mark.asyncio
+async def test_relay_persists_failed_status_error_labels_from_runner() -> None:
+    """Runner ``session.status: failed`` error details survive reload."""
+    from omnigent.server.routes.sessions import _relay_runner_stream
+
+    store = _ConversationStore()
+    client = _FakeStreamingRunnerClient(
+        [
+            _sse_frame(
+                {
+                    "type": "session.status",
+                    "status": "failed",
+                    "error": {
+                        "code": "required_terminal_exited",
+                        "message": "Required terminal exited unexpectedly",
+                    },
+                }
+            ),
+            "data: [DONE]\n\n",
+        ]
+    )
+
+    await _relay_runner_stream("conv_proxy", client, store)  # type: ignore[arg-type]
+
+    assert (
+        store._conversations["conv_proxy"].labels["omnigent.last_task_error_code"]
+        == "required_terminal_exited"
+    )
+    assert (
+        store._conversations["conv_proxy"].labels["omnigent.last_task_error_message"]
+        == "Required terminal exited unexpectedly"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -240,6 +240,43 @@ async def test_session_snapshot_surfaces_runner_exit_report_as_failed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error() -> None:
+    """
+    A terminal/runtime failure captured from ``session.status`` survives reload.
+
+    Required terminal boot failures can happen before any assistant transcript
+    or runner-crash report exists. The live SSE carries ``error``, and the
+    relay persists it as labels so a later snapshot can still render a useful
+    failure banner instead of ``last_task_error=None``.
+    """
+    conv = Conversation(
+        id="conv_failed_terminal",
+        created_at=1,
+        updated_at=1,
+        root_conversation_id="conv_failed_terminal",
+        agent_id="ag_test",
+        labels={
+            "omnigent.last_task_error_code": "required_terminal_exited",
+            "omnigent.last_task_error_message": "Required terminal exited unexpectedly",
+        },
+    )
+    conv_store = _ConversationStore(
+        [_message_item("item_1", "hi")],
+        conversations={"conv_failed_terminal": conv},
+    )
+
+    snapshot = await _get_session_snapshot(  # type: ignore[arg-type]
+        conv_store,
+        "conv_failed_terminal",
+    )
+
+    assert snapshot.last_task_error == {
+        "code": "required_terminal_exited",
+        "message": "Required terminal exited unexpectedly",
+    }
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_no_exit_report_stays_unfailed() -> None:
     """A session whose runner has no exit report is not marked failed.
 

--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -24,8 +24,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
-from omnigent.inner.terminal import TerminalInstance
+from omnigent.inner.terminal import TerminalCreateResult, TerminalInstance
 from omnigent.terminals import TerminalRegistry
+from omnigent.terminals import registry as registry_mod
 from omnigent.terminals.registry import TerminalListEntry, conversation_link_for_id
 
 # ── Pure bookkeeping (no tmux) ────────────────────────────────
@@ -156,6 +157,67 @@ async def test_shutdown_on_empty_registry_is_noop() -> None:
     reg = TerminalRegistry()
     await reg.shutdown()
     assert reg.active_conversation_ids() == []
+
+
+async def test_launch_replaces_stale_running_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``launch`` verifies a cached running entry before returning it."""
+
+    class _FlagTerminal(TerminalInstance):
+        """Terminal instance whose liveness is controlled by a flag."""
+
+        alive: bool = True
+        closed: bool = False
+
+        async def launch(self, *, cwd: Path | None = None) -> None:
+            del cwd
+            self.running = True
+
+        async def is_alive(self) -> bool:
+            if not self.alive:
+                self.running = False
+            return self.alive
+
+        async def close(self) -> None:
+            self.closed = True
+            self.running = False
+
+    reg = TerminalRegistry()
+    stale = _FlagTerminal(
+        name="shell",
+        session_key="s1",
+        socket_path=tmp_path / "stale.sock",
+        private_dir=tmp_path / "stale",
+        running=True,
+    )
+    stale.alive = False
+    created = _FlagTerminal(
+        name="shell",
+        session_key="s1",
+        socket_path=tmp_path / "created.sock",
+        private_dir=tmp_path / "created",
+        running=False,
+    )
+    reg._by_conversation["conv_x"] = {("shell", "s1"): stale}
+    reg._instance_locks[("conv_x", "shell", "s1")] = threading.Lock()
+
+    def _fake_create_terminal_instance(*_args: object, **_kwargs: object) -> TerminalCreateResult:
+        return TerminalCreateResult(instance=created, cwd=tmp_path)
+
+    monkeypatch.setattr(registry_mod, "create_terminal_instance", _fake_create_terminal_instance)
+
+    result = await reg.launch(
+        "conv_x",
+        "shell",
+        "s1",
+        TerminalEnvSpec(command="bash"),
+    )
+
+    assert result is created
+    assert stale.closed is True
+    assert reg.get("conv_x", "shell", "s1") is created
 
 
 def test_transfer_moves_terminal_without_closing_tmux(tmp_path: Path) -> None:


### PR DESCRIPTION
I keep running into lifecycle issues... One that's particularly insidious has to do with what happens when a terminal session corresponding to a subagent shuts down for some reason. In the UI, it shows the task as idle, and when using Polly, Polly has no visibility into whether the task is actually running (it's not). Often this happens when the TUI throws some kind of error or requests user input in setup, e.g., Claude SDK needing bypassPermissions toggled on, or /login rerun.

My goal was for this to be as agent-independent as possible, however, it has to differentiate between agents whose lifecycles directly depend on a terminal session, versus agents who depend on some server session (e.g., claude vs codex). Hence the lifecycle builtin to terminal launch for "required" terminal sessions (e.g., claude) or ones where the terminal resource is auxilary (codex)

As you can see, I followed the lifecycle management all the way through to the UI, so at least the UI shows when a subagent fails, and clicking into its chat shows the failure that at least allows you to debug.

Following the template:

## Summary

  - Adds explicit required vs auxiliary terminal lifecycle handling so a session fails when its required
  runtime terminal exits, while ordinary terminal resources only disappear as resources.
  - Propagates required-terminal failures through runner events, durable session error labels, child-session
  snapshots, and the UI so users see a real failed subagent instead of an idle phantom.
  - Updates terminal/resource registry tests plus UI rendering/state tests for failure visibility and wrapped
  diagnostics.

  ELI5: if the terminal that is the agent’s actual engine dies, Omnigent now marks the agent as failed and
  shows the error, instead of leaving it looking idle/alive.

  ```mermaid
  flowchart LR
    T[Terminal exits] --> R{Required?}
    R -- yes --> F[Mark session failed]
    F --> L[Persist error labels]
    L --> U[Show failed child in UI]
    R -- no --> A[Remove auxiliary resource only]
```

  ## Type of change

  - [x] Bug fix
  - [ ] Feature
  - [x] Refactor / chore
  - [ ] Docs
  - [x] Test / CI
  - [ ] Breaking change

  ## Test coverage

  - [x] Unit tests added / updated
  - [x] Integration tests added / updated
  - [ ] E2E tests added / updated
  - [x] Manual verification completed
  - [ ] Existing tests cover this change
  - [ ] Not applicable

  ## Coverage rationale

  Added/updated backend tests for terminal/resource lifecycle handling, runner failure propagation, persisted
  session error labels, child-session snapshots, and terminal registry behavior. Added/updated frontend tests
  for child-session failure state, store updates, subagent panel rendering, and wrapped multiline error
  diagnostics.

  Commands run:

```
  - uv run pre-commit run --all-files passed
  - uv run pytest tests/runner/test_resource_registry.py tests/inner/test_terminal.py tests/terminals/
    test_registry.py passed

  - uv run pytest tests/runner/
    test_app_sessions_native.py::test_required_terminal_exit_publishes_deleted_and_failed tests/server/routes/
    test_session_resources.py::test_relay_persists_failed_status_error_labels_from_runner tests/server/routes/
    test_sessions_snapshot.py::test_session_snapshot_surfaces_status_error_labels_as_last_task_error tests/
    server/integration/test_sessions_child_sessions.py::test_child_sessions_surfaces_durable_failure_error
    passed

  - cd ap-web && npm run test -- src/shell/SubagentsPanel.test.tsx src/components/blocks/BlockRenderer.test.tsx
    src/store/chatStore.test.ts passed

  - cd ap-web && npm run type-check passed
  - cd ap-web && npm run build passed
```

  Also attempted uv run pytest; it timed out in tests/cli/
  test_configure_models.py::test_readd_same_source_key_updates_in_place, which appears unrelated to this branch
  and got stuck in the interactive Claude credential/setup menu loop.

  No E2E UI test was added; this change is covered by focused backend lifecycle tests and frontend state/
  rendering tests, plus manual local verification of failed subagents surfacing as failures instead of
  remaining idle.

<img width="1165" height="777" alt="Screenshot 2026-06-15 at 1 57 34 PM" src="https://github.com/user-attachments/assets/b662dffb-f466-4bc8-9971-395efa2d3a92" />
<img width="1178" height="780" alt="Screenshot 2026-06-15 at 1 57 22 PM" src="https://github.com/user-attachments/assets/82f0ddd9-53a6-4a2c-91c0-d2c30d929121" />
<img width="1179" height="496" alt="Screenshot 2026-06-15 at 1 56 36 PM" src="https://github.com/user-attachments/assets/181693a7-3eb2-43af-96a9-adccb980b3c1" />

