### PR TITLE
fix(native): build conversation links on the web-UI mount, not the API mount

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -2854,7 +2854,8 @@ def _run_with_remote_server(
         if prepared is not None and outcome is _AttachOutcome.DETACHED:
             active_session_id = read_active_session_id(prepared.bridge_dir) or prepared.session_id
             click.echo(
-                f"\nDetached. Agent still running at {base_url}/c/{active_session_id}",
+                f"\nDetached. Agent still running at "
+                f"{conversation_url(base_url, active_session_id)}",
                 err=True,
             )
             echo_native_resume_hint(

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -494,7 +494,12 @@ def _conversation_url_for_active_session(
     ap_server_url = config.get("ap_server_url")
     session_id = read_active_session_id(bridge_dir)
     if isinstance(ap_server_url, str) and ap_server_url and session_id:
-        return f"{ap_server_url.rstrip('/')}/c/{url_component(session_id)}"
+        # ``ap_server_url`` is the API base; route through the shared
+        # builder so workspace-hosted servers land on the ``/omnigent``
+        # SPA mount (with ``?o=<org>``) rather than the JSON API mount.
+        from omnigent.conversation_browser import conversation_url
+
+        return conversation_url(ap_server_url, session_id)
     return fallback_url
 
 

--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -72,10 +72,16 @@ def conversation_link_for_id(
     :returns: Web UI link, e.g. ``"/c/conv_abc123"`` or
         ``"http://127.0.0.1:6767/c/conv_abc123"``.
     """
-    path = f"/c/{quote(conversation_id, safe='')}"
     if base_url is None or not base_url.strip():
-        return path
-    return f"{base_url.strip().rstrip('/')}{path}"
+        return f"/c/{quote(conversation_id, safe='')}"
+    # Delegate to the shared builder so workspace-hosted servers get the
+    # API→UI mount swap (``/api/2.0/omnigent`` → ``/omnigent``) and the
+    # ``?o=<org>`` selector — keeping the terminal status-bar link in
+    # lockstep with the CLI's ``Web UI:`` link instead of pointing at the
+    # JSON API mount.
+    from omnigent.conversation_browser import conversation_url
+
+    return conversation_url(base_url.strip(), conversation_id)
 
 
 @dataclass(frozen=True)

--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -90,6 +90,43 @@ def test_conversation_link_for_id_uses_base_url_when_provided() -> None:
     )
 
 
+def test_conversation_link_for_id_maps_workspace_hosted_server_to_ui_mount(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Workspace-hosted runners link to the SPA mount, not the API mount.
+
+    The runner threads ``RUNNER_SERVER_URL`` — the API proxy base
+    (``/api/2.0/omnigent``) — into the registry. A naive
+    ``{base}/c/<id>`` would put the JSON API path in the tmux status
+    bar; the link must instead land on the ``/omnigent`` SPA mount and
+    carry the ``?o=<org>`` selector ``omnigent login`` recorded, exactly
+    like the CLI's ``Web UI:`` line. Pins parity with
+    :func:`omnigent.conversation_browser.conversation_url`.
+
+    :param tmp_path: Pytest tmp dir for the stubbed auth-token file.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.cli_auth import store_databricks_auth
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    store_databricks_auth(
+        server,
+        "https://example.databricks.com",
+        org_id="2850744067564480",
+    )
+
+    assert (
+        conversation_link_for_id("conv_abc123", base_url=server)
+        == "https://example.databricks.com/omnigent/c/conv_abc123?o=2850744067564480"
+    )
+
+
 async def test_close_unknown_triple_returns_false() -> None:
     """
     Closing a never-launched (or already-closed) terminal returns

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -112,6 +112,58 @@ def test_session_start_hook_emits_conversation_url_system_message(
     assert read_transcript_path(bridge_dir) == transcript_path
 
 
+def test_session_start_hook_maps_workspace_hosted_server_to_ui_mount(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    SessionStart links to the SPA mount for workspace-hosted servers.
+
+    ``ap_server_url`` is the API proxy base (``/api/2.0/omnigent``);
+    pointing the "Open this session" message there returns JSON, not
+    the web UI. The message must land on the ``/omnigent`` SPA mount
+    with the ``?o=<org>`` selector — matching the CLI's ``Web UI:``
+    line and the tmux status bar.
+    """
+    from omnigent.cli_auth import store_databricks_auth
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    store_databricks_auth(
+        server,
+        "https://example.databricks.com",
+        org_id="2850744067564480",
+    )
+    bridge_dir = prepare_bridge_dir(
+        "conv_abc",
+        bridge_id="bridge_shared",
+        workspace=tmp_path,
+    )
+    build_hook_settings(bridge_dir, ap_server_url=server)
+    payload = {
+        "hook_event_name": "SessionStart",
+        "transcript_path": str(tmp_path / "session.jsonl"),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    exit_code = claude_native_hook.main(["--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert json.loads(captured.out) == {
+        "systemMessage": (
+            "Open this session in Omnigent: "
+            "https://example.databricks.com/omnigent/c/conv_abc?o=2850744067564480"
+        )
+    }
+
+
 def test_clear_session_start_hook_rotates_before_printing_conversation_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Workspace-hosted Omnigent serves the JSON API at `/api/2.0/omnigent` and the web SPA at `/omnigent`. `conversation_browser.conversation_url()` already maps the API base onto the UI mount (and appends `?o=<org>`), so the CLI's `Web UI:` line is correct — but three other surfaces still built the link by raw string concatenation against the API base, so they emitted the un-browsable `/api/2.0/omnigent/c/<id>`:

- **`terminals/registry.py` → `conversation_link_for_id()`** — the tmux status-bar link the runner sets from `RUNNER_SERVER_URL` (the API base). *This is the reported bug: the terminal shows `/api/2.0/omnigent/c/...` while the CLI shows `/omnigent/c/...`.*
- **`claude_native_hook.py` → `_conversation_url_for_active_session()`** — the "Open this session in Omnigent" `SessionStart` message, built from `ap_server_url` (the API base).
- **`claude_native.py`** — the "Detached. Agent still running at …" message.

All three now route through `conversation_url()`, so every surface lands on the SPA mount with the org selector, in lockstep with the CLI. The runner is local (host-daemon spawned), so it reads the same `~/.omnigent` auth record and resolves `?o=<org>` too; with no recorded org id the link still correctly targets `/omnigent/c/<id>`.

This completes the partial fix that taught only `conversation_url()` (the CLI print path) about the API→UI mount split.

databricks server:
```
$ omni claude --server https://eng-ml-agent-platform.staging.cloud.databricks.com/
Using https://eng-ml-agent-platform.staging.cloud.databricks.com/api/2.0/omnigent (Databricks workspace-hosted omnigent).
Web UI: https://eng-ml-agent-platform.staging.cloud.databricks.com/omnigent/c/1988892233223193?o=2850744067564480
[exited]
Resume with: omnigent claude --server https://eng-ml-agent-platform.staging.cloud.databricks.com/api/2.0/omnigent --resume 1988892233223193
```

<img width="549" height="269" alt="Screenshot 2026-06-15 at 2 16 30 PM" src="https://github.com/user-attachments/assets/85b8dafc-52ca-4d6c-bf43-0563b79f4232" />

db app server:
```
$ omni claude --server https://omnigents-3272836215725701.aws.databricksapps.com/
Web UI: https://omnigents-3272836215725701.aws.databricksapps.com/c/conv_84c73bfaceaa47a780523643ad4da5e0
[exited]
Resume with: omnigent claude --server https://omnigents-3272836215725701.aws.databricksapps.com --resume conv_84c73bfaceaa47a780523643ad4da5e0
```

localhost server:
```
$ omni claude --server http://127.0.0.1:6767
Web UI: http://127.0.0.1:6767/c/conv_1a7f7febae7c45a6aac91279bd58da69
[exited]
Resume with: omnigent claude --server http://127.0.0.1:6767 --resume conv_1a7f7febae7c45a6aac91279bd58da69
```


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added two regression tests pinning the two distinct runner-facing surfaces:

- `tests/terminals/test_registry.py::test_conversation_link_for_id_maps_workspace_hosted_server_to_ui_mount` — workspace API base → `/omnigent/c/<id>?o=<org>` for the tmux status bar.
- `tests/test_claude_native_hook.py::test_session_start_hook_maps_workspace_hosted_server_to_ui_mount` — the `SessionStart` "Open this session" message uses the SPA mount.

Existing tests (relative-path default, plain non-workspace base, all 17 prior hook tests) still pass — confirming non-workspace links are unchanged. Commands run:

```
pytest tests/terminals/test_registry.py tests/runner/test_resource_registry.py tests/test_claude_native_hook.py
# 43 + 18 passed
ruff check / ruff format --check on the 5 changed files — clean
```

This pull request and its description were written by Isaac.