### PR TITLE
fix(cli): tolerate a vanished log file when pruning (concurrent-run TOCTOU)

### DIFF
--- a/omnigent/cli_diagnostics.py
+++ b/omnigent/cli_diagnostics.py
@@ -573,6 +573,22 @@ def _update_latest_symlink(log_dir: Path, log_path: Path) -> None:
         pass
 
 
+def _safe_mtime(path: Path) -> float:
+    """Return *path*'s mtime, or ``0.0`` if it has vanished.
+
+    ``_prune_old_logs`` runs at the start of every ``omnigent run``, so two
+    concurrent launches can glob the same log set then race to delete it. A
+    plain ``p.stat()`` in the sort key would then hit a just-removed file and
+    raise ``FileNotFoundError``, aborting the whole prune and crashing CLI
+    startup. Treat a vanished file as oldest (it's already gone, so the
+    suppressed ``unlink`` below is a no-op).
+    """
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def _prune_old_logs(log_dir: Path) -> None:
     """
     Remove the oldest ``cli-*.log`` files when the count exceeds
@@ -584,7 +600,7 @@ def _prune_old_logs(log_dir: Path) -> None:
     :param log_dir: Directory to prune.
     """
     pattern = "cli-*.log*"
-    logs = sorted(log_dir.glob(pattern), key=lambda p: p.stat().st_mtime)
+    logs = sorted(log_dir.glob(pattern), key=_safe_mtime)
     # Keep the newest MAX_LOG_FILES; delete the rest.
     excess = logs[: max(0, len(logs) - MAX_LOG_FILES)]
     for old in excess:

--- a/tests/cli/test_cli_diagnostics.py
+++ b/tests/cli/test_cli_diagnostics.py
@@ -448,3 +448,29 @@ async def test_slash_command_exceptions_reach_cli_log(
     assert "openai/gpt-5.4-mini" not in log_text, (
         f"slash-command diagnostics should not copy command arguments into the log: {log_text!r}"
     )
+
+
+def test_safe_mtime_returns_zero_for_vanished_file(tmp_path: Path) -> None:
+    """A file present at glob time but gone before stat resolves to 0.0, not a raise."""
+    real = tmp_path / "cli-real.log"
+    real.write_text("x")
+    assert cli_diagnostics._safe_mtime(real) > 0.0
+    assert cli_diagnostics._safe_mtime(tmp_path / "cli-gone.log") == 0.0
+
+
+def test_prune_old_logs_survives_file_vanishing_mid_sort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent ``omnigent run`` launches race to prune the same logs; a file
+    globbed by one but deleted by the other must not crash the sort (previously a
+    FileNotFoundError in the stat sort key aborted CLI startup)."""
+    real = [tmp_path / f"cli-{i:03d}.log" for i in range(cli_diagnostics.MAX_LOG_FILES + 3)]
+    for p in real:
+        p.write_text("x")
+    vanished = tmp_path / "cli-vanished.log"  # globbed, then deleted by a peer run
+    monkeypatch.setattr(Path, "glob", lambda self, pattern: [*real, vanished])
+
+    cli_diagnostics._prune_old_logs(tmp_path)  # must not raise
+
+    surviving = [p for p in real if p.exists()]
+    assert len(surviving) == cli_diagnostics.MAX_LOG_FILES  # newest kept, oldest pruned


### PR DESCRIPTION
## What

The cursor SDK bug-bash crashed 1 of 3 concurrent `omnigent run` launches at startup. Root cause: `cli_diagnostics._prune_old_logs` runs on every `run`, and two concurrent launches glob the same `cli-*.log` set then race to delete it. The `stat` in the sort key —

```python
logs = sorted(log_dir.glob(pattern), key=lambda p: p.stat().st_mtime)
```

— hits a just-removed file and raises `FileNotFoundError`, aborting the whole prune and crashing CLI startup **before the turn runs**. (The `unlink` loop was already `suppress(OSError)`; the sort key wasn't.)

## Fix

Extract a `_safe_mtime` helper that returns `0.0` for a vanished file (it sorts oldest; the already-suppressed `unlink` is then a no-op). Harness-agnostic — protects all `omnigent run` invocations.

## Test
Direct `_safe_mtime` coverage + a prune test that simulates a peer deleting a globbed file mid-sort (must not raise; newest kept). `tests/cli/test_cli_diagnostics.py` → 10 passed; ruff clean.

This pull request and its description were written by Isaac.