### PR TITLE
fix(polly): use claude-native `auto` permission mode instead of bypassPermissions

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -6,10 +6,10 @@ executor:
   type: omnigent
   config:
     harness: claude-native
-    # YOLO: headless workers can't answer ApprovalCards, so run Claude
-    # Code with full bypass. The server translates this into
-    # ``--permission-mode bypassPermissions`` (native sub-agents only).
-    permission_mode: bypassPermissions
+    # Headless workers can't answer ApprovalCards, and managed Claude
+    # settings disable ``bypassPermissions``. ``auto`` auto-approves without
+    # prompting and is allowed under managed settings (-> ``--permission-mode auto``).
+    permission_mode: auto
 
 prompt: |
   You are Claude Code, a coding sub-agent dispatched by the polly

--- a/omnigent/resources/examples/polly/agents/claude_code/config.yaml
+++ b/omnigent/resources/examples/polly/agents/claude_code/config.yaml
@@ -6,10 +6,10 @@ executor:
   type: omnigent
   config:
     harness: claude-native
-    # YOLO: headless workers can't answer ApprovalCards, so run Claude
-    # Code with full bypass. The server translates this into
-    # ``--permission-mode bypassPermissions`` (native sub-agents only).
-    permission_mode: bypassPermissions
+    # Headless workers can't answer ApprovalCards, and managed Claude
+    # settings disable ``bypassPermissions``. ``auto`` auto-approves without
+    # prompting and is allowed under managed settings (-> ``--permission-mode auto``).
+    permission_mode: auto
 
 prompt: |
   You are Claude Code, a coding sub-agent dispatched by the polly


### PR DESCRIPTION
## What

Switch polly's `claude_code` sub-agent from `permission_mode: bypassPermissions` to `permission_mode: auto` (in both the `examples/polly` bundle and the packaged `omnigent/resources/examples/polly` copy).

## Why

Headless polly workers can't answer an `ApprovalCard`, so they need a non-prompting permission mode. `bypassPermissions` is **disabled by managed Claude Code settings** (`permissions.disableBypassPermissionsMode`). Where that is in effect, the flag silently falls back to the prompt-on-everything `default` mode and the worker stalls on its first edit/bash — which presents as "the sub-agent launched in default mode, not YOLO."

`auto` is the classifier-based mode that auto-approves without prompting and **is permitted under managed settings**, so headless workers run unattended there. (`acceptEdits` is not a substitute — it still prompts on arbitrary Bash, so a worker would stall on test/lint/git calls.)

## How it flows

No code change needed: the server already translates `executor.config.permission_mode` verbatim into `--permission-mode <value>` for native sub-agents via `_derive_terminal_launch_args_from_spec`. Verified the derivation now yields `['--permission-mode', 'auto']` for `claude_code`.

## Scope / notes

- `codex`'s `yolo: true` (→ `--dangerously-bypass-approvals-and-sandbox`) is **unchanged** — Codex is a separate harness, not governed by managed Claude settings, and has no classifier-based `auto` equivalent.
- `auto` requires the account/managed entitlement per the [Claude Code permission-modes docs](https://code.claude.com/docs/en/permission-modes); this assumes the deployment's managed settings enable it (the stated reason for the change).

## Test

- `tests/e2e/omnigent/test_example_polly.py` + `tests/server/routes/test_sessions_yolo_launch_args.py` — 22 passed.
- Confirmed spec-load derivation: `claude_code` → `--permission-mode auto`.

This pull request and its description were written by Isaac.