### PR TITLE
test(tools): add unit tests for untested tool builtins

### DIFF
--- a/tests/tools/builtins/test_agents.py
+++ b/tests/tools/builtins/test_agents.py
@@ -1,0 +1,103 @@
+"""Unit tests for :mod:`omnigent.tools.builtins.agents`.
+
+These tools are runner-dispatched (schema-only); tests verify schema
+shapes, name/description class methods, and that the base-class
+``invoke`` raises ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.agents import (
+    SysAgentDownloadTool,
+    SysAgentGetTool,
+    SysAgentListTool,
+)
+
+_CTX = ToolContext(task_id="task_test", agent_id="agent_test")
+
+
+# ── SysAgentGetTool ──────────────────────────────────────
+
+
+class TestSysAgentGetTool:
+    def test_name(self) -> None:
+        assert SysAgentGetTool.name() == "sys_agent_get"
+
+    def test_description_non_empty(self) -> None:
+        assert len(SysAgentGetTool.description()) > 0
+
+    def test_schema_shape(self) -> None:
+        tool = SysAgentGetTool()
+        schema = tool.get_schema()
+        assert schema["type"] == "function"
+        func = schema["function"]
+        assert func["name"] == "sys_agent_get"
+        params = func["parameters"]
+        assert "session_id" in params["required"]
+        assert params["properties"]["session_id"]["type"] == "string"
+        assert params.get("additionalProperties") is False
+
+    def test_invoke_raises(self) -> None:
+        """Runner-dispatched; invoke raises NotImplementedError."""
+        tool = SysAgentGetTool()
+        with pytest.raises(NotImplementedError):
+            tool.invoke("{}", _CTX)
+
+
+# ── SysAgentDownloadTool ─────────────────────────────────
+
+
+class TestSysAgentDownloadTool:
+    def test_name(self) -> None:
+        assert SysAgentDownloadTool.name() == "sys_agent_download"
+
+    def test_description_non_empty(self) -> None:
+        assert len(SysAgentDownloadTool.description()) > 0
+
+    def test_schema_shape(self) -> None:
+        tool = SysAgentDownloadTool()
+        schema = tool.get_schema()
+        assert schema["type"] == "function"
+        func = schema["function"]
+        assert func["name"] == "sys_agent_download"
+        params = func["parameters"]
+        assert "session_id" in params["required"]
+        props = params["properties"]
+        assert props["session_id"]["type"] == "string"
+        assert "dest_filename" in props
+        assert props["dest_filename"]["type"] == "string"
+        assert params.get("additionalProperties") is False
+
+    def test_invoke_raises(self) -> None:
+        tool = SysAgentDownloadTool()
+        with pytest.raises(NotImplementedError):
+            tool.invoke("{}", _CTX)
+
+
+# ── SysAgentListTool ─────────────────────────────────────
+
+
+class TestSysAgentListTool:
+    def test_name(self) -> None:
+        assert SysAgentListTool.name() == "sys_agent_list"
+
+    def test_description_non_empty(self) -> None:
+        assert len(SysAgentListTool.description()) > 0
+
+    def test_schema_shape(self) -> None:
+        tool = SysAgentListTool()
+        schema = tool.get_schema()
+        assert schema["type"] == "function"
+        func = schema["function"]
+        assert func["name"] == "sys_agent_list"
+        params = func["parameters"]
+        assert params["properties"] == {}
+        assert params.get("additionalProperties") is False
+
+    def test_invoke_raises(self) -> None:
+        tool = SysAgentListTool()
+        with pytest.raises(NotImplementedError):
+            tool.invoke("{}", _CTX)

--- a/tests/tools/builtins/test_export_agent.py
+++ b/tests/tools/builtins/test_export_agent.py
@@ -1,0 +1,145 @@
+"""Unit tests for :mod:`omnigent.tools.builtins.export_agent`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.export_agent import ExportAgentTool
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    """Create a workspace with a sample agent directory."""
+    agent_dir = tmp_path / "workspace" / "my-agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "config.yaml").write_text("name: my-agent\n")
+    (agent_dir / "prompt.md").write_text("# Prompt\n")
+    return tmp_path / "workspace"
+
+
+@pytest.fixture()
+def tool_ctx(workspace: Path) -> ToolContext:
+    return ToolContext(
+        task_id="task_test",
+        agent_id="agent_test",
+        workspace=workspace,
+    )
+
+
+# ── Schema ───────────────────────────────────────────────
+
+
+def test_schema_shape() -> None:
+    """Schema has source and target as required string params."""
+    tool = ExportAgentTool()
+    schema = tool.get_schema()
+    assert schema["type"] == "function"
+    func = schema["function"]
+    assert func["name"] == "export_agent"
+    assert set(func["parameters"]["required"]) == {"source", "target"}
+    props = func["parameters"]["properties"]
+    assert props["source"]["type"] == "string"
+    assert props["target"]["type"] == "string"
+
+
+def test_name_and_description() -> None:
+    assert ExportAgentTool.name() == "export_agent"
+    assert len(ExportAgentTool.description()) > 0
+
+
+# ── Invoke: success ──────────────────────────────────────
+
+
+def test_invoke_copies_directory(
+    tool_ctx: ToolContext,
+    tmp_path: Path,
+) -> None:
+    """invoke() copies the agent directory to the target path."""
+    target = tmp_path / "export-target" / "my-agent"
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "my-agent", "target": str(target)}),
+        tool_ctx,
+    )
+    assert "Exported agent to" in result
+    assert (target / "config.yaml").exists()
+    assert (target / "prompt.md").exists()
+
+
+def test_invoke_overwrites_existing_target(
+    tool_ctx: ToolContext,
+    tmp_path: Path,
+) -> None:
+    """invoke() replaces an existing target directory."""
+    target = tmp_path / "export-overwrite"
+    target.mkdir()
+    (target / "old-file.txt").write_text("stale")
+
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "my-agent", "target": str(target)}),
+        tool_ctx,
+    )
+    assert "Exported agent to" in result
+    assert (target / "config.yaml").exists()
+    assert not (target / "old-file.txt").exists()
+
+
+# ── Invoke: error cases ──────────────────────────────────
+
+
+def test_invoke_missing_source(tool_ctx: ToolContext) -> None:
+    """Error when source is empty."""
+    tool = ExportAgentTool()
+    result = tool.invoke(json.dumps({"target": "/tmp/out"}), tool_ctx)
+    assert "Error" in result and "source" in result.lower()
+
+
+def test_invoke_missing_target(tool_ctx: ToolContext) -> None:
+    """Error when target is empty."""
+    tool = ExportAgentTool()
+    result = tool.invoke(json.dumps({"source": "my-agent"}), tool_ctx)
+    assert "Error" in result and "target" in result.lower()
+
+
+def test_invoke_source_not_found(
+    tool_ctx: ToolContext,
+    tmp_path: Path,
+) -> None:
+    """Error when source directory doesn't exist in workspace."""
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "nonexistent", "target": str(tmp_path / "out")}),
+        tool_ctx,
+    )
+    assert "Error" in result and "not found" in result.lower()
+
+
+def test_invoke_source_is_file(
+    tool_ctx: ToolContext,
+    tmp_path: Path,
+) -> None:
+    """Error when source is a file, not a directory."""
+    assert tool_ctx.workspace is not None
+    (tool_ctx.workspace / "just-a-file.txt").write_text("not a dir")
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "just-a-file.txt", "target": str(tmp_path / "out")}),
+        tool_ctx,
+    )
+    assert "Error" in result and "not a directory" in result.lower()
+
+
+def test_invoke_no_workspace() -> None:
+    """Error when workspace is None."""
+    ctx = ToolContext(task_id="t", agent_id="a", workspace=None)
+    tool = ExportAgentTool()
+    result = tool.invoke(
+        json.dumps({"source": "my-agent", "target": "/tmp/out"}),
+        ctx,
+    )
+    assert "Error" in result and "workspace" in result.lower()

--- a/tests/tools/builtins/test_list_models.py
+++ b/tests/tools/builtins/test_list_models.py
@@ -1,0 +1,70 @@
+"""Unit tests for :mod:`omnigent.tools.builtins.list_models`."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from omnigent.spec.types import AgentSpec
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.list_models import SysListModelsTool
+
+
+def _make_spec() -> AgentSpec:
+    """Minimal AgentSpec for constructing the tool."""
+    return AgentSpec(spec_version=1)
+
+
+def _ctx() -> ToolContext:
+    return ToolContext(task_id="task_test", agent_id="agent_test")
+
+
+# ── Schema ───────────────────────────────────────────────
+
+
+def test_schema_shape() -> None:
+    """Schema is a function-type tool with no parameters."""
+    tool = SysListModelsTool(spec=_make_spec())
+    schema = tool.get_schema()
+    assert schema["type"] == "function"
+    func = schema["function"]
+    assert func["name"] == "sys_list_models"
+    assert func["parameters"]["properties"] == {}
+    assert func["parameters"]["required"] == []
+
+
+def test_name_and_description() -> None:
+    """Class methods return stable name and non-empty description."""
+    assert SysListModelsTool.name() == "sys_list_models"
+    assert len(SysListModelsTool.description()) > 0
+
+
+# ── Invoke ───────────────────────────────────────────────
+
+
+def test_invoke_returns_catalog(
+    monkeypatch: Any,
+) -> None:
+    """
+    invoke() delegates to catalog_for_spec and returns its JSON output.
+    """
+    fake_catalog = {
+        "self": {
+            "source": "env",
+            "verified": True,
+            "models": [{"id": "gpt-4o", "family": "openai"}],
+            "note": "",
+        },
+    }
+    with patch(
+        "omnigent.model_catalog.catalog_for_spec",
+        return_value=fake_catalog,
+    ) as mock_catalog:
+        tool = SysListModelsTool(spec=_make_spec())
+        result = tool.invoke("{}", _ctx())
+
+    mock_catalog.assert_called_once()
+    parsed = json.loads(result)
+    assert "self" in parsed
+    assert parsed["self"]["models"][0]["id"] == "gpt-4o"

--- a/tests/tools/builtins/test_policy.py
+++ b/tests/tools/builtins/test_policy.py
@@ -1,0 +1,77 @@
+"""Unit tests for :mod:`omnigent.tools.builtins.policy`."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.tools.builtins.policy import SysAddPolicyTool, SysPolicyRegistryTool
+
+# ── SysAddPolicyTool ─────────────────────────────────────
+
+
+class TestSysAddPolicyTool:
+    """Tests for the sys_add_policy tool schema."""
+
+    def test_name(self) -> None:
+        assert SysAddPolicyTool.name() == "sys_add_policy"
+
+    def test_description_non_empty(self) -> None:
+        assert len(SysAddPolicyTool.description()) > 0
+
+    def test_schema_shape(self) -> None:
+        tool = SysAddPolicyTool()
+        schema = tool.get_schema()
+        assert schema["type"] == "function"
+        func = schema["function"]
+        assert func["name"] == "sys_add_policy"
+        params = func["parameters"]
+        assert params["type"] == "object"
+        assert set(params["required"]) == {"name", "handler"}
+        props = params["properties"]
+        assert props["name"]["type"] == "string"
+        assert props["handler"]["type"] == "string"
+        assert props["factory_params"]["type"] == "object"
+
+    def test_invoke_raises_not_implemented(self) -> None:
+        """
+        sys_add_policy is runner-dispatched; invoking it in-process
+        raises NotImplementedError.
+        """
+        from omnigent.tools.base import ToolContext
+
+        tool = SysAddPolicyTool()
+        ctx = ToolContext(task_id="t", agent_id="a")
+        with pytest.raises(NotImplementedError):
+            tool.invoke("{}", ctx)
+
+
+# ── SysPolicyRegistryTool ────────────────────────────────
+
+
+class TestSysPolicyRegistryTool:
+    """Tests for the sys_policy_registry tool schema."""
+
+    def test_name(self) -> None:
+        assert SysPolicyRegistryTool.name() == "sys_policy_registry"
+
+    def test_description_non_empty(self) -> None:
+        assert len(SysPolicyRegistryTool.description()) > 0
+
+    def test_schema_shape(self) -> None:
+        tool = SysPolicyRegistryTool()
+        schema = tool.get_schema()
+        assert schema["type"] == "function"
+        func = schema["function"]
+        assert func["name"] == "sys_policy_registry"
+        params = func["parameters"]
+        assert params["properties"] == {}
+        assert params["required"] == []
+
+    def test_invoke_raises_not_implemented(self) -> None:
+        """Runner-dispatched; raises if called in-process."""
+        from omnigent.tools.base import ToolContext
+
+        tool = SysPolicyRegistryTool()
+        ctx = ToolContext(task_id="t", agent_id="a")
+        with pytest.raises(NotImplementedError):
+            tool.invoke("{}", ctx)

--- a/tests/tools/builtins/test_search_conversations.py
+++ b/tests/tools/builtins/test_search_conversations.py
@@ -1,0 +1,207 @@
+"""Unit tests for :mod:`omnigent.tools.builtins.search_conversations`."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from omnigent.entities.conversation import (
+    FunctionCallData,
+    FunctionCallOutputData,
+    MessageData,
+)
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.search_conversations import (
+    SearchConversationsTool,
+    _extract_text,
+    _format_results,
+)
+
+_CTX = ToolContext(task_id="task_test", agent_id="agent_test")
+
+
+# ── Stubs ────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeItem:
+    """Minimal stub for ConversationItem."""
+
+    id: str
+    response_id: str
+    created_at: int
+    type: str
+    data: Any
+
+
+class _FakeConversationStore:
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+
+    def search(self, query: str, limit: int = 10) -> list[Any]:
+        return self._items[:limit]
+
+
+def _message_data(text: str = "Hello world", role: str = "assistant") -> MessageData:
+    """Build a MessageData with a single text block."""
+    return MessageData(
+        role=role,
+        content=[{"text": text}],
+        agent="test-agent" if role == "assistant" else None,
+    )
+
+
+def _function_call_data() -> FunctionCallData:
+    return FunctionCallData(
+        agent="test-agent",
+        name="web_search",
+        arguments='{"query": "test"}',
+        call_id="call_1",
+    )
+
+
+def _function_call_output_data() -> FunctionCallOutputData:
+    return FunctionCallOutputData(
+        call_id="call_1",
+        output="Search results here",
+    )
+
+
+# ── Schema ───────────────────────────────────────────────
+
+
+def test_schema_shape() -> None:
+    """Schema requires 'query' and has optional 'limit'."""
+    tool = SearchConversationsTool()
+    schema = tool.get_schema()
+    assert schema["type"] == "function"
+    func = schema["function"]
+    assert func["name"] == "search_conversations"
+    assert "query" in func["parameters"]["required"]
+    props = func["parameters"]["properties"]
+    assert "query" in props
+    assert "limit" in props
+    assert props["query"]["type"] == "string"
+    assert props["limit"]["type"] == "integer"
+
+
+def test_name_and_description() -> None:
+    assert SearchConversationsTool.name() == "search_conversations"
+    assert len(SearchConversationsTool.description()) > 0
+
+
+# ── Invoke ───────────────────────────────────────────────
+
+
+def test_invoke_returns_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    """invoke() returns formatted search results."""
+    items = [
+        _FakeItem(
+            id="item_1",
+            response_id="conv_1",
+            created_at=1000,
+            type="message",
+            data=_message_data(),
+        ),
+    ]
+    monkeypatch.setattr(
+        "omnigent.runtime.get_conversation_store",
+        lambda: _FakeConversationStore(items),
+    )
+
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke('{"query": "hello"}', _CTX))
+    assert len(result["results"]) == 1
+    assert result["results"][0]["conversation_id"] == "conv_1"
+    assert result["results"][0]["text"] == "Hello world"
+    assert result["results"][0]["role"] == "assistant"
+
+
+def test_invoke_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    """invoke() returns empty results with a message."""
+    monkeypatch.setattr(
+        "omnigent.runtime.get_conversation_store",
+        lambda: _FakeConversationStore([]),
+    )
+
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke('{"query": "nothing"}', _CTX))
+    assert result["results"] == []
+    assert "message" in result
+
+
+def test_invoke_missing_query() -> None:
+    """invoke() returns error when query is missing."""
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke("{}", _CTX))
+    assert "error" in result
+
+
+def test_invoke_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """invoke() passes limit to the store."""
+    items = [_FakeItem(f"item_{i}", f"conv_{i}", i, "message", _message_data()) for i in range(20)]
+    store = _FakeConversationStore(items)
+    monkeypatch.setattr(
+        "omnigent.runtime.get_conversation_store",
+        lambda: store,
+    )
+
+    tool = SearchConversationsTool()
+    result = json.loads(tool.invoke('{"query": "test", "limit": 3}', _CTX))
+    assert len(result["results"]) == 3
+
+
+# ── _extract_text ────────────────────────────────────────
+
+
+def test_extract_text_message() -> None:
+    """Extract text from a message item."""
+    item = _FakeItem("i", "r", 0, "message", _message_data("Hello world"))
+    assert _extract_text(item) == "Hello world"
+
+
+def test_extract_text_function_call() -> None:
+    """Extract text from a function call item."""
+    item = _FakeItem("i", "r", 0, "function_call", _function_call_data())
+    text = _extract_text(item)
+    assert "web_search" in text
+    assert '{"query": "test"}' in text
+
+
+def test_extract_text_function_call_output() -> None:
+    """Extract text from a function call output item."""
+    item = _FakeItem("i", "r", 0, "function_call_output", _function_call_output_data())
+    assert _extract_text(item) == "Search results here"
+
+
+def test_extract_text_unknown_type() -> None:
+    """Unknown data type returns empty string."""
+
+    @dataclass
+    class _Unknown:
+        pass
+
+    item = _FakeItem("i", "r", 0, "unknown", _Unknown())
+    assert _extract_text(item) == ""
+
+
+# ── _format_results ──────────────────────────────────────
+
+
+def test_format_results_includes_all_fields() -> None:
+    """Each result has conversation_id, item_id, created_at, type."""
+    items = [
+        _FakeItem("i1", "conv_1", 1000, "message", _message_data()),
+    ]
+    results = _format_results(items)
+    assert len(results) == 1
+    r = results[0]
+    assert r["conversation_id"] == "conv_1"
+    assert r["item_id"] == "i1"
+    assert r["created_at"] == 1000
+    assert r["type"] == "message"
+    assert r["role"] == "assistant"
+    assert r["text"] == "Hello world"

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -1,0 +1,184 @@
+"""Unit tests for :mod:`omnigent.tools.base`.
+
+Covers ``ToolContext`` construction, ``Tool`` ABC contract, and the
+``is_valid_tool_name`` validator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent.tools.base import Tool, ToolContext, is_valid_tool_name
+
+# ── is_valid_tool_name ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "get_weather",
+        "web-search",
+        "a",
+        "A1_b2-c3",
+        "a" * 256,
+    ],
+    ids=["snake_case", "kebab-case", "single_char", "mixed", "max_length"],
+)
+def test_valid_names(name: str) -> None:
+    assert is_valid_tool_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "has space",
+        "has:colon",
+        "has.dot",
+        "a" * 257,
+        "hello world",
+    ],
+    ids=["empty", "space", "colon", "dot", "too_long", "multi_word"],
+)
+def test_invalid_names(name: str) -> None:
+    assert is_valid_tool_name(name) is False
+
+
+# ── ToolContext ──────────────────────────────────────────
+
+
+def test_tool_context_minimal() -> None:
+    """ToolContext with only required fields."""
+    ctx = ToolContext(task_id="t1", agent_id="a1")
+    assert ctx.task_id == "t1"
+    assert ctx.agent_id == "a1"
+    assert ctx.workspace is None
+    assert ctx.conversation_id is None
+
+
+def test_tool_context_full() -> None:
+    """ToolContext with all fields set."""
+    ws = Path("/tmp/workspace")
+    ctx = ToolContext(
+        task_id="t1",
+        agent_id="a1",
+        workspace=ws,
+        conversation_id="conv_123",
+    )
+    assert ctx.workspace == ws
+    assert ctx.conversation_id == "conv_123"
+
+
+def test_tool_context_is_frozen() -> None:
+    """ToolContext is immutable (frozen dataclass)."""
+    ctx = ToolContext(task_id="t", agent_id="a")
+    with pytest.raises(AttributeError):
+        ctx.task_id = "new"  # type: ignore[misc]
+
+
+# ── Tool ABC ─────────────────────────────────────────────
+
+
+def test_tool_abc_cannot_instantiate() -> None:
+    """Tool cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        Tool()  # type: ignore[abstract]
+
+
+def test_concrete_tool_subclass() -> None:
+    """A concrete Tool subclass can be instantiated and used."""
+
+    class DummyTool(Tool):
+        @classmethod
+        def name(cls) -> str:
+            return "dummy"
+
+        @classmethod
+        def description(cls) -> str:
+            return "A dummy tool."
+
+        def get_schema(self) -> dict[str, Any]:
+            return {
+                "type": "function",
+                "function": {
+                    "name": "dummy",
+                    "description": "A dummy tool.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+
+        def invoke(self, arguments: str, ctx: ToolContext) -> str:
+            return "ok"
+
+    tool = DummyTool()
+    assert tool.name() == "dummy"
+    assert tool.description() == "A dummy tool."
+    assert tool.get_schema()["function"]["name"] == "dummy"
+    ctx = ToolContext(task_id="t", agent_id="a")
+    assert tool.invoke("{}", ctx) == "ok"
+
+
+def test_default_invoke_raises() -> None:
+    """
+    The base Tool.invoke raises NotImplementedError for runner-dispatched
+    tools that don't override it.
+    """
+
+    class SchemaOnlyTool(Tool):
+        @classmethod
+        def name(cls) -> str:
+            return "schema_only"
+
+        @classmethod
+        def description(cls) -> str:
+            return "Schema only."
+
+        def get_schema(self) -> dict[str, Any]:
+            return {"type": "function", "function": {"name": "schema_only"}}
+
+    tool = SchemaOnlyTool()
+    ctx = ToolContext(task_id="t", agent_id="a")
+    with pytest.raises(NotImplementedError, match="runner-dispatched"):
+        tool.invoke("{}", ctx)
+
+
+def test_default_is_async_false() -> None:
+    """is_async() defaults to False."""
+
+    class SyncTool(Tool):
+        @classmethod
+        def name(cls) -> str:
+            return "sync"
+
+        @classmethod
+        def description(cls) -> str:
+            return "Sync."
+
+        def get_schema(self) -> dict[str, Any]:
+            return {}
+
+    tool = SyncTool()
+    assert tool.is_async() is False
+    assert tool.is_async(arguments='{"key": "value"}') is False
+
+
+def test_cancel_is_noop() -> None:
+    """cancel() is a no-op by default (does not raise)."""
+
+    class NoCancelTool(Tool):
+        @classmethod
+        def name(cls) -> str:
+            return "nc"
+
+        @classmethod
+        def description(cls) -> str:
+            return "No cancel."
+
+        def get_schema(self) -> dict[str, Any]:
+            return {}
+
+    tool = NoCancelTool()
+    tool.cancel()  # should not raise


### PR DESCRIPTION
## Summary
- Add unit tests for previously untested tool builtin modules: `list_models`, `export_agent`, `search_conversations`, `policy`, `agents`, and `base`
- Tests cover schema shapes, name/description class methods, argument parsing, mocked execution paths, and error handling
- 62 new tests across 6 test files, all passing

## Test plan
- [x] `python -m pytest tests/tools/test_base.py tests/tools/builtins/test_list_models.py tests/tools/builtins/test_export_agent.py tests/tools/builtins/test_search_conversations.py tests/tools/builtins/test_policy.py tests/tools/builtins/test_agents.py -v --timeout=30` — 62 passed
- [x] `ruff format` and `ruff check` pass with no issues

This pull request and its description were written by Isaac.