### PR TITLE
feat(pi-native): authenticate Pi via omnigent setup (no separate pi /login)

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -1,0 +1,247 @@
+"""Translate the omnigent-configured model provider into native Pi config.
+
+A native Pi session launches the ``pi`` CLI, which authenticates from its own
+config directory (``~/.pi/agent``). Without help, a user who ran ``omnigent
+setup`` would still have to run ``pi`` ``/login`` separately — unlike
+claude-native / codex-native, which route through the provider that ``omnigent
+setup`` configured.
+
+This module closes that gap. It resolves the provider configured for the Pi
+surface (``~/.omnigent/config.yaml``) and writes a per-session ``models.json``
+into a *managed* Pi config dir (selected via ``PI_CODING_AGENT_DIR``), so the
+runner-owned ``pi`` process authenticates exactly like the configured harness —
+mirroring how codex-native routes through the Databricks AI Gateway.
+
+The managed config dir is per-session (like codex-native's managed
+``CODEX_HOME``), so this never mutates the user's global ``~/.pi/agent``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from omnigent.onboarding.provider_config import (
+    ANTHROPIC_FAMILY,
+    DATABRICKS_KIND,
+    GATEWAY_KIND,
+    KEY_KIND,
+    LOCAL_KIND,
+    OPENAI_FAMILY,
+    PI_SURFACE,
+    ProviderEntry,
+    get_default_provider,
+    load_config,
+)
+
+# Env var the ``pi`` CLI reads to relocate its config dir (default
+# ``~/.pi/agent``). Setting it per session gives Pi a managed, isolated
+# config dir we own — the analog of codex-native's ``CODEX_HOME``.
+PI_CODING_AGENT_DIR_ENV_VAR = "PI_CODING_AGENT_DIR"
+
+# Provider id registered in the generated ``models.json``. Stable so
+# ``--provider`` can select it.
+_PI_PROVIDER_ID = "omnigent"
+
+# Default model for the Databricks AI Gateway's Anthropic surface — the same
+# default the in-process Databricks executor pins. Used when the session
+# carries no explicit model override.
+_DATABRICKS_PI_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
+
+# Databricks AI Gateway Anthropic Messages surface. Pi speaks this protocol
+# natively (``api: anthropic-messages``); the gateway authenticates with a
+# workspace bearer token, so we set ``authHeader`` (Authorization: Bearer).
+_DATABRICKS_ANTHROPIC_GATEWAY_PATH = "/ai-gateway/anthropic"
+
+
+@dataclass(frozen=True)
+class PiProviderConfig:
+    """A resolved native-Pi provider, ready to render into ``models.json``.
+
+    :param provider_id: Provider id used in ``models.json`` and ``--provider``.
+    :param base_url: Endpoint base URL the ``pi`` CLI talks to.
+    :param api: Pi API type, e.g. ``"anthropic-messages"`` or
+        ``"openai-responses"``.
+    :param model: Model id to select, e.g. ``"databricks-claude-sonnet-4-6"``.
+    :param api_key: Credential value for ``models.json`` ``apiKey`` — a literal
+        key, an env-var name, or a ``"!command"`` shell form (resolved by Pi at
+        request time, used for short-lived gateway tokens).
+    :param auth_header: When ``True``, Pi sends ``Authorization: Bearer
+        <apiKey>`` (gateways) instead of a provider-native key header.
+    """
+
+    provider_id: str
+    base_url: str
+    api: str
+    model: str
+    api_key: str
+    auth_header: bool
+
+    def to_models_config(self) -> dict[str, Any]:
+        """Render this provider as a Pi ``models.json`` mapping."""
+        provider: dict[str, Any] = {
+            "baseUrl": self.base_url,
+            "api": self.api,
+            "apiKey": self.api_key,
+            "models": [{"id": self.model}],
+        }
+        if self.auth_header:
+            provider["authHeader"] = True
+        return {"providers": {self.provider_id: provider}}
+
+
+def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiProviderConfig | None:
+    """Resolve a Databricks-profile provider into Pi gateway config.
+
+    :param entry: The resolved default provider entry (``kind="databricks"``).
+    :param model: Session model override, or ``None`` to use the default.
+    :returns: The Pi provider config, or ``None`` when the profile's host
+        can't be resolved (caller falls back to Pi's own login).
+    """
+    # Imported lazily: codex_executor pulls in heavy inner deps, and this
+    # module is imported on the runner's session-create path.
+    from omnigent.inner.codex_executor import _databricks_codex_auth_command
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+    host = _read_databrickscfg_host(entry.profile)
+    if not host:
+        return None
+    host = host.rstrip("/")
+    auth_command = _databricks_codex_auth_command(host, entry.profile)
+    return PiProviderConfig(
+        provider_id=_PI_PROVIDER_ID,
+        base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
+        api="anthropic-messages",
+        model=model or _DATABRICKS_PI_DEFAULT_MODEL,
+        # Pi resolves a "!command" apiKey at request time, so the gateway
+        # bearer token is refreshed per request (the auth command itself
+        # force-refreshes), matching codex-native's refresh semantics.
+        api_key=f"!{auth_command}",
+        auth_header=True,
+    )
+
+
+def _inline_family_pi_provider(
+    entry: ProviderEntry, *, model: str | None
+) -> PiProviderConfig | None:
+    """Resolve a key/gateway/local provider into Pi config from its family.
+
+    Prefers the Anthropic family (Pi speaks ``anthropic-messages`` natively),
+    falling back to the OpenAI family via the Responses API.
+
+    :param entry: The resolved default provider entry.
+    :param model: Session model override, or ``None`` to use the family default.
+    :returns: The Pi provider config, or ``None`` when no usable family with a
+        base URL and credential is configured.
+    """
+    for family_name, api in (("anthropic", "anthropic-messages"), ("openai", "openai-responses")):
+        family = entry.family(family_name)
+        if family is None or not family.base_url:
+            continue
+        # A static key (or $VAR) — Pi reads a literal/env apiKey directly; an
+        # auth_command becomes a "!command" Pi resolves at request time.
+        if family.api_key:
+            api_key = family.api_key
+            auth_header = False
+        elif family.auth_command:
+            api_key = f"!{family.auth_command}"
+            auth_header = True
+        else:
+            continue
+        resolved_model = model or entry.family_default_model(family_name)
+        if not resolved_model:
+            continue
+        return PiProviderConfig(
+            provider_id=_PI_PROVIDER_ID,
+            base_url=family.base_url,
+            api=api,
+            model=resolved_model,
+            api_key=api_key,
+            auth_header=auth_header,
+        )
+    return None
+
+
+def resolve_pi_native_provider(
+    *,
+    model: str | None = None,
+    config_loader: Callable[[], dict[str, Any]] = load_config,
+) -> PiProviderConfig | None:
+    """Resolve the omnigent-configured provider for a native Pi session.
+
+    Reads the default provider for the Pi surface from
+    ``~/.omnigent/config.yaml`` and translates it into Pi ``models.json``
+    config. Returns ``None`` — leaving Pi to use its own ``/login`` — when no
+    usable provider is configured, or the default is a subscription / CLI-login
+    provider (a CLI's own login can't be reused outside that CLI).
+
+    :param model: Session model override (``model_override``), or ``None`` to
+        use the provider's default model.
+    :param config_loader: Injection seam for tests; defaults to
+        :func:`load_config`.
+    :returns: The resolved provider config, or ``None`` to fall back to Pi's
+        own credentials.
+    """
+    try:
+        config = config_loader()
+    except Exception:  # noqa: BLE001 — any config failure must not break launch
+        # A malformed/absent config must not break session launch — fall back
+        # to Pi's own login.
+        return None
+    # Pi is multi-family. ``omnigent setup`` marks a provider default for the
+    # ``anthropic`` / ``openai`` surfaces, not for ``pi`` specifically, so
+    # resolve in preference order: an explicit pi default, then the Anthropic
+    # surface (Pi speaks ``anthropic-messages`` natively), then OpenAI.
+    entry = (
+        get_default_provider(config, PI_SURFACE)
+        or get_default_provider(config, ANTHROPIC_FAMILY)
+        or get_default_provider(config, OPENAI_FAMILY)
+    )
+    if entry is None:
+        return None
+    if entry.kind == DATABRICKS_KIND:
+        return _databricks_pi_provider(entry, model=model)
+    if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+        return _inline_family_pi_provider(entry, model=model)
+    # subscription / cli-config: a CLI's own login (or a provider pinned in the
+    # CLI's config) is unusable outside that CLI — let Pi use its own login.
+    return None
+
+
+def write_pi_models_config(agent_dir: Path, provider: PiProviderConfig) -> Path:
+    """Write *provider* as ``models.json`` into a managed Pi config dir.
+
+    :param agent_dir: The managed Pi config dir (``PI_CODING_AGENT_DIR``).
+    :param provider: The resolved provider config to render.
+    :returns: Path to the written ``models.json``.
+    """
+    agent_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(agent_dir, 0o700)
+    models_path = agent_dir / "models.json"
+    # 0o600: the apiKey may be a literal token (key-kind providers).
+    fd = os.open(models_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(provider.to_models_config(), handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return models_path
+
+
+def pi_native_provider_launch(
+    agent_dir: Path, provider: PiProviderConfig
+) -> tuple[dict[str, str], list[str]]:
+    """Write the managed config and return the launch env + CLI args for Pi.
+
+    :param agent_dir: The managed Pi config dir for this session.
+    :param provider: The resolved provider config.
+    :returns: ``(env, args)`` — the env vars to merge into the terminal spec
+        (relocating Pi's config dir) and the ``--provider``/``--model`` args to
+        append to the Pi command.
+    """
+    write_pi_models_config(agent_dir, provider)
+    env = {PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
+    args = ["--provider", provider.provider_id, "--model", provider.model]
+    return env, args

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -655,6 +655,25 @@ def _pi_args_have_session_control(args: list[str]) -> bool:
     return False
 
 
+def _pi_args_have_provider(args: list[str]) -> bool:
+    """Return whether user Pi args already pin a provider/model/key.
+
+    When the user passes their own ``--provider`` / ``--model`` / ``--api-key``,
+    Omnigent must not inject the ``omnigent setup`` provider on top — the
+    explicit choice wins.
+
+    :param args: User pass-through Pi CLI args.
+    :returns: ``True`` when Omnigent should not add provider/model args.
+    """
+    provider_flags = {"--provider", "--model", "--api-key"}
+    for arg in args:
+        if arg in provider_flags:
+            return True
+        if arg.startswith(("--provider=", "--model=", "--api-key=")):
+            return True
+    return False
+
+
 def _build_pi_native_args(
     *,
     terminal_launch_args: list[str] | None,
@@ -735,6 +754,28 @@ async def _auto_create_pi_terminal(
         session_dir=session_dir,
         external_session_id=launch_config.external_session_id,
     )
+    pi_env = {
+        PI_NATIVE_CONFIG_ENV_VAR: str(config),
+        "OMNIGENT_PI_NATIVE_BRIDGE_DIR": str(bridge_dir),
+    }
+    # Route the runner-owned Pi process through the provider configured by
+    # ``omnigent setup`` (Databricks gateway / API key), so a separate
+    # ``pi /login`` isn't required — the parity codex-native/claude-native
+    # already have. Skipped when the user pinned their own provider/model via
+    # terminal_launch_args, or when no usable provider is configured (Pi then
+    # falls back to its own login). Writes a managed per-session Pi config dir,
+    # never touching the user's global ``~/.pi/agent``.
+    if not _pi_args_have_provider(launch_config.terminal_launch_args or []):
+        from omnigent.pi_native_credentials import (
+            pi_native_provider_launch,
+            resolve_pi_native_provider,
+        )
+
+        provider = resolve_pi_native_provider()
+        if provider is not None:
+            cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
+            pi_env.update(cred_env)
+            pi_args.extend(cred_args)
     terminal_view = await resource_registry.launch_terminal(
         session_id=session_id,
         terminal_name="pi",
@@ -744,10 +785,7 @@ async def _auto_create_pi_terminal(
             os_env=OSEnvSpec(type="caller_process", cwd=workspace),
             command=pi_command,
             args=pi_args,
-            env={
-                PI_NATIVE_CONFIG_ENV_VAR: str(config),
-                "OMNIGENT_PI_NATIVE_BRIDGE_DIR": str(bridge_dir),
-            },
+            env=pi_env,
             scrollback=100_000,
             tmux_allow_passthrough=True,
             tmux_start_on_attach=False,

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -172,12 +172,12 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     ``_HARNESS_MODULES``, this file must gain a live round-trip row
     for it.
 
-    ``claude-native`` and ``codex-native`` are excluded because their
-    inner executors require bridge directories plus runner-managed
-    terminal panes to inject keys into — both set up by their native
-    launchers, not by ``omnigent run --harness <native>``. Running
-    them through this matrix would hang or crash. Their e2e coverage
-    is via native launcher smoke tests (tracked separately as
+    ``claude-native``, ``codex-native``, and ``pi-native`` are excluded
+    because their inner executors require bridge directories plus
+    runner-managed terminal panes to inject keys into — both set up by
+    their native launchers, not by ``omnigent run --harness <native>``.
+    Running them through this matrix would hang or crash. Their e2e
+    coverage is via native launcher smoke tests (tracked separately as
     native-launcher PTY/REPL smoke tests).
 
     ``cursor`` is excluded because this matrix authenticates through
@@ -189,6 +189,7 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     expected_live_harnesses = set(OMNIGENT_HARNESSES).intersection(_HARNESS_MODULES) - {
         "claude-native",
         "codex-native",
+        "pi-native",
         "cursor",
     }
     # ``supervisor`` is registered in ``_HARNESS_MODULES`` but is not

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -430,6 +430,25 @@ async def _drive_pi_native_start(base_url: str, session_id: str) -> None:
                 create_bodies=create_bodies,
                 agents_body=_pi_native_agents_body(),
             )
+
+            # Neutralize agent discovery so the picker shows ONLY the stubbed
+            # built-in Pi. The landing picker merges `/v1/agents` with agents
+            # found by scanning the caller's sessions (`/v1/sessions?kind=any`);
+            # on the shared e2e_ui server, sessions other tests left behind
+            # (e.g. a claude-native fork) would otherwise leak in and — ranking
+            # ahead of Pi — auto-select, so the chip would read "Claude Code".
+            # Registered after _register_common_routes so it wins for the
+            # kind=any scan; the bare POST /v1/sessions create still falls
+            # through to the capturing handler.
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
             # Seed a recent working directory so the working-directory chip
             # auto-fills and Send can enable without touching the file browser.
             await page.add_init_script(

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -1,0 +1,160 @@
+"""Tests for omnigent.pi_native_credentials (native Pi provider wiring)."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from omnigent import pi_native_credentials as creds
+
+
+def _databricks_config() -> dict[str, object]:
+    """A config whose default provider is a Databricks profile (serves pi)."""
+    return {
+        "providers": {
+            "databricks": {"kind": "databricks", "default": True, "profile": "demo-staging"},
+        }
+    }
+
+
+def test_resolves_databricks_default_to_anthropic_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Databricks default → Pi anthropic-messages gateway provider.
+
+    The Databricks profile is marked default for the anthropic/openai surfaces
+    (not ``pi`` directly), so the resolver must fall back to the Anthropic
+    surface — which Pi speaks natively — and build a gateway provider with a
+    bearer-token refresh command.
+    """
+    from omnigent.inner import databricks_executor
+
+    def _host(profile: str | None) -> str:
+        return "https://wkspc.example.com/"
+
+    monkeypatch.setattr(databricks_executor, "_read_databrickscfg_host", _host)
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.api == "anthropic-messages"
+    assert provider.base_url == "https://wkspc.example.com/ai-gateway/anthropic"
+    assert provider.model == "databricks-claude-sonnet-4-6"
+    assert provider.auth_header is True
+    # apiKey is a "!command" so Pi refreshes the gateway token per request.
+    assert provider.api_key.startswith("!")
+    assert "demo-staging" in provider.api_key
+
+
+def test_databricks_unresolvable_host_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No host for the profile → fall back to Pi's own login (None)."""
+    from omnigent.inner import databricks_executor
+
+    def _no_host(profile: str | None) -> None:
+        return None
+
+    monkeypatch.setattr(databricks_executor, "_read_databrickscfg_host", _no_host)
+    assert creds.resolve_pi_native_provider(config_loader=_databricks_config) is None
+
+
+def test_key_provider_resolves_to_inline_family() -> None:
+    """A key-kind provider with an anthropic family → inline Pi provider."""
+    config = {
+        "providers": {
+            "anthropic": {
+                "kind": "key",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "sk-test-literal",
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(
+        model="claude-sonnet-4-6", config_loader=lambda: config
+    )
+    assert provider is not None
+    assert provider.api == "anthropic-messages"
+    assert provider.base_url == "https://api.anthropic.com"
+    assert provider.api_key == "sk-test-literal"
+    assert provider.auth_header is False
+    assert provider.model == "claude-sonnet-4-6"
+
+
+def test_subscription_default_returns_none() -> None:
+    """A subscription (CLI-login) default isn't reusable by Pi → None."""
+    config = {"providers": {"claude": {"kind": "subscription", "default": True, "cli": "claude"}}}
+    assert creds.resolve_pi_native_provider(config_loader=lambda: config) is None
+
+
+def test_no_providers_returns_none() -> None:
+    """No configured providers → None (Pi uses its own login)."""
+    assert creds.resolve_pi_native_provider(config_loader=dict) is None
+
+
+def test_malformed_config_returns_none() -> None:
+    """A loader that raises must not break launch — resolve to None."""
+
+    def _boom() -> dict[str, object]:
+        raise RuntimeError("bad config")
+
+    assert creds.resolve_pi_native_provider(config_loader=_boom) is None
+
+
+def test_to_models_config_shape() -> None:
+    """The rendered models.json carries baseUrl/api/apiKey/models (+authHeader)."""
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://x/ai-gateway/anthropic",
+        api="anthropic-messages",
+        model="databricks-claude-sonnet-4-6",
+        api_key="!get-token",
+        auth_header=True,
+    )
+    cfg = provider.to_models_config()
+    entry = cfg["providers"]["omnigent"]
+    assert entry["baseUrl"] == "https://x/ai-gateway/anthropic"
+    assert entry["api"] == "anthropic-messages"
+    assert entry["apiKey"] == "!get-token"
+    assert entry["authHeader"] is True
+    assert entry["models"] == [{"id": "databricks-claude-sonnet-4-6"}]
+
+
+def test_write_models_config_is_owner_only(tmp_path: Path) -> None:
+    """models.json is written 0600 in a 0700 dir (it may hold a literal key)."""
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://api.anthropic.com",
+        api="anthropic-messages",
+        model="claude-sonnet-4-6",
+        api_key="sk-secret",
+        auth_header=False,
+    )
+    agent_dir = tmp_path / "pi-agent"
+    path = creds.write_pi_models_config(agent_dir, provider)
+
+    assert path == agent_dir / "models.json"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(agent_dir.stat().st_mode) == 0o700
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written["providers"]["omnigent"]["apiKey"] == "sk-secret"
+
+
+def test_provider_launch_returns_env_and_args(tmp_path: Path) -> None:
+    """pi_native_provider_launch writes config and returns the env + CLI args."""
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://api.anthropic.com",
+        api="anthropic-messages",
+        model="claude-sonnet-4-6",
+        api_key="sk-secret",
+        auth_header=False,
+    )
+    agent_dir = tmp_path / "pi-agent"
+    env, args = creds.pi_native_provider_launch(agent_dir, provider)
+
+    assert env == {creds.PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
+    assert args == ["--provider", "omnigent", "--model", "claude-sonnet-4-6"]
+    assert (agent_dir / "models.json").exists()


### PR DESCRIPTION
## Problem

Native Pi sessions launched bare `pi`, which authenticates from its own config
dir (`~/.pi/agent`). So a user who ran `omnigent setup` still had to run `pi`
`/login` separately to get a model — unlike **claude-native** (subscription
login) and **codex-native** (routes through the configured Databricks AI
Gateway). Picking **Pi** in the web UI produced *"No API key found for the
selected model. Use /login…"*.

## Fix

Wire Pi to the provider `omnigent setup` already configured, mirroring
codex-native's gateway routing.

- **New `omnigent/pi_native_credentials.py`** resolves the default provider for
  the Pi surface — Anthropic preferred (Pi speaks `anthropic-messages`
  natively), then OpenAI — and renders a Pi `models.json`:
  - **Databricks profile** → `{host}/ai-gateway/anthropic` (`anthropic-messages`),
    bearer token supplied via a `!databricks auth token … --force-refresh`
    shell command that Pi resolves **at request time** — the same refresh
    semantics codex-native uses, so long sessions don't 401 mid-turn.
  - **key / gateway / local** provider → the family's `base_url` + `api_key`.
  - **subscription / cli-config / unconfigured** → `None`: Pi keeps its own
    `/login` (a CLI's own login can't be reused outside that CLI).

- **The runner** (`_auto_create_pi_terminal`) writes that `models.json` into a
  *managed per-session* config dir selected via `PI_CODING_AGENT_DIR` — the
  analog of codex-native's managed `CODEX_HOME` — so it **never touches the
  user's global `~/.pi/agent`**, and appends `--provider/--model`. It backs off
  entirely when the user pins their own `--provider/--model/--api-key` via
  `terminal_launch_args`.

## Verification

Tested end to end against a real `omnigent setup` (Databricks AI Gateway,
`demo-staging` profile). A fresh Pi session authenticates with **no `pi
/login`** and completes a turn:

```
user:      Reply with exactly the single word: PONG
assistant: PONG
```

Plus unit tests for the resolver (Databricks → anthropic gateway, key-kind →
inline family, subscription/unconfigured → None, malformed config → None), the
`models.json` rendering + `0600` perms, and the launch env/args. `ruff` clean.

## Notes

- **Stacked on #22** (native Pi TUI integration). The base of this PR is the
  #22 branch content, so the diff is just the credential commit. Retarget to
  `main` once #22 merges.
- **Follow-up:** thread a per-session `model_override` into the Pi launch config
  (pi-native is intentionally absent from `_PROVIDER_RESOLUTION_HARNESS` today),
  and consider teaching `omnigent setup` to mark a provider default for the
  `pi` surface explicitly rather than relying on the anthropic/openai fallback.

This pull request and its description were written by Isaac.