### PR TITLE
fix(cursor): tear down the SDK bridge via aclose() (was leaking subprocess + daemon thread)

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -562,9 +562,21 @@ class CursorExecutor(Executor):
 
 
 async def _safe_close(obj: Any) -> None:  # type: ignore[explicit-any]
-    """Best-effort ``await obj.close()``; a teardown failure must not mask the
-    original error or leave ``close()`` raising."""
+    """Best-effort async close of a ``cursor_sdk`` object, preferring ``aclose()``.
+
+    The SDK's :class:`cursor_sdk.AsyncClient` exposes only ``aclose()`` — and
+    that is the *only* path that terminates the launched bridge subprocess and
+    shuts down the tool-callback server's daemon HTTP thread. :class:`AsyncAgent`
+    exposes ``close()`` instead. Calling a method the object doesn't have raised
+    ``AttributeError`` (swallowed below), so the client was never torn down and
+    every session leaked its bridge subprocess + daemon thread. Prefer ``aclose``
+    and fall back to ``close``; a teardown failure must not mask the original
+    error or leave the closer raising.
+    """
+    closer = getattr(obj, "aclose", None) or getattr(obj, "close", None)
+    if closer is None:
+        return
     try:
-        await obj.close()
+        await closer()
     except Exception as exc:  # noqa: BLE001 — best-effort teardown
         logger.debug("CursorExecutor: close failed: %s", exc)

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -67,6 +67,8 @@ def _install_fake_sdk(
         "launch_kwargs": [],
         "sent": [],
         "closed": 0,
+        "client_closed": 0,
+        "agent_closed": 0,
     }
 
     class _FakeRun:
@@ -88,8 +90,10 @@ def _install_fake_sdk(
             state["sent"].append(prompt)
             return _FakeRun(scripts.pop(0))
 
+        # AsyncAgent exposes close() (a CloseAgent RPC + tool unregister).
         async def close(self) -> None:
             state["closed"] += 1
+            state["agent_closed"] += 1
 
     class _FakeClient:
         @classmethod
@@ -97,8 +101,13 @@ def _install_fake_sdk(
             state["launch_kwargs"].append(kwargs)
             return cls()
 
-        async def close(self) -> None:
+        # The real AsyncClient exposes ONLY aclose() (no close()); it owns the
+        # bridge subprocess + the daemon tool-callback server, both torn down
+        # there. Deliberately no close() here so a regression that closes the
+        # client via close() fails (AttributeError -> swallowed -> leak).
+        async def aclose(self) -> None:
             state["closed"] += 1
+            state["client_closed"] += 1
 
     class _FakeAsyncAgent:
         @classmethod
@@ -357,7 +366,26 @@ async def test_setup_failure_closes_client_and_drops_session(
     errors = [e for e in events if isinstance(e, ExecutorError)]
     assert len(errors) == 1 and "bad CURSOR_API_KEY" in errors[0].message
     assert "conv1" not in executor._session_states  # session dropped
-    assert state["closed"] == 1  # the launched bridge client was closed → no leak
+    # The launched bridge client was torn down via aclose() → no orphaned bridge.
+    assert state["closed"] == 1
+    assert state["client_closed"] == 1
+
+
+async def test_close_session_tears_down_bridge_client_via_aclose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A normal session close must tear the bridge-owning AsyncClient down via
+    ``aclose()`` — its only teardown path (it owns the bridge subprocess + the
+    daemon tool-callback thread). The real SDK client has no ``close()``, so
+    closing via ``close()`` silently leaks; this pins the client to aclose()."""
+    state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    executor = CursorExecutor(api_key="crsr_x")
+    _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    assert state["client_closed"] == 0  # still live mid-conversation
+    await executor.close()
+    # Both the agent (close) and the bridge-owning client (aclose) are released.
+    assert state["agent_closed"] == 1
+    assert state["client_closed"] == 1
 
 
 async def test_mid_turn_error_status_drops_session(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

A swarm audit of the merged Cursor harness (#203/#204) surfaced a **critical resource leak**: the bridge subprocess and its daemon tool-callback HTTP thread are leaked on *every* session teardown.

`_safe_close()` did `await obj.close()`, but the cursor-sdk `AsyncClient` (returned by `launch_bridge()`) **has no `close()` — only `aclose()`**, and `aclose()` is the only path that terminates the bridge subprocess and shuts down the `ToolCallbackServer` daemon thread. The `close()` call raised `AttributeError`, which `_safe_close` swallows at `logger.debug`, so the client was never torn down.

Verified at runtime against the installed SDK:
```
AsyncClient has close: False   aclose: True
```

This leaked on every teardown path: `close_session`, `interrupt_session`, every `run_turn` error path, the restart-on-changed-prompt/model/tools path, and the `_ensure_session` bring-up-failure path (whose docstring claims it prevents orphaning a bridge subprocess — it didn't). In a long-lived host driving many cursor sessions this is **unbounded growth of orphaned `cursor-sdk-bridge` subprocesses and zombie daemon threads**.

The unit tests passed only because the **fake** `_FakeClient` defined a `close()` the real `AsyncClient` doesn't have — the fake diverged from the real API and masked the bug.

## Fix

- `_safe_close()` now prefers `aclose()` and falls back to `close()` (`AsyncAgent` uses `close()`), so the client's bridge/daemon-thread teardown actually runs.
- The test fake's `_FakeClient` is corrected to expose **`aclose()` only**, matching the real SDK contract — so a future regression that closes the client via `close()` fails loudly (`AttributeError` → swallowed → no teardown).
- New `test_close_session_tears_down_bridge_client_via_aclose` pins the client to `aclose()`; the existing setup-failure test now asserts the client specifically.

## Test

`uv run --frozen --extra dev python -m pytest tests/inner/test_cursor_executor.py` → **22 passed**.

This pull request and its description were written by Isaac.
