### PR TITLE
fix(web): stop composer agent-picker label from overflowing the card

### DIFF
--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3274,9 +3274,9 @@ export function Composer({
             {commandError}
           </div>
         )}
-        <div className="flex items-center justify-between px-2 pb-2">
+        <div className="flex items-center justify-between gap-2 px-2 pb-2">
           {/* Attach + mic — left side of the action row */}
-          <div className="flex items-center gap-0.5">
+          <div className="flex shrink-0 items-center gap-0.5">
             <Button
               type="button"
               size="icon"
@@ -3302,7 +3302,7 @@ export function Composer({
             />
           </div>
           {/* Cost toggle + agent picker + Send — right side */}
-          <div className="flex items-center gap-0.5">
+          <div className="flex min-w-0 items-center gap-0.5">
             {/* Temporarily hidden (#3021): re-enable by removing the false gate. */}
             {false && costRoutingEligible && (
               <IntelligentModelControl
@@ -3336,7 +3336,7 @@ export function Composer({
               // overrides the base 50% disabled-opacity so the affordance
               // reads as "waiting for input", not "almost active".
               className={cn(
-                "size-9 rounded-full md:size-8",
+                "size-9 shrink-0 rounded-full md:size-8",
                 !showInterruptButton && "hover:bg-primary/90 disabled:opacity-30",
               )}
               // Interrupt stays live during a pending elicitation —
@@ -3705,12 +3705,10 @@ function AgentPicker({
           size="sm"
           disabled={!hasAgents || disabled || !hasPickerActions}
           data-testid="agent-picker-trigger"
-          className="h-7 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+          className="h-7 min-w-0 shrink gap-1.5 px-2 text-muted-foreground hover:text-foreground"
         >
-          <span className="max-w-20 truncate text-xs tabular-nums md:max-w-[18rem]">
-            {triggerLabel}
-          </span>
-          {hasPickerActions && <ChevronDownIcon className="size-3.5 opacity-60" />}
+          <span className="min-w-0 truncate text-xs tabular-nums">{triggerLabel}</span>
+          {hasPickerActions && <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-64 p-1">


### PR DESCRIPTION
## Problem

The composer's agent-picker trigger label (e.g. `Polly (OpenAI Agents SDK)`) was being clipped past the right edge of the input card, and the **Send button was pushed off-screen entirely**.

## Root cause

Two compounding issues:

1. The label's width cap keyed off the **viewport** breakpoint (`md:max-w-[18rem]`), not the container. In a narrow chat panel on a wide screen, `md` is active, so the label was allowed up to ~18rem and overflowed the panel.
2. The shadcn `Button` base class includes `shrink-0`. So the picker trigger never shrank — adding `min-w-0` to its parents did nothing because the button itself refused to give up width.

## Fix

Make the composer action row shrink correctly (`ap-web/src/pages/ChatPage.tsx`):

- Action row: `gap-2`; left group (attach/mic) `shrink-0`.
- Right group: `min-w-0` so it can shrink within the row.
- Send button: `shrink-0` so it's never squeezed off-screen.
- Agent-picker trigger: **`shrink`** (overrides the base `shrink-0` via tailwind-merge) + `min-w-0`; label is `min-w-0 truncate` (dropped the viewport-based `max-w` caps); chevron `shrink-0`.

The label now ellipsizes to the available width at any container size, and the Send button always stays visible.

## Verification

- `npx vitest run src/pages/ChatPage.composer.test.tsx` — 39/39 passing
- `tsc --noEmit` — clean
- Verified via tailwind-merge that `shrink` overrides the Button base `shrink-0`.