### PR TITLE
fix(web): correct /model readout and group request-phase elicitations

### DIFF
--- a/ap-web/src/lib/blockStream.test.ts
+++ b/ap-web/src/lib/blockStream.test.ts
@@ -1450,6 +1450,34 @@ describe("BlockStream — elicitation", () => {
     expect(elic!.ctx.responseId).toBe("resp_1");
   });
 
+  it("stamps a REQUEST-phase elicitation with its own response id, not the prior turn's", () => {
+    // A follow-up REQUEST-phase ASK arrives BEFORE the next turn starts,
+    // so `state.responseId` still holds the previous turn's id. If the
+    // card inherited it, bubble grouping would fold the card into the last
+    // answer's bubble. Stamping a unique id keeps it standalone so the
+    // ChatPage reorder can lift the prompt above it.
+    const blocks = reduce([
+      { type: "response_created", response: makeResponse({ responseId: "resp_prev" }) },
+      { type: "text_delta", delta: "Previous answer." },
+      {
+        type: "elicitation_request",
+        elicitationId: "elic_req",
+        message: "Session cost passed the threshold. Continue?",
+        requestedSchema: {},
+        mode: "form",
+        phase: "request",
+        policyName: "session_cost_budget",
+        contentPreview: '{"role":"user","content":[{"type":"input_text","text":"Hi again"}]}',
+      },
+    ]);
+
+    const elic = blocks.find((b): b is ElicitationBlock => b.type === "elicitation");
+    expect(elic).toBeDefined();
+    expect(elic!.phase).toBe("request");
+    expect(elic!.ctx.responseId).toBe("elicit_elic_req");
+    expect(elic!.ctx.responseId).not.toBe("resp_prev");
+  });
+
   it("carries structured Codex command approval details", () => {
     const blocks = reduce([
       { type: "response_created", response: makeResponse({ responseId: "resp_cmd" }) },

--- a/ap-web/src/lib/blockStream.ts
+++ b/ap-web/src/lib/blockStream.ts
@@ -816,7 +816,20 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
       // `POST /v1/sessions/{id}/events {type: "approval"}`.
       yield {
         type: "elicitation",
-        ctx: ctx(state),
+        // A REQUEST-phase elicitation gates the user's prompt BEFORE any
+        // turn is forwarded, so no `response_start` has reset
+        // `state.responseId` — it still holds the PREVIOUS turn's response
+        // id. Left as-is, bubble grouping would fold this card into the
+        // prior assistant bubble (a follow-up "Hi again" ASK lands inside
+        // the last answer), defeating the ChatPage reorder that keeps the
+        // prompt above its card. Stamp a unique id off the elicitation so
+        // the card always forms its own standalone bubble. Other phases
+        // (tool_call) keep the active response id so the card renders
+        // inline with the turn that triggered it.
+        ctx:
+          event.phase === "request"
+            ? ctx(state, null, `elicit_${event.elicitationId}`)
+            : ctx(state),
         elicitationId: event.elicitationId,
         targetSessionId: event.targetSessionId,
         message: event.message,

--- a/ap-web/src/lib/renderItems.test.ts
+++ b/ap-web/src/lib/renderItems.test.ts
@@ -134,6 +134,40 @@ describe("buildBubbles — bubble grouping", () => {
     expect(bubble.stableKey).toBeUndefined();
   });
 
+  it("a REQUEST-phase elicitation with its own response id is a standalone bubble", () => {
+    // The blockStream stamps a unique response id on REQUEST-phase
+    // elicitations precisely so they do NOT fold into the previous turn's
+    // assistant bubble. With that distinct id, the card is its own
+    // elicitation-only bubble, which is what `isRequestElicitationBubble`
+    // (ChatPage) keys on to lift the prompt above it.
+    const blocks: AnyBlock[] = [
+      {
+        type: "text_done",
+        ctx: ctx({ itemId: "a1", responseId: "resp_prev" }),
+        fullText: "Previous answer.",
+        hasCodeBlocks: false,
+      },
+      {
+        type: "elicitation",
+        ctx: ctx({ itemId: null, responseId: "elicit_elic_req" }),
+        elicitationId: "elic_req",
+        message: "Continue?",
+        phase: "request",
+        policyName: "session_cost_budget",
+        contentPreview: "{}",
+        requestedSchema: {},
+        status: "pending",
+        response: null,
+      },
+    ];
+    const bubbles = buildBubbles(blocks, null);
+    expect(bubbles.length).toBe(2);
+    const answer = bubbles[0] as Extract<Bubble, { kind: "assistant" }>;
+    expect(answer.items.map((i) => i.kind)).toEqual(["text"]);
+    const card = bubbles[1] as Extract<Bubble, { kind: "assistant" }>;
+    expect(card.items.map((i) => i.kind)).toEqual(["elicitation"]);
+  });
+
   it("two response_ids produce two assistant bubbles in order", () => {
     const blocks: AnyBlock[] = [
       {

--- a/ap-web/src/pages/ChatPage.test.ts
+++ b/ap-web/src/pages/ChatPage.test.ts
@@ -14,7 +14,9 @@ import {
   dispatchInitialPrompt,
   isSessionSharedWithOthers,
   isUnboundCodingFork,
+  mergePendingBubbles,
   readOnlyReasonForSessionLabels,
+  reorderCommittedRequestElicitations,
   shouldSendInitialPrompt,
   shouldShowAuthorBadge,
   shouldShowWorkingIndicator,
@@ -329,6 +331,145 @@ describe("buildPendingBubbles", () => {
     ];
     // p.author ("bob") wins over the viewer's selfAuthor ("alice").
     expect(bubble.createdBy).toBe("bob@example.com");
+  });
+});
+
+// ── mergePendingBubbles ────────────────────────────────────────────────────
+
+// Shared bubble builders for the request-elicitation ordering tests.
+const userBubble = (id: string): Bubble => ({
+  kind: "user",
+  itemId: id,
+  content: [{ type: "input_text", text: id }],
+});
+const assistantText = (id: string): Bubble => ({
+  kind: "assistant",
+  responseId: id,
+  stableId: id,
+  lifecycle: "completed",
+  error: null,
+  items: [{ kind: "text", itemId: id, text: "hi", final: true }],
+});
+const elicitationBubble = (id: string, phase: string): Bubble => ({
+  kind: "assistant",
+  responseId: id,
+  stableId: id,
+  lifecycle: "completed",
+  error: null,
+  items: [
+    {
+      kind: "elicitation",
+      itemId: id,
+      elicitationId: id,
+      message: "Continue?",
+      phase,
+      policyName: "session_cost_budget",
+      contentPreview: "{}",
+      requestedSchema: {},
+      status: "pending",
+      response: null,
+    },
+  ],
+});
+const bubbleIds = (bubbles: Bubble[]): string[] =>
+  bubbles.map((b) => (b.kind === "user" ? b.itemId : b.kind === "assistant" ? b.stableId : ""));
+
+describe("mergePendingBubbles", () => {
+  it("appends pending bubbles at the end when nothing trails", () => {
+    const committed = [userBubble("u1"), assistantText("a1")];
+    const pending = [userBubble("pend_1")];
+    const merged = mergePendingBubbles(committed, pending);
+    expect(merged.map((b) => (b.kind === "assistant" ? b.stableId : b.itemId))).toEqual([
+      "u1",
+      "a1",
+      "pend_1",
+    ]);
+  });
+
+  it("returns committed unchanged when there are no pending bubbles", () => {
+    const committed = [userBubble("u1"), elicitationBubble("e1", "request")];
+    const merged = mergePendingBubbles(committed, []);
+    expect(merged).toBe(committed);
+  });
+
+  it("splices the pending prompt ABOVE a trailing request-phase elicitation card", () => {
+    // The bug: a REQUEST-phase ASK parks the user message server-side, so
+    // it stays an optimistic pending bubble while its card arrives as a
+    // committed bubble — appending after the card would show the approval
+    // prompt above the message that triggered it.
+    const committed = [assistantText("a1"), elicitationBubble("e1", "request")];
+    const pending = [userBubble("pend_1")];
+    const merged = mergePendingBubbles(committed, pending);
+    expect(merged.map((b) => (b.kind === "assistant" ? b.stableId : b.itemId))).toEqual([
+      "a1",
+      "pend_1",
+      "e1",
+    ]);
+  });
+
+  it("splices above a run of multiple trailing request-phase elicitations", () => {
+    const committed = [elicitationBubble("e1", "request"), elicitationBubble("e2", "request")];
+    const pending = [userBubble("pend_1")];
+    const merged = mergePendingBubbles(committed, pending);
+    expect(merged.map((b) => (b.kind === "assistant" ? b.stableId : b.itemId))).toEqual([
+      "pend_1",
+      "e1",
+      "e2",
+    ]);
+  });
+
+  it("does NOT reorder for a tool_call-phase elicitation (message already committed)", () => {
+    // A tool_call ASK fires after the user message is committed into the
+    // timeline, so the trailing append is correct — only request-phase
+    // cards need the prompt lifted above them.
+    const committed = [userBubble("u1"), elicitationBubble("e1", "tool_call")];
+    const pending = [userBubble("pend_1")];
+    const merged = mergePendingBubbles(committed, pending);
+    expect(merged.map((b) => (b.kind === "assistant" ? b.stableId : b.itemId))).toEqual([
+      "u1",
+      "e1",
+      "pend_1",
+    ]);
+  });
+});
+
+// ── reorderCommittedRequestElicitations ─────────────────────────────────────
+
+describe("reorderCommittedRequestElicitations", () => {
+  it("swaps an approved request card below the user message it gated", () => {
+    // After approval the parked message is consumed into `blocks` AFTER
+    // the card, giving [card, message]. The card must drop below the
+    // prompt that triggered it.
+    const committed = [elicitationBubble("e1", "request"), userBubble("u1")];
+    expect(bubbleIds(reorderCommittedRequestElicitations(committed))).toEqual(["u1", "e1"]);
+  });
+
+  it("keeps the card between the prompt and the assistant response", () => {
+    const committed = [
+      assistantText("a0"),
+      elicitationBubble("e1", "request"),
+      userBubble("u1"),
+      assistantText("a1"),
+    ];
+    expect(bubbleIds(reorderCommittedRequestElicitations(committed))).toEqual([
+      "a0",
+      "u1",
+      "e1",
+      "a1",
+    ]);
+  });
+
+  it("leaves a lone request card (declined / still pending) untouched and returns same ref", () => {
+    const committed = [assistantText("a0"), elicitationBubble("e1", "request")];
+    const result = reorderCommittedRequestElicitations(committed);
+    expect(result).toBe(committed);
+  });
+
+  it("does NOT reorder a tool_call-phase card followed by a user message", () => {
+    const committed = [elicitationBubble("e1", "tool_call"), userBubble("u1")];
+    const result = reorderCommittedRequestElicitations(committed);
+    expect(result).toBe(committed);
+    expect(bubbleIds(result)).toEqual(["e1", "u1"]);
   });
 });
 

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -224,6 +224,70 @@ export function buildPendingBubbles(
   });
 }
 
+// A committed bubble that exists ONLY to render one or more
+// REQUEST-phase policy elicitation cards. A REQUEST-phase ASK parks the
+// user message server-side (it is not persisted / consumed until the
+// human approves — POLICIES.md §7.2), so the message lingers as an
+// optimistic pending bubble (and later a consumed committed bubble) while
+// its elicitation card arrives as a standalone committed assistant
+// bubble. Used by `mergePendingBubbles` and
+// `reorderCommittedRequestElicitations` to keep the prompt above the card
+// that asks about it, both before and after approval.
+function isRequestElicitationBubble(bubble: Bubble): boolean {
+  return (
+    bubble.kind === "assistant" &&
+    bubble.items.length > 0 &&
+    bubble.items.every((it) => it.kind === "elicitation" && it.phase === "request")
+  );
+}
+
+// Pull a committed REQUEST-phase elicitation card below the user message
+// it gated.
+//
+// Once a REQUEST-phase ASK is approved, the parked user message is
+// consumed and appended to `blocks` — but AFTER the elicitation card,
+// which arrived (and committed) while the message was still parked
+// server-side. The committed order is therefore [card, message], so the
+// approved card would sit ABOVE the prompt that triggered it. Swap each
+// such card with the user bubble that immediately follows it so the
+// prompt stays on top, matching the pre-approval pending layout
+// (`mergePendingBubbles`). A card with no following user bubble (declined
+// / still pending) is left untouched. Returns the input array unchanged
+// (same reference) when no swap applies, so the memo stays stable.
+export function reorderCommittedRequestElicitations(committed: Bubble[]): Bubble[] {
+  let result: Bubble[] | null = null;
+  for (let i = 0; i < committed.length - 1; i += 1) {
+    if (isRequestElicitationBubble(committed[i]!) && committed[i + 1]!.kind === "user") {
+      if (result === null) result = [...committed];
+      const card = result[i]!;
+      result[i] = result[i + 1]!;
+      result[i + 1] = card;
+    }
+  }
+  return result ?? committed;
+}
+
+// Place optimistic pending user bubbles into the committed timeline.
+//
+// Pending sends normally trail everything (the input should be visible
+// immediately, and they migrate into `blocks` once their
+// `session.input.consumed` event lands). The exception is a REQUEST-phase
+// policy ASK: that message never gets a consumed event until approval, so
+// it stays pending while its elicitation card renders as a committed
+// bubble — appending the pending bubble after the card would show the
+// approval prompt ABOVE the message that triggered it. When the timeline
+// ends in a run of such request-elicitation bubbles, splice the pending
+// bubbles in just before that run so the prompt stays on top.
+export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bubble[] {
+  if (pending.length === 0) return committed;
+  let insertAt = committed.length;
+  while (insertAt > 0 && isRequestElicitationBubble(committed[insertAt - 1]!)) {
+    insertAt -= 1;
+  }
+  if (insertAt === committed.length) return [...committed, ...pending];
+  return [...committed.slice(0, insertAt), ...pending, ...committed.slice(insertAt)];
+}
+
 // Whether a user bubble should carry the author's avatar badge (and the
 // author-tinted background): only in a shared session, only when a human
 // author is attached (agent/tool/system output and pre-attribution
@@ -449,18 +513,25 @@ export function ChatPage() {
   // active bubble, reusing the finalized prefix by reference.
   const bubbleCacheRef = useRef<BubbleCache>(createBubbleCache());
   const bubbles = useMemo<Bubble[]>(() => {
-    const committed = buildBubbles(
-      blocks,
-      activeResponse,
-      bubbleCacheRef.current,
-      interruptedResponseIds,
+    // A REQUEST-phase elicitation card commits before the user message it
+    // gates: while pending, the message is an optimistic trailing bubble
+    // (`mergePendingBubbles` lifts it above the card); once approved, the
+    // consumed message lands in `blocks` AFTER the card
+    // (`reorderCommittedRequestElicitations` swaps the card below it).
+    // Both keep the prompt on top across the pending → approved flip.
+    const committed = reorderCommittedRequestElicitations(
+      buildBubbles(blocks, activeResponse, bubbleCacheRef.current, interruptedResponseIds),
     );
     // claude-native live previews are NOT trailing bubbles — they live in
     // `blocks` as provisional `live:*` text blocks at their streamed
     // position (see chatStore), so they render in-order with later tool /
-    // elicitation cards. Only the optimistic pending user message trails.
+    // elicitation cards. The optimistic pending user message trails too,
+    // except when the timeline ends in a REQUEST-phase elicitation card.
     if (pendingUserMessages.length === 0) return committed;
-    return [...committed, ...buildPendingBubbles(pendingUserMessages, getCurrentAuthorId())];
+    return mergePendingBubbles(
+      committed,
+      buildPendingBubbles(pendingUserMessages, getCurrentAuthorId()),
+    );
   }, [blocks, activeResponse, interruptedResponseIds, pendingUserMessages]);
 
   // Picker selection. ChatPage stays mounted across `/` to `/c/:id`,
@@ -2677,9 +2748,9 @@ export function Composer({
         if (!showModel) return false;
         const target = arg.trim();
         if (!target) {
-          const { selectedModel, llmModel } = useChatStore.getState();
-          const current = selectedModel
-            ? `${selectedModel} (override)`
+          const { sessionModelOverride, llmModel } = useChatStore.getState();
+          const current = sessionModelOverride
+            ? `${sessionModelOverride} (override)`
             : (llmModel ?? "agent default");
           setCommandError(`Model: ${current}\nUsage: /model <name> · /model default to reset`);
           return true;
@@ -2703,9 +2774,9 @@ export function Composer({
       }
       case "/context": {
         const state = useChatStore.getState();
-        const { contextWindow, llmModel, selectedModel, tokensUsed, blocks } = state;
+        const { contextWindow, llmModel, sessionModelOverride, tokensUsed, blocks } = state;
         const lines: string[] = [];
-        if (selectedModel) lines.push(`Model: ${selectedModel} (override)`);
+        if (sessionModelOverride) lines.push(`Model: ${sessionModelOverride} (override)`);
         else if (llmModel) lines.push(`Model: ${llmModel}`);
         // contextWindow > 0 keeps a zero window out of the division (0/0 → "NaN%").
         if (tokensUsed != null && contextWindow != null && contextWindow > 0) {

--- a/ap-web/src/store/chatStore.test.ts
+++ b/ap-web/src/store/chatStore.test.ts
@@ -4710,6 +4710,58 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     const state = useChatStore.getState();
     expect(state.selectedEffort).toBe("low");
     expect(state.selectedModel).toBe("claude-sonnet-4-6");
+    // The server override is the session truth shown by `/model`.
+    expect(state.sessionModelOverride).toBe("claude-sonnet-4-6");
+  });
+
+  it("does NOT surface an unapplied sticky model as the session override (custom session)", async () => {
+    // Regression: a fresh non-claude-native session inherits the global
+    // sticky pick into `selectedModel`, but the pick is NOT applied
+    // server-side. `/model` reads `sessionModelOverride`, which must stay
+    // null so the readout shows "agent default" rather than a bogus
+    // "(override)". See ChatPage `/model` and `/context` readouts.
+    seedSession("conv_sticky_custom", []);
+    withSnapshot("conv_sticky_custom", { labels: {} });
+
+    useChatStore.setState({ selectedModel: "claude-sonnet-4-6", sessionModelOverride: null });
+    await useChatStore.getState().switchTo("conv_sticky_custom");
+
+    const patches = patchCallsFor("conv_sticky_custom");
+    expect(patches.some((p) => "model_override" in p)).toBe(false);
+
+    const state = useChatStore.getState();
+    // Sticky pick preserved for cross-session restore...
+    expect(state.selectedModel).toBe("claude-sonnet-4-6");
+    // ...but it is NOT the session's active override.
+    expect(state.sessionModelOverride).toBeNull();
+  });
+
+  it("surfaces the applied sticky model as the session override (claude-native)", async () => {
+    // The claude-native handoff persists the sticky model, so it IS the
+    // session's active override — `/model` should show it.
+    seedSession("conv_sticky_cn", []);
+    withSnapshot("conv_sticky_cn", { labels: { "omnigent.wrapper": "claude-code-native-ui" } });
+
+    useChatStore.setState({ selectedModel: "claude-opus-4-7", sessionModelOverride: null });
+    await useChatStore.getState().switchTo("conv_sticky_cn");
+
+    expect(patchCallsFor("conv_sticky_cn")).toEqual(
+      expect.arrayContaining([{ model_override: "claude-opus-4-7", silent: true }]),
+    );
+    expect(useChatStore.getState().sessionModelOverride).toBe("claude-opus-4-7");
+  });
+
+  it("does NOT surface a non-Claude sticky model as the session override (claude-native)", async () => {
+    // The handoff skips a non-Claude sticky pick (Claude Code can't run
+    // it), so it never becomes the session override.
+    seedSession("conv_sticky_gpt", []);
+    withSnapshot("conv_sticky_gpt", { labels: { "omnigent.wrapper": "claude-code-native-ui" } });
+
+    useChatStore.setState({ selectedModel: "gpt-5.4", sessionModelOverride: null });
+    await useChatStore.getState().switchTo("conv_sticky_gpt");
+
+    expect(patchCallsFor("conv_sticky_gpt").some((p) => "model_override" in p)).toBe(false);
+    expect(useChatStore.getState().sessionModelOverride).toBeNull();
   });
 });
 

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -274,6 +274,17 @@ export interface ChatState {
    */
   selectedModel: string | null;
   /**
+   * The active session's REAL model override (server ``model_override``):
+   * what the next turn actually uses, ``null`` when none and the agent
+   * ``llmModel`` default applies. Session-scoped (NOT a sticky pick):
+   * hydrated from the session snapshot on bind and kept in sync on
+   * ``setModel`` / terminal ``/model`` switches. Distinct from
+   * ``selectedModel`` (a single global sticky pick kept for cross-session
+   * restore) so the ``/model`` readout never shows an unapplied sticky
+   * pick as an active "(override)".
+   */
+  sessionModelOverride: string | null;
+  /**
    * Per-session cost-control switch for the active session: ``"on"``
    * activates the spec's configured cost-control mode, ``"off"``
    * disables cost control, ``null`` defers to the spec default.
@@ -643,6 +654,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   conversationLoadError: null,
   selectedEffort: loadPickerPref(PICKER_PREF_EFFORT_KEY),
   selectedModel: loadPickerPref(PICKER_PREF_MODEL_KEY),
+  sessionModelOverride: null,
   costControlModeOverride: null,
   hasMoreHistory: false,
   loadingMoreHistory: false,
@@ -1119,7 +1131,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
         sessionHarness: null,
         // ``selectedEffort`` / ``selectedModel`` are sticky user picks —
         // not reset here so a CLI-created new chat inherits them.
-        // The cost switch IS session-scoped, so it resets with the session.
+        // ``sessionModelOverride`` and the cost switch ARE session-scoped,
+        // so they reset with the session and re-hydrate from the snapshot.
+        sessionModelOverride: null,
         costControlModeOverride: null,
         contextWindow: null,
         tokensUsed: null,
@@ -1225,7 +1239,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   setModel: async (model) => {
-    set({ selectedModel: model });
+    // `selectedModel` is the sticky pick; `sessionModelOverride` is this
+    // session's applied override. An explicit `/model` sets both.
+    set({ selectedModel: model, sessionModelOverride: model });
     savePickerPref(PICKER_PREF_MODEL_KEY, model);
     const { conversationId } = get();
     if (conversationId) {
@@ -1233,7 +1249,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Server-canonical may differ from the optimistic write (e.g.
       // when a clear alias was sent) — refresh local state to match.
       const canonical = session.modelOverride ?? null;
-      set({ selectedModel: canonical });
+      set({ selectedModel: canonical, sessionModelOverride: canonical });
       savePickerPref(PICKER_PREF_MODEL_KEY, canonical);
     }
   },
@@ -1484,6 +1500,7 @@ function sessionBindingPatch(
   | "boundAgentId"
   | "boundAgentName"
   | "llmModel"
+  | "sessionModelOverride"
   | "sessionHarness"
   | "costControlModeOverride"
   | "contextWindow"
@@ -1498,6 +1515,7 @@ function sessionBindingPatch(
     boundAgentId: session.agentId,
     boundAgentName: session.agentName,
     llmModel: session.llmModel ?? null,
+    sessionModelOverride: session.modelOverride ?? null,
     sessionHarness: session.harness ?? null,
     costControlModeOverride: session.costControlModeOverride ?? null,
     contextWindow: session.contextWindow ?? null,
@@ -1629,6 +1647,29 @@ async function bindStream(
     const effectiveModel = isClaudeNativeSession
       ? (session.modelOverride ?? stickyModel)
       : stickyModel;
+    // Whether the claude-native handoff below is about to persist the
+    // sticky model as this session's override. Only hand over a
+    // Claude-compatible model: `selectedModel` is a single global pick
+    // shared across harnesses, so it can hold a foreign default (e.g. a
+    // Codex session sitting on `gpt-5.4`). Applying that here would
+    // persist model_override=gpt-5.4 and launch Claude Code with
+    // `--model gpt-5.4`, which it cannot run. When the sticky pick isn't
+    // a Claude model we skip the handoff and let the session fall back to
+    // the agent's own Claude default.
+    const willApplyStickyModel =
+      !isSubAgentSession &&
+      isClaudeNativeSession &&
+      session.modelOverride == null &&
+      stickyModel != null &&
+      isClaudeNativeModel(stickyModel);
+    // The session's REAL effective override: the server's stored value,
+    // plus the sticky model the handoff is about to apply. Unlike
+    // `effectiveModel`/`selectedModel` (which hold the unapplied sticky
+    // pick for non-CN sessions), this is the session truth the `/model`
+    // readout shows, so a non-applied sticky pick is never mislabeled as
+    // an active "(override)".
+    const effectiveSessionOverride =
+      session.modelOverride ?? (willApplyStickyModel ? stickyModel : null);
     if (
       !isSubAgentSession &&
       canApplyEffort &&
@@ -1640,20 +1681,7 @@ async function bindStream(
         console.warn(`Failed to apply sticky effort=${stickyEffort} to session ${id}:`, err);
       });
     }
-    if (
-      !isSubAgentSession &&
-      isClaudeNativeSession &&
-      session.modelOverride == null &&
-      stickyModel != null &&
-      // Only hand over a Claude-compatible model. `selectedModel` is a
-      // single global pick shared across harnesses, so it can hold a
-      // foreign default (e.g. a Codex session sitting on `gpt-5.4`).
-      // Applying that here would persist model_override=gpt-5.4 and launch
-      // Claude Code with `--model gpt-5.4`, which it cannot run. When the
-      // sticky pick isn't a Claude model we skip the handoff and let the
-      // session fall back to the agent's own Claude default.
-      isClaudeNativeModel(stickyModel)
-    ) {
+    if (willApplyStickyModel) {
       updateSession(id, { modelOverride: stickyModel, silent: true }).catch((err: unknown) => {
         console.warn(`Failed to apply sticky model=${stickyModel} to session ${id}:`, err);
       });
@@ -1811,6 +1839,10 @@ async function bindStream(
         sessionStatus: session.status,
         selectedEffort: effectiveEffort,
         selectedModel: effectiveModel,
+        // Session truth for the `/model` readout — overrides the snapshot
+        // value spread via `...bindingPatch` so the claude-native sticky
+        // handoff (fired above, silent) shows immediately.
+        sessionModelOverride: effectiveSessionOverride,
         tokensUsed: session.lastTotalTokens ?? null,
         sessionCostUsd: session.totalCostUsd ?? null,
         sessionUsageByModel: session.usageByModel ?? null,
@@ -3208,7 +3240,10 @@ export function handleSessionEvent(event: StreamEvent): void {
       // persisted `model_override`, so a reload restores it; the
       // cross-session sticky pref is intentionally left untouched (a
       // terminal switch is a per-session choice, not a new default).
-      useChatStore.setState({ selectedModel: event.model });
+      useChatStore.setState({
+        selectedModel: event.model,
+        sessionModelOverride: event.model,
+      });
       return;
     case "session_presence":
       // Full-state replacement — every presence event carries the


### PR DESCRIPTION
## Summary

Two independent web-UI fixes, both verified against the running local server.

### 1. `/model` readout no longer shows an unapplied sticky pick as an active override
`selectedModel` is a single **global sticky pick** kept for cross-session restore. For non-claude-native sessions (e.g. **polly** on the `claude-sdk` harness) it is **not** applied to the session, yet the `/model` and `/context` readouts displayed it as `X (override)`. Result: a brand-new session reported a stale model (`claude-sonnet-4-6 (override)`) that wasn't actually in effect — the session was really running the agent default.

**Fix:** add a session-scoped `sessionModelOverride` (the server `model_override` truth) — hydrated from the session snapshot, reset on bind, and synced on `setModel` / terminal `/model` switches — and base the `/model` and `/context` readouts on it. A fresh session with no real override now shows `agent default`. The sticky `selectedModel` and the claude-native auto-apply behavior are unchanged.

### 2. REQUEST-phase elicitations form their own standalone bubble
A REQUEST-phase ASK gates the user's prompt **before** any turn is forwarded, so no `response_start` has reset the response id — the elicitation card would fold into the previous assistant bubble. Stamp a unique id off the elicitation id so the card always forms its own bubble, and keep the pending prompt above its gating card via `reorderCommittedRequestElicitations` / `mergePendingBubbles`. Other phases (`tool_call`) keep the active response id and render inline.

## Testing
- `npm run build` (`tsc -b && vite build`) — clean
- Affected suites: **427 passing** (`chatStore`, `ChatPage`, `blockStream`, `renderItems`)