### PR TITLE
fix(setup): confirm hidden API-key input in the credential picker

### DIFF
--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import io
 import os
 import sys
+from collections.abc import Callable
+from typing import Protocol, cast
 
 import click
 from rich.console import Console
@@ -40,6 +42,10 @@ MUTED = "#6a6a6a"
 # Shared Rich console for all onboarding interactive output. A module
 # singleton so all callers render through one surface.
 console = Console()
+
+
+class _TermUIWithHiddenPrompt(Protocol):
+    hidden_prompt_func: Callable[[str], str]
 
 
 def clear_screen() -> None:
@@ -427,8 +433,10 @@ def prompt_text(
 
     On a TTY this prints an accent label line, then reads the value via
     ``click.prompt`` (which handles ``hide_input`` masking and the
-    ``default`` echo). On a non-TTY the same ``click.prompt`` path runs,
-    so pipes / tests behave identically.
+    ``default`` echo). Hidden prompts also print muted metadata-only
+    feedback so users can tell a pasted secret registered without seeing
+    the secret. On a non-TTY the same ``click.prompt`` path runs, so pipes
+    / tests behave identically.
 
     :param label: The prompt label, e.g. ``"anthropic API key"``.
     :param default: Pre-filled default returned on an empty enter, or
@@ -442,11 +450,45 @@ def prompt_text(
         prompt_label = "  ❯"
     else:
         prompt_label = label
-    return str(
-        click.prompt(
-            prompt_label,
-            default=default,
-            hide_input=hide_input,
-            show_default=default is not None,
+
+    if not hide_input:
+        return str(
+            click.prompt(
+                prompt_label,
+                default=default,
+                hide_input=False,
+                show_default=default is not None,
+            )
         )
-    )
+
+    console.print(f"  [{MUTED}](input hidden; paste your key, then press Enter)[/{MUTED}]")
+    received_hidden_input = False
+    termui = cast(_TermUIWithHiddenPrompt, click.termui)
+    hidden_prompt_func = termui.hidden_prompt_func
+
+    def _record_hidden_input(text: str) -> str:
+        nonlocal received_hidden_input
+        value = hidden_prompt_func(text)
+        if value:
+            received_hidden_input = True
+        return value
+
+    termui.hidden_prompt_func = _record_hidden_input
+    try:
+        value = str(
+            click.prompt(
+                prompt_label,
+                default=default,
+                hide_input=True,
+                show_default=False,
+            )
+        )
+    finally:
+        termui.hidden_prompt_func = hidden_prompt_func
+
+    if received_hidden_input and value:
+        count = len(value)
+        unit = "character" if count == 1 else "characters"
+        console.print(f"  [{MUTED}]✓ received ({count} {unit})[/{MUTED}]")
+
+    return value

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -23,7 +23,7 @@ from omnigent.onboarding import interactive
 
 
 @pytest.fixture()
-def non_tty(monkeypatch):
+def non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Force the interactive module onto its non-TTY numbered fallback.
 
     Patches ``sys.stdin.isatty`` to report ``False`` so :func:`select`
@@ -36,7 +36,7 @@ def non_tty(monkeypatch):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
 
 
-def _feed(monkeypatch, lines: list[str]) -> None:
+def _feed(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
     """Route *lines* to ``click.prompt`` as if typed at the console.
 
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -55,7 +55,26 @@ def _feed(monkeypatch, lines: list[str]) -> None:
     monkeypatch.setattr("click.termui.visible_prompt_func", _fake_prompt)
 
 
-def test_select_fallback_returns_chosen_index(non_tty, monkeypatch, capsys) -> None:
+def _feed_hidden(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    """Route *lines* to hidden ``click.prompt`` input without echoing them.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param lines: The hidden lines to feed, one per ``click.prompt`` call.
+    :returns: None.
+    """
+    fed = iter(lines)
+
+    def _fake_prompt(_text: str) -> str:
+        return next(fed)
+
+    monkeypatch.setattr("click.termui.hidden_prompt_func", _fake_prompt)
+
+
+def test_select_fallback_returns_chosen_index(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """``select`` non-TTY returns the zero-based index of the typed number.
 
     Feeds ``"2"`` against three options; the fallback must return index
@@ -74,7 +93,11 @@ def test_select_fallback_returns_chosen_index(non_tty, monkeypatch, capsys) -> N
     assert "2. beta" in out
 
 
-def test_select_fallback_reprompts_on_invalid_then_accepts(non_tty, monkeypatch, capsys) -> None:
+def test_select_fallback_reprompts_on_invalid_then_accepts(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """``select`` non-TTY rejects an out-of-range pick, then accepts a valid one.
 
     Feeds ``"9"`` (out of range for two options) followed by ``"1"``. The
@@ -95,7 +118,7 @@ def test_select_fallback_reprompts_on_invalid_then_accepts(non_tty, monkeypatch,
     assert "Invalid selection." in out
 
 
-def test_select_rejects_mismatched_descriptions(non_tty) -> None:
+def test_select_rejects_mismatched_descriptions(non_tty: None) -> None:
     """``select`` fails loud when descriptions length differs from options.
 
     A mismatch is a caller bug (the selected description would index out
@@ -106,7 +129,7 @@ def test_select_rejects_mismatched_descriptions(non_tty) -> None:
         interactive.select("Pick", ["a", "b"], descriptions=["only one"])
 
 
-def test_select_empty_options_raises(non_tty) -> None:
+def test_select_empty_options_raises(non_tty: None) -> None:
     """``select`` rejects an empty option list.
 
     There is nothing to choose from, so the function must raise rather
@@ -116,7 +139,11 @@ def test_select_empty_options_raises(non_tty) -> None:
         interactive.select("Pick", [])
 
 
-def test_select_fallback_skips_header_rows_in_numbering(non_tty, monkeypatch, capsys) -> None:
+def test_select_fallback_skips_header_rows_in_numbering(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Non-selectable header rows are unnumbered; numbers map to originals.
 
     A grouped tree passes header rows (harness names) interleaved with
@@ -144,7 +171,10 @@ def test_select_fallback_skips_header_rows_in_numbering(non_tty, monkeypatch, ca
     assert "Codex" in out and "3. Codex" not in out
 
 
-def test_select_fallback_default_maps_to_numbered_position(non_tty, monkeypatch) -> None:
+def test_select_fallback_default_maps_to_numbered_position(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """An empty enter returns the row at *default* (mapped past headers).
 
     With ``default=2`` (original index of the 2nd selectable row) and a
@@ -161,7 +191,7 @@ def test_select_fallback_default_maps_to_numbered_position(non_tty, monkeypatch)
     assert result == 2
 
 
-def test_select_rejects_mismatched_selectable(non_tty) -> None:
+def test_select_rejects_mismatched_selectable(non_tty: None) -> None:
     """``select`` fails loud when the selectable mask length differs.
 
     A mismatch is a caller bug (the mask would index out of range during
@@ -172,7 +202,7 @@ def test_select_rejects_mismatched_selectable(non_tty) -> None:
         interactive.select("Pick", ["a", "b", "c"], selectable=[True, False])
 
 
-def test_select_rejects_all_header_rows(non_tty) -> None:
+def test_select_rejects_all_header_rows(non_tty: None) -> None:
     """``select`` rejects a mask with no selectable row.
 
     There would be nothing to choose, so the function must raise rather
@@ -215,7 +245,10 @@ def test_first_selectable_falls_to_first_selectable() -> None:
     assert interactive._first_selectable(mask, 3) == 3
 
 
-def test_prompt_text_fallback_returns_typed_value(non_tty, monkeypatch) -> None:
+def test_prompt_text_fallback_returns_typed_value(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``prompt_text`` non-TTY returns the typed string verbatim.
 
     Feeds ``"my-gateway"``; the function must return exactly that. A
@@ -229,7 +262,10 @@ def test_prompt_text_fallback_returns_typed_value(non_tty, monkeypatch) -> None:
     assert result == "my-gateway"
 
 
-def test_prompt_text_fallback_uses_default_on_empty(non_tty, monkeypatch) -> None:
+def test_prompt_text_fallback_uses_default_on_empty(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``prompt_text`` non-TTY returns the default when the user enters nothing.
 
     Feeds an empty line with ``default="databricks"``; the function must
@@ -242,7 +278,60 @@ def test_prompt_text_fallback_uses_default_on_empty(non_tty, monkeypatch) -> Non
     assert result == "databricks"
 
 
-def test_clear_screen_emits_clear_sequence_only_on_a_tty(monkeypatch) -> None:
+def test_prompt_text_fallback_hidden_value_confirms_without_echoing_secret(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Hidden ``prompt_text`` feedback confirms paste registration safely."""
+    secret = "sk-test-hidden-secret-1234567890"
+    _feed_hidden(monkeypatch, [secret])
+
+    result = interactive.prompt_text("openai API key", hide_input=True)
+
+    assert result == secret
+    out = capsys.readouterr().out
+    assert "input hidden" in out
+    assert f"received ({len(secret)} characters)" in out
+    assert secret not in out
+
+
+def test_prompt_text_fallback_hidden_empty_input_does_not_confirm(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Hidden ``prompt_text`` does not claim an accepted default was pasted."""
+    default = "existing-hidden-secret"
+    _feed_hidden(monkeypatch, [""])
+
+    result = interactive.prompt_text("openai API key", default=default, hide_input=True)
+
+    assert result == default
+    out = capsys.readouterr().out
+    assert "input hidden" in out
+    assert "received" not in out
+    assert default not in out
+
+
+def test_prompt_text_fallback_visible_value_has_no_hidden_feedback(
+    non_tty: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Visible ``prompt_text`` behavior stays unchanged."""
+    value = "plain-provider-name"
+    _feed(monkeypatch, [value])
+
+    result = interactive.prompt_text("Name for this provider", hide_input=False)
+
+    assert result == value
+    out = capsys.readouterr().out
+    assert "input hidden" not in out
+    assert "received" not in out
+
+
+def test_clear_screen_emits_clear_sequence_only_on_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
     """``clear_screen`` wipes the terminal on a TTY and is a no-op otherwise.
 
     The TTY branch must emit the full clear (screen + scrollback + home) so the


### PR DESCRIPTION
Before: pasting a hidden setup API key gave no visual feedback, so users could not tell whether the paste registered.
After: hidden `prompt_text` calls show a muted hidden-input hint before entry and a length-only received confirmation after non-empty input, without printing the key or hidden defaults.

The fix is centralized in `omnigent/onboarding/interactive.py::prompt_text`, so Claude, Codex, gateway, Cursor, and future setup key-paste paths inherit the same behavior.

Verification:
- `uv run --frozen --extra dev python -m pytest tests/onboarding/test_interactive.py -q`
- `uv run --frozen --extra dev ruff check omnigent/onboarding/interactive.py tests/onboarding/test_interactive.py`
- `uv run --frozen --extra dev ruff format --check omnigent/onboarding/interactive.py tests/onboarding/test_interactive.py`
- `uv run --frozen --extra dev mypy omnigent/onboarding/interactive.py tests/onboarding/test_interactive.py`
- PTY smoke: `uv run --frozen omni setup` through Codex add-provider API-key flow with isolated temp config; confirmed hidden hint and `received (51 characters)` appeared, and the dummy key was absent from the transcript.

Note: the non-frozen `uv run --extra dev ...` path currently fails before test execution because dependency resolution considers Python 3.13 and `omnigent[cwsandbox]` requires unavailable `cwsandbox>=0.26,<1`; the locked `--frozen` environment was used for verification.