### PR TITLE
fix(oss): clean-resolve the npm lockfile so the cooldown actually applies

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -154,10 +154,14 @@ jobs:
       # npm >= 11.10.0; node 20 ships npm 10.x, which silently ignores it.
       - name: Ensure npm honors the dependency cooldown
         run: npm install -g "npm@>=11.10.0"
+      # Delete package-lock.json so npm RESOLVES from scratch: min-release-age
+      # only filters candidates during resolution, and `--package-lock-only`
+      # keeps an existing in-range pin without re-applying the cooldown, so a
+      # too-fresh version already in the lock would survive a plain regen.
       - name: Regenerate lockfiles against public PyPI/npm
         run: |
           uv lock
-          ( cd ap-web && npm install --package-lock-only --no-audit --no-fund )
+          ( cd ap-web && rm -f package-lock.json && npm install --package-lock-only --no-audit --no-fund )
 
       # Mint the App installation token only AFTER `uv lock` so untrusted PR
       # build backends never see it, and never via the checkout (credentials

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -80,9 +80,18 @@ jobs:
       #    too fresh for the downstream JFrog mirror to serve.
       - name: Ensure npm honors the dependency cooldown
         run: npm install -g "npm@>=11.10.0"
+      # Delete the lockfile so npm RESOLVES from scratch. `min-release-age`
+      # only filters candidates during resolution; with an existing
+      # lockfile, `npm install --package-lock-only` keeps any pin that
+      # still satisfies package.json (it prints "up to date") and never
+      # re-applies the cooldown — so a too-fresh version already in the
+      # lock would survive. A clean resolve re-picks every dep to the
+      # newest version that clears the 7-day cooldown.
       - name: Regenerate package-lock.json
         working-directory: ap-web
-        run: npm install --package-lock-only --no-audit --no-fund
+        run: |
+          rm -f package-lock.json
+          npm install --package-lock-only --no-audit --no-fund
 
       # 3. Validate BEFORE committing: the Docker build is the real test that
       #    the regenerated locks + public registries produce a working image


### PR DESCRIPTION
## Summary

Follow-up to #195. The cooldown config landed, but a regen was still a **no-op**
for versions already pinned in the lockfile.

`min-release-age` only filters candidate versions during a *fresh resolution*.
`npm install --package-lock-only` keeps any existing pin that still satisfies
`package.json` (it prints "up to date") and never re-checks it against the
cooldown — so `postcss-selector-parser@7.1.2`, baked in by a pre-cooldown regen,
survived. (The smoke build stayed green because it installs from public npm,
where 7.1.2 is fine; the block is JFrog-mirror-only.)

**Fix:** delete `ap-web/package-lock.json` before regenerating, in both regen
workflows, so npm resolves from scratch and re-picks every dep to the newest
version that clears the 7-day cooldown.

**Verified:** dispatched the regen on this branch
([run 27581560042](https://github.com/omnigent-ai/omnigent/actions/runs/27581560042));
the regenerated lockfile pins `postcss-selector-parser@7.1.1` (was 7.1.2), with
no 7.1.2/7.1.3/7.1.4 remaining, and the Docker FE build + CLI smoke pass.

> A clean resolve re-picks the whole tree to newest-allowed versions, so the
> regenerated lockfile PR will have a larger diff than an incremental update —
> that is expected and is what makes the published lockfile fully respect the
> cooldown.
