### PR TITLE
fix(web): vertically center the author avatar with the user bubble

### DIFF
--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1967,7 +1967,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
       {/* w-fit + ml-auto shrink-wrap the row so the author avatar sits
           immediately left of the right-aligned bubble (the bubble's own
           ml-auto has no free space to absorb inside a fit-width row). */}
-      <div className="ml-auto flex w-fit max-w-full items-start gap-1.5">
+      <div className="ml-auto flex w-fit max-w-full items-center gap-1.5">
         {showAuthorBadge && author && (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -1975,7 +1975,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                 size="sm"
                 data-testid="message-author"
                 aria-label={author}
-                className="mt-1.5 shrink-0"
+                className="shrink-0"
               >
                 <AvatarFallback
                   className="font-medium text-white"


### PR DESCRIPTION
## Summary

Vertically center the shared-conversation author avatar with the user bubble. The badge previously top-aligned its avatar via a hand-tuned `mt-1.5` plus `items-start` on the row, so against single-line bubbles the avatar floated above the bubble's center. Switch the row to `items-center` and drop the manual margin so the avatar centers against the bubble at any height.

Ports the alignment hunk from the internal `omniagents_ui` change. The other hunk in that change (scoping `usePromptHistory` to `conversationId`) is intentionally omitted — it is already present on `main`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Pure Tailwind class-name change on the author-badge row (`items-start` → `items-center`) and the avatar (`mt-1.5 shrink-0` → `shrink-0`). No TypeScript types, props, or behavior are touched, so there is no type surface to test and `npm run type-check` is unaffected (node_modules was not installed in this environment, so type-check was not run; the change is a string-literal class swap with no type impact). The existing `data-testid="message-author"` selector and the `UserBubble` markdown test remain valid.

This pull request and its description were written by Isaac.