### PR TITLE
feat(sandbox): secretless credential_proxy for egress (bearer + basic)

### DIFF
--- a/designs/SANDBOX_CREDENTIAL_PROXY.md
+++ b/designs/SANDBOX_CREDENTIAL_PROXY.md
@@ -1,0 +1,282 @@
+# Secretless Credential Proxy
+
+> **IMPLEMENTED.** Config surface: `os_env.sandbox.credential_proxy`.
+> Code: `omnigent/inner/credential_proxy.py`,
+> `omnigent/inner/egress/proxy.py`, `omnigent/spec/parser.py`.
+
+## Problem
+
+A sandboxed tool often needs to authenticate to an external host —
+`gh api`, `git clone https://github.com/...`, a Bearer-token SaaS API.
+The naive approach injects the real token into the sandbox env (or a
+config file the sandbox can read). That defeats much of the point of
+the sandbox: any code the agent runs — including code it was tricked
+into running by a prompt-injection payload in a fetched web page or a
+malicious dependency — can read the token out of `os.environ` /
+`~/.gitconfig` and exfiltrate it to an attacker-controlled host that
+happens to be on the egress allow-list (or over a covert channel).
+
+We want tools inside the sandbox to be able to authenticate **without
+the real secret ever entering the sandbox**.
+
+## Approach
+
+The L7 egress proxy is already a mandatory MITM for all HTTP(S) traffic
+leaving the sandbox (see the egress allow-list machinery in
+`omnigent/inner/egress/`). We extend it to attach credentials. The
+default model is **swap-on-access**: nothing credential-shaped enters
+the sandbox at all.
+
+1. **Parent resolves the real secret.** When the helper starts
+   (`_HelperProcessClient._start_locked`), the parent — which is *not*
+   sandboxed — resolves each configured secret from its source
+   (`{env: ...}`, `{file: ...}`, or `{command: ...}`). The real secret
+   stays in the parent and the proxy's in-memory rewrite table.
+
+2. **The egress proxy injects on access (default).** A tool simply
+   makes its request to the bound host with **no `Authorization`
+   header**. The proxy recognises the bound host and injects
+   `Authorization: <scheme> <real>` on the way out. `git clone`,
+   `curl`, `python`, `node` — any HTTP client — authenticate with zero
+   in-sandbox wiring. The sandbox holds nothing to leak.
+
+3. **Opt-in placeholder injection for credential-gating clients.** Some
+   clients refuse to issue a request when they don't see a credential
+   locally — most notably `gh`, which short-circuits with
+   "authentication required" *before* touching the network, so there is
+   no outbound request for the proxy to decorate. For those, an entry
+   sets `env:` (e.g. `GH_TOKEN`). The parent mints a random, single-use
+   placeholder prefixed `oa_cred_` (`secrets.token_urlsafe`) and injects
+   *only the placeholder* into that env var. The client believes it is
+   authenticated, issues the request carrying the placeholder, and the
+   proxy swaps it. The placeholder is non-secret and bound to one host.
+
+4. **Leak guard (placeholder path only).** A placeholder presented for a
+   host it is not bound to (an exfiltration attempt) is rejected with
+   HTTP 403; an unknown `oa_cred_*`-shaped value is likewise rejected. So
+   even if a tool reads the placeholder out of its own env and replays it
+   against an attacker host, the proxy attaches no real credential. (Pure
+   swap-on-access entries inject no placeholder, so there is nothing in
+   the sandbox to replay in the first place.)
+
+5. **No clobbering.** A real, non-placeholder `Authorization` header the
+   client set itself is forwarded untouched and suppresses injection, so
+   the proxy never overwrites an unrelated credential a tool deliberately
+   sent.
+
+```
+  Default — swap-on-access (nothing in the sandbox):
+
+   parent (unsandboxed)               sandbox                 upstream
+   ────────────────────               ───────                 ────────
+   resolve real secret
+   (held in proxy table)     git/curl → GET /repo (no auth)
+                                                    │
+                               egress MITM proxy ◀──┘
+                               host bound? inject Authorization: <scheme> <real>
+                                                    └────────────────▶  200 OK
+
+  Opt-in — placeholder injection (gh-class clients):
+
+   resolve real secret
+   mint  oa_cred_XXXX  ──inject GH_TOKEN──▶  gh builds
+                                             Authorization: token oa_cred_XXXX
+                                                    │
+                               egress MITM proxy ◀──┘
+                               verify host binding; swap → token <real>  ──▶ 200 OK
+                               (wrong host → 403)
+```
+
+## YAML surface
+
+All entries live in a `credential_proxy:` list under
+`os_env.sandbox`. The block **requires** `egress_rules` and a
+hard-isolating backend (`linux_bwrap` or `darwin_seatbelt`) — the
+parser rejects it otherwise, because only those two backends can
+guarantee the MITM proxy is the *only* egress path (a tool can't open a
+raw socket around it). The bound host of every entry must also be
+reachable under `egress_rules`.
+
+Four types, two generic primitives and two presets. All default to
+swap-on-access:
+
+| Type | Wire scheme | Injection | Notes |
+|------|-------------|-----------|-------|
+| `https_bearer` | `Authorization: Bearer <real>` | swap-on-access (optional `env:`) | Generic Bearer-token SaaS. |
+| `https_basic` | `Authorization: Basic b64(user:<real>)` | swap-on-access (optional `env:`) | Generic Basic auth; `username` defaults to `x-access-token`. |
+| `git_https` | `Authorization: Basic b64(user:<real>)` | swap-on-access | Preset for git-over-HTTPS; nothing in the sandbox. |
+| `gh_basic` | Basic for git host, `token` for api host | swap-on-access for git; `GH_TOKEN`/`GITHUB_TOKEN` env for api | Preset for GitHub CLI + git; defaults to `github.com` + `api.github.com`. |
+
+Common fields: `target`/`targets` (host + optional path glob — only the
+host binds the credential; path scoping is delegated to `egress_rules`),
+and `source`, a single-key nested mapping naming where the parent reads
+the real secret — `{env: VAR}`, `{file: /path}`, or `{command: ...}`.
+`https_*` take an **optional** `env` (the opt-in injection shim — when
+present, a synthetic placeholder is injected into that env var);
+`https_basic` / `git_https` take an optional `username`.
+
+```yaml
+os_env:
+  sandbox:
+    type: linux_bwrap
+    egress_rules:
+      - "* github.com/**"
+      - "* api.github.com/**"
+      - "* mycorp.atlassian.net/**"
+    credential_proxy:
+      # gh_basic: git host is pure swap-on-access; the api host injects
+      # GH_TOKEN/GITHUB_TOKEN because gh gates on a local token.
+      - type: gh_basic
+        source: {command: gh auth token}
+      # git_https: nothing enters the sandbox — git fires its request and
+      # the proxy injects Basic auth for the bound host.
+      - type: git_https
+        target: github.com/databricks-eng/agent-framework.git
+        source: {env: OA_TEST_GITHUB_PAT}
+      # https_bearer with no `env`: swap-on-access. curl/python send no
+      # Authorization header; the proxy attaches Bearer <real>.
+      - type: https_bearer
+        target: mycorp.atlassian.net/rest/**
+        source: {env: JIRA_PAT}
+      # https_bearer WITH `env`: opt-in placeholder injection for a
+      # client that won't call without a local token.
+      - type: https_bearer
+        target: gating-saas.example.com
+        source: {env: SAAS_PAT}
+        env: SAAS_TOKEN
+```
+
+The `source` mapping is validated by a small pydantic boundary model
+(`_CredentialProxyItemModel` / `_CredentialSourceModel` in the spec
+parser) that rejects unknown keys, enforces exactly one source key, and
+checks POSIX env-var names — then converts to the `CredentialSourceSpec`
+dataclass the runtime consumes.
+
+## Internal model
+
+`omnigent/inner/datamodel.py`:
+
+- `CredentialSourceSpec` — `kind` (`env`/`file`/`command`) + the
+  corresponding field.
+- `CredentialProxyEntry` — the normalized internal shape every YAML
+  type compiles down to: `host`, `scheme` (`basic`/`bearer`/`token`),
+  `source`, `username | None`, `inject_env: list[str]` (empty for
+  swap-on-access; populated only by the opt-in `env` shim).
+- `CredentialProxySpec` — list of entries; attached to
+  `OSEnvSandboxSpec.credential_proxy`.
+
+The parser (`omnigent/spec/parser.py`, `_parse_credential_proxy`)
+validates each raw entry with a pydantic boundary model
+(`_CredentialProxyItemModel`, which nests `_CredentialSourceModel` for
+the `source` mapping) — type, target/targets cardinality, source shape,
+POSIX env var names, unknown-key rejection — wrapping any
+`ValidationError` as an `OmnigentError`. It then normalizes the four
+user-facing types into `CredentialProxyEntry` lists and applies the
+checks pydantic can't express: DNS-safe host (reuses
+`is_dns_safe_host`), duplicate-host rejection, `egress_rules` present,
+backend allow-list, and the `gh_basic`-on-macOS guard.
+
+## Runtime
+
+`omnigent/inner/credential_proxy.py`:
+
+- `prepare_credential_proxy_runtime(spec, parent_env)` runs in the
+  parent. For each entry it resolves the real secret and returns a
+  `CredentialProxyRuntime` with:
+  - `helper_env_updates` — synthetic values for each `inject_env` var
+    (empty for swap-on-access entries),
+  - `rewrites: list[CredentialRewriteRule]` — `(host, scheme,
+    real_secret, synthetic | None, username)` for the proxy. `synthetic`
+    is `None` for swap-on-access entries; it is minted (and the matching
+    placeholder injected) only when the entry sets `env`.
+
+The real secret lives **only** in the parent process and the proxy's
+in-memory rewrite table. It is never serialized into the
+`SandboxPolicy` (which can reach logs/dumps), never placed on argv, and
+never written to disk in the sandbox. Swap-on-access puts *nothing*
+credential-shaped in the sandbox; the opt-in path puts only the
+non-secret `oa_cred_*` placeholder.
+
+> **Removed: the git credential helper.** Earlier revisions installed a
+> per-host git credential helper inside the sandbox (an `oa_cred_*`-
+> returning script wired via `GIT_CONFIG_*`) so `git` over HTTPS would
+> emit the placeholder. Swap-on-access makes that unnecessary: `git`
+> fires its unauthenticated request and the proxy injects the real Basic
+> credential directly. The helper, its config-pipe payload, and the
+> `OMNIGENT_CREDENTIAL_PROXY_GIT_HTTPS` env var are gone.
+
+## Proxy rewrite
+
+`omnigent/inner/egress/proxy.py`: `EgressProxy` takes
+`credential_rewrites` and builds two indexes — `_cred_by_host` (the
+swap-on-access path) and `_cred_by_synthetic` (the opt-in placeholder
+path, populated only for rules carrying a synthetic).
+`_rewrite_authorization` (called from both `_forward_https` and
+`_handle_http`, the same call sites as the egress allow-list check):
+
+- If the inner request carries an `oa_cred_*` placeholder (across
+  `Basic` / `Bearer` / `token`), verify it is bound to this request's
+  host (else 403) and re-emit the configured scheme with the real
+  secret.
+- Else if a rule binds this host and the request carries **no**
+  `Authorization` header, inject `Authorization: <scheme> <real>`
+  (swap-on-access).
+- Else (a foreign non-placeholder header, or no bound rule) forward
+  unchanged.
+
+Header parsing/serialization goes through the stdlib email parser
+(`BytesParser` + `policy.HTTP`, the same machinery `http.client` uses)
+rather than a hand-rolled `split(b"\r\n")` loop — it handles
+case-insensitive field names, whitespace, folding, and repeated headers,
+and `policy.HTTP` round-trips with CRLF line endings and no folding so
+the forwarded request stays byte-faithful. The same helper backs
+`_force_connection_close` (dropping hop-by-hop headers) and the
+`Authorization` rewrite. When nothing matches, the original client bytes
+are forwarded untouched (no needless re-serialization).
+
+`omnigent/inner/egress/controller.py` threads `credential_rewrites`
+through `start_egress_proxy`, and keeps `GIT_SSL_CAINFO` in the CA env
+keys so `git`/libcurl trusts the MITM CA when it connects to the bound
+host (the CA trust is what lets the proxy terminate TLS and inject the
+header — it is independent of how the credential is supplied).
+
+## Wiring
+
+- `omnigent/inner/os_env.py` — `_start_locked` builds a scoped parent
+  env, calls `prepare_credential_proxy_runtime`, merges
+  `helper_env_updates` into the helper env (only non-empty for the
+  opt-in `env` shim), and passes `rewrites` to the egress proxy. No
+  config-pipe credential payload and no helper-side install step.
+- `omnigent/inner/sandbox.py` — `credential_proxy` field on
+  `SandboxPolicy`, preserved across `_clone_policy_with`. It is
+  deliberately **not** part of `to_jsonable`/`from_jsonable`: it's
+  parent-side only, and serializing it would risk leaking resolved
+  secrets into dumps. The child receives only the optional `oa_cred_*`
+  placeholders in its env (swap-on-access entries send nothing); the
+  proxy receives only the rewrite table.
+- The `resolve` methods of `bwrap_sandbox.py`, `seatbelt_sandbox.py`,
+  and `landlock_sandbox.py` propagate
+  `credential_proxy=sandbox_spec.credential_proxy`.
+
+## Tests
+
+- `tests/inner/test_credential_proxy.py` — source resolution
+  (env/file/command), the swap-on-access default (nothing injected, no
+  synthetic minted), opt-in synthetic minting, and the `gh_basic` shape
+  (git host swap-on-access, api host env injection).
+- `tests/inner/egress/test_proxy.py` — swap-on-access injection on a
+  bare request, synthetic→real swap for basic/bearer/token against a
+  real capturing upstream, the wrong-host 403 leak guard, and
+  non-synthetic pass-through.
+- `tests/spec/test_parser.py` — round-trip + fail-loud for all four
+  types, plus `env`-optional (swap-on-access) parsing.
+- `tests/inner/sandbox/test_egress_e2e.py` — real-sandbox e2e:
+  swap-on-access injects Basic auth on a bare request while the sandbox
+  holds neither the secret nor a placeholder; `https_bearer` with `env`
+  performs the full env-injection → proxy swap → upstream-sees-real-token
+  path.
+
+## Non-goals
+
+- **SSH.** This phase covers HTTP(S) Bearer/Basic only. SSH-based git
+  remotes are out of scope.

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -275,6 +275,7 @@ class BwrapSandboxBackend(SandboxBackend):
                 if sandbox_spec.env_passthrough is not None
                 else None
             ),
+            credential_proxy=sandbox_spec.credential_proxy,
         )
 
     def wrap_launcher_argv(

--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -1,0 +1,217 @@
+"""Runtime for the secretless sandbox credential proxy.
+
+Real, long-lived secrets stay in the parent process. For each
+:class:`~omnigent.inner.datamodel.CredentialProxyEntry` the parent
+resolves the real secret and hands the egress MITM proxy a
+:class:`CredentialRewriteRule` that binds it to one host. The proxy
+attaches the real credential to outbound requests for that host (see
+:mod:`omnigent.inner.egress.proxy`).
+
+The default model is **swap-on-access**: nothing credential-shaped
+enters the sandbox. A tool makes its request with no ``Authorization``
+header and the proxy injects the real credential on the way out. An
+entry may additionally opt into injecting a synthetic ``oa_cred_*``
+placeholder into the sandbox env (``inject_env``) for clients that
+refuse to issue a request without a local credential (e.g. ``gh``); the
+proxy then recognises the placeholder and swaps it, rejecting a
+placeholder replayed to a different host with HTTP 403.
+
+This module owns two pieces:
+
+- :func:`prepare_credential_proxy_runtime` — parent-side: resolve
+  secrets, mint placeholders for ``inject_env`` entries, and build the
+  helper env updates plus the proxy rewrite rules.
+- :class:`CredentialRewriteRule` — the host-scoped real-credential
+  mapping the proxy enforces.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from omnigent.inner.datamodel import (
+    CredentialProxySpec,
+    CredentialSourceSpec,
+)
+
+# Prefix on every minted placeholder. The proxy uses it to recognise a
+# value as one of *its* synthetic credentials (so it can reject a
+# placeholder sent to the wrong host instead of forwarding it). Chosen
+# to be unmistakable and to use only base64url-safe characters so it
+# survives Basic-auth ``base64(user:pass)`` round-trips intact.
+SYNTHETIC_CREDENTIAL_PREFIX = "oa_cred_"
+# Timeout for a ``command:`` source subprocess, in seconds.
+_COMMAND_SOURCE_TIMEOUT_SECONDS = 30
+
+
+@dataclass
+class CredentialRewriteRule:
+    """Host-scoped mapping to a real secret enforced by the egress proxy.
+
+    Consumed by the egress proxy in two ways:
+
+    - **Swap-on-access (default).** For an outbound request to
+      :attr:`host` that carries no ``Authorization`` header, the proxy
+      injects ``Authorization: <scheme> <real>`` on the way out.
+    - **Placeholder swap (opt-in).** When :attr:`synthetic` is set, a
+      request whose ``Authorization`` header carries that placeholder is
+      rewritten to the real credential. A request carrying *any*
+      ``oa_cred_*`` placeholder bound to a different host is rejected
+      with HTTP 403 (the cross-host leak guard).
+
+    :param host: Exact hostname this rewrite applies to (lower-cased),
+        e.g. ``"github.com"``.
+    :param scheme: ``Authorization`` scheme emitted upstream, one of
+        ``"basic"``, ``"bearer"``, or ``"token"``.
+    :param real_secret: The real upstream credential the proxy attaches.
+    :param synthetic: The placeholder the sandbox sees when the entry
+        opted into ``inject_env``, e.g. ``"oa_cred_xT9..."``. ``None``
+        for pure swap-on-access entries (nothing is injected, so no
+        placeholder will appear in requests).
+    :param username: Basic-auth username emitted when ``scheme="basic"``,
+        e.g. ``"x-access-token"``. ``None`` for ``bearer`` / ``token``.
+    """
+
+    host: str
+    scheme: str
+    real_secret: str
+    synthetic: str | None = None
+    username: str | None = None
+
+
+@dataclass
+class CredentialProxyRuntime:
+    """Prepared parent-side assets for one helper process.
+
+    :param helper_env_updates: Environment-variable names mapped to a
+        synthetic placeholder, merged into the helper's spawn env so a
+        credential-gating tool that reads them emits the placeholder,
+        e.g. ``{"GH_TOKEN": "oa_cred_...", "GITHUB_TOKEN": "oa_cred_..."}``.
+        Empty when every entry uses pure swap-on-access.
+    :param rewrites: Host-scoped real-credential rewrite rules the egress
+        proxy enforces.
+    """
+
+    helper_env_updates: dict[str, str] = field(default_factory=dict)
+    rewrites: list[CredentialRewriteRule] = field(default_factory=list)
+
+
+def prepare_credential_proxy_runtime(
+    spec: CredentialProxySpec | None,
+    *,
+    parent_env: dict[str, str],
+) -> CredentialProxyRuntime:
+    """
+    Resolve secrets, mint placeholders, and build the proxy rewrite rules.
+
+    Each entry resolves its real secret in the (unsandboxed) parent. An
+    entry that opts into ``inject_env`` also gets a freshly minted
+    synthetic placeholder, which is injected into the helper env so a
+    credential-gating client emits a request the proxy can recognise.
+    Pure swap-on-access entries mint nothing — the proxy attaches the
+    real credential to bound-host requests directly.
+
+    :param spec: Parsed credential-proxy policy, or ``None`` (no-op).
+    :param parent_env: Parent process environment used to resolve
+        ``env`` / ``command`` sources. ``file`` sources read the
+        filesystem directly.
+    :returns: A :class:`CredentialProxyRuntime` with helper env updates
+        (only for ``inject_env`` entries) and the proxy rewrite rules.
+    :raises ValueError: If any configured source cannot be resolved to a
+        non-empty secret.
+    """
+    runtime = CredentialProxyRuntime()
+    if spec is None:
+        return runtime
+
+    for entry in spec.entries:
+        real_secret = _resolve_secret(entry.source, parent_env=parent_env)
+        # Mint a placeholder only when the entry injects an env var. The
+        # placeholder is what the cross-host leak guard keys on; pure
+        # swap-on-access entries put nothing in the sandbox, so there is
+        # no placeholder to mint or guard.
+        synthetic: str | None = None
+        if entry.inject_env:
+            # 24 bytes -> 192 bits of entropy, well past any brute-force or
+            # collision concern for a short-lived per-session placeholder.
+            synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}{secrets.token_urlsafe(24)}"
+            for env_name in entry.inject_env:
+                runtime.helper_env_updates[env_name] = synthetic
+        runtime.rewrites.append(
+            CredentialRewriteRule(
+                host=entry.host,
+                scheme=entry.scheme,
+                real_secret=real_secret,
+                synthetic=synthetic,
+                username=entry.username,
+            )
+        )
+    return runtime
+
+
+def _resolve_secret(source: CredentialSourceSpec, *, parent_env: dict[str, str]) -> str:
+    """
+    Resolve a real secret from an ``env`` / ``file`` / ``command`` source.
+
+    :param source: The parsed source descriptor.
+    :param parent_env: Parent process environment for ``env`` lookups and
+        as the environment for ``command`` execution.
+    :returns: The resolved secret with surrounding whitespace stripped.
+    :raises ValueError: If the source is misconfigured, missing, empty,
+        or (for ``command``) exits non-zero.
+    """
+    if source.kind == "env":
+        if not source.env:
+            raise ValueError("credential_proxy env source requires an 'env' name")
+        value = parent_env.get(source.env)
+        if value is None or not value.strip():
+            raise ValueError(f"credential_proxy env source {source.env!r} is missing or empty")
+        return value.strip()
+    if source.kind == "file":
+        if not source.path:
+            raise ValueError("credential_proxy file source requires a 'path'")
+        path = Path(os.path.expanduser(source.path))
+        if not path.is_file():
+            raise ValueError(f"credential_proxy file source does not exist: {path}")
+        value = path.read_text(encoding="utf-8").strip()
+        if not value:
+            raise ValueError(f"credential_proxy file source is empty: {path}")
+        return value
+    if source.kind == "command":
+        if not source.command:
+            raise ValueError("credential_proxy command source requires a 'command'")
+        # ``shell=True`` is intentional: the command is spec-author
+        # supplied (e.g. ``gh auth token``) and runs in the trusted
+        # parent process, never inside the sandbox.
+        completed = subprocess.run(
+            source.command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            env=parent_env,
+            timeout=_COMMAND_SOURCE_TIMEOUT_SECONDS,
+            check=False,
+        )
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            raise ValueError(
+                f"credential_proxy command source exited {completed.returncode}"
+                + (f": {stderr}" if stderr else "")
+            )
+        value = completed.stdout.strip()
+        if not value:
+            raise ValueError("credential_proxy command source produced empty stdout")
+        return value
+    raise ValueError(f"unsupported credential_proxy source kind: {source.kind!r}")
+
+
+__all__ = [
+    "SYNTHETIC_CREDENTIAL_PREFIX",
+    "CredentialProxyRuntime",
+    "CredentialRewriteRule",
+    "prepare_credential_proxy_runtime",
+]

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -356,6 +356,102 @@ class ExecutorSpec:
 # OS environment
 # ---------------------------------------------------------------------------
 
+# Basic-auth username GitHub (and ``gh``) accept for token auth: the
+# token lives in the password field, so this placeholder username works
+# for any GitHub PAT / gh token. Shared by the spec parser (default for
+# ``https_basic`` / ``git_https`` / ``gh_basic``), the runtime, and the
+# egress proxy's Basic emit path so the literal lives in exactly one
+# place.
+DEFAULT_BASIC_USERNAME = "x-access-token"
+
+
+@dataclass
+class CredentialSourceSpec:
+    """Where the parent process resolves a real secret from.
+
+    The secret is resolved in the *parent* (trusted) process and never
+    handed to the sandbox verbatim — only a synthetic placeholder is.
+
+    :param kind: Resolution mode, one of ``"env"``, ``"file"``, or
+        ``"command"``.
+    :param env: Environment-variable name carrying the secret when
+        ``kind="env"``, e.g. ``"OA_TEST_GITHUB_PAT"``.
+    :param path: File path to read when ``kind="file"`` (``~`` is
+        expanded), e.g. ``"~/.config/tokens/github_pat.txt"``.
+    :param command: Shell command whose stdout is the secret when
+        ``kind="command"``, e.g. ``"gh auth token"``.
+    """
+
+    kind: Literal["env", "file", "command"]
+    env: str | None = None
+    path: str | None = None
+    command: str | None = None
+
+
+@dataclass
+class CredentialProxyEntry:
+    """One normalized host binding for the secretless credential proxy.
+
+    Every YAML ``credential_proxy`` type (``https_bearer``,
+    ``https_basic``, ``git_https``, ``gh_basic``) is normalized by the
+    spec parser into one or more of these entries. The runtime resolves
+    :attr:`source` in the parent (it never enters the sandbox) and the
+    egress MITM proxy attaches the real credential to outbound requests
+    bound for :attr:`host`.
+
+    **Default: swap-on-access.** The sandbox holds *nothing*
+    credential-shaped. A tool simply makes its request to :attr:`host`
+    with no ``Authorization`` header, and the proxy injects
+    ``Authorization: <scheme> <real>`` on the way out. Git over HTTPS,
+    ``curl``, and any HTTP client work this way with zero in-sandbox
+    wiring.
+
+    **Opt-in: env injection.** Some clients refuse to issue a request
+    when they don't see a credential locally — most notably ``gh``,
+    which short-circuits with "authentication required" before touching
+    the network. For those, :attr:`inject_env` names env vars that
+    receive a synthetic ``oa_cred_*`` placeholder so the client believes
+    it is authenticated and actually sends the request; the proxy then
+    swaps the placeholder for the real secret (and rejects a placeholder
+    replayed to any other host with HTTP 403, the cross-host leak guard).
+    The placeholder is non-secret — the real secret still never enters
+    the sandbox.
+
+    :param host: Exact hostname this binding applies to (lower-cased),
+        e.g. ``"github.com"`` or ``"api.github.com"``. Path scoping is
+        delegated to ``egress_rules``; the credential binds to the host.
+    :param scheme: HTTP ``Authorization`` scheme the proxy emits upstream,
+        one of ``"basic"``, ``"bearer"``, or ``"token"``.
+    :param source: Where the parent resolves the real secret from.
+    :param username: Basic-auth username emitted upstream when
+        ``scheme="basic"``, e.g. ``"x-access-token"``. ``None`` for the
+        ``bearer`` / ``token`` schemes.
+    :param inject_env: Opt-in environment-variable names set to a
+        synthetic placeholder inside the sandbox so a credential-gating
+        client (e.g. ``gh`` via ``GH_TOKEN`` / ``GITHUB_TOKEN``) will
+        emit a request the proxy can rewrite. Empty (the default) means
+        pure swap-on-access — nothing is injected and the proxy attaches
+        the credential unconditionally for :attr:`host`.
+    """
+
+    host: str
+    scheme: Literal["basic", "bearer", "token"]
+    source: CredentialSourceSpec
+    username: str | None = None
+    inject_env: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CredentialProxySpec:
+    """Secretless credential-proxy policy for a sandbox.
+
+    :param entries: Normalized per-host credential bindings. The real
+        secrets stay in the parent; the sandbox only ever sees synthetic
+        placeholders that the egress proxy rewrites.
+    """
+
+    entries: list[CredentialProxyEntry]
+
 
 @dataclass
 class OSEnvSandboxSpec:
@@ -543,6 +639,18 @@ class OSEnvSandboxSpec:
     # this check including the cloud-trap list, so flip it on only
     # for workloads that genuinely need cloud-host metadata.
     egress_allow_private_destinations: bool = False
+    # Optional secretless credential-proxy policy. Real tokens stay in
+    # the parent process and are attached to outbound requests by the
+    # egress MITM proxy. By default the sandbox holds nothing
+    # credential-shaped at all (swap-on-access): a tool makes its
+    # request with no ``Authorization`` header and the proxy injects the
+    # real credential for the bound host. Entries may opt into injecting
+    # a synthetic ``oa_cred_*`` placeholder env var for clients that
+    # won't issue a request without a local credential (e.g. ``gh``).
+    # Requires ``egress_rules`` (the proxy is what attaches the
+    # credential and rejects placeholder leaks) and a backend that
+    # hard-isolates the network (``linux_bwrap`` / ``darwin_seatbelt``).
+    credential_proxy: CredentialProxySpec | None = None
 
 
 @dataclass

--- a/omnigent/inner/egress/controller.py
+++ b/omnigent/inner/egress/controller.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from omnigent.inner.credential_proxy import CredentialRewriteRule
 from omnigent.inner.egress.ca import ensure_ca, ensure_ca_bundle
 from omnigent.inner.egress.proxy import EgressProxy
 from omnigent.inner.egress.rules import parse_rules
@@ -53,6 +54,10 @@ _CA_ENV_KEYS = (
     "NODE_EXTRA_CA_CERTS",
     "CURL_CA_BUNDLE",
     "PIP_CERT",
+    # git/libcurl on macOS can ignore the generic SSL_CERT_FILE in some
+    # builds; set the git-specific CA var too so ``git`` over HTTPS
+    # consistently trusts the egress proxy's MITM CA.
+    "GIT_SSL_CAINFO",
 )
 
 
@@ -123,6 +128,7 @@ def start_egress_proxy(
     tmpdir: Path,
     allow_private_destinations: bool,
     require_auth: bool,
+    credential_rewrites: Sequence[CredentialRewriteRule] | None = None,
 ) -> EgressProxyHandle:
     """Start the parent-side MITM egress proxy.
 
@@ -145,6 +151,11 @@ def start_egress_proxy(
         When ``False``, the proxy accepts any unauthenticated
         request — used by the terminal path where there's no
         out-of-band channel through tmux.
+    :param credential_rewrites: Optional host-scoped real-credential
+        rules the proxy applies for exact-host matches — swap-on-access
+        injection by default, plus synthetic-placeholder swap for entries
+        that opted into ``inject_env`` (secretless ``credential_proxy``
+        support).
     :returns: A live :class:`EgressProxyHandle`. Caller must invoke
         :meth:`EgressProxyHandle.stop` on cleanup.
     """
@@ -193,6 +204,7 @@ def start_egress_proxy(
         # request when set. Helper path uses it; terminal path skips
         # it (no out-of-band channel through tmux).
         auth_token=auth_token,
+        credential_rewrites=list(credential_rewrites or []),
     )
 
     loop = asyncio.new_event_loop()

--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -25,14 +25,23 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
+import email.policy
 import hmac
 import ipaddress
 import logging
 import socket
 import ssl
+from dataclasses import dataclass
+from email.message import Message
+from email.parser import BytesParser
 from pathlib import Path
 from urllib.parse import urlparse
 
+from omnigent.inner.credential_proxy import (
+    SYNTHETIC_CREDENTIAL_PREFIX,
+    CredentialRewriteRule,
+)
 from omnigent.inner.egress.certs import HostCertCache
 from omnigent.inner.egress.rules import (
     EgressRule,
@@ -50,6 +59,49 @@ _HEADER_MAX = 65536
 # this is a control byte and is rejected in the inner request line — see
 # ``_handle_connect`` for the request-line-smuggling rationale.
 _MIN_PRINTABLE_BYTE = 0x20
+
+
+def _parse_http_headers(headers_raw: bytes) -> Message:
+    """
+    Parse a raw HTTP request header block with the stdlib email parser.
+
+    HTTP/1.1's header grammar descends from the RFC 822 message format,
+    so the standard library's email parser — the same machinery
+    :mod:`http.client` uses under the hood — tokenizes header blocks
+    correctly: case-insensitive field names, surrounding whitespace,
+    obsolete line folding, and repeated headers, none of which a
+    hand-rolled ``split(b"\\r\\n")`` loop handles. ``policy.HTTP``
+    round-trips with CRLF line separators and ``max_line_length=None``
+    (no folding on output), preserving header order and values so a
+    re-serialized block stays byte-faithful to what the client sent.
+
+    :param headers_raw: Raw request header block (CRLF-separated,
+        terminated by a blank line), e.g.
+        ``b"Host: github.com\\r\\nUser-Agent: git/2\\r\\n\\r\\n"``. The
+        request line and body are handled by the caller, not included
+        here.
+    :returns: The parsed message (headers only; an empty payload). Set
+        headers via ``msg["Name"] = value`` / ``del msg["Name"]`` and
+        re-serialize with ``msg.as_bytes(policy=email.policy.HTTP)``.
+    """
+    return BytesParser(policy=email.policy.HTTP).parsebytes(headers_raw)
+
+
+@dataclass(frozen=True)
+class _AuthRewriteResult:
+    """Outcome of a credential-proxy ``Authorization`` rewrite pass.
+
+    :param headers: The header block to forward upstream — rewritten
+        when a synthetic placeholder matched, otherwise the input bytes
+        unchanged.
+    :param error: A human-readable reason to reject the request with
+        ``403`` (a placeholder was sent to the wrong host or is unknown),
+        or ``None`` when the request may proceed.
+    """
+
+    headers: bytes
+    error: str | None
+
 
 # S2 (security): CSP-internal endpoints that present as globally
 # routable IPs but actually reach inside the cloud tenant. These slip
@@ -129,6 +181,14 @@ class EgressProxy:
         KERN_PROCARGS2``. The header is stripped before forwarding
         upstream (``Proxy-Authorization`` is hop-by-hop per RFC 7235
         but be paranoid). ``None`` (the default) disables the check.
+    :param credential_rewrites: Optional host-scoped real-credential
+        rules. By default (swap-on-access) the proxy attaches the real
+        credential to a bound-host request that carries no
+        ``Authorization`` header — nothing credential-shaped ever enters
+        the sandbox. A rule whose entry opted into ``inject_env`` also
+        carries a synthetic placeholder; the proxy swaps that placeholder
+        for the real secret and rejects the same placeholder sent to any
+        other host with ``403`` (the cross-host leak guard).
     """
 
     def __init__(
@@ -140,6 +200,7 @@ class EgressProxy:
         upstream_ca_bundle: Path | None = None,
         block_private_destinations: bool = True,
         auth_token: str | None = None,
+        credential_rewrites: list[CredentialRewriteRule] | None = None,
     ) -> None:
         self._rules = rules
         self._cert_cache = HostCertCache(ca_cert_path, ca_key_path)
@@ -160,6 +221,23 @@ class EgressProxy:
             self._upstream_ssl_ctx = ssl.create_default_context()
         self._block_private_destinations = block_private_destinations
         self._auth_token = auth_token
+        # Two indexes over the rewrite rules:
+        #
+        # - ``_cred_by_host``: the swap-on-access path. For a request to a
+        #   bound host that carries no Authorization header, the proxy
+        #   injects the real credential. Exactly one rule per host — the
+        #   parser rejects duplicate-host bindings, so this map never
+        #   silently drops a rule.
+        # - ``_cred_by_synthetic``: the opt-in placeholder path. Only
+        #   entries that injected an ``oa_cred_*`` env var register here;
+        #   the synthetic is globally unique so it alone identifies the
+        #   rule (and thus the bound host) for the swap + leak guard.
+        self._cred_by_host: dict[str, CredentialRewriteRule] = {}
+        self._cred_by_synthetic: dict[str, CredentialRewriteRule] = {}
+        for rule in credential_rewrites or []:
+            self._cred_by_host[rule.host.lower()] = rule
+            if rule.synthetic is not None:
+                self._cred_by_synthetic[rule.synthetic] = rule
         # Precompute the expected header bytes ONCE so the per-request
         # comparison is a constant-time memcmp instead of repeating
         # the base64 round-trip on every connection. Stored as bytes
@@ -173,6 +251,14 @@ class EgressProxy:
             self._expected_auth_value = None
         self._servers: list[asyncio.AbstractServer] = []
         self._tcp_port: int | None = None
+        # In-flight connection handlers, tracked from accept time by
+        # ``_client_connected`` (which creates the task itself rather than
+        # letting ``asyncio.start_server`` wrap a coroutine in a Task we
+        # never see). Without this, a handler parked in a readline/relay
+        # read would outlive ``loop.stop()`` and surface as "Task was
+        # destroyed but it is pending"; holding the handle lets
+        # :meth:`stop` cancel and drain every handler before the loop closes.
+        self._client_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def port(self) -> int:
@@ -191,7 +277,7 @@ class EgressProxy:
         :param host: Bind address, e.g. ``"127.0.0.1"``.
         :returns: The assigned port number.
         """
-        server = await asyncio.start_server(self._handle_client, host, 0)
+        server = await asyncio.start_server(self._client_connected, host, 0)
         addr = server.sockets[0].getsockname()
         self._tcp_port = addr[1]
         self._servers.append(server)
@@ -207,22 +293,63 @@ class EgressProxy:
         """
         sock_path = Path(path)
         sock_path.unlink(missing_ok=True)
-        server = await asyncio.start_unix_server(self._handle_client, str(sock_path))
+        server = await asyncio.start_unix_server(self._client_connected, str(sock_path))
         self._servers.append(server)
         logger.info("Egress proxy listening on unix:%s", sock_path)
 
     async def stop(self) -> None:
-        """Stop all proxy listeners."""
+        """Stop all proxy listeners and drain in-flight handlers."""
         for server in self._servers:
             server.close()
             await server.wait_closed()
         self._servers.clear()
         self._tcp_port = None
+        # Cancel any connection handlers still parked in a read/relay so
+        # they run their ``finally`` close blocks and reach a terminal
+        # state before the owning loop is stopped, rather than being
+        # abandoned mid-await (which surfaces as "Task was destroyed but
+        # it is pending"). The listeners are already closed, so no new
+        # handlers can appear; every accepted connection is tracked from
+        # accept time (see ``_client_connected``), so this single snapshot
+        # is complete.
+        pending = [task for task in self._client_tasks if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._client_tasks.clear()
         logger.info("Egress proxy stopped")
 
     # ------------------------------------------------------------------
     # Connection handling
     # ------------------------------------------------------------------
+
+    def _client_connected(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Server accept callback — create and track the handler task.
+
+        Passed to ``asyncio.start_server`` as a *plain* (non-coroutine)
+        callback so asyncio does not wrap the handler itself: we create
+        the task here and add it to :attr:`_client_tasks` synchronously,
+        the instant the connection is accepted. That closes the race a
+        self-registering handler would have — a handler whose task is
+        scheduled but has not yet run its first line is invisible to a
+        ``_client_tasks`` snapshot in :meth:`stop`, so it would leak past
+        ``loop.stop()`` as "Task was destroyed but it is pending". Holding
+        the handle from accept time means :meth:`stop` can always cancel
+        it.
+
+        :param reader: Stream reader for the accepted client connection,
+            handed straight to :meth:`_handle_client`.
+        :param writer: Stream writer for the accepted client connection,
+            handed straight to :meth:`_handle_client`.
+        """
+        task = asyncio.ensure_future(self._handle_client(reader, writer))
+        self._client_tasks.add(task)
+        task.add_done_callback(self._client_tasks.discard)
 
     async def _handle_client(
         self,
@@ -282,6 +409,8 @@ class EgressProxy:
         except Exception:
             logger.exception("Unexpected error in proxy handler")
         finally:
+            # Task removal from ``_client_tasks`` is handled by the
+            # done-callback wired in ``_client_connected``.
             try:
                 writer.close()
                 await asyncio.wait_for(writer.wait_closed(), timeout=2)
@@ -545,6 +674,20 @@ class EgressProxy:
         # exists to close. ``server_hostname=host`` keeps TLS SNI and
         # certificate verification bound to the original hostname.
         connect_host = pinned_ip or host
+        # Swap any synthetic credential placeholder for the real secret,
+        # bound to this host (rejects cross-host replay with 403).
+        rewrite = self._rewrite_authorization(host=host, headers_raw=headers_raw)
+        if rewrite.error is not None:
+            logger.warning(
+                "BLOCKED-CREDENTIAL %s https://%s%s — %s", method, host, path, rewrite.error
+            )
+            await self._send_forbidden(client_writer, rewrite.error)
+            return
+        # Single-shot the upstream so ``_relay_response`` gets a prompt EOF
+        # instead of blocking on a keep-alive socket — and so pipelining
+        # clients (git's libcurl) don't stall waiting to reuse a tunnel the
+        # proxy only services once. See ``_force_connection_close``.
+        headers_raw = self._force_connection_close(rewrite.headers)
         try:
             upstream_reader, upstream_writer = await asyncio.wait_for(
                 asyncio.open_connection(
@@ -673,6 +816,16 @@ class EgressProxy:
             body = await asyncio.wait_for(reader.readexactly(content_length), timeout=30)
 
         relative_line = f"{method} {path} HTTP/1.1\r\n".encode("latin-1")
+        rewrite = self._rewrite_authorization(host=host, headers_raw=headers_raw)
+        if rewrite.error is not None:
+            logger.warning(
+                "BLOCKED-CREDENTIAL %s http://%s%s — %s", method, host, path, rewrite.error
+            )
+            await self._send_forbidden(writer, rewrite.error)
+            return
+        # Single-shot the upstream (prompt EOF for the relay, no stalled
+        # tunnel reuse). See ``_force_connection_close``.
+        headers_raw = self._force_connection_close(rewrite.headers)
 
         # Connect to the IP pinned by the destination check (or the
         # hostname when blocking is disabled and ``pinned_ip`` is
@@ -740,13 +893,21 @@ class EgressProxy:
 
     @staticmethod
     def _parse_header_dict(raw: bytes) -> dict[str, str]:
-        """Parse raw header bytes into a lowercase-keyed dict."""
-        result: dict[str, str] = {}
-        for line in raw.split(b"\r\n"):
-            if b":" in line:
-                key, _, val = line.partition(b":")
-                result[key.decode("latin-1").strip().lower()] = val.decode("latin-1").strip()
-        return result
+        """
+        Parse raw header bytes into a lowercase-keyed dict.
+
+        :param raw: Raw request header block (CRLF-separated,
+            terminated by a blank line), e.g.
+            ``b"Host: github.com\\r\\nContent-Length: 12\\r\\n\\r\\n"``.
+        :returns: A dict mapping each lowercased header name to its
+            value (last value wins on repeats), e.g.
+            ``{"host": "github.com", "content-length": "12"}``.
+        """
+        msg = _parse_http_headers(raw)
+        # Last value wins on repeated header names, matching the prior
+        # hand-rolled parser; the only consumer reads single-valued
+        # headers (e.g. ``content-length``).
+        return {key.lower(): value for key, value in msg.items()}
 
     async def _assert_destination_allowed(self, host: str, port: int) -> str | None:
         """
@@ -920,6 +1081,143 @@ class EgressProxy:
         except Exception:  # noqa: BLE001 — response write is best-effort
             pass
 
+    def _rewrite_authorization(self, *, host: str, headers_raw: bytes) -> _AuthRewriteResult:
+        """
+        Attach the real credential to a bound-host request.
+
+        Two paths, both keyed on the request host:
+
+        - **Swap-on-access (default).** When a rule binds *host* and the
+          request carries no ``Authorization`` header, the proxy injects
+          ``Authorization: <scheme> <real>`` on the way out. The sandbox
+          never held anything credential-shaped.
+        - **Placeholder swap (opt-in).** When the request's
+          ``Authorization`` header carries one of this proxy's synthetic
+          placeholders (recognised by
+          :data:`~omnigent.inner.credential_proxy.SYNTHETIC_CREDENTIAL_PREFIX`
+          across the ``Basic`` / ``Bearer`` / ``token`` schemes), the
+          header is rewritten to the real credential. A placeholder that
+          is unknown or bound to a *different* host is rejected with
+          ``403`` — the cross-host leak guard for a compromised sandbox.
+
+        A non-synthetic ``Authorization`` header the client set itself is
+        left untouched (and suppresses injection), so the proxy never
+        clobbers an unrelated credential a tool deliberately sent.
+
+        :param host: Upstream request host (case-insensitive).
+        :param headers_raw: Raw HTTP header block (CRLF-separated).
+        :returns: An :class:`_AuthRewriteResult` carrying either the
+            (possibly rewritten / injected) headers or a rejection reason.
+        """
+        if not self._cred_by_host:
+            return _AuthRewriteResult(headers=headers_raw, error=None)
+
+        host_key = host.lower()
+        host_rule = self._cred_by_host.get(host_key)
+        msg = _parse_http_headers(headers_raw)
+        existing = msg.get_all("Authorization")
+        changed = False
+        if existing:
+            rewritten: list[str] = []
+            for value in existing:
+                synthetic = self._extract_synthetic(value)
+                if synthetic is None:
+                    # A real/foreign Authorization the client set itself —
+                    # leave it alone (and don't also inject over it).
+                    rewritten.append(value)
+                    continue
+                rule = self._cred_by_synthetic.get(synthetic)
+                if rule is None or rule.host != host_key:
+                    # A value carrying our placeholder prefix that we don't
+                    # recognise for this host. Refuse rather than forward —
+                    # this is the leak guard for a compromised sandbox that
+                    # tries to send a placeholder to an attacker host.
+                    return _AuthRewriteResult(
+                        headers=headers_raw,
+                        error="synthetic credential is not allowed for this host",
+                    )
+                rewritten.append(self._format_real_auth(rule))
+                changed = True
+            if changed:
+                del msg["Authorization"]
+                for value in rewritten:
+                    msg["Authorization"] = value
+        elif host_rule is not None:
+            # Swap-on-access: the request reached a bound host with no
+            # Authorization header, so attach the real credential now.
+            msg["Authorization"] = self._format_real_auth(host_rule)
+            changed = True
+        if not changed:
+            # Nothing matched — forward the client's bytes untouched rather
+            # than round-tripping them through the serializer.
+            return _AuthRewriteResult(headers=headers_raw, error=None)
+        return _AuthRewriteResult(headers=msg.as_bytes(policy=email.policy.HTTP), error=None)
+
+    @staticmethod
+    def _extract_synthetic(auth_value: str) -> str | None:
+        """
+        Extract a synthetic placeholder from an ``Authorization`` value.
+
+        :param auth_value: The header value after ``Authorization:``,
+            e.g. ``"Bearer oa_cred_..."`` or
+            ``"Basic <base64(user:oa_cred_...)>"``.
+        :returns: The placeholder string when the value carries one (in
+            the Bearer/token token position or the Basic password field),
+            else ``None``.
+        """
+        lowered = auth_value.lower()
+        if lowered.startswith("basic "):
+            encoded = auth_value[6:].strip()
+            try:
+                decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+            except (binascii.Error, UnicodeDecodeError):
+                return None
+            _, sep, password = decoded.partition(":")
+            if not sep:
+                return None
+            candidate = password
+        elif lowered.startswith("bearer "):
+            candidate = auth_value[7:].strip()
+        elif lowered.startswith("token "):
+            candidate = auth_value[6:].strip()
+        else:
+            return None
+        return candidate if candidate.startswith(SYNTHETIC_CREDENTIAL_PREFIX) else None
+
+    @staticmethod
+    def _format_real_auth(rule: CredentialRewriteRule) -> str:
+        """
+        Format the real ``Authorization`` value for a matched rule.
+
+        Returns a ``str`` because the value is set on an
+        :class:`email.message.Message` header, which the ``policy.HTTP``
+        serializer renders back to bytes. All three schemes use the same
+        encoding path: tokens / PATs are ASCII in practice, and Basic
+        base64-encodes the ``username:secret`` pair as UTF-8 (permitted by
+        RFC 7617), so there is no scheme-specific encoding divergence.
+
+        :param rule: The matched synthetic-to-real rewrite rule.
+        :returns: The header value string, e.g.
+            ``"Bearer <real>"``, ``"token <real>"``, or
+            ``"Basic <base64(username:real)>"``.
+        :raises ValueError: If the rule carries an unsupported scheme.
+        """
+        if rule.scheme == "bearer":
+            return f"Bearer {rule.real_secret}"
+        if rule.scheme == "token":
+            return f"token {rule.real_secret}"
+        if rule.scheme == "basic":
+            # The parser always populates ``username`` for Basic
+            # bindings; fail loud rather than invent one if a malformed
+            # rule reaches the emit path.
+            if rule.username is None:
+                raise ValueError(
+                    f"basic credential rewrite for host {rule.host!r} is missing a username"
+                )
+            pair = f"{rule.username}:{rule.real_secret}".encode()
+            return "Basic " + base64.b64encode(pair).decode("ascii")
+        raise ValueError(f"unsupported credential rewrite scheme: {rule.scheme!r}")
+
     @staticmethod
     async def _send_bad_gateway(writer: asyncio.StreamWriter, message: str) -> None:
         """Send HTTP 502 response."""
@@ -1028,3 +1326,49 @@ class EgressProxy:
                 continue
             kept.append(line)
         return b"\r\n".join(kept)
+
+    @staticmethod
+    def _force_connection_close(headers_raw: bytes) -> bytes:
+        """
+        Force ``Connection: close`` on a request's forwarded header block.
+
+        The proxy serves exactly one inner HTTP request per upstream
+        connection and relays the reply by reading until EOF
+        (:meth:`_relay_response`). An HTTP/1.1 upstream defaults to
+        keep-alive and holds the socket open after the response, so the
+        relay would otherwise block on its read until the 60 s timeout
+        rather than finishing the moment the body is done.
+
+        That stall also breaks clients that pipeline requests on a single
+        connection. ``git``'s libcurl sends its unauthenticated
+        ``/info/refs`` probe, receives ``401``, then sends the
+        authenticated retry **on the same tunnel**. Because the proxy is
+        still parked in the relay read (no upstream EOF), it never reads
+        git's second request and git hangs until the caller's timeout.
+        ``curl`` happened to dodge this: it consumed a
+        ``Content-Length``-framed body and exited while the orphaned relay
+        read lingered invisibly.
+
+        Rewriting the hop-by-hop connection headers to a single
+        ``Connection: close`` makes the upstream close after one response
+        (a prompt, clean EOF for the relay) and signals the client that
+        the tunnel is single-shot, so git transparently opens a fresh
+        ``CONNECT`` for its retry. ``Connection``, ``Proxy-Connection``,
+        and ``Keep-Alive`` are all hop-by-hop (RFC 7230 §6.1), so dropping
+        the client's originals and substituting our own is correct rather
+        than merely expedient.
+
+        :param headers_raw: Raw request header block (CRLF-separated,
+            terminated by a blank line).
+        :returns: The header block with any ``Connection`` /
+            ``Proxy-Connection`` / ``Keep-Alive`` headers dropped and a
+            single ``Connection: close`` appended in the header section.
+        """
+        msg = _parse_http_headers(headers_raw)
+        # ``del`` removes every instance of each hop-by-hop header
+        # (RFC 7230 §6.1) before we substitute our own single directive.
+        del msg["Connection"]
+        del msg["Proxy-Connection"]
+        del msg["Keep-Alive"]
+        msg["Connection"] = "close"
+        return msg.as_bytes(policy=email.policy.HTTP)

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -762,6 +762,37 @@ def _parse_os_env_sandbox_spec(data: YamlData | str | bool | None) -> OSEnvSandb
             "os_env.sandbox.egress_allow_private_destinations must be a "
             f"boolean, got {type(allow_private).__name__}"
         )
+    # Secretless credential proxy. Reuse the single canonical parser
+    # (``omnigent.spec.parser._parse_credential_proxy``) rather than a
+    # second copy so the single-file omnigent-YAML path and the
+    # bundle/config.yaml path can never drift — a duplicated parser here
+    # is exactly what silently dropped ``credential_proxy`` on this path
+    # before. Lazy-imported to avoid an import-time cycle with the spec
+    # layer (which imports inner.datamodel). The two cross-field guards
+    # below mirror the spec parser so an inert credential_proxy (no
+    # hardened backend / no egress rules) is rejected on both paths.
+    from omnigent.spec.parser import (
+        _credential_proxy_macos_unsupported_reason,
+        _parse_credential_proxy,
+    )
+
+    credential_proxy = _parse_credential_proxy(data.get("credential_proxy"))
+    if credential_proxy is not None and sandbox_type not in ("linux_bwrap", "darwin_seatbelt"):
+        raise ValueError(
+            "os_env.sandbox.credential_proxy requires sandbox.type=linux_bwrap "
+            "(Linux) or sandbox.type=darwin_seatbelt (macOS) so credentials are "
+            "bound to a hardened helper boundary. "
+            f"Got sandbox.type={sandbox_type!r}."
+        )
+    if credential_proxy is not None and not egress_rules:
+        raise ValueError(
+            "os_env.sandbox.credential_proxy requires os_env.sandbox.egress_rules: "
+            "the MITM egress proxy is what swaps the synthetic placeholder for the "
+            "real credential and rejects placeholder leaks, so it must be active."
+        )
+    macos_reason = _credential_proxy_macos_unsupported_reason(credential_proxy, sandbox_type)
+    if macos_reason is not None:
+        raise ValueError(macos_reason)
     # Defer the absent-field defaults to the dataclass so there is a single
     # source of truth: re-stating literals here (e.g. ``"warn"``, ``50000``)
     # silently drifts the moment the OSEnvSandboxSpec defaults change. An
@@ -797,6 +828,7 @@ def _parse_os_env_sandbox_spec(data: YamlData | str | bool | None) -> OSEnvSandb
         env_passthrough=data.get("env_passthrough"),
         egress_rules=egress_rules,
         egress_allow_private_destinations=allow_private,
+        credential_proxy=credential_proxy,
     )
 
 

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -21,7 +21,12 @@ from urllib.parse import urlparse, urlunparse
 from omnigent.runner.identity import strip_runner_auth_secrets
 
 from .async_utils import run_sync_on_thread
-from .datamodel import OSEnvSpec
+from .credential_proxy import (
+    CredentialProxyRuntime,
+    CredentialRewriteRule,
+    prepare_credential_proxy_runtime,
+)
+from .datamodel import CredentialProxySpec, OSEnvSpec
 from .sandbox import (
     SandboxPolicy,
     activate_sandbox,
@@ -207,6 +212,38 @@ def build_helper_env(
     return strip_runner_auth_secrets(env)
 
 
+def _build_credential_proxy_parent_env(
+    *,
+    helper_env: Mapping[str, str],
+    parent_env: Mapping[str, str],
+    spec: CredentialProxySpec,
+) -> dict[str, str]:
+    """
+    Build the parent-side env used to resolve credential-proxy sources.
+
+    ``file:`` / ``command:`` sources run against the same filtered
+    baseline the sandbox helper gets (so a ``command`` source can't
+    enumerate the parent's full secret-bearing environment), with the
+    one narrow addition that ``env:`` sources need: their referenced
+    variable, lifted from the real parent environment.
+
+    :param helper_env: The filtered helper environment from
+        :func:`build_helper_env`.
+    :param parent_env: The real parent process environment (typically
+        ``os.environ``).
+    :param spec: The credential-proxy policy whose ``env:`` source names
+        are lifted from *parent_env*.
+    :returns: An env map suitable for source resolution.
+    """
+    resolved = dict(helper_env)
+    for entry in spec.entries:
+        if entry.source.kind == "env" and entry.source.env:
+            value = parent_env.get(entry.source.env)
+            if value is not None:
+                resolved[entry.source.env] = value
+    return resolved
+
+
 @dataclass
 class OSEnvironment(ABC):
     """Base OS environment interface."""
@@ -360,6 +397,7 @@ class _HelperProcessClient:
         )
 
         helper_cwd = self.cwd
+        credential_runtime: CredentialProxyRuntime | None = None
         if sandbox.active:
             self._tmpdir = create_private_tmpdir()
             sandbox = with_additional_write_roots(sandbox, [self._tmpdir])
@@ -367,13 +405,36 @@ class _HelperProcessClient:
             if self.start_in_scratch:
                 helper_cwd = self._tmpdir
                 env["PWD"] = str(self._tmpdir)
+            if sandbox.credential_proxy is not None:
+                # Resolve real secrets in the parent. Real secrets stay
+                # here and are attached to outbound requests by the egress
+                # proxy (swap-on-access). Only entries that opted into
+                # ``inject_env`` contribute a synthetic placeholder, merged
+                # into the helper env below; nothing else crosses into the
+                # sandbox.
+                credential_parent_env = _build_credential_proxy_parent_env(
+                    helper_env=env,
+                    parent_env=os.environ,
+                    spec=sandbox.credential_proxy,
+                )
+                credential_runtime = prepare_credential_proxy_runtime(
+                    sandbox.credential_proxy,
+                    parent_env=credential_parent_env,
+                )
+                env.update(credential_runtime.helper_env_updates)
 
         # Start L7 egress proxy if rules are configured. The proxy
         # listens on a Unix socket in the scratch tmpdir; the helper
         # starts a relay inside the network namespace that bridges
         # loopback TCP to this socket.
         if self._egress_rules and self._tmpdir is not None:
-            sandbox = self._start_egress_proxy_locked(sandbox, env)
+            sandbox = self._start_egress_proxy_locked(
+                sandbox,
+                env,
+                credential_rewrites=(
+                    credential_runtime.rewrites if credential_runtime is not None else None
+                ),
+            )
 
         config: dict[str, JsonValue] = {
             "cwd": str(helper_cwd),
@@ -519,7 +580,11 @@ class _HelperProcessClient:
     # ------------------------------------------------------------------
 
     def _start_egress_proxy_locked(
-        self, sandbox: SandboxPolicy, env: dict[str, str]
+        self,
+        sandbox: SandboxPolicy,
+        env: dict[str, str],
+        *,
+        credential_rewrites: list[CredentialRewriteRule] | None = None,
     ) -> SandboxPolicy:
         """Start the egress MITM proxy and inject env vars.
 
@@ -570,6 +635,8 @@ class _HelperProcessClient:
             replacement for egress fields).
         :param env: The helper environment dict — proxy/CA env vars
             are added in-place.
+        :param credential_rewrites: Optional synthetic-to-real credential
+            rewrites the proxy applies (secretless ``credential_proxy``).
         :returns: Updated :class:`SandboxPolicy` with egress relay
             port and socket path set. The egress auth token is NOT
             stored on the policy (which serialises to JSON and
@@ -592,6 +659,7 @@ class _HelperProcessClient:
             tmpdir=self._tmpdir,
             allow_private_destinations=self._egress_allow_private_destinations,
             require_auth=True,
+            credential_rewrites=credential_rewrites,
         )
 
         # S4 (security): hold the controller refs on the client so
@@ -1248,6 +1316,7 @@ def _run_helper(config_fd: int) -> int:
 
     cwd = Path(cwd_value)
     os.chdir(cwd)
+
     sandbox = SandboxPolicy.from_jsonable(sandbox_value)
     activate_sandbox(sandbox)
 

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -18,7 +18,7 @@ from typing import TypeAlias, cast
 
 from omnigent.runner.identity import RUNNER_AUTH_SECRET_ENV_VARS
 
-from .datamodel import OSEnvSandboxSpec, OSEnvSpec
+from .datamodel import CredentialProxySpec, OSEnvSandboxSpec, OSEnvSpec
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +148,13 @@ class SandboxPolicy:
     egress_relay_port: int | None = None
     egress_socket_path: str | None = None
     deny_unix_socket_paths: list[Path] | None = None
+    # Parent-side only: the resolved credential-proxy policy. Read in
+    # ``_HelperProcessClient._start_locked`` (parent) to mint synthetic
+    # placeholders and proxy rewrite rules. Intentionally NOT carried in
+    # ``to_jsonable`` / ``from_jsonable`` — the helper receives only the
+    # non-secret synthetic payload over the config FD, and resolved
+    # secrets never touch the policy that serialises into logs / dumps.
+    credential_proxy: CredentialProxySpec | None = None
 
     def to_jsonable(self) -> dict[str, JsonValue]:
         result: dict[str, JsonValue] = {
@@ -384,6 +391,11 @@ def _clone_policy_with(
             if policy.deny_unix_socket_paths is not None
             else None
         ),
+        # Preserve the credential-proxy policy across clones: the
+        # ``with_additional_*`` helpers run before the parent reads it in
+        # ``_start_locked``, so dropping it here would silently disable
+        # the feature.
+        credential_proxy=policy.credential_proxy,
         # Egress fields are intentionally NOT preserved here — the
         # ``with_additional_*`` helpers run BEFORE the egress proxy
         # starts, so the source policy never carries egress fields.

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -438,6 +438,7 @@ class SeatbeltSandboxBackend(SandboxBackend):
                 if sandbox_spec.env_passthrough is not None
                 else None
             ),
+            credential_proxy=sandbox_spec.credential_proxy,
         )
 
     def wrap_launcher_argv(

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -10,9 +10,18 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
 
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
+from omnigent.inner.datamodel import (
+    DEFAULT_BASIC_USERNAME,
+    CredentialProxyEntry,
+    CredentialProxySpec,
+    CredentialSourceSpec,
+    OSEnvSandboxSpec,
+    OSEnvSpec,
+    TerminalEnvSpec,
+)
 from omnigent.spec.types import (
     DEFAULT_ASK_TIMEOUT,
     AgentSpec,
@@ -1123,6 +1132,25 @@ def _parse_os_env_sandbox(
             f"Got sandbox.type={sandbox_type!r}.",
             code=ErrorCode.INVALID_INPUT,
         )
+    credential_proxy = _parse_credential_proxy(raw.get("credential_proxy"))
+    if credential_proxy is not None and sandbox_type not in ("linux_bwrap", "darwin_seatbelt"):
+        raise OmnigentError(
+            "os_env.sandbox.credential_proxy requires sandbox.type=linux_bwrap "
+            "(Linux) or sandbox.type=darwin_seatbelt (macOS) so credentials are "
+            "bound to a hardened helper boundary. "
+            f"Got sandbox.type={sandbox_type!r}.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    if credential_proxy is not None and not egress_rules:
+        raise OmnigentError(
+            "os_env.sandbox.credential_proxy requires os_env.sandbox.egress_rules: "
+            "the MITM egress proxy is what swaps the synthetic placeholder for the "
+            "real credential and rejects placeholder leaks, so it must be active.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    macos_reason = _credential_proxy_macos_unsupported_reason(credential_proxy, sandbox_type)
+    if macos_reason is not None:
+        raise OmnigentError(macos_reason, code=ErrorCode.INVALID_INPUT)
     allow_private = raw.get("egress_allow_private_destinations", False)
     if not isinstance(allow_private, bool):
         raise OmnigentError(
@@ -1142,6 +1170,7 @@ def _parse_os_env_sandbox(
         env_passthrough=env_passthrough,
         egress_rules=egress_rules,
         egress_allow_private_destinations=allow_private,
+        credential_proxy=credential_proxy,
     )
 
 
@@ -1365,6 +1394,560 @@ def _parse_egress_rules(raw: object) -> list[str] | None:
             ) from exc
         validated.append(entry)
     return validated
+
+
+# YAML ``credential_proxy[*].type`` values are validated by the
+# ``Literal`` on :class:`_CredentialProxyItemModel`. ``https_*`` are
+# low-level primitives that work for any SaaS; ``git_https`` /
+# ``gh_basic`` are presets that auto-wire git / the GitHub CLI.
+# ``gh_basic`` hosts when ``targets`` is omitted: the git host plus the
+# REST/GraphQL API host.
+_GH_BASIC_DEFAULT_TARGETS = ("github.com", "api.github.com")
+# Env vars the GitHub CLI reads for its API token; both are set to the
+# synthetic placeholder so ``gh api`` authenticates through the proxy.
+_GH_TOKEN_ENV_VARS = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+class _CredentialSourceModel(BaseModel):
+    """Pydantic boundary model for a ``credential_proxy[*].source`` mapping.
+
+    The secret origin is a structured single-key mapping —
+    ``{env: VAR}``, ``{file: path}``, or ``{command: cmd}`` — rather than
+    a prefix-encoded string. Exactly one key must be set. Pydantic
+    validates the shape here; :meth:`to_spec` converts it to the internal
+    :class:`CredentialSourceSpec` dataclass the runtime consumes.
+
+    :param env: Parent environment variable name carrying the secret,
+        e.g. ``"OA_TEST_GITHUB_PAT"``.
+    :param file: File path (``~`` expanded at resolution time) holding the
+        secret, e.g. ``"~/.config/tokens/github_pat.txt"``.
+    :param command: Shell command whose stdout is the secret, e.g.
+        ``"gh auth token"``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    env: str | None = None
+    file: str | None = None
+    command: str | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> _CredentialSourceModel:
+        """
+        Require exactly one source key and validate its value.
+
+        :returns: ``self`` once validated.
+        :raises ValueError: If zero or multiple keys are set, ``env`` is
+            not a POSIX environment variable name, or ``file`` / ``command``
+            is blank.
+        """
+        set_keys = [
+            name
+            for name, value in (("env", self.env), ("file", self.file), ("command", self.command))
+            if value is not None
+        ]
+        if len(set_keys) != 1:
+            raise ValueError("source must set exactly one of 'env', 'file', or 'command'")
+        if self.env is not None and not _ENV_VAR_NAME_RE.match(self.env):
+            raise ValueError("source 'env' must be a POSIX environment variable name")
+        if self.file is not None and not self.file.strip():
+            raise ValueError("source 'file' must be a non-empty path")
+        if self.command is not None and not self.command.strip():
+            raise ValueError("source 'command' must be a non-empty command")
+        return self
+
+    def to_spec(self) -> CredentialSourceSpec:
+        """
+        Convert this validated model into a :class:`CredentialSourceSpec`.
+
+        :returns: The internal dataclass the runtime resolves the secret
+            from. Exactly one of ``env`` / ``file`` / ``command`` is set
+            (guaranteed by :meth:`_exactly_one_source`).
+        """
+        if self.env is not None:
+            return CredentialSourceSpec(kind="env", env=self.env)
+        if self.file is not None:
+            return CredentialSourceSpec(kind="file", path=self.file.strip())
+        assert self.command is not None
+        return CredentialSourceSpec(kind="command", command=self.command.strip())
+
+
+class _CredentialProxyItemModel(BaseModel):
+    """Pydantic boundary model for one raw ``credential_proxy`` entry.
+
+    Validates the entry's *shape* — ``type``, ``source``, ``target`` /
+    ``targets`` cardinality, the optional ``env`` injection shim, and the
+    optional Basic ``username`` — replacing the hand-rolled per-field
+    ``isinstance`` checks. The parser then normalizes each validated model
+    into one or more :class:`CredentialProxyEntry` host bindings (the
+    domain transformation pydantic can't express: host/path splitting,
+    ``gh_basic`` git-vs-API split, default targets). Unknown keys are
+    rejected (``extra="forbid"``) so typos fail loud.
+
+    :param type: Credential preset / primitive, one of ``"https_bearer"``,
+        ``"https_basic"``, ``"git_https"``, ``"gh_basic"``.
+    :param source: Where the parent resolves the real secret from.
+    :param target: A single ``host`` or ``host/path`` binding, e.g.
+        ``"github.com/org/repo.git"``. Mutually exclusive with ``targets``.
+    :param targets: A non-empty list of ``host`` / ``host/path`` bindings.
+        Mutually exclusive with ``target``.
+    :param env: Optional sandbox env var that receives the synthetic
+        placeholder (opt-in injection shim for credential-gating clients);
+        a POSIX environment variable name. Only accepted for the
+        ``https_*`` primitives — ``git_https`` / ``gh_basic`` manage
+        injection themselves.
+    :param username: Optional Basic-auth username for ``https_basic`` /
+        ``git_https`` (defaults to ``x-access-token``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["https_bearer", "https_basic", "git_https", "gh_basic"]
+    source: _CredentialSourceModel
+    target: str | None = None
+    targets: list[str] | None = None
+    env: str | None = None
+    username: str | None = None
+
+    @field_validator("env")
+    @classmethod
+    def _env_is_posix(cls, value: str | None) -> str | None:
+        """
+        Reject an ``env`` that is not a POSIX environment variable name.
+
+        :param value: The raw ``env`` value, or ``None`` when absent.
+        :returns: ``value`` unchanged when valid.
+        :raises ValueError: If ``env`` is present but malformed.
+        """
+        if value is not None and not _ENV_VAR_NAME_RE.match(value):
+            raise ValueError("env must be a POSIX environment variable name")
+        return value
+
+    @field_validator("username")
+    @classmethod
+    def _username_nonempty(cls, value: str | None) -> str | None:
+        """
+        Reject an empty ``username``.
+
+        :param value: The raw ``username`` value, or ``None`` when absent.
+        :returns: ``value`` unchanged when valid.
+        :raises ValueError: If ``username`` is present but empty.
+        """
+        if value is not None and not value:
+            raise ValueError("username must be a non-empty string")
+        return value
+
+    @model_validator(mode="after")
+    def _check_target_cardinality(self) -> _CredentialProxyItemModel:
+        """
+        Enforce ``target`` / ``targets`` cardinality and per-type options.
+
+        ``https_*`` and ``git_https`` require exactly one of ``target`` or
+        ``targets``; ``gh_basic`` allows neither (it defaults to the
+        GitHub git + API hosts) but not both. The ``env`` shim is only
+        meaningful for the ``https_*`` primitives, and ``username`` only
+        applies to the Basic schemes.
+
+        :returns: ``self`` once validated.
+        :raises ValueError: On a cardinality violation or a per-type
+            option that does not apply.
+        """
+        has_target = self.target is not None
+        has_targets = self.targets is not None
+        if has_targets and not self.targets:
+            raise ValueError("targets must be a non-empty list")
+        if self.type == "gh_basic":
+            if has_target and has_targets:
+                raise ValueError("gh_basic accepts at most one of 'target' or 'targets'")
+        elif has_target == has_targets:
+            raise ValueError("must declare exactly one of 'target' or 'targets'")
+        if self.env is not None and self.type in ("git_https", "gh_basic"):
+            raise ValueError(f"{self.type} does not accept an 'env' injection shim")
+        if self.username is not None and self.type == "https_bearer":
+            raise ValueError("https_bearer does not accept a 'username'")
+        return self
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    """
+    Render a pydantic ``ValidationError`` as one compact line.
+
+    The credential-proxy parser wraps pydantic failures in
+    :class:`OmnigentError` so the CLI / loader surface a single error
+    type. This flattens pydantic's structured errors into ``field:
+    message`` clauses joined by ``; ``, keyed by the dotted field
+    location.
+
+    :param exc: The raised pydantic validation error.
+    :returns: A semicolon-joined summary, e.g. ``"source: source must
+        set exactly one of 'env', 'file', or 'command'"``. When the
+        failure is on the entry root (e.g. a cardinality model
+        validator), the location renders as ``"(entry)"``.
+    """
+    clauses: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err["loc"]) or "(entry)"
+        clauses.append(f"{loc}: {err['msg']}")
+    return "; ".join(clauses)
+
+
+def _parse_credential_proxy(raw: object) -> CredentialProxySpec | None:
+    """
+    Parse and validate the ``credential_proxy:`` field of ``os_env.sandbox``.
+
+    Each list entry declares one of four ``type`` values and is normalized
+    into one or more :class:`CredentialProxyEntry` bindings. All four
+    default to **swap-on-access** — nothing credential-shaped enters the
+    sandbox; the egress proxy attaches the real credential to bound-host
+    requests:
+
+    - ``https_bearer``: ``target``/``targets`` + ``source`` + optional
+      ``env``. Emits ``Authorization: Bearer <real>`` upstream.
+    - ``https_basic``: ``target``/``targets`` + ``source`` + optional
+      ``env`` + optional ``username``. Emits ``Authorization: Basic <real>``.
+    - ``git_https``: ``target``/``targets`` + ``source`` + optional
+      ``username``. Git over HTTPS via swap-on-access (Basic).
+    - ``gh_basic``: ``source`` + optional ``targets``. Swap-on-access for
+      the git host; injects ``GH_TOKEN`` / ``GITHUB_TOKEN`` for the API
+      host because ``gh`` won't call without a local token.
+
+    The optional ``env`` field is the opt-in injection shim for clients
+    that refuse to issue a request without a local credential.
+
+    Each entry's shape is validated by :class:`_CredentialProxyItemModel`
+    (pydantic) before normalization; a :class:`pydantic.ValidationError`
+    is re-raised as an :class:`OmnigentError` so callers see one error
+    type.
+
+    :param raw: Raw value from the YAML, e.g. ``[{"type": "git_https",
+        "target": "github.com/org/repo.git", "source": {"env": "GH_PAT"}}]``,
+        or ``None`` when the field is absent.
+    :returns: A populated :class:`CredentialProxySpec`, or ``None`` when
+        ``raw`` is absent or an empty list.
+    :raises OmnigentError: If the value isn't a list, an entry fails
+        validation (unknown ``type``, bad ``source``, target cardinality,
+        etc.), or two entries bind the same host.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise OmnigentError(
+            f"os_env.sandbox.credential_proxy must be a list, got {type(raw).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    if not raw:
+        return None
+    entries: list[CredentialProxyEntry] = []
+    for i, item in enumerate(raw):
+        try:
+            model = _CredentialProxyItemModel.model_validate(item)
+        except ValidationError as exc:
+            raise OmnigentError(
+                f"os_env.sandbox.credential_proxy[{i}] is invalid: "
+                f"{_format_validation_error(exc)}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+        source = model.source.to_spec()
+        if model.type == "gh_basic":
+            entries.extend(_normalize_gh_basic(model, source=source, index=i))
+        elif model.type == "https_bearer":
+            entries.extend(_normalize_https_bearer(model, source=source, index=i))
+        elif model.type == "https_basic":
+            entries.extend(_normalize_https_basic(model, source=source, index=i))
+        else:  # git_https
+            entries.extend(_normalize_git_https(model, source=source, index=i))
+    if not entries:
+        return None
+    # Fail loud on conflicting host bindings. The egress proxy keys its
+    # rewrite table by host, so two entries binding the same host would
+    # silently last-win (one credential dropped). Reject it at parse time
+    # rather than picking a binding nondeterministically.
+    seen_hosts: dict[str, str] = {}
+    for entry in entries:
+        host_key = entry.host.lower()
+        if host_key in seen_hosts:
+            raise OmnigentError(
+                "os_env.sandbox.credential_proxy binds host "
+                f"{entry.host!r} more than once (also via "
+                f"{seen_hosts[host_key]!r}); each host may be bound by at "
+                "most one credential. Remove the duplicate entry.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        seen_hosts[host_key] = entry.host
+    return CredentialProxySpec(entries=entries)
+
+
+def _credential_proxy_macos_unsupported_reason(
+    credential_proxy: CredentialProxySpec | None,
+    sandbox_type: str,
+) -> str | None:
+    """
+    Explain why a ``credential_proxy`` cannot work under ``darwin_seatbelt``.
+
+    The ``gh_basic`` preset emits a ``token``-scheme binding for the GitHub
+    API host (``api.*``) and injects ``GH_TOKEN`` / ``GITHUB_TOKEN`` so the
+    GitHub CLI authenticates through the egress MITM proxy. ``gh`` is a Go
+    binary, and Go on macOS verifies TLS against the system keychain via
+    Security.framework -- it ignores ``SSL_CERT_FILE`` / ``SSL_CERT_DIR``,
+    which is exactly how the egress proxy publishes its MITM CA to sandboxed
+    tools. ``gh`` therefore rejects the proxy's forged certificate and every
+    ``gh`` call fails with ``"certificate is not trusted"``. Since
+    ``darwin_seatbelt`` is macOS-only, the combination can never succeed, so we
+    reject it at parse time instead of surfacing an opaque runtime TLS error.
+
+    The ``token`` scheme is emitted only by ``gh_basic`` (see
+    :func:`_normalize_gh_basic`); keying on the scheme rather than re-deriving
+    the original ``type`` keeps this check independent of how the presets
+    normalize into bindings.
+
+    :param credential_proxy: Parsed credential-proxy spec, or ``None`` when the
+        ``credential_proxy:`` field is absent.
+    :param sandbox_type: Resolved sandbox backend, e.g. ``"darwin_seatbelt"``
+        (macOS) or ``"linux_bwrap"`` (Linux).
+    :returns: A human-readable rejection message when a ``gh_basic`` (i.e. a
+        ``token``-scheme) binding is configured on ``darwin_seatbelt``, else
+        ``None``.
+    """
+    if credential_proxy is None or sandbox_type != "darwin_seatbelt":
+        return None
+    if not any(entry.scheme == "token" for entry in credential_proxy.entries):
+        return None
+    return (
+        "os_env.sandbox.credential_proxy type 'gh_basic' does not work on macOS "
+        "(sandbox.type=darwin_seatbelt). 'gh_basic' wires the GitHub CLI 'gh', "
+        "which is a Go binary, and Go on macOS verifies TLS against the system "
+        "keychain (Security.framework) and ignores SSL_CERT_FILE -- the "
+        "environment variable the egress MITM proxy uses to publish its CA to "
+        "sandboxed tools. 'gh' therefore rejects the proxy's certificate and "
+        "every 'gh' call fails with 'certificate is not trusted'. Use "
+        "sandbox.type=linux_bwrap (Go honors SSL_CERT_FILE on Linux), or use "
+        "the 'https_bearer' / 'https_basic' primitives with a non-Go client "
+        "(curl / python / node) that trusts the proxy CA on macOS."
+    )
+
+
+def _normalize_https_bearer(
+    model: _CredentialProxyItemModel,
+    *,
+    source: CredentialSourceSpec,
+    index: int,
+) -> list[CredentialProxyEntry]:
+    """
+    Normalize an ``https_bearer`` entry into per-host Bearer bindings.
+
+    The default is swap-on-access: a tool makes its request with no
+    ``Authorization`` header and the proxy injects ``Bearer <real>`` for
+    the bound host. The optional ``env`` field is an opt-in shim for
+    clients that won't issue a request without a local credential — when
+    present, the synthetic placeholder is injected into that env var.
+
+    :param model: The validated ``https_bearer`` entry; carries
+        ``target``/``targets`` and an optional ``env`` (the sandbox env
+        var that receives the synthetic placeholder).
+    :param source: Parsed credential source shared by every host binding.
+    :param index: Entry index for error messages.
+    :returns: One :class:`CredentialProxyEntry` per declared host, each
+        wiring ``Authorization: Bearer <real>`` upstream.
+    :raises OmnigentError: If a host fails DNS-safety validation.
+    """
+    inject_env = [model.env] if model.env is not None else []
+    return [
+        CredentialProxyEntry(
+            host=host,
+            scheme="bearer",
+            source=source,
+            inject_env=inject_env,
+        )
+        for host in _resolve_credential_hosts(model, index=index)
+    ]
+
+
+def _normalize_https_basic(
+    model: _CredentialProxyItemModel,
+    *,
+    source: CredentialSourceSpec,
+    index: int,
+) -> list[CredentialProxyEntry]:
+    """
+    Normalize an ``https_basic`` entry into per-host Basic bindings.
+
+    Like ``https_bearer`` this defaults to swap-on-access; ``env`` is an
+    optional opt-in injection shim.
+
+    :param model: The validated ``https_basic`` entry; carries
+        ``target``/``targets`` with optional ``env`` and optional
+        ``username`` (defaults to ``x-access-token``).
+    :param source: Parsed credential source shared by every host binding.
+    :param index: Entry index for error messages.
+    :returns: One :class:`CredentialProxyEntry` per declared host, each
+        wiring ``Authorization: Basic b64(username:<real>)`` upstream.
+    :raises OmnigentError: If a host fails DNS-safety validation.
+    """
+    inject_env = [model.env] if model.env is not None else []
+    username = model.username or DEFAULT_BASIC_USERNAME
+    return [
+        CredentialProxyEntry(
+            host=host,
+            scheme="basic",
+            source=source,
+            username=username,
+            inject_env=inject_env,
+        )
+        for host in _resolve_credential_hosts(model, index=index)
+    ]
+
+
+def _normalize_git_https(
+    model: _CredentialProxyItemModel,
+    *,
+    source: CredentialSourceSpec,
+    index: int,
+) -> list[CredentialProxyEntry]:
+    """
+    Normalize a ``git_https`` entry into per-host Basic bindings.
+
+    Git over HTTPS works purely via swap-on-access: git fires its
+    unauthenticated request and the proxy injects ``Basic
+    b64(username:<real>)`` for the bound host before it leaves. No env
+    var, no in-sandbox git credential helper, nothing credential-shaped
+    in the sandbox. (It is the ``https_basic`` primitive with a git-
+    friendly default username and no ``env`` shim.)
+
+    :param model: The validated ``git_https`` entry; carries
+        ``target``/``targets`` with optional ``username`` (defaults to
+        ``x-access-token``).
+    :param source: Parsed credential source shared by every host binding.
+    :param index: Entry index for error messages.
+    :returns: One :class:`CredentialProxyEntry` per declared host (Basic
+        upstream, swap-on-access).
+    :raises OmnigentError: If a host fails DNS-safety validation.
+    """
+    username = model.username or DEFAULT_BASIC_USERNAME
+    return [
+        CredentialProxyEntry(
+            host=host,
+            scheme="basic",
+            source=source,
+            username=username,
+        )
+        for host in _resolve_credential_hosts(model, index=index)
+    ]
+
+
+def _normalize_gh_basic(
+    model: _CredentialProxyItemModel,
+    *,
+    source: CredentialSourceSpec,
+    index: int,
+) -> list[CredentialProxyEntry]:
+    """
+    Normalize a ``gh_basic`` entry into git + API credential bindings.
+
+    The git host (anything not prefixed ``api.``) authenticates via
+    swap-on-access (Basic), exactly like ``git_https``. The API host
+    (prefixed ``api.``, e.g. ``api.github.com``) keeps ``GH_TOKEN`` /
+    ``GITHUB_TOKEN`` injection (the ``token`` scheme): ``gh`` refuses to
+    issue an API request unless it sees a token locally, so the synthetic
+    placeholder is injected to make it emit a request the proxy can swap.
+
+    :param model: The validated ``gh_basic`` entry; ``target``/``targets``
+        are optional and default to ``github.com`` + ``api.github.com``.
+    :param source: Parsed credential source shared by both bindings.
+    :param index: Entry index for error messages.
+    :returns: One or two :class:`CredentialProxyEntry` bindings.
+    :raises OmnigentError: If an explicit host fails DNS-safety validation.
+    """
+    if model.target is not None or model.targets is not None:
+        hosts = _resolve_credential_hosts(model, index=index)
+    else:
+        hosts = list(_GH_BASIC_DEFAULT_TARGETS)
+    entries: list[CredentialProxyEntry] = []
+    for host in hosts:
+        if host.startswith("api."):
+            entries.append(
+                CredentialProxyEntry(
+                    host=host,
+                    scheme="token",
+                    source=source,
+                    inject_env=list(_GH_TOKEN_ENV_VARS),
+                )
+            )
+        else:
+            entries.append(
+                CredentialProxyEntry(
+                    host=host,
+                    scheme="basic",
+                    source=source,
+                    username=DEFAULT_BASIC_USERNAME,
+                )
+            )
+    return entries
+
+
+def _resolve_credential_hosts(model: _CredentialProxyItemModel, *, index: int) -> list[str]:
+    """
+    Resolve a validated entry's ``target`` / ``targets`` into bound hosts.
+
+    Cardinality (exactly one of ``target`` / ``targets`` for the
+    ``https_*`` / ``git_https`` types; at most one for ``gh_basic``) is
+    already enforced by :class:`_CredentialProxyItemModel`; this only
+    splits each ``host`` / ``host/path`` value and validates the host
+    against the DNS grammar. Only the host component binds the credential
+    — path scoping is enforced by ``egress_rules``.
+
+    :param model: The validated entry model. Exactly one of ``target`` /
+        ``targets`` is set when this is called.
+    :param index: Entry index for error messages.
+    :returns: De-duplicated, order-preserving list of lower-cased hosts.
+    :raises OmnigentError: If a host fails DNS-safety validation.
+    """
+    if model.target is not None:
+        raw_targets = [model.target]
+        field_paths = [f"os_env.sandbox.credential_proxy[{index}].target"]
+    else:
+        # The model validator guarantees ``targets`` is a non-empty list
+        # whenever ``target`` is absent for the types that reach here.
+        assert model.targets is not None
+        raw_targets = model.targets
+        field_paths = [
+            f"os_env.sandbox.credential_proxy[{index}].targets[{j}]"
+            for j in range(len(model.targets))
+        ]
+    hosts: list[str] = []
+    for raw_target, field_path in zip(raw_targets, field_paths, strict=True):
+        host = _parse_credential_proxy_host(raw_target, field_path=field_path)
+        if host not in hosts:
+            hosts.append(host)
+    return hosts
+
+
+def _parse_credential_proxy_host(raw: str, *, field_path: str) -> str:
+    """
+    Parse one ``host`` or ``host/path`` target into a validated host.
+
+    :param raw: Raw target value, e.g. ``"github.com/org/repo.git"`` or
+        ``"api.github.com"``.
+    :param field_path: Human-readable path for parse errors.
+    :returns: The lower-cased host component.
+    :raises OmnigentError: If the value is empty or the host contains
+        characters outside the DNS grammar ``[A-Za-z0-9.-]`` (wildcards
+        included — credentials bind to an exact host).
+    """
+    from omnigent.inner.egress.rules import is_dns_safe_host
+
+    if not raw.strip():
+        raise OmnigentError(
+            f"{field_path} must be a non-empty string (host or host/path), got {raw!r}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    host = raw.strip().split("/", 1)[0].lower()
+    if not is_dns_safe_host(host):
+        raise OmnigentError(
+            f"{field_path} host {host!r} must be an exact DNS hostname "
+            "(letters/digits/dot/hyphen, no wildcards)",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return host
 
 
 def _parse_compaction(

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import socket
 import ssl
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
+from omnigent.inner.credential_proxy import (
+    SYNTHETIC_CREDENTIAL_PREFIX,
+    CredentialRewriteRule,
+)
 from omnigent.inner.egress.ca import ensure_ca, ensure_ca_bundle
 from omnigent.inner.egress.certs import HostCertCache
 from omnigent.inner.egress.proxy import EgressProxy
@@ -1446,3 +1451,509 @@ async def test_upstream_ca_pinned_at_construction_not_reread_per_request(
         )
     finally:
         await proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# Credential-proxy rewrite (secretless credential_proxy) — real round trips
+# through the plain-HTTP proxy path with a local capturing upstream.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CapturedRequest:
+    """Selected headers captured by the local upstream.
+
+    :param authorization: The exact ``Authorization`` header value the
+        upstream received, e.g. ``"Bearer real-secret"``, or ``None``
+        when the request carried no such header.
+    :param connection: Every ``Connection`` header value the upstream
+        received, lowercased, in order. A list (not a scalar) so a test
+        can assert the proxy collapsed any client-supplied
+        ``Connection`` / ``Keep-Alive`` headers into exactly one
+        ``close`` rather than forwarding duplicates.
+    """
+
+    authorization: str | None
+    connection: list[str] = field(default_factory=list)
+
+
+async def _start_capturing_upstream(captured: list[_CapturedRequest]) -> asyncio.Server:
+    """Start a loopback HTTP server that records each ``Authorization`` header.
+
+    The server reads the request head, appends the captured authorization
+    to *captured*, and always replies ``200 OK``. This is the upstream the
+    proxy forwards rewritten requests to, so the captured value is exactly
+    what crossed the proxy boundary toward the real service.
+
+    :param captured: List the server appends one entry to per request.
+    :returns: A running :class:`asyncio.Server` on ``127.0.0.1``.
+    """
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        head = await reader.readuntil(b"\r\n\r\n")
+        auth: str | None = None
+        connection: list[str] = []
+        for line in head.split(b"\r\n"):
+            if line[:14].lower() == b"authorization:":
+                auth = line.partition(b":")[2].strip().decode("latin-1")
+            elif line[:11].lower() == b"connection:":
+                connection.append(line.partition(b":")[2].strip().decode("latin-1").lower())
+        captured.append(_CapturedRequest(authorization=auth, connection=connection))
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+        await writer.drain()
+        writer.close()
+
+    return await asyncio.start_server(_handle, "127.0.0.1", 0)
+
+
+async def _proxied_http_get(
+    *,
+    proxy_port: int,
+    upstream_port: int,
+    authorization: str | None,
+) -> bytes:
+    """Send one plain-HTTP GET through the proxy, optionally authenticated.
+
+    :param proxy_port: Loopback TCP port the proxy listens on.
+    :param upstream_port: Port of the local capturing upstream.
+    :param authorization: The raw ``Authorization`` value the sandbox
+        would send (carrying a synthetic placeholder), or ``None`` to
+        send a bare request with no ``Authorization`` header — the
+        swap-on-access client shape.
+    :returns: The raw response bytes the client received from the proxy.
+    """
+    reader, writer = await asyncio.open_connection("127.0.0.1", proxy_port)
+    auth_line = f"Authorization: {authorization}\r\n" if authorization is not None else ""
+    request = (
+        f"GET http://127.0.0.1:{upstream_port}/probe HTTP/1.1\r\n"
+        f"Host: 127.0.0.1:{upstream_port}\r\n"
+        f"{auth_line}"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("latin-1")
+    writer.write(request)
+    await writer.drain()
+    response = await asyncio.wait_for(reader.read(4096), timeout=5)
+    writer.close()
+    with contextlib.suppress(Exception):
+        await writer.wait_closed()
+    return response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scheme,username,sent_authorization_tmpl,expected_upstream",
+    [
+        # bearer: sandbox sends "Bearer <synthetic>"; upstream gets the real secret.
+        ("bearer", None, "Bearer {synthetic}", "Bearer real-secret-value"),
+        # token (GitHub CLI): sandbox sends "token <synthetic>".
+        ("token", None, "token {synthetic}", "token real-secret-value"),
+    ],
+)
+async def test_credential_rewrite_swaps_bearer_and_token(
+    ca_paths: tuple[Path, Path, Path],
+    scheme: str,
+    username: str | None,
+    sent_authorization_tmpl: str,
+    expected_upstream: str,
+) -> None:
+    """The proxy swaps a synthetic bearer/token placeholder for the real secret.
+
+    A failure means the rewrite didn't fire (upstream would see the
+    synthetic, never the real value) — i.e. the secretless proxy isn't
+    actually authenticating the upstream call.
+    """
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}abc123"
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme=scheme,
+        synthetic=synthetic,
+        real_secret="real-secret-value",
+        username=username,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_get(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            authorization=sent_authorization_tmpl.format(synthetic=synthetic),
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete through proxy: {response[:200]!r}"
+    assert len(captured) == 1, "Upstream should have received exactly one request"
+    # The upstream MUST receive the REAL secret, formatted per the rule's
+    # scheme — proving the synthetic→real swap happened at the proxy.
+    assert captured[0].authorization == expected_upstream
+    # And the synthetic placeholder must NOT have leaked upstream.
+    assert synthetic not in (captured[0].authorization or "")
+
+
+@pytest.mark.asyncio
+async def test_credential_rewrite_swaps_basic_password(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """A Basic-auth synthetic password is swapped for the real secret upstream.
+
+    Covers the git_https / https_basic shape where the synthetic lives in
+    the password field of ``Basic base64(user:pass)``.
+    """
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}basicpw"
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="basic",
+        synthetic=synthetic,
+        real_secret="gho_realtoken",
+        username="x-access-token",
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    sent = "Basic " + base64.b64encode(f"x-access-token:{synthetic}".encode()).decode()
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_get(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            authorization=sent,
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    # Exactly one upstream request — the proxy forwarded once, not 0
+    # (dropped) or >1 (retried/duplicated).
+    assert len(captured) == 1
+    received = captured[0].authorization or ""
+    assert received.startswith("Basic ")
+    decoded = base64.b64decode(received.split(" ", 1)[1]).decode()
+    # The real token reaches upstream in the password field, behind the
+    # configured username — the synthetic must be gone.
+    assert decoded == "x-access-token:gho_realtoken"
+    assert synthetic not in decoded
+
+
+@pytest.mark.asyncio
+async def test_credential_rewrite_rejects_synthetic_on_wrong_host(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """A placeholder bound to one host is refused (403) when sent to another.
+
+    This is the leak guard: a compromised sandbox must not be able to
+    relay its synthetic placeholder to an attacker-controlled host. If the
+    binding check regressed, the proxy would forward the request and the
+    upstream would receive a (swapped) real secret — a credential
+    exfiltration. The test asserts the request is 403'd and the upstream
+    is never contacted.
+    """
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}boundelsewhere"
+    # Rule binds the synthetic to a DIFFERENT host than the request target.
+    rule = CredentialRewriteRule(
+        host="api.github.com",
+        scheme="bearer",
+        synthetic=synthetic,
+        real_secret="real-secret-value",
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_get(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            authorization=f"Bearer {synthetic}",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    # 403 = the proxy refused to forward the cross-host placeholder.
+    assert b"403 Forbidden" in response, (
+        f"Synthetic bound to api.github.com MUST be refused on 127.0.0.1. Got: {response[:200]!r}"
+    )
+    # The upstream must NEVER have been reached — no swapped secret leaked.
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_credential_rewrite_passes_through_non_synthetic(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """A real (non-synthetic) Authorization header is forwarded untouched.
+
+    Ensures the rewrite only acts on this proxy's own placeholders and
+    never mangles a legitimate token a tool sends directly.
+    """
+    cert_path, key_path, _ = ca_paths
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        synthetic=f"{SYNTHETIC_CREDENTIAL_PREFIX}unused",
+        real_secret="real-secret-value",
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_get(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            authorization="Bearer a-users-own-real-token",
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response
+    # Exactly one forwarded request (not dropped, not duplicated).
+    assert len(captured) == 1
+    # Non-synthetic header forwarded verbatim — no accidental rewrite.
+    assert captured[0].authorization == "Bearer a-users-own-real-token"
+
+
+@pytest.mark.asyncio
+async def test_credential_rewrite_injects_on_access_without_header(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """Swap-on-access: a bare request to a bound host gets the real credential.
+
+    This is the default model — the entry injected nothing into the
+    sandbox (``synthetic=None``), so the request arrives with no
+    ``Authorization`` header and the proxy attaches the real credential on
+    the way out. If injection regressed, the upstream would receive no
+    ``Authorization`` header (``None``) and authenticate as nobody.
+    """
+    cert_path, key_path, _ = ca_paths
+    rule = CredentialRewriteRule(
+        host="127.0.0.1",
+        scheme="bearer",
+        real_secret="real-secret-value",
+        synthetic=None,
+        username=None,
+    )
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[rule],
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        response = await _proxied_http_get(
+            proxy_port=proxy_port,
+            upstream_port=upstream_port,
+            authorization=None,
+        )
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete: {response[:200]!r}"
+    assert len(captured) == 1
+    # The proxy synthesized the Authorization header from the rule — the
+    # client sent none.
+    assert captured[0].authorization == "Bearer real-secret-value"
+
+
+# ---------------------------------------------------------------------------
+# Single-shot upstream framing (Connection: close) and shutdown draining.
+#
+# Regression coverage for the git-over-proxy hang: the proxy serves one
+# inner request per upstream connection and relays by reading to EOF, so a
+# keep-alive upstream would park the relay until its 60 s timeout and a
+# pipelining client (git's libcurl: unauth /info/refs -> 401 -> auth retry
+# on the same tunnel) would stall. ``_force_connection_close`` makes every
+# forwarded request single-shot; ``stop`` cancels handlers still parked in
+# a read so they don't leak past the loop.
+# ---------------------------------------------------------------------------
+
+
+def test_force_connection_close_replaces_hop_by_hop_headers() -> None:
+    """``_force_connection_close`` collapses connection headers to one ``close``.
+
+    The header block the proxy forwards upstream MUST carry exactly one
+    ``Connection: close`` and none of the client's keep-alive-flavored
+    hop-by-hop headers (``Connection`` / ``Proxy-Connection`` /
+    ``Keep-Alive``). If any survived, a keep-alive upstream would hold the
+    socket open and ``_relay_response`` would block until its timeout
+    instead of returning at end-of-body. The directive must also land in
+    the header section (before the blank-line separator), not after it.
+    """
+    headers = (
+        b"Host: example.com\r\n"
+        b"Connection: keep-alive\r\n"
+        b"Proxy-Connection: keep-alive\r\n"
+        b"Keep-Alive: timeout=5, max=100\r\n"
+        b"User-Agent: probe\r\n"
+        b"\r\n"
+    )
+
+    out = EgressProxy._force_connection_close(headers)
+
+    head, sep, _body = out.partition(b"\r\n\r\n")
+    assert sep == b"\r\n\r\n", "header block must retain its blank-line terminator"
+    lines = head.split(b"\r\n")
+    # Exactly one Connection header, and it is the forced close.
+    connection_lines = [ln for ln in lines if ln.lower().startswith(b"connection:")]
+    assert connection_lines == [b"Connection: close"], connection_lines
+    # None of the keep-alive-flavored hop-by-hop headers survived.
+    assert not any(ln.lower().startswith(b"proxy-connection:") for ln in lines)
+    assert not any(ln.lower().startswith(b"keep-alive:") for ln in lines)
+    # Unrelated headers are preserved untouched.
+    assert b"Host: example.com" in lines
+    assert b"User-Agent: probe" in lines
+
+
+@pytest.mark.asyncio
+async def test_forwarded_request_is_single_shot_connection_close(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """A keep-alive client request reaches the upstream as ``Connection: close``.
+
+    End-to-end proof that ``_force_connection_close`` is wired into the
+    forward path: the client asks for keep-alive, but the upstream — the
+    real network peer the proxy talks to — must receive exactly one
+    ``Connection: close`` so it closes after the response and the relay
+    gets a prompt EOF. A regression here reintroduces the git-over-proxy
+    hang.
+    """
+    cert_path, key_path, _ = ca_paths
+    captured: list[_CapturedRequest] = []
+    upstream = await _start_capturing_upstream(captured)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+
+    proxy = EgressProxy(
+        parse_rules(["* 127.0.0.1/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+    )
+    proxy_port = await proxy.start_tcp()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy_port)
+        request = (
+            f"GET http://127.0.0.1:{upstream_port}/probe HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{upstream_port}\r\n"
+            "Connection: keep-alive\r\n"
+            "Keep-Alive: timeout=5\r\n"
+            "\r\n"
+        ).encode("latin-1")
+        writer.write(request)
+        await writer.drain()
+        response = await asyncio.wait_for(reader.read(4096), timeout=5)
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+    assert b"200 OK" in response, f"Request did not complete through proxy: {response[:200]!r}"
+    assert len(captured) == 1, "Upstream should have received exactly one request"
+    # The client's keep-alive was rewritten to a single close upstream.
+    assert captured[0].connection == ["close"], captured[0].connection
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_in_flight_connection_handlers(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    """``stop`` cancels handlers parked in a read instead of leaking them.
+
+    A client that connects but sends no request line leaves
+    ``_handle_client`` parked in its 30 s readline. Without explicit
+    cancellation in ``stop`` such handlers outlive the event loop and the
+    interpreter prints "Task was destroyed but it is pending" on teardown.
+    The test parks two handlers, stops the proxy, and asserts the tracked
+    set is drained and every handler task reached a terminal (done) state.
+    """
+    cert_path, key_path, _ = ca_paths
+    proxy = EgressProxy(parse_rules(["GET example.com/**"]), cert_path, key_path)
+    port = await proxy.start_tcp()
+
+    socks = [socket.create_connection(("127.0.0.1", port)) for _ in range(2)]
+    try:
+        # Wait (event-driven, not a fixed sleep) until the server has
+        # accepted both connections and registered their handler tasks.
+        async def _both_parked() -> list[asyncio.Task[None]]:
+            while True:
+                parked = [t for t in proxy._client_tasks if not t.done()]
+                if len(parked) == 2:
+                    return parked
+                await asyncio.sleep(0)
+
+        # Two connections opened -> exactly two parked handlers; a
+        # different count would mean accept-time tracking (_client_connected)
+        # dropped or duplicated a handler.
+        parked = await asyncio.wait_for(_both_parked(), timeout=5)
+
+        await proxy.stop()
+
+        # Every previously-parked handler must be terminal (done) the moment
+        # stop() returns. This is the real regression detector: the handlers
+        # are blocked in a 30 s readline, so without stop()'s cancel/gather
+        # loop they would still be pending here (and leak past the loop as
+        # "Task was destroyed but it is pending"). They finish done-not-
+        # cancelled because _handle_client's finally swallows the injected
+        # CancelledError while closing the writer — but they only got to run
+        # that cleanup because stop() cancelled them.
+        assert all(t.done() for t in parked)
+    finally:
+        for s in socks:
+            s.close()

--- a/tests/inner/sandbox/conftest.py
+++ b/tests/inner/sandbox/conftest.py
@@ -40,7 +40,7 @@ from typing import Any
 
 import pytest
 
-from omnigent.inner.datamodel import OSEnvSandboxSpec
+from omnigent.inner.datamodel import CredentialProxySpec, OSEnvSandboxSpec
 
 _BWRAP_AVAILABLE = shutil.which("bwrap") is not None
 _SANDBOX_EXEC_AVAILABLE = shutil.which("sandbox-exec") is not None
@@ -130,6 +130,7 @@ def active_sandbox_spec_factory(
         cwd_allow_hidden: list[str] | None = None,
         extra_read_paths: list[str] | None = None,
         egress_allow_private_destinations: bool = False,
+        credential_proxy: CredentialProxySpec | None = None,
     ) -> OSEnvSandboxSpec:
         read_paths = [repo_root]
         if extra_read_paths:
@@ -143,6 +144,7 @@ def active_sandbox_spec_factory(
             env_passthrough=env_passthrough,
             egress_rules=egress_rules,
             egress_allow_private_destinations=egress_allow_private_destinations,
+            credential_proxy=credential_proxy,
         )
 
     return _make

--- a/tests/inner/sandbox/test_egress_e2e.py
+++ b/tests/inner/sandbox/test_egress_e2e.py
@@ -42,7 +42,14 @@ from pathlib import Path
 
 import pytest
 
-from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.credential_proxy import SYNTHETIC_CREDENTIAL_PREFIX
+from omnigent.inner.datamodel import (
+    CredentialProxyEntry,
+    CredentialProxySpec,
+    CredentialSourceSpec,
+    OSEnvSandboxSpec,
+    OSEnvSpec,
+)
 from omnigent.inner.os_env import create_os_environment
 from tests.inner.sandbox.conftest import run_async
 
@@ -893,6 +900,258 @@ def test_s4_two_sandboxes_cannot_borrow_each_others_proxy(
     finally:
         env_a.close()
         env_b.close()
+
+
+# ---------------------------------------------------------------------------
+# Secretless credential_proxy end-to-end (local upstream, no internet)
+# ---------------------------------------------------------------------------
+
+
+class _CapturingUpstream:
+    """A loopback HTTP server that records each ``Authorization`` header.
+
+    The sandbox makes requests through the egress proxy to this local
+    upstream, so the captured value is exactly what the proxy forwarded
+    after rewriting — proving the real secret reached the service while
+    the sandbox only ever held the synthetic placeholder.
+
+    :param captured: Authorization header values seen, in arrival order.
+    :param port: The bound loopback port.
+    """
+
+    def __init__(self) -> None:
+        import http.server
+        import threading
+
+        captured: list[str | None] = []
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                captured.append(self.headers.get("Authorization"))
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *_args: object) -> None:
+                # Silence the default stderr access log.
+                return
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.captured = captured
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def close(self) -> None:
+        """Stop the server and join its thread."""
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+def _proxied_http_probe(target_url: str, *, auth_expr: str) -> str:
+    """
+    Build a Python probe that GETs *target_url* through ``HTTP_PROXY``.
+
+    The probe constructs ``Proxy-Authorization`` from the proxy URL's
+    embedded token (the helper rewrote ``HTTP_PROXY`` in-process to carry
+    it) and sends ``Authorization`` built from *auth_expr*, then prints
+    ``STATUS <code>``.
+
+    :param target_url: Absolute http URL of the local upstream, e.g.
+        ``"http://127.0.0.1:54321/probe"``.
+    :param auth_expr: A Python expression (evaluated in the probe) that
+        yields the ``Authorization`` header value, e.g.
+        ``"'Bearer ' + os.environ['JIRA_TOKEN']"``.
+    :returns: Python source for use with :func:`_python_probe_argv`.
+    """
+    return "\n".join(
+        [
+            "import os, base64, http.client",
+            "from urllib.parse import urlparse",
+            "p = urlparse(os.environ['HTTP_PROXY'])",
+            "headers = {'Connection': 'close'}",
+            f"headers['Authorization'] = {auth_expr}",
+            "if p.username and p.password:",
+            "    creds = f'{p.username}:{p.password}'.encode()",
+            "    headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(creds).decode()",
+            "conn = http.client.HTTPConnection(p.hostname, p.port, timeout=30)",
+            f"conn.request('GET', '{target_url}', headers=headers)",
+            "resp = conn.getresponse()",
+            "print('STATUS', resp.status)",
+            "conn.close()",
+        ]
+    )
+
+
+def _proxied_http_probe_no_auth(target_url: str) -> str:
+    """
+    Build a Python probe that GETs *target_url* through ``HTTP_PROXY`` with
+    no ``Authorization`` header.
+
+    This is the swap-on-access client: it sends the request bare and
+    relies on the egress proxy to attach the real credential for the
+    bound host. Only ``Proxy-Authorization`` (built from the proxy URL's
+    embedded token) is set, never ``Authorization``.
+
+    :param target_url: Absolute http URL of the local upstream, e.g.
+        ``"http://127.0.0.1:54321/probe"``.
+    :returns: Python source for use with :func:`_python_probe_argv`.
+    """
+    return "\n".join(
+        [
+            "import os, base64, http.client",
+            "from urllib.parse import urlparse",
+            "p = urlparse(os.environ['HTTP_PROXY'])",
+            "headers = {'Connection': 'close'}",
+            "if p.username and p.password:",
+            "    creds = f'{p.username}:{p.password}'.encode()",
+            "    headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(creds).decode()",
+            "conn = http.client.HTTPConnection(p.hostname, p.port, timeout=30)",
+            f"conn.request('GET', '{target_url}', headers=headers)",
+            "resp = conn.getresponse()",
+            "print('STATUS', resp.status)",
+            "conn.close()",
+        ]
+    )
+
+
+def test_credential_proxy_swap_on_access_injects_basic_without_sandbox_secret(
+    tmp_path: Path,
+    active_sandbox_spec_factory: Callable[..., OSEnvSandboxSpec],
+    sandbox_pythonpath_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Swap-on-access (the default): the proxy injects Basic auth on a bare request.
+
+    This is the git_https / no-``env`` path. The binding has NO
+    ``inject_env``, so nothing credential-shaped is placed in the sandbox.
+    The probe sends a request with no ``Authorization`` header at all; the
+    egress proxy attaches ``Basic b64(x-access-token:<real>)`` for the
+    bound host on the way out. We assert both halves: the upstream
+    received the real Basic credential AND the sandbox env never held the
+    real secret or any ``oa_cred_*`` placeholder.
+    """
+    import base64
+
+    real_secret = "gho_real_git_token_5k1"
+    monkeypatch.setenv("OA_TEST_GIT_SECRET", real_secret)
+    upstream = _CapturingUpstream()
+    spec = active_sandbox_spec_factory(
+        egress_rules=["* 127.0.0.1/**"],
+        egress_allow_private_destinations=True,
+        credential_proxy=CredentialProxySpec(
+            entries=[
+                CredentialProxyEntry(
+                    host="127.0.0.1",
+                    scheme="basic",
+                    source=CredentialSourceSpec(kind="env", env="OA_TEST_GIT_SECRET"),
+                    username="x-access-token",
+                )
+            ]
+        ),
+    )
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(tmp_path), sandbox=spec)
+    )
+    probe = _proxied_http_probe_no_auth(f"http://127.0.0.1:{upstream.port}/probe")
+    try:
+        result = run_async(os_env.shell(_python_probe_argv(probe)))
+        # Dump every credential-shaped env var the sandbox can see.
+        sandbox_env = run_async(
+            os_env.shell('env | grep -E "OA_TEST_GIT_SECRET|oa_cred_" || true')
+        )
+    finally:
+        os_env.close()
+        upstream.close()
+
+    assert result["exit_code"] == 0, (
+        f"Probe failed. stdout={result.get('stdout')!r} stderr={result.get('stderr')!r}"
+    )
+    assert "STATUS 200" in result["stdout"], f"Did not reach upstream: {result['stdout']!r}"
+    expected = "Basic " + base64.b64encode(f"x-access-token:{real_secret}".encode()).decode()
+    # The proxy synthesized the Authorization header from nothing the
+    # client sent — if injection regressed, captured would be [None]
+    # (the bare request) instead of the real Basic credential.
+    assert upstream.captured == [expected], (
+        "Upstream MUST receive the proxy-injected Basic credential on a bare "
+        f"request. Captured: {upstream.captured!r}."
+    )
+    # The sandbox never held the real secret nor a placeholder — pure
+    # swap-on-access puts nothing credential-shaped in the env.
+    assert real_secret not in sandbox_env["stdout"], (
+        f"real secret leaked into the sandbox env: {sandbox_env['stdout']!r}"
+    )
+    assert SYNTHETIC_CREDENTIAL_PREFIX not in sandbox_env["stdout"], (
+        f"a synthetic placeholder was injected for a swap-on-access entry: "
+        f"{sandbox_env['stdout']!r}"
+    )
+
+
+def test_credential_proxy_https_bearer_swaps_injected_env_token(
+    tmp_path: Path,
+    active_sandbox_spec_factory: Callable[..., OSEnvSandboxSpec],
+    sandbox_pythonpath_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    https_bearer: the synthetic env token is swapped for the real secret.
+
+    Full path: parser-shaped spec -> parent resolves ``env:OA_TEST_SECRET``
+    -> mints ``oa_cred_*`` -> injects it as ``JIRA_TOKEN`` in the sandbox
+    -> probe sends ``Bearer <synthetic>`` -> egress proxy swaps it -> local
+    upstream sees the REAL secret. We assert both halves: the upstream got
+    the real token AND the sandbox env held only the synthetic.
+    """
+    real_secret = "real-bearer-secret-9f3a"
+    monkeypatch.setenv("OA_TEST_SECRET", real_secret)
+    upstream = _CapturingUpstream()
+    spec = active_sandbox_spec_factory(
+        egress_rules=["* 127.0.0.1/**"],
+        egress_allow_private_destinations=True,
+        credential_proxy=CredentialProxySpec(
+            entries=[
+                CredentialProxyEntry(
+                    host="127.0.0.1",
+                    scheme="bearer",
+                    source=CredentialSourceSpec(kind="env", env="OA_TEST_SECRET"),
+                    inject_env=["JIRA_TOKEN"],
+                )
+            ]
+        ),
+    )
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(tmp_path), sandbox=spec)
+    )
+    probe = _proxied_http_probe(
+        f"http://127.0.0.1:{upstream.port}/probe",
+        auth_expr="'Bearer ' + os.environ['JIRA_TOKEN']",
+    )
+    try:
+        result = run_async(os_env.shell(_python_probe_argv(probe)))
+        sandbox_token = run_async(os_env.shell('printf "%s" "$JIRA_TOKEN"'))
+    finally:
+        os_env.close()
+        upstream.close()
+
+    assert result["exit_code"] == 0, (
+        f"Probe failed. stdout={result.get('stdout')!r} stderr={result.get('stderr')!r}"
+    )
+    assert "STATUS 200" in result["stdout"], f"Did not reach upstream: {result['stdout']!r}"
+    assert upstream.captured == [f"Bearer {real_secret}"], (
+        "Upstream MUST receive the real bearer secret after the proxy swap. "
+        f"Captured: {upstream.captured!r}. If it shows oa_cred_*, the rewrite "
+        "did not fire; if empty, the request never reached upstream."
+    )
+    # The sandbox itself only ever held the synthetic placeholder — the
+    # real secret must never have been injected into the sandbox env.
+    injected = sandbox_token["stdout"]
+    assert injected.startswith(SYNTHETIC_CREDENTIAL_PREFIX), (
+        f"Sandbox JIRA_TOKEN should be a synthetic placeholder, got {injected!r}"
+    )
+    assert real_secret not in injected
 
 
 # Module guard so the helpers don't trigger lint warnings about

--- a/tests/inner/test_credential_proxy.py
+++ b/tests/inner/test_credential_proxy.py
@@ -1,0 +1,238 @@
+"""Unit tests for omnigent.inner.credential_proxy.
+
+These cover the parent-side runtime: secret resolution from
+``env`` / ``file`` / ``command`` sources, the default swap-on-access
+model (nothing injected into the sandbox), and the opt-in synthetic
+placeholder minting for ``inject_env`` entries. The end-to-end swap /
+injection through a real sandbox + proxy is covered in
+``tests/inner/sandbox/test_egress_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.credential_proxy import (
+    SYNTHETIC_CREDENTIAL_PREFIX,
+    prepare_credential_proxy_runtime,
+)
+from omnigent.inner.datamodel import (
+    CredentialProxyEntry,
+    CredentialProxySpec,
+    CredentialSourceSpec,
+)
+
+
+def _bearer_entry(
+    host: str, *, env_var: str, source: CredentialSourceSpec
+) -> CredentialProxyEntry:
+    """
+    Build a bearer-scheme entry that injects its placeholder into an env var.
+
+    :param host: Bound host, e.g. ``"jira.example.com"``.
+    :param env_var: Env var name to receive the synthetic, e.g. ``"JIRA"``.
+    :param source: Secret source to resolve in the parent.
+    :returns: A populated :class:`CredentialProxyEntry`.
+    """
+    return CredentialProxyEntry(
+        host=host,
+        scheme="bearer",
+        source=source,
+        inject_env=[env_var],
+    )
+
+
+def test_swap_on_access_entry_injects_nothing() -> None:
+    """The default (no ``inject_env``) resolves the secret but injects nothing.
+
+    This is the swap-on-access contract: the real secret reaches the
+    proxy rewrite rule, but the sandbox env stays empty and no synthetic
+    placeholder is minted (there is no placeholder to leak-guard because
+    the sandbox never holds one). If injection regressed to always-on,
+    ``helper_env_updates`` would be non-empty here; if minting regressed
+    to always-on, ``rule.synthetic`` would be set.
+    """
+    spec = CredentialProxySpec(
+        entries=[
+            CredentialProxyEntry(
+                host="github.com",
+                scheme="basic",
+                source=CredentialSourceSpec(kind="env", env="OA_SECRET"),
+                username="x-access-token",
+            )
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={"OA_SECRET": "real-secret"})
+
+    # Swap-on-access puts nothing in the sandbox env.
+    assert runtime.helper_env_updates == {}
+    assert len(runtime.rewrites) == 1
+    rule = runtime.rewrites[0]
+    # No env injection => no placeholder minted; the proxy injects the
+    # real credential directly on a bound-host request.
+    assert rule.synthetic is None
+    assert rule.real_secret == "real-secret"
+    assert rule.host == "github.com"
+    assert rule.scheme == "basic"
+    assert rule.username == "x-access-token"
+
+
+def test_env_source_resolves_and_mints_synthetic() -> None:
+    """An ``inject_env`` entry resolves the real secret and mints a placeholder.
+
+    Proves the placeholder (not the real secret) lands in the helper env
+    and that the rewrite rule carries the real secret for the proxy. If
+    resolution broke, the rewrite rule's real_secret would be wrong; if
+    minting broke, the synthetic would not carry the recognizable prefix.
+    """
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry(
+                "jira.example.com",
+                env_var="JIRA_TOKEN",
+                source=CredentialSourceSpec(kind="env", env="OA_SECRET"),
+            )
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={"OA_SECRET": "real-jira-secret"})
+
+    synthetic = runtime.helper_env_updates["JIRA_TOKEN"]
+    # The sandbox only ever sees the synthetic placeholder, never the
+    # real secret. If env injection regressed, the real secret would
+    # leak into the helper env here.
+    assert synthetic.startswith(SYNTHETIC_CREDENTIAL_PREFIX)
+    assert "real-jira-secret" not in synthetic
+
+    assert len(runtime.rewrites) == 1
+    rule = runtime.rewrites[0]
+    # The proxy rule pairs the exact placeholder the sandbox holds with
+    # the real upstream secret — the swap only works if these match.
+    assert rule.synthetic == synthetic
+    assert rule.real_secret == "real-jira-secret"
+    assert rule.host == "jira.example.com"
+    assert rule.scheme == "bearer"
+
+
+def test_file_source_resolves_secret(tmp_path: Path) -> None:
+    """A ``file`` source reads the secret from disk, stripped of whitespace.
+
+    A failure here means the file contents didn't reach the rewrite rule,
+    so the proxy would forward a wrong/blank credential upstream.
+    """
+    secret_file = tmp_path / "token.txt"
+    secret_file.write_text("  file-secret\n", encoding="utf-8")
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry(
+                "api.example.com",
+                env_var="API_TOKEN",
+                source=CredentialSourceSpec(kind="file", path=str(secret_file)),
+            )
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={})
+    # Trailing newline / leading spaces must be stripped so the upstream
+    # gets exactly the token, not a token with embedded whitespace.
+    assert runtime.rewrites[0].real_secret == "file-secret"
+
+
+def test_command_source_resolves_secret() -> None:
+    """A ``command`` source captures stdout as the secret.
+
+    Uses a real subprocess (``python -c``) rather than a mock so the
+    test exercises the actual ``subprocess.run`` path. If command
+    resolution regressed (wrong stream, missing strip), the real_secret
+    would not equal the printed value.
+    """
+    command = f"{sys.executable} -c \"print('cmd-secret')\""
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry(
+                "svc.example.com",
+                env_var="SVC_TOKEN",
+                source=CredentialSourceSpec(kind="command", command=command),
+            )
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env=dict(os.environ))
+    assert runtime.rewrites[0].real_secret == "cmd-secret"
+
+
+@pytest.mark.parametrize(
+    "source,parent_env,expected_fragment",
+    [
+        (CredentialSourceSpec(kind="env", env="MISSING"), {}, "missing or empty"),
+        (CredentialSourceSpec(kind="file", path="/no/such/file"), {}, "does not exist"),
+        (
+            CredentialSourceSpec(kind="command", command="exit 7"),
+            {},
+            "exited 7",
+        ),
+    ],
+)
+def test_source_resolution_fails_loud(
+    source: CredentialSourceSpec,
+    parent_env: dict[str, str],
+    expected_fragment: str,
+) -> None:
+    """Unresolvable sources raise rather than minting a blank placeholder.
+
+    Fail-loud is the security property here: a silently-empty secret
+    would let the sandbox authenticate as nobody (or, worse, mask a
+    misconfiguration). Each case asserts the specific failure reason.
+    """
+    spec = CredentialProxySpec(
+        entries=[_bearer_entry("h.example.com", env_var="T", source=source)]
+    )
+    with pytest.raises(ValueError, match=expected_fragment):
+        prepare_credential_proxy_runtime(spec, parent_env=parent_env)
+
+
+def test_gh_basic_shape_injects_env_for_api_host_only() -> None:
+    """gh_basic injects GH env vars only for the API host; git is swap-on-access.
+
+    Mirrors what the parser emits for ``gh_basic``: the API host gets
+    ``GH_TOKEN``/``GITHUB_TOKEN`` injection (token scheme) because ``gh``
+    won't call without a local token, while the git host authenticates
+    purely via swap-on-access (basic scheme, nothing injected). A
+    regression that injected the git host's credential, or dropped the
+    API host's env injection, would break one of the two GitHub paths.
+    """
+    source = CredentialSourceSpec(kind="env", env="GH_PAT")
+    spec = CredentialProxySpec(
+        entries=[
+            CredentialProxyEntry(
+                host="github.com",
+                scheme="basic",
+                source=source,
+                username="x-access-token",
+            ),
+            CredentialProxyEntry(
+                host="api.github.com",
+                scheme="token",
+                source=source,
+                inject_env=["GH_TOKEN", "GITHUB_TOKEN"],
+            ),
+        ]
+    )
+    runtime = prepare_credential_proxy_runtime(spec, parent_env={"GH_PAT": "ghp_real"})
+
+    # Both gh env vars carry the *same* synthetic as the api.github.com
+    # rewrite rule, so ``gh api`` sends a placeholder the proxy can swap.
+    api_rule = next(r for r in runtime.rewrites if r.host == "api.github.com")
+    assert runtime.helper_env_updates["GH_TOKEN"] == api_rule.synthetic
+    assert runtime.helper_env_updates["GITHUB_TOKEN"] == api_rule.synthetic
+    assert api_rule.scheme == "token"
+    assert api_rule.real_secret == "ghp_real"
+
+    # The git host is pure swap-on-access: nothing injected, no synthetic
+    # minted. Only the API host's two gh env vars are present.
+    git_rule = next(r for r in runtime.rewrites if r.host == "github.com")
+    assert git_rule.scheme == "basic"
+    assert git_rule.synthetic is None
+    assert git_rule.real_secret == "ghp_real"
+    assert set(runtime.helper_env_updates) == {"GH_TOKEN", "GITHUB_TOKEN"}

--- a/tests/inner/test_loader.py
+++ b/tests/inner/test_loader.py
@@ -823,6 +823,149 @@ os_env:
             finally:
                 os.unlink(f.name)
 
+    def test_load_agent_def_parses_credential_proxy(self):
+        """Single-file omnigent YAML must parse ``credential_proxy``.
+
+        Regression: this loader (the path ``omnigent run agent.yaml``
+        takes, distinct from the bundle ``parse(config.yaml)`` path)
+        had no ``credential_proxy`` parsing, so the field was silently
+        dropped and the secretless proxy never armed even though the
+        YAML declared it. We assert the entry actually reaches the spec
+        with the right host/scheme/injection — not merely that the
+        sandbox is non-None — because a dropped field would leave
+        ``credential_proxy`` as ``None`` while everything else parsed.
+        """
+        yaml_content = """
+name: t
+prompt: hi
+os_env:
+  type: caller_process
+  sandbox:
+    type: darwin_seatbelt
+    egress_rules:
+      - "* corp.example.com/**"
+    credential_proxy:
+      - type: https_bearer
+        target: corp.example.com/rest
+        source: {env: CORP}
+        env: CORP_TOKEN
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            try:
+                agent = load_agent_def(f.name)
+            finally:
+                os.unlink(f.name)
+        proxy = agent.os_env.sandbox.credential_proxy
+        self.assertIsNotNone(proxy)
+        # The YAML declares exactly one credential_proxy binding; a
+        # different count would mean the loader dropped it (the original
+        # bug) or duplicated it.
+        self.assertEqual(len(proxy.entries), 1)
+        entry = proxy.entries[0]
+        self.assertEqual(entry.host, "corp.example.com")
+        self.assertEqual(entry.scheme, "bearer")
+        self.assertEqual(entry.inject_env, ["CORP_TOKEN"])
+        self.assertEqual(entry.source.kind, "env")
+        self.assertEqual(entry.source.env, "CORP")
+
+    def test_load_agent_def_rejects_credential_proxy_without_egress_rules(self):
+        """``credential_proxy`` without ``egress_rules`` is rejected here too.
+
+        The MITM egress proxy (driven by egress_rules) is what performs
+        the synthetic->real swap and blocks placeholder leaks; without it
+        the proxy injects a placeholder the agent can't use. The loader
+        must fail loud rather than hand back an inert, half-wired policy
+        — mirroring the bundle parser guard so the two paths can't drift.
+        """
+        yaml_content = """
+name: t
+prompt: hi
+os_env:
+  type: caller_process
+  sandbox:
+    type: darwin_seatbelt
+    credential_proxy:
+      - type: git_https
+        target: github.com
+        source: {env: GH_PAT}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            try:
+                with self.assertRaisesRegex(ValueError, r"requires os_env\.sandbox\.egress_rules"):
+                    load_agent_def(f.name)
+            finally:
+                os.unlink(f.name)
+
+    def test_load_agent_def_rejects_credential_proxy_on_soft_backend(self):
+        """``credential_proxy`` requires a network-isolating backend.
+
+        On a soft backend (here ``none``) the egress proxy is not the
+        only way out, so binding credentials to it is unsafe. We omit
+        ``egress_rules`` so the backend guard (checked first) is the one
+        that fires, isolating the credential_proxy-specific backend
+        requirement rather than the generic egress-rules backend guard.
+        """
+        yaml_content = """
+name: t
+prompt: hi
+os_env:
+  type: caller_process
+  sandbox:
+    type: none
+    credential_proxy:
+      - type: git_https
+        target: github.com
+        source: {env: GH_PAT}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            try:
+                with self.assertRaisesRegex(
+                    ValueError, r"credential_proxy requires sandbox\.type"
+                ):
+                    load_agent_def(f.name)
+            finally:
+                os.unlink(f.name)
+
+    def test_load_agent_def_rejects_gh_basic_on_macos(self):
+        """Single-file YAML rejects ``gh_basic`` on macOS too.
+
+        ``gh_basic`` wires the GitHub CLI (a Go binary); Go on macOS ignores
+        SSL_CERT_FILE and verifies TLS via the keychain, so it rejects the
+        egress MITM CA and every ``gh`` call fails at runtime with
+        ``certificate is not trusted``. The single-file loader (the
+        ``omnigent run agent.yaml`` path) must fail loud at load time with the
+        same explanation as the bundle parser — sharing one detection helper so
+        the two paths can't drift.
+        """
+        yaml_content = """
+name: t
+prompt: hi
+os_env:
+  type: caller_process
+  sandbox:
+    type: darwin_seatbelt
+    egress_rules:
+      - "* github.com/**"
+      - "* api.github.com/**"
+    credential_proxy:
+      - type: gh_basic
+        source: {env: GH_PAT}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            try:
+                with self.assertRaisesRegex(ValueError, r"gh_basic' does not work on macOS"):
+                    load_agent_def(f.name)
+            finally:
+                os.unlink(f.name)
+
 
 def test_factory_params_with_unresolvable_handler_does_not_crash() -> None:
     """factory_params + a handler that cannot be imported must not raise.

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -3279,3 +3279,357 @@ def test_parse_executor_auth_api_key_base_url_absent(
 
     assert isinstance(spec.executor.auth, ApiKeyAuth)
     assert spec.executor.auth.base_url is None
+
+
+# ── credential_proxy parser tests ─────────────────────────────────
+
+
+def _credential_proxy_config(entries: list[dict[str, object]]) -> dict[str, object]:
+    """
+    Build a minimal agent config carrying a ``credential_proxy`` block.
+
+    :param entries: The ``credential_proxy`` list to embed under
+        ``os_env.sandbox``.
+    :returns: A config dict ready to ``yaml.dump`` for :func:`parse`.
+    """
+    return {
+        "spec_version": 1,
+        "name": "cred-proxy",
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {
+                "type": "linux_bwrap",
+                "egress_rules": [
+                    "* github.com/**",
+                    "* api.github.com/**",
+                    "* corp.example.com/**",
+                    "* git.example.com/**",
+                    "* bearer.example.com/**",
+                    "* basic.example.com/**",
+                ],
+                "credential_proxy": entries,
+            },
+        },
+    }
+
+
+def test_parse_credential_proxy_all_four_types(tmp_path: Path) -> None:
+    """All four ``credential_proxy`` types normalize to host bindings.
+
+    What breaks if this fails: the YAML the user writes wouldn't reach
+    the runtime as the right per-host scheme/injection, so the egress
+    proxy wouldn't swap credentials (or would swap the wrong scheme).
+    """
+    config = _credential_proxy_config(
+        [
+            {"type": "gh_basic", "source": {"env": "GH_PAT"}},
+            {
+                "type": "git_https",
+                "target": "git.example.com/org/repo.git",
+                "source": {"env": "GH_PAT"},
+            },
+            {
+                "type": "https_bearer",
+                "target": "bearer.example.com/rest",
+                "source": {"env": "CORP"},
+                "env": "CORP_TOKEN",
+            },
+            {
+                "type": "https_basic",
+                "targets": ["basic.example.com"],
+                "source": {"file": "/tmp/secret"},
+                "username": "svc",
+            },
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    proxy = spec.os_env.sandbox.credential_proxy
+    assert proxy is not None
+    by = {(e.host, e.scheme): e for e in proxy.entries}
+
+    # gh_basic -> github.com (basic, swap-on-access) and api.github.com
+    # (token + GH_TOKEN/GITHUB_TOKEN injection because gh gates locally).
+    gh_git = by[("github.com", "basic")]
+    assert gh_git.inject_env == []  # swap-on-access: nothing injected for git
+    gh_api = by[("api.github.com", "token")]
+    assert gh_api.inject_env == ["GH_TOKEN", "GITHUB_TOKEN"]
+
+    # git_https -> swap-on-access Basic for its bound host (nothing injected).
+    git_https = by[("git.example.com", "basic")]
+    assert git_https.inject_env == []
+
+    # https_bearer with an explicit ``env`` opts into placeholder injection.
+    bearer = by[("bearer.example.com", "bearer")]
+    assert bearer.inject_env == ["CORP_TOKEN"]
+    assert bearer.source.kind == "env" and bearer.source.env == "CORP"
+
+    # https_basic keeps the explicit username and a file source; with no
+    # ``env`` it is pure swap-on-access (inject_env empty).
+    basic = by[("basic.example.com", "basic")]
+    assert basic.username == "svc"
+    assert basic.inject_env == []
+    assert basic.source.kind == "file" and basic.source.path == "/tmp/secret"
+
+
+def test_parse_credential_proxy_rejects_duplicate_host(tmp_path: Path) -> None:
+    """Two entries binding the same host fail loudly at parse time.
+
+    The egress proxy keys its swap-on-access table by host, so a
+    duplicate-host config would silently drop one credential (last
+    wins). Rejecting it up front prevents a nondeterministic,
+    hard-to-debug "wrong scheme on the wire" outcome. Here ``gh_basic``
+    already binds ``github.com`` and the explicit ``git_https`` binds it
+    again.
+    """
+    config = _credential_proxy_config(
+        [
+            {"type": "gh_basic", "source": {"env": "GH_PAT"}},
+            {"type": "git_https", "target": "github.com", "source": {"env": "GH_PAT"}},
+        ]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"binds host 'github.com' more than once"):
+        parse(tmp_path)
+
+
+def test_parse_credential_proxy_git_https_default_username(tmp_path: Path) -> None:
+    """``git_https`` defaults the Basic username to ``x-access-token``.
+
+    A wrong default would make GitHub reject the Basic auth even though
+    the token is valid.
+    """
+    config = _credential_proxy_config(
+        [{"type": "git_https", "target": "github.com", "source": {"env": "GH_PAT"}}]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    entry = spec.os_env.sandbox.credential_proxy.entries[0]
+    assert entry.username == "x-access-token"
+
+
+def test_parse_credential_proxy_https_env_optional(tmp_path: Path) -> None:
+    """``https_*`` without ``env`` parses as a swap-on-access binding.
+
+    The ``env`` field is the opt-in injection shim, not a requirement.
+    Omitting it must yield a valid entry with an empty ``inject_env`` so
+    the proxy attaches the credential on access. If ``env`` were still
+    treated as required, parsing would raise instead.
+    """
+    config = _credential_proxy_config(
+        [{"type": "https_bearer", "target": "corp.example.com", "source": {"env": "CORP"}}]
+    )
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    entry = spec.os_env.sandbox.credential_proxy.entries[0]
+    assert entry.host == "corp.example.com"
+    assert entry.scheme == "bearer"
+    assert entry.inject_env == []
+
+
+@pytest.mark.parametrize(
+    "entries,match",
+    [
+        # Unknown ``type`` — caught by the pydantic ``Literal``.
+        ([{"type": "bogus", "source": {"env": "X"}}], r"type: Input should be"),
+        # Missing ``source`` — pydantic ``Field required``.
+        ([{"type": "https_bearer", "target": "h.example.com"}], r"source: Field required"),
+        # ``source`` as a bare string (the old surface) is now rejected —
+        # it must be a nested ``{env|file|command: ...}`` mapping.
+        (
+            [{"type": "https_bearer", "target": "h.example.com", "source": "env:X", "env": "T"}],
+            r"source:.*valid dictionary",
+        ),
+        # Two source keys set — exactly one is allowed.
+        (
+            [
+                {
+                    "type": "https_bearer",
+                    "target": "h.example.com",
+                    "source": {"env": "X", "file": "/tmp/s"},
+                }
+            ],
+            r"exactly one of 'env', 'file', or 'command'",
+        ),
+        # Malformed ``env`` injection-shim name.
+        (
+            [
+                {
+                    "type": "https_bearer",
+                    "target": "h.example.com",
+                    "source": {"env": "X"},
+                    "env": "not a valid name",
+                }
+            ],
+            r"env must be a POSIX",
+        ),
+        # Both ``target`` and ``targets`` set.
+        (
+            [
+                {
+                    "type": "https_bearer",
+                    "target": "h.example.com",
+                    "targets": ["h2.example.com"],
+                    "source": {"env": "X"},
+                    "env": "T",
+                }
+            ],
+            r"exactly one of 'target' or 'targets'",
+        ),
+        # Host fails DNS-safety validation (still enforced post-pydantic).
+        (
+            [{"type": "git_https", "target": "bad_host!", "source": {"env": "X"}}],
+            r"must be an exact DNS hostname",
+        ),
+        # Unknown key — ``extra="forbid"`` rejects typos.
+        (
+            [
+                {
+                    "type": "https_bearer",
+                    "target": "h.example.com",
+                    "source": {"env": "X"},
+                    "bogus": 1,
+                }
+            ],
+            r"bogus: Extra inputs are not permitted",
+        ),
+    ],
+)
+def test_parse_credential_proxy_fail_loud(
+    tmp_path: Path, entries: list[dict[str, object]], match: str
+) -> None:
+    """Malformed ``credential_proxy`` entries fail loudly at parse time.
+
+    Each case proves a specific misconfiguration is rejected up front
+    rather than silently producing a half-wired (insecure) policy.
+    """
+    config = _credential_proxy_config(entries)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=match):
+        parse(tmp_path)
+
+
+def test_parse_credential_proxy_requires_egress_rules(tmp_path: Path) -> None:
+    """``credential_proxy`` without ``egress_rules`` is rejected.
+
+    The MITM proxy (driven by egress_rules) is what performs the swap and
+    blocks placeholder leaks; without it the feature would be a no-op that
+    injects placeholders the agent can't use — fail loud instead.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "cred-proxy-no-egress",
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {
+                "type": "linux_bwrap",
+                "credential_proxy": [
+                    {"type": "git_https", "target": "github.com", "source": {"env": "X"}}
+                ],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"requires os_env.sandbox.egress_rules"):
+        parse(tmp_path)
+
+
+def test_parse_credential_proxy_requires_hard_backend(tmp_path: Path) -> None:
+    """``credential_proxy`` requires a network-isolating backend.
+
+    On ``linux_landlock`` (no hard network deny) the egress proxy isn't
+    the only path out, so binding credentials there is unsafe — rejected.
+
+    We deliberately OMIT ``egress_rules`` here so the egress-rules backend
+    guard doesn't fire first: that isolates the credential_proxy-specific
+    backend check (parser.py:1117). The ``match`` asserts the
+    credential_proxy message, not the egress one — so deleting the
+    credential_proxy backend guard (falling through to the
+    "requires egress_rules" error with its different text) would fail
+    this test.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "cred-proxy-soft-backend",
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {
+                "type": "linux_landlock",
+                "credential_proxy": [
+                    {"type": "git_https", "target": "github.com", "source": {"env": "X"}}
+                ],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"credential_proxy requires sandbox.type"):
+        parse(tmp_path)
+
+
+def test_parse_credential_proxy_gh_basic_rejected_on_macos(tmp_path: Path) -> None:
+    """``gh_basic`` is rejected on macOS (``darwin_seatbelt``).
+
+    ``gh_basic`` wires the GitHub CLI, a Go binary, and Go on macOS verifies
+    TLS via the system keychain and ignores ``SSL_CERT_FILE`` — the var the
+    egress MITM proxy uses to publish its CA — so every ``gh`` call would fail
+    at runtime with an opaque ``certificate is not trusted`` error. We fail
+    loud at parse time instead. The ``match`` asserts the macOS-specific
+    message (not the backend/egress guards, which pass here since
+    ``darwin_seatbelt`` + ``egress_rules`` are both present), so removing the
+    macOS guard would let the spec parse and fail this test.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "cred-proxy-gh-macos",
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {
+                "type": "darwin_seatbelt",
+                "egress_rules": ["* github.com/**", "* api.github.com/**"],
+                "credential_proxy": [{"type": "gh_basic", "source": {"env": "GH_PAT"}}],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"gh_basic' does not work on macOS"):
+        parse(tmp_path)
+
+
+def test_parse_credential_proxy_https_primitive_allowed_on_macos(tmp_path: Path) -> None:
+    """The generic primitives are NOT rejected on macOS.
+
+    The macOS guard must fire ONLY for the Go-based ``gh_basic`` preset (the
+    ``token`` scheme). ``https_bearer`` (and ``https_basic`` / ``git_https``)
+    are consumed by curl/python/git, which trust ``SSL_CERT_FILE`` on macOS, so
+    they must still parse on ``darwin_seatbelt``. This guards against the guard
+    being too broad and breaking the primitives that DO work.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "cred-proxy-bearer-macos",
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {
+                "type": "darwin_seatbelt",
+                "egress_rules": ["* corp.example.com/**"],
+                "credential_proxy": [
+                    {
+                        "type": "https_bearer",
+                        "target": "corp.example.com/rest",
+                        "source": {"env": "CORP"},
+                        "env": "CORP_TOKEN",
+                    }
+                ],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    proxy = spec.os_env.sandbox.credential_proxy
+    assert proxy is not None
+    assert proxy.entries[0].scheme == "bearer"


### PR DESCRIPTION
## Summary

- Adds `os_env.sandbox.credential_proxy` so sandboxed tools can authenticate to allow-listed hosts **without the real secret ever entering the sandbox**. The default is **swap-on-access**: a tool makes its request to the bound host with **no `Authorization` header**, and the egress MITM proxy injects `Authorization: <scheme> <real>` on the way out — for the bound host only. The parent (unsandboxed) resolves the real secret (`source: {env|file|command: ...}`) and the proxy holds it in memory; nothing credential-shaped is placed in the sandbox.
- For clients that gate on a local token *before* touching the network (notably `gh`), an entry can set an optional `env:`: the parent mints a non-secret `oa_cred_*` placeholder and injects only that into the named env var so the client emits a request the proxy can swap. A placeholder replayed against the wrong host is rejected with HTTP 403.
- Four YAML types: `https_bearer` / `https_basic` (generic primitives) and `git_https` / `gh_basic` (auto-wired presets for git-over-HTTPS and the GitHub CLI). Requires `egress_rules` and a hard-isolating backend (`linux_bwrap` / `darwin_seatbelt`); the parser fails loud otherwise, and rejects duplicate host bindings. SSH is explicitly out of scope for this phase.
- The real secret stays parent-side: it is never serialized into `SandboxPolicy` (`to_jsonable` excludes it), never placed on argv, and never logged. Swap-on-access entries cross the boundary as nothing at all; the opt-in path crosses only as the non-secret `oa_cred_*` placeholder.

Design doc: `designs/SANDBOX_CREDENTIAL_PROXY.md`.

## How it works

The egress proxy already terminates TLS as a mandatory MITM for the bound host, so it can attach the real credential to any request to that host. That makes the default model **swap-on-access**:

- `git clone https://github.com/...`, `curl`, `python`, `node` — any HTTP client — authenticate with **zero in-sandbox wiring** and nothing to leak.
- `git_https` is pure swap-on-access: there is no in-sandbox git credential helper. git fires its unauthenticated request and the proxy injects Basic auth for the bound host.
- The opt-in `env:` shim exists only for credential-gating clients like `gh`, which short-circuit before issuing a request. The parent injects a non-secret `oa_cred_*` placeholder into the named env var; the proxy swaps it for the real value on egress and rejects it (403) if it is replayed against any other host.

Config is validated through Pydantic boundary models (`extra="forbid"`) that enforce the `type` enum, source kind, `target`/`targets` cardinality, POSIX env-var names, and unknown-key rejection, then convert to the internal `CredentialProxyEntry` / `CredentialSourceSpec` dataclasses; `ValidationError` is flattened into `OmnigentError` so CLI error reporting is unchanged. The egress header rewrite uses the stdlib `email` parser (`BytesParser` + `email.policy.HTTP`) so re-serialization is byte-faithful and preserves header order/duplicates; when no credential rule matches, the client's original bytes are forwarded untouched. Each forwarded request is sent with `Connection: close` so an HTTP/1.1 upstream releases the socket after one response instead of stalling the one-request-per-connection relay.

## Usage examples

Every block lives under `os_env.sandbox.credential_proxy` and **requires** `egress_rules` plus a hard-isolating backend (`linux_bwrap` or `darwin_seatbelt`) — the parser rejects it otherwise. Common fields: `target` / `targets` (`host` + optional path glob; only the host binds the credential, path scoping is delegated to `egress_rules`) and `source` (a nested mapping — `{env: VAR}`, `{file: /path}`, or `{command: ...}`, resolved in the unsandboxed parent).

**`https_bearer`** — generic `Authorization: Bearer <token>` SaaS API. Swap-on-access: the tool sends no auth header and the proxy attaches `Bearer <real>` (bound to `api.example.com` only):

```yaml
os_env:
  sandbox:
    type: linux_bwrap
    egress_rules:
      - "* api.example.com/**"
    credential_proxy:
      - type: https_bearer
        target: api.example.com/**
        source: {env: EXAMPLE_API_TOKEN}   # resolved in the parent
```

Inside the sandbox: `curl https://api.example.com/v1/...` — no token in the request, the proxy attaches it. Add an optional `env: API_TOKEN` only if your client refuses to call without a local token; the parent then injects `oa_cred_…` into `$API_TOKEN`.

**`https_basic`** — generic `Authorization: Basic b64(user:<secret>)`. `username` defaults to `x-access-token`:

```yaml
    credential_proxy:
      - type: https_basic
        target: registry.example.com/**
        source: {file: /run/secrets/registry_pw}
        username: deploy-bot       # optional; defaults to x-access-token
```

**`git_https`** — preset for git-over-HTTPS. Pure swap-on-access: nothing enters the sandbox, git fires its unauthenticated request and the proxy injects Basic auth for the bound host:

```yaml
    egress_rules:
      - "* github.com/**"
    credential_proxy:
      - type: git_https
        target: github.com/owner/repo.git
        source: {command: gh auth token}   # real PAT resolved in the parent
```

Inside the sandbox: `git clone https://github.com/owner/repo.git` just works; the real PAT is never in the sandbox env or `~/.gitconfig`, and there is no credential helper.

**`gh_basic`** — preset for the GitHub CLI + git. Defaults to `github.com` + `api.github.com`. The git host is swap-on-access; the api host injects `GH_TOKEN` / `GITHUB_TOKEN` (synthetic) because `gh` gates on a local token:

```yaml
    egress_rules:
      - "* github.com/**"
      - "* api.github.com/**"
    credential_proxy:
      - type: gh_basic
        source: {command: gh auth token}
```

> ⚠️ **`gh_basic` is rejected on `darwin_seatbelt` (macOS).** `gh` is a Go binary and Go on macOS verifies TLS against the system keychain, ignoring `SSL_CERT_FILE` (the var the proxy uses to publish its MITM CA), so `gh` can never trust the proxy. Use `linux_bwrap`, or the `https_*` primitives with a non-Go client. The parser fails loud with this explanation.

Multiple entries can be combined in one block, each bound to its own host (duplicate host bindings are rejected at parse time):

```yaml
    egress_rules:
      - "* github.com/**"
      - "* api.github.com/**"
      - "* mycorp.atlassian.net/**"
    credential_proxy:
      - type: gh_basic
        source: {command: gh auth token}
      # swap-on-access: curl/python send no Authorization header
      - type: https_bearer
        target: mycorp.atlassian.net/rest/**
        source: {env: JIRA_PAT}
```

## Test coverage

- `tests/inner/test_credential_proxy.py` — source resolution (env/file/command), the swap-on-access default (nothing injected, no synthetic minted), opt-in synthetic minting (placeholder, not the secret, lands in the helper env), and the `gh_basic` shape (git host swap-on-access, api host env injection).
- `tests/inner/egress/test_proxy.py` — swap-on-access injection on a bare request (real secret reaches upstream), synthetic→real swap for `basic` / `bearer` / `token` against a real capturing upstream (and the synthetic is gone), the wrong-host 403 leak guard (upstream never contacted), non-synthetic pass-through, the `Connection: close` regression guard, the `stop()` drain test, and byte-faithful header rewrite.
- `tests/spec/test_parser.py` — parse/normalize for all four types, default usernames, `env`-optional (swap-on-access) parsing, duplicate-host rejection, `gh_basic`-on-`darwin_seatbelt` rejection (with a positive control that `https_bearer` is still allowed on macOS), and the Pydantic fail-loud cases (unknown type, missing/invalid source, missing target, non-DNS host, missing `egress_rules`, soft backend, unknown keys).
- `tests/inner/test_loader.py` — the single-file YAML path parses `credential_proxy` (nested `source`), enforces the egress-rules / hardened-backend guards, and rejects `gh_basic` on macOS.
- `tests/inner/sandbox/test_egress_e2e.py` — real-sandbox e2e: swap-on-access injects Basic auth on a bare request while the sandbox holds **neither the secret nor a placeholder**; `https_bearer` with `env` performs the full env-injection → proxy swap → upstream-sees-real-token path.

Manual verification: end-to-end CLI runs of all four types. `https_bearer` / `https_basic` swap correctly (real secret reaches upstream, nothing in the sandbox); `git_https` completes `git ls-remote` against a private GitHub repo through the proxy with zero in-sandbox wiring; `gh_basic` on macOS is rejected at load with the explanatory error.
