### PR TITLE
fix(cli): surface a persisted terminal error in headless -p (no more silent exit-0)

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2250,7 +2250,19 @@ async def _query_sessions_once(
         raise
     if result.text:
         return result.text
-    return await _persisted_turn_text(client, bound.id)
+    reconciled = await _persisted_turn_text(client, bound.id)
+    if reconciled is not None:
+        return reconciled
+    # No assistant text for this turn. If the runner persisted a terminal
+    # ``error`` item (e.g. a harness start failure like the cursor SDK's
+    # invalid-model rejection), surface it instead of returning ``None`` —
+    # otherwise the headless caller renders a failed turn as a silent,
+    # exit-0 empty success. The callers wrap this in ``except
+    # ClientOmnigentError`` and print the message to stderr + exit non-zero.
+    turn_error = await _persisted_turn_error(client, bound.id)
+    if turn_error is not None:
+        raise ClientOmnigentError(turn_error)
+    return None
 
 
 def _sessions_tool_callables(
@@ -2369,6 +2381,44 @@ async def _persisted_turn_text(
     # Restore chronological order so multi-message output joins correctly.
     this_turn_assistant.reverse()
     return _response_output_text(this_turn_assistant)
+
+
+async def _persisted_turn_error(
+    client: OmnigentClient,
+    session_id: str,
+) -> str | None:
+    """Read the latest turn's persisted terminal error message, if any.
+
+    Companion to :func:`_persisted_turn_text`. When a turn produced no
+    ``completed`` assistant text, the runner may still have persisted a
+    terminal ``error`` item — e.g. a harness *start* failure such as the
+    cursor SDK rejecting an unknown model. Without this, the headless ``-p``
+    path renders that as a silent, exit-0 empty success; returning the message
+    lets the caller surface it and exit non-zero.
+
+    Mirrors :func:`_persisted_turn_text`'s walk: newest → oldest, stopping at
+    the current turn's user message, so a prior turn's error is never
+    attributed to this turn.
+
+    :param client: Connected SDK client bound to the session's server.
+    :param session_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+    :returns: The current turn's terminal error message, or ``None``.
+    """
+    try:
+        recent: _ResponseOutput = await client.sessions.list_items(
+            session_id, limit=_RECONCILE_ITEMS_LIMIT, order="desc"
+        )
+    except ClientOmnigentError as exc:
+        logger.debug("reconcile error read failed for %s: %r", session_id, exc)
+        return None
+    for item in recent:
+        if item.get("type") == "message" and item.get("role") == "user":
+            break  # reached the start of the current turn
+        if item.get("type") == "error":
+            message = item.get("message")
+            if isinstance(message, str) and message:
+                return message
+    return None
 
 
 def _resolve_resume_target(

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3146,6 +3146,23 @@ def _item_assistant(text: str, *, status: str = "completed") -> dict[str, object
     }
 
 
+def _item_error(message: str) -> dict[str, object]:
+    """
+    Build a persisted terminal ``error`` item (harness start-failure shape).
+
+    :param message: The error text, e.g.
+        ``"inner executor error: Failed to start cursor-sdk agent: ..."``.
+    :returns: An item dict matching the flat API shape for an error item.
+    """
+    return {
+        "type": "error",
+        "status": "completed",
+        "source": "execution",
+        "code": "RuntimeError",
+        "message": message,
+    }
+
+
 class _FakeSessionsNamespace:
     """
     Minimal stand-in for ``client.sessions`` used by the reconcile tests.
@@ -3352,6 +3369,36 @@ async def test_query_sessions_once_reraises_when_no_persisted_text(
     client = _FakeAPClient([_item_user("say hi")])
     with pytest.raises(ClientOmnigentError, match="auth misconfigured"):
         await _run_one_shot(client, _raise_genuine_failure, monkeypatch)
+
+
+async def test_query_sessions_once_surfaces_persisted_error_when_no_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A turn that produced no assistant text but persisted a terminal error
+    (e.g. cursor's invalid-model start failure) surfaces that error instead of
+    returning None. If this fails, headless ``-p`` renders a failed turn as a
+    silent, exit-0 empty success.
+    """
+    client = _FakeAPClient(
+        [
+            _item_user("say hi"),
+            _item_error("inner executor error: Failed to start cursor-sdk agent: bad model"),
+        ]
+    )
+    with pytest.raises(ClientOmnigentError, match="Failed to start cursor-sdk agent"):
+        await _run_one_shot(client, _return_empty, monkeypatch)
+
+
+async def test_query_sessions_once_returns_none_when_no_text_and_no_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No assistant text and no persisted error item → None (the caller prints
+    nothing). Guards against the error-surfacing path raising spuriously when a
+    turn genuinely produced nothing and recorded no error.
+    """
+    client = _FakeAPClient([_item_user("unanswered")])
+    result = await _run_one_shot(client, _return_empty, monkeypatch)
+    assert result is None
 
 
 async def test_query_sessions_once_returns_text_without_reconcile_on_success(


### PR DESCRIPTION
## What

The cursor SDK bug-bash's most serious *user-facing* finding: an invalid/unavailable `--model` (or any harness start failure) made `omnigent run -p` print **nothing and exit 0**, while the server recorded a `failed` session + a descriptive `RuntimeError` the user never saw. A scripted/CI caller can't tell the turn never ran.

Root cause: the headless/bundle path (`_query_sessions_once` → `_persisted_turn_text`) reconciles only `completed` assistant messages and **ignores persisted `error` items**. A turn that produced no text but recorded a terminal error returned `None`, which the caller rendered as an empty success.

## Fix

Add `_persisted_turn_error` — a companion to `_persisted_turn_text` using the same newest→oldest, stop-at-the-user-message walk — and, when a turn has no assistant text, **raise `ClientOmnigentError` with the persisted error message**. Both callers already wrap `_query_sessions_once` in `except ClientOmnigentError` → print to stderr + `SystemExit(1)`, so the failure now surfaces with a non-zero exit.

Harness-agnostic CLI fix; the cursor invalid-model rejection is the motivating example. (The cursor executor *does* emit the error — this is purely the headless CLI dropping it.)

## Test
New tests: a turn with an error item + no text **raises** with the error message; a turn with neither text nor error still returns `None` (no spurious raise). Existing reconcile tests unchanged. `tests/cli/test_chat.py -k "query_sessions_once or persisted_turn"` → 11 passed; ruff clean.

This pull request and its description were written by Isaac.