### PR TITLE
feat(cursor): register CURSOR_API_KEY via omnigent setup

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7631,50 +7631,99 @@ def _manage_harness_providers(family: str) -> None:
 
 
 def _manage_cursor_harness() -> None:
-    """Run the level-2 loop for Cursor: install hint, then sign in / out.
+    """Run the level-2 loop for Cursor: manage its ``CURSOR_API_KEY``.
 
-    Cursor authenticates against its own backend (``cursor-agent login`` /
-    ``CURSOR_API_KEY``), so it has no provider/gateway credential — this drives
-    the CLI's own auth, not the provider menu. An uninstalled CLI shows the
-    install command (curl installer, not npm) and returns; otherwise the loop
-    toggles sign-in / sign-out, confirming each via the CLI's status.
+    Cursor runs via the ``cursor-sdk`` package and authenticates against
+    Cursor's own backend with a ``CURSOR_API_KEY`` — the SDK requires one (a
+    ``cursor-agent login`` does not apply, and cursor has no provider/gateway
+    family). So this manages exactly that credential: set / replace / remove an
+    API key stored in the omnigent secret store, mirroring how the other
+    harnesses persist their api keys (the secret in the store, a
+    ``keychain:``/``env:`` reference in ``~/.omnigent/config.yaml``).
+
+    :returns: None. Side effects: may write the ``cursor:`` block of
+        ``~/.omnigent/config.yaml`` and the secret store.
     """
-    from omnigent.onboarding.harness_install import (
-        CURSOR_KEY,
-        harness_cli_installed,
-        harness_cli_logged_in,
-        harness_install_spec,
-        harness_login,
-        harness_logout,
-    )
-    from omnigent.onboarding.interactive import console, select
-
-    if not harness_cli_installed(CURSOR_KEY):
-        spec = harness_install_spec(CURSOR_KEY)
-        hint = spec.install_hint if spec is not None else None
-        console.print(
-            "  Cursor's CLI (`cursor-agent`) isn't installed. Install it with:\n"
-            f"    [bold]{hint}[/bold]\n"
-            "  then re-open setup to sign in (or set CURSOR_API_KEY)."
-        )
-        return
+    from omnigent.onboarding import secrets as secret_store
+    from omnigent.onboarding.cursor_auth import cursor_api_key_configured, cursor_api_key_ref
+    from omnigent.onboarding.interactive import select
 
     status: str | None = None
     while True:
-        logged_in = harness_cli_logged_in(CURSOR_KEY)
-        action = "Sign out (cursor-agent logout)" if logged_in else "Sign in (cursor-agent login)"
-        idx = select(
-            "Cursor — " + ("signed in" if logged_in else "not signed in"),
-            [action, "← Back"],
-            clear_on_exit=True,
-            status=status,
-        )
-        if idx < 0 or idx == 1:  # Esc / q / Back
+        config = _load_global_config()
+        key_set = cursor_api_key_configured(config)
+
+        rows: list[_HarnessMenuRow] = [
+            _HarnessMenuRow(
+                "Replace API key (CURSOR_API_KEY)" if key_set else "Set API key (CURSOR_API_KEY)",
+                action="set_key",
+            )
+        ]
+        if key_set:
+            rows.append(_HarnessMenuRow("Remove API key", action="remove_key"))
+        rows.append(_HarnessMenuRow("← Back", action="back"))
+
+        header = "Cursor — API key configured" if key_set else "Cursor — no API key yet"
+        idx = select(header, [r.label for r in rows], clear_on_exit=True, status=status)
+        if idx < 0:  # Esc / q
             return
-        if logged_in:
-            status = "Signed out" if harness_logout(CURSOR_KEY) else "Sign-out did not complete"
-        else:
-            status = "✓ Signed in" if harness_login(CURSOR_KEY) else "Sign-in did not complete"
+        action = rows[idx].action
+        if action == "back":
+            return
+        if action == "set_key":
+            status = _set_cursor_api_key()
+        elif action == "remove_key":
+            ref = cursor_api_key_ref(config)
+            # Only a keychain-stored secret is ours to delete; an ``env:`` ref
+            # points at the user's own environment, so just drop the config.
+            if ref is not None and ref.startswith("keychain:"):
+                secret_store.delete_secret(ref[len("keychain:") :])
+            _save_global_config({}, unset_keys=("cursor",))
+            status = "✓ Removed Cursor API key"
+
+
+def _set_cursor_api_key() -> str | None:
+    """Prompt for and store a Cursor ``CURSOR_API_KEY``; return a status line.
+
+    Offers an existing ``CURSOR_API_KEY`` from the environment first (recorded
+    as an ``env:`` reference, so the secret never enters the config or the
+    secret store), else reads the key with a hidden prompt and stores it in the
+    omnigent secret store under ``keychain:cursor``. The ``crsr_`` prefix is
+    validated with a soft warning so a wrong paste is caught without
+    hard-blocking a future key format. The key value is never echoed.
+
+    :returns: A confirmation string for the menu's transient status, or
+        ``None`` when the user aborted (empty input / declined the warning).
+    """
+    from omnigent.onboarding import secrets as secret_store
+    from omnigent.onboarding.cursor_auth import (
+        CURSOR_SECRET_NAME,
+        cursor_api_key_settings,
+        looks_like_cursor_api_key,
+    )
+    from omnigent.onboarding.interactive import prompt_text
+
+    detected = os.environ.get("CURSOR_API_KEY")
+    if detected and click.confirm(
+        "Detected CURSOR_API_KEY in the environment — use it?", default=True
+    ):
+        if not looks_like_cursor_api_key(detected) and not click.confirm(
+            "$CURSOR_API_KEY doesn't start with 'crsr_'. Use it anyway?", default=False
+        ):
+            return None
+        _save_global_config(cursor_api_key_settings("env:CURSOR_API_KEY"))
+        return "✓ Cursor API key set (from $CURSOR_API_KEY)"
+
+    pasted = prompt_text("Cursor API key (CURSOR_API_KEY)", hide_input=True).strip()
+    if not pasted:
+        return None
+    if not looks_like_cursor_api_key(pasted) and not click.confirm(
+        "That doesn't start with 'crsr_'. Store it anyway?", default=False
+    ):
+        return None
+    secret_store.store_secret(CURSOR_SECRET_NAME, pasted)
+    _save_global_config(cursor_api_key_settings(f"keychain:{CURSOR_SECRET_NAME}"))
+    return "✓ Cursor API key stored"
 
 
 def _manage_credential(provider: str, family: str) -> str | None:
@@ -7956,11 +8005,8 @@ def _run_configure_harnesses_interactive() -> None:
         performs while navigating.
     """
     from omnigent.onboarding.configure_models import family_label
-    from omnigent.onboarding.harness_install import (
-        CURSOR_KEY,
-        harness_cli_installed,
-        harness_cli_logged_in,
-    )
+    from omnigent.onboarding.cursor_auth import cursor_api_key_configured
+    from omnigent.onboarding.harness_install import CURSOR_KEY, harness_cli_installed
     from omnigent.onboarding.interactive import select
     from omnigent.onboarding.provider_config import (
         ANTHROPIC_FAMILY,
@@ -8036,20 +8082,23 @@ def _run_configure_harnesses_interactive() -> None:
                 options.append(f"  {sub_line}")
                 selectable.append(False)  # a sub-line — cursor skips it
                 row_target.append(None)
-        # Cursor: login-only (own backend), no provider credential to configure.
-        # Readiness is "CLI installed + signed in"; its drill-in drives
-        # cursor-agent's own auth, not the provider menu.
-        cursor_installed = harness_cli_installed(CURSOR_KEY)
-        cursor_ready = cursor_installed and harness_cli_logged_in(CURSOR_KEY)
-        options.append(f"{'  ' if cursor_ready else '[red]✗[/] '}Cursor")
+        # Cursor: runs via the ``cursor-sdk`` package and authenticates with a
+        # ``CURSOR_API_KEY`` (the SDK requires one; it has no provider/gateway
+        # family and a ``cursor-agent login`` does not apply). So readiness is
+        # simply whether an API key is configured — one stored by setup (the
+        # ``cursor:`` block) or inherited from the environment — and its
+        # drill-in manages exactly that key.
+        cursor_key_set = cursor_api_key_configured(config) or bool(
+            os.environ.get("CURSOR_API_KEY")
+        )
+        options.append(f"{'  ' if cursor_key_set else '[red]✗[/] '}Cursor")
         selectable.append(True)
         row_target.append(CURSOR_KEY)
-        if not cursor_installed:
-            cursor_sub = "[dim]not installed yet — open to install[/]"
-        elif cursor_ready:
-            cursor_sub = "[green]✓[/] signed in via cursor-agent"
-        else:
-            cursor_sub = "[dim]not signed in — open to log in[/]"
+        cursor_sub = (
+            "[green]✓[/] API key configured"
+            if cursor_key_set
+            else "[dim]no API key yet — open to add one[/]"
+        )
         options.append(f"  {cursor_sub}")
         selectable.append(False)
         row_target.append(None)

--- a/omnigent/onboarding/cursor_auth.py
+++ b/omnigent/onboarding/cursor_auth.py
@@ -1,0 +1,128 @@
+"""Cursor API-key credential storage for ``omnigent setup`` and the runtime.
+
+Cursor is deliberately outside the anthropic/openai provider-family + gateway
+machinery (see :func:`omnigent.runtime.workflow._build_cursor_spawn_env`): the
+Cursor SDK (``cursor-sdk``) talks only to Cursor's own backend via a
+``CURSOR_API_KEY`` — which it requires — never the Databricks AI gateway. It
+therefore has no ``providers:`` family entry, but a user should still be able to
+register a ``CURSOR_API_KEY`` once through ``omnigent setup`` rather than
+exporting it in every shell.
+
+This module is that home. The key is stored exactly like the api-key
+providers' secrets — in the omnigent secret store (OS keychain, else a
+``0600`` JSON file; see :mod:`omnigent.onboarding.secrets`) — and referenced
+from a dedicated top-level ``cursor:`` block in ``~/.omnigent/config.yaml``::
+
+    cursor:
+      api_key_ref: keychain:cursor   # or env:CURSOR_API_KEY
+
+The reference is resolved with the same :func:`resolve_secret` resolver the
+provider families use. A dedicated block (rather than the shared global
+``auth:`` block) is required because ``auth:`` is the *gateway* credential the
+SDK harnesses inherit when their spec declares no auth
+(:func:`omnigent.runtime.workflow._load_global_auth`) — a Cursor key parked
+there would be mis-consumed by claude-sdk / codex / pi / openai-agents.
+"""
+
+from __future__ import annotations
+
+from omnigent.errors import OmnigentError
+from omnigent.onboarding.provider_config import load_config, resolve_secret
+
+# The secret-store name (and thus ``keychain:<name>``) under which a Cursor
+# API key is stored — stable so the setup flow and the resolver agree.
+CURSOR_SECRET_NAME = "cursor"
+
+# The dedicated top-level config block and the field that references the key.
+CURSOR_CONFIG_KEY = "cursor"
+_API_KEY_REF_FIELD = "api_key_ref"
+_API_KEY_FIELD = "api_key"
+
+# Cursor API keys are issued with this prefix (e.g. ``crsr_AbC123…``); the
+# setup flow validates against it so an obviously-wrong paste (a different
+# vendor's key, a stray token) is caught before it is stored. The check is
+# deliberately *soft* — a user may force a non-matching value through — so a
+# future prefix change can never lock anyone out of their own key.
+CURSOR_API_KEY_PREFIX = "crsr_"
+
+
+def looks_like_cursor_api_key(value: str) -> bool:
+    """Return whether *value* has the shape of a Cursor API key.
+
+    :param value: A pasted/typed candidate key, e.g. ``"crsr_AbC123"``.
+    :returns: ``True`` when *value* starts with :data:`CURSOR_API_KEY_PREFIX`.
+    """
+    return value.startswith(CURSOR_API_KEY_PREFIX)
+
+
+def cursor_api_key_ref(config: dict[str, object] | None = None) -> str | None:
+    """Return the configured Cursor API-key secret reference, if any.
+
+    Reads the dedicated ``cursor:`` block of the global config. Both the
+    ``api_key_ref`` (``keychain:`` / ``env:``) and an inline ``api_key``
+    (``$VAR`` / literal) shapes are accepted so a hand-edited config works
+    too; ``api_key_ref`` wins when both are present.
+
+    :param config: A pre-loaded config mapping; ``None`` loads
+        ``~/.omnigent/config.yaml`` via :func:`load_config`.
+    :returns: The secret reference, e.g. ``"keychain:cursor"`` or
+        ``"env:CURSOR_API_KEY"``, or ``None`` when no Cursor key is
+        configured.
+    """
+    cfg = load_config() if config is None else config
+    block = cfg.get(CURSOR_CONFIG_KEY)
+    if not isinstance(block, dict):
+        return None
+    ref = block.get(_API_KEY_REF_FIELD) or block.get(_API_KEY_FIELD)
+    return ref if isinstance(ref, str) and ref else None
+
+
+def resolve_cursor_api_key(config: dict[str, object] | None = None) -> str | None:
+    """Resolve the configured Cursor API key to its plaintext value, softly.
+
+    Looks up the ``cursor:`` block's secret reference and resolves it via
+    :func:`resolve_secret`. Unlike :func:`resolve_secret`, this **never
+    raises**: a missing block or an unresolvable reference (deleted keychain
+    entry, unset env var) returns ``None`` so the caller — the cursor
+    spawn-env builder and the setup readout — can fall back to an inherited
+    ``CURSOR_API_KEY`` instead of crashing a run.
+
+    :param config: A pre-loaded config mapping; ``None`` loads the global
+        config.
+    :returns: The plaintext Cursor API key, or ``None`` when none is
+        configured or it cannot be resolved.
+    """
+    ref = cursor_api_key_ref(config)
+    if ref is None:
+        return None
+    try:
+        return resolve_secret(ref)
+    except OmnigentError:
+        return None
+
+
+def cursor_api_key_configured(config: dict[str, object] | None = None) -> bool:
+    """Return whether a usable Cursor API key is configured.
+
+    ``True`` only when the ``cursor:`` block names a reference **and** it
+    resolves — a dangling reference reads as not-configured so the setup
+    readout never claims a credential the runtime can't actually use.
+
+    :param config: A pre-loaded config mapping; ``None`` loads the global
+        config.
+    :returns: ``True`` when a Cursor API key is configured and resolvable.
+    """
+    return resolve_cursor_api_key(config) is not None
+
+
+def cursor_api_key_settings(ref: str) -> dict[str, object]:
+    """Build the ``{"cursor": {...}}`` settings dict that records *ref*.
+
+    Handed to :func:`omnigent.cli._save_global_config` (a shallow update, so
+    it replaces the whole ``cursor:`` block) to persist the reference.
+
+    :param ref: The secret reference to record, e.g. ``"keychain:cursor"``
+        or ``"env:CURSOR_API_KEY"``.
+    :returns: ``{"cursor": {"api_key_ref": ref}}``.
+    """
+    return {CURSOR_CONFIG_KEY: {_API_KEY_REF_FIELD: ref}}

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -24,7 +24,7 @@ that would actually work.
 
 from __future__ import annotations
 
-import importlib.util
+import os
 
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.onboarding.harness_install import CURSOR_KEY, PI_KEY, harness_cli_installed
@@ -91,12 +91,18 @@ def harness_is_configured(harness: str) -> bool:
     if canonical in _SDK_HARNESSES:
         return True
     if canonical == CURSOR_KEY:
-        # Cursor drives the ``cursor-sdk`` Python package (a baseline dependency
-        # that bundles its own bridge), NOT a ``cursor-agent`` CLI on PATH. Gate
-        # on the SDK being importable; its Cursor API key resolves at runtime
-        # from sources the daemon can't enumerate (like the other SDK harnesses),
-        # so the key is not gated here.
-        return importlib.util.find_spec("cursor_sdk") is not None
+        # Cursor runs in-process via the ``cursor-sdk`` package (a baseline
+        # dependency, always importable) and authenticates against Cursor's own
+        # backend with a ``CURSOR_API_KEY`` — the SDK requires one, and a
+        # ``cursor-agent login`` does not apply. So, unlike the CLI-wrapping
+        # harnesses, there is no binary to gate on: readiness is whether a key
+        # is resolvable — one stored by ``omnigent setup`` (the ``cursor:``
+        # config block — see :mod:`omnigent.onboarding.cursor_auth`) or
+        # inherited from the environment. That is the one cursor credential the
+        # daemon can check cheaply and locally; a bad key surfaces at run time.
+        from omnigent.onboarding.cursor_auth import cursor_api_key_configured
+
+        return cursor_api_key_configured() or bool(os.environ.get("CURSOR_API_KEY"))
     if canonical not in _HARNESS_FAMILY and canonical != PI_SURFACE:
         # Unknown harness — the daemon has no install metadata for it, so
         # it can't assess readiness. Fail open (custom/newer harnesses,

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1399,16 +1399,23 @@ def _build_cursor_spawn_env(
     """
     Build the ``HARNESS_CURSOR_*`` env-var dict the cursor harness wrap reads.
 
-    Unlike the gateway-backed builders (claude-sdk / codex / pi / openai-agents),
-    there is NO gateway or Databricks-profile resolution: cursor-agent talks only
-    to Cursor's own backend (``CURSOR_API_KEY`` / ``cursor-agent login``), so it
-    never routes through the Databricks AI gateway — also why cursor is absent
-    from :data:`AgentHarnessType` and the gateway/ucode dicts above.
+    Maps spec.executor fields → the ``HARNESS_CURSOR_*`` env vars defined
+    in ``omnigent/inner/cursor_harness.py``. Unlike the gateway-backed
+    builders (claude-sdk / codex / pi / openai-agents), there is NO gateway or
+    Databricks-profile resolution: the Cursor SDK talks only to Cursor's own
+    backend (``CURSOR_API_KEY``) and has no custom API base-URL override, so it
+    never routes through the Databricks AI gateway. That is also why cursor is
+    intentionally absent from :data:`AgentHarnessType` and the gateway/ucode
+    dicts above.
 
-    Auth: an explicit ``executor.auth`` api-key is forwarded as
-    ``HARNESS_CURSOR_API_KEY``; otherwise cursor falls back to an inherited
-    ``CURSOR_API_KEY`` / ``cursor-agent login`` (a ``DatabricksAuth`` profile is
-    ignored).
+    Auth: an explicit ``executor.auth: {type: api_key, api_key: ...}`` is
+    forwarded as ``HARNESS_CURSOR_API_KEY`` (the cursor harness passes it to the
+    Cursor SDK as its ``api_key``). When the spec declares no auth at all, a
+    ``CURSOR_API_KEY`` registered once via ``omnigent setup`` (the dedicated
+    ``cursor:`` config block — see :mod:`omnigent.onboarding.cursor_auth`) is
+    used instead, so a user need not export it in every shell. With neither, the
+    harness falls back to an inherited ``CURSOR_API_KEY`` — a ``DatabricksAuth``
+    profile does not apply to cursor and is ignored.
 
     :param spec: The agent spec.
     :param workdir: The bundle's on-disk path, threaded as
@@ -1420,17 +1427,26 @@ def _build_cursor_spawn_env(
     model = _resolve_spec_model(spec)
     if model is not None:
         env["HARNESS_CURSOR_MODEL"] = model
-    # Only api-key auth maps to CURSOR_API_KEY; Databricks/provider auth has no
-    # cursor equivalent and is left to cursor's own login. With no spec api-key
-    # auth, fall back to an ambient CURSOR_API_KEY so a user who exported the key
-    # (or a host launched with it) can run cursor without declaring auth in every
-    # spec — the SDK requires the key in the spawned harness's environment.
+    # Auth precedence: an explicit api-key auth on the spec wins; with NO spec
+    # auth at all, fall back to a CURSOR_API_KEY registered once via
+    # ``omnigent setup`` (the dedicated ``cursor:`` config block), else an
+    # ambient CURSOR_API_KEY (an exported key / a host launched with one). A
+    # Databricks / provider auth has no cursor equivalent and never silently
+    # adopts a stored or ambient cursor key.
     if isinstance(spec.executor.auth, ApiKeyAuth):
         env["HARNESS_CURSOR_API_KEY"] = spec.executor.auth.api_key
-    elif os.environ.get("CURSOR_API_KEY"):
-        env["HARNESS_CURSOR_API_KEY"] = os.environ["CURSOR_API_KEY"]
-    # Always set so the wrap doesn't default to ``"all"`` over an explicit
-    # ``skills: none`` (parity with the peer builders).
+    elif spec.executor.auth is None:
+        # Imported lazily — the onboarding layer pulls in the secret store /
+        # keyring, which the hot spawn-env path shouldn't import eagerly.
+        from omnigent.onboarding.cursor_auth import resolve_cursor_api_key
+
+        stored_key = resolve_cursor_api_key()
+        if stored_key is not None:
+            env["HARNESS_CURSOR_API_KEY"] = stored_key
+        elif os.environ.get("CURSOR_API_KEY"):
+            env["HARNESS_CURSOR_API_KEY"] = os.environ["CURSOR_API_KEY"]
+    # Always set so the wrap doesn't fall back to ``"all"`` and override an
+    # explicit ``skills: none`` from the spec (parity with the peer builders).
     env["HARNESS_CURSOR_SKILLS_FILTER"] = json.dumps(spec.skills_filter)
     if spec.name:
         env["HARNESS_CURSOR_AGENT_NAME"] = spec.name

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -9,7 +9,8 @@ shape, not just the command's exit code, so a regression in the
 add/set-default/remove write paths surfaces here rather than silently.
 
 ``configure harnesses`` is a **three-level** picker. Level 1 picks a harness —
-the cursor moves between ``1=Claude``, ``2=Codex``, ``3=Pi``, and ``4=Quit`` (each
+the cursor moves between ``1=Claude``, ``2=Codex``, ``3=Pi``, ``4=Cursor``, and
+``5=Quit`` (each
 harness's prominent default + ``+N more`` summary renders as non-selectable
 sub-lines that are skipped; a harness with no usable default — uninstalled or
 unconfigured — shows a red ✗, while a configured one carries no name-level
@@ -80,6 +81,7 @@ def isolated_config(tmp_path, monkeypatch):
         "GEMINI_API_KEY",
         "OPENROUTER_API_KEY",
         "DATABRICKS_TOKEN",
+        "CURSOR_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
     # Redirect CLI-detected credential homes so a developer's real
@@ -1960,3 +1962,85 @@ def test_add_menu_readds_dismissed_cli_config_credential(isolated_config) -> Non
     # The dismissal is cleared, so the credential behaves like an ordinary
     # detection again instead of staying half-dismissed.
     assert cfg["dismissed_detections"] == []
+
+
+# ── Cursor API-key flow ─────────────────────────────────────────────────────
+# Cursor runs via the ``cursor-sdk`` package and authenticates with a
+# ``CURSOR_API_KEY``; it has no provider/gateway family. Its drill-in (L1 row 4)
+# stores the key in the secret store + a dedicated ``cursor:`` config block,
+# mirroring the other harnesses' api-key persistence. The menu is API-key-only
+# (Set/Replace/Remove), so it touches neither the ``cursor-agent`` binary nor a
+# login probe. ``isolated_config`` clears any ambient ``CURSOR_API_KEY``.
+
+
+def test_cursor_set_api_key_paste_writes_block_and_secret(isolated_config) -> None:
+    """Pasting a ``crsr_`` key stores the secret + writes the ``cursor:`` block.
+
+    Proves the api-key path: the secret lands in the store (never plaintext in
+    config) and the config references it via ``keychain:cursor``.
+    """
+    # L1 4=Cursor → cursor menu 1=Set API key → paste key (crsr_ → no warn) →
+    # cursor menu q=back → L1 q=quit.
+    stdin = "\n".join(["4", "1", "crsr_test_key_123", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["cursor"] == {"api_key_ref": "keychain:cursor"}
+    # The pasted secret reached the store under the ``cursor`` name; config
+    # holds only the reference.
+    assert secrets.load_secret("cursor") == "crsr_test_key_123"
+
+
+def test_cursor_adopt_env_api_key_writes_env_ref(isolated_config, monkeypatch) -> None:
+    """Adopting an existing ``$CURSOR_API_KEY`` records an ``env:`` ref only.
+
+    The env path must NOT copy the secret into the store — it points the config
+    at the live environment variable so the key never leaves the user's shell.
+    """
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_env_key_456")
+    # L1 4=Cursor → 1=Set API key → "y" adopt detected $CURSOR_API_KEY →
+    # q back → q quit.
+    stdin = "\n".join(["4", "1", "y", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["cursor"] == {"api_key_ref": "env:CURSOR_API_KEY"}
+    assert secrets.load_secret("cursor") is None
+
+
+def test_cursor_remove_api_key_drops_block_and_secret(isolated_config) -> None:
+    """Removing a Cursor key deletes the stored secret AND drops the config block."""
+    # Seed a stored key: the keychain secret + the ``cursor:`` block referencing it.
+    secrets.store_secret("cursor", "crsr_seeded")
+    config_path = os.path.join(isolated_config, "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.safe_dump({"cursor": {"api_key_ref": "keychain:cursor"}}, f)
+
+    # L1 4=Cursor → cursor menu (key set: 1=Replace 2=Remove 3=Back) → 2=Remove
+    # → q back → q quit.
+    stdin = "\n".join(["4", "2", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert "cursor" not in cfg
+    assert secrets.load_secret("cursor") is None
+
+
+def test_cursor_set_api_key_non_crsr_declined_is_not_stored(isolated_config) -> None:
+    """A non-``crsr_`` paste that the user declines to force is NOT persisted.
+
+    The soft prefix check warns and asks to store anyway; declining must leave
+    both the secret store and the config untouched.
+    """
+    # L1 4=Cursor → 1=Set API key → paste non-crsr_ key → "n" decline warning →
+    # q back → q quit.
+    stdin = "\n".join(["4", "1", "sk-not-a-cursor-key", "n", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert "cursor" not in cfg
+    assert secrets.load_secret("cursor") is None

--- a/tests/onboarding/test_cursor_auth.py
+++ b/tests/onboarding/test_cursor_auth.py
@@ -1,0 +1,108 @@
+"""Tests for ``omnigent/onboarding/cursor_auth.py`` — the Cursor API-key store.
+
+Cursor's ``CURSOR_API_KEY`` lives in a dedicated top-level ``cursor:`` config
+block (not the shared global ``auth:``) and the omnigent secret store, resolved
+with the same ``resolve_secret`` resolver the provider families use. These
+tests isolate the config + secret store to a tmp dir (file backend, no OS
+keychain) and assert the read/resolve/configured helpers behave — including the
+**soft** resolution that returns ``None`` on a dangling reference instead of
+raising, so a run / setup readout falls back rather than crashing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.onboarding import secrets as secret_store
+from omnigent.onboarding.cursor_auth import (
+    CURSOR_SECRET_NAME,
+    cursor_api_key_configured,
+    cursor_api_key_ref,
+    cursor_api_key_settings,
+    looks_like_cursor_api_key,
+    resolve_cursor_api_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Isolate config + secrets to tmp with the file secret backend.
+
+    :returns: The tmp config-home dir, so a test can write a ``config.yaml``.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    return tmp_path
+
+
+def _write_config(tmp_path: Path, block: dict[str, object]) -> None:
+    """Write *block* as the isolated ``config.yaml``."""
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(block))
+
+
+def test_looks_like_cursor_api_key() -> None:
+    """The soft prefix check accepts ``crsr_`` keys and rejects others."""
+    assert looks_like_cursor_api_key("crsr_AbC123")
+    assert not looks_like_cursor_api_key("sk-ant-123")
+    assert not looks_like_cursor_api_key("")
+
+
+def test_unconfigured_reads_as_none(_isolate: Path) -> None:
+    """With no ``cursor:`` block, every accessor reports "not configured"."""
+    assert cursor_api_key_ref() is None
+    assert resolve_cursor_api_key() is None
+    assert cursor_api_key_configured() is False
+
+
+def test_keychain_ref_resolves(_isolate: Path) -> None:
+    """A ``keychain:`` ref resolves to the secret stored under that name."""
+    secret_store.store_secret(CURSOR_SECRET_NAME, "crsr_stored")
+    _write_config(_isolate, {"cursor": {"api_key_ref": "keychain:cursor"}})
+    assert cursor_api_key_ref() == "keychain:cursor"
+    assert resolve_cursor_api_key() == "crsr_stored"
+    assert cursor_api_key_configured() is True
+
+
+def test_env_ref_resolves(_isolate: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ``env:`` ref resolves from the environment (no secret-store entry)."""
+    monkeypatch.setenv("MY_CURSOR_KEY", "crsr_fromenv")
+    _write_config(_isolate, {"cursor": {"api_key_ref": "env:MY_CURSOR_KEY"}})
+    assert resolve_cursor_api_key() == "crsr_fromenv"
+    assert cursor_api_key_configured() is True
+
+
+def test_inline_api_key_field_accepted(_isolate: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hand-edited inline ``api_key: $VAR`` is honored as a fallback shape."""
+    monkeypatch.setenv("INLINE_CURSOR", "crsr_inline")
+    _write_config(_isolate, {"cursor": {"api_key": "$INLINE_CURSOR"}})
+    assert resolve_cursor_api_key() == "crsr_inline"
+
+
+def test_dangling_keychain_ref_is_soft_none(_isolate: Path) -> None:
+    """A reference to a never-stored keychain entry resolves softly to ``None``.
+
+    Failure (an ``OmnigentError`` escaping) would crash a cursor run / the
+    setup readout on a deleted secret instead of falling back to cursor's own
+    login.
+    """
+    _write_config(_isolate, {"cursor": {"api_key_ref": "keychain:cursor"}})
+    assert resolve_cursor_api_key() is None
+    assert cursor_api_key_configured() is False
+
+
+def test_unset_env_ref_is_soft_none(_isolate: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ``env:`` ref to an unset variable resolves softly to ``None``."""
+    monkeypatch.delenv("NOPE_CURSOR_KEY", raising=False)
+    _write_config(_isolate, {"cursor": {"api_key_ref": "env:NOPE_CURSOR_KEY"}})
+    assert resolve_cursor_api_key() is None
+
+
+def test_settings_shape() -> None:
+    """``cursor_api_key_settings`` builds the dedicated ``cursor:`` block."""
+    assert cursor_api_key_settings("keychain:cursor") == {
+        "cursor": {"api_key_ref": "keychain:cursor"}
+    }

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+import yaml
 
 import omnigent.onboarding.harness_install as hi
 from omnigent.onboarding.harness_readiness import (
     configured_harness_map,
     harness_is_configured,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Isolate cursor's API-key sources so its readiness is deterministic.
+
+    Cursor readiness keys off a configured ``CURSOR_API_KEY`` (the ``cursor:``
+    config block or the environment), so point the config home at an empty tmp
+    dir and clear any ambient ``CURSOR_API_KEY`` — otherwise a developer's real
+    key would flip cursor's verdict under these tests.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
 
 
 def _all_clis_installed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,33 +96,6 @@ def test_cli_harness_configured_only_when_binary_installed(
     assert harness_is_configured(harness) is False
 
 
-def test_cursor_configured_gated_on_cursor_sdk_not_cli(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Cursor readiness follows the ``cursor-sdk`` package (its runtime), not
-    the ``cursor-agent`` CLI on PATH — so a valid SDK install with no standalone
-    cursor-agent is still launchable, and a missing SDK is not."""
-    import importlib.util as _ilu
-
-    _no_clis_installed(monkeypatch)  # cursor-agent absent from PATH
-    real_find_spec = _ilu.find_spec
-
-    def _with_sdk(name: str, *args: object, **kwargs: object) -> object:
-        return object() if name == "cursor_sdk" else real_find_spec(name, *args, **kwargs)  # type: ignore[arg-type]
-
-    def _without_sdk(name: str, *args: object, **kwargs: object) -> object:
-        return None if name == "cursor_sdk" else real_find_spec(name, *args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(
-        "omnigent.onboarding.harness_readiness.importlib.util.find_spec", _with_sdk
-    )
-    assert harness_is_configured("cursor") is True  # SDK present, CLI absent
-    monkeypatch.setattr(
-        "omnigent.onboarding.harness_readiness.importlib.util.find_spec", _without_sdk
-    )
-    assert harness_is_configured("cursor") is False  # SDK missing
-
-
 def test_configured_harness_map_covers_all_spellings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -161,6 +150,8 @@ def test_configured_harness_map_gates_only_cli_harnesses(
     ):
         assert result[sdk] is True, f"{sdk} should never be gated"
     # CLI-wrapping spellings — gated, so False when the binary is absent.
+    # (Cursor is excluded: it runs via the ``cursor-sdk`` package and gates on
+    # a configured ``CURSOR_API_KEY``, not a binary — covered separately.)
     for cli in (
         "claude-native",
         "native-claude",
@@ -170,19 +161,48 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         "pi",
     ):
         assert result[cli] is False, f"{cli} should be gated on its CLI binary"
-    # Cursor drives the cursor-sdk Python package (installed in tests), not a
-    # CLI binary, so it is NOT gated on PATH and reads True here.
-    assert result["cursor"] is True
 
 
 def test_configured_harness_map_all_true_with_clis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Every spelling reads True once the CLIs are installed.
+    """Every spelling reads True once the CLIs are installed and cursor has a key.
 
-    The CLI harnesses pass their binary check and the SDK harnesses are
-    ungated, so nothing is reported unconfigured.
+    The CLI harnesses pass their binary check, the SDK harnesses are ungated,
+    and cursor (key-gated) is satisfied by a ``CURSOR_API_KEY`` — so nothing is
+    reported unconfigured.
     """
     _all_clis_installed(monkeypatch)
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_ready")
     result = configured_harness_map()
     assert all(result.values())
+
+
+def test_cursor_readiness_keys_off_api_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cursor is configured iff a ``CURSOR_API_KEY`` is resolvable — not a binary.
+
+    The cursor harness runs via the always-present ``cursor-sdk`` package, so
+    its readiness ignores the ``cursor-agent`` binary entirely: no key → not
+    configured (even with every CLI installed); an env key or a stored
+    ``cursor:`` block → configured (even with no CLI at all). A wrong verdict
+    would either warn a key-configured cursor user "needs setup" or greenlight a
+    keyless one that fails at the first turn.
+    """
+    # No key anywhere (autouse isolation), even with all CLIs present → False.
+    _all_clis_installed(monkeypatch)
+    assert harness_is_configured("cursor") is False
+
+    # An inherited environment key satisfies it, with no CLI installed.
+    _no_clis_installed(monkeypatch)
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_from_env")
+    assert harness_is_configured("cursor") is True
+
+    # A key stored in the ``cursor:`` config block also satisfies it.
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    monkeypatch.setenv("MY_CURSOR_KEY", "crsr_from_config")
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"cursor": {"api_key_ref": "env:MY_CURSOR_KEY"}})
+    )
+    assert harness_is_configured("cursor") is True

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from omnigent.runtime.workflow import _build_cursor_spawn_env
 from omnigent.spec.types import (
@@ -131,3 +132,65 @@ def test_no_workdir_omits_bundle_dir_env_var() -> None:
     """No ``workdir`` omits ``HARNESS_CURSOR_BUNDLE_DIR``."""
     env = _build_cursor_spawn_env(_make_spec())
     assert "HARNESS_CURSOR_BUNDLE_DIR" not in env
+
+
+def _write_cursor_config(tmp_path: Path, ref: str) -> None:
+    """Write a ``cursor:`` block referencing *ref* into the isolated config.
+
+    :param tmp_path: The isolated ``OMNIGENT_CONFIG_HOME`` (see the autouse
+        fixture).
+    :param ref: The secret reference to record, e.g. ``"env:CURSOR_KEY_SRC"``.
+    """
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({"cursor": {"api_key_ref": ref}}))
+
+
+def test_stored_cursor_key_used_when_spec_has_no_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A CURSOR_API_KEY registered via ``omnigent setup`` flows when the spec
+    declares no auth — so a user need not export it in every shell."""
+    monkeypatch.setenv("CURSOR_KEY_SRC", "crsr_stored_123")
+    _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_CURSOR_API_KEY"] == "crsr_stored_123"
+
+
+def test_spec_api_key_auth_wins_over_stored_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit api-key auth on the spec takes precedence over the stored key.
+
+    Failure means a per-agent ``executor.auth`` is silently overridden by the
+    machine-wide default — the spec must always win.
+    """
+    monkeypatch.setenv("CURSOR_KEY_SRC", "crsr_stored_123")
+    _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
+    env = _build_cursor_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="crsr_explicit_999")))
+    assert env["HARNESS_CURSOR_API_KEY"] == "crsr_explicit_999"
+
+
+def test_databricks_auth_does_not_adopt_stored_cursor_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit ``DatabricksAuth`` never adopts the stored cursor key.
+
+    The stored-key fallback applies ONLY to a spec with no auth at all; a
+    databricks-routed spec has explicitly chosen a non-cursor credential, so
+    pulling the cursor key would mis-authenticate the run.
+    """
+    monkeypatch.setenv("CURSOR_KEY_SRC", "crsr_stored_123")
+    _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
+    env = _build_cursor_spawn_env(_make_spec(auth=DatabricksAuth(profile="oss")))
+    assert "HARNESS_CURSOR_API_KEY" not in env
+
+
+def test_unresolvable_stored_key_is_omitted(tmp_path: Path) -> None:
+    """A dangling stored reference resolves softly to no env var.
+
+    The ``cursor:`` block names ``env:CURSOR_KEY_SRC`` but the var is unset, so
+    the builder must omit ``HARNESS_CURSOR_API_KEY`` (leaving cursor's own
+    login / inherited key to satisfy auth) rather than crash the spawn.
+    """
+    _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert "HARNESS_CURSOR_API_KEY" not in env


### PR DESCRIPTION
Stacked on `feat/cursor-tool-bridge` (the Cursor-SDK harness) — review the top commit only; the base diff is the SDK work.

## What

Let a user register their Cursor `CURSOR_API_KEY` once via `omnigent setup` and thread it to the cursor harness, so the SDK-backed cursor agent authenticates without exporting the key in every shell.

The cursor harness drives the Cursor SDK (`cursor-sdk`), which **requires** a `CURSOR_API_KEY` (a `cursor-agent login` does not apply) — so the API key is now cursor's primary credential.

## Changes

- **`omnigent/onboarding/cursor_auth.py`** (new) — store the key in the omnigent secret store and reference it from a dedicated top-level `cursor:` block in `~/.omnigent/config.yaml` (`keychain:` / `env:`), resolved via the shared `resolve_secret()`. The secret is never written to config in plaintext.
- **`omnigent/cli.py`** — the Cursor entry in `omnigent setup` now sets / replaces / removes the API key: a hidden prompt (never echoed), a soft `crsr_` prefix check, and adoption of an existing `$CURSOR_API_KEY` (recorded as an `env:` reference so it never enters the store). The per-harness status shows ✓ once a key is configured.
- **`omnigent/runtime/workflow.py`** (`_build_cursor_spawn_env`) — when a spec declares no auth, resolve the stored `CURSOR_API_KEY` → `HARNESS_CURSOR_API_KEY` (which the harness passes to the SDK as `api_key`). An explicit `executor.auth` api-key still wins; a `DatabricksAuth` never adopts the stored key.
- **`omnigent/onboarding/harness_readiness.py`** — cursor is "ready" when a key is resolvable (the `cursor:` block or an inherited `CURSOR_API_KEY`), not gated on the `cursor-agent` binary the SDK no longer needs.

## Design note

The key lives in a **dedicated `cursor:` block**, not the shared global `auth:` block, because `auth:` is the gateway credential the other SDK harnesses (claude-sdk / codex / pi / openai-agents) inherit when their spec declares no auth — a Cursor key parked there would be mis-consumed by them. Cursor is intentionally outside the anthropic/openai provider-family + gateway machinery, so it gets its own minimal credential home that reuses the existing secret store and resolver.

## Testing

- `tests/onboarding/test_cursor_auth.py` (new) — ref / resolve / configured plus soft resolution (dangling refs → `None`, never raises).
- `tests/runtime/test_cursor_spawn_env.py` — stored-key fallback, spec-auth precedence, `DatabricksAuth` non-adoption, unresolvable-key omission.
- `tests/onboarding/test_harness_readiness.py` — key-based cursor readiness (config + env), no longer binary-gated.
- `tests/cli/test_configure_models.py` — setup add (paste + `$CURSOR_API_KEY` adoption) / remove / declined-non-`crsr_` flows.

All green; `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.

This pull request and its description were written by Isaac.
