### PR TITLE
fix(pi-native): fall back to Pi's own login on any provider-resolution error

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -188,28 +188,28 @@ def resolve_pi_native_provider(
     """
     try:
         config = config_loader()
-    except Exception:  # noqa: BLE001 — any config failure must not break launch
-        # A malformed/absent config must not break session launch — fall back
-        # to Pi's own login.
+        # Pi is multi-family; ``omnigent setup`` marks defaults per family, not
+        # for ``pi``. Prefer an explicit pi default, then Anthropic (Pi's native
+        # surface), then OpenAI.
+        entry = (
+            get_default_provider(config, PI_SURFACE)
+            or get_default_provider(config, ANTHROPIC_FAMILY)
+            or get_default_provider(config, OPENAI_FAMILY)
+        )
+        if entry is None:
+            return None
+        if entry.kind == DATABRICKS_KIND:
+            return _databricks_pi_provider(entry, model=model)
+        if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+            return _inline_family_pi_provider(entry, model=model)
+        # subscription / cli-config: a CLI's own login can't be reused outside
+        # that CLI — let Pi use its own login.
         return None
-    # Pi is multi-family. ``omnigent setup`` marks a provider default for the
-    # ``anthropic`` / ``openai`` surfaces, not for ``pi`` specifically, so
-    # resolve in preference order: an explicit pi default, then the Anthropic
-    # surface (Pi speaks ``anthropic-messages`` natively), then OpenAI.
-    entry = (
-        get_default_provider(config, PI_SURFACE)
-        or get_default_provider(config, ANTHROPIC_FAMILY)
-        or get_default_provider(config, OPENAI_FAMILY)
-    )
-    if entry is None:
+    except Exception:  # noqa: BLE001 — any resolution failure must not break launch
+        # Any failure (malformed config, duplicate per-family default, or an
+        # unresolved ``api_key: $VAR``) falls back to Pi's own login rather than
+        # failing the terminal launch.
         return None
-    if entry.kind == DATABRICKS_KIND:
-        return _databricks_pi_provider(entry, model=model)
-    if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
-        return _inline_family_pi_provider(entry, model=model)
-    # subscription / cli-config: a CLI's own login (or a provider pinned in the
-    # CLI's config) is unusable outside that CLI — let Pi use its own login.
-    return None
 
 
 def write_pi_models_config(agent_dir: Path, provider: PiProviderConfig) -> Path:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -103,6 +103,31 @@ def test_malformed_config_returns_none() -> None:
     assert creds.resolve_pi_native_provider(config_loader=_boom) is None
 
 
+def test_unresolvable_secret_falls_back_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A provider whose secret can't resolve → None, not a hard launch failure.
+
+    A key-kind default whose ``api_key`` references an env var absent from the
+    runner env makes ``entry.family()`` raise during resolution (not during the
+    config load). The contract is "any resolution failure → fall back to Pi's
+    own login", so the resolver must swallow it and return ``None`` rather than
+    let the exception fail the Pi terminal launch.
+    """
+    monkeypatch.delenv("PI_NATIVE_AUDIT_UNSET_KEY", raising=False)
+    config = {
+        "providers": {
+            "anthropic": {
+                "kind": "key",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "$PI_NATIVE_AUDIT_UNSET_KEY",
+                },
+            }
+        }
+    }
+    assert creds.resolve_pi_native_provider(config_loader=lambda: config) is None
+
+
 def test_to_models_config_shape() -> None:
     """The rendered models.json carries baseUrl/api/apiKey/models (+authHeader)."""
     provider = creds.PiProviderConfig(


### PR DESCRIPTION
## Problem
`omnigent/pi_native_credentials.py` `resolve_pi_native_provider` wraps only the `config_loader()` call in its `try/except`. But resolution continues past that: `get_default_provider` raises `OmnigentError` on a duplicate `default: true` provider for a family, and `entry.family()` raises on an **unresolved secret** — e.g. `api_key: $ANTHROPIC_API_KEY` (the default for the anthropic surface) when that env var isn't exported in the runner's environment.

The module/​resolver docstrings promise *"any config failure must not break launch — fall back to Pi's own login"*, but those post-load failures instead turn a recoverable misconfig into a **hard "Pi terminal failed to start"** (both call sites catch `Exception`, so the runner survives, but the terminal doesn't launch and Pi never gets its own-login fallback).

## Fix
Widen the `try/except` to wrap the entire resolution body, so **any** resolution failure returns `None` → Pi uses its own `/login`. Added a test for the unresolved-`$VAR` secret path.

Found by a post-merge audit of the native-Pi feature.

This pull request and its description were written by Isaac.