### PR TITLE
fix(pi-native): clear the stale inbox on Pi terminal (re)launch

### DIFF
--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import itertools
 import json
@@ -55,6 +56,27 @@ def prepare_bridge_dir(session_id: str) -> Path:
     (bridge_dir / _INBOX_DIR).mkdir(mode=0o700, exist_ok=True)
     (bridge_dir / _SESSIONS_DIR).mkdir(mode=0o700, exist_ok=True)
     return bridge_dir
+
+
+def clear_inbox(bridge_dir: Path) -> None:
+    """
+    Drop leftover inbox payloads from a previous Pi process.
+
+    A freshly launched Pi process has an empty in-memory dedup set, so any
+    payload a prior process left undelivered would replay into it. Call on
+    terminal (re)launch — mirroring codex-native's ``clear_bridge_state``.
+    Best-effort: a concurrent drain removing a file first is benign.
+
+    :param bridge_dir: The session's prepared bridge directory.
+    :returns: None.
+    """
+    inbox = bridge_dir / _INBOX_DIR
+    if not inbox.is_dir():
+        return
+    for entry in inbox.iterdir():
+        if entry.is_file():
+            with contextlib.suppress(OSError):
+                entry.unlink()
 
 
 def build_pi_native_spawn_env(conversation_id: str) -> dict[str, str]:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -722,6 +722,7 @@ async def _auto_create_pi_terminal(
     from omnigent.pi_native import resolve_pi_executable
     from omnigent.pi_native_bridge import (
         PI_NATIVE_CONFIG_ENV_VAR,
+        clear_inbox,
         pi_session_dir,
         prepare_bridge_dir,
         write_extension_files,
@@ -735,6 +736,8 @@ async def _auto_create_pi_terminal(
     )
     workspace = str(launch_config.workspace)
     bridge_dir = prepare_bridge_dir(session_id)
+    # Drop stale payloads so a relaunched Pi process can't replay them.
+    clear_inbox(bridge_dir)
     pi_extension = pi_extension_path(bridge_dir)
     session_dir = pi_session_dir(bridge_dir)
     auth_factory = _make_auth_token_factory()

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -96,3 +96,27 @@ def test_prepare_bridge_dir_is_owner_only(tmp_path: Path, monkeypatch) -> None:
 
     assert stat.S_IMODE((bridge_dir).stat().st_mode) == 0o700
     assert stat.S_IMODE((bridge_dir / "inbox").stat().st_mode) == 0o700
+
+
+def test_clear_inbox_drops_leftover_payloads(tmp_path: Path) -> None:
+    """clear_inbox empties the queue so a relaunched Pi process can't replay.
+
+    A fresh Pi process starts with an empty dedup set; without clearing, a
+    payload a prior process left behind would replay into the new session.
+    """
+    bridge_dir = tmp_path / "bridge"
+    (bridge_dir / "inbox").mkdir(parents=True)
+    pi_native_bridge.enqueue_user_message(bridge_dir, "stale")
+    pi_native_bridge.enqueue_interrupt(bridge_dir)
+    assert _inbox_files(bridge_dir), "precondition: inbox has payloads"
+
+    pi_native_bridge.clear_inbox(bridge_dir)
+
+    assert _inbox_files(bridge_dir) == []
+    # The inbox dir itself survives (only its contents are dropped).
+    assert (bridge_dir / "inbox").is_dir()
+
+
+def test_clear_inbox_is_a_noop_without_an_inbox(tmp_path: Path) -> None:
+    """clear_inbox tolerates a bridge dir that has no inbox yet."""
+    pi_native_bridge.clear_inbox(tmp_path / "nonexistent")  # must not raise


### PR DESCRIPTION
## Problem
The Pi inbox (`~/.omnigent/pi-native/<hash>/inbox/`) is an at-least-once delivery queue drained by the resident extension's **in-memory** `seen` dedup set — which is empty in a freshly launched Pi process. `prepare_bridge_dir` only `mkdir(exist_ok=True)`s the inbox and never clears it, so any payload a prior Pi process left undelivered (it died, was restarted, or stopped mid-poll) is **replayed into the next — possibly different — session** when a new Pi process boots. Codex-native avoids this by calling `clear_bridge_state` on every launch; the Pi path had no equivalent.

## Fix
Add `clear_inbox(bridge_dir)` to `pi_native_bridge.py` and call it in `_auto_create_pi_terminal` immediately after `prepare_bridge_dir`, so a (re)launched Pi process starts from an empty queue. Best-effort unlink (a concurrent drain by a live extension is benign). Added tests for the clear + the no-inbox no-op.

Found by a post-merge audit of the native-Pi feature (corroborated by two reviewers).

This pull request and its description were written by Isaac.