### PR TITLE
docs: add bubblewrap as a prerequisite and install step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ Install local prerequisites first:
   environments and dependency management.
 - `tmux`, required for native Claude/Codex terminals launched by the local host
   (`brew install tmux` on macOS, or `apt install tmux` on Debian/Ubuntu).
+- `bubblewrap` (`bwrap`), **Linux only**, used to OS-sandbox those native
+  Claude/Codex/Pi terminals (`apt install bubblewrap` on Debian/Ubuntu). macOS
+  uses the built-in `seatbelt` sandbox and needs nothing extra.
 - Node.js 22 LTS or newer with `npm` when working on `ap-web/`.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ uv tool install -q --python 3.12 git+https://github.com/omnigent-ai/omnigent.git
 - **`tmux`**, required by the native `omnigent claude` / `omnigent codex`
   wrappers (`brew install tmux` / `apt install tmux`; the installer offers
   to install it for you).
+- **`bubblewrap`** (`bwrap`), **Linux only**. The native `omnigent claude` /
+  `omnigent codex` and `pi` harnesses wrap each agent terminal in a `bwrap`
+  OS-sandbox; on Linux that isolation is mandatory, so a missing `bwrap`
+  binary makes those terminals fail to start (`apt install bubblewrap`; the
+  installer offers to install it for you). macOS uses the built-in `seatbelt`
+  sandbox and needs nothing extra.
 - **Databricks** (optional). To use a Databricks workspace as your model
   provider, install Omnigent with the `databricks` extra:
   `uv tool install "omnigent[databricks]"`. Signing in to the workspace also

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -144,10 +144,11 @@ FROM node:${NODE_VERSION}-slim AS node-runtime
 
 # ── Host runtime (`--target host`) ──────────────────────
 # Prebaked Omnigent host for remote sandboxes: full omnigent install,
-# git + tmux for harness runtime needs, curl + CA certificates for
-# outbound HTTPS and in-sandbox downloads, plus the coding-harness
-# CLIs (claude / codex / pi) so claude-sdk, claude-native, codex, and
-# pi agents can run in managed sandboxes without an in-sandbox
+# git + tmux for harness runtime needs, bubblewrap to OS-sandbox the
+# native harness terminals (mandatory and fail-loud on Linux), curl + CA
+# certificates for outbound HTTPS and in-sandbox downloads, plus the
+# coding-harness CLIs (claude / codex / pi) so claude-sdk, claude-native,
+# codex, and pi agents can run in managed sandboxes without an in-sandbox
 # install. No SPA, no psycopg, no server entrypoint.
 FROM python:${PYTHON_VERSION}-slim AS host
 ARG NPM_CONFIG_REGISTRY=
@@ -165,7 +166,7 @@ ENV PYTHONUNBUFFERED=1 \
     IS_SANDBOX=1
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git tmux curl ca-certificates \
+ && apt-get install -y --no-install-recommends git tmux bubblewrap curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
 # Git credential helper for private repositories over HTTPS: answers

--- a/scripts/install_oss.sh
+++ b/scripts/install_oss.sh
@@ -13,9 +13,10 @@
 #   --non-interactive, --verbose
 #
 # uv and git (only with --repo) are required; the installer offers to install
-# them if missing. Node/npm are needed by the Claude/Codex/Pi harnesses and
-# tmux by their terminal launchers — missing ones are warnings, not errors,
-# unless building from source.
+# them if missing. Node/npm are needed by the Claude/Codex/Pi harnesses, tmux
+# by their terminal launchers, and bubblewrap (Linux only) to OS-sandbox those
+# terminals — missing ones are warnings, not errors, unless building from
+# source.
 
 set -eu
 
@@ -396,6 +397,31 @@ check_tmux() {
   esac
 }
 
+# The native `omnigent claude` / `omnigent codex` / `pi` harnesses wrap each
+# agent terminal in a bubblewrap (`bwrap`) OS-sandbox; on Linux that isolation
+# is mandatory and fail-loud, so a missing `bwrap` binary makes those terminals
+# fail to start. macOS sandboxes with the built-in seatbelt backend and needs
+# nothing here, so this check is Linux-only.
+check_bubblewrap() {
+  [ "$(uname -s)" = Linux ] || return
+
+  if command -v bwrap >/dev/null 2>&1; then
+    step "bubblewrap (bwrap) is available"
+    return
+  fi
+
+  install_cmd="$(linux_pkg_install_cmd bubblewrap)"
+  if [ -n "$install_cmd" ] && prompt_yes_no "bubblewrap is missing (needed to sandbox native \`omnigent claude\` / \`omnigent codex\` terminals). Install it now ($install_cmd)?"; then
+    run_with_spinner "install bubblewrap" sh -c "$install_cmd" || warn "bubblewrap install failed — run manually: $install_cmd"
+    return
+  fi
+  if [ -n "$install_cmd" ]; then
+    warn "bubblewrap (bwrap) not found — native \`omnigent claude\` / \`omnigent codex\` terminals need it on Linux. Install with: $install_cmd"
+  else
+    warn "bubblewrap (bwrap) not found — native \`omnigent claude\` / \`omnigent codex\` terminals need it on Linux. Install it with your package manager."
+  fi
+}
+
 install_omnigent() {
   # Default: the published PyPI wheel (`omnigent`, optionally `omnigent==X`).
   # The wheel ships the prebuilt web UI, so there is no npm/Node step and no
@@ -550,6 +576,7 @@ main() {
   check_node
   check_npm
   check_tmux
+  check_bubblewrap
   install_omnigent
   bin_dir="$(uv_tool_bin_dir)"
   verify_omnigent "$bin_dir"

--- a/scripts/install_oss.sh
+++ b/scripts/install_oss.sh
@@ -403,7 +403,7 @@ check_tmux() {
 # fail to start. macOS sandboxes with the built-in seatbelt backend and needs
 # nothing here, so this check is Linux-only.
 check_bubblewrap() {
-  [ "$(uname -s)" = Linux ] || return
+  [ "$(uname -s)" = Linux ] || return 0
 
   if command -v bwrap >/dev/null 2>&1; then
     step "bubblewrap (bwrap) is available"


### PR DESCRIPTION
## What & why

`bubblewrap` (`bwrap`) is required on Linux but was listed nowhere in the prerequisites, and the installer never offered to set it up the way it does for `uv`, `git`, and `tmux`.

The native `omnigent claude` / `omnigent codex` / `pi` harnesses wrap each agent terminal in a `bwrap` OS-sandbox. On Linux the `linux_bwrap` backend is the platform default and is **mandatory and fail-loud** — without the `bwrap` binary on `PATH`, those terminals fail to start (`linux_bwrap sandbox requires the 'bwrap' binary on PATH`). macOS uses the built-in `darwin_seatbelt` sandbox, so it needs nothing extra.

Fixes #177.

## Changes

- **`README.md`** — list `bubblewrap` in "Toolchain and prerequisites" as a Linux-only requirement, mirroring the existing `tmux` entry, and note macOS uses the built-in seatbelt sandbox.
- **`CONTRIBUTING.md`** — add the same prerequisite to the dev "Install local prerequisites" list.
- **`scripts/install_oss.sh`** — add a Linux-only `check_bubblewrap` step that mirrors `check_tmux`: detects `bwrap`, offers to install `bubblewrap` via the detected package manager, and warns (rather than fails) when missing/declined. Wired into `main()` after `check_tmux`; no-op on macOS.
- **`deploy/docker/Dockerfile`** — install `bubblewrap` in the `host` stage. `deploy/islo/README.md` already states *"The `host` Dockerfile target installs `bubblewrap`"*, but the image only installed `git tmux curl ca-certificates`; native harness terminals would fail to start in managed sandboxes built from it.

## Testing

- `sh -n`, `bash -n`, and `dash -n` all pass on `scripts/install_oss.sh`.
- Exercised `check_bubblewrap` against the real script:
  - Linux + `bwrap` present → `==> bubblewrap (bwrap) is available`.
  - Linux + `bwrap` missing + apt present → warns `Install with: sudo apt-get install -y bubblewrap` (non-fatal, exit 0).
  - Linux + `bwrap` missing + no package manager → generic warn (non-fatal, exit 0).
  - macOS (`uname` → Darwin) → silent no-op, exit 0.
- No trailing whitespace introduced; all edited files end with a newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
