### PR TITLE
fix(pi-native): harden the extension inbox poller (retry cap, id dedup, bounded seen)

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -150,7 +150,18 @@ function interruptActiveContext(ctx) {
 
 function startInboxPoller(pi, config, handleInterrupt) {
   if (!config || !config.inboxDir || pi.__omnigentInboxPoller) return;
+  // Bound the dedup set (FIFO eviction) — delivered files are unlinked, so a
+  // long-lived TUI mustn't grow it unboundedly.
   const seen = new Set();
+  const SEEN_CAP = 4096;
+  const rememberSeen = (id) => {
+    seen.add(id);
+    while (seen.size > SEEN_CAP) seen.delete(seen.values().next().value);
+  };
+  // Cap send attempts so a persistently-failing sendUserMessage can't
+  // re-read+re-throw the same file forever (the turn is already reported done).
+  const deliverAttempts = new Map();
+  const MAX_DELIVER_ATTEMPTS = 5;
   pi.__omnigentInboxPoller = setInterval(() => {
     let files = [];
     try {
@@ -169,13 +180,15 @@ function startInboxPoller(pi, config, handleInterrupt) {
       } catch (_err) {
         continue;
       }
-      if (!payload || seen.has(payload.id)) {
+      // Dedup only on a real string id; seen.has(undefined) would drop every
+      // later id-less payload.
+      const id = typeof payload?.id === "string" ? payload.id : null;
+      if (!payload || (id !== null && seen.has(id))) {
         try {
           fs.unlinkSync(fullPath);
         } catch (_err) {}
         continue;
       }
-      seen.add(payload.id);
       if (
         payload.type === "user_message" &&
         typeof payload.content === "string"
@@ -183,9 +196,26 @@ function startInboxPoller(pi, config, handleInterrupt) {
         try {
           pi.sendUserMessage(payload.content, { deliverAs: "followUp" });
         } catch (_err) {
-          seen.delete(payload.id);
+          // Leave the file to retry next tick, capped by attempt count.
+          const key = id ?? fullPath;
+          const attempts = (deliverAttempts.get(key) ?? 0) + 1;
+          if (attempts < MAX_DELIVER_ATTEMPTS) {
+            deliverAttempts.set(key, attempts);
+            continue;
+          }
+          // Cap reached: surface a failure (a silent drop would be invisible)
+          // and consume the file to stop the spin.
+          deliverAttempts.delete(key);
+          postEvent(config, {
+            type: "external_session_status",
+            data: { status: "failed", response_id: `pi-deliver-failed-${Date.now()}` },
+          });
+          try {
+            fs.unlinkSync(fullPath);
+          } catch (_err) {}
           continue;
         }
+        deliverAttempts.delete(id ?? fullPath);
       }
       if (payload.type === "interrupt") {
         // An interrupt is point-in-time: make one delivery attempt, then
@@ -197,6 +227,7 @@ function startInboxPoller(pi, config, handleInterrupt) {
         // turn starting just after this still gets aborted via replay.
         if (typeof handleInterrupt === "function") handleInterrupt();
       }
+      if (id !== null) rememberSeen(id);
       try {
         fs.unlinkSync(fullPath);
       } catch (_err) {}


### PR DESCRIPTION
## Problem
Three robustness issues in the resident Pi extension's inbox poller (`omnigent/resources/pi_native/omnigent_pi_native_extension.js`):

1. **Silent infinite retry of a failed send.** On a `pi.sendUserMessage` throw, the handler did `seen.delete; continue` — skipping the unlink — so the 250 ms poller re-read and re-threw the same file **forever**, while Omnigent had already yielded `TurnComplete`. A persistent failure = invisible hot-spin + lost message.
2. **Missing-`id` payload poisons dedup.** `seen.has(payload.id)` with `payload.id === undefined` did `seen.add(undefined)`, after which **every later id-less payload** matched `seen.has(undefined)` and was silently dropped.
3. **`seen` grows unbounded** for the life of the (long-lived) TUI process.

## Fix
- **Bounded retry:** cap delivery attempts (per id/path); after the cap, `postEvent` a `failed` status (so the loss surfaces) and unlink the file to stop the spin.
- **Safe dedup:** key only on a real string `id`; treat an id-less payload as non-dedupable (deliver once).
- **Bounded `seen`:** FIFO-evict at a cap — safe because delivered files are unlinked.

## Testing
There is **no JS test harness** for this extension yet (a known, separate coverage gap from the audit), so this is verified by `node --check` + review. Deferred (riskier without a harness, and there's no Pi unload hook): wrapping all async `pi.on` handlers against unhandled rejections, and `setInterval` teardown.

Found by a post-merge audit of the native-Pi feature.

This pull request and its description were written by Isaac.