### PR TITLE
fix(native): sync active model every poll; render policy deny once

### DIFF
--- a/ap-web/src/store/chatStore.test.ts
+++ b/ap-web/src/store/chatStore.test.ts
@@ -23,6 +23,7 @@ import type {
   ElicitationBlock,
   ErrorBlock,
   NativeToolBlock,
+  TextDone,
   UserMessageBlock,
 } from "@/lib/blocks";
 import type { ConversationItem } from "@/lib/conversationItems";
@@ -6742,5 +6743,81 @@ describe("chatStore — elicitations across stream drops and re-publishes", () =
     expect(cards[0]!.response?.action).toBe("accept");
 
     await abortLoop(sinks, controller, loop);
+  });
+});
+
+describe("chatStore — policy deny renders once", () => {
+  const setState = useChatStore.setState as unknown as Parameters<typeof pumpStreamEvents>[3];
+  const getState = useChatStore.getState as unknown as Parameters<typeof pumpStreamEvents>[4];
+
+  function manualSched() {
+    let cb: (() => void) | null = null;
+    return {
+      scheduler: {
+        schedule: (c: () => void) => {
+          cb = c;
+        },
+        cancel: () => {
+          cb = null;
+        },
+      } as FrameScheduler,
+      fire: () => {
+        const c = cb;
+        cb = null;
+        if (c) c();
+      },
+    };
+  }
+
+  function denyCount(): number {
+    return useChatStore
+      .getState()
+      .blocks.filter(
+        (b) => b.type === "text_done" && (b as TextDone).fullText.includes("Denied by policy"),
+      ).length;
+  }
+
+  async function run(denyData: Record<string, unknown>): Promise<number> {
+    useChatStore.setState({ conversationId: "conv_deny", blocks: [] });
+    const sink = pushableStream();
+    const controller = new AbortController();
+    const manual = manualSched();
+    void pumpStreamEvents(
+      "conv_deny",
+      sink.stream,
+      controller,
+      setState,
+      getState,
+      manual.scheduler,
+    );
+    // Message 2 denied — server publishes the sentinel.
+    sink.push(sse("response.output_text.delta", denyData));
+    await tick();
+    manual.fire();
+    await tick();
+    // Message 3 submitted → next response starts (the switch that doubled it).
+    sink.push(sse("response.created", { id: "resp_2", status: "in_progress", output: [] }));
+    sink.push(
+      sse("response.output_text.delta", {
+        delta: "Hello there friend",
+        message_id: "m_reply",
+        index: 0,
+      }),
+    );
+    await tick();
+    manual.fire();
+    await tick();
+    const n = denyCount();
+    controller.abort();
+    return n;
+  }
+
+  it("renders once when the deny carries a message_id", async () => {
+    // A deny stamped with a stable message_id folds into a single
+    // live-preview block and survives the next response switch as one bubble
+    // (the server stamps one for every session — native and non-native).
+    expect(
+      await run({ delta: "[Denied by policy: over budget]", message_id: "deny_abc", index: 0 }),
+    ).toBe(1);
   });
 });

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -676,6 +676,18 @@ async def forward_claude_transcript_to_session(
                         dedupe=dedupe,
                         cost_cache=cost_cache,
                     )
+                    # Mirror the live statusLine model EVERY poll (not just
+                    # when a turn produced new transcript items, which
+                    # _forward_available_items early-returns without). This
+                    # propagates an in-pane /model switch to model_override
+                    # before the user's next message, so model-gated policies
+                    # (cost-budget hard cap) no longer lag a switch by one turn.
+                    await _forward_model_from_status(
+                        client=client,
+                        session_id=current_session_id,
+                        bridge_dir=bridge_dir,
+                        dedupe=dedupe,
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -2598,37 +2610,18 @@ async def _forward_available_items(
             )
     # Mirror a TUI-side `/model` switch to the web picker. The transcript
     # records the resolved concrete id (e.g. "claude-opus-4-8"); collapse
-    # it to the picker's tier alias. ``observed_model`` is sticky across
-    # polls — the incremental window usually has no fresh message.model —
-    # so a failed POST is retried on the next poll rather than lost.
-    alias = _model_alias_for(result.latest_model)
-    if alias is not None:
-        dedupe.observed_model = alias
-    if dedupe.observed_model is not None and dedupe.observed_model != dedupe.posted_model:
-        if dedupe.posted_model is None:
-            # First observation = the spawn default; seed the baseline
-            # without posting so it can't clobber a pending silent model
-            # handoff. Only a later in-TUI switch is mirrored.
-            dedupe.posted_model = dedupe.observed_model
-        else:
-            try:
-                await _post_external_model_change(
-                    client,
-                    session_id=session_id,
-                    model=dedupe.observed_model,
-                )
-                dedupe.posted_model = dedupe.observed_model
-            except httpx.HTTPError as exc:
-                # Leave posted_model behind observed_model so the next
-                # poll retries (best-effort, like the usage post above).
-                _logger.warning(
-                    "Failed to forward Claude model change; session=%s bridge_dir=%s "
-                    "http_status=%s",
-                    session_id,
-                    bridge_dir,
-                    _http_status_for_log(exc),
-                    exc_info=True,
-                )
+    # it to the picker's tier alias. This transcript-derived observation
+    # only fires when a turn produces a fresh ``message.model``, so it lags
+    # an in-pane switch by one turn — the per-poll statusLine sync
+    # (:func:`_forward_model_from_status`) is the primary, low-latency
+    # source; this stays as a fallback for cold-resume before the first
+    # statusLine render. Both share ``dedupe`` so neither double-posts.
+    await _post_model_change_if_new(
+        client,
+        session_id=session_id,
+        dedupe=dedupe,
+        alias=_model_alias_for(result.latest_model),
+    )
     return updated
 
 
@@ -3029,6 +3022,103 @@ async def _post_external_model_change(
         json={"type": "external_model_change", "data": {"model": model}},
     )
     resp.raise_for_status()
+
+
+async def _post_model_change_if_new(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    dedupe: _ForwardDedupeState,
+    alias: str | None,
+) -> None:
+    """
+    Mirror an observed model tier alias to ``model_override``, deduped.
+
+    Shared by the transcript-driven path (:func:`_forward_available_items`)
+    and the statusLine-driven per-poll path
+    (:func:`_forward_model_from_status`). The FIRST observation is the
+    session's spawn default, not a switch, so it seeds the dedupe baseline
+    WITHOUT posting (posting it could clobber a pending silent model
+    handoff). Every later change posts ``external_model_change``. Both
+    callers pass the same ``dedupe`` so whichever observes a switch first
+    posts it and the other no-ops. Best-effort: a failed POST leaves
+    ``posted_model`` behind ``observed_model`` so the next poll retries.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    :param dedupe: Shared per-session dedupe state; mutated in place.
+    :param alias: Tier alias just observed (``"opus"`` / ``"sonnet"`` /
+        …), or ``None`` when this source carried no recognizable model on
+        this poll. ``observed_model`` is sticky across polls, so passing
+        ``None`` does NOT clear it — it just means "no fresh observation,"
+        and a previously-observed-but-unposted model is still reconciled
+        (retried) here.
+    """
+    if alias is not None:
+        dedupe.observed_model = alias
+    if dedupe.observed_model is None or dedupe.observed_model == dedupe.posted_model:
+        return
+    if dedupe.posted_model is None:
+        # First observation = the spawn default; seed the baseline without
+        # posting so it can't clobber a pending silent model handoff.
+        dedupe.posted_model = dedupe.observed_model
+        return
+    try:
+        await _post_external_model_change(
+            client,
+            session_id=session_id,
+            model=dedupe.observed_model,
+        )
+        dedupe.posted_model = dedupe.observed_model
+    except httpx.HTTPError:
+        # Leave posted_model behind observed_model so the next poll retries.
+        _logger.warning(
+            "Failed to mirror model change to Omnigent session=%s; model pill / "
+            "cost-budget gate may lag until the next poll",
+            session_id,
+            exc_info=True,
+        )
+
+
+async def _forward_model_from_status(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    dedupe: _ForwardDedupeState,
+) -> None:
+    """
+    Mirror the statusLine-reported active model to ``model_override`` each poll.
+
+    Claude Code rewrites the statusLine stdin on every TUI render — including
+    right after an in-pane ``/model`` switch, BEFORE the next turn runs. The
+    wrapper (:mod:`omnigent.claude_native_status`) persists that model into
+    ``context.json``. Reading it here, every poll and independently of new
+    transcript items, is what lets a policy that gates on the active model
+    (e.g. the session cost-budget hard cap, which only blocks expensive
+    tiers) see the new model on the user's NEXT message — instead of one
+    turn later, which is what happened when the model was derived solely
+    from the next turn's transcript ``message.model``.
+
+    Best-effort and idempotent: shares ``dedupe`` with the transcript path,
+    so a no-op when the model is unchanged.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    :param bridge_dir: Native Claude bridge directory.
+    :param dedupe: Shared per-session model dedupe state.
+    """
+    status_state = await asyncio.to_thread(read_claude_context_state, bridge_dir)
+    if status_state is None:
+        return
+    model = status_state.get("model")
+    alias = _model_alias_for(model if isinstance(model, str) else None)
+    await _post_model_change_if_new(
+        client,
+        session_id=session_id,
+        dedupe=dedupe,
+        alias=alias,
+    )
 
 
 async def _post_external_session_status(

--- a/omnigent/claude_native_status.py
+++ b/omnigent/claude_native_status.py
@@ -99,6 +99,24 @@ def _write_context_atomic(bridge_dir: Path, payload: dict[str, object]) -> None:
             and total_cost >= 0
         ):
             record["total_cost_usd"] = float(total_cost)
+    # Claude Code's statusLine stdin carries the active model as a ``model``
+    # block (``{"id": "claude-opus-4-8", "display_name": "Opus"}``), rewritten
+    # on every render — including right after an in-pane ``/model`` switch.
+    # Capture the concrete id so the forwarder can mirror the switch to
+    # ``model_override`` on the next poll, before the user's next message,
+    # rather than waiting for the next turn's transcript to reveal the model
+    # (which lagged model-gated policies by one turn). Defensive about the
+    # shape: accept a ``{id|display_name}`` dict or a bare string.
+    model = payload.get("model")
+    model_id: str | None = None
+    if isinstance(model, dict):
+        raw_model = model.get("id") or model.get("display_name")
+        if isinstance(raw_model, str) and raw_model.strip():
+            model_id = raw_model.strip()
+    elif isinstance(model, str) and model.strip():
+        model_id = model.strip()
+    if model_id is not None:
+        record["model"] = model_id
     try:
         bridge_dir.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(prefix=".context-", dir=str(bridge_dir))

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8969,6 +8969,46 @@ def _extract_user_text_from_event(body: SessionEventInput) -> str:
     return "\n".join(parts)
 
 
+def _publish_policy_deny(session_id: str, reason: str) -> None:
+    """
+    Publish the ``[Denied by policy: ...]`` sentinel on the session stream.
+
+    The sentinel text is a load-bearing contract (the REPL renders it, e2e
+    tests assert it, and native harnesses relay it to the model), so it is
+    always carried in a ``response.output_text.delta``.
+
+    The deny is never persisted as a conversation item — the input gate
+    publishes it and returns without forwarding — so a ``message_id``-less
+    delta lands in the web reducer's response-scoped text path as an
+    un-reconciled "stray bubble" with no item to dedupe against. On the next
+    user submit the response switch re-finalizes that still-open text,
+    rendering the deny twice (observed on both native and non-native web
+    sessions). Stamping a unique ``message_id`` (matching how live streaming
+    text is tagged) routes it through the web's live-preview path instead,
+    where it folds into a single ``live:<id>`` block.
+
+    Safe for the other consumers: the REPL converts any ``output_text.delta``
+    to a ``TextDelta`` regardless of ``message_id``; the ``/v1/responses`` API
+    surfaces the deny via input-deny synthesis (not session-stream deltas);
+    and the only ``message_id``-gated accumulator (``_relay_runner_stream``)
+    reads runner-relayed deltas, never this server-published one.
+
+    :param session_id: Session/conversation identifier.
+    :param reason: Human-readable deny reason from the policy verdict.
+    """
+    session_stream.publish(
+        session_id,
+        {
+            "type": "response.output_text.delta",
+            "delta": f"[Denied by policy: {reason}]",
+            # Unique per deny so two separate denials don't fold into one
+            # block; a single delta carries the whole sentinel, so index 0.
+            "message_id": f"deny_{secrets.token_hex(8)}",
+            "index": 0,
+        },
+    )
+
+
 async def _evaluate_input_policy(
     request: Request,
     session_id: str,
@@ -15519,13 +15559,7 @@ def create_sessions_router(
                 # client/REPL sees feedback.
                 reason = _input_verdict.get("reason", "Denied by policy")
                 _publish_status(session_id, "running")
-                session_stream.publish(
-                    session_id,
-                    {
-                        "type": "response.output_text.delta",
-                        "delta": f"[Denied by policy: {reason}]",
-                    },
-                )
+                _publish_policy_deny(session_id, reason)
                 _publish_status(session_id, "idle")
                 # Return the same shape the client expects from POST
                 # /events so postEvent doesn't throw on an unexpected
@@ -15545,13 +15579,7 @@ def create_sessions_router(
             if _input_verdict is not None:
                 reason = _input_verdict.get("reason", "Denied by policy")
                 _publish_status(session_id, "running")
-                session_stream.publish(
-                    session_id,
-                    {
-                        "type": "response.output_text.delta",
-                        "delta": f"[Denied by policy: {reason}]",
-                    },
-                )
+                _publish_policy_deny(session_id, reason)
                 _publish_status(session_id, "idle")
                 return {"queued": False, "denied": True, "reason": reason}
         elif (


### PR DESCRIPTION
## Problem

Two bugs surfaced while debugging why a session cost-budget policy didn't gate native sessions correctly:

1. **Model state lagged a turn (native).** A native session only learned its active model from an assistant message's `model` field in the *next* turn's transcript, so the policy engine's `conv.model_override` trailed a TUI `/model` switch by one full turn. The cost-budget hard cap gates on the model (it blocks only expensive tiers), so the first message after a switch was mis-evaluated — under-blocking right after switching **to** an expensive model, and over-blocking (citing the old model) right after switching to a cheaper one.

2. **A policy deny rendered twice (web).** The input-policy gate publishes the `[Denied by policy: ...]` sentinel as a lone `response.output_text.delta` and never persists it. With no `message_id` and no committed item, the web reducer parks it in the response-scoped text path as an un-reconciled "stray bubble"; submitting the next message starts a new response whose switch re-finalizes that still-open text, so the deny shows twice. Reproduced on both native and non-native sessions; confirmed server-side the deny is published exactly once.

## Fix

- **Model propagation:** the claude-native status hook captures the live `model` from the statusLine payload (rewritten on every render, including right after a switch) into `context.json`, and the forwarder mirrors it to `model_override` on every poll via the existing `external_model_change` path — independent of new transcript items. The transcript-derived value remains as a cold-resume fallback (shared dedupe).
- **Deny rendering:** stamp a unique `message_id` on the deny delta so the web folds it into a single live-preview block instead of the stray-bubble path. The sentinel text is unchanged, so the REPL / e2e / native-relay contracts hold; the only `message_id`-gated accumulator (`_relay_runner_stream`) reads runner-relayed deltas and never sees this server-published one.

## Notes / tradeoffs

- The deny is now a transient live-preview block, so it clears on reconnect/refresh — acceptable since it was never persisted.
- A small residual window remains for model propagation (one forwarder poll, sub-second) vs. the previous full-turn lag.

## Testing

- `tests/test_claude_native_forwarder.py`, `tests/server/routes/test_sessions_policy.py` — pass (97).
- New `ap-web` reducer regression test: a `message_id`-stamped deny renders as exactly one block and survives the next response switch.
- Manually verified on a local deployment: switching model now gates the next message correctly, and the deny renders once on native and non-native sessions.
