### PR TITLE
ci(fork-e2e): drop pull_request_review trigger that can't get secrets

### DIFF
--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -22,16 +22,20 @@ name: Fork e2e mirror
 # commits). Accepted risk: an approved first-timer's later pushes then run with
 # the secret unreviewed -- bounded by the rate-limited, revocable test token.
 #
-# pull_request_target / pull_request_review run the workflow + scripts from the
-# base (default branch), never the PR head, so a PR cannot alter the gate; the
-# script checkout is additionally pinned to main.
+# Runs on pull_request_target only: it executes the workflow + scripts from the
+# base (default branch), never the PR head, so a PR cannot alter the gate, and
+# -- unlike pull_request / pull_request_review on a fork -- it actually receives
+# the secrets/vars needed to mint the App token below. (A fork-triggered
+# pull_request_review gets no secrets, so it could only ever fail at "Mint
+# mirror App token" -- which is why it is NOT a trigger here.) A maintainer's
+# approval of a first-time contributor therefore takes effect on the PR's next
+# sync (or a manual workflow re-run), when the gate re-evaluates. The script
+# checkout is additionally pinned to main.
 #
 # leak-scan-allow: pull_request_target
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
-  pull_request_review:
-    types: [submitted]
 
 # Read-only at the top level (Scorecard Token-Permissions); write scope is on
 # the job.


### PR DESCRIPTION
## Problem

Every fork PR shows a spurious red **Fork e2e mirror / mirror (pull_request_review)** check. The `mirror` job fails at its **Mint mirror App token** step:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

The job runs on both `pull_request_target` **and** `pull_request_review`. With the sole exception of `GITHUB_TOKEN`, GitHub does **not** pass secrets or repo variables to a workflow triggered from a **fork** — and that restriction includes `pull_request_review`. So on the review-triggered run, `vars.FORK_E2E_APP_ID` / `secrets.FORK_E2E_APP_PRIVATE_KEY` resolve to empty and the App-token mint fails.

`pull_request_target` is the one PR event that *is* exempt, which is why those runs mint the token and mirror correctly. Concretely on #83: the `pull_request_target` run mirrored the head SHA onto `fork-e2e/pr-83` fine; only the `pull_request_review` run went red. Across the workflow's history the split is 100% by event — every `pull_request_target` run passes, every `pull_request_review` run fails identically.

Since `pull_request_review` can never mint the token on a fork PR, it can never do useful work — it only ever produces a red check.

## Fix

Drop the `pull_request_review` trigger; keep `pull_request_target` (which receives secrets). Header comment updated to explain why `pull_request_review` is intentionally not a trigger.

## Behavior after the change

- **Returning contributors** (gate case 2) are unaffected — they already mirror on every `synchronize` via `pull_request_target`.
- **Branch-already-exists** re-mirror (gate case 1) is unaffected.
- **First-time contributor + maintainer approval** (gate case 3): approval now takes effect on the PR's next sync (or a manual workflow re-run) rather than instantly on review submission. The approval-triggered path never actually worked on forks (no secrets), so this removes a guaranteed failure rather than a working feature. A `workflow_run`/comment-based re-trigger (cf. `maintainer-approval-rerun*.yml`) would be the follow-up if instant-on-approval mirroring is wanted.

This pull request and its description were written by Isaac.