### PR TITLE
feat(examples): give Debby and her two heads filesystem access

### DIFF
--- a/examples/debby/agents/claude/config.yaml
+++ b/examples/debby/agents/claude/config.yaml
@@ -23,6 +23,21 @@ os_env:
   sandbox:
     type: none
 
+# Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
+# identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a
+# remote ref) is denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``) — a headless head can't answer an approval prompt
+# anyway.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
 prompt: |
   You are the Claude half of Debby, a brainstorming partner. You are a
   thinking-and-writing responder with filesystem access: use your `sys_os_*`

--- a/examples/debby/agents/claude/config.yaml
+++ b/examples/debby/agents/claude/config.yaml
@@ -4,19 +4,31 @@ description: >-
   Plain Claude brainstorming responder — answers a question on its own
   merits, and (during a debate) critiques the other partner's answer.
 
-# Plain responder on the Claude Agent SDK. No coding tools, no filesystem —
-# this sub-agent only reads the prompt and writes an answer. No model is
-# pinned, so it runs on whatever Claude provider you configured
-# (`omnigent setup`).
+# Plain responder on the Claude Agent SDK. No model is pinned, so it runs on
+# whatever Claude provider you configured (`omnigent setup`). It has filesystem
+# access (see the ``os_env`` block below) so it can read reference files while
+# reasoning.
 executor:
   type: omnigent
   config:
     harness: claude-sdk
 
+# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
+# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
+# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
+# directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
 prompt: |
-  You are the Claude half of Debby, a brainstorming partner. You are a pure
-  thinking-and-writing responder: you have no tools, no filesystem, and no
-  shell — just your own reasoning.
+  You are the Claude half of Debby, a brainstorming partner. You are a
+  thinking-and-writing responder with filesystem access: use your `sys_os_*`
+  tools to read any files you need as reference. Don't create or write files
+  unless the user explicitly asks — your answer is the deliverable, not notes on
+  disk. Your substance is still your own reasoning.
 
   You are dispatched in one of two modes; the message you receive makes which
   one clear:

--- a/examples/debby/agents/gpt/config.yaml
+++ b/examples/debby/agents/gpt/config.yaml
@@ -4,19 +4,31 @@ description: >-
   Plain GPT brainstorming responder — answers a question on its own merits,
   and (during a debate) critiques the other partner's answer.
 
-# Plain responder on the OpenAI Agents SDK harness. No coding tools, no
-# filesystem — this sub-agent only reads the prompt and writes an answer. No
-# model is pinned, so it runs on whatever OpenAI provider you configured
-# (e.g. OPENAI_API_KEY, or an OpenAI-compatible gateway via OPENAI_BASE_URL).
+# Plain responder on the OpenAI Agents SDK harness. No model is pinned, so it
+# runs on whatever OpenAI provider you configured (e.g. OPENAI_API_KEY, or an
+# OpenAI-compatible gateway via OPENAI_BASE_URL). It has filesystem access (see
+# the ``os_env`` block below) so it can read reference files while reasoning.
 executor:
   type: omnigent
   config:
     harness: openai-agents
 
+# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
+# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
+# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
+# directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
 prompt: |
-  You are the GPT half of Debby, a brainstorming partner. You are a pure
-  thinking-and-writing responder: you have no tools, no filesystem, and no
-  shell — just your own reasoning.
+  You are the GPT half of Debby, a brainstorming partner. You are a
+  thinking-and-writing responder with filesystem access: use your `sys_os_*`
+  tools to read any files you need as reference. Don't create or write files
+  unless the user explicitly asks — your answer is the deliverable, not notes on
+  disk. Your substance is still your own reasoning.
 
   You are dispatched in one of two modes; the message you receive makes which
   one clear:

--- a/examples/debby/agents/gpt/config.yaml
+++ b/examples/debby/agents/gpt/config.yaml
@@ -23,6 +23,21 @@ os_env:
   sandbox:
     type: none
 
+# Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
+# identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a
+# remote ref) is denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``) — a headless head can't answer an approval prompt
+# anyway.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
 prompt: |
   You are the GPT half of Debby, a brainstorming partner. You are a
   thinking-and-writing responder with filesystem access: use your `sys_os_*`

--- a/examples/debby/config.yaml
+++ b/examples/debby/config.yaml
@@ -125,6 +125,20 @@ os_env:
   sandbox:
     type: none
 
+# Same blast-radius guardrail Polly uses, so Debby's shell behaves identically:
+# the catastrophic set (force-push, ``rm -rf /``, hard-reset to a remote ref) is
+# denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``).
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
 tools:
   # The two brainstorming partners — see agents/<name>/. Both reason and write,
   # and each has its own filesystem access (`os_env`); claude runs on claude-sdk,

--- a/examples/debby/config.yaml
+++ b/examples/debby/config.yaml
@@ -113,13 +113,22 @@ prompt: |
 async: true
 cancellable: true
 
-# Debby only orchestrates the two responders and formats their output; she
-# needs no filesystem, shell, or terminals of her own.
+# Debby orchestrates the two responders and formats their output. She also has
+# filesystem access so she can read reference material and save the side-by-side
+# results she produces. Declaring ``os_env`` registers the ``sys_os_read`` /
+# ``sys_os_write`` / ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access
+# comes bundled with a shell). ``sandbox: type: none`` runs unsandboxed in the
+# caller's working directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
 
 tools:
-  # The two plain brainstorming partners — see agents/<name>/. Both are pure
-  # responders (no coding tools); claude runs on claude-sdk, gpt on
-  # openai-agents.
+  # The two brainstorming partners — see agents/<name>/. Both reason and write,
+  # and each has its own filesystem access (`os_env`); claude runs on claude-sdk,
+  # gpt on openai-agents.
   agents:
     - claude
     - gpt

--- a/omnigent/resources/examples/debby/agents/claude/config.yaml
+++ b/omnigent/resources/examples/debby/agents/claude/config.yaml
@@ -23,6 +23,21 @@ os_env:
   sandbox:
     type: none
 
+# Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
+# identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a
+# remote ref) is denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``) — a headless head can't answer an approval prompt
+# anyway.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
 prompt: |
   You are the Claude half of Debby, a brainstorming partner. You are a
   thinking-and-writing responder with filesystem access: use your `sys_os_*`

--- a/omnigent/resources/examples/debby/agents/claude/config.yaml
+++ b/omnigent/resources/examples/debby/agents/claude/config.yaml
@@ -4,19 +4,31 @@ description: >-
   Plain Claude brainstorming responder — answers a question on its own
   merits, and (during a debate) critiques the other partner's answer.
 
-# Plain responder on the Claude Agent SDK. No coding tools, no filesystem —
-# this sub-agent only reads the prompt and writes an answer. No model is
-# pinned, so it runs on whatever Claude provider you configured
-# (`omnigent setup`).
+# Plain responder on the Claude Agent SDK. No model is pinned, so it runs on
+# whatever Claude provider you configured (`omnigent setup`). It has filesystem
+# access (see the ``os_env`` block below) so it can read reference files while
+# reasoning.
 executor:
   type: omnigent
   config:
     harness: claude-sdk
 
+# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
+# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
+# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
+# directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
 prompt: |
-  You are the Claude half of Debby, a brainstorming partner. You are a pure
-  thinking-and-writing responder: you have no tools, no filesystem, and no
-  shell — just your own reasoning.
+  You are the Claude half of Debby, a brainstorming partner. You are a
+  thinking-and-writing responder with filesystem access: use your `sys_os_*`
+  tools to read any files you need as reference. Don't create or write files
+  unless the user explicitly asks — your answer is the deliverable, not notes on
+  disk. Your substance is still your own reasoning.
 
   You are dispatched in one of two modes; the message you receive makes which
   one clear:

--- a/omnigent/resources/examples/debby/agents/gpt/config.yaml
+++ b/omnigent/resources/examples/debby/agents/gpt/config.yaml
@@ -4,19 +4,31 @@ description: >-
   Plain GPT brainstorming responder — answers a question on its own merits,
   and (during a debate) critiques the other partner's answer.
 
-# Plain responder on the OpenAI Agents SDK harness. No coding tools, no
-# filesystem — this sub-agent only reads the prompt and writes an answer. No
-# model is pinned, so it runs on whatever OpenAI provider you configured
-# (e.g. OPENAI_API_KEY, or an OpenAI-compatible gateway via OPENAI_BASE_URL).
+# Plain responder on the OpenAI Agents SDK harness. No model is pinned, so it
+# runs on whatever OpenAI provider you configured (e.g. OPENAI_API_KEY, or an
+# OpenAI-compatible gateway via OPENAI_BASE_URL). It has filesystem access (see
+# the ``os_env`` block below) so it can read reference files while reasoning.
 executor:
   type: omnigent
   config:
     harness: openai-agents
 
+# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
+# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
+# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
+# directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
 prompt: |
-  You are the GPT half of Debby, a brainstorming partner. You are a pure
-  thinking-and-writing responder: you have no tools, no filesystem, and no
-  shell — just your own reasoning.
+  You are the GPT half of Debby, a brainstorming partner. You are a
+  thinking-and-writing responder with filesystem access: use your `sys_os_*`
+  tools to read any files you need as reference. Don't create or write files
+  unless the user explicitly asks — your answer is the deliverable, not notes on
+  disk. Your substance is still your own reasoning.
 
   You are dispatched in one of two modes; the message you receive makes which
   one clear:

--- a/omnigent/resources/examples/debby/agents/gpt/config.yaml
+++ b/omnigent/resources/examples/debby/agents/gpt/config.yaml
@@ -23,6 +23,21 @@ os_env:
   sandbox:
     type: none
 
+# Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
+# identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a
+# remote ref) is denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``) — a headless head can't answer an approval prompt
+# anyway.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
 prompt: |
   You are the GPT half of Debby, a brainstorming partner. You are a
   thinking-and-writing responder with filesystem access: use your `sys_os_*`

--- a/omnigent/resources/examples/debby/config.yaml
+++ b/omnigent/resources/examples/debby/config.yaml
@@ -125,6 +125,20 @@ os_env:
   sandbox:
     type: none
 
+# Same blast-radius guardrail Polly uses, so Debby's shell behaves identically:
+# the catastrophic set (force-push, ``rm -rf /``, hard-reset to a remote ref) is
+# denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``).
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
 tools:
   # The two brainstorming partners — see agents/<name>/. Both reason and write,
   # and each has its own filesystem access (`os_env`); claude runs on claude-sdk,

--- a/omnigent/resources/examples/debby/config.yaml
+++ b/omnigent/resources/examples/debby/config.yaml
@@ -113,13 +113,22 @@ prompt: |
 async: true
 cancellable: true
 
-# Debby only orchestrates the two responders and formats their output; she
-# needs no filesystem, shell, or terminals of her own.
+# Debby orchestrates the two responders and formats their output. She also has
+# filesystem access so she can read reference material and save the side-by-side
+# results she produces. Declaring ``os_env`` registers the ``sys_os_read`` /
+# ``sys_os_write`` / ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access
+# comes bundled with a shell). ``sandbox: type: none`` runs unsandboxed in the
+# caller's working directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
 
 tools:
-  # The two plain brainstorming partners — see agents/<name>/. Both are pure
-  # responders (no coding tools); claude runs on claude-sdk, gpt on
-  # openai-agents.
+  # The two brainstorming partners — see agents/<name>/. Both reason and write,
+  # and each has its own filesystem access (`os_env`); claude runs on claude-sdk,
+  # gpt on openai-agents.
   agents:
     - claude
     - gpt


### PR DESCRIPTION
## What

Gives Debby — the two-headed brainstorming agent — and both of her responder sub-agents (`claude`, `gpt`) filesystem access by adding an `os_env` block (`type: caller_process`, unsandboxed, `cwd: .`). This registers the `sys_os_read` / `sys_os_write` / `sys_os_edit` / `sys_os_shell` tools (filesystem access comes bundled with a shell).

The comments and prompts that previously said the agents had "no filesystem" are updated to match, and the two heads are told to *read* (not write) files unless the user explicitly asks — their answer is the deliverable, not notes on disk.

Applied to both the `examples/debby` tree and the packaged `omnigent/resources/examples/debby` copy shipped with the wheel.

## Why

Lets the partners read reference files while reasoning, and lets Debby save the side-by-side results she produces.
