### PR TITLE
feat(cli): add `omnigent import` for existing Claude Code / Codex chats

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1130,6 +1130,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "debby",
         "debug",
         "host",
+        "import",
         "lakebox",
         "login",
         "pane-picker",
@@ -8655,6 +8656,183 @@ def _databricks_workspace_token(workspace_host: str) -> str | None:
         return auth.current_token()
     except (DatabricksAuthError, ValueError):
         return None
+
+
+def _resolve_import_agent_id(base_url: str) -> str:
+    """Pick an agent to bind an imported (history-only) session to.
+
+    Queries ``GET /v1/agents`` and returns the first agent's id. There is no
+    server-side "default" marker, so when several agents exist the first
+    (the server's default ordering) is used and the user is told how to
+    override it.
+
+    :param base_url: Resolved Omnigent server base URL.
+    :returns: A durable agent id, e.g. ``"ag_abc123"``.
+    :raises click.ClickException: When agents cannot be listed or none exist.
+    """
+    result = _host_http_json(base_url=base_url, method="GET", path="/v1/agents")
+    if result.status_code != 200 or not isinstance(result.body, dict):
+        raise click.ClickException(
+            f"Could not list agents to bind the import "
+            f"({result.status_code}): {_host_error_text(result.body)}. "
+            f"Pass --agent <agent_id>."
+        )
+    data = result.body.get("data")
+    ids: list[str] = []
+    for entry in data if isinstance(data, list) else []:
+        if isinstance(entry, dict):
+            entry_id = entry.get("id")
+            if isinstance(entry_id, str):
+                ids.append(entry_id)
+    if not ids:
+        raise click.ClickException(
+            "No agents are registered on the server. Pass --agent <agent_id>."
+        )
+    if len(ids) > 1:
+        click.echo(
+            f"Multiple agents available; binding the imported session to {ids[0]!r}. "
+            f"Use --agent to choose another.",
+            err=True,
+        )
+    return ids[0]
+
+
+@cli.command("import")
+@click.argument("transcript", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--source",
+    type=click.Choice(["auto", "claude", "codex"]),
+    default="auto",
+    show_default=True,
+    help="Transcript format. 'auto' detects Claude vs Codex from the file.",
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Omnigent server to import into. Defaults to the 'server' in your "
+        "config, then a running local server."
+    ),
+)
+@click.option(
+    "--agent",
+    "agent_id",
+    default=None,
+    help="Durable agent id to bind the imported session to (default: the server's first agent).",
+)
+@click.option(
+    "--title",
+    default=None,
+    help="Session title (default: synthesized from the first message).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Parse and summarize the transcript without creating a session.",
+)
+def import_(
+    transcript: Path,
+    source: str,
+    server: str | None,
+    agent_id: str | None,
+    title: str | None,
+    dry_run: bool,
+) -> None:
+    # Click uses the docstring as --help text — keep param docs in comments
+    # so they don't leak into CLI output.
+    #
+    # :param transcript: Path to a Claude or Codex ``.jsonl`` transcript.
+    # :param source: ``auto`` / ``claude`` / ``codex``.
+    # :param server: Target server URL, or None to resolve from config/local.
+    # :param agent_id: Agent to bind, or None to pick the server's first.
+    # :param title: Session title, or None to synthesize from the transcript.
+    # :param dry_run: When set, parse and summarize without importing.
+    """Import an existing Claude Code or Codex chat into an Omnigent server.
+
+    Parses a finished local transcript and creates a new history-only session
+    seeded with its messages and tool calls, viewable (and resumable) in the
+    web UI.
+
+    \b
+    Examples:
+      omnigent import ~/.claude/projects/-home-me-repo/<session-id>.jsonl
+      omnigent import ./rollout-<ts>-<thread-id>.jsonl --source codex
+      omnigent import chat.jsonl --server https://example.com --dry-run
+    """
+    from omnigent.transcript_import import (
+        TranscriptImportError,
+        parse_transcript_file,
+        to_initial_items,
+    )
+
+    try:
+        parsed = parse_transcript_file(transcript, source=source)
+    except TranscriptImportError as err:
+        raise click.ClickException(str(err)) from err
+
+    final_title = title or parsed.title or f"Imported {parsed.source} chat"
+    click.echo(
+        f"Parsed {parsed.source} transcript: {parsed.message_count} messages, "
+        f"{parsed.tool_call_count} tool calls, {parsed.tool_output_count} tool outputs.",
+        err=True,
+    )
+    if dry_run:
+        click.echo(
+            f"Dry run — would create session titled {final_title!r}. Nothing imported.",
+            err=True,
+        )
+        return
+
+    resolved_server = _resolve_host_server(server)
+    if resolved_server is None:
+        resolved_server = local_server_url_if_healthy()
+    if resolved_server is None:
+        raise click.ClickException(
+            "No server specified. Pass --server <url>, set 'server' in your "
+            "config, or start one with `omnigent server start`."
+        )
+    base_url = resolved_server.rstrip("/")
+
+    resolved_agent_id = agent_id or _resolve_import_agent_id(base_url)
+
+    # The transcript items are JSON-shaped dicts typed with ``object`` values;
+    # cast to the strict request alias at this boundary (httpx serializes any
+    # JSON-able payload). Mirrors the decode-side cast in ``_host_http_json``.
+    body = {
+        "agent_id": resolved_agent_id,
+        "title": final_title,
+        "initial_items": to_initial_items(parsed.items),
+        "labels": {"imported_from": parsed.source},
+    }
+    result = _host_http_json(
+        base_url=base_url,
+        method="POST",
+        path="/v1/sessions",
+        json_body=cast(_HostJsonObject, body),
+        timeout_s=60.0,
+    )
+    if result.status_code not in (200, 201) or not isinstance(result.body, dict):
+        raise click.ClickException(
+            f"Import failed ({result.status_code}): {_host_error_text(result.body)}"
+        )
+    session_id = result.body.get("id")
+    if not isinstance(session_id, str):
+        raise click.ClickException(
+            f"Import succeeded but the server returned no session id: {result.body!r}"
+        )
+
+    from omnigent.conversation_browser import conversation_url
+
+    # Human-facing lines go to stderr; stdout carries only the bare session id
+    # so `SID=$(omnigent import ...)` captures just the id.
+    click.echo(
+        f"Imported {parsed.message_count} messages and "
+        f"{parsed.tool_call_count} tool calls into session {session_id}.",
+        err=True,
+    )
+    click.echo(session_id)
+    click.echo(f"Web UI: {conversation_url(base_url, session_id)}", err=True)
 
 
 @cli.command("login")

--- a/omnigent/transcript_import.py
+++ b/omnigent/transcript_import.py
@@ -1,0 +1,528 @@
+"""Import existing Claude Code and Codex chat transcripts into Omnigent.
+
+Claude Code and Codex each persist a finished local conversation as a
+JSON-Lines transcript:
+
+- Claude Code: ``~/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`` — one
+  record per line with a top-level ``type`` and a nested
+  ``message: {"role", "content"}`` (the Anthropic message shape).
+- Codex: ``~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<thread-id>.jsonl`` — one
+  record per line wrapping an OpenAI Responses-API item under ``payload``
+  (``session_meta`` / ``turn_context`` / ``response_item`` envelopes).
+
+This module converts either format into a list of Omnigent conversation items
+(:class:`ImportedItem`) carrying user/assistant messages and tool calls. Each
+item is shaped to match the ``initial_items`` contract of ``POST /v1/sessions``
+(see :mod:`omnigent.entities.conversation` — ``MessageData`` /
+``FunctionCallData`` / ``FunctionCallOutputData``), so a caller can seed a
+history-only session from a finished transcript.
+
+Scope: messages and tool calls only. Reasoning/thinking blocks, image and file
+attachments, and harness-internal metadata records are skipped. The wire shape
+uses the ``"agent"`` key on assistant/function items (``"model"`` is the
+output-only serialization alias and is rejected on input).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "ImportedItem",
+    "ParsedTranscript",
+    "TranscriptImportError",
+    "detect_source",
+    "parse_claude_lines",
+    "parse_codex_lines",
+    "parse_transcript",
+    "parse_transcript_file",
+    "to_initial_items",
+]
+
+# Source labels (also used as the default ``agent`` label when the transcript
+# carries no model id of its own).
+CLAUDE = "claude"
+CODEX = "codex"
+
+# Claude top-level record ``type`` values that are structural metadata and
+# never carry a user/assistant message. Used only for format detection.
+_CLAUDE_METADATA_TYPES = frozenset(
+    {
+        "permission-mode",
+        "branch-update",
+        "queue-operation",
+        "progress",
+        "pr-link",
+        "summary",
+        "system",
+    }
+)
+
+# Prefixes/markers that flag a Claude user "message" as CLI scaffolding
+# (slash-command echoes, local-command caveats, shell markup) rather than text
+# the user actually typed. Such content is dropped.
+_CLAUDE_SCAFFOLDING_PREFIXES = (
+    "<command-message>",
+    "<command-args>",
+    "<local-command-caveat>",
+    "<local-command-stdout>",
+    "<local-command-stderr>",
+)
+
+# Content-block ``type`` values that carry plain message text.
+_TEXT_BLOCK_TYPES = frozenset({"input_text", "output_text", "text"})
+
+# Substituted for a tool output that carries only non-text content (e.g. an
+# image), so the call/output pairing is preserved without embedding a base64
+# payload. Images and files are out of this importer's scope.
+_NON_TEXT_OUTPUT_PLACEHOLDER = "[non-text tool output omitted]"
+
+
+class TranscriptImportError(Exception):
+    """Raised when a transcript cannot be parsed into importable items."""
+
+
+@dataclass(frozen=True)
+class ImportedItem:
+    """A single Omnigent conversation item parsed from a transcript.
+
+    :param item_type: Omnigent item type — ``"message"``,
+        ``"function_call"``, or ``"function_call_output"``.
+    :param data: The item payload, shaped to match the corresponding
+        :mod:`omnigent.entities.conversation` data model (e.g.
+        ``{"role": "user", "content": [...]}``). Assistant messages and
+        function calls carry ``"agent"`` (NOT ``"model"`` — ``model`` is the
+        output-only serialization alias and is rejected on input).
+    """
+
+    item_type: str
+    data: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ParsedTranscript:
+    """The result of parsing a transcript file.
+
+    :param source: Detected or declared source, ``"claude"`` or ``"codex"``.
+    :param items: Ordered conversation items ready to seed a session.
+    :param title: A one-line title synthesized from the first user message, or
+        ``None`` when no user text is present.
+    """
+
+    source: str
+    items: list[ImportedItem]
+    title: str | None
+
+    @property
+    def message_count(self) -> int:
+        """Number of message items (user + assistant)."""
+        return sum(1 for item in self.items if item.item_type == "message")
+
+    @property
+    def tool_call_count(self) -> int:
+        """Number of tool/function call items."""
+        return sum(1 for item in self.items if item.item_type == "function_call")
+
+    @property
+    def tool_output_count(self) -> int:
+        """Number of tool/function output items."""
+        return sum(1 for item in self.items if item.item_type == "function_call_output")
+
+
+# ── JSON helpers (keep the parsers free of bare ``Any``) ───────────────────
+
+
+def _as_record(value: object) -> dict[str, object] | None:
+    """Return *value* as a ``dict[str, object]`` when it is a JSON object."""
+    if isinstance(value, dict):
+        return {str(key): val for key, val in value.items()}
+    return None
+
+
+def _as_str(value: object) -> str | None:
+    """Return *value* when it is a string, else ``None``."""
+    return value if isinstance(value, str) else None
+
+
+def _load_record(line: str) -> dict[str, object] | None:
+    """Parse one JSONL line into a record dict, or ``None`` to skip it.
+
+    Blank lines, malformed JSON, and non-object records are skipped rather
+    than raising, mirroring how the live forwarders tolerate partial writes.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    return _as_record(parsed)
+
+
+def _text_from_blocks(content: object, wanted: frozenset[str]) -> str:
+    """Join the text of content blocks whose ``type`` is in *wanted*.
+
+    A plain string *content* is returned verbatim. Blocks without usable text
+    (images, files, unknown types) are skipped.
+
+    :param content: A string or a list of content blocks.
+    :param wanted: Block ``type`` values to keep.
+    :returns: The joined text, or ``""`` when nothing usable is present.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for raw_block in content:
+        block = _as_record(raw_block)
+        if block is None:
+            continue
+        if _as_str(block.get("type")) not in wanted:
+            continue
+        text = _as_str(block.get("text"))
+        if text:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+# ── Item builders ──────────────────────────────────────────────────────────
+
+
+def _user_message(text: str) -> ImportedItem:
+    """Build a user message item from plain text."""
+    return ImportedItem(
+        "message", {"role": "user", "content": [{"type": "input_text", "text": text}]}
+    )
+
+
+def _assistant_message(text: str, agent: str) -> ImportedItem:
+    """Build an assistant message item from plain text and an agent label."""
+    return ImportedItem(
+        "message",
+        {"role": "assistant", "agent": agent, "content": [{"type": "output_text", "text": text}]},
+    )
+
+
+def _function_call(agent: str, name: str, arguments: str, call_id: str) -> ImportedItem:
+    """Build a function_call item. *arguments* is a JSON-encoded string."""
+    return ImportedItem(
+        "function_call",
+        {"agent": agent, "name": name, "arguments": arguments, "call_id": call_id},
+    )
+
+
+def _function_call_output(call_id: str, output: str) -> ImportedItem:
+    """Build a function_call_output item paired to *call_id*."""
+    return ImportedItem("function_call_output", {"call_id": call_id, "output": output})
+
+
+# ── Claude Code transcript parsing ──────────────────────────────────────────
+
+
+def _is_claude_scaffolding(text: str) -> bool:
+    """True when a Claude user string is CLI scaffolding, not a real message."""
+    stripped = text.lstrip()
+    if stripped.startswith(_CLAUDE_SCAFFOLDING_PREFIXES):
+        return True
+    return "<command-name>" in text or "<bash-" in text
+
+
+def _stringify_output(raw: object) -> str | None:
+    """Coerce a tool output value into a string, or ``None`` when absent.
+
+    Strings pass through. A content-block list is reduced to its text — image
+    and file blocks are out of scope, so a list with no text yields a short
+    placeholder rather than a base64 dump, which keeps the call/output pairing
+    intact. A missing or otherwise non-string value yields ``None``.
+    """
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        return _text_from_blocks(raw, _TEXT_BLOCK_TYPES) or _NON_TEXT_OUTPUT_PLACEHOLDER
+    return None
+
+
+def _claude_tool_result_output(block: dict[str, object]) -> str:
+    """Extract a tool_result block's textual output (``""`` when absent)."""
+    return _stringify_output(block.get("content")) or ""
+
+
+def _claude_user_items(content: object) -> list[ImportedItem]:
+    """Convert a Claude user record's content into items.
+
+    Text becomes a single user message; ``tool_result`` blocks become
+    function_call_output items. CLI scaffolding and images are dropped.
+    """
+    if isinstance(content, str):
+        if not content.strip() or _is_claude_scaffolding(content):
+            return []
+        return [_user_message(content)]
+    if not isinstance(content, list):
+        return []
+    items: list[ImportedItem] = []
+    text_parts: list[str] = []
+    for raw_block in content:
+        block = _as_record(raw_block)
+        if block is None:
+            continue
+        block_type = _as_str(block.get("type"))
+        if block_type == "text":
+            text = _as_str(block.get("text"))
+            if text and text.strip() and not _is_claude_scaffolding(text):
+                text_parts.append(text)
+        elif block_type == "tool_result":
+            tool_use_id = _as_str(block.get("tool_use_id"))
+            if tool_use_id:
+                items.append(_function_call_output(tool_use_id, _claude_tool_result_output(block)))
+    joined = "\n".join(text_parts)
+    if joined:
+        items.insert(0, _user_message(joined))
+    return items
+
+
+def _claude_assistant_items(content: object, agent: str) -> list[ImportedItem]:
+    """Convert a Claude assistant record's content into items.
+
+    Text becomes a single assistant message; ``tool_use`` blocks become
+    function_call items. ``thinking`` blocks and images are dropped.
+    """
+    if isinstance(content, str):
+        return [_assistant_message(content, agent)] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    items: list[ImportedItem] = []
+    text_parts: list[str] = []
+    for raw_block in content:
+        block = _as_record(raw_block)
+        if block is None:
+            continue
+        block_type = _as_str(block.get("type"))
+        if block_type == "text":
+            text = _as_str(block.get("text"))
+            if text and text.strip():
+                text_parts.append(text)
+        elif block_type == "tool_use":
+            call_id = _as_str(block.get("id"))
+            name = _as_str(block.get("name"))
+            if call_id and name:
+                arguments = json.dumps(block.get("input") or {}, separators=(",", ":"))
+                items.append(_function_call(agent, name, arguments, call_id))
+    joined = "\n".join(text_parts)
+    if joined:
+        items.insert(0, _assistant_message(joined, agent))
+    return items
+
+
+def parse_claude_lines(lines: Iterable[str]) -> list[ImportedItem]:
+    """Parse Claude Code transcript JSONL lines into Omnigent items.
+
+    :param lines: The transcript's lines (with or without trailing newlines).
+    :returns: Ordered conversation items (messages + tool calls).
+    """
+    items: list[ImportedItem] = []
+    latest_model: str | None = None
+    for line in lines:
+        record = _load_record(line)
+        if record is None:
+            continue
+        if record.get("isSidechain") is True or record.get("isMeta") is True:
+            continue
+        message = _as_record(record.get("message"))
+        if message is None:
+            continue
+        model = _as_str(message.get("model"))
+        if model:
+            latest_model = model
+        role = _as_str(message.get("role"))
+        content = message.get("content")
+        if role == "user":
+            items.extend(_claude_user_items(content))
+        elif role == "assistant":
+            items.extend(_claude_assistant_items(content, latest_model or CLAUDE))
+    return items
+
+
+# ── Codex rollout parsing ───────────────────────────────────────────────────
+
+
+# Codex response_item payload types that carry a tool call / its output. Both
+# the OpenAI function-tool shape and the freeform ``custom_tool_call`` shape
+# (e.g. ``apply_patch``, Codex's primary file-editing tool) are imported.
+_CODEX_CALL_TYPES = frozenset({"function_call", "custom_tool_call"})
+_CODEX_OUTPUT_TYPES = frozenset({"function_call_output", "custom_tool_call_output"})
+
+
+def parse_codex_lines(lines: Iterable[str]) -> list[ImportedItem]:
+    """Parse Codex rollout JSONL lines into Omnigent items.
+
+    Only ``response_item`` records carry conversation content. ``message``
+    payloads become user/assistant messages; ``function_call`` and
+    ``custom_tool_call`` (e.g. ``apply_patch``) become function_call items;
+    ``function_call_output`` and ``custom_tool_call_output`` become outputs.
+    ``session_meta`` / ``turn_context`` (structural), ``event_msg`` (a
+    duplicate of message response_items), ``reasoning``, ``developer`` /
+    ``system`` messages, and search-tool payloads (``tool_search_*`` /
+    ``web_search_*``) are skipped.
+
+    :param lines: The rollout's lines.
+    :returns: Ordered conversation items (messages + tool calls).
+    """
+    items: list[ImportedItem] = []
+    # call_ids of emitted calls whose output has not yet been seen, in order.
+    # Used to pair an output that omits its own call_id: Codex emits parallel
+    # tool calls as a burst followed by their outputs in matching order, so a
+    # FIFO pairs correctly where a single "most recent call" would not.
+    pending_call_ids: list[str] = []
+    for line in lines:
+        record = _load_record(line)
+        if record is None or _as_str(record.get("type")) != "response_item":
+            continue
+        payload = _as_record(record.get("payload"))
+        if payload is None:
+            continue
+        payload_type = _as_str(payload.get("type"))
+        if payload_type == "message":
+            text = _text_from_blocks(payload.get("content"), _TEXT_BLOCK_TYPES)
+            role = _as_str(payload.get("role"))
+            if not text:
+                continue
+            if role == "user":
+                items.append(_user_message(text))
+            elif role == "assistant":
+                items.append(_assistant_message(text, CODEX))
+        elif payload_type in _CODEX_CALL_TYPES:
+            name = _as_str(payload.get("name"))
+            call_id = _as_str(payload.get("call_id"))
+            if name and call_id:
+                # function_call carries JSON ``arguments``; custom_tool_call
+                # (e.g. apply_patch) carries a raw string ``input`` instead.
+                arguments = (
+                    _as_str(payload.get("arguments")) or _as_str(payload.get("input")) or "{}"
+                )
+                pending_call_ids.append(call_id)
+                items.append(_function_call(CODEX, name, arguments, call_id))
+        elif payload_type in _CODEX_OUTPUT_TYPES:
+            output = _stringify_output(payload.get("output"))
+            explicit = _as_str(payload.get("call_id"))
+            if explicit is not None:
+                call_id = explicit
+                if explicit in pending_call_ids:
+                    pending_call_ids.remove(explicit)
+            elif pending_call_ids:
+                call_id = pending_call_ids.pop(0)
+            else:
+                call_id = None
+            if output is not None and call_id:
+                items.append(_function_call_output(call_id, output))
+    return items
+
+
+# ── Detection, titling, and top-level entry points ──────────────────────────
+
+
+def detect_source(lines: Iterable[str]) -> str | None:
+    """Detect whether *lines* are a Claude or Codex transcript.
+
+    Scans records until one is decisive: a Codex rollout opens with a
+    ``session_meta`` record and wraps items under ``payload``; a Claude
+    transcript nests a ``message`` with a user/assistant role, or carries a
+    known Claude metadata ``type``.
+
+    :param lines: The transcript's lines.
+    :returns: ``"claude"``, ``"codex"``, or ``None`` when undetermined.
+    """
+    for line in lines:
+        record = _load_record(line)
+        if record is None:
+            continue
+        record_type = _as_str(record.get("type"))
+        if record_type == "session_meta":
+            return CODEX
+        if record_type in {"response_item", "turn_context", "event_msg"} and (
+            _as_record(record.get("payload")) is not None
+        ):
+            return CODEX
+        message = _as_record(record.get("message"))
+        if message is not None and _as_str(message.get("role")) in {"user", "assistant"}:
+            return CLAUDE
+        if record_type in _CLAUDE_METADATA_TYPES:
+            return CLAUDE
+    return None
+
+
+def _synthesize_title(text: str, *, limit: int = 60) -> str | None:
+    """Collapse whitespace and truncate *text* into a one-line title."""
+    collapsed = " ".join(text.split())
+    if not collapsed:
+        return None
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 1].rstrip() + "…"
+
+
+def _title_from_items(items: list[ImportedItem]) -> str | None:
+    """Derive a title from the first user message's text, if any."""
+    for item in items:
+        if item.item_type != "message" or item.data.get("role") != "user":
+            continue
+        text = _text_from_blocks(item.data.get("content"), frozenset({"input_text"}))
+        title = _synthesize_title(text)
+        if title:
+            return title
+    return None
+
+
+def parse_transcript(lines: Iterable[str], *, source: str = "auto") -> ParsedTranscript:
+    """Parse transcript *lines* into a :class:`ParsedTranscript`.
+
+    :param lines: The transcript's lines.
+    :param source: ``"claude"``, ``"codex"``, or ``"auto"`` (detect).
+    :returns: The parsed transcript with its items and a synthesized title.
+    :raises TranscriptImportError: When the format cannot be detected, the
+        source is unknown, or no importable items are found.
+    """
+    line_list = list(lines)
+    resolved = source
+    if resolved == "auto":
+        detected = detect_source(line_list)
+        if detected is None:
+            raise TranscriptImportError(
+                "could not detect transcript format; pass --source claude or --source codex"
+            )
+        resolved = detected
+    if resolved == CLAUDE:
+        items = parse_claude_lines(line_list)
+    elif resolved == CODEX:
+        items = parse_codex_lines(line_list)
+    else:
+        raise TranscriptImportError(
+            f"unknown source {source!r}; expected 'claude', 'codex', or 'auto'"
+        )
+    if not items:
+        raise TranscriptImportError("no importable messages or tool calls found in the transcript")
+    return ParsedTranscript(source=resolved, items=items, title=_title_from_items(items))
+
+
+def parse_transcript_file(path: Path, *, source: str = "auto") -> ParsedTranscript:
+    """Read and parse a transcript file.
+
+    :param path: Path to a Claude or Codex ``.jsonl`` transcript.
+    :param source: ``"claude"``, ``"codex"``, or ``"auto"`` (detect).
+    :returns: The parsed transcript.
+    :raises TranscriptImportError: On read failure or unparseable content.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as err:
+        raise TranscriptImportError(f"could not read transcript {path}: {err}") from err
+    return parse_transcript(text.splitlines(), source=source)
+
+
+def to_initial_items(items: list[ImportedItem]) -> list[dict[str, object]]:
+    """Render items as the ``initial_items`` payload for ``POST /v1/sessions``."""
+    return [{"type": item.item_type, "data": item.data} for item in items]

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -1,0 +1,321 @@
+"""Tests for the ``omnigent import`` CLI command.
+
+Exercise the command end-to-end with ``CliRunner``, stubbing the network seam
+(``omnigent.cli._host_http_json``) and server resolution — no live server. The
+parser itself is covered by ``tests/test_transcript_import.py``; here we verify
+the command's parse → resolve → list-agents → POST → report flow and its error
+handling.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from omnigent.cli import _HostHttpResult, cli
+
+
+def _write_claude_transcript(tmp_path: Path) -> Path:
+    """Write a small valid Claude transcript and return its path."""
+    path = tmp_path / "session.jsonl"
+    records = [
+        {"type": "user", "message": {"role": "user", "content": "inspect TODO.md"}},
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {"type": "text", "text": "Reading it."},
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "Read",
+                        "input": {"file_path": "TODO.md"},
+                    },
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "body"}],
+            },
+        },
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+def _fake_http(
+    calls: list[dict[str, Any]],
+    *,
+    agents_status: int = 200,
+    agents_body: Any = None,
+    create_status: int = 200,
+    create_body: Any = None,
+) -> Callable[..., _HostHttpResult]:
+    """Build a stub for ``_host_http_json`` that records calls and routes by path."""
+    resolved_agents = (
+        agents_body if agents_body is not None else {"data": [{"id": "ag_1", "name": "a"}]}
+    )
+    resolved_create = (
+        create_body if create_body is not None else {"id": "conv_abc", "object": "session"}
+    )
+
+    def fake(
+        *,
+        base_url: str,
+        method: str,
+        path: str,
+        params: Any = None,
+        json_body: Any = None,
+        timeout_s: float = 10.0,
+    ) -> _HostHttpResult:
+        calls.append(
+            {"method": method, "path": path, "json_body": json_body, "base_url": base_url}
+        )
+        if path == "/v1/agents":
+            return _HostHttpResult(status_code=agents_status, body=resolved_agents)
+        if path == "/v1/sessions":
+            return _HostHttpResult(status_code=create_status, body=resolved_create)
+        return _HostHttpResult(status_code=404, body={"detail": "unexpected path"})
+
+    return fake
+
+
+def _patch_server(monkeypatch: pytest.MonkeyPatch, url: str | None) -> None:
+    """Force server resolution to *url* (None = no server available)."""
+    monkeypatch.setattr("omnigent.cli._resolve_host_server", lambda _server: url)
+    monkeypatch.setattr("omnigent.cli.local_server_url_if_healthy", lambda: None)
+
+
+def test_import_dry_run_summarizes_without_network(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--dry-run`` parses and summarizes but makes no server calls."""
+    transcript = _write_claude_transcript(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http(calls))
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Parsed claude transcript: 2 messages, 1 tool calls, 1 tool outputs" in result.output
+    assert "Dry run" in result.output
+    assert calls == []
+
+
+def test_import_creates_session_and_reports_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A successful import lists agents, POSTs the history, and prints the id."""
+    transcript = _write_claude_transcript(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http(calls))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code == 0, result.output
+    assert "conv_abc" in result.output
+    paths = [c["path"] for c in calls]
+    assert paths == ["/v1/agents", "/v1/sessions"]
+
+    create = next(c for c in calls if c["path"] == "/v1/sessions")
+    body = create["json_body"]
+    assert body["agent_id"] == "ag_1"
+    assert body["labels"] == {"imported_from": "claude"}
+    assert body["title"] == "inspect TODO.md"
+    types = [item["type"] for item in body["initial_items"]]
+    assert types == ["message", "message", "function_call", "function_call_output"]
+    # The assistant/function items carry 'agent' (not the output-only 'model').
+    assert body["initial_items"][1]["data"]["agent"] == "claude-sonnet-4-6"
+    assert "model" not in body["initial_items"][1]["data"]
+
+
+def test_import_with_explicit_agent_skips_listing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--agent`` binds directly and avoids the GET /v1/agents lookup."""
+    transcript = _write_claude_transcript(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http(calls))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(
+        cli, ["import", str(transcript), "--server", "http://test.local", "--agent", "ag_explicit"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [c["path"] for c in calls] == ["/v1/sessions"]
+    create = next(c for c in calls if c["path"] == "/v1/sessions")
+    assert create["json_body"]["agent_id"] == "ag_explicit"
+
+
+def test_import_custom_title_and_source_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--title`` and ``--source`` override detection and the synthesized title."""
+    transcript = _write_claude_transcript(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http(calls))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "import",
+            str(transcript),
+            "--server",
+            "http://test.local",
+            "--source",
+            "claude",
+            "--title",
+            "My import",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    create = next(c for c in calls if c["path"] == "/v1/sessions")
+    assert create["json_body"]["title"] == "My import"
+
+
+def test_import_no_server_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With no --server and no configured/local server, the command fails loud."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http([]))
+    _patch_server(monkeypatch, None)
+
+    result = CliRunner().invoke(cli, ["import", str(transcript)])
+
+    assert result.exit_code != 0
+    assert "No server specified" in result.output
+
+
+def test_import_unparseable_transcript_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An undetectable transcript surfaces a clean error and no network call."""
+    path = tmp_path / "junk.jsonl"
+    path.write_text(json.dumps({"unrelated": "object"}) + "\n", encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http(calls))
+
+    result = CliRunner().invoke(cli, ["import", str(path), "--server", "http://test.local"])
+
+    assert result.exit_code != 0
+    assert "could not detect transcript format" in result.output
+    assert calls == []
+
+
+def test_import_server_error_surfaces(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A non-2xx create response surfaces the status and error text."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr(
+        "omnigent.cli._host_http_json",
+        _fake_http([], create_status=500, create_body={"detail": "boom"}),
+    )
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code != 0
+    assert "Import failed (500)" in result.output
+    assert "boom" in result.output
+
+
+def test_import_no_agents_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When the server has no agents and none is given, the command fails loud."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http([], agents_body={"data": []}))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code != 0
+    assert "No agents are registered" in result.output
+
+
+def test_import_multiple_agents_picks_first_with_warning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With several agents and no --agent, the first is bound and a warning shown."""
+    transcript = _write_claude_transcript(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "omnigent.cli._host_http_json",
+        _fake_http(calls, agents_body={"data": [{"id": "ag_1"}, {"id": "ag_2"}]}),
+    )
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code == 0, result.output
+    assert "Multiple agents available" in result.output
+    create = next(c for c in calls if c["path"] == "/v1/sessions")
+    assert create["json_body"]["agent_id"] == "ag_1"
+
+
+def test_import_agents_list_failure_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-200 GET /v1/agents surfaces a clean error with the --agent hint."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http([], agents_status=500))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code != 0
+    assert "Could not list agents" in result.output
+    assert "--agent" in result.output
+
+
+def test_import_success_without_id_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A 2xx create whose body lacks an id fails loud rather than printing junk."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr(
+        "omnigent.cli._host_http_json", _fake_http([], create_body={"object": "session"})
+    )
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code != 0
+    assert "returned no session id" in result.output
+
+
+def test_import_accepts_201_created(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A 201 Created response is treated as success (not only 200)."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http([], create_status=201))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner().invoke(cli, ["import", str(transcript), "--server", "http://test.local"])
+
+    assert result.exit_code == 0, result.output
+    assert "conv_abc" in result.output
+
+
+def test_import_bare_session_id_only_on_stdout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Only the bare session id reaches stdout; summaries go to stderr."""
+    transcript = _write_claude_transcript(tmp_path)
+    monkeypatch.setattr("omnigent.cli._host_http_json", _fake_http([]))
+    _patch_server(monkeypatch, "http://test.local")
+
+    result = CliRunner(mix_stderr=False).invoke(
+        cli, ["import", str(transcript), "--server", "http://test.local"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "conv_abc"
+    assert "Imported" in result.stderr

--- a/tests/test_transcript_import.py
+++ b/tests/test_transcript_import.py
@@ -1,0 +1,717 @@
+"""Unit tests for :mod:`omnigent.transcript_import`.
+
+These cover the Claude Code and Codex transcript parsers, format detection,
+title synthesis, and a contract test proving the produced item ``data`` shapes
+validate against the server-side conversation models (the ``agent`` vs ``model``
+wire invariant). All fixtures are inline JSONL strings — no live LLM, no server.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnigent.entities.conversation import NewConversationItem
+from omnigent.transcript_import import (
+    ImportedItem,
+    TranscriptImportError,
+    detect_source,
+    parse_claude_lines,
+    parse_codex_lines,
+    parse_transcript,
+    parse_transcript_file,
+    to_initial_items,
+)
+
+
+def _jsonl(*records: object) -> list[str]:
+    """Render records as JSONL lines (one JSON object per line)."""
+    return [json.dumps(record) for record in records]
+
+
+# ── Claude Code parsing ─────────────────────────────────────────────────────
+
+
+def test_parse_claude_messages_and_tool_calls() -> None:
+    """A full Claude turn maps to message + function_call + output items.
+
+    Proves the core mapping: user text, assistant text, ``tool_use`` →
+    ``function_call`` (with compact JSON ``arguments`` and ``id`` → ``call_id``),
+    and ``tool_result`` → ``function_call_output``. The assistant ``agent`` is
+    taken from ``message.model``.
+    """
+    lines = _jsonl(
+        {"type": "user", "message": {"role": "user", "content": "inspect TODO.md"}},
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {"type": "text", "text": "Reading it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "Read",
+                        "input": {"file_path": "TODO.md"},
+                    },
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": "TODO body"}
+                ],
+            },
+        },
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert [item.item_type for item in items] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    assert items[0].data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "inspect TODO.md"}],
+    }
+    assert items[1].data == {
+        "role": "assistant",
+        "agent": "claude-sonnet-4-6",
+        "content": [{"type": "output_text", "text": "Reading it."}],
+    }
+    assert items[2].data == {
+        "agent": "claude-sonnet-4-6",
+        "name": "Read",
+        "arguments": '{"file_path":"TODO.md"}',
+        "call_id": "toolu_1",
+    }
+    assert items[3].data == {"call_id": "toolu_1", "output": "TODO body"}
+
+
+def test_claude_skips_thinking_metadata_sidechain_and_scaffolding() -> None:
+    """Thinking blocks, metadata records, sidechains, and CLI scaffolding drop."""
+    lines = _jsonl(
+        {"type": "permission-mode", "mode": "default"},
+        {"type": "branch-update", "gitBranch": "feature/x"},
+        {"type": "summary", "summary": "..."},
+        {"message": {"role": "assistant", "model": "m"}, "isSidechain": True},
+        {"type": "user", "isMeta": True, "message": {"role": "user", "content": "<caveat>"}},
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "<command-name>/clear</command-name>"},
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "claude-x",
+                "content": [
+                    {"type": "thinking", "thinking": "secret"},
+                    {"type": "text", "text": "visible"},
+                    {"type": "image", "source": {"data": "..."}},
+                ],
+            },
+        },
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert len(items) == 1
+    assert items[0].item_type == "message"
+    assert items[0].data["content"] == [{"type": "output_text", "text": "visible"}]
+
+
+def test_claude_user_content_as_list_merges_text() -> None:
+    """A user record with a content list yields one merged user message."""
+    lines = _jsonl(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "line one"},
+                    {"type": "text", "text": "line two"},
+                ],
+            },
+        }
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert len(items) == 1
+    assert items[0].data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "line one\nline two"}],
+    }
+
+
+def test_claude_tool_result_list_content_extracts_text() -> None:
+    """A tool_result whose content is a block list extracts the text blocks."""
+    lines = _jsonl(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t9",
+                        "content": [
+                            {"type": "text", "text": "first"},
+                            {"type": "image", "source": {}},
+                            {"type": "text", "text": "second"},
+                        ],
+                    }
+                ],
+            },
+        }
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert items == [
+        ImportedItem("function_call_output", {"call_id": "t9", "output": "first\nsecond"})
+    ]
+
+
+def test_claude_assistant_string_content() -> None:
+    """An assistant record with string content yields one output_text message."""
+    lines = _jsonl(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "model": "m1", "content": "just text"},
+        }
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert items == [
+        ImportedItem(
+            "message",
+            {
+                "role": "assistant",
+                "agent": "m1",
+                "content": [{"type": "output_text", "text": "just text"}],
+            },
+        )
+    ]
+
+
+def test_claude_assistant_without_model_falls_back_to_claude_label() -> None:
+    """When no model id appears, the assistant agent label defaults to 'claude'."""
+    lines = _jsonl(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        }
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert items[0].data["agent"] == "claude"
+
+
+# ── Codex parsing ───────────────────────────────────────────────────────────
+
+
+def test_parse_codex_messages_and_tool_calls() -> None:
+    """A Codex rollout's response_items map to messages + tool calls."""
+    lines = _jsonl(
+        {"type": "session_meta", "payload": {"id": "019e", "cwd": "/r"}},
+        {"type": "turn_context", "payload": {"turn_id": "turn_1", "cwd": "/r"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "open TODO.md"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": '{"command":"cat TODO.md"}',
+                "call_id": "call_1",
+                "id": "fc_1",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call_output", "call_id": "call_1", "output": "body"},
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Done."}],
+            },
+        },
+    )
+
+    items = parse_codex_lines(lines)
+
+    assert [item.item_type for item in items] == [
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert items[0].data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "open TODO.md"}],
+    }
+    assert items[1].data == {
+        "agent": "codex",
+        "name": "shell",
+        "arguments": '{"command":"cat TODO.md"}',
+        "call_id": "call_1",
+    }
+    assert items[2].data == {"call_id": "call_1", "output": "body"}
+    assert items[3].data == {
+        "role": "assistant",
+        "agent": "codex",
+        "content": [{"type": "output_text", "text": "Done."}],
+    }
+
+
+def test_codex_skips_structural_reasoning_developer_and_event_msg() -> None:
+    """session_meta/turn_context/reasoning/developer/event_msg carry no items."""
+    lines = _jsonl(
+        {"type": "session_meta", "payload": {"id": "x"}},
+        {"type": "turn_context", "payload": {"turn_id": "t"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "<env>"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "reasoning", "summary": [], "encrypted_content": "zzz"},
+        },
+        {"type": "event_msg", "payload": {"type": "agent_message", "message": "dup"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "real"}],
+            },
+        },
+    )
+
+    items = parse_codex_lines(lines)
+
+    assert len(items) == 1
+    assert items[0].data["content"] == [{"type": "output_text", "text": "real"}]
+
+
+def test_codex_function_output_missing_call_id_pairs_positionally() -> None:
+    """A function_call_output without call_id pairs to the most recent call."""
+    lines = _jsonl(
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": "{}",
+                "call_id": "call_42",
+            },
+        },
+        {"type": "response_item", "payload": {"type": "function_call_output", "output": "stdout"}},
+    )
+
+    items = parse_codex_lines(lines)
+
+    assert items[1].data == {"call_id": "call_42", "output": "stdout"}
+
+
+def test_codex_function_call_missing_arguments_defaults_to_empty_object() -> None:
+    """A function_call without arguments still produces a valid item."""
+    lines = _jsonl(
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "noop", "call_id": "c1"},
+        }
+    )
+
+    items = parse_codex_lines(lines)
+
+    assert items[0].data == {"agent": "codex", "name": "noop", "arguments": "{}", "call_id": "c1"}
+
+
+# ── Detection, titling, and top-level entry points ──────────────────────────
+
+
+def test_detect_source_distinguishes_claude_and_codex() -> None:
+    """Detection keys off session_meta/payload (codex) vs message.role (claude)."""
+    codex = _jsonl({"type": "session_meta", "payload": {"id": "x"}})
+    claude_meta_first = _jsonl(
+        {"type": "permission-mode", "mode": "default"},
+        {"type": "user", "message": {"role": "user", "content": "hi"}},
+    )
+    assert detect_source(codex) == "codex"
+    assert detect_source(claude_meta_first) == "claude"
+    assert detect_source(_jsonl({"unrelated": "object"})) is None
+    assert detect_source([""]) is None
+
+
+def test_parse_transcript_auto_and_explicit_source() -> None:
+    """``auto`` detects; an explicit source skips detection."""
+    codex = _jsonl(
+        {"type": "session_meta", "payload": {"id": "x"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "q"}],
+            },
+        },
+    )
+    auto = parse_transcript(codex, source="auto")
+    explicit = parse_transcript(codex, source="codex")
+    assert auto.source == "codex"
+    assert explicit.source == "codex"
+    assert auto.items == explicit.items
+
+
+def test_parse_transcript_errors() -> None:
+    """Undetectable format, empty result, and unknown source all raise."""
+    with pytest.raises(TranscriptImportError, match="could not detect"):
+        parse_transcript(_jsonl({"unrelated": 1}), source="auto")
+    with pytest.raises(TranscriptImportError, match="no importable"):
+        parse_transcript(_jsonl({"type": "permission-mode"}), source="claude")
+    with pytest.raises(TranscriptImportError, match="unknown source"):
+        parse_transcript(
+            _jsonl({"type": "user", "message": {"role": "user", "content": "x"}}), source="bogus"
+        )
+
+
+def test_title_synthesized_from_first_user_message_and_truncated() -> None:
+    """The title comes from the first user message, collapsed and truncated."""
+    short = parse_transcript(
+        _jsonl({"type": "user", "message": {"role": "user", "content": "  hello   world  "}}),
+        source="claude",
+    )
+    assert short.title == "hello world"
+
+    long_text = "word " * 40
+    long = parse_transcript(
+        _jsonl({"type": "user", "message": {"role": "user", "content": long_text}}),
+        source="claude",
+    )
+    assert long.title is not None
+    assert len(long.title) == 60
+    assert long.title.endswith("…")
+
+
+def test_title_none_when_no_user_text() -> None:
+    """An assistant-only transcript has no synthesized title."""
+    parsed = parse_transcript(
+        _jsonl(
+            {"type": "assistant", "message": {"role": "assistant", "model": "m", "content": "hi"}}
+        ),
+        source="claude",
+    )
+    assert parsed.title is None
+
+
+def test_to_initial_items_shape_and_counts() -> None:
+    """``to_initial_items`` renders {type, data} dicts; counts are reported."""
+    parsed = parse_transcript(
+        _jsonl(
+            {"type": "user", "message": {"role": "user", "content": "q"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "model": "m",
+                    "content": [{"type": "tool_use", "id": "t", "name": "Run", "input": {}}],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "t", "content": "r"}],
+                },
+            },
+        ),
+        source="claude",
+    )
+    payload = to_initial_items(parsed.items)
+    assert all(set(item) == {"type", "data"} for item in payload)
+    assert payload[0] == {"type": "message", "data": parsed.items[0].data}
+    assert parsed.message_count == 1
+    assert parsed.tool_call_count == 1
+    assert parsed.tool_output_count == 1
+
+
+def test_parse_transcript_file_reads_and_parses(tmp_path: Path) -> None:
+    """``parse_transcript_file`` reads a .jsonl file and auto-detects format."""
+    path = tmp_path / "session.jsonl"
+    path.write_text(
+        "\n".join(_jsonl({"type": "user", "message": {"role": "user", "content": "from file"}}))
+        + "\n",
+        encoding="utf-8",
+    )
+    parsed = parse_transcript_file(path)
+    assert parsed.source == "claude"
+    assert parsed.title == "from file"
+
+
+def test_parse_transcript_file_missing_raises(tmp_path: Path) -> None:
+    """A missing file raises TranscriptImportError, not a bare OSError."""
+    with pytest.raises(TranscriptImportError, match="could not read"):
+        parse_transcript_file(tmp_path / "nope.jsonl")
+
+
+def test_malformed_lines_are_skipped_not_fatal() -> None:
+    """Blank and non-JSON lines are tolerated and skipped."""
+    lines = [
+        "",
+        "not json at all",
+        json.dumps({"type": "user", "message": {"role": "user", "content": "survived"}}),
+    ]
+    items = parse_claude_lines(lines)
+    assert len(items) == 1
+    assert items[0].data["content"] == [{"type": "input_text", "text": "survived"}]
+
+
+# ── Contract test: produced data validates against the server models ─────────
+
+
+def test_produced_items_validate_against_conversation_models() -> None:
+    """Every produced item's data validates as the server route builds it.
+
+    The route constructs ``NewConversationItem(type=..., data=item.data)`` on
+    the history-only seed path, which coerces ``data`` into the matching
+    ``ItemData`` model and enforces type↔data agreement. If this fails, the
+    importer would produce payloads the server rejects with a 422 — e.g. using
+    the output-only ``model`` alias instead of the required ``agent`` key.
+    """
+    claude = parse_transcript(
+        _jsonl(
+            {"type": "user", "message": {"role": "user", "content": "q"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-x",
+                    "content": [
+                        {"type": "text", "text": "a"},
+                        {"type": "tool_use", "id": "c1", "name": "Read", "input": {"p": 1}},
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "c1", "content": "o"}],
+                },
+            },
+        ),
+        source="claude",
+    )
+    for item in claude.items:
+        # Must not raise — mirrors omnigent/server/routes/sessions.py seed path.
+        NewConversationItem(type=item.item_type, response_id="seed", data=item.data)
+
+
+# ── Regression tests for review findings ────────────────────────────────────
+
+
+def test_codex_imports_custom_tool_call_apply_patch() -> None:
+    """custom_tool_call (apply_patch) and its output map to function items.
+
+    apply_patch is Codex's primary file-editing tool, encoded as a
+    custom_tool_call whose payload carries a raw string ``input`` (not JSON
+    ``arguments``). Dropping it would lose every edit a coding session made.
+    """
+    lines = _jsonl(
+        {"type": "session_meta", "payload": {"id": "x"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "apply_patch",
+                "input": "*** Begin Patch\n...",
+                "call_id": "c_patch",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "custom_tool_call_output", "call_id": "c_patch", "output": "ok"},
+        },
+    )
+
+    items = parse_codex_lines(lines)
+
+    assert [item.item_type for item in items] == ["function_call", "function_call_output"]
+    assert items[0].data == {
+        "agent": "codex",
+        "name": "apply_patch",
+        "arguments": "*** Begin Patch\n...",
+        "call_id": "c_patch",
+    }
+    assert items[1].data == {"call_id": "c_patch", "output": "ok"}
+
+
+def test_codex_list_shaped_output_keeps_pairing_with_placeholder() -> None:
+    """A list (image) tool output becomes a placeholder, never dropped.
+
+    Dropping it would orphan the preceding function_call (no matching output),
+    breaking rendering and any later resume.
+    """
+    lines = _jsonl(
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "view_image",
+                "arguments": "{}",
+                "call_id": "c_img",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "c_img",
+                "output": [{"type": "input_image", "image_url": "data:image/png;base64,AAAA"}],
+            },
+        },
+    )
+
+    items = parse_codex_lines(lines)
+
+    assert [item.item_type for item in items] == ["function_call", "function_call_output"]
+    assert items[1].data == {"call_id": "c_img", "output": "[non-text tool output omitted]"}
+
+
+def test_codex_parallel_call_burst_outputs_without_call_id_pair_fifo() -> None:
+    """Outputs lacking call_id pair to calls in FIFO order (parallel bursts)."""
+    lines = _jsonl(
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "a", "arguments": "{}", "call_id": "A"},
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "b", "arguments": "{}", "call_id": "B"},
+        },
+        {"type": "response_item", "payload": {"type": "function_call_output", "output": "out-a"}},
+        {"type": "response_item", "payload": {"type": "function_call_output", "output": "out-b"}},
+    )
+
+    outputs = [
+        item for item in parse_codex_lines(lines) if item.item_type == "function_call_output"
+    ]
+
+    assert outputs[0].data == {"call_id": "A", "output": "out-a"}
+    assert outputs[1].data == {"call_id": "B", "output": "out-b"}
+
+
+def test_codex_explicit_call_id_consumed_so_later_blank_output_pairs_next() -> None:
+    """An explicit call_id is consumed, so a later blank output pairs the next call."""
+    lines = _jsonl(
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "a", "arguments": "{}", "call_id": "A"},
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "b", "arguments": "{}", "call_id": "B"},
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call_output", "call_id": "A", "output": "out-a"},
+        },
+        {"type": "response_item", "payload": {"type": "function_call_output", "output": "out-b"}},
+    )
+
+    outputs = [
+        item for item in parse_codex_lines(lines) if item.item_type == "function_call_output"
+    ]
+
+    assert outputs[0].data == {"call_id": "A", "output": "out-a"}
+    assert outputs[1].data == {"call_id": "B", "output": "out-b"}
+
+
+def test_claude_whitespace_only_list_text_block_is_dropped() -> None:
+    """A whitespace-only text block in a content list yields no message."""
+    lines = _jsonl(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "m",
+                "content": [{"type": "text", "text": "   "}],
+            },
+        }
+    )
+    assert parse_claude_lines(lines) == []
+
+
+def test_claude_image_only_tool_result_uses_placeholder_not_base64() -> None:
+    """An image-only tool_result becomes a placeholder, never a base64 dump."""
+    lines = _jsonl(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t",
+                        "content": [{"type": "image", "source": {"data": "iVBORw0KGgo"}}],
+                    }
+                ],
+            },
+        }
+    )
+
+    items = parse_claude_lines(lines)
+
+    assert items == [
+        ImportedItem(
+            "function_call_output", {"call_id": "t", "output": "[non-text tool output omitted]"}
+        )
+    ]
+
+
+def test_detect_source_scans_past_non_decisive_first_record() -> None:
+    """A non-decisive first record is skipped to reach a decisive later one."""
+    codex = _jsonl({"foo": "bar"}, {"type": "session_meta", "payload": {"id": "x"}})
+    claude = _jsonl({"foo": "bar"}, {"type": "user", "message": {"role": "user", "content": "hi"}})
+    assert detect_source(codex) == "codex"
+    assert detect_source(claude) == "claude"
+
+
+def test_title_rstrip_drops_trailing_space_before_ellipsis() -> None:
+    """When the truncation cut lands just after a space, no ' …' dangles."""
+    text = ("x" * 58) + " tail words here"
+    parsed = parse_transcript(
+        _jsonl({"type": "user", "message": {"role": "user", "content": text}}),
+        source="claude",
+    )
+    assert parsed.title is not None
+    assert parsed.title.endswith("…")
+    assert not parsed.title.endswith(" …")
+    assert len(parsed.title) < 60


### PR DESCRIPTION
Closes #189.

## What

Adds **`omnigent import <transcript>`** — import an existing local **Claude Code** or **Codex** chat into an Omnigent server as a history-only session you can view (and later resume) in the web UI.

```bash
omnigent import ~/.claude/projects/-home-me-repo/<session-id>.jsonl
omnigent import ./rollout-<ts>-<thread-id>.jsonl --source codex
omnigent import chat.jsonl --server https://example.com --dry-run
```

Scope (agreed up front): **both sources**, **messages + tool calls** (reasoning/thinking, images, and harness metadata are skipped), delivered as a **CLI command that creates the session on a server**.

## How it works

- **`omnigent/transcript_import.py`** (new, pure/stdlib-only) — converts each format's JSONL into Omnigent conversation items:
  - Claude (`~/.claude/projects/<cwd>/<id>.jsonl`): nested `message.{role,content}`; `tool_use`→`function_call`, `tool_result`→`function_call_output`; skips thinking/images/metadata/sidechain/`isMeta`/CLI-scaffolding; labels the assistant with `message.model`.
  - Codex (`~/.codex/sessions/.../rollout-*.jsonl`): only `response_item` payloads; `function_call`/`function_call_output` **and** `custom_tool_call`/`custom_tool_call_output` (`apply_patch` — Codex's primary edit tool); skips `session_meta`/`turn_context`/`event_msg`/`reasoning`/`developer`/`system`.
  - Format is auto-detected (override with `--source`).
- **`omnigent/cli.py`** — the `import` command: parse locally → resolve server (`--server`/config/local) → bind an agent (`--agent`, else the server's first via `GET /v1/agents`) → `POST /v1/sessions` with `initial_items` (the no-runner **seed** path persists history directly). `--dry-run` summarizes without importing; the bare session id prints to **stdout** (summary/link to stderr) for scripting.

**Wire-shape correctness:** assistant/function items use the `agent` key — **not** the output-only `model` serialization alias, which the seed path's Pydantic validation rejects. A unit contract test builds `NewConversationItem` from every produced item to lock this.

## Testing

- `tests/test_transcript_import.py` — both parsers, detection, titling, edge cases (string vs list content, list-shaped tool output, parallel tool-call bursts, image-only results, whitespace), and the server-model contract test.
- `tests/cli/test_import.py` — `CliRunner` coverage of the full flow and every error/branch (dry-run, multi-agent pick + warning, agents-list failure, missing id, 200/201, no server, unparseable, stdout/stderr split).
- All green: `uv run --extra dev pytest tests/test_transcript_import.py tests/cli/test_import.py` (41 passed); `tests/cli` regression 583 passed. `ruff check`/`ruff format --check` clean; `mypy omnigent/transcript_import.py` clean (the module is in strict, `disallow_any_explicit` scope).

## Process note

Built with multi-agent orchestration (ultracode): a research pass to pin down the exact on-disk formats and server contract, then an adversarial review pass over the diff. The review caught and this PR fixes: Codex `apply_patch` (`custom_tool_call`) being dropped, list-shaped tool outputs orphaning their call, FIFO pairing for parallel tool-call bursts, base64-image bloat, and a stdout/stderr split for the scriptable id — each with a regression test.

## Out of scope (follow-ups)

Reasoning/thinking and image/file-attachment fidelity, a web-UI import button, and a server-side upload endpoint (this is a local-file CLI importer).
