### PR TITLE
surface terminal startup errors in failure messages

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -154,6 +154,13 @@ _PASTED_PLACEHOLDER_PREFIX = "[Pasted text"
 # whether the draft is rendered in the input box. Short enough to fit
 # on the prompt row of a default 80-column detached pane.
 _DRAFT_NEEDLE_MAX_CHARS = 24
+# When Claude Code's input prompt never renders (it failed to boot), the
+# readiness gate attaches the tail of the captured pane to its error so
+# the real cause — often Claude Code's own startup crash, e.g. a
+# ``JSON Parse error`` from an HTML page served to its API client —
+# surfaces in the web UI error banner instead of only in the terminal.
+_TERMINAL_FAILURE_TAIL_LINES = 12
+_TERMINAL_FAILURE_TAIL_CHARS = 800
 
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
 
@@ -2766,6 +2773,32 @@ def _draft_in_input_box(pane: str, needle: str) -> bool:
     return bool(needle) and needle in tail
 
 
+def _format_terminal_failure_tail(pane: str) -> str:
+    r"""
+    Format the tail of a captured tmux pane for a failure message.
+
+    When Claude Code's input prompt never renders, its own on-screen
+    output — often a startup error or stack trace (e.g. a ``JSON Parse
+    error`` raised when its API client receives an HTML page instead of
+    JSON) — is the only signal of the real cause. The readiness gate
+    raises into the web UI's error banner, so attaching this tail
+    surfaces that cause without the user having to open the terminal.
+
+    :param pane: Captured pane text from :func:`_capture_pane`.
+    :returns: A ``" Last terminal output:\n<tail>"`` block — the last
+        :data:`_TERMINAL_FAILURE_TAIL_LINES` non-blank lines, capped at
+        :data:`_TERMINAL_FAILURE_TAIL_CHARS` characters — or ``""`` when
+        the pane has no visible text.
+    """
+    lines = [line.rstrip() for line in pane.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    tail = "\n".join(lines[-_TERMINAL_FAILURE_TAIL_LINES:])
+    if len(tail) > _TERMINAL_FAILURE_TAIL_CHARS:
+        tail = "…" + tail[-_TERMINAL_FAILURE_TAIL_CHARS:]
+    return f" Last terminal output:\n{tail}"
+
+
 def _wait_for_claude_prompt_ready(
     socket_path: str,
     tmux_target: str,
@@ -2794,16 +2827,25 @@ def _wait_for_claude_prompt_ready(
     :param timeout_s: Seconds to wait for the prompt, e.g. ``30.0``.
     :returns: None.
     :raises RuntimeError: If the prompt never renders within
-        *timeout_s* (Claude failed to boot).
+        *timeout_s* (Claude failed to boot). The message carries the
+        tail of the captured pane (see :func:`_format_terminal_failure_tail`)
+        so Claude Code's own startup output surfaces in the caller's error.
     """
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if _claude_prompt_rendered(_capture_pane(socket_path, tmux_target)):
             return
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+    # Timed out: Claude Code never rendered its input prompt. Capture the
+    # pane one last time and attach its tail so the real cause — often a
+    # startup crash like a ``JSON Parse error`` — surfaces in the web UI
+    # error banner this raises into, instead of only a generic timeout
+    # the user has to open the terminal to diagnose.
+    pane = _capture_pane(socket_path, tmux_target)
     raise RuntimeError(
         f"Claude Code terminal did not become ready within {timeout_s}s "
         "(input prompt never rendered). The message was not delivered."
+        + _format_terminal_failure_tail(pane)
     )
 
 

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -803,6 +803,40 @@ async def _write_subagent_forward_state_async(
     await asyncio.to_thread(_write_subagent_forward_state, bridge_dir, state)
 
 
+def _parse_json_response(resp: httpx.Response, *, context: str) -> Any:
+    """
+    Parse an Omnigent JSON response, failing loudly on a non-JSON body.
+
+    The forwarder calls ``resp.json()`` on Sessions API responses after
+    ``resp.raise_for_status()``. That guards non-2xx statuses but not a
+    2xx body that simply is not JSON: an auth or proxy layer in front of
+    the server — most commonly an expired Databricks Apps OAuth session —
+    can serve an HTML login or error page with a 200 status. A bare
+    ``resp.json()`` then raises an opaque ``json.JSONDecodeError``
+    ("Expecting value: line 1 column 1 (char 0)") with no hint that the
+    body was HTML, and the forwarder supervisor turns that into a silent
+    restart loop. This wrapper re-raises with the response content type
+    and a body snippet so the cause is obvious in logs.
+
+    :param resp: HTTP response whose body is expected to be JSON.
+    :param context: Short request description for the error message,
+        e.g. ``"session conv_abc123 snapshot"``.
+    :returns: The parsed JSON value (object, array, or scalar).
+    :raises RuntimeError: If the response body is not valid JSON.
+    """
+    try:
+        return resp.json()
+    except ValueError as exc:
+        content_type = resp.headers.get("content-type") or "<unknown>"
+        snippet = " ".join(resp.text[:200].split())
+        raise RuntimeError(
+            f"{context} returned a non-JSON body (content-type "
+            f"{content_type!r}); an auth or proxy page was likely served "
+            f"instead of the API response (e.g. an expired login session). "
+            f"Body starts with: {snippet!r}"
+        ) from exc
+
+
 async def _post_external_subagent_start(
     client: httpx.AsyncClient,
     *,
@@ -833,6 +867,7 @@ async def _post_external_subagent_start(
     :raises KeyError: If the server response is missing
         ``child_session_id`` — indicates a server/forwarder version
         mismatch and is unrecoverable for this sub-agent.
+    :raises RuntimeError: If the server response body is not JSON.
     """
     resp = await client.post(
         f"/v1/sessions/{parent_session_id}/events",
@@ -847,7 +882,7 @@ async def _post_external_subagent_start(
         },
     )
     resp.raise_for_status()
-    body = resp.json()
+    body = _parse_json_response(resp, context=f"sub-agent start for {parent_session_id!r}")
     return body["child_session_id"]
 
 
@@ -1708,7 +1743,7 @@ async def _create_clear_replacement_session(
         },
     )
     create_resp.raise_for_status()
-    created = create_resp.json()
+    created = _parse_json_response(create_resp, context="clear-replacement session create")
     new_session_id = created.get("id")
     if not isinstance(new_session_id, str) or not new_session_id:
         raise RuntimeError("clear replacement session response did not include id")
@@ -1828,7 +1863,7 @@ async def _create_fork_replacement_session(
         json={},
     )
     fork_resp.raise_for_status()
-    forked = fork_resp.json()
+    forked = _parse_json_response(fork_resp, context=f"fork of session {old_session_id!r}")
     new_session_id = forked.get("id")
     if not isinstance(new_session_id, str) or not new_session_id:
         raise RuntimeError("fork replacement session response did not include id")
@@ -1942,7 +1977,7 @@ async def _fetch_session_snapshot(
     """
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     resp.raise_for_status()
-    payload = resp.json()
+    payload = _parse_json_response(resp, context=f"session {session_id!r} snapshot")
     if not isinstance(payload, dict):
         raise RuntimeError(f"session {session_id!r} snapshot was not an object")
     return payload

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4833,3 +4833,77 @@ def test_compute_transcript_cumulative_cost_none_when_nothing_priceable(
         claude_native_bridge.compute_transcript_cumulative_cost(priced, include_sidechains=True)
         is None
     )
+
+
+def test_format_terminal_failure_tail_returns_empty_for_blank_pane() -> None:
+    """
+    A pane with no visible text yields no tail block.
+
+    :returns: None.
+    """
+    assert claude_native_bridge._format_terminal_failure_tail("   \n\n  ") == ""
+
+
+def test_format_terminal_failure_tail_includes_recent_error_lines() -> None:
+    """
+    The tail block carries the pane's trailing non-blank lines, so a
+    startup crash surfaces in the readiness-timeout error.
+
+    :returns: None.
+    """
+    pane = "ERROR  JSON Parse error: Unrecognized token '<'\n  at <parse> (:0)\n"
+    tail = claude_native_bridge._format_terminal_failure_tail(pane)
+    assert tail.startswith(" Last terminal output:\n")
+    assert "JSON Parse error: Unrecognized token '<'" in tail
+
+
+def test_format_terminal_failure_tail_caps_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A very long pane is truncated to the configured character cap.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TERMINAL_FAILURE_TAIL_CHARS", 50)
+    pane = "\n".join(f"line {i}" for i in range(100))
+    tail = claude_native_bridge._format_terminal_failure_tail(pane)
+    body = tail.split("\n", 1)[1]
+    assert body.startswith("…")
+    # Leading ellipsis marker plus at most the configured character cap.
+    assert len(body) <= 51
+
+
+def test_wait_for_claude_prompt_ready_surfaces_terminal_output_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    On a readiness timeout, the RuntimeError carries Claude Code's own
+    terminal output (e.g. a startup ``JSON Parse error``) so the cause
+    surfaces in the web UI error banner, not only in the terminal.
+
+    Without the tail, the user sees a generic "terminal did not become
+    ready" timeout in the UI while the actual crash sits unread in the
+    terminal pane.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    crash_pane = (
+        "ERROR  JSON Parse error: Unrecognized token '<'\n"
+        "  at <parse> (:0)\n"
+        "  at parse (unknown)\n"
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._capture_pane",
+        lambda socket_path, tmux_target: crash_pane,
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        claude_native_bridge._wait_for_claude_prompt_ready(
+            "/tmp/example/tmux.sock",
+            "claude:0.0",
+            timeout_s=0.0,
+        )
+    message = str(excinfo.value)
+    assert "did not become ready" in message
+    assert "Last terminal output:" in message
+    assert "JSON Parse error: Unrecognized token '<'" in message

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5315,3 +5315,65 @@ async def test_forward_session_cost_posts_status_when_no_subagents(
     ]
     assert dedupe.posted_cost == pytest.approx(0.25)
     assert dedupe.posted_policy_cost == pytest.approx(0.25)
+
+
+def test_parse_json_response_returns_value_on_valid_json() -> None:
+    """
+    A normal JSON body parses through ``_parse_json_response`` unchanged.
+
+    :returns: None.
+    """
+    resp = httpx.Response(200, json={"id": "conv_abc123"})
+    assert forwarder._parse_json_response(resp, context="session snapshot") == {
+        "id": "conv_abc123"
+    }
+
+
+def test_parse_json_response_raises_diagnosable_error_on_html_body() -> None:
+    """
+    An HTML body (e.g. an expired Databricks Apps OAuth login page served
+    with a 200) raises a ``RuntimeError`` naming the content type and a
+    body snippet, not an opaque ``json.JSONDecodeError``. The original
+    parser error is preserved as ``__cause__`` for debugging.
+
+    :returns: None.
+    """
+    resp = httpx.Response(
+        200,
+        html="<!DOCTYPE html><html><body>Sign in to continue</body></html>",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        forwarder._parse_json_response(resp, context="session 'conv_abc123' snapshot")
+    message = str(excinfo.value)
+    assert "session 'conv_abc123' snapshot" in message
+    assert "text/html" in message
+    assert "<!DOCTYPE html>" in message
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+@pytest.mark.asyncio
+async def test_fetch_session_snapshot_raises_diagnosable_error_on_html_body() -> None:
+    """
+    ``_fetch_session_snapshot`` surfaces a clear error when the Sessions
+    API returns a 200 HTML body instead of JSON — the failure mode behind
+    Claude Code's "Unrecognized token '<'" crash when an auth/proxy page is
+    served in place of the API response. Without the guard this raised a
+    bare ``json.JSONDecodeError`` that the forwarder supervisor turned into
+    a silent restart loop.
+
+    :returns: None.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            html="<!DOCTYPE html><html><body>Sign in to continue</body></html>",
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        with pytest.raises(RuntimeError) as excinfo:
+            await forwarder._fetch_session_snapshot(client, "conv_abc123")
+    message = str(excinfo.value)
+    assert "conv_abc123" in message
+    assert "text/html" in message


### PR DESCRIPTION
## What happened

Motivation - hit: `JSON Parse error: Unrecognized token '<'` in a claude-native session. The web UI showed only a generic error and want to see if we can surface a more readable error here

<img width="849" height="358" alt="image" src="https://github.com/user-attachments/assets/e7b4a187-5a10-4717-8537-785cad8e9ca1" />

<img width="1277" height="680" alt="image" src="https://github.com/user-attachments/assets/f636fa58-aa44-4d45-86f1-3176a2501208" />

> Error · execution · RuntimeError
> inner executor error: Claude Code terminal did not become ready within 30.0s (input prompt never rendered). The message was not delivered.

…while the **actual** cause — a full `JSON Parse error` stack trace — was visible only in the in-app terminal pane.

## Root cause

The stack trace is inside **Claude Code's own bundled `cli.js`** (`/$bunfs/root/src/entrypoints/cli.js`), not omnigent: its HTTP client `JSON.parse`'d an HTML body (`<` → `Unrecognized token '<'`), almost certainly an auth/proxy page (an expired Databricks Apps OAuth session is the prime suspect). That crash happened during startup, so Claude Code's TUI input prompt never rendered, and omnigent's readiness gate (`_wait_for_claude_prompt_ready`) timed out after 30s.

The readiness gate **already polls `capture-pane`** every interval — so Claude Code's on-screen crash output is right there at timeout, but it was discarded and only a generic message was raised.

## Changes

**1. Surface the terminal's output in the readiness-timeout error (fix for the observed symptom).**
`omnigent/claude_native_bridge.py`: on timeout, capture the pane one last time and append its tail (last 12 non-blank lines, capped at 800 chars) to the `RuntimeError`. Because that error is what renders in the UI banner, the UI now shows the real cause:

> inner executor error: Claude Code terminal did not become ready within 30.0s (input prompt never rendered). The message was not delivered. Last terminal output:
> ERROR  JSON Parse error: Unrecognized token '<'
>   at &lt;parse&gt; (:0)
>   at parse (unknown)

**2. Harden the forwarder's own JSON parsing against the same failure mode (defensive).**
`omnigent/claude_native_forwarder.py`: four Sessions-API call sites did `raise_for_status()` then a bare `resp.json()`. If the same expired-OAuth/proxy layer returns a **200 with an HTML body**, that raised an opaque `json.JSONDecodeError` — which the forwarder supervisor turns into a silent restart loop. They now route through a new `_parse_json_response(resp, context=...)` helper that re-raises a clear `RuntimeError` naming the content type and a body snippet (e.g. `… returned a non-JSON body (content-type 'text/html; charset=utf-8'); an auth or proxy page was likely served …`).

## Not addressed (upstream)

The `JSON.parse` crash itself lives in Claude Code's binary and can't be patched here; worth filing upstream so its HTTP client surfaces a typed error on non-JSON responses instead of throwing raw.

## Tests

Adds 7 unit tests:
- `_format_terminal_failure_tail`: blank pane → empty; error lines included; length cap.
- `_wait_for_claude_prompt_ready`: timeout error carries the captured `JSON Parse error` output.
- `_parse_json_response`: happy path; HTML body → diagnosable `RuntimeError` with cause preserved.
- `_fetch_session_snapshot`: 200 HTML body → diagnosable error (mirrors the incident).

## Verification

`python -m py_compile` and `ruff check` / `ruff format --check` pass on all four files. The full pytest suite could **not** be executed in my environment (no PyPI access to install deps; local `uv` predates the repo's `uv.toml`), so the new logic was additionally exercised via faithful-copy logic checks (incl. real `httpx`). **Please run the test suite in CI to confirm.**
