### PR TITLE
feat(native): gate the request phase for native terminal sessions

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1152,6 +1152,15 @@ def build_hook_settings(
         # a catch-all policy evaluation entry so TOOL_RESULT policies
         # fire for all tools, not just the forwarder-specific ones.
         hooks["PostToolUse"].append({"hooks": [evaluate_policy_hook]})
+        # UserPromptSubmit already carries the transcript forwarder's
+        # status hook (running). Append the policy hook so REQUEST-phase
+        # policies gate native prompts — for native sessions this is the
+        # sole request gate (the server-level ``_evaluate_input_policy``
+        # skips native message events). A DENY emits ``decision: "block"``,
+        # dropping the prompt before the model sees it; ASK is resolved
+        # server-side. Covers both web-UI-injected and direct-terminal
+        # prompts, since both fire UserPromptSubmit.
+        hooks["UserPromptSubmit"].append({"hooks": [evaluate_policy_hook]})
     settings: dict[str, Any] = {"hooks": hooks}
     if api_key_helper:
         settings["apiKeyHelper"] = api_key_helper

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -713,22 +713,30 @@ def _main_ask_user_question(argv: list[str]) -> int:
 
 def _main_evaluate_policy(argv: list[str]) -> int:
     """
-    Evaluate a Claude Code ``PreToolUse`` or ``PostToolUse`` hook against Omnigent policies.
+    Evaluate a Claude Code ``PreToolUse`` / ``PostToolUse`` /
+    ``UserPromptSubmit`` hook against Omnigent policies.
 
     Reads the hook JSON payload from stdin, converts it into the
     proto-compatible ``EvaluationRequest`` schema (``PHASE_TOOL_CALL``
-    for PreToolUse, ``PHASE_TOOL_RESULT`` for PostToolUse), POSTs to
+    for PreToolUse, ``PHASE_TOOL_RESULT`` for PostToolUse,
+    ``PHASE_REQUEST`` for UserPromptSubmit), POSTs to
     ``/v1/sessions/{id}/policies/evaluate``, and converts the
     ``EvaluationResponse`` back into Claude Code's hook output format.
 
-    For ``PreToolUse``, only constraining verdicts map to a
-    ``permissionDecision``: ``POLICY_ACTION_DENY`` → ``"deny"`` and
-    ``POLICY_ACTION_ASK`` → ``"defer"`` (falls through to the
-    ``PermissionRequest`` hook for interactive approval).
-    ``POLICY_ACTION_ALLOW`` (the engine's default when no policy matches)
-    emits no output — "no opinion" — so Claude's own permission prompt
-    still fires and the ``PermissionRequest`` hook can route it to the
-    web UI. See :func:`omnigent.native_policy_hook.evaluation_response_to_hook_output`.
+    For ``PreToolUse``, only the constraining ``POLICY_ACTION_DENY``
+    verdict maps to a ``permissionDecision`` (``"deny"``); ASK is
+    resolved server-side (the endpoint parks via ``_hold_native_ask_gate``
+    and returns a hard ALLOW/DENY). ``POLICY_ACTION_ALLOW`` (the engine's
+    default when no policy matches) emits no output — "no opinion" — so
+    Claude's own permission prompt still fires and the
+    ``PermissionRequest`` hook can route it to the web UI. See
+    :func:`omnigent.native_policy_hook.evaluation_response_to_hook_output`.
+
+    For ``UserPromptSubmit``, this is the request-phase gate for native
+    sessions (the server-level ``_evaluate_input_policy`` skips native
+    message events). A DENY emits top-level ``decision: "block"``, which
+    drops the prompt before the model sees it; ASK is resolved
+    server-side; ALLOW proceeds with no output.
 
     For ``PostToolUse``, policy denials are surfaced as
     ``additionalContext`` (Claude sees the warning but the tool result

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -802,11 +802,14 @@ def _codex_policy_hooks_settings(
     """
     Build the ``hooks.json`` payload registering the policy hook.
 
-    Registers one catch-all (no ``matcher``) command hook on both
-    ``PreToolUse`` (blocks before execution) and ``PostToolUse`` (warns
-    after). ``mcp__*`` tools are filtered out inside the hook itself, not
-    by a matcher, so the relay path remains the single MCP enforcement
-    point.
+    Registers one catch-all (no ``matcher``) command hook on
+    ``PreToolUse`` (blocks before execution), ``PostToolUse`` (warns
+    after), and ``UserPromptSubmit`` (blocks a user prompt before the
+    model sees it — the request-phase gate for native sessions, since
+    the server-level ``_evaluate_input_policy`` skips native message
+    events). ``mcp__*`` tools are filtered out inside the hook itself,
+    not by a matcher, so the relay path remains the single MCP
+    enforcement point.
 
     :param bridge_dir: Native Codex bridge directory.
     :param python_executable: Python executable for the hook command.
@@ -817,7 +820,13 @@ def _codex_policy_hooks_settings(
         "command": _codex_policy_hook_command(bridge_dir, python_executable),
         "timeout": _POLICY_HOOK_TIMEOUT_SECONDS,
     }
-    return {"hooks": {"PreToolUse": [{"hooks": [hook]}], "PostToolUse": [{"hooks": [hook]}]}}
+    return {
+        "hooks": {
+            "PreToolUse": [{"hooks": [hook]}],
+            "PostToolUse": [{"hooks": [hook]}],
+            "UserPromptSubmit": [{"hooks": [hook]}],
+        }
+    }
 
 
 def _write_codex_policy_hooks_file(

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -61,7 +61,8 @@ def main(argv: list[str] | None = None) -> int:
 
 def _main_evaluate_policy(argv: list[str]) -> int:
     """
-    Evaluate a Codex ``PreToolUse`` or ``PostToolUse`` hook against Omnigent policies.
+    Evaluate a Codex ``PreToolUse`` / ``PostToolUse`` /
+    ``UserPromptSubmit`` hook against Omnigent policies.
 
     Reads the hook JSON payload from stdin, converts it into the
     proto-compatible ``EvaluationRequest`` schema via
@@ -69,7 +70,9 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     POSTs to ``/v1/sessions/{id}/policies/evaluate``, and converts the
     ``EvaluationResponse`` back into Codex's hook output format
     (``hookSpecificOutput.permissionDecision`` for PreToolUse;
-    ``additionalContext`` warning for PostToolUse).
+    ``additionalContext`` warning for PostToolUse; top-level
+    ``decision: "block"`` for UserPromptSubmit — the request-phase gate
+    for native sessions, which drops the prompt before the model runs).
 
     On any transport or lookup failure the hook returns exit 0 with no
     output, which Codex treats as "no opinion". This is the deliberate

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -1,24 +1,38 @@
-"""Shared conversion between native-harness tool hooks and Omnigent policy events.
+"""Shared conversion between native-harness hooks and Omnigent policy events.
 
 Both Claude Code and Codex expose a command-hook system whose
 ``PreToolUse`` / ``PostToolUse`` payloads use the same field names
 (``hook_event_name``, ``tool_name``, ``tool_input``, ``tool_output``)
-and the same ``hookSpecificOutput.permissionDecision`` output contract.
-This module owns the harness-neutral translation between that hook shape
-and the server's proto-compatible ``EvaluationRequest`` /
-``EvaluationResponse`` schema served by
+and whose ``UserPromptSubmit`` payload carries the user prompt under
+``prompt``. This module owns the harness-neutral translation between
+that hook shape and the server's proto-compatible ``EvaluationRequest``
+/ ``EvaluationResponse`` schema served by
 ``POST /v1/sessions/{id}/policies/evaluate``, so the per-harness hook
 entrypoints (:mod:`omnigent.claude_native_hook`,
 :mod:`omnigent.codex_native_hook`) share one implementation.
+
+The output contract differs by hook event: ``PreToolUse`` enforces via
+``hookSpecificOutput.permissionDecision``, while ``UserPromptSubmit``
+enforces via the top-level ``decision`` / ``reason`` fields (both
+harnesses parse ``decision: "block"`` to drop the prompt before the
+model sees it).
 """
 
 from __future__ import annotations
+
+import json
 
 # Hook event names that gate tool execution and therefore carry policy
 # meaning. ``PreToolUse`` fires before the tool runs (can block);
 # ``PostToolUse`` fires after (observational — can only warn).
 _PRE_TOOL_USE = "PreToolUse"
 _POST_TOOL_USE = "PostToolUse"
+# ``UserPromptSubmit`` fires when a new user prompt reaches the harness —
+# for native sessions this is the request-phase gate (the server-level
+# ``_evaluate_input_policy`` is bypassed for native message events, so
+# this hook is the sole REQUEST gate and covers both web-UI-injected and
+# direct-terminal prompts). It can block the prompt before the model runs.
+_USER_PROMPT_SUBMIT = "UserPromptSubmit"
 
 
 def hook_payload_to_evaluation_request(
@@ -28,8 +42,10 @@ def hook_payload_to_evaluation_request(
     """
     Convert a native-harness tool-hook payload into a proto ``EvaluationRequest``.
 
-    Maps ``PreToolUse`` to a ``PHASE_TOOL_CALL`` event and
-    ``PostToolUse`` to a ``PHASE_TOOL_RESULT`` event. Omnigent MCP tools
+    Maps ``PreToolUse`` to a ``PHASE_TOOL_CALL`` event, ``PostToolUse``
+    to a ``PHASE_TOOL_RESULT`` event, and ``UserPromptSubmit`` to a
+    ``PHASE_REQUEST`` event (the prompt text from the payload's
+    ``prompt`` field becomes the request content). Omnigent MCP tools
     (``mcp__omnigent__*``) are skipped because they are already
     policy-checked by the relay path (``ProxyMcpManager`` → Omnigent
     ``/mcp`` endpoint → ``_evaluate_tool_call_policy``); evaluating
@@ -37,8 +53,8 @@ def hook_payload_to_evaluation_request(
     (for example ``mcp__github__*``) still need this pre-call gate.
 
     :param hook_event: Hook event name from the payload's
-        ``hook_event_name`` field, e.g. ``"PreToolUse"`` or
-        ``"PostToolUse"``.
+        ``hook_event_name`` field, e.g. ``"PreToolUse"``,
+        ``"PostToolUse"``, or ``"UserPromptSubmit"``.
     :param payload: Raw hook JSON from the harness, e.g.
         ``{"hook_event_name": "PreToolUse", "tool_name": "Bash",
         "tool_input": {"command": "rm -rf /"}}``.
@@ -46,6 +62,20 @@ def hook_payload_to_evaluation_request(
         ``/policies/evaluate``, or ``None`` when the event is not
         policy-relevant (unknown event or an ``mcp__omnigent__*`` tool).
     """
+    if hook_event == _USER_PROMPT_SUBMIT:
+        # Request-phase gate for native sessions. The server reads REQUEST
+        # content from ``data.text`` (see ``_build_evaluation_context``).
+        prompt = payload.get("prompt", "")
+        return {
+            "event": {
+                "type": "PHASE_REQUEST",
+                "target": "",
+                "data": {
+                    "text": prompt if isinstance(prompt, str) else json.dumps(prompt),
+                },
+                "context": {},
+            },
+        }
     tool_name = payload.get("tool_name", "")
     # Omnigent MCP tools are already policy-checked by the relay path
     # (ProxyMcpManager → Omnigent /mcp endpoint → _evaluate_tool_call_policy).
@@ -115,11 +145,21 @@ def evaluation_response_to_hook_output(
     ``additionalContext`` because the tool result is already committed
     — PostToolUse hooks cannot block.
 
-    Both Claude Code and Codex consume this exact output shape, so the
+    For ``UserPromptSubmit`` the output uses the top-level ``decision`` /
+    ``reason`` contract (not ``permissionDecision``): ``DENY`` → ``{"decision":
+    "block", "reason": ...}``, which drops the prompt before the model sees
+    it. ASK is resolved server-side (``_hold_native_ask_gate`` collapses it
+    to a hard ALLOW/DENY before the response reaches the hook), so the hook
+    should never see ASK; if it somehow does, it fails closed by blocking.
+    ALLOW (and the engine's no-match default) returns ``None`` so the prompt
+    proceeds. Unlike ``PreToolUse``, there is no separate user-consent gate
+    on a prompt, so ALLOW need not preserve one.
+
+    Both Claude Code and Codex consume these exact output shapes, so the
     ``hookEventName`` echoed back is the harness-supplied ``hook_event``.
 
-    :param hook_event: Hook event name, e.g. ``"PreToolUse"`` or
-        ``"PostToolUse"``.
+    :param hook_event: Hook event name, e.g. ``"PreToolUse"``,
+        ``"PostToolUse"``, or ``"UserPromptSubmit"``.
     :param eval_response: Parsed ``EvaluationResponse`` from AP, e.g.
         ``{"result": "POLICY_ACTION_DENY", "reason": "blocked by policy"}``.
     :returns: Hook output dict for the harness to read on stdout, or
@@ -128,6 +168,19 @@ def evaluation_response_to_hook_output(
     """
     action = eval_response.get("result", "POLICY_ACTION_UNSPECIFIED")
     reason = eval_response.get("reason")
+
+    if hook_event == _USER_PROMPT_SUBMIT:
+        # DENY blocks the prompt; a stray ASK fails closed (also block) since
+        # ASK is meant to be resolved server-side before reaching the hook.
+        # ALLOW / no-match → None so the prompt proceeds. A non-empty reason
+        # is required for the block to take effect (both harnesses drop a
+        # block with an empty reason), so default one in.
+        if action in ("POLICY_ACTION_DENY", "POLICY_ACTION_ASK"):
+            return {
+                "decision": "block",
+                "reason": reason or "Denied by policy",
+            }
+        return None
 
     if hook_event == _PRE_TOOL_USE:
         # ALLOW (the engine default when no policy matches) is omitted → None,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6871,10 +6871,11 @@ def create_runner_app(
         Covers the case where the ASK fired while no terminal client was
         attached (the user was in the web Chat), then the user opens the
         Terminal: on attach this re-checks the session snapshot and, if a
-        native approval is still outstanding — the server-side
-        tool-policy gate (``TOOL_CALL`` / ``LLM_REQUEST``, e.g. a
-        cost-budget checkpoint) — pops it on the now-attached
-        client. Self-correcting — it only pops while the elicitation is still
+        native approval is still outstanding — the server-side policy gate
+        (``TOOL_CALL`` / ``LLM_REQUEST``, e.g. a cost-budget checkpoint, or
+        the ``REQUEST`` gate a native session enforces via the
+        ``UserPromptSubmit`` hook) — pops it on the now-attached client.
+        Self-correcting — it only pops while the elicitation is still
         pending, so an already-answered approval is not re-shown. Complements
         the ASK-time forward (which covers clients attached *before* the
         ASK). Best-effort: any miss leaves the web card.
@@ -6903,17 +6904,21 @@ def create_runner_app(
         if resp.status_code != 200:
             return
         pending = resp.json().get("pending_elicitations") or []
-        # The native popup surfaces the server-side tool-policy gate
-        # (tool_call / llm_request — including cost-budget checkpoints),
-        # which parks and resolves via the same endpoint. Re-pop whichever
-        # is pending.
+        # The native popup surfaces the server-side policy gate, which parks
+        # and resolves via the same endpoint. Re-pop whichever is pending:
+        # the tool-policy gate (tool_call / llm_request — including
+        # cost-budget checkpoints) and the request-phase gate (request),
+        # which native sessions enforce via the UserPromptSubmit hook. A
+        # request-phase ASK typically fires while the user is in the web
+        # Chat (no client attached), so the on-attach re-pop is its main
+        # path onto the terminal.
         approval = next(
             (
                 e
                 for e in pending
                 if isinstance(e, dict)
                 and isinstance(e.get("params"), dict)
-                and e["params"].get("phase") in ("tool_call", "llm_request")
+                and e["params"].get("phase") in ("request", "tool_call", "llm_request")
             ),
             None,
         )

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -13569,6 +13569,10 @@ def create_sessions_router(
         "PHASE_TOOL_RESULT": Phase.TOOL_RESULT,
         "PHASE_LLM_REQUEST": Phase.LLM_REQUEST,
         "PHASE_LLM_RESPONSE": Phase.LLM_RESPONSE,
+        # A native session's UserPromptSubmit hook posts the request phase
+        # here (the server-level _evaluate_input_policy skips native message
+        # events). The prompt text rides in ``event.data.text``.
+        "PHASE_REQUEST": Phase.REQUEST,
     }
     _PHASE_TO_PROTO_ACTION: dict[PolicyAction, str] = {
         PolicyAction.ALLOW: "POLICY_ACTION_ALLOW",
@@ -13654,6 +13658,22 @@ def create_sessions_router(
                 f"Session {session_id!r} not found.",
                 code=ErrorCode.NOT_FOUND,
             )
+        # Dedup the native request-phase gate. A native session's
+        # ``UserPromptSubmit`` hook posts ``PHASE_REQUEST`` here for *every*
+        # prompt, but a web-UI prompt was already gated server-side by
+        # ``_evaluate_input_policy`` at POST /events (before injection, so no
+        # TUI freeze). Re-gating it here would double-prompt the human. A
+        # web-UI prompt in flight has a ``pending_inputs`` entry (recorded at
+        # dispatch, drained when the forwarder mirrors it back); a prompt
+        # typed directly in the TUI has none and never hit POST /events, so it
+        # is gated here — the hook is its only request-phase gate. The signal
+        # is "is a web prompt in flight", not text correlation (the native
+        # transcript gives no reliable id channel — see ``pending_inputs``).
+        if phase == Phase.REQUEST and pending_inputs.snapshot_for(session_id):
+            return Response(
+                content=json.dumps({"result": "POLICY_ACTION_ALLOW"}),
+                media_type="application/json",
+            )
         agent = agent_store.get(conv.agent_id) if conv.agent_id else None
         if agent is None:
             # No agent — no policies. Return unspecified (pass-through).
@@ -13705,9 +13725,15 @@ def create_sessions_router(
         # the human. Instead we publish the approval elicitation, park
         # until the human resolves it via the resolve URL, and collapse
         # to a hard ALLOW / DENY so the caller never sees ASK.
-        # TOOL_CALL and LLM_REQUEST are the two phases that can block
-        # execution before it starts (tool dispatch / LLM call).
-        if result.action == PolicyAction.ASK and phase in (Phase.TOOL_CALL, Phase.LLM_REQUEST):
+        # TOOL_CALL, LLM_REQUEST, and REQUEST are the phases that can block
+        # before the action proceeds (tool dispatch / LLM call / a native
+        # session's user prompt via the UserPromptSubmit hook — which has no
+        # ASK primitive of its own, so the server resolves ASK here).
+        if result.action == PolicyAction.ASK and phase in (
+            Phase.TOOL_CALL,
+            Phase.LLM_REQUEST,
+            Phase.REQUEST,
+        ):
             if is_read_only:
                 # Read-only callers must not enter the ASK gate — parking
                 # creates an elicitation (a server-side mutation). Return
@@ -13729,6 +13755,7 @@ def create_sessions_router(
                     if result.action == PolicyAction.ASK and phase in (
                         Phase.TOOL_CALL,
                         Phase.LLM_REQUEST,
+                        Phase.REQUEST,
                     ):
                         approved = await _hold_native_ask_gate(
                             request,

--- a/tests/server/integration/test_sessions_policy_evaluate_read_only.py
+++ b/tests/server/integration/test_sessions_policy_evaluate_read_only.py
@@ -29,7 +29,7 @@ from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.caps import RuntimeCaps
 from omnigent.server.app import create_app
 from omnigent.server.auth import LEVEL_EDIT, LEVEL_READ
-from omnigent.spec.types import FunctionPolicySpec, FunctionRef
+from omnigent.spec.types import FunctionPolicySpec, FunctionRef, Phase
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
@@ -63,6 +63,22 @@ def _allow_and_label(event: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _ask_on_request(event: dict[str, Any]) -> dict[str, Any]:
+    """
+    Policy that demands approval (ASK) for every event.
+
+    Used to exercise the endpoint's server-side ASK park on the REQUEST
+    phase — the phase a native session's ``UserPromptSubmit`` hook hits.
+
+    :param event: V0 event dict.
+    :returns: ASK with a reason.
+    """
+    return {
+        "result": "ASK",
+        "reason": "Prompt requires approval",
+    }
+
+
 # ── Helpers ──────────────────────────────────────────────────────
 
 OWNER = "owner@example.com"
@@ -82,6 +98,23 @@ def _tool_call_request(tool_name: str = "Bash") -> dict[str, Any]:
             "type": "PHASE_TOOL_CALL",
             "target": "",
             "data": {"name": tool_name, "arguments": {}},
+            "context": {},
+        },
+    }
+
+
+def _request_request(text: str = "do the thing") -> dict[str, Any]:
+    """
+    Build a PHASE_REQUEST EvaluationRequest (the UserPromptSubmit shape).
+
+    :param text: The user prompt text.
+    :returns: EvaluationRequest JSON dict.
+    """
+    return {
+        "event": {
+            "type": "PHASE_REQUEST",
+            "target": "",
+            "data": {"text": text},
             "context": {},
         },
     }
@@ -310,3 +343,167 @@ async def test_edit_caller_persists_labels_as_before(
     assert labels_after.get("evaluated") == "true", (
         "LEVEL_EDIT caller's policy evaluation must still persist labels"
     )
+
+
+async def test_request_phase_ask_parks_server_side_and_collapses_to_allow(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    db_uri: str,
+) -> None:
+    """
+    A REQUEST-phase ASK is parked server-side and collapses to a hard verdict.
+
+    This is the path a native session's ``UserPromptSubmit`` hook takes: it
+    POSTs a PHASE_REQUEST event and must NEVER see raw ASK (the hook has no
+    ASK primitive — it can only block or allow). The endpoint holds the gate
+    via ``_hold_native_ask_gate`` and returns ALLOW on approve / DENY on
+    decline. Before REQUEST was added to the endpoint's ASK-park phases, this
+    returned a raw ``POLICY_ACTION_ASK`` the hook couldn't act on safely.
+    """
+    held: dict[str, Any] = {}
+
+    async def _fake_hold(_request: Any, **kwargs: Any) -> bool:
+        held["phase"] = kwargs["phase"]
+        return True  # human approved
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._hold_native_ask_gate",
+        _fake_hold,
+    )
+    ask_policy = FunctionPolicySpec(
+        name="admin__ask",
+        on=None,
+        function=FunctionRef(path=f"{__name__}._ask_on_request"),
+    )
+    original_caps = get_caps()
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_caps",
+        lambda: RuntimeCaps(
+            execution_timeout=original_caps.execution_timeout,
+            default_policies=[ask_policy],
+        ),
+    )
+
+    agent = await create_test_agent(auth_client, user=OWNER)
+    session_id = await _create_session_as(auth_client, OWNER, agent["id"])
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json=_request_request("delete prod"),
+        headers={"X-Forwarded-Email": OWNER},
+    )
+    assert resp.status_code == 200, resp.text
+    # The gate was entered AT the REQUEST phase (not skipped as a raw ASK).
+    assert held.get("phase") == Phase.REQUEST
+    # Approval collapses the ASK to a hard ALLOW — the hook never sees ASK.
+    assert resp.json()["result"] == "POLICY_ACTION_ALLOW"
+
+
+async def test_request_phase_ask_decline_collapses_to_deny(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    db_uri: str,
+) -> None:
+    """
+    A declined / timed-out REQUEST-phase ASK collapses to DENY (fail closed).
+
+    The companion to the approve case: when the human declines (or the park
+    times out / disconnects), the endpoint returns DENY so the native hook
+    blocks the prompt rather than letting it through.
+    """
+
+    async def _fake_hold(_request: Any, **_kwargs: Any) -> bool:
+        return False  # declined / timeout
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._hold_native_ask_gate",
+        _fake_hold,
+    )
+    ask_policy = FunctionPolicySpec(
+        name="admin__ask",
+        on=None,
+        function=FunctionRef(path=f"{__name__}._ask_on_request"),
+    )
+    original_caps = get_caps()
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_caps",
+        lambda: RuntimeCaps(
+            execution_timeout=original_caps.execution_timeout,
+            default_policies=[ask_policy],
+        ),
+    )
+
+    agent = await create_test_agent(auth_client, user=OWNER)
+    session_id = await _create_session_as(auth_client, OWNER, agent["id"])
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/policies/evaluate",
+        json=_request_request("delete prod"),
+        headers={"X-Forwarded-Email": OWNER},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["result"] == "POLICY_ACTION_DENY"
+
+
+async def test_request_phase_skips_gate_when_web_prompt_pending(
+    auth_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    db_uri: str,
+) -> None:
+    """
+    A REQUEST-phase eval is skipped (ALLOW) when a web prompt is in flight.
+
+    A native session's ``UserPromptSubmit`` hook posts ``PHASE_REQUEST`` for
+    every prompt, but a web-UI prompt was already gated server-side by
+    ``_evaluate_input_policy`` before injection. The presence of a
+    ``pending_inputs`` entry marks the prompt as web-origin, so the endpoint
+    short-circuits to ALLOW rather than re-gating (which would double-prompt
+    the human). If the dedup regressed, the ASK policy below would enter the
+    gate instead of returning a clean ALLOW.
+    """
+    from omnigent.runtime import pending_inputs
+
+    # If the dedup is bypassed and the gate runs, this records the failure.
+    gate_ran = {"called": False}
+
+    async def _fail_hold(_request: Any, **_kwargs: Any) -> bool:
+        gate_ran["called"] = True
+        return True
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._hold_native_ask_gate",
+        _fail_hold,
+    )
+    ask_policy = FunctionPolicySpec(
+        name="admin__ask",
+        on=None,
+        function=FunctionRef(path=f"{__name__}._ask_on_request"),
+    )
+    original_caps = get_caps()
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_caps",
+        lambda: RuntimeCaps(
+            execution_timeout=original_caps.execution_timeout,
+            default_policies=[ask_policy],
+        ),
+    )
+
+    agent = await create_test_agent(auth_client, user=OWNER)
+    session_id = await _create_session_as(auth_client, OWNER, agent["id"])
+
+    # Mark a web-composer prompt as in flight (recorded at POST /events for a
+    # native session, before the runner forward).
+    pending_inputs.record(session_id, [{"type": "input_text", "text": "delete prod"}])
+    try:
+        resp = await auth_client.post(
+            f"/v1/sessions/{session_id}/policies/evaluate",
+            json=_request_request("delete prod"),
+            headers={"X-Forwarded-Email": OWNER},
+        )
+    finally:
+        pending_inputs.reset_for_tests()
+
+    assert resp.status_code == 200, resp.text
+    # Skipped → clean ALLOW, and the ASK gate was never entered.
+    assert resp.json()["result"] == "POLICY_ACTION_ALLOW"
+    assert gate_ran["called"] is False, "dedup must skip the gate when a web prompt is pending"

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2029,6 +2029,61 @@ def test_augment_claude_args_registers_permission_command_hook(
     assert "omnigent.claude_native_status" in settings["statusLine"]["command"]
 
 
+def test_augment_claude_args_registers_user_prompt_submit_policy_hook(
+    tmp_path: Path,
+) -> None:
+    """
+    Passing ``ap_server_url`` wires the evaluate-policy hook onto
+    ``UserPromptSubmit`` alongside the transcript forwarder's status hook.
+
+    For native sessions the server-level ``_evaluate_input_policy`` skips
+    message events, so this hook is the sole REQUEST-phase gate (covering
+    both web-UI-injected and direct-terminal prompts). If it regressed,
+    native prompts would reach the model with no request-phase policy. The
+    forwarder's own UserPromptSubmit hook (status → running) must survive,
+    so the policy hook is appended, not substituted.
+    """
+    args = augment_claude_args(
+        (),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+        ap_server_url="http://127.0.0.1:8787/",
+        ap_auth_headers={"Authorization": "Bearer xyz"},
+    )
+    settings = json.loads(args[args.index("--settings") + 1])
+    entries = settings["hooks"]["UserPromptSubmit"]
+    commands = [h["command"] for entry in entries for h in entry["hooks"]]
+    # The forwarder status hook stays; the policy hook is appended.
+    assert any("evaluate-policy" in command for command in commands), (
+        f"UserPromptSubmit must carry the evaluate-policy hook; got {commands!r}."
+    )
+    assert any("evaluate-policy" not in command for command in commands), (
+        "The transcript forwarder's UserPromptSubmit hook must not be replaced."
+    )
+
+
+def test_augment_claude_args_omits_user_prompt_submit_policy_hook_without_server(
+    tmp_path: Path,
+) -> None:
+    """
+    Without ``ap_server_url`` the UserPromptSubmit policy hook is not wired.
+
+    Policy hooks only make sense when an Omnigent server is configured to
+    evaluate against; the forwarder's status hook still registers, but no
+    evaluate-policy command should appear (mirrors PreToolUse/PostToolUse,
+    which are also gated behind ``ap_server_url``).
+    """
+    args = augment_claude_args(
+        (),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+    settings = json.loads(args[args.index("--settings") + 1])
+    entries = settings["hooks"]["UserPromptSubmit"]
+    commands = [h["command"] for entry in entries for h in entry["hooks"]]
+    assert all("evaluate-policy" not in command for command in commands)
+
+
 def test_augment_claude_args_keeps_permission_hook_without_launch_session_id(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1028,6 +1028,18 @@ def test_build_hook_settings_registers_policy_hooks_when_omnigent_server_url_set
     # The last entry is the catch-all policy evaluation hook.
     policy_entry_cmd = post_tool_use_entries[-1]["hooks"][0]["command"]
     assert "evaluate-policy" in policy_entry_cmd
+    # UserPromptSubmit carries the forwarder's status hook PLUS the policy
+    # hook appended as a catch-all. For native sessions this is the sole
+    # REQUEST-phase gate (the server-level _evaluate_input_policy skips
+    # native message events), so a missing policy hook here means native
+    # prompts reach the model with no request-phase policy.
+    user_prompt_entries = hooks["UserPromptSubmit"]
+    user_prompt_cmds = [h["command"] for entry in user_prompt_entries for h in entry["hooks"]]
+    assert any("evaluate-policy" in cmd for cmd in user_prompt_cmds), (
+        f"UserPromptSubmit policy hook not registered; got {user_prompt_cmds!r}"
+    )
+    # The forwarder's status hook must survive (the policy hook is appended).
+    assert any("evaluate-policy" not in cmd for cmd in user_prompt_cmds)
 
 
 def test_build_hook_settings_registers_message_display_hook(

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -686,17 +686,37 @@ def test_policy_hooks_timeout_outlasts_the_hooks_request_budget() -> None:
     """
     settings = _codex_policy_hooks_settings(Path("/b"), "/venv/bin/python")
     hooks = settings["hooks"]
-    # Both phases register the same command hook; assert the timeout on each so
-    # neither can silently regress independently.
+    # All registered phases share the same command hook; assert the timeout on
+    # each so none can silently regress independently. UserPromptSubmit gates
+    # the request phase and also blocks on a server-side ASK park, so it needs
+    # the same generous timeout as the tool phases.
     pre = hooks["PreToolUse"][0]["hooks"][0]
     post = hooks["PostToolUse"][0]["hooks"][0]
+    prompt = hooks["UserPromptSubmit"][0]["hooks"][0]
     assert pre["timeout"] == _POLICY_HOOK_TIMEOUT_SECONDS
     assert post["timeout"] == _POLICY_HOOK_TIMEOUT_SECONDS
+    assert prompt["timeout"] == _POLICY_HOOK_TIMEOUT_SECONDS
     # The invariant that actually prevents the bug: codex must wait at least as
     # long as the hook itself will block on the server. If this fails (e.g. the
     # constant is dropped back to 30), the gate becomes advisory for every
     # native tool call, sub-agent or not.
     assert _POLICY_HOOK_TIMEOUT_SECONDS >= _EVALUATE_POLICY_TIMEOUT_S
+
+
+def test_policy_hooks_register_user_prompt_submit() -> None:
+    """The request-phase gate must be wired onto UserPromptSubmit.
+
+    For native sessions the server-level ``_evaluate_input_policy`` skips
+    message events, so this hook is the sole REQUEST gate. If it were dropped
+    from ``hooks.json``, native prompts (web-UI-injected and direct-terminal
+    alike) would reach the model with no request-phase policy at all.
+    """
+    settings = _codex_policy_hooks_settings(Path("/b"), "/venv/bin/python")
+    hooks = settings["hooks"]
+    assert "UserPromptSubmit" in hooks
+    prompt_hook = hooks["UserPromptSubmit"][0]["hooks"][0]
+    # Same evaluate-policy command as the tool phases.
+    assert prompt_hook["command"] == hooks["PreToolUse"][0]["hooks"][0]["command"]
 
 
 class TestPinCodexConfigModel:

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -225,6 +225,49 @@ def test_pre_tool_use_converts_posts_and_returns_deny(
     assert captured.err == ""
 
 
+def test_user_prompt_submit_converts_posts_and_blocks(
+    bridge_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    A UserPromptSubmit hook converts to PHASE_REQUEST and maps DENY to block.
+
+    This is the request-phase enforcement path for native Codex sessions
+    (the server-level ``_evaluate_input_policy`` skips native message
+    events). The prompt rides in ``event.data.text``; a DENY maps to the
+    top-level ``decision: "block"`` contract — NOT ``permissionDecision`` —
+    which drops the prompt before the model sees it. A break here means a
+    blocked prompt would still reach the model.
+    """
+    _DenyHttpxClient.captured = {}
+    write_policy_hook_config(
+        bridge_dir,
+        ap_server_url="http://127.0.0.1:8787",
+        ap_auth_headers={"Authorization": "Bearer test-token"},
+    )
+    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+
+    exit_code = _run_hook(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "delete the prod database",
+        },
+        monkeypatch,
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    sent = _DenyHttpxClient.captured["json"]
+    assert sent["event"]["type"] == "PHASE_REQUEST"
+    assert sent["event"]["data"] == {"text": "delete the prod database"}
+    # DENY → top-level decision/reason block (not permissionDecision).
+    result = json.loads(captured.out)
+    assert result == {"decision": "block", "reason": "rm blocked by admin policy"}
+    assert captured.err == ""
+
+
 def test_pre_tool_use_stamps_model_from_config(
     bridge_dir: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -230,3 +230,83 @@ def test_post_tool_use_allow_returns_none() -> None:
     """
     output = evaluation_response_to_hook_output("PostToolUse", {"result": "POLICY_ACTION_ALLOW"})
     assert output is None
+
+
+def test_user_prompt_submit_maps_to_phase_request() -> None:
+    """
+    A UserPromptSubmit payload becomes a PHASE_REQUEST EvaluationRequest.
+
+    The prompt text must land in ``event.data.text`` because the server's
+    ``_build_evaluation_context`` reads REQUEST content from ``data.text``
+    (falling back to ``data.content``). If the prompt were dropped, the
+    request-phase gate would evaluate empty content and ALLOW everything.
+    """
+    result = hook_payload_to_evaluation_request(
+        "UserPromptSubmit",
+        {"prompt": "delete the prod database"},
+    )
+    assert result is not None
+    event = result["event"]
+    assert event["type"] == "PHASE_REQUEST"
+    assert event["data"] == {"text": "delete the prod database"}
+    # A context dict must exist so the per-harness hook can stamp model/harness.
+    assert event["context"] == {}
+
+
+def test_user_prompt_submit_missing_prompt_yields_empty_text() -> None:
+    """
+    A UserPromptSubmit payload with no ``prompt`` still produces a request.
+
+    The text falls back to an empty string rather than ``None`` so the
+    server always receives a well-formed REQUEST event.
+    """
+    result = hook_payload_to_evaluation_request("UserPromptSubmit", {})
+    assert result is not None
+    assert result["event"]["data"] == {"text": ""}
+
+
+@pytest.mark.parametrize("action", ["POLICY_ACTION_DENY", "POLICY_ACTION_ASK"])
+def test_user_prompt_submit_blocking_actions_emit_decision_block(action: str) -> None:
+    """
+    DENY (and a stray ASK) block the prompt via top-level ``decision``.
+
+    UserPromptSubmit uses the top-level ``decision`` / ``reason`` contract
+    (NOT ``permissionDecision``) — both harnesses parse ``decision: "block"``
+    to drop the prompt before the model sees it. ASK is meant to be resolved
+    server-side (``_hold_native_ask_gate``), so if the hook ever sees it, it
+    must fail closed by blocking rather than letting the prompt through.
+    """
+    output = evaluation_response_to_hook_output(
+        "UserPromptSubmit",
+        {"result": action, "reason": "no prod mutations"},
+    )
+    assert output is not None
+    # Top-level decision/reason, not hookSpecificOutput.permissionDecision.
+    assert output == {"decision": "block", "reason": "no prod mutations"}
+
+
+def test_user_prompt_submit_block_defaults_reason() -> None:
+    """
+    A block with no reason still carries a non-empty reason.
+
+    Both harnesses drop a block whose reason is empty (the block is treated
+    as invalid), so a missing reason must be defaulted or the gate would
+    silently fail open.
+    """
+    output = evaluation_response_to_hook_output(
+        "UserPromptSubmit", {"result": "POLICY_ACTION_DENY"}
+    )
+    assert output == {"decision": "block", "reason": "Denied by policy"}
+
+
+@pytest.mark.parametrize("action", ["POLICY_ACTION_ALLOW", "POLICY_ACTION_UNSPECIFIED"])
+def test_user_prompt_submit_non_blocking_actions_return_none(action: str) -> None:
+    """
+    ALLOW and the no-match default proceed with no output.
+
+    Returning None lets the prompt reach the model. Unlike PreToolUse there
+    is no separate user-consent gate on a prompt to preserve, so ALLOW need
+    not emit anything.
+    """
+    output = evaluation_response_to_hook_output("UserPromptSubmit", {"result": action})
+    assert output is None


### PR DESCRIPTION
Adds request-phase policy enforcement for claude-native and codex-native sessions. Web-UI prompts were already gated server-side by `_evaluate_input_policy` before injection; this closes the gap for prompts typed **directly in the TUI**, which never reach `POST /events`.

## Changes
- **`native_policy_hook`**: convert `UserPromptSubmit` → `PHASE_REQUEST`; emit the top-level `decision:"block"` contract on DENY (shared by both harnesses).
- **`sessions.py`**: accept `PHASE_REQUEST` at `/policies/evaluate`; park REQUEST ASKs server-side via `_hold_native_ask_gate` (reusing the tool-call path, so ASK is resolved server-side and the hook never sees it); dedup so a web-UI prompt already gated server-side isn't re-gated by the hook (keyed on a `pending_inputs` entry in flight).
- **`claude_native_bridge` / `codex_native_app_server`**: register the evaluate-policy hook on `UserPromptSubmit`.
- **`runner/app.py`**: re-pop a pending REQUEST-phase ASK on terminal attach (the filter previously covered only `tool_call` / `llm_request`).

## Behavior
- **Web-UI prompt** → gated server-side before injection (unchanged: no TUI freeze, natural ordering).
- **Direct-terminal prompt** → gated via the `UserPromptSubmit` hook (new coverage). DENY drops the prompt before the model sees it; ASK parks via the existing server-side approval path.

## Tests
Unit coverage for the `UserPromptSubmit` converter, hook wiring on both harnesses, and integration tests for the REQUEST ASK-park and the pending-input dedup.

This pull request and its description were written by Isaac.