### PR TITLE
docs: update stale @mariozechner/pi-coding-agent docstring references

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1186,7 +1186,7 @@ def _extract_pi_turn_usage(
     that :class:`TurnComplete` consumes, so pi sub-agent cost is priced
     the same way as ``claude-sdk`` and ``codex`` turns.
 
-    Pi (``@mariozechner/pi-coding-agent``) forwards assistant messages
+    Pi (``@earendil-works/pi-coding-agent``) forwards assistant messages
     whose ``usage`` dict carries ``input`` / ``output`` / ``cacheRead`` /
     ``cacheWrite`` / ``totalTokens`` token counts, and the message itself
     carries the resolved ``model``. This translates those into omnigent's

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -345,10 +345,10 @@ class _PiRetryAdapter:
         before subprocess spawn.
 
         Schema audited from
-        ``@mariozechner/pi-coding-agent@0.68.1/docs/settings.md``
-        (the package now ships as ``@earendil-works/pi-coding-agent``
-        — github.com/earendil-works/pi — with the same settings
-        schema). Pi natively implements exponential backoff with
+        ``@earendil-works/pi-coding-agent/docs/settings.md``
+        (github.com/earendil-works/pi — the maintained successor to the
+        deprecated ``@mariozechner/pi-coding-agent@0.68.1``, with the same
+        settings schema). Pi natively implements exponential backoff with
         jitter and ``Retry-After`` honoring; we configure the budget
         and shape.
 

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -2866,7 +2866,7 @@ def test_run_turn_bridge_extension_carries_live_server_token(monkeypatch) -> Non
 # ---------------------------------------------------------------------------
 # Pi token-usage → TurnComplete.usage tests
 #
-# pi (``@mariozechner/pi-coding-agent``) forwards assistant messages whose
+# pi (``@earendil-works/pi-coding-agent``) forwards assistant messages whose
 # ``usage`` object carries ``input`` / ``output`` / ``cacheRead`` /
 # ``cacheWrite`` / ``totalTokens`` token counts (plus a ``cost`` breakdown),
 # and the message itself carries the resolved ``model``. The executor maps


### PR DESCRIPTION
## Summary

The pi harness npm package `@mariozechner/pi-coding-agent` is deprecated on npm, with its successor being the actively-maintained `@earendil-works/pi-coding-agent` (same `pi` bin). The functional code already installs the maintained package (`omnigent/onboarding/harness_install.py`, `deploy/docker/Dockerfile`, and the install hint in `omnigent/inner/pi_executor.py`), but a few docstrings/comments still referenced the deprecated name.

This updates the remaining stale references:

- `omnigent/inner/pi_executor.py:1189` — docstring
- `omnigent/spec/types.py:348` — now points the audited schema at `@earendil-works/pi-coding-agent` and keeps a one-line note that it supersedes the deprecated `@mariozechner` package
- `tests/inner/test_pi_executor.py:2869` — comment

Docs/comments only; no behavior change.

Fixes #117