### PR TITLE
fix(cursor): warn when a pinned model is dropped to auto-select

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -81,8 +81,15 @@ def _resolve_model(model: str | None) -> str:
     """
     if not model or model.startswith(("databricks-", "databricks/")):
         if model:
-            logger.debug(
-                "CursorExecutor: %r is not a cursor model; using %r", model, _DEFAULT_CURSOR_MODEL
+            # Warn, not debug: the requested model is silently NOT honored
+            # (cursor has no Databricks gateway), and a debug line is invisible
+            # in the harness subprocess — so a user who pinned a databricks-*
+            # model would otherwise have no idea it was dropped.
+            logger.warning(
+                "CursorExecutor: requested model %r is not a Cursor model "
+                "(cursor has no Databricks gateway); falling back to %r auto-select.",
+                model,
+                _DEFAULT_CURSOR_MODEL,
             )
         return _DEFAULT_CURSOR_MODEL
     return model

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -174,6 +174,26 @@ def test_resolve_model_drops_databricks_and_defaults_to_auto() -> None:
     assert _resolve_model(None) == "auto"
 
 
+def test_resolve_model_warns_when_dropping_a_pinned_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dropping an explicit (non-cursor) model must warn, not whisper at debug —
+    otherwise a user who pinned a databricks-* model has no idea it was ignored."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.inner.cursor_executor"):
+        assert _resolve_model("databricks-claude-opus-4-8") == "auto"
+    assert any(
+        r.levelno == logging.WARNING and "not a Cursor model" in r.getMessage()
+        for r in caplog.records
+    )
+    # No warning when there was no explicit model to honor.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="omnigent.inner.cursor_executor"):
+        assert _resolve_model(None) == "auto"
+    assert not caplog.records
+
+
 def test_sdk_message_to_events_maps_text_thinking_and_tools() -> None:
     assert isinstance(_sdk_message_to_events(_assistant("hi"))[0], TextChunk)
     think = _sdk_message_to_events(_thinking("hmm"))


### PR DESCRIPTION
## What

The cursor SDK bug-bash confirmed live (= static-audit finding #7): `_resolve_model` silently coerces any `databricks-*`/non-cursor model id to cursor `auto` at `logger.debug` — invisible in the harness subprocess. A user who runs `--model databricks-claude-opus-4-8` gets cursor auto-select with **no notice the request wasn't honored** (cursor has no Databricks gateway).

## Fix

Promote the drop notice from `logger.debug` to `logger.warning`. Behavior is unchanged — only the silence is fixed. Added a `caplog` test asserting the warning fires for a dropped model and stays silent when no model was pinned.

## Test
`tests/inner/test_cursor_executor.py` → 24 passed; ruff clean.

This pull request and its description were written by Isaac.