### PR TITLE
fix(oss): add a 7-day npm dependency cooldown

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -149,6 +149,11 @@ jobs:
       # here would override the config with an absolute date and stamp
       # it into the lock, breaking every later `uv sync --locked` that
       # runs without the same env.)
+      # npm's 7-day cooldown lives in ap-web/.npmrc (`min-release-age=7`,
+      # the mirror of uv's `exclude-newer = "P7D"`) and is only honored by
+      # npm >= 11.10.0; node 20 ships npm 10.x, which silently ignores it.
+      - name: Ensure npm honors the dependency cooldown
+        run: npm install -g "npm@>=11.10.0"
       - name: Regenerate lockfiles against public PyPI/npm
         run: |
           uv lock

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -72,6 +72,14 @@ jobs:
 
       # 2. Regenerate ap-web/package-lock.json against public npm. Lockfile
       #    only (the Docker build does the full install) — fast, deterministic.
+      #    The 7-day dependency cooldown comes from ap-web/.npmrc
+      #    (`min-release-age=7`, the npm mirror of uv.toml's
+      #    `exclude-newer = "P7D"`); it is only honored by npm >= 11.10.0,
+      #    and node 20 ships npm 10.x, so install a new-enough npm first or
+      #    the cooldown is silently ignored and the lock can pin a release
+      #    too fresh for the downstream JFrog mirror to serve.
+      - name: Ensure npm honors the dependency cooldown
+        run: npm install -g "npm@>=11.10.0"
       - name: Regenerate package-lock.json
         working-directory: ap-web
         run: npm install --package-lock-only --no-audit --no-fund

--- a/ap-web/.npmrc
+++ b/ap-web/.npmrc
@@ -1,0 +1,14 @@
+# Dependency cooldown: never resolve an npm version published within the
+# last 7 days, so a compromised or yanked release has a window to surface
+# before it is pinned. This is the npm mirror of the Python-side cooldown
+# in uv.toml (`exclude-newer = "P7D"`).
+#
+# Applied at RESOLUTION time (`npm install` / lockfile regen); `npm ci`
+# just installs the already-cooled lockfile. Value is in DAYS.
+#
+# Requires npm >= 11.10.0 — `min-release-age` landed there. An older npm
+# silently ignores this key, so the lockfile-regen workflows
+# (`oss-regenerate-and-smoke.yml`, `oss-regen-on-comment.yml`) install a
+# new-enough npm before regenerating; that workflow, not this file, is the
+# real enforcement point.
+min-release-age=7


### PR DESCRIPTION
## Summary

Adds a **7-day npm dependency cooldown** — the npm mirror of the Python-side
`exclude-newer = "P7D"` already in `uv.toml`.

`ap-web/package-lock.json` is regenerated against public npm by the regen
workflows with no cooldown, so it can pin a release published minutes ago. The
secure-release pipeline (`databricks/secure-public-registry-releases-eng`)
installs through the JFrog mirror, which **403s a too-fresh version** — first hit
was `postcss-selector-parser@7.1.2` (pulled in transitively by the `shadcn` CLI).
uv was already protected by its cooldown; npm had none.

**Changes:**
- New `ap-web/.npmrc` with `min-release-age=7` (npm's cooldown, which landed in
  npm 11.10.0). Value is in days.
- Both regen workflows (`oss-regenerate-and-smoke.yml`, `oss-regen-on-comment.yml`)
  now `npm install -g "npm@>=11.10.0"` before regenerating the lockfile — node 20
  ships npm 10.x, which silently ignores `min-release-age`.

After this merges, run a lockfile regen (the regen workflow / `/regen`) so the
public `package-lock.json` no longer pins a quarantined version; the secure
build's `npm ci` then succeeds.

> Note: the durable source for this lives in the internal repo
> (`databricks-eng/agent-framework`, as `ap-web/.npmrc.oss` + the same workflow
> change); this PR applies the generated form directly so the OSS release path is
> unblocked without waiting on a full re-export.
