### PR TITLE
fix(pi-native): resolve model provider for pi-native sub-agents

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -91,6 +91,8 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
     "codex-native": "codex",
     "native-codex": "codex",
     "pi": "pi",
+    "pi-native": "pi",
+    "native-pi": "pi",
     "openai-agents": "openai-agents-sdk",
     "openai-agents-sdk": "openai-agents-sdk",
     "agents_sdk": "openai-agents-sdk",

--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -12,6 +12,7 @@ from omnigent._wrapper_labels import (
     UI_MODE_TERMINAL_VALUE,
     WRAPPER_LABEL_KEY,
 )
+from omnigent.harness_aliases import canonicalize_harness
 
 
 @dataclass(frozen=True)
@@ -82,8 +83,13 @@ def native_coding_agent_for_agent_name(name: str | None) -> NativeCodingAgent | 
 
 
 def native_coding_agent_for_harness(harness: str | None) -> NativeCodingAgent | None:
-    """Return the native coding-agent metadata for *harness*, if any."""
-    return _BY_HARNESS.get(harness or "")
+    """Return the native coding-agent metadata for *harness*, if any.
+
+    Canonicalizes first, so a reversed alias (e.g. ``native-pi``) resolves to
+    the same agent as its canonical spelling (``pi-native``) and keeps
+    terminal-first presentation labels.
+    """
+    return _BY_HARNESS.get(canonicalize_harness(harness) or "")
 
 
 def native_coding_agent_for_wrapper_label(wrapper: str | None) -> NativeCodingAgent | None:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -135,7 +135,7 @@ def test_resolve_provider_databricks_default(
     :param tmp_path: Per-test temp dir.
     """
     _isolate_config(monkeypatch, tmp_path, _DATABRICKS_DEFAULT_CONFIG)
-    for harness in ("claude-native", "codex-native", "pi"):
+    for harness in ("claude-native", "codex-native", "pi", "pi-native", "native-pi"):
         provider = resolve_model_provider(_worker_spec(harness), harness)
         assert provider.kind == "databricks", f"harness {harness}: {provider}"
         assert provider.profile == "prof-a"

--- a/tests/test_native_coding_agents.py
+++ b/tests/test_native_coding_agents.py
@@ -1,0 +1,43 @@
+"""Native coding-agent harness lookups, including reversed-alias folding."""
+
+from __future__ import annotations
+
+from omnigent._wrapper_labels import (
+    PI_NATIVE_WRAPPER_VALUE,
+    UI_MODE_LABEL_KEY,
+    UI_MODE_TERMINAL_VALUE,
+    WRAPPER_LABEL_KEY,
+)
+from omnigent.native_coding_agents import (
+    PI_NATIVE_CODING_AGENT,
+    native_coding_agent_for_harness,
+)
+
+
+def test_native_pi_alias_resolves_like_canonical() -> None:
+    """``native-pi`` resolves to the same native agent as ``pi-native``.
+
+    ``AgentSpec.harness_kind`` returns the raw ``executor.config.harness``, so
+    an agent authored as ``native-pi`` must still resolve — else fork/switch
+    would drop its terminal-first presentation labels. ``canonicalize_harness``
+    folds the alias before the lookup.
+    """
+    agent = native_coding_agent_for_harness("native-pi")
+    assert agent is PI_NATIVE_CODING_AGENT
+    assert agent is native_coding_agent_for_harness("pi-native")
+    assert agent.presentation_labels == {
+        UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY: PI_NATIVE_WRAPPER_VALUE,
+    }
+
+
+def test_canonical_native_harnesses_resolve() -> None:
+    """The canonical native spellings all resolve to their agents."""
+    for harness in ("claude-native", "codex-native", "pi-native"):
+        assert native_coding_agent_for_harness(harness) is not None
+
+
+def test_unknown_harness_returns_none() -> None:
+    """A non-native harness stays unresolved (no terminal presentation)."""
+    assert native_coding_agent_for_harness("claude-sdk") is None
+    assert native_coding_agent_for_harness(None) is None


### PR DESCRIPTION
## Problem
`omnigent/model_catalog.py` `_PROVIDER_RESOLUTION_HARNESS` maps `pi` but not the native spellings `pi-native` / `native-pi` — whereas Claude and Codex map both their native and reversed-alias spellings. A pi-native sub-agent's `spec_harness()` returns `pi-native`, and this map is queried with the **raw** harness (no `canonicalize_harness`), so `resolve_model_provider(spec, "pi-native")` returns `kind="none"`.

Effect: `sys_list_models` reports `source: "none"` / *"harness 'pi-native' has no model-provider resolution"* for a pi-native worker — a false "this worker cannot run here" dead-worker preflight signal to the orchestrator, while claude-native/codex-native sub-agents enumerate correctly.

## Fix
Add `"pi-native": "pi"` and `"native-pi": "pi"` to the map (mirroring the dual claude/codex native entries). Extended `test_resolve_provider_databricks_default` to cover both spellings.

Found by a post-merge audit of the native-Pi feature.

This pull request and its description were written by Isaac.