### PR TITLE
ci(oss): remove tag-push trigger from release-omnigent.yml

### DIFF
--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -34,17 +34,16 @@
 name: Release omnigent (PyPI)
 
 on:
-  # The release trigger: push a version tag. SemVer + PEP 440 pre-releases:
-  #   v0.1.0a1 (alpha) · v0.1.0b1 (beta) · v0.1.0rc1 (release candidate) · v0.1.0
-  # Burn pre-release tags on the pipeline first; reserve the clean vX.Y.Z
-  # for the real launch (PyPI versions are immutable — a version can't be
-  # re-used, on TestPyPI either).
-  push:
-    tags:
-      - "v*"
+  # NOTE: PyPI publishing has moved to the central secure-release repo
+  # (databricks/secure-public-registry-releases-eng, workflow `omnigent.yml`).
+  # The tag-push trigger is REMOVED so a version tag no longer fires this
+  # workflow — otherwise it double-publishes and collides with the secure
+  # pipeline on the same tag. This workflow is kept only as a manual fallback
+  # (workflow_dispatch) and will be deleted once the secure path has done a
+  # production release.
+  #
   # Manual run: builds + gates always run; destination picks the index.
-  # `pypi` is the ONLY path to a real-PyPI publish (tag pushes stop at
-  # TestPyPI), and it binds the protected `pypi` environment.
+  # `pypi` binds the protected `pypi` environment.
   workflow_dispatch:
     inputs:
       destination:


### PR DESCRIPTION
## Summary

Remove the `push: tags: ['v*']` trigger from `release-omnigent.yml`.

PyPI publishing has moved to the central secure-release repo
(`databricks/secure-public-registry-releases-eng`, workflow `omnigent.yml`).
This in-repo workflow still fired on version-tag pushes and published to
TestPyPI with `skip-existing`, so pushing a tag now double-publishes and
**collides with the secure pipeline on the same tag** — observed on `v0.1.1rc1`:
the secure pipeline's core upload failed with `400 File already exists` because
this workflow had already uploaded `omnigent-0.1.1rc1` from the tag push.

Dropping the tag trigger leaves the secure pipeline as the sole publisher.
`workflow_dispatch` is kept as a manual fallback; the build/scan gates still run
on PRs. The whole workflow will be deleted once the secure path has completed a
production release.

## Type of change

- [x] Test / CI
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Breaking change

## Test coverage

- [x] Not applicable

## Coverage rationale

CI-trigger change only — no code paths affected. Verified the workflow still
parses and its triggers are now `workflow_dispatch` + `pull_request` (no
`push`). The downstream `github.event_name == 'push'` conditions simply become
inert; the manual `workflow_dispatch` publish path is unchanged.
