### PR TITLE
fix(cursor): harden the bridged-tool callback (timeout, isError, exception guard)

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -71,12 +71,9 @@ ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # typ
 # ``None``).
 _DEFAULT_CURSOR_MODEL = "auto"
 
-# Upper bound (seconds) on a single bridged-tool call. ``sys_session_send`` and
-# friends can dispatch long-running sub-agents, so this is deliberately generous
-# — its job is to stop a wedged tool from blocking the SDK's daemon callback
-# thread (and the Cursor turn) *forever*, surfacing a tool error instead of an
-# unbounded hang. It is a wall-clock cap on the daemon thread's wait, not a
-# per-turn budget.
+# Upper bound (seconds) on one bridged-tool call: generous (sub-agent dispatches
+# can run for minutes) but finite, so a wedged tool surfaces a timeout error
+# instead of blocking the SDK's daemon callback thread forever.
 _TOOL_CALL_TIMEOUT_S = 1800.0
 
 
@@ -427,13 +424,10 @@ class CursorExecutor(Executor):
                 return _tool_error_payload(
                     f"Tool {tool_name!r} timed out after {_TOOL_CALL_TIMEOUT_S:.0f}s."
                 )
-            # A failed *or cancelled* coroutine: future.result() raises the
-            # coroutine's exception, or concurrent.futures.CancelledError (an
-            # Exception subclass) when the future is cancelled. Catch Exception —
-            # not BaseException — so any tool failure becomes a tool error
-            # instead of crashing the daemon thread, while KeyboardInterrupt /
-            # SystemExit still propagate.
-            except Exception as exc:  # noqa: BLE001 — thread boundary: failures become tool errors
+            # Exception (not BaseException) still covers a cancelled coroutine —
+            # future.result() raises concurrent.futures.CancelledError, an
+            # Exception — while letting KeyboardInterrupt / SystemExit propagate.
+            except Exception as exc:  # noqa: BLE001 — surface as a tool error
                 future.cancel()
                 return _tool_error_payload(f"Tool {tool_name!r} failed: {exc}")
             return _encode_tool_result(result)

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -427,7 +427,13 @@ class CursorExecutor(Executor):
                 return _tool_error_payload(
                     f"Tool {tool_name!r} timed out after {_TOOL_CALL_TIMEOUT_S:.0f}s."
                 )
-            except BaseException as exc:  # noqa: BLE001 — must never crash the daemon thread
+            # A failed *or cancelled* coroutine: future.result() raises the
+            # coroutine's exception, or concurrent.futures.CancelledError (an
+            # Exception subclass) when the future is cancelled. Catch Exception —
+            # not BaseException — so any tool failure becomes a tool error
+            # instead of crashing the daemon thread, while KeyboardInterrupt /
+            # SystemExit still propagate.
+            except Exception as exc:  # noqa: BLE001 — thread boundary: failures become tool errors
                 future.cancel()
                 return _tool_error_payload(f"Tool {tool_name!r} failed: {exc}")
             return _encode_tool_result(result)

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -33,6 +33,7 @@ Requirements:
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import os
@@ -69,6 +70,14 @@ ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # typ
 # requires a model for local agents, so unlike the old ACP path we can't pass
 # ``None``).
 _DEFAULT_CURSOR_MODEL = "auto"
+
+# Upper bound (seconds) on a single bridged-tool call. ``sys_session_send`` and
+# friends can dispatch long-running sub-agents, so this is deliberately generous
+# — its job is to stop a wedged tool from blocking the SDK's daemon callback
+# thread (and the Cursor turn) *forever*, surfacing a tool error instead of an
+# unbounded hang. It is a wall-clock cap on the daemon thread's wait, not a
+# per-turn budget.
+_TOOL_CALL_TIMEOUT_S = 1800.0
 
 
 def _resolve_model(model: str | None) -> str:
@@ -239,6 +248,42 @@ def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore
 
 
 # ---------------------------------------------------------------------------
+# Bridged-tool result encoding
+# ---------------------------------------------------------------------------
+
+
+def _tool_error_payload(text: str) -> dict[str, Any]:  # type: ignore[explicit-any]
+    """An SDK custom-tool *error* result.
+
+    A mapping with a ``content`` list and ``isError`` is passed through unchanged
+    by the SDK's ``_normalize_custom_tool_result``, so the Cursor model sees a
+    failure — unlike a bare string, which the SDK wraps as a *successful* result.
+    """
+    return {"content": [{"type": "text", "text": text}], "isError": True}
+
+
+def _encode_tool_result(result: Any) -> Any:  # type: ignore[explicit-any]
+    """Encode a bridged-tool result for the SDK custom-tool return.
+
+    A dict carrying a truthy ``error`` or ``blocked`` is a dispatch failure or a
+    policy block (the shapes ``_bridge_one_dispatch`` / the policy layer return):
+    surface it as an ``isError`` payload so the model sees a failure — parity with
+    the claude-sdk handler, which the cursor harness otherwise diverged from by
+    delivering errors as ordinary, apparently-successful results. Everything else
+    returns its text: a ``str`` passthrough (the SDK wraps it as success), else
+    JSON.
+    """
+    if isinstance(result, dict) and (result.get("error") or result.get("blocked")):
+        return _tool_error_payload(json.dumps(result, default=str))
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, default=str)
+    except (TypeError, ValueError):
+        return str(result)
+
+
+# ---------------------------------------------------------------------------
 # CursorExecutor
 # ---------------------------------------------------------------------------
 
@@ -356,26 +401,36 @@ class CursorExecutor(Executor):
 
     def _make_execute(
         self, tool_name: str, loop: asyncio.AbstractEventLoop
-    ) -> Callable[[dict[str, Any], Any], str]:  # type: ignore[explicit-any]
+    ) -> Callable[[dict[str, Any], Any], Any]:  # type: ignore[explicit-any]
         """Build a sync ``execute`` that bridges a cursor tool call to Omnigent.
 
-        Runs on the SDK callback thread; blocks it on the main-loop coroutine via
-        ``run_coroutine_threadsafe`` (no tight timeout — ``sys_session_send`` and
-        friends can legitimately run for minutes).
+        Runs on the SDK callback server's daemon thread and blocks it on the
+        main-loop coroutine via ``run_coroutine_threadsafe``. The wait is bounded
+        by ``_TOOL_CALL_TIMEOUT_S`` (generous — ``sys_session_send`` and friends
+        can legitimately run for minutes) so a wedged tool surfaces as a tool
+        error instead of hanging the daemon thread / Cursor turn forever, and any
+        exception (a failed or cancelled coroutine) becomes a tool error rather
+        than propagating raw onto the daemon thread.
         """
 
-        def execute(args: dict[str, Any], _ctx: Any) -> str:  # type: ignore[explicit-any]
+        def execute(args: dict[str, Any], _ctx: Any) -> Any:  # type: ignore[explicit-any]
             if self._tool_executor is None:
-                return f"Tool {tool_name!r} is unavailable: no tool executor wired."
+                return _tool_error_payload(
+                    f"Tool {tool_name!r} is unavailable: no tool executor wired."
+                )
             coro = self._tool_executor(tool_name, dict(args or {}))
             future = asyncio.run_coroutine_threadsafe(coro, loop)
-            result = future.result()
-            if isinstance(result, str):
-                return result
             try:
-                return json.dumps(result, default=str)
-            except (TypeError, ValueError):
-                return str(result)
+                result = future.result(timeout=_TOOL_CALL_TIMEOUT_S)
+            except concurrent.futures.TimeoutError:
+                future.cancel()
+                return _tool_error_payload(
+                    f"Tool {tool_name!r} timed out after {_TOOL_CALL_TIMEOUT_S:.0f}s."
+                )
+            except BaseException as exc:  # noqa: BLE001 — must never crash the daemon thread
+                future.cancel()
+                return _tool_error_payload(f"Tool {tool_name!r} failed: {exc}")
+            return _encode_tool_result(result)
 
         return execute
 

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -356,6 +356,74 @@ async def test_custom_tool_execute_bridges_to_tool_executor() -> None:
     assert json.loads(result) == {"ok": True, "echo": {"x": 1}}
 
 
+def _bridged_execute(tool_executor: Any) -> Any:
+    """Wire *tool_executor* onto a CursorExecutor and return its sync ``execute``."""
+    executor = CursorExecutor(api_key="crsr_x")
+    executor._tool_executor = tool_executor
+    return executor._make_execute("sys_session_send", asyncio.get_running_loop())
+
+
+async def test_custom_tool_execute_flags_error_dict_with_iserror() -> None:
+    """A dispatch failure ({"error": ...}) must surface to the model as an SDK
+    error (isError), not an apparently-successful result."""
+
+    async def err(name: str, args: dict[str, Any]) -> Any:
+        return {"error": "dispatch failed"}
+
+    result = await asyncio.to_thread(_bridged_execute(err), {}, None)
+    assert isinstance(result, dict) and result["isError"] is True
+    assert "dispatch failed" in result["content"][0]["text"]
+
+
+async def test_custom_tool_execute_flags_blocked_dict_with_iserror() -> None:
+    """A policy-blocked result ({"blocked": True}) is delivered as an error."""
+
+    async def blocked(name: str, args: dict[str, Any]) -> Any:
+        return {"blocked": True, "reason": "policy"}
+
+    result = await asyncio.to_thread(_bridged_execute(blocked), {}, None)
+    assert isinstance(result, dict) and result["isError"] is True
+    assert "policy" in result["content"][0]["text"]
+
+
+async def test_custom_tool_execute_success_dict_is_not_flagged() -> None:
+    """An ordinary result is returned as text (a str the SDK treats as success),
+    never flagged as an error."""
+
+    async def ok(name: str, args: dict[str, Any]) -> Any:
+        return {"ok": True, "value": 42}
+
+    result = await asyncio.to_thread(_bridged_execute(ok), {}, None)
+    assert isinstance(result, str)
+    assert json.loads(result) == {"ok": True, "value": 42}
+
+
+async def test_custom_tool_execute_times_out_to_iserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool that never completes must not block the daemon thread forever — the
+    bounded wait surfaces a timeout tool error instead of hanging."""
+    monkeypatch.setattr("omnigent.inner.cursor_executor._TOOL_CALL_TIMEOUT_S", 0.05)
+
+    async def slow(name: str, args: dict[str, Any]) -> Any:
+        await asyncio.sleep(30)
+        return "never"
+
+    result = await asyncio.to_thread(_bridged_execute(slow), {}, None)
+    assert isinstance(result, dict) and result["isError"] is True
+    assert "timed out" in result["content"][0]["text"]
+
+
+async def test_custom_tool_execute_surfaces_coroutine_exception_as_iserror() -> None:
+    """A raising coroutine becomes a structured tool error, not an uncaught
+    exception on the SDK's daemon callback thread."""
+
+    async def boom(name: str, args: dict[str, Any]) -> Any:
+        raise RuntimeError("kaboom")
+
+    result = await asyncio.to_thread(_bridged_execute(boom), {}, None)
+    assert isinstance(result, dict) and result["isError"] is True
+    assert "kaboom" in result["content"][0]["text"]
+
+
 async def test_setup_failure_closes_client_and_drops_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

Re-do of #223, based on `main`. #223 was stacked on #221's branch; when #221 squash-merged to `main`, #223's base hadn't been retargeted, so #223 ended up **merged into #221's (now-dead) branch instead of `main`** — its content never reached `main`. GitHub won't reopen a merged PR, so this is a fresh PR carrying the same commit, rebased onto `main`.

Identical to the reviewed #223 — the bridge-robustness hardening of the cursor custom-tool `execute()` (runs on the SDK's daemon callback thread):

- **Timeout** — `future.result()` is now bounded by `_TOOL_CALL_TIMEOUT_S` (1800s); on timeout it cancels the future + returns a tool error, so a wedged tool can't hang the daemon thread / Cursor turn forever.
- **Exception guard** — `future.result()` is wrapped so a failed or cancelled coroutine becomes a tool error instead of propagating raw onto the daemon thread.
- **`isError`** — dispatch failures / policy blocks (`{"error"|"blocked": ...}`) return an SDK error payload (`content` + `isError`) so the model sees a failure rather than an apparently-successful result; ordinary results still pass through as text.

> ⚠️ **Reviewer input wanted on the timeout value** (`_TOOL_CALL_TIMEOUT_S = 1800.0`, 30 min) — generous so a long `sys_session_send` sub-agent dispatch isn't killed, finite so a wedged tool eventually errors. Bump it (or make it env-overridable) if dispatches can legitimately run longer.

## Test

`tests/inner/test_cursor_executor.py` → **27 passed** (5 bridge tests); `ruff` clean. Verified `main`'s #221 `aclose` fix and this `_TOOL_CALL_TIMEOUT_S` change coexist with no duplication.

This pull request and its description were written by Isaac.
