### PR TITLE
feat(web): add "Jump to top" affordance to the conversation

### DIFF
--- a/ap-web/src/components/ai-elements/conversation.tsx
+++ b/ap-web/src/components/ai-elements/conversation.tsx
@@ -75,7 +75,13 @@ export const ConversationScrollButton = ({
     !isAtBottom && (
       <Button
         className={cn(
-          "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full dark:bg-background dark:hover:bg-muted",
+          "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full",
+          // Keep the fill OPAQUE on hover. The outline variant's hover (bg-muted)
+          // is a translucent black wash (--muted is #0000000f), so over the chat
+          // content behind it the button reads as transparent on hover. Hover
+          // feedback comes from a brightness filter instead, which stays opaque.
+          "bg-background hover:bg-background hover:brightness-95",
+          "dark:bg-background dark:hover:bg-background dark:hover:brightness-125",
           className,
         )}
         onClick={handleScrollToBottom}

--- a/ap-web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/ap-web/src/pages/ChatPage.historyLoad.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
 import { HistoryAutoLoader, JumpToTopButton } from "./ChatPage";
@@ -157,7 +157,17 @@ describe("JumpToTopButton", () => {
     useChatStore.setState({ loadMoreHistory: originalLoadMoreHistory, hasMoreHistory: false });
   });
 
-  const pill = () => screen.getByRole("button", { name: /jump to the first message/i });
+  // Query by the aria-label attribute rather than role/accessible-name: when
+  // hidden the button is aria-hidden (out of the accessibility tree, so its
+  // accessible name computes to ""), and these tests assert on its
+  // className/visibility rather than reachability.
+  const pill = () => {
+    const el = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Jump to the first message"]',
+    );
+    if (!el) throw new Error("Jump-to-top pill not found");
+    return el;
+  };
 
   /**
    * A wrapper (hover/anchor) + inner scroll container, plus a stub of the

--- a/ap-web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/ap-web/src/pages/ChatPage.historyLoad.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
-import { HistoryAutoLoader } from "./ChatPage";
+import { HistoryAutoLoader, JumpToTopButton } from "./ChatPage";
 
 const stickContext = vi.hoisted(() => ({
   scrollRef: { current: null as HTMLElement | null },
@@ -148,5 +148,99 @@ describe("HistoryAutoLoader", () => {
     holder.cb?.();
 
     expect(loadMoreHistory).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("JumpToTopButton", () => {
+  afterEach(() => {
+    cleanup();
+    useChatStore.setState({ loadMoreHistory: originalLoadMoreHistory, hasMoreHistory: false });
+  });
+
+  const pill = () => screen.getByRole("button", { name: /jump to the first message/i });
+
+  /**
+   * A wrapper (hover/anchor) + inner scroll container, plus a stub of the
+   * StickToBottom lock controls — mirrors the real ConversationScroller.
+   */
+  function makeScroller(metrics: {
+    scrollTop: number;
+    scrollHeight: number;
+    clientHeight?: number;
+  }) {
+    const container = document.createElement("div");
+    const scroll = document.createElement("div");
+    container.append(scroll);
+    setScrollMetrics(scroll, metrics);
+    const state = { isAtBottom: true, escapedFromLock: false };
+    const stopScroll = vi.fn();
+    return { container, scroll, scroller: { el: scroll, state, stopScroll } };
+  }
+
+  it("stays non-interactive at the first message (nothing above)", () => {
+    const { container, scroller } = makeScroller({
+      scrollTop: 0,
+      scrollHeight: 100,
+      clientHeight: 100,
+    });
+
+    render(<JumpToTopButton containerEl={container} scroller={scroller} hasMoreHistory={false} />);
+    // Hover the top edge (jsdom getBoundingClientRect().top is 0).
+    act(() => {
+      fireEvent.mouseMove(container, { clientY: 10 });
+    });
+
+    expect(pill().className).toContain("pointer-events-none");
+  });
+
+  it("reveals on hover near the top when there is history above", () => {
+    const { container, scroller } = makeScroller({
+      scrollTop: 0,
+      scrollHeight: 100,
+      clientHeight: 100,
+    });
+
+    render(<JumpToTopButton containerEl={container} scroller={scroller} hasMoreHistory={true} />);
+    expect(pill().className).toContain("pointer-events-none");
+
+    // Hovering the wrapper near the top reveals and arms the pill.
+    act(() => {
+      fireEvent.mouseMove(container, { clientY: 10 });
+    });
+    expect(pill().className).toContain("pointer-events-auto");
+
+    // Leaving the conversation hides it again.
+    act(() => {
+      fireEvent.mouseLeave(container);
+    });
+    expect(pill().className).toContain("pointer-events-none");
+  });
+
+  it("releases the bottom-lock, pages in all history, then scrolls to the top", async () => {
+    const { container, scroller, scroll } = makeScroller({
+      scrollTop: 500,
+      scrollHeight: 1000,
+      clientHeight: 400,
+    });
+    const metrics = scroll as unknown as { scrollTop: number };
+
+    let calls = 0;
+    const loadMoreHistory = vi.fn(async () => {
+      calls += 1;
+      // Simulate the library trying to re-stick to the bottom on each prepend;
+      // jumpToTop must keep clearing the lock for the final scroll to hold.
+      scroller.state.isAtBottom = true;
+      if (calls >= 2) useChatStore.setState({ hasMoreHistory: false });
+    });
+    useChatStore.setState({ hasMoreHistory: true, loadMoreHistory });
+
+    render(<JumpToTopButton containerEl={container} scroller={scroller} hasMoreHistory={true} />);
+    fireEvent.click(pill());
+
+    await waitFor(() => expect(useChatStore.getState().hasMoreHistory).toBe(false));
+    await waitFor(() => expect(metrics.scrollTop).toBe(0));
+    expect(scroller.stopScroll).toHaveBeenCalled();
+    expect(scroller.state.isAtBottom).toBe(false);
+    expect(loadMoreHistory).toHaveBeenCalledTimes(2);
   });
 });

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1297,10 +1297,7 @@ function MainAgentSurface({
     <>
       {/* Wrapper div gives us a ref to scope the SelectionPopup to the
           conversation area without requiring Conversation to forward refs. */}
-      <div
-        ref={setConversationEl}
-        className="relative flex min-h-0 flex-1 overflow-hidden"
-      >
+      <div ref={setConversationEl} className="relative flex min-h-0 flex-1 overflow-hidden">
         {/* chat-scroll-fade masks the viewport's top edge so scrolling
             content dissolves into the canvas before reaching the
             ChatHeader overlay's controls (geometry in index.css). */}

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1743,7 +1743,10 @@ export function JumpToTopButton({
   useEffect(() => {
     if (!containerEl) return;
     const onMove = (e: MouseEvent) => {
-      setHovering(e.clientY - containerEl.getBoundingClientRect().top < HOVER_BAND_PX);
+      const next = e.clientY - containerEl.getBoundingClientRect().top < HOVER_BAND_PX;
+      // Only commit on a transition — mousemove fires continuously, and React
+      // bails on a no-op setState anyway, but skipping it avoids the work.
+      setHovering((prev) => (prev === next ? prev : next));
     };
     const onLeave = () => setHovering(false);
     containerEl.addEventListener("mousemove", onMove, { passive: true });
@@ -1758,7 +1761,10 @@ export function JumpToTopButton({
   const scrollEl = scroller?.el ?? null;
   useEffect(() => {
     if (!scrollEl) return;
-    const onScroll = () => setAtTop(scrollEl.scrollTop <= 1);
+    const onScroll = () => {
+      const next = scrollEl.scrollTop <= 1;
+      setAtTop((prev) => (prev === next ? prev : next));
+    };
     onScroll();
     scrollEl.addEventListener("scroll", onScroll, { passive: true });
     return () => scrollEl.removeEventListener("scroll", onScroll);
@@ -1833,6 +1839,11 @@ export function JumpToTopButton({
         disabled={jumping}
         onClick={() => void jumpToTop()}
         aria-label="Jump to the first message"
+        // When hidden (opacity-0 / pointer-events-none) keep the button out of
+        // the tab order and the accessibility tree so it can't take focus or be
+        // announced while invisible.
+        tabIndex={visible ? 0 : -1}
+        aria-hidden={!visible}
         className={cn(
           "h-7 gap-1.5 rounded-full px-3 text-xs shadow-sm",
           // Force an OPAQUE background in both themes and on hover. The outline

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1227,8 +1227,21 @@ function MainAgentSurface({
 
   // Ref forwarded to SelectionPopup to scope selection detection to the
   // conversation area, preventing selections in the composer from triggering
-  // the popup.
+  // the popup. Mirrored into state (`containerEl`) so JumpToTopButton — which
+  // renders inside this wrapper, outside the mask-faded scroll viewport — can
+  // attach its hover listeners to the wrapper (the common ancestor of both the
+  // scroll area and the pill, so moving the cursor onto the pill keeps it live).
   const conversationRef = useRef<HTMLElement | null>(null);
+  const [containerEl, setContainerEl] = useState<HTMLElement | null>(null);
+  const setConversationEl = useCallback((el: HTMLDivElement | null) => {
+    conversationRef.current = el;
+    setContainerEl(el);
+  }, []);
+  // The conversation's scroll container + the StickToBottom controls needed to
+  // override its bottom-lock, lifted out of the context by
+  // ConversationScrollRefBridge so the pinned-but-unmasked JumpToTopButton can
+  // read and drive the scroll.
+  const [scroller, setScroller] = useState<ConversationScroller | null>(null);
   const [sendScrollNonce, setSendScrollNonce] = useState(0);
   const handleSend = useCallback(
     (text: string, files?: File[]) => {
@@ -1285,8 +1298,8 @@ function MainAgentSurface({
       {/* Wrapper div gives us a ref to scope the SelectionPopup to the
           conversation area without requiring Conversation to forward refs. */}
       <div
-        ref={conversationRef as React.Ref<HTMLDivElement>}
-        className="flex min-h-0 flex-1 overflow-hidden"
+        ref={setConversationEl}
+        className="relative flex min-h-0 flex-1 overflow-hidden"
       >
         {/* chat-scroll-fade masks the viewport's top edge so scrolling
             content dissolves into the canvas before reaching the
@@ -1296,6 +1309,7 @@ function MainAgentSurface({
           <ConversationContent className={cn("mx-auto w-full gap-4 pt-20 pb-6", CHAT_COLUMN_WIDTH)}>
             {/* Scroll helpers — must live inside StickToBottom to access context. */}
             <ScrollToBottomOnSend nonce={sendScrollNonce} />
+            <ConversationScrollRefBridge onScroller={setScroller} />
             <HistoryAutoLoader
               hasMoreHistory={hasMoreHistory}
               loadingMoreHistory={loadingMoreHistory}
@@ -1371,6 +1385,15 @@ function MainAgentSurface({
             hidden={userMessageIds.length === 0}
           />
         </Conversation>
+        {/* Hover the top edge to reveal a pill that loads all older history and
+            scrolls to the first message. Rendered here (a wrapper sibling of
+            Conversation) rather than inside it so it escapes the chat-scroll-fade
+            mask and can sit right at the fade border. */}
+        <JumpToTopButton
+          containerEl={containerEl}
+          scroller={scroller}
+          hasMoreHistory={hasMoreHistory}
+        />
       </div>
       {/* Floating reply button — scoped to the conversation container. */}
       <SelectionPopup
@@ -1638,6 +1661,203 @@ export function HistoryAutoLoader({
 
   // No visible control — history loads purely on scroll-up / viewport fill.
   return null;
+}
+
+/**
+ * The conversation's scroll container plus the minimal StickToBottom controls
+ * the JumpToTopButton needs to override the library's bottom-lock. `state` is a
+ * stable, mutable object: clearing `isAtBottom`/`escapedFromLock` makes the
+ * resize-driven `scrollToBottom({preserveScrollPosition})` — fired on every
+ * history prepend — bail instead of yanking the view back to the bottom.
+ */
+type ConversationScroller = {
+  el: HTMLElement;
+  state: { isAtBottom: boolean; escapedFromLock: boolean };
+  stopScroll: () => void;
+};
+
+/**
+ * Lifts the StickToBottom scroll container (and lock controls) out of the
+ * context so a sibling rendered *outside* `<Conversation>` (and thus outside
+ * its `chat-scroll-fade` mask) can still read and drive it. `scrollRef`,
+ * `state`, and `stopScroll` are stable identities (see HistoryAutoLoader for
+ * the runtime-vs-types cast). Renders nothing.
+ */
+function ConversationScrollRefBridge({
+  onScroller,
+}: {
+  onScroller: (s: ConversationScroller | null) => void;
+}) {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef: React.RefObject<HTMLElement>;
+    state: ConversationScroller["state"];
+    stopScroll: () => void;
+  };
+  useEffect(() => {
+    // Runs after commit, when StickToBottom has populated scrollRef.current.
+    const el = ctx.scrollRef?.current ?? null;
+    onScroller(el ? { el, state: ctx.state, stopScroll: ctx.stopScroll } : null);
+    return () => onScroller(null);
+  }, [ctx.scrollRef, ctx.state, ctx.stopScroll, onScroller]);
+  return null;
+}
+
+/**
+ * Hover-revealed "Jump to top" pill, mirroring {@link ConversationScrollButton}
+ * but for the other end. Hovering near the top edge of the conversation
+ * surfaces a pill at the fade border; clicking it pages in every older history
+ * block (the conversation is lazily paginated — see {@link HistoryAutoLoader})
+ * and then scrolls to the very first message.
+ *
+ * Rendered as a sibling of `<Conversation>`, not a child: the scroll viewport's
+ * top ~80px is mask-faded (`chat-scroll-fade`), so a pill inside it would fade
+ * out too. Sitting in the wrapper keeps it at full opacity right at the fade
+ * line, and `z-40` lifts it over the `z-30` ChatHeader so it stays clickable.
+ *
+ * Hover is detected in JS off the **wrapper** (`containerEl`), the common
+ * ancestor of both the scroll area and this pill — listening on the scroll
+ * element instead would fire `mouseleave` the instant the cursor crossed onto
+ * the pill (a non-descendant), killing the click. `scroller` carries the inner
+ * scroll container plus the StickToBottom lock controls.
+ *
+ * @param containerEl - The conversation wrapper; hover/anchor reference.
+ * @param scroller - Scroll container + lock controls (ConversationScrollRefBridge).
+ * @param hasMoreHistory - Whether older messages exist before the loaded window.
+ */
+export function JumpToTopButton({
+  containerEl,
+  scroller,
+  hasMoreHistory,
+}: {
+  containerEl: HTMLElement | null;
+  scroller: ConversationScroller | null;
+  hasMoreHistory: boolean;
+}) {
+  const [atTop, setAtTop] = useState(true);
+  const [hovering, setHovering] = useState(false);
+  const [jumping, setJumping] = useState(false);
+
+  // Pixels below the conversation's top edge that count as "hovering the top".
+  // Comfortably clears the pill (anchored at the fade border, ~50px) so moving
+  // onto it to click never drops the hover state.
+  const HOVER_BAND_PX = 140;
+
+  // Hover detection on the wrapper so the pill (a wrapper child) stays in-band.
+  useEffect(() => {
+    if (!containerEl) return;
+    const onMove = (e: MouseEvent) => {
+      setHovering(e.clientY - containerEl.getBoundingClientRect().top < HOVER_BAND_PX);
+    };
+    const onLeave = () => setHovering(false);
+    containerEl.addEventListener("mousemove", onMove, { passive: true });
+    containerEl.addEventListener("mouseleave", onLeave);
+    return () => {
+      containerEl.removeEventListener("mousemove", onMove);
+      containerEl.removeEventListener("mouseleave", onLeave);
+    };
+  }, [containerEl]);
+
+  // Track whether the loaded window is scrolled to its very top.
+  const scrollEl = scroller?.el ?? null;
+  useEffect(() => {
+    if (!scrollEl) return;
+    const onScroll = () => setAtTop(scrollEl.scrollTop <= 1);
+    onScroll();
+    scrollEl.addEventListener("scroll", onScroll, { passive: true });
+    return () => scrollEl.removeEventListener("scroll", onScroll);
+  }, [scrollEl]);
+
+  // Somewhere to go: older pages exist, or we're scrolled down within the
+  // loaded window. At the very first message there's nothing to jump to.
+  const canJump = hasMoreHistory || !atTop;
+  const visible = jumping || (hovering && canJump);
+
+  const jumpToTop = useCallback(async () => {
+    if (!scroller) return;
+    const { el, state, stopScroll } = scroller;
+    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    setJumping(true);
+    try {
+      // Release StickToBottom's bottom-lock. Without this, every history prepend
+      // resizes the content and the library's ResizeObserver yanks the view back
+      // to the bottom (scrollToBottom with preserveScrollPosition, which sticks
+      // whenever state.isAtBottom is true) — so our scrollTop=0 lost the fight
+      // and only a *second* click (everything already loaded, no resizes) won.
+      // Clearing the lock here makes those prepend-driven scrolls bail.
+      stopScroll();
+      state.isAtBottom = false;
+      state.escapedFromLock = true;
+
+      // Page in every older block before scrolling. loadMoreHistory serializes
+      // via its own loadingMoreHistory guard (so a concurrent HistoryAutoLoader
+      // fetch is harmless), and flips hasMoreHistory to false at the start of
+      // history or on error. The rAF wait yields a frame for the prepend to
+      // commit and for the in-flight flag to settle between pages. The
+      // iteration cap is a backstop against a server that never reports done.
+      for (let i = 0; i < 1000 && useChatStore.getState().hasMoreHistory; i++) {
+        await useChatStore.getState().loadMoreHistory();
+        // Keep the lock released — a prepend that briefly lands us near the
+        // bottom can otherwise re-arm it via the library's scroll handler.
+        state.isAtBottom = false;
+        state.escapedFromLock = true;
+        await nextFrame();
+      }
+      // Pin to the very top, re-asserting across frames until it holds. The last
+      // prepends keep growing scrollHeight after the store settles, and
+      // HistoryAutoLoader's offset-preservation can bump scrollTop right after
+      // we zero it. Force 0 each frame until it stays 0 for two consecutive
+      // frames (or we hit the frame cap).
+      for (let i = 0, stable = 0; i < 60 && stable < 2; i++) {
+        if (el.scrollTop === 0) stable += 1;
+        else {
+          el.scrollTop = 0;
+          stable = 0;
+        }
+        await nextFrame();
+      }
+    } finally {
+      setJumping(false);
+    }
+  }, [scroller]);
+
+  return (
+    <div
+      className={cn(
+        // top-[50px]: centers the pill on the chat-scroll-fade border (the mask
+        // ramps 48px→80px), just below the h-14 ChatHeader. z-40 > header z-30.
+        "pointer-events-none absolute inset-x-0 top-[50px] z-40 flex justify-center transition-opacity duration-150",
+        visible ? "opacity-100" : "opacity-0",
+      )}
+    >
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={jumping}
+        onClick={() => void jumpToTop()}
+        aria-label="Jump to the first message"
+        className={cn(
+          "h-7 gap-1.5 rounded-full px-3 text-xs shadow-sm",
+          // Force an OPAQUE background in both themes and on hover. The outline
+          // variant's hover (bg-muted) is a translucent black wash (--muted is
+          // #0000000f), so over the faded chat text behind the pill it bleeds
+          // through and reads as transparent. bg-background is opaque (#fff /
+          // #0d1218); hover feedback comes from a brightness filter, which keeps
+          // the fill fully opaque.
+          "bg-background hover:bg-background hover:brightness-95",
+          "dark:bg-background dark:hover:bg-background dark:hover:brightness-125",
+          visible ? "pointer-events-auto" : "pointer-events-none",
+        )}
+      >
+        {jumping ? (
+          <Loader2Icon className="size-3.5 animate-spin" aria-hidden />
+        ) : (
+          <ArrowUpIcon className="size-3.5" aria-hidden />
+        )}
+        {jumping ? "Loading history…" : "Jump to top"}
+      </Button>
+    </div>
+  );
 }
 
 /** Stable React key per bubble. */

--- a/tests/e2e_ui/chat/test_jump_to_top.py
+++ b/tests/e2e_ui/chat/test_jump_to_top.py
@@ -1,0 +1,90 @@
+"""UI journey: the "Jump to top" affordance returns to the first message.
+
+A long assistant reply makes the conversation overflow the viewport; after
+scrolling to the bottom, hovering the conversation's top edge reveals a
+"Jump to top" pill. Clicking it scrolls the view back to the very first
+message (the affordance also pages in older history first, but a single
+loaded window is enough to prove the scroll-to-top behavior here).
+
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_USER = '[data-testid="message-bubble"][data-role="user"]'
+_WORKING = '[data-testid="working-indicator"]'
+_PILL = "button[aria-label='Jump to the first message']"
+
+# Tags the scrollable StickToBottom container so the test can read scrollTop
+# and anchor the hover. The conversation viewport is the tallest scrollable
+# descendant of the role="log" region.
+_TAG_SCROLLER = """
+() => {
+  const log = document.querySelector('[role="log"]');
+  let best = null;
+  log.querySelectorAll('*').forEach((el) => {
+    if (el.scrollHeight > el.clientHeight + 4) {
+      if (!best || el.scrollHeight > best.scrollHeight) best = el;
+    }
+  });
+  const el = best || log;
+  el.setAttribute('data-pw-scroller', '1');
+  el.scrollTop = el.scrollHeight;
+  return el.scrollTop;
+}
+"""
+_SCROLL_TOP = "document.querySelector('[data-pw-scroller]').scrollTop"
+
+
+def _send(page: Page, text: str) -> None:
+    """Type *text* into the composer and click Send."""
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible()
+    composer.fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+def test_jump_to_top_returns_to_first_message(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    base_url, session_id = seeded_session
+    first_token = f"first-{uuid.uuid4().hex[:8]}"
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Turn 1: a recognizable FIRST message — this is the jump target.
+    _send(page, f"Reply with exactly this token and nothing else: {first_token}")
+    expect(page.locator(_ASSISTANT, has_text=first_token).first).to_be_visible(timeout=60_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+
+    # Turn 2: a long reply so the conversation overflows the viewport and
+    # becomes scrollable — otherwise there's no "up" to jump to.
+    _send(page, "Reply with the numbers 1 through 100, each on its own line, and nothing else.")
+    expect(page.locator(_USER)).to_have_count(2, timeout=15_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=90_000)
+
+    # Scroll to the bottom so the first message is well out of view.
+    scroll_top = page.evaluate(_TAG_SCROLLER)
+    assert scroll_top > 100, (
+        f"conversation did not overflow enough to scroll (scrollTop={scroll_top})"
+    )
+    # The first message is no longer in the viewport.
+    expect(page.locator(_USER).first).not_to_be_in_viewport()
+
+    # Hover the top edge to reveal the pill, then click it. The hover is
+    # detected on the conversation wrapper, so moving the cursor onto the pill
+    # (which Playwright does on click) keeps it revealed and clickable.
+    box = page.locator("[data-pw-scroller]").bounding_box()
+    assert box is not None
+    page.mouse.move(box["x"] + box["width"] / 2, box["y"] + 40)
+    page.locator(_PILL).click()
+
+    # It lands at the very top: the first message is back in view and the
+    # scroll position has settled at (or within a pixel of) the top.
+    expect(page.locator(_USER).first).to_be_in_viewport(timeout=30_000)
+    page.wait_for_function(f"{_SCROLL_TOP} <= 2", timeout=30_000)

--- a/tests/e2e_ui/chat/test_jump_to_top.py
+++ b/tests/e2e_ui/chat/test_jump_to_top.py
@@ -1,16 +1,18 @@
 """UI journey: the "Jump to top" affordance returns to the first message.
 
-A long assistant reply makes the conversation overflow the viewport; after
-scrolling to the bottom, hovering the conversation's top edge reveals a
-"Jump to top" pill. Clicking it scrolls the view back to the very first
-message (the affordance also pages in older history first, but a single
+A few short turns in a deliberately short viewport make the conversation
+overflow; after scrolling to the bottom, hovering the conversation's top edge
+reveals a "Jump to top" pill. Clicking it scrolls the view back to the very
+first message (the affordance also pages in older history first, but a single
 loaded window is enough to prove the scroll-to-top behavior here).
+
+Overflow is forced by the small viewport + turn *count*, never by the length
+of any model reply — asserting on what the LLM says (a tall numbered list, an
+exact echoed token) proved flaky in CI.
 
 """
 
 from __future__ import annotations
-
-import uuid
 
 from playwright.sync_api import Page, expect
 
@@ -19,6 +21,10 @@ _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
 _USER = '[data-testid="message-bubble"][data-role="user"]'
 _WORKING = '[data-testid="working-indicator"]'
 _PILL = "button[aria-label='Jump to the first message']"
+
+# A short viewport so a handful of short turns overflow the conversation
+# deterministically — see module docstring.
+_VIEWPORT = {"width": 1280, "height": 320}
 
 # Tags the scrollable StickToBottom container so the test can read scrollTop
 # and anchor the hover. The conversation viewport is the tallest scrollable
@@ -41,12 +47,20 @@ _TAG_SCROLLER = """
 _SCROLL_TOP = "document.querySelector('[data-pw-scroller]').scrollTop"
 
 
-def _send(page: Page, text: str) -> None:
-    """Type *text* into the composer and click Send."""
+def _send_turn(page: Page, text: str, turn: int) -> None:
+    """Send *text* and wait for the *turn*-th round trip to fully render.
+
+    Waits on bubble counts (one user + one assistant bubble per turn) and the
+    working indicator clearing, so the next turn isn't sent mid-stream — no
+    dependence on the reply's text or length.
+    """
     composer = page.get_by_placeholder(_COMPOSER)
     expect(composer).to_be_visible()
     composer.fill(text)
     page.get_by_role("button", name="Send", exact=True).click()
+    expect(page.locator(_USER)).to_have_count(turn, timeout=15_000)
+    expect(page.locator(_ASSISTANT)).to_have_count(turn, timeout=90_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=90_000)
 
 
 def test_jump_to_top_returns_to_first_message(
@@ -54,34 +68,30 @@ def test_jump_to_top_returns_to_first_message(
     seeded_session: tuple[str, str],
 ) -> None:
     base_url, session_id = seeded_session
-    first_token = f"first-{uuid.uuid4().hex[:8]}"
     page.goto(f"{base_url}/c/{session_id}")
+    page.set_viewport_size(_VIEWPORT)
 
-    # Turn 1: a recognizable FIRST message — this is the jump target.
-    _send(page, f"Reply with exactly this token and nothing else: {first_token}")
-    expect(page.locator(_ASSISTANT, has_text=first_token).first).to_be_visible(timeout=60_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+    # Three short turns. The first user bubble is the jump target; the rest
+    # exist only to push it out of view in the short viewport.
+    for turn, prompt in enumerate(("Say hello.", "Say hello again.", "Say hello once more."), 1):
+        _send_turn(page, prompt, turn)
 
-    # Turn 2: a long reply so the conversation overflows the viewport and
-    # becomes scrollable — otherwise there's no "up" to jump to.
-    _send(page, "Reply with the numbers 1 through 100, each on its own line, and nothing else.")
-    expect(page.locator(_USER)).to_have_count(2, timeout=15_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=90_000)
-
-    # Scroll to the bottom so the first message is well out of view.
+    # Scroll to the bottom so the first message is out of view.
     scroll_top = page.evaluate(_TAG_SCROLLER)
-    assert scroll_top > 100, (
+    assert scroll_top > 50, (
         f"conversation did not overflow enough to scroll (scrollTop={scroll_top})"
     )
-    # The first message is no longer in the viewport.
     expect(page.locator(_USER).first).not_to_be_in_viewport()
 
-    # Hover the top edge to reveal the pill, then click it. The hover is
-    # detected on the conversation wrapper, so moving the cursor onto the pill
-    # (which Playwright does on click) keeps it revealed and clickable.
+    # Hover the top of the conversation to reveal the pill, then click it. The
+    # hover is detected on the conversation wrapper, so moving the cursor onto
+    # the pill (which Playwright does on click) keeps it revealed and clickable.
+    # The hover point must clear the ~56px ChatHeader overlay — a separate DOM
+    # subtree whose box would otherwise swallow the mousemove — while staying
+    # inside the pill's reveal band (140px from the top).
     box = page.locator("[data-pw-scroller]").bounding_box()
     assert box is not None
-    page.mouse.move(box["x"] + box["width"] / 2, box["y"] + 40)
+    page.mouse.move(box["x"] + box["width"] / 2, box["y"] + 90)
     page.locator(_PILL).click()
 
     # It lands at the very top: the first message is back in view and the


### PR DESCRIPTION
## What

Adds a **Jump to top** affordance to the chat conversation. Hovering near the top edge reveals a pill; clicking it pages in all older history (the conversation is lazily paginated) and scrolls to the very first message.

## How it works

- **Outside the mask, at the fade border.** The pill renders as a sibling of `<Conversation>`, not a child — the scroll viewport's top ~80px is mask-faded (`chat-scroll-fade`), so a pill inside it would fade out too. It's anchored at `top-[50px]` (the fade border) with `z-40` so it clears the `z-30` ChatHeader and stays clickable.
- **Hover detection on the wrapper.** Listeners are on the wrapper (the common ancestor of the scroll area and the pill) rather than the scroll element, so moving the cursor onto the pill doesn't fire `mouseleave` and hide it mid-click.
- **Releases the stick-to-bottom lock before scrolling.** `use-stick-to-bottom` re-pins to the bottom on every history prepend (its ResizeObserver calls `scrollToBottom({preserveScrollPosition})`, which sticks while `state.isAtBottom`). The jump calls `stopScroll()` and clears `isAtBottom`/`escapedFromLock` (re-cleared after each page) so those prepend-driven scrolls bail, then pins to the top re-asserting across frames until it holds. Without this it took a *second* click on long conversations.
- The scroll container + lock controls are lifted out of the StickToBottom context via a small `ConversationScrollRefBridge`.

https://github.com/user-attachments/assets/d4cfae2d-d807-481f-b77e-ecf28034e65e

## Also fixed

The existing **scroll-to-bottom** button went transparent on hover: the outline variant's hover (`bg-muted`) is a translucent black wash (`--muted` is `#0000000f`), so it read as see-through over chat content. Both buttons now force an opaque background and use a `brightness` filter for hover feedback.

## Testing

- New/updated unit tests in `ChatPage.historyLoad.test.tsx` (9 passing): hover reveal/hide, non-interactive at the first message, and the full "release lock → page in all history → scroll to top" path.
- `tsc --noEmit` clean; 177/177 ChatPage tests pass.
- Verified live with Playwright against a long (~199k px) conversation: a single click now lands at `scrollTop=0` on the first message and holds (previously it ended at the bottom and needed a second click); confirmed the scroll-to-bottom button stays `rgb(255,255,255)` on hover.