### PR TITLE
fix(codex-native): context ring accuracy + native /compact support

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -4508,20 +4508,19 @@ def _session_usage_data_from_params(params: dict[str, Any]) -> dict[str, int] | 
     total = token_usage.get("total")
     if not isinstance(total, dict):
         return None
-    context_tokens = total.get("inputTokens")
+    cumulative_input_tokens = total.get("inputTokens")
     context_window = total.get("contextWindow")
     output_tokens = total.get("outputTokens")
     cached_input_tokens = total.get("cachedInputTokens")
     data: dict[str, int] = {}
-    if isinstance(context_tokens, int) and context_tokens >= 0:
-        data["context_tokens"] = context_tokens
+    if isinstance(cumulative_input_tokens, int) and cumulative_input_tokens >= 0:
         # Codex's ``tokenUsage.total`` is CUMULATIVE across the whole thread
         # (the CLI subtracts prior totals to recover per-turn deltas), so
         # ``total.inputTokens`` / ``outputTokens`` are the session's cumulative
         # token counts. Forward them as the cumulative fields the server prices
         # into ``total_cost_usd`` (SET semantics) — codex-native produces no
         # ``response.completed``, so the Omnigent relay never accounts its cost.
-        data["cumulative_input_tokens"] = context_tokens
+        data["cumulative_input_tokens"] = cumulative_input_tokens
         # Codex's ``inputTokens`` is INCLUSIVE of cached tokens
         # (``non_cached_input = input_tokens - cached_input_tokens`` in
         # codex-rs ``protocol.rs``). Forward the cumulative cached count so the
@@ -4530,6 +4529,19 @@ def _session_usage_data_from_params(params: dict[str, Any]) -> dict[str, int] | 
         # cumulative (SET) semantics as ``cumulative_input_tokens``.
         if isinstance(cached_input_tokens, int) and cached_input_tokens >= 0:
             data["cumulative_cache_read_input_tokens"] = cached_input_tokens
+    # ``context_tokens`` drives the context-window ring in the web UI. It
+    # must reflect the CURRENT context occupancy (how much of the window
+    # the latest turn consumed), NOT the cumulative total across all turns.
+    # Codex's ``tokenUsage.last`` carries the per-turn breakdown; fall back
+    # to ``total.inputTokens`` only when ``last`` is unavailable (first
+    # frame before a turn completes).
+    last = token_usage.get("last")
+    if isinstance(last, dict):
+        last_input = last.get("inputTokens")
+        if isinstance(last_input, int) and last_input >= 0:
+            data["context_tokens"] = last_input
+    elif isinstance(cumulative_input_tokens, int) and cumulative_input_tokens >= 0:
+        data["context_tokens"] = cumulative_input_tokens
     if isinstance(output_tokens, int) and output_tokens >= 0:
         data["cumulative_output_tokens"] = output_tokens
     if isinstance(context_window, int) and context_window > 0:

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -4536,10 +4536,9 @@ def _session_usage_data_from_params(params: dict[str, Any]) -> dict[str, int] | 
     # to ``total.inputTokens`` only when ``last`` is unavailable (first
     # frame before a turn completes).
     last = token_usage.get("last")
-    if isinstance(last, dict):
-        last_input = last.get("inputTokens")
-        if isinstance(last_input, int) and last_input >= 0:
-            data["context_tokens"] = last_input
+    last_input = last.get("inputTokens") if isinstance(last, dict) else None
+    if isinstance(last_input, int) and last_input >= 0:
+        data["context_tokens"] = last_input
     elif isinstance(cumulative_input_tokens, int) and cumulative_input_tokens >= 0:
         data["context_tokens"] = cumulative_input_tokens
     if isinstance(output_tokens, int) and output_tokens >= 0:

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -7302,6 +7302,59 @@ def test_session_usage_data_without_output_tokens_omits_cumulative_output() -> N
     assert "cumulative_output_tokens" not in data
 
 
+def test_session_usage_data_context_tokens_uses_last_turn_input() -> None:
+    """
+    ``context_tokens`` (the context-ring value) should reflect the LAST
+    turn's input — how much of the window the latest request occupied —
+    not the cumulative total across the whole thread.
+
+    When ``tokenUsage.last`` is present, ``context_tokens`` comes from
+    ``last.inputTokens``; ``cumulative_input_tokens`` still uses
+    ``total.inputTokens`` for cost pricing.
+    """
+    params = {
+        "tokenUsage": {
+            "total": {
+                "inputTokens": 4_800_000,
+                "outputTokens": 200_000,
+                "contextWindow": 1_178_000,
+            },
+            "last": {
+                "inputTokens": 950_000,
+                "outputTokens": 12_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    # Ring shows current context occupancy from the last turn.
+    assert data["context_tokens"] == 950_000
+    # Cost pricing uses cumulative totals.
+    assert data["cumulative_input_tokens"] == 4_800_000
+    assert data["cumulative_output_tokens"] == 200_000
+    assert data["context_window"] == 1_178_000
+
+
+def test_session_usage_data_context_tokens_falls_back_without_last() -> None:
+    """
+    When ``tokenUsage.last`` is absent (e.g. first frame before a turn
+    completes), ``context_tokens`` falls back to ``total.inputTokens``.
+    """
+    params = {
+        "tokenUsage": {
+            "total": {
+                "inputTokens": 1000,
+                "outputTokens": 250,
+                "contextWindow": 200_000,
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_tokens"] == 1000
+    assert data["cumulative_input_tokens"] == 1000
+
+
 def test_usage_coalescer_flush_attaches_model_to_every_post() -> None:
     """
     ``flush`` attaches the recorded model to each token-bearing post.

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -7355,6 +7355,31 @@ def test_session_usage_data_context_tokens_falls_back_without_last() -> None:
     assert data["cumulative_input_tokens"] == 1000
 
 
+def test_session_usage_data_context_tokens_falls_back_when_last_missing_input() -> None:
+    """
+    When ``tokenUsage.last`` is present but lacks a usable ``inputTokens``,
+    ``context_tokens`` falls back to ``total.inputTokens`` rather than being
+    omitted (which would leave the UI ring stuck on a stale value from a
+    previous coalescer frame).
+    """
+    params = {
+        "tokenUsage": {
+            "total": {
+                "inputTokens": 3000,
+                "outputTokens": 500,
+                "contextWindow": 200_000,
+            },
+            "last": {
+                "outputTokens": 100,
+                # inputTokens intentionally absent
+            },
+        },
+    }
+    data = codex_native_forwarder._session_usage_data_from_params(params)
+    assert data is not None
+    assert data["context_tokens"] == 3000
+
+
 def test_usage_coalescer_flush_attaches_model_to_every_post() -> None:
     """
     ``flush`` attaches the recorded model to each token-bearing post.


### PR DESCRIPTION
## Summary
- **Context ring fix**: The context-window ring was stuck at 100% on long Codex sessions because `context_tokens` was sourced from `tokenUsage.total.inputTokens` (cumulative across all turns). Now reads from `tokenUsage.last.inputTokens` (per-turn breakdown) so the ring reflects actual window usage.
- **Native /compact**: Codex-native sessions now handle `/compact` by injecting the slash command into the Codex tmux pane (via resource registry), matching the claude-native pattern. Returns 200 so the server skips AP-side compaction.

## Test plan
- [x] 173 codex-native tests pass
- [x] 10 compact tests pass (7 existing + 3 new)
- [x] `test_session_usage_data_context_tokens_uses_last_turn_input` — `last.inputTokens` used for ring
- [x] `test_session_usage_data_context_tokens_falls_back_without_last` — fallback when `last` absent
- [x] `test_session_usage_data_context_tokens_falls_back_when_last_missing_input` — fallback when `last` lacks `inputTokens`
- [x] `test_events_compact_on_codex_native_injects_slash_command` — happy path, 3 tmux calls
- [x] `test_events_compact_on_codex_native_returns_204_when_no_terminal` — graceful fallback
- [x] `test_events_compact_on_codex_native_returns_503_on_tmux_failure` — error surfacing
- [ ] Manual: verify ring shows accurate % and `/compact` reduces context on a live Codex session

This pull request and its description were written by Isaac.