### PR TITLE
feat(sandbox): add NVIDIA OpenShell sandbox launcher

### DIFF
--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -1,0 +1,396 @@
+# Omnigent on NVIDIA OpenShell
+
+[NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) is a self-hosted sandbox
+provider. Omnigent connects to an OpenShell **gateway** with the official
+[`openshell`](https://pypi.org/project/openshell/) Python SDK and asks that
+gateway to create, execute in, and delete sandboxes on the gateway's configured
+compute driver.
+
+This guide covers the Omnigent-specific OpenShell setup:
+
+- install the `openshell` extra;
+- select a working OpenShell gateway;
+- use an OpenShell-compatible Omnigent host image;
+- configure CLI-launched or server-managed sandboxes.
+
+```bash
+pip install 'omnigent[openshell]'
+```
+
+Omnigent uses OpenShell two ways:
+
+- **CLI-launched**: `omnigent sandbox create` / `connect` provisions a sandbox
+  from your terminal, ships your local checkout into it, and registers it as a
+  host with your server.
+- **Server-managed**: the server provisions a sandbox automatically when a
+  session is created with `"host_type": "managed"` and terminates it when the
+  session is deleted.
+
+This is a sandbox-provider guide, not a server deploy target.
+
+Two traits shape the rest of this guide:
+
+- **gRPC, and a gateway you select — not an API key.** Omnigent connects through
+  the OpenShell gateway you've made active with `openshell gateway select`. The
+  SDK's `from_active_cluster()` resolves that gateway's endpoint, TLS material,
+  and OIDC token from `$OPENSHELL_GATEWAY` / `~/.config/openshell/active_gateway`.
+  There is no base-URL or token knob in Omnigent — gateway setup and auth are an
+  OpenShell concern.
+- **No local port forward.** OpenShell has no sandbox→laptop callback path, so
+  the interactive in-sandbox `omnigent login` / App OAuth step is skipped
+  automatically (as on Modal, Daytona, and CoreWeave) — fine for token/OIDC-auth
+  servers.
+
+## Prerequisites
+
+You need a **running OpenShell gateway** with a compute driver, made active on
+the machine the launcher runs on. Installing and operating the gateway is an
+OpenShell concern — follow the
+[OpenShell docs](https://docs.nvidia.com/openshell). Install the runtime + CLI:
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+```
+
+(Apple Silicon macOS installs the Homebrew formula; Linux installs the deb/rpm.)
+
+> [!IMPORTANT]
+> **The gateway host must be amd64 Linux.** The official host image is amd64-only,
+> and OpenShell's supervisor (Landlock/seccomp/netns) does not run reliably under
+> emulation — on an arm64 host (e.g. Apple Silicon via colima) the sandbox never
+> reaches READY. An arm64 host image can't be built either (a transitive
+> dependency, `cel-expr-python`, publishes no linux-arm64 wheel). On an
+> Apple-Silicon laptop, point the gateway at a remote **amd64 Linux** box (and the
+> server at that gateway) rather than the local Docker VM.
+
+### Minimal local Docker gateway (for trying it out)
+
+For a quick local test, run one OpenShell gateway backed by your local Docker
+daemon. The gateway needs a signing key so sandbox containers can authenticate
+back to it; the helper script creates that key, writes the gateway config, starts
+the gateway, registers it with the OpenShell CLI, and waits for `openshell status`
+to report `Connected`.
+
+Make sure Docker is running first. If you use colima, set `DOCKER_HOST` before
+running the script:
+
+```bash
+export DOCKER_HOST=unix://$HOME/.colima/default/docker.sock
+```
+
+Then start and register the gateway:
+
+```bash
+deploy/openshell/start-local-docker-gateway.sh
+```
+
+The script writes local development state under `~/.openshell-local` and leaves
+gateway logs at `~/.openshell-local/gateway.log`.
+
+For a real deployment, run the gateway behind TLS with OIDC or mTLS (see the
+OpenShell docs), then `openshell gateway add <https-url>` and `openshell gateway
+login`; the SDK picks up the TLS/OIDC material from the gateway metadata
+automatically — Omnigent needs no extra configuration.
+
+> [!WARNING]
+> `allow_unauthenticated_users = true` and `--disable-tls` are local-development
+> conveniences. Don't expose such a gateway on a network.
+
+## The host image
+
+Sandboxes boot from `ghcr.io/omnigent-ai/omnigent-host:latest`, published by CI
+from the `host` target of [`deploy/docker/Dockerfile`](../docker/Dockerfile) with
+Omnigent and its dependencies preinstalled — including the coding-harness CLIs
+(`claude`, `codex`, `pi`), so agents on any harness run without an in-sandbox
+install. OpenShell injects its own supervisor as the container entrypoint.
+
+The `host` target also carries the two things OpenShell's image contract requires
+(and which are inert for the root-based providers): a non-root **`sandbox`
+user/group** and **`iproute2`/`nftables`** for the per-sandbox network namespace.
+A custom image used with OpenShell must include both, or the supervisor refuses to
+start. (The launcher handles the remaining non-root detail — pinning each exec's
+cwd and `$HOME` to `/home/sandbox` — so the image's `/root` default still works
+for the other providers.)
+
+Before using an image with OpenShell, smoke-test that contract from the same
+Docker daemon the gateway uses:
+
+```bash
+docker run --rm --entrypoint sh ghcr.io/omnigent-ai/omnigent-host:latest \
+  -lc 'id sandbox && command -v ip && command -v nft'
+```
+
+To use a different image (a fork, or extra tooling baked in), run the build from
+an Omnigent repository checkout on an amd64 Docker-capable machine, then push it
+where the gateway's driver can pull from:
+
+```bash
+docker build -f deploy/docker/Dockerfile --target host \
+  --platform linux/amd64 \
+  -t docker.io/<you>/omnigent-host:latest .
+docker push docker.io/<you>/omnigent-host:latest
+```
+
+Then point Omnigent at it with `OMNIGENT_OPENSHELL_HOST_IMAGE`.
+
+> [!NOTE]
+> **Air-gapped?** Pre-load the host image (and OpenShell's supervisor image) into
+> the registry or host the gateway pulls from — the first launch from an uncached
+> image otherwise waits on a registry pull.
+
+## CLI-launched sandboxes
+
+With a gateway selected, provision a sandbox and ship your local checkout into
+it:
+
+```bash
+omnigent sandbox create --provider openshell --server https://your-host
+```
+
+This creates a sandbox from the host image, builds wheels from your local
+checkout, and overlays them on top — so the sandbox runs *your* code, not
+whatever the image was built from. Then register it as a host with your server:
+
+```bash
+omnigent sandbox connect --provider openshell \
+  --sandbox-id <id-printed-by-create> \
+  --server https://your-host
+```
+
+`connect` runs `omnigent host` inside the sandbox and holds the connection open
+in your terminal — Ctrl-C tears it down (stopping the in-sandbox host). New
+sessions targeting that host now run in the sandbox. Pass a unique `--host-name
+<label>` per sandbox when connecting several to one server (the server keys hosts
+on (owner, name)). Sandboxes are disposable; when your code changes, create a new
+one.
+
+To inject LLM/git credentials into the sandbox, set `OMNIGENT_OPENSHELL_SANDBOX_ENV`
+in your shell to a comma-separated list of variable names before running
+`create` — the named variables are copied from your environment into the sandbox
+at provision time. A listed name that is **not** set fails the launch loudly (it
+would otherwise surface much later as an opaque harness auth failure inside the
+sandbox):
+
+```bash
+export OMNIGENT_OPENSHELL_SANDBOX_ENV=ANTHROPIC_API_KEY,GIT_TOKEN
+omnigent sandbox create --provider openshell --server https://your-host
+```
+
+## Server-managed sandboxes
+
+Add a `sandbox:` section to the server config (`omnigent server -c config.yaml`,
+or `<data_dir>/config.yaml`):
+
+```yaml
+sandbox:
+  provider: openshell
+  server_url: https://your-host    # public URL sandboxes dial back to
+```
+
+`provider` + `server_url` is a complete config. Sessions created with
+`host_type: "managed"` (the API call or the Web UI's New Sandbox option) then run
+on a fresh OpenShell sandbox; the create returns immediately and provisioning
+happens in the background, exactly like the [Modal managed
+flow](../modal/README.md#server-managed-sandboxes). Each managed sandbox
+authenticates back with a server-minted, per-launch token — no user credentials
+enter the sandbox for the server connection.
+
+```bash
+curl -X POST https://your-host/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "agent_...", "host_type": "managed"}'
+```
+
+Unlike the cloud providers, OpenShell needs no API key in the server environment —
+the **server process** must instead have OpenShell gateway access: it connects
+with the same `from_active_cluster()` resolution as the CLI, so select a gateway
+with `openshell gateway select` (or set `OPENSHELL_GATEWAY` /
+`sandbox.openshell.cluster`) where the server runs. `server_url` must be reachable
+**from the sandbox** — and because OpenShell is deny-by-default on egress, that
+reachability is not automatic; see [Network egress policy](#network-egress-policy).
+
+Optional `openshell:` settings:
+
+```yaml
+sandbox:
+  provider: openshell
+  server_url: https://your-host
+  openshell:
+    image: docker.io/<you>/omnigent-host:latest         # default: official image
+    env: [OPENAI_API_KEY, ANTHROPIC_API_KEY, GIT_TOKEN]  # server env var NAMES to inject
+    cluster: my-gateway                                  # default: active gateway
+```
+
+How the managed dial-back interacts with the server's auth mode is a
+framework-level behavior shared by all providers; see
+[`deploy/cwsandbox/README.md`](../cwsandbox/README.md#managed-hosts-and-server-auth).
+
+## Network egress policy
+
+This is the part of an OpenShell deployment most likely to trip you up. OpenShell
+is **deny-by-default**: every sandbox runs in its own network namespace with all
+egress forced through a policy proxy, and anything not explicitly allowed is
+blocked (the in-sandbox `https_proxy` returns `403`). The agent and host run with
+*no* outbound access until the sandbox policy grants it. The policy is resolved
+from `/etc/openshell/policy.yaml` baked into the image, or set per-sandbox; see
+the [OpenShell policy schema](https://docs.nvidia.com/openshell). A managed host
+needs egress to:
+
+- **the server URL** (`server_url`) — the host and runner dial it back over a
+  WebSocket tunnel; without it the host can connect but the runner never registers;
+- **the LLM provider host** — the agent's model calls originate *inside* the
+  sandbox (e.g. `*.googleapis.com` for Gemini, `api.anthropic.com` for Claude,
+  `api.openai.com` for OpenAI);
+- **tokenizer/asset hosts** some harnesses fetch on first use, e.g.
+  `*.blob.core.windows.net` (the openai-agents harness downloads the `tiktoken`
+  encoding).
+
+A minimal `network_policies` block (in the image's `policy.yaml`) looks like:
+
+```yaml
+network_policies:
+  server:
+    endpoints: [{ host: "your-host.example.com", port: 443, tls: skip }]
+    binaries:  [{ path: /** }]
+  llm:
+    endpoints: [{ host: "*.googleapis.com", port: 443, tls: skip }]
+    binaries:  [{ path: /** }]
+```
+
+> [!IMPORTANT]
+> **Forward the proxy vars to the runner.** The host inherits the sandbox's
+> `https_proxy`/`http_proxy`, but the runner subprocess it spawns does **not** —
+> so the runner fails with `Temporary failure in name resolution` even though the
+> host connected. Inject `OMNIGENT_RUNNER_ENV_PASSTHROUGH` naming the proxy vars so
+> the host forwards them:
+> ```yaml
+> sandbox:
+>   openshell:
+>     env: [OMNIGENT_RUNNER_ENV_PASSTHROUGH, …]   # value set in the server env:
+> # OMNIGENT_RUNNER_ENV_PASSTHROUGH=https_proxy,http_proxy,HTTPS_PROXY,HTTP_PROXY,NO_PROXY,no_proxy
+> ```
+
+> [!TIP]
+> For LLM traffic specifically, OpenShell recommends its **inference routing**
+> over allow-listing the provider host directly, so a stolen key can't be used to
+> reach the provider from inside the sandbox. The allow-list above is the simplest
+> path to get a turn working; inference routing is the hardened one.
+
+## Model credentials (LLM keys)
+
+A fresh sandbox has no model credentials. Name the variables to inject in
+`OMNIGENT_OPENSHELL_SANDBOX_ENV`; the launcher copies the value from your
+environment into the sandbox, and the in-sandbox host forwards the standard
+harness credential vars (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`,
+`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `GEMINI_API_KEY`, …) to its runners.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-…
+export OMNIGENT_OPENSHELL_SANDBOX_ENV=ANTHROPIC_API_KEY
+```
+
+Which variables to inject — providers, gateways, subscriptions — is identical to
+the other providers; see the [Modal variable table and per-plan
+recipes](../modal/README.md#llm-credentials-for-managed-sandboxes). For a Claude
+**subscription**, run `claude setup-token` on your own machine (one-time browser
+auth) and inject the resulting `CLAUDE_CODE_OAUTH_TOKEN`. For env vars beyond the
+standard set, inject `OMNIGENT_RUNNER_ENV_PASSTHROUGH=NAME1,NAME2`.
+
+> [!TIP]
+> OpenShell can also enforce credential and egress policy at the sandbox boundary
+> via its declarative YAML policy (a gateway-side feature, independent of
+> Omnigent). See the [OpenShell policy docs](https://docs.nvidia.com/openshell).
+
+## Git credentials (private repositories)
+
+Inject an HTTPS token as `GIT_TOKEN` (GitLab: add `GIT_USERNAME=oauth2`) via
+`OMNIGENT_OPENSHELL_SANDBOX_ENV`. The host image's git credential helper answers
+HTTPS auth from it for both the launch-time clone and the agent's later `fetch` /
+`push`, writing nothing to disk. Use HTTPS repository URLs. Details by provider
+match the [Modal git guide](../modal/README.md#git-credentials-private-repositories).
+
+## How it works
+
+- **Connection.** `OpenShellSandboxLauncher` builds a `SandboxClient` via
+  `from_active_cluster()` and calls the gateway over gRPC: `CreateSandbox` +
+  `wait_ready` to provision, `ExecSandbox` to run commands, `DeleteSandbox` to
+  terminate.
+- **File shipping.** OpenShell exposes command execution but no upload RPC, so
+  `put` streams the file's bytes to `cat` over the exec channel's stdin (the same
+  approach NVIDIA's own LangChain backend uses). Wheels are shipped this way, then
+  installed with the shared host-image overlay command.
+- **Sandbox identity.** OpenShell assigns each sandbox a petname (e.g.
+  `touched-urial`); that name is the handle Omnigent prints and reuses. The
+  requested `--name` is advisory.
+- **Non-root execution.** OpenShell runs the agent as the `sandbox` user, so the
+  launcher pins every exec's cwd and `$HOME` to `/home/sandbox` (the image keeps
+  `/root` as its default for the root-based providers).
+- **Long-lived host.** OpenShell terminates an exec's process tree the moment the
+  exec returns, so the in-sandbox host can't be detached with the usual
+  `setsid nohup … &` (it gets reaped instantly). The launcher instead runs it as a
+  foreground exec held open on a daemon thread for the session's lifetime.
+
+## Troubleshooting
+
+- **`docker sandboxes require gateway JWT auth; configure [openshell.gateway.gateway_jwt]`**
+  — the Docker driver needs a gateway-minted sandbox JWT. Generate the Ed25519
+  key material and add the `[openshell.gateway.gateway_jwt]` block as shown in
+  [Minimal local Docker gateway](#minimal-local-docker-gateway-for-trying-it-out),
+  then restart the gateway.
+- **`No OpenShell server configured` / `Could not connect to an OpenShell gateway`**
+  — no gateway is active. Run `openshell gateway select <name>` (or set
+  `OPENSHELL_GATEWAY`), and confirm with `openshell status`.
+- **Sandbox stuck in `Provisioning`** — usually a slow first image pull. Confirm
+  the gateway's Docker daemon can pull the host image (`docker pull <image>` from
+  the same `DOCKER_HOST`); pre-pull it to cache. On colima, make sure the gateway
+  was started with `DOCKER_HOST` pointed at colima's socket — `/var/run/docker.sock`
+  may point at a different (stopped) Docker.
+- **Agent has no credentials** — verify the injected var names match the forwarded
+  set (or are named in `OMNIGENT_RUNNER_ENV_PASSTHROUGH`), and that each name was
+  actually set in the launching environment.
+- **Host registers but the runner never comes online / runner log shows
+  `Temporary failure in name resolution`** — the runner subprocess isn't getting
+  the sandbox's proxy vars. Forward them with `OMNIGENT_RUNNER_ENV_PASSTHROUGH`
+  (see [Network egress policy](#network-egress-policy)).
+- **Turn fails reaching the model, or proxy returns `403`** — the destination
+  isn't in the sandbox's egress allow-list. Add the LLM host (and any
+  tokenizer/asset host) to `network_policies` (see
+  [Network egress policy](#network-egress-policy)).
+- **Sandbox container restarts / `sandbox user 'sandbox' not found` or
+  `trusted ip helper not found`** — the image isn't OpenShell-compatible. Use the
+  official host image (or include the `sandbox` user + `iproute2` in your custom
+  one); see [The host image](#the-host-image).
+
+## Environment variable reference
+
+| Variable | Where it's read | Purpose |
+|---|---|---|
+| `OPENSHELL_GATEWAY` | CLI machine / server | Gateway name to use; overrides `~/.config/openshell/active_gateway` (read by the SDK). `sandbox.openshell.cluster` takes precedence for managed. |
+| `OMNIGENT_OPENSHELL_HOST_IMAGE` | CLI machine | Override the host image ref (default `ghcr.io/omnigent-ai/omnigent-host:latest`); `sandbox.openshell.image` is the managed equivalent |
+| `OMNIGENT_OPENSHELL_SANDBOX_ENV` | CLI machine | Comma-separated launcher-side env var names to inject into the sandbox; `sandbox.openshell.env` is the managed equivalent |
+| `OMNIGENT_RUNNER_ENV_PASSTHROUGH` | inside the sandbox (injected) | Extra env var names the host forwards to runners |
+| `GIT_TOKEN` / `GIT_USERNAME` | inside the sandbox (injected) | HTTPS credentials for private repository clone / fetch / push |
+
+## Validation
+
+Exercised end-to-end against a live OpenShell gateway on an **amd64 Linux** host
+(Docker driver, the official host image):
+
+- **Launcher primitives** — provision → run (`echo` / `uname`) → put (file upload
+  over exec stdin) → verify → terminate, plus `exec_foreground` (the `connect`
+  primitive) streaming output and propagating exit codes; the gateway logs the
+  matching `CreateSandbox` / `ExecSandbox` / `DeleteSandbox` RPCs.
+- **Full server-managed session** — a `host_type:"managed"` session drove the
+  server to provision a sandbox on the gateway, start `omnigent host` in it (held
+  foreground exec), dial back over the tunnel, register, spawn the runner, and
+  complete a real agent turn (a Gemini model via the openai-agents harness) — the
+  agent's reply came back from inside the sandbox.
+
+Unit tests (a faked SDK / launcher, no gateway needed) cover provision, run, file
+upload, foreground streaming, attach, terminate, env passthrough, error handling,
+and the managed-config parsing:
+
+```bash
+pip install -e '.[openshell,dev]'
+pytest tests/onboarding/sandboxes/test_openshell.py tests/server/test_managed_hosts.py
+```

--- a/deploy/openshell/start-local-docker-gateway.sh
+++ b/deploy/openshell/start-local-docker-gateway.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENSHELL_LOCAL_DIR="${OPENSHELL_LOCAL_DIR:-$HOME/.openshell-local}"
+OPENSHELL_GATEWAY_PORT="${OPENSHELL_GATEWAY_PORT:-17670}"
+OPENSHELL_GATEWAY_ENDPOINT="http://127.0.0.1:${OPENSHELL_GATEWAY_PORT}"
+JWT_DIR="${OPENSHELL_LOCAL_DIR}/jwt"
+GATEWAY_CONFIG="${OPENSHELL_LOCAL_DIR}/gateway.toml"
+GATEWAY_LOG="${OPENSHELL_LOCAL_DIR}/gateway.log"
+
+mkdir -p "${JWT_DIR}"
+
+if [[ ! -f "${JWT_DIR}/signing.pem" ]]; then
+  openssl genpkey -algorithm ed25519 -out "${JWT_DIR}/signing.pem"
+fi
+
+if [[ ! -f "${JWT_DIR}/public.pem" ]]; then
+  openssl pkey -in "${JWT_DIR}/signing.pem" -pubout -out "${JWT_DIR}/public.pem"
+fi
+
+printf 'local-dev\n' > "${JWT_DIR}/kid"
+
+cat > "${GATEWAY_CONFIG}" <<TOML
+[openshell.gateway.gateway_jwt]
+signing_key_path = "${JWT_DIR}/signing.pem"
+public_key_path  = "${JWT_DIR}/public.pem"
+kid_path         = "${JWT_DIR}/kid"
+gateway_id       = "openshell"
+ttl_secs         = 0
+
+[openshell.gateway.auth]
+allow_unauthenticated_users = true
+TOML
+
+if pgrep -a -x openshell-gateway | grep -F -- "--port ${OPENSHELL_GATEWAY_PORT}" >/dev/null; then
+  echo "OpenShell gateway already appears to be running on port ${OPENSHELL_GATEWAY_PORT}."
+else
+  : > "${GATEWAY_LOG}"
+  nohup openshell-gateway --config "${GATEWAY_CONFIG}" \
+    --disable-tls --drivers docker --port "${OPENSHELL_GATEWAY_PORT}" \
+    > "${GATEWAY_LOG}" 2>&1 &
+fi
+
+echo "Waiting for OpenShell gateway to listen on ${OPENSHELL_GATEWAY_ENDPOINT}..."
+for _ in {1..60}; do
+  if grep -q 'Server listening' "${GATEWAY_LOG}" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if ! grep -q 'Server listening' "${GATEWAY_LOG}" 2>/dev/null; then
+  echo "OpenShell gateway did not become ready. Last log lines:" >&2
+  tail -50 "${GATEWAY_LOG}" >&2 || true
+  exit 1
+fi
+
+openshell gateway add "${OPENSHELL_GATEWAY_ENDPOINT}" --local || true
+openshell status
+
+echo "Gateway log: ${GATEWAY_LOG}"

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -65,6 +65,7 @@ _LAUNCHERS: dict[str, str] = {
     # E2B (https://e2b.dev) via the official `e2b` SDK (the
     # `omnigent[e2b]` extra), imported lazily like modal/daytona.
     "e2b": "omnigent.onboarding.sandboxes.e2b:E2BSandboxLauncher",
+    "openshell": "omnigent.onboarding.sandboxes.openshell:OpenShellSandboxLauncher",
 }
 
 

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -1,0 +1,337 @@
+"""
+NVIDIA OpenShell sandbox launcher.
+
+Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
+for `NVIDIA OpenShell <https://github.com/NVIDIA/openshell>`_ sandboxes.
+OpenShell provides AI-agent sandboxes via Docker containers exposed
+through a FastAPI REST API. The integration talks to the OpenShell HTTP
+API directly through ``httpx`` (already a base Omnigent dependency), so
+there is no provider SDK extra to install.
+
+Platform notes that shape this launcher:
+
+- **Self-hosted.** OpenShell runs on the user's own infrastructure via
+  Docker, making it suitable for on-prem deployments where cloud
+  providers (Modal, Daytona, E2B) are unavailable.
+- **API-driven.** All operations use OpenShell's REST API: sandbox
+  create/delete for lifecycle, command execution for running code, and
+  file upload/download for wheel shipping.
+- **No local port forwarding.** OpenShell does not provide a
+  local-to-sandbox port forward for the in-sandbox App OAuth callback.
+  The CLI therefore skips that auth step automatically.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, ClassVar
+from urllib.parse import quote
+
+import click
+import httpx
+
+from omnigent.onboarding.sandboxes.base import (
+    DEFAULT_HOST_IMAGE,
+    RemoteCommandResult,
+    SandboxLauncher,
+    host_image_wheel_install_command,
+)
+
+BASE_URL_ENV_VAR: str = "OPENSHELL_BASE_URL"
+"""OpenShell server base URL, e.g. ``http://localhost:8000``."""
+
+HOST_IMAGE_ENV_VAR: str = "OMNIGENT_OPENSHELL_HOST_IMAGE"
+"""Environment variable overriding :data:`DEFAULT_HOST_IMAGE` for
+OpenShell sandboxes."""
+
+SANDBOX_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_OPENSHELL_SANDBOX_ENV"
+"""Comma-separated server-process environment variable names injected
+into created OpenShell sandboxes."""
+
+_DEFAULT_SANDBOX_CPU = 2
+_DEFAULT_SANDBOX_MEMORY_MB = 4096
+_REQUEST_TIMEOUT_S = 30.0
+_PROVISION_TIMEOUT_S = 300.0
+
+
+class _OpenShellAPIError(RuntimeError):
+    """Provider-boundary error with a user-facing message."""
+
+
+class _OpenShellClient:
+    """Small synchronous OpenShell HTTP API client."""
+
+    def __init__(self, *, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.Client(timeout=_REQUEST_TIMEOUT_S)
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._client.close()
+
+    def create_sandbox(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a sandbox and return the response object."""
+        return self._request_json("POST", "/sandboxes", json=payload, timeout=_PROVISION_TIMEOUT_S)
+
+    def execute(self, sandbox_id: str, command: str, timeout: int = 300) -> dict[str, Any]:
+        """Execute a command in a sandbox and return the result."""
+        return self._request_json(
+            "POST",
+            f"/sandboxes/{_url_component(sandbox_id)}/execute",
+            json={"command": command, "timeout": timeout},
+            timeout=max(float(timeout) + 10.0, _REQUEST_TIMEOUT_S),
+        )
+
+    def upload_file(
+        self, sandbox_id: str, local_path: Path, remote_path: str
+    ) -> None:
+        """Upload one file to an absolute path in the sandbox."""
+        with local_path.open("rb") as file_obj:
+            files = {"file": (local_path.name, file_obj, "application/octet-stream")}
+            self._request(
+                "POST",
+                f"/sandboxes/{_url_component(sandbox_id)}/upload",
+                files=files,
+                data={"path": remote_path},
+            )
+
+    def get_status(self, sandbox_id: str) -> dict[str, Any]:
+        """Get the status of a sandbox."""
+        return self._request_json(
+            "GET", f"/sandboxes/{_url_component(sandbox_id)}/status"
+        )
+
+    def delete_sandbox(self, sandbox_id: str) -> None:
+        """Delete a sandbox. Missing sandboxes are treated as gone."""
+        try:
+            self._request("DELETE", f"/sandboxes/{_url_component(sandbox_id)}")
+        except _OpenShellAPIError as exc:
+            if "HTTP 404" not in str(exc):
+                raise
+
+    def _request_json(
+        self, method: str, endpoint: str, timeout: float | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        response = self._request(method, endpoint, timeout=timeout, **kwargs)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise _OpenShellAPIError(
+                f"openshell {method} {endpoint} returned invalid JSON"
+            ) from exc
+        if not isinstance(data, dict):
+            raise _OpenShellAPIError(
+                f"openshell {method} {endpoint} returned a non-object response"
+            )
+        return data
+
+    def _request(
+        self, method: str, endpoint: str, timeout: float | None = None, **kwargs: Any
+    ) -> httpx.Response:
+        url = self._url(endpoint)
+        effective_timeout = timeout if timeout is not None else _REQUEST_TIMEOUT_S
+        try:
+            response = self._client.request(
+                method, url, timeout=effective_timeout, **kwargs
+            )
+        except httpx.HTTPError as exc:
+            raise _OpenShellAPIError(
+                f"openshell {method} {endpoint} failed: {exc}"
+            ) from exc
+        if response.status_code >= 400:
+            raise self._response_error(method, endpoint, response)
+        return response
+
+    def _url(self, endpoint: str) -> str:
+        return self._base_url + endpoint
+
+    def _response_error(
+        self, method: str, endpoint: str, response: httpx.Response
+    ) -> _OpenShellAPIError:
+        try:
+            text = response.text
+        except httpx.ResponseNotRead:
+            text = response.read().decode("utf-8", errors="replace")
+        snippet = text.strip()[:1024]
+        detail = f": {snippet}" if snippet else ""
+        return _OpenShellAPIError(
+            f"openshell {method} {endpoint} failed with HTTP {response.status_code}{detail}"
+        )
+
+
+class OpenShellSandboxLauncher(SandboxLauncher):
+    """
+    :class:`SandboxLauncher` for NVIDIA OpenShell sandboxes.
+
+    All primitives use OpenShell's REST API: sandbox create/delete for
+    lifecycle, command execution for running code, and file upload for
+    wheel shipping.
+    """
+
+    provider: ClassVar[str] = "openshell"
+    supports_local_port_forward: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        *,
+        image: str | None = None,
+        env: Sequence[str] | None = None,
+        base_url: str | None = None,
+        cpu: int | None = None,
+        memory_mb: int | None = None,
+    ) -> None:
+        self._image_ref = image
+        self._env_names = tuple(env) if env is not None else None
+        self._base_url = base_url
+        self._cpu = cpu
+        self._memory_mb = memory_mb
+        self._client: _OpenShellClient | None = None
+
+    def prepare(self) -> None:
+        """Verify OpenShell server URL is available."""
+        if not (self._base_url or os.environ.get(BASE_URL_ENV_VAR)):
+            raise click.ClickException(
+                "No OpenShell server configured. Set OPENSHELL_BASE_URL to "
+                "the OpenShell server address (e.g. http://localhost:8000)."
+            )
+
+    def provision(self, name: str) -> str:
+        """Create a new OpenShell sandbox from the host image."""
+        resolved_ref = (
+            self._image_ref
+            or os.environ.get(HOST_IMAGE_ENV_VAR)
+            or DEFAULT_HOST_IMAGE
+        )
+        payload: dict[str, Any] = {
+            "image": resolved_ref,
+            "name": name,
+        }
+        cpu = self._cpu or _DEFAULT_SANDBOX_CPU
+        memory = self._memory_mb or _DEFAULT_SANDBOX_MEMORY_MB
+        payload["cpu"] = cpu
+        payload["memory_mb"] = memory
+        env_vars = self._resolve_sandbox_env()
+        if env_vars:
+            payload["env"] = env_vars
+        click.echo(f"▸ Creating OpenShell sandbox from {resolved_ref}")
+        try:
+            sandbox = self._openshell().create_sandbox(payload)
+        except _OpenShellAPIError as exc:
+            raise click.ClickException(
+                f"OpenShell sandbox creation failed: {exc}"
+            ) from exc
+        sandbox_id = sandbox.get("id") or sandbox.get("sandbox_id") or sandbox.get("name")
+        if not isinstance(sandbox_id, str) or not sandbox_id:
+            raise click.ClickException(
+                "OpenShell sandbox creation returned no sandbox identifier"
+            )
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
+
+    def attach(self, sandbox_id: str) -> None:
+        """Validate access to an existing OpenShell sandbox."""
+        click.echo(f"▸ Reusing existing OpenShell sandbox '{sandbox_id}'")
+        try:
+            self._openshell().get_status(sandbox_id)
+        except _OpenShellAPIError as exc:
+            raise click.ClickException(
+                f"Could not attach to OpenShell sandbox '{sandbox_id}': {exc}"
+            ) from exc
+
+    def keep_alive(self, sandbox_id: str) -> None:
+        """No idle auto-stop management is exposed by the OpenShell API."""
+        click.echo(
+            f"  → OpenShell sandbox '{sandbox_id}' remains active until destroyed"
+        )
+
+    def run(
+        self, sandbox_id: str, command: str, *, check: bool = True
+    ) -> RemoteCommandResult:
+        """Run a shell command in the sandbox and capture its output."""
+        try:
+            result = self._openshell().execute(sandbox_id, command)
+        except _OpenShellAPIError as exc:
+            raise click.ClickException(
+                f"Remote command failed on OpenShell sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        stdout = result.get("stdout", "")
+        stderr = result.get("stderr", "")
+        exit_code = result.get("exit_code", 1)
+        if stdout:
+            click.echo(stdout, nl=False)
+        if stderr:
+            click.echo(stderr, nl=False, err=True)
+        if check and exit_code != 0:
+            raise click.ClickException(
+                f"Remote command failed on OpenShell sandbox '{sandbox_id}' "
+                f"(exit {exit_code}): {command}"
+            )
+        return RemoteCommandResult(
+            returncode=exit_code, stdout=stdout, stderr=stderr
+        )
+
+    def put(
+        self, sandbox_id: str, local_path: Path, remote_path: str
+    ) -> None:
+        """Copy a local file into the sandbox."""
+        try:
+            self._openshell().upload_file(sandbox_id, local_path, remote_path)
+        except _OpenShellAPIError as exc:
+            raise click.ClickException(
+                f"File upload to OpenShell sandbox '{sandbox_id}' failed: {exc}"
+            ) from exc
+
+    def wheel_install_command(self, remote_tgz_path: str) -> str:
+        """Remote command that overlays shipped wheels onto the host image."""
+        return host_image_wheel_install_command(remote_tgz_path)
+
+    def terminate(self, sandbox_id: str) -> None:
+        """Delete a sandbox, releasing its compute."""
+        try:
+            self._openshell().delete_sandbox(sandbox_id)
+        finally:
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+
+    def _openshell(self) -> _OpenShellClient:
+        if self._client is None:
+            base_url = self._base_url or os.environ.get(BASE_URL_ENV_VAR)
+            if not base_url:
+                raise click.ClickException(
+                    "No OpenShell server configured. Set OPENSHELL_BASE_URL to "
+                    "the OpenShell server address (e.g. http://localhost:8000)."
+                )
+            self._client = _OpenShellClient(base_url=base_url)
+        return self._client
+
+    def _resolve_sandbox_env(self) -> dict[str, str]:
+        if self._env_names is not None:
+            names: Sequence[str] = self._env_names
+        else:
+            names = [
+                name.strip()
+                for name in os.environ.get(
+                    SANDBOX_ENV_PASSTHROUGH_ENV_VAR, ""
+                ).split(",")
+                if name.strip()
+            ]
+        resolved: dict[str, str] = {}
+        for name in names:
+            value = os.environ.get(name)
+            if value is None:
+                raise click.ClickException(
+                    f"sandbox env passthrough names '{name}' but it is not set "
+                    "in the server's environment — set it (or remove it from "
+                    f"sandbox.openshell.env / {SANDBOX_ENV_PASSTHROUGH_ENV_VAR})."
+                )
+            resolved[name] = value
+        return resolved
+
+
+def _url_component(value: str) -> str:
+    return quote(value, safe="")

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -24,8 +24,6 @@ Platform notes that shape this launcher:
 from __future__ import annotations
 
 import os
-import re
-import uuid
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, ClassVar
@@ -86,9 +84,7 @@ class _OpenShellClient:
             timeout=max(float(timeout) + 10.0, _REQUEST_TIMEOUT_S),
         )
 
-    def upload_file(
-        self, sandbox_id: str, local_path: Path, remote_path: str
-    ) -> None:
+    def upload_file(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
         """Upload one file to an absolute path in the sandbox."""
         with local_path.open("rb") as file_obj:
             files = {"file": (local_path.name, file_obj, "application/octet-stream")}
@@ -101,9 +97,7 @@ class _OpenShellClient:
 
     def get_status(self, sandbox_id: str) -> dict[str, Any]:
         """Get the status of a sandbox."""
-        return self._request_json(
-            "GET", f"/sandboxes/{_url_component(sandbox_id)}/status"
-        )
+        return self._request_json("GET", f"/sandboxes/{_url_component(sandbox_id)}/status")
 
     def delete_sandbox(self, sandbox_id: str) -> None:
         """Delete a sandbox. Missing sandboxes are treated as gone."""
@@ -135,13 +129,9 @@ class _OpenShellClient:
         url = self._url(endpoint)
         effective_timeout = timeout if timeout is not None else _REQUEST_TIMEOUT_S
         try:
-            response = self._client.request(
-                method, url, timeout=effective_timeout, **kwargs
-            )
+            response = self._client.request(method, url, timeout=effective_timeout, **kwargs)
         except httpx.HTTPError as exc:
-            raise _OpenShellAPIError(
-                f"openshell {method} {endpoint} failed: {exc}"
-            ) from exc
+            raise _OpenShellAPIError(f"openshell {method} {endpoint} failed: {exc}") from exc
         if response.status_code >= 400:
             raise self._response_error(method, endpoint, response)
         return response
@@ -201,11 +191,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
 
     def provision(self, name: str) -> str:
         """Create a new OpenShell sandbox from the host image."""
-        resolved_ref = (
-            self._image_ref
-            or os.environ.get(HOST_IMAGE_ENV_VAR)
-            or DEFAULT_HOST_IMAGE
-        )
+        resolved_ref = self._image_ref or os.environ.get(HOST_IMAGE_ENV_VAR) or DEFAULT_HOST_IMAGE
         payload: dict[str, Any] = {
             "image": resolved_ref,
             "name": name,
@@ -221,14 +207,10 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         try:
             sandbox = self._openshell().create_sandbox(payload)
         except _OpenShellAPIError as exc:
-            raise click.ClickException(
-                f"OpenShell sandbox creation failed: {exc}"
-            ) from exc
+            raise click.ClickException(f"OpenShell sandbox creation failed: {exc}") from exc
         sandbox_id = sandbox.get("id") or sandbox.get("sandbox_id") or sandbox.get("name")
         if not isinstance(sandbox_id, str) or not sandbox_id:
-            raise click.ClickException(
-                "OpenShell sandbox creation returned no sandbox identifier"
-            )
+            raise click.ClickException("OpenShell sandbox creation returned no sandbox identifier")
         click.echo(f"  → created {sandbox_id}")
         return sandbox_id
 
@@ -244,13 +226,9 @@ class OpenShellSandboxLauncher(SandboxLauncher):
 
     def keep_alive(self, sandbox_id: str) -> None:
         """No idle auto-stop management is exposed by the OpenShell API."""
-        click.echo(
-            f"  → OpenShell sandbox '{sandbox_id}' remains active until destroyed"
-        )
+        click.echo(f"  → OpenShell sandbox '{sandbox_id}' remains active until destroyed")
 
-    def run(
-        self, sandbox_id: str, command: str, *, check: bool = True
-    ) -> RemoteCommandResult:
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
         """Run a shell command in the sandbox and capture its output."""
         try:
             result = self._openshell().execute(sandbox_id, command)
@@ -270,13 +248,9 @@ class OpenShellSandboxLauncher(SandboxLauncher):
                 f"Remote command failed on OpenShell sandbox '{sandbox_id}' "
                 f"(exit {exit_code}): {command}"
             )
-        return RemoteCommandResult(
-            returncode=exit_code, stdout=stdout, stderr=stderr
-        )
+        return RemoteCommandResult(returncode=exit_code, stdout=stdout, stderr=stderr)
 
-    def put(
-        self, sandbox_id: str, local_path: Path, remote_path: str
-    ) -> None:
+    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
         """Copy a local file into the sandbox."""
         try:
             self._openshell().upload_file(sandbox_id, local_path, remote_path)
@@ -315,9 +289,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         else:
             names = [
                 name.strip()
-                for name in os.environ.get(
-                    SANDBOX_ENV_PASSTHROUGH_ENV_VAR, ""
-                ).split(",")
+                for name in os.environ.get(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
                 if name.strip()
             ]
         resolved: dict[str, str] = {}

--- a/tests/onboarding/sandboxes/test_openshell.py
+++ b/tests/onboarding/sandboxes/test_openshell.py
@@ -203,9 +203,7 @@ def test_provision_env_passthrough_missing_var_fails(
     """A configured but unset env name aborts before creating a sandbox."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(
-        base_url="http://localhost:8000", env=["OPENAI_API_KEY"]
-    )
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000", env=["OPENAI_API_KEY"])
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     with pytest.raises(click.ClickException, match="OPENAI_API_KEY"):
@@ -230,7 +228,6 @@ def test_run_captures_output(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_run_check_raises_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
     """``run`` with ``check=True`` raises on non-zero exit."""
     fake = _FakeOpenShellAPI()
-    fake_execute_orig = fake.execute
 
     def _failing_execute(sandbox_id: str, command: str, timeout: int = 300) -> dict:
         fake.exec_calls.append((sandbox_id, command))
@@ -329,9 +326,7 @@ def test_client_delete_ignores_404(monkeypatch: pytest.MonkeyPatch) -> None:
     import omnigent.onboarding.sandboxes.openshell as openshell_mod
 
     fake = _FakeHTTPClient()
-    fake.next_response = _FakeResponse(
-        404, {}, text="not found"
-    )
+    fake.next_response = _FakeResponse(404, {}, text="not found")
     monkeypatch.setattr(openshell_mod.httpx, "Client", lambda **kwargs: fake)
 
     client = _OpenShellClient(base_url="http://localhost:8000")

--- a/tests/onboarding/sandboxes/test_openshell.py
+++ b/tests/onboarding/sandboxes/test_openshell.py
@@ -1,0 +1,344 @@
+"""Tests for :mod:`omnigent.onboarding.sandboxes.openshell`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes.base import DEFAULT_HOST_IMAGE
+from omnigent.onboarding.sandboxes.openshell import (
+    BASE_URL_ENV_VAR,
+    HOST_IMAGE_ENV_VAR,
+    SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
+    OpenShellSandboxLauncher,
+    _OpenShellClient,
+)
+
+
+@dataclass
+class _HttpRequest:
+    """One recorded fake HTTP request."""
+
+    method: str
+    url: str
+    kwargs: dict[str, Any]
+
+
+class _FakeResponse:
+    """Minimal ``httpx.Response`` stand-in for client tests."""
+
+    def __init__(self, status_code: int, data: dict[str, Any], text: str = "") -> None:
+        self.status_code = status_code
+        self._data = data
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+class _FakeHTTPClient:
+    """Recorder for the subset of ``httpx.Client`` used by ``_OpenShellClient``."""
+
+    def __init__(self) -> None:
+        self.requests: list[_HttpRequest] = []
+        self.closed = False
+        self.next_response: _FakeResponse | None = None
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        self.requests.append(_HttpRequest(method=method, url=url, kwargs=kwargs))
+        if self.next_response is not None:
+            resp = self.next_response
+            self.next_response = None
+            return resp
+        return _FakeResponse(200, {"id": "sb-1", "ok": True})
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class _FakeOpenShellAPI:
+    """Recorder for the launcher-facing OpenShell API client."""
+
+    create_payloads: list[dict[str, Any]] = field(default_factory=list)
+    exec_calls: list[tuple[str, str]] = field(default_factory=list)
+    uploads: list[tuple[str, Path, str]] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+    statuses: list[str] = field(default_factory=list)
+    closed: bool = False
+
+    def create_sandbox(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.create_payloads.append(dict(payload))
+        return {"id": "sb-test-123"}
+
+    def execute(self, sandbox_id: str, command: str, timeout: int = 300) -> dict[str, Any]:
+        self.exec_calls.append((sandbox_id, command))
+        return {"stdout": "out\n", "stderr": "err\n", "exit_code": 0}
+
+    def upload_file(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
+        self.uploads.append((sandbox_id, local_path, remote_path))
+
+    def get_status(self, sandbox_id: str) -> dict[str, Any]:
+        self.statuses.append(sandbox_id)
+        return {"status": "running"}
+
+    def delete_sandbox(self, sandbox_id: str) -> None:
+        self.deleted.append(sandbox_id)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_prepare_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preflight fails when ``OPENSHELL_BASE_URL`` is absent."""
+    monkeypatch.delenv(BASE_URL_ENV_VAR, raising=False)
+    with pytest.raises(click.ClickException, match="OPENSHELL_BASE_URL"):
+        OpenShellSandboxLauncher().prepare()
+
+    monkeypatch.setenv(BASE_URL_ENV_VAR, "http://localhost:8000")
+    OpenShellSandboxLauncher().prepare()
+
+
+def test_prepare_accepts_constructor_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Constructor ``base_url`` satisfies the preflight check."""
+    monkeypatch.delenv(BASE_URL_ENV_VAR, raising=False)
+    OpenShellSandboxLauncher(base_url="http://localhost:8000").prepare()
+
+
+def test_provision_creates_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provisioning sends image, cpu, and memory in the create payload."""
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(
+        base_url="http://localhost:8000",
+        image="custom-image:latest",
+        cpu=4,
+        memory_mb=8192,
+    )
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    sandbox_id = launcher.provision("test-host")
+
+    assert sandbox_id == "sb-test-123"
+    assert fake.create_payloads == [
+        {
+            "image": "custom-image:latest",
+            "name": "test-host",
+            "cpu": 4,
+            "memory_mb": 8192,
+        }
+    ]
+
+
+def test_provision_uses_default_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without an explicit image, the official host image is used."""
+    monkeypatch.delenv(HOST_IMAGE_ENV_VAR, raising=False)
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    launcher.provision("host")
+
+    [payload] = fake.create_payloads
+    assert payload["image"] == DEFAULT_HOST_IMAGE
+
+
+def test_provision_uses_image_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Host image can be overridden via environment variable."""
+    monkeypatch.setenv(HOST_IMAGE_ENV_VAR, "docker.io/custom/host:1")
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    launcher.provision("host")
+
+    [payload] = fake.create_payloads
+    assert payload["image"] == "docker.io/custom/host:1"
+
+
+def test_provision_with_env_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configured env vars are injected into the sandbox create payload."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("GIT_TOKEN", "ghp-test")
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(
+        base_url="http://localhost:8000",
+        env=["OPENAI_API_KEY", "GIT_TOKEN"],
+    )
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    launcher.provision("host")
+
+    [payload] = fake.create_payloads
+    assert payload["env"] == {"OPENAI_API_KEY": "sk-test", "GIT_TOKEN": "ghp-test"}
+
+
+def test_provision_env_passthrough_via_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env passthrough names can come from the process environment."""
+    monkeypatch.setenv(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "OPENAI_API_KEY")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    launcher.provision("host")
+
+    [payload] = fake.create_payloads
+    assert payload["env"] == {"OPENAI_API_KEY": "sk-test"}
+
+
+def test_provision_env_passthrough_missing_var_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured but unset env name aborts before creating a sandbox."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(
+        base_url="http://localhost:8000", env=["OPENAI_API_KEY"]
+    )
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    with pytest.raises(click.ClickException, match="OPENAI_API_KEY"):
+        launcher.provision("host")
+    assert fake.create_payloads == []
+
+
+def test_run_captures_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run`` captures stdout, stderr, and exit code from the API response."""
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    result = launcher.run("sb-1", "echo hello")
+
+    assert fake.exec_calls == [("sb-1", "echo hello")]
+    assert result.returncode == 0
+    assert result.stdout == "out\n"
+    assert result.stderr == "err\n"
+
+
+def test_run_check_raises_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run`` with ``check=True`` raises on non-zero exit."""
+    fake = _FakeOpenShellAPI()
+    fake_execute_orig = fake.execute
+
+    def _failing_execute(sandbox_id: str, command: str, timeout: int = 300) -> dict:
+        fake.exec_calls.append((sandbox_id, command))
+        return {"stdout": "", "stderr": "error\n", "exit_code": 1}
+
+    fake.execute = _failing_execute  # type: ignore[assignment]
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    with pytest.raises(click.ClickException, match="exit 1"):
+        launcher.run("sb-1", "false")
+
+
+def test_run_no_check_allows_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run`` with ``check=False`` returns the result even on non-zero exit."""
+    fake = _FakeOpenShellAPI()
+
+    def _failing_execute(sandbox_id: str, command: str, timeout: int = 300) -> dict:
+        fake.exec_calls.append((sandbox_id, command))
+        return {"stdout": "", "stderr": "error\n", "exit_code": 1}
+
+    fake.execute = _failing_execute  # type: ignore[assignment]
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    result = launcher.run("sb-1", "false", check=False)
+
+    assert result.returncode == 1
+    assert result.stderr == "error\n"
+
+
+def test_put_uploads_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``put`` delegates to the client's upload_file method."""
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    local_file = tmp_path / "wheels.tgz"
+    local_file.write_bytes(b"fake-tarball")
+
+    launcher.put("sb-1", local_file, "/tmp/wheels.tgz")
+
+    assert fake.uploads == [("sb-1", local_file, "/tmp/wheels.tgz")]
+
+
+def test_attach_validates_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``attach`` checks sandbox status via the API."""
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    launcher.attach("sb-1")
+
+    assert fake.statuses == ["sb-1"]
+
+
+def test_terminate_deletes_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``terminate`` calls delete and cleans up the client."""
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+    monkeypatch.setattr(launcher, "_client", fake)  # So terminate can close it
+
+    launcher.terminate("sb-1")
+
+    assert fake.deleted == ["sb-1"]
+
+
+def test_wheel_install_command() -> None:
+    """``wheel_install_command`` delegates to the shared helper."""
+    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    cmd = launcher.wheel_install_command("/tmp/oa-wheels.tgz")
+    assert "pip install" in cmd
+    assert "/tmp/oa-wheels.tgz" in cmd
+
+
+def test_client_create_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The HTTP client sends a POST to /sandboxes."""
+    import omnigent.onboarding.sandboxes.openshell as openshell_mod
+
+    fake = _FakeHTTPClient()
+    monkeypatch.setattr(openshell_mod.httpx, "Client", lambda **kwargs: fake)
+
+    client = _OpenShellClient(base_url="http://localhost:8000/")
+
+    result = client.create_sandbox({"image": "python:3.11"})
+    assert result == {"id": "sb-1", "ok": True}
+
+    assert len(fake.requests) == 1
+    assert fake.requests[0].method == "POST"
+    assert fake.requests[0].url == "http://localhost:8000/sandboxes"
+
+
+def test_client_delete_ignores_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deleting a missing sandbox is treated as success (idempotent)."""
+    import omnigent.onboarding.sandboxes.openshell as openshell_mod
+
+    fake = _FakeHTTPClient()
+    fake.next_response = _FakeResponse(
+        404, {}, text="not found"
+    )
+    monkeypatch.setattr(openshell_mod.httpx, "Client", lambda **kwargs: fake)
+
+    client = _OpenShellClient(base_url="http://localhost:8000")
+
+    # The 404 triggers _response_error which raises _OpenShellAPIError
+    # containing "HTTP 404", which delete_sandbox catches.
+    client.delete_sandbox("gone-sandbox")
+
+    assert len(fake.requests) == 1
+    assert fake.requests[0].method == "DELETE"


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

Motivation: All existing remote sandbox providers (Modal, Daytona, CoreWeave, Islo) require cloud infrastructure. OpenShell runs on the user's own Docker host, filling the gap for on-prem and air-gapped deployments.

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

  - Add `OpenShellSandboxLauncher` implementing `SandboxLauncher` for Docker sandbox service
  - Pure HTTP integration via `httpx` (no extra SDK dependency)
  - Register as `"openshell"` in the launcher registry
  - Configured via `OPENSHELL_BASE_URL` environment variable



## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
  - [x] 17 unit tests covering provision, run, put, attach, terminate,
    env passthrough, config resolution, error handling, and idempotent
    deletion
  - [x] Existing sandbox tests pass (no regressions)
  - [x] `available_providers()` includes `"openshell"`