### PR TITLE
Fix native subagent Databricks gateway spawn env

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -27,7 +27,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     # Type-only import: the runner keeps codex deps out of its runtime import
     # graph (they are imported lazily inside the codex-native helpers).
-    from omnigent.codex_native_app_server import CodexAppServerClient
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
+    from omnigent.codex_native_app_server import CodexAppServerClient, NativeCodexLaunch
     from omnigent.runner.cost_advisor import AdvisorTurnResult
     from omnigent.terminals.registry import TerminalListEntry
 
@@ -628,7 +629,9 @@ async def _auto_create_codex_terminal(
     # synthesis can stamp session_meta.model_provider with the provider
     # this launch actually routes through.
     default_model = launch_config.model_override or _codex_native_model_from_spec(agent_spec)
-    _codex_launch = resolve_native_codex_launch(model=default_model)
+    _codex_launch = _codex_native_launch_from_env() or resolve_native_codex_launch(
+        model=default_model
+    )
     _session_meta_provider = codex_session_meta_model_provider(_codex_launch)
     from omnigent.inner.codex_executor import _find_codex_cli
 
@@ -1677,7 +1680,6 @@ async def _auto_create_claude_terminal(
     _runner_auth = _RunnerDatabricksAuth(_auth_factory)
 
     from omnigent.claude_native import (
-        ClaudeNativeUcodeConfig,
         augment_claude_args,
         build_native_claude_terminal_env,
         resolve_native_claude_config,
@@ -1922,7 +1924,7 @@ async def _auto_create_claude_terminal(
     # CLI path.
     claude_config: ClaudeNativeUcodeConfig | None = None
     try:
-        claude_config = resolve_native_claude_config(spec=None)
+        claude_config = _claude_native_config_from_env() or resolve_native_claude_config(spec=None)
     except Exception:  # noqa: BLE001 — best-effort; fall back to native auth
         _logger.warning(
             "native-claude: could not derive a provider/ucode launch config "
@@ -4559,7 +4561,7 @@ def create_runner_app(
                 harness_name,
                 workdir=_resolved_spec_workdir(spec_entry),
             )
-            if harness_name == "claude-native" and spawn_env is None:
+            if harness_name == "claude-native":
                 from omnigent.claude_native_bridge import (
                     build_claude_native_spawn_env,
                 )
@@ -4568,8 +4570,11 @@ def create_runner_app(
                     server_client=server_client,
                     session_id=session_id,
                 )
-                spawn_env = build_claude_native_spawn_env(session_id, bridge_id=bridge_id)
-            if harness_name == "codex-native" and spawn_env is None:
+                spawn_env = _merge_spawn_env(
+                    spawn_env,
+                    build_claude_native_spawn_env(session_id, bridge_id=bridge_id),
+                )
+            if harness_name == "codex-native":
                 from omnigent.codex_native_bridge import (
                     CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
                     build_codex_native_spawn_env,
@@ -4580,7 +4585,10 @@ def create_runner_app(
                     session_id=session_id,
                 )
                 bridge_id = labels.get(CODEX_NATIVE_BRIDGE_ID_LABEL_KEY)
-                spawn_env = build_codex_native_spawn_env(session_id, bridge_id=bridge_id)
+                spawn_env = _merge_spawn_env(
+                    spawn_env,
+                    build_codex_native_spawn_env(session_id, bridge_id=bridge_id),
+                )
             _session_spec_cache[session_id] = spec_entry
             from omnigent.llms.context_window import get_model_context_window
             from omnigent.runtime.workflow import _resolve_spec_model
@@ -8041,15 +8049,18 @@ def create_runner_app(
                         "detail": _client_safe_error_detail(exc, context="spec resolve"),
                     },
                 )
-        if harness_name == "claude-native" and spawn_env is None:
+        if harness_name == "claude-native":
             from omnigent.claude_native_bridge import build_claude_native_spawn_env
 
             bridge_id = await _claude_native_bridge_id_for_session(
                 server_client=server_client,
                 session_id=conv_id,
             )
-            spawn_env = build_claude_native_spawn_env(conv_id, bridge_id=bridge_id)
-        if harness_name == "codex-native" and spawn_env is None:
+            spawn_env = _merge_spawn_env(
+                spawn_env,
+                build_claude_native_spawn_env(conv_id, bridge_id=bridge_id),
+            )
+        if harness_name == "codex-native":
             from omnigent.codex_native_bridge import (
                 CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
                 build_codex_native_spawn_env,
@@ -8060,7 +8071,10 @@ def create_runner_app(
                 session_id=conv_id,
             )
             bridge_id = labels.get(CODEX_NATIVE_BRIDGE_ID_LABEL_KEY)
-            spawn_env = build_codex_native_spawn_env(conv_id, bridge_id=bridge_id)
+            spawn_env = _merge_spawn_env(
+                spawn_env,
+                build_codex_native_spawn_env(conv_id, bridge_id=bridge_id),
+            )
 
         agent_version = dispatch.agent_version if dispatch else body.get("agent_version")
         if agent_version is not None and conv_id in _version_cache:
@@ -11658,7 +11672,129 @@ _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     "codex": "HARNESS_CODEX_MODEL",
     "pi": "HARNESS_PI_MODEL",
     "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",
+    "claude-native": "HARNESS_CLAUDE_NATIVE_MODEL",
+    "codex-native": "HARNESS_CODEX_NATIVE_MODEL",
 }
+
+
+def _build_claude_native_spawn_provider_env(
+    spec: Any,
+    *,
+    model_override: str | None,
+) -> dict[str, str] | None:
+    """
+    Build provider/ucode spawn-env for a child ``claude-native`` harness.
+
+    The child harness process ultimately starts Claude Code from
+    :func:`_auto_create_claude_terminal`. It cannot rely on the parent
+    native CLI's already-resolved env, so resolve the same native launch
+    config here and carry it through the subprocess env with harness-scoped
+    keys. ``None`` preserves the no-provider path: Claude Code uses its own
+    native ``~/.claude`` config exactly as before.
+    """
+    from omnigent.claude_native import resolve_native_claude_config
+    from omnigent.runtime.workflow import _resolve_spec_model
+
+    model = model_override or _resolve_spec_model(spec)
+    claude_config = resolve_native_claude_config(spec=spec)
+    if claude_config is None:
+        return None
+    if "ANTHROPIC_BASE_URL" not in claude_config.env or not claude_config.model:
+        return None
+    env = {
+        "HARNESS_CLAUDE_NATIVE_GATEWAY": "true",
+        "HARNESS_CLAUDE_NATIVE_API_KEY_HELPER": claude_config.api_key_helper,
+    }
+    for key, value in claude_config.env.items():
+        env[f"HARNESS_CLAUDE_NATIVE_ENV_{key}"] = value
+    if model or claude_config.model:
+        env["HARNESS_CLAUDE_NATIVE_MODEL"] = model or claude_config.model or ""
+    return env
+
+
+def _build_codex_native_spawn_provider_env(
+    spec: Any,
+    *,
+    model_override: str | None,
+) -> dict[str, str] | None:
+    """
+    Build provider/ucode spawn-env for a child ``codex-native`` harness.
+
+    The native Codex auto-launch path consumes a ``NativeCodexLaunch`` shape
+    (model, Databricks profile, and Codex ``-c`` overrides). Resolve that same
+    shape here and pass only explicit routing choices through env; an empty
+    result keeps Codex-native on its own native login/config path.
+    """
+    from omnigent.codex_native_app_server import resolve_native_codex_launch
+    from omnigent.runtime.workflow import _resolve_spec_model
+
+    model = model_override or _resolve_spec_model(spec)
+    launch = resolve_native_codex_launch(model=model)
+    env: dict[str, str] = {}
+    if launch.profile is None:
+        return None
+    env["HARNESS_CODEX_NATIVE_GATEWAY"] = "true"
+    env["HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE"] = launch.profile
+    if launch.model is not None:
+        env["HARNESS_CODEX_NATIVE_MODEL"] = launch.model
+    if launch.config_overrides:
+        env["HARNESS_CODEX_NATIVE_CONFIG_OVERRIDES"] = json.dumps(launch.config_overrides)
+    return env or None
+
+
+def _merge_spawn_env(*envs: dict[str, str] | None) -> dict[str, str] | None:
+    """Merge optional spawn-env dictionaries, returning ``None`` if empty."""
+    merged: dict[str, str] = {}
+    for env in envs:
+        if env:
+            merged.update(env)
+    return merged or None
+
+
+def _claude_native_config_from_env() -> ClaudeNativeUcodeConfig | None:
+    """Read child-spawned claude-native provider config from process env."""
+    api_key_helper = os.environ.get("HARNESS_CLAUDE_NATIVE_API_KEY_HELPER")
+    if not api_key_helper:
+        return None
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
+
+    prefix = "HARNESS_CLAUDE_NATIVE_ENV_"
+    terminal_env = {
+        key.removeprefix(prefix): value
+        for key, value in os.environ.items()
+        if key.startswith(prefix)
+    }
+    return ClaudeNativeUcodeConfig(
+        env=terminal_env,
+        api_key_helper=api_key_helper,
+        model=os.environ.get("HARNESS_CLAUDE_NATIVE_MODEL"),
+    )
+
+
+def _codex_native_launch_from_env() -> NativeCodexLaunch | None:
+    """Read child-spawned codex-native provider config from process env."""
+    model = os.environ.get("HARNESS_CODEX_NATIVE_MODEL")
+    profile = os.environ.get("HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE")
+    raw_overrides = os.environ.get("HARNESS_CODEX_NATIVE_CONFIG_OVERRIDES")
+    overrides: list[str] = []
+    if raw_overrides:
+        try:
+            parsed = json.loads(raw_overrides)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list) and all(isinstance(item, str) for item in parsed):
+            overrides = parsed
+        else:
+            _logger.warning("Ignoring malformed HARNESS_CODEX_NATIVE_CONFIG_OVERRIDES")
+    if model is None and profile is None and not overrides:
+        return None
+    from omnigent.codex_native_app_server import NativeCodexLaunch
+
+    return NativeCodexLaunch(
+        config_overrides=overrides,
+        model=model,
+        profile=profile,
+    )
 
 
 def _build_spawn_env_from_spec(
@@ -11681,7 +11817,7 @@ def _build_spawn_env_from_spec(
         via ``--model`` in :func:`_build_claude_native_base_args`; the
         SDK harnesses have no such arg, so the override must land in the
         env var here.)
-    :returns: The spawn-env dict, or ``None`` for native / unknown harnesses.
+    :returns: The spawn-env dict, or ``None`` when no explicit routing env is needed.
     """
     try:
         from omnigent.runtime.workflow import (
@@ -11699,8 +11835,18 @@ def _build_spawn_env_from_spec(
             env = _build_pi_spawn_env(spec, workdir=workdir)
         elif harness == "openai-agents":
             env = _build_openai_agents_sdk_spawn_env(spec)
+        elif harness == "claude-native":
+            env = _build_claude_native_spawn_provider_env(
+                spec,
+                model_override=model_override,
+            )
+        elif harness == "codex-native":
+            env = _build_codex_native_spawn_provider_env(
+                spec,
+                model_override=model_override,
+            )
         else:
-            # claude-native / codex-native / unknown — no spawn-env.
+            # Unknown harness — no spawn-env.
             return None
     except ImportError:
         return None
@@ -11708,7 +11854,7 @@ def _build_spawn_env_from_spec(
     # Per-session ``/model`` override wins over everything the builder baked
     # into HARNESS_<H>_MODEL. Without this, `/model` is recorded in the
     # readout but the turn still uses the provider/catalog default.
-    if model_override:
+    if env is not None and model_override:
         model_key = _HARNESS_MODEL_ENV_KEY.get(harness)
         if model_key is not None:
             env[model_key] = model_override

--- a/tests/runner/test_native_spawn_env.py
+++ b/tests/runner/test_native_spawn_env.py
@@ -1,0 +1,118 @@
+"""Tests for native child-harness spawn environment propagation."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from omnigent.claude_native_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    REQUEST_SESSION_ID_ENV_VAR,
+    build_claude_native_spawn_env,
+)
+from omnigent.codex_native_bridge import (
+    CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
+    CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    build_codex_native_spawn_env,
+)
+from omnigent.runner.app import _merge_spawn_env
+
+
+def test_claude_native_spawn_env_merges_bridge_and_provider_config() -> None:
+    """Bridge/session ids survive alongside provider/ucode routing env."""
+    provider_env = {
+        "HARNESS_CLAUDE_NATIVE_GATEWAY": "true",
+        "HARNESS_CLAUDE_NATIVE_ENV_ANTHROPIC_BASE_URL": "https://gw.example/anthropic",
+        "HARNESS_CLAUDE_NATIVE_API_KEY_HELPER": "databricks auth token --profile DEFAULT",
+        "HARNESS_CLAUDE_NATIVE_MODEL": "databricks-claude-opus-4-8",
+    }
+
+    env = _merge_spawn_env(
+        provider_env,
+        build_claude_native_spawn_env("conv_123", bridge_id="bridge_123"),
+    )
+
+    assert env is not None
+    assert env["HARNESS_CLAUDE_NATIVE_GATEWAY"] == "true"
+    assert env["HARNESS_CLAUDE_NATIVE_ENV_ANTHROPIC_BASE_URL"] == "https://gw.example/anthropic"
+    assert env["HARNESS_CLAUDE_NATIVE_API_KEY_HELPER"] == "databricks auth token --profile DEFAULT"
+    assert env["HARNESS_CLAUDE_NATIVE_MODEL"] == "databricks-claude-opus-4-8"
+    assert env[REQUEST_SESSION_ID_ENV_VAR] == "conv_123"
+    assert BRIDGE_DIR_ENV_VAR in env
+
+
+def test_codex_native_spawn_env_merges_bridge_and_provider_config() -> None:
+    """Bridge/session ids survive alongside Codex provider routing env."""
+    provider_env = {
+        "HARNESS_CODEX_NATIVE_GATEWAY": "true",
+        "HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE": "DEFAULT",
+        "HARNESS_CODEX_NATIVE_MODEL": "databricks-gpt-5",
+    }
+
+    env = _merge_spawn_env(
+        provider_env,
+        build_codex_native_spawn_env("conv_123", bridge_id="bridge_123"),
+    )
+
+    assert env is not None
+    assert env["HARNESS_CODEX_NATIVE_GATEWAY"] == "true"
+    assert env["HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE"] == "DEFAULT"
+    assert env["HARNESS_CODEX_NATIVE_MODEL"] == "databricks-gpt-5"
+    assert env[CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR] == "conv_123"
+    assert CODEX_NATIVE_BRIDGE_DIR_ENV_VAR in env
+
+
+def test_claude_native_provider_env_rehydrates_terminal_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Child harness env becomes Claude terminal env/apiKeyHelper/model config."""
+    from omnigent.runner.app import _claude_native_config_from_env
+
+    monkeypatch.setenv(
+        "HARNESS_CLAUDE_NATIVE_API_KEY_HELPER", "databricks auth token --profile DEFAULT"
+    )
+    monkeypatch.setenv(
+        "HARNESS_CLAUDE_NATIVE_ENV_ANTHROPIC_BASE_URL", "https://gw.example/anthropic"
+    )
+    monkeypatch.setenv("HARNESS_CLAUDE_NATIVE_MODEL", "databricks-claude-opus-4-8")
+
+    config = _claude_native_config_from_env()
+
+    assert config is not None
+    assert config.env == {"ANTHROPIC_BASE_URL": "https://gw.example/anthropic"}
+    assert config.api_key_helper == "databricks auth token --profile DEFAULT"
+    assert config.model == "databricks-claude-opus-4-8"
+
+
+def test_codex_native_provider_env_rehydrates_launch_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Child harness env becomes Codex app-server profile/model/overrides."""
+    from omnigent.runner.app import _codex_native_launch_from_env
+
+    monkeypatch.setenv("HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE", "DEFAULT")
+    monkeypatch.setenv("HARNESS_CODEX_NATIVE_MODEL", "databricks-gpt-5")
+    monkeypatch.setenv(
+        "HARNESS_CODEX_NATIVE_CONFIG_OVERRIDES",
+        '["model_provider=\\"omnigent_databricks\\""]',
+    )
+
+    launch = _codex_native_launch_from_env()
+
+    assert launch is not None
+    assert launch.profile == "DEFAULT"
+    assert launch.model == "databricks-gpt-5"
+    assert launch.config_overrides == ['model_provider="omnigent_databricks"']
+
+
+def test_native_provider_env_absent_when_not_forced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No HARNESS native routing keys means native CLIs keep their own config."""
+    from omnigent.runner.app import _claude_native_config_from_env, _codex_native_launch_from_env
+
+    for key in list(os.environ):
+        if key.startswith(("HARNESS_CLAUDE_NATIVE", "HARNESS_CODEX_NATIVE")):
+            monkeypatch.delenv(key, raising=False)
+
+    assert _claude_native_config_from_env() is None
+    assert _codex_native_launch_from_env() is None

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -1359,6 +1359,144 @@ def test_build_spawn_env_applies_model_override(
     assert overridden["HARNESS_CLAUDE_SDK_MODEL"] == "claude-sonnet-4-6"
 
 
+def test_build_spawn_env_claude_native_carries_ucode_provider_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native Claude child spawns carry gateway env plus model override."""
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="native-claude",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "claude-native", "model": "spec-model"},
+            model="spec-model",
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native.resolve_native_claude_config",
+        lambda *, spec: ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": "https://gw.example/anthropic"},
+            api_key_helper="databricks auth token --profile DEFAULT",
+            model="databricks-claude-opus-4-8",
+        ),
+    )
+
+    env = _build_spawn_env_from_spec(
+        spec,
+        "claude-native",
+        model_override="override-claude-model",
+    )
+
+    assert env == {
+        "HARNESS_CLAUDE_NATIVE_GATEWAY": "true",
+        "HARNESS_CLAUDE_NATIVE_API_KEY_HELPER": "databricks auth token --profile DEFAULT",
+        "HARNESS_CLAUDE_NATIVE_ENV_ANTHROPIC_BASE_URL": "https://gw.example/anthropic",
+        "HARNESS_CLAUDE_NATIVE_MODEL": "override-claude-model",
+    }
+
+
+def test_build_spawn_env_codex_native_carries_ucode_provider_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native Codex child spawns carry Databricks profile plus model override."""
+    from omnigent.codex_native_app_server import NativeCodexLaunch
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="native-codex",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex-native", "model": "spec-model"},
+            model="spec-model",
+        ),
+    )
+    seen: dict[str, str | None] = {}
+
+    def _fake_resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
+        seen["model"] = model
+        return NativeCodexLaunch(
+            config_overrides=[],
+            model=model or "databricks-gpt-5",
+            profile="DEFAULT",
+        )
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.resolve_native_codex_launch",
+        _fake_resolve_native_codex_launch,
+    )
+
+    env = _build_spawn_env_from_spec(
+        spec,
+        "codex-native",
+        model_override="override-codex-model",
+    )
+
+    assert seen["model"] == "override-codex-model"
+    assert env == {
+        "HARNESS_CODEX_NATIVE_GATEWAY": "true",
+        "HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE": "DEFAULT",
+        "HARNESS_CODEX_NATIVE_MODEL": "override-codex-model",
+    }
+
+
+@pytest.mark.parametrize("harness", ["claude-native", "codex-native"])
+def test_build_spawn_env_native_no_provider_path_unchanged(
+    harness: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native harnesses still emit no routing env when no provider resolves."""
+    spec = AgentSpec(
+        spec_version=1,
+        name="native",
+        executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native.resolve_native_claude_config",
+        lambda *, spec: None,
+    )
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.resolve_native_codex_launch",
+        lambda *, model: SimpleNamespace(config_overrides=[], model=model, profile=None),
+    )
+
+    assert _build_spawn_env_from_spec(spec, harness) is None
+
+
+@pytest.mark.parametrize("harness", ["claude-native", "codex-native"])
+def test_build_spawn_env_native_non_databricks_provider_path_unchanged(
+    harness: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-ucode native provider paths still do not force gateway routing."""
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="native",
+        executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native.resolve_native_claude_config",
+        lambda *, spec: ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": "https://api.anthropic.com"},
+            api_key_helper="printf %s sk-ant-test",
+            model=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.resolve_native_codex_launch",
+        lambda *, model: SimpleNamespace(
+            config_overrides=['model_provider="openai"'],
+            model=model,
+            profile=None,
+        ),
+    )
+
+    assert _build_spawn_env_from_spec(spec, harness) is None
+
+
 @pytest.mark.asyncio
 async def test_resolve_harness_config_applies_harness_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -6618,3 +6756,75 @@ async def test_create_session_reinit_preserves_existing_inbox() -> None:
             )
     finally:
         runner_app._session_inboxes_ref.pop(session_id, None)
+
+
+def test_build_spawn_env_claude_native_databricks_default_uses_ucode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured Databricks default emits native Claude gateway spawn env."""
+    from omnigent.claude_native import ClaudeNativeUcodeConfig
+
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  databricks:\n"
+        "    kind: databricks\n"
+        "    default: true\n"
+        "    profile: DEFAULT\n"
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native._ucode_config_for_profile",
+        lambda profile: ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_BASE_URL": "https://workspace.example/ai-gateway/anthropic"},
+            api_key_helper=f"databricks auth token --profile {profile}",
+            model="databricks-claude-opus-4-8",
+        ),
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="native-claude",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+
+    env = _build_spawn_env_from_spec(spec, "claude-native")
+
+    assert env is not None
+    assert env["HARNESS_CLAUDE_NATIVE_GATEWAY"] == "true"
+    assert env["HARNESS_CLAUDE_NATIVE_ENV_ANTHROPIC_BASE_URL"] == (
+        "https://workspace.example/ai-gateway/anthropic"
+    )
+    assert env["HARNESS_CLAUDE_NATIVE_API_KEY_HELPER"] == "databricks auth token --profile DEFAULT"
+    assert env["HARNESS_CLAUDE_NATIVE_MODEL"] == "databricks-claude-opus-4-8"
+
+
+def test_build_spawn_env_codex_native_databricks_default_uses_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured Databricks default emits native Codex profile spawn env."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  databricks:\n"
+        "    kind: databricks\n"
+        "    default: true\n"
+        "    profile: DEFAULT\n"
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name="native-codex",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex-native", "model": "databricks-gpt-5"},
+            model="databricks-gpt-5",
+        ),
+    )
+
+    env = _build_spawn_env_from_spec(spec, "codex-native")
+
+    assert env == {
+        "HARNESS_CODEX_NATIVE_GATEWAY": "true",
+        "HARNESS_CODEX_NATIVE_DATABRICKS_PROFILE": "DEFAULT",
+        "HARNESS_CODEX_NATIVE_MODEL": "databricks-gpt-5",
+    }


### PR DESCRIPTION
## Root cause

Spawned `claude-native` / `codex-native` child harness subprocesses were getting only bridge/session env. `_build_spawn_env_from_spec()` returned `None` for native harnesses, so native child launches fell back to their local Claude/Codex defaults instead of inheriting the Databricks ucode/gateway routing the parent native launch resolved.

## Fix

- Build Databricks/ucode provider spawn-env for `claude-native` and `codex-native` using the existing native resolvers (`resolve_native_claude_config()` and `resolve_native_codex_launch()`).
- Merge that provider env with the native bridge/session env at both runner spawn sites.
- Rehydrate the env inside the child harness and feed it into the actual native launch paths:
  - Claude: `ANTHROPIC_BASE_URL`-style terminal env, `apiKeyHelper`, and model pin.
  - Codex: Databricks profile/model/config override launch config.
- Preserve precedence: `model_override` wins over spec/provider defaults.
- Preserve non-Databricks/native-login behavior: no provider env is emitted unless the native resolver identifies a ucode/Databricks route.

## Tests

Added/extended tests for:

- `_build_spawn_env_from_spec()` emitting native gateway env for Databricks defaults.
- `/model` override taking precedence for native spawn env.
- Native bridge/session env merging with provider env.
- Child-process env rehydration into Claude/Codex native launch config.
- No forced gateway env when no Databricks/ucode route is selected.

## Gates

- `uv run --extra dev ruff format --check omnigent/runner/app.py tests/runner/test_runner_dispatch.py tests/runner/test_native_spawn_env.py` ✅
- `uv run --extra dev ruff check omnigent/runner/app.py tests/runner/test_runner_dispatch.py tests/runner/test_native_spawn_env.py` ✅
- `uv run --extra dev pytest -q tests/runner/test_runner_dispatch.py::test_build_spawn_env_applies_model_override tests/runner/test_runner_dispatch.py::test_build_spawn_env_claude_native_carries_ucode_provider_config tests/runner/test_runner_dispatch.py::test_build_spawn_env_codex_native_carries_ucode_provider_config tests/runner/test_runner_dispatch.py::test_build_spawn_env_native_no_provider_path_unchanged tests/runner/test_runner_dispatch.py::test_build_spawn_env_native_non_databricks_provider_path_unchanged tests/runner/test_runner_dispatch.py::test_build_spawn_env_claude_native_databricks_default_uses_ucode tests/runner/test_runner_dispatch.py::test_build_spawn_env_codex_native_databricks_default_uses_profile tests/runner/test_native_spawn_env.py tests/runner/test_app_sessions_native.py::test_auto_create_claude_terminal_injects_ucode_gateway_config tests/test_claude_native.py::test_resolve_native_claude_config_databricks_provider_uses_ucode tests/test_codex_native_app_server.py` ✅ (`38 passed, 1 known-failures warning`)
- `uv tool run pyrefly check omnigent/runner/app.py tests/runner/test_runner_dispatch.py tests/runner/test_native_spawn_env.py` ⚠️ reports 14 existing errors in `omnigent/runner/app.py` / `tests/runner/test_runner_dispatch.py`; the new pyrefly issue in `_build_spawn_env_from_spec()` was fixed, and `uv run --extra dev mypy tests/runner/test_native_spawn_env.py` passes.
