### PR TITLE
chore(cursor): drop Databricks naming from the model-drop warning/docs

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -78,22 +78,21 @@ _TOOL_CALL_TIMEOUT_S = 1800.0
 
 
 def _resolve_model(model: str | None) -> str:
-    """Resolve the cursor model id, dropping non-cursor ``databricks-*`` ids.
+    """Resolve the cursor model id, dropping ids cursor can't honor.
 
     cursor-sdk accepts only Cursor model ids (``auto``, ``gpt-5``,
-    ``composer-2.5``, ...) and rejects gateway ids, so a ``databricks-*`` model
-    (from a spec authored for another harness) falls back to cursor's auto
-    select. ``None`` likewise resolves to ``auto`` (the SDK requires a model).
+    ``composer-2.5``, ...), so a gateway-routed model id (carried by a spec
+    authored for another harness) falls back to cursor's auto-select. ``None``
+    likewise resolves to ``auto`` (the SDK requires a model).
     """
     if not model or model.startswith(("databricks-", "databricks/")):
         if model:
-            # Warn, not debug: the requested model is silently NOT honored
-            # (cursor has no Databricks gateway), and a debug line is invisible
-            # in the harness subprocess — so a user who pinned a databricks-*
-            # model would otherwise have no idea it was dropped.
+            # Warn, not debug: the requested model is silently NOT honored, and
+            # a debug line is invisible in the harness subprocess — so a user who
+            # pinned a non-Cursor model would otherwise have no idea it was dropped.
             logger.warning(
-                "CursorExecutor: requested model %r is not a Cursor model "
-                "(cursor has no Databricks gateway); falling back to %r auto-select.",
+                "CursorExecutor: requested model %r is not a Cursor model id; "
+                "falling back to %r auto-select.",
                 model,
                 _DEFAULT_CURSOR_MODEL,
             )
@@ -324,7 +323,7 @@ class CursorExecutor(Executor):
             falls back to ``os_env.cwd`` then the process cwd.
         :param os_env: Optional OS environment / sandbox spec (its ``cwd`` is
             used when *cwd* is unset).
-        :param model: Cursor model id (e.g. ``"gpt-5"``); a ``databricks-*`` id
+        :param model: Cursor model id (e.g. ``"gpt-5"``); a gateway-routed id
             or ``None`` falls back to cursor's ``auto`` select.
         :param api_key: Cursor API key. ``None`` falls back to ``CURSOR_API_KEY``
             in the environment.

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -178,7 +178,7 @@ def test_resolve_model_warns_when_dropping_a_pinned_model(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Dropping an explicit (non-cursor) model must warn, not whisper at debug —
-    otherwise a user who pinned a databricks-* model has no idea it was ignored."""
+    otherwise a user who pinned a non-Cursor model has no idea it was ignored."""
     import logging
 
     with caplog.at_level(logging.WARNING, logger="omnigent.inner.cursor_executor"):


### PR DESCRIPTION
## What

Follow-up to #246. The warning + comment it added editorialized **"cursor has no Databricks gateway"** in a user-facing log line, and the docstring/param docs named `databricks-*` — not appropriate for an OSS repo. Genericized all of it:

- Warning: `"... is not a Cursor model (cursor has no Databricks gateway); ..."` → `"... is not a Cursor model id; falling back to <auto>."`
- Comment / docstring / `:param model:` → "non-Cursor model" / "gateway-routed model id".

## Behavior unchanged

The `databricks-`/`databricks/` **prefix detection stays** in the code — it's the actual gateway model-id namespace specs carry, and the same convention the `codex` / `claude-sdk` harnesses and `claude_gateway_shim` use. So a gateway-routed model still falls back to auto-select with a warning; the only change is wording. The #246 test still passes (the warning still contains "not a Cursor model").

> If you'd rather remove the `databricks-` literal entirely, that's a behavior change (a gateway-routed model id would then error via the SDK instead of falling back to auto) — say the word and I'll do that variant instead.

## Test
`tests/inner/test_cursor_executor.py -k resolve_model` → 2 passed; ruff clean. Only the functional prefix literal remains in the file.

This pull request and its description were written by Isaac.