### PR TITLE
test(cursor): cover mcp-unwrap-on-completion and stored>ambient key precedence

### DIFF
--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -217,6 +217,36 @@ def test_sdk_message_to_events_unwraps_cursor_custom_tool_envelope() -> None:
     assert events[0].args == {"session": "s1", "message": "go"}
 
 
+def test_sdk_message_to_events_unwraps_envelope_on_completion_and_error() -> None:
+    # The same mcp envelope (name == "mcp", real tool nested in args) also arrives
+    # on the completed/error branch. The unwrap must apply there too so the
+    # ToolCallComplete carries the real tool name (not "mcp") — otherwise any
+    # name-keyed request<->complete correlation in policy/UI would break.
+    def _envelope(status: str, result: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            type="tool_call",
+            name="mcp",
+            call_id="c1",
+            status=status,
+            args={
+                "providerIdentifier": "custom-user-tools",
+                "toolName": "sys_session_send",
+                "args": {"session": "s1"},
+            },
+            result=result,
+        )
+
+    done = _sdk_message_to_events(_envelope("completed", [{"type": "text", "text": "ok"}]))
+    assert isinstance(done[0], ToolCallComplete)
+    assert done[0].name == "sys_session_send"  # unwrapped, not "mcp"
+    assert done[0].metadata == {"call_id": "c1"}
+
+    err = _sdk_message_to_events(_envelope("error", "boom"))
+    assert isinstance(err[0], ToolCallComplete)
+    assert err[0].name == "sys_session_send"
+    assert err[0].status == ToolCallStatus.ERROR
+
+
 def test_build_cursor_prompt_prepends_system_then_drops_it() -> None:
     msgs = [_user("hello")]
     first = _build_cursor_prompt(msgs, is_first_turn=True, system_prompt="SYS")

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -155,6 +155,23 @@ def test_stored_cursor_key_used_when_spec_has_no_auth(
     assert env["HARNESS_CURSOR_API_KEY"] == "crsr_stored_123"
 
 
+def test_stored_cursor_key_wins_over_ambient_when_both_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With no spec auth, the stored ``cursor:`` key (registered via ``omnigent
+    setup``) wins over an ambient ``CURSOR_API_KEY`` when BOTH are present.
+
+    This pins the middle rung of the precedence chain (spec auth > stored >
+    ambient): a refactor that swapped the two branches would silently let an
+    ambient key override the user's configured one, with no other test failing.
+    """
+    monkeypatch.setenv("CURSOR_KEY_SRC", "crsr_stored_123")
+    _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_ambient_456")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_CURSOR_API_KEY"] == "crsr_stored_123"
+
+
 def test_spec_api_key_auth_wins_over_stored_key(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## What

Stacked on #223. Two test-only coverage gaps the audit surfaced — both lock in correct behavior the production code already has, so a future refactor can't silently regress it.

**1. mcp-envelope unwrap on completion/error.** Cursor surfaces host custom tools wrapped (`name == "mcp"`, real tool nested in `args`). The unwrap was only tested on the `running` status (→ `ToolCallRequest`). The same unwrap runs on the `completed`/`error` branch too — if it regressed there, the `ToolCallComplete` would report `name == "mcp"` and break any name-keyed request↔complete correlation in policy/UI. New test asserts the completed/error events carry the real tool name.

**2. Auth-precedence middle rung.** Precedence is spec `api_key` > stored `cursor:` block > ambient `CURSOR_API_KEY`. Existing tests covered spec-over-stored, spec-over-ambient, stored-alone, ambient-alone — but never **stored winning over ambient when BOTH are set**. New test pins it, so a refactor swapping the two branches (silently letting an ambient key override the `omnigent setup`-registered one) fails loudly.

## Test

`tests/inner/test_cursor_executor.py` + `tests/runtime/test_cursor_spawn_env.py` → **44 passed**; `ruff` clean.

This pull request and its description were written by Isaac.
