### PR TITLE
fix(oss): add READMEs to SDK packages so twine check --strict passes

### DIFF
--- a/sdks/python-client/README.md
+++ b/sdks/python-client/README.md
@@ -1,0 +1,20 @@
+# omnigent-client
+
+Python client SDK for the [omnigent](https://github.com/omnigent-ai/omnigent)
+server API.
+
+`omnigent-client` is a typed client for driving omnigent sessions over the
+server's HTTP + SSE API — creating sessions, sending turns, and streaming
+responses. It shares the `StreamEvent` / `SessionStreamEventType` types that the
+server emits, so streamed envelopes are validated against a single source of
+truth.
+
+It is released in lockstep with the core `omnigent` package at a matching
+version:
+
+```bash
+pip install omnigent-client
+```
+
+See the [omnigent repository](https://github.com/omnigent-ai/omnigent) for full
+documentation.

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "omnigent-client"
 version = "0.1.0"
 description = "Python client SDK for the omnigent server API"
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     # Sibling package — provides the SessionStreamEventType /

--- a/sdks/ui/README.md
+++ b/sdks/ui/README.md
@@ -1,0 +1,15 @@
+# omnigent-ui-sdk
+
+Terminal UI components (Rich + prompt_toolkit) for building
+[omnigent](https://github.com/omnigent-ai/omnigent) frontends.
+
+`omnigent-ui-sdk` provides the reusable rendering and input building blocks used
+by the omnigent CLI to display streaming agent output in the terminal. It is
+released in lockstep with the core `omnigent` package at a matching version:
+
+```bash
+pip install omnigent-ui-sdk
+```
+
+See the [omnigent repository](https://github.com/omnigent-ai/omnigent) for full
+documentation.

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "omnigent-ui-sdk"
 version = "0.1.0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     # Version-locked (==) with the sibling client SDK; released together


### PR DESCRIPTION
## Summary

The secure-release build runs `twine check --strict`, which fails the two SDK
packages because they declare no long description:

```
omnigent          → PASSED
omnigent-client   → FAILED: `long_description` missing
omnigent-ui-sdk   → FAILED: `long_description` missing
```

The core `omnigent` package passes because it sets `readme = "README.md"`; the
two SDKs never did. Add a real `README.md` to each SDK and point `readme` at it,
so they build with a long description (and get a proper rendered page on PyPI).

**Verified:** built both SDKs and ran `twine check --strict` — all four
distributions PASS.

This unblocks the secure-publishing pipeline (the npm cooldown work in #195 /
#198 / #199 cleared the earlier JFrog 403; this clears the next gate).
