### PR TITLE
test(sdk): drop now-redundant flaky marker on overflow-render test

### DIFF
--- a/tests/frontends/sdk/test_overflow_render.py
+++ b/tests/frontends/sdk/test_overflow_render.py
@@ -162,23 +162,6 @@ def _scrollback_text(screen: pyte.HistoryScreen) -> str:
     return "\n".join(parts)
 
 
-# Reruns on failure: the assertions are deterministic, but the
-# capture path is not — ``_drain_pty`` races the forked driver under a
-# fixed wall-clock deadline, so a slow/loaded CI worker can truncate the
-# byte stream and drop a trailing item (count == 0). A rerun re-forks a
-# fresh PTY and re-captures, which clears the transient timing failure
-# without masking a real regression (those fail every attempt).
-#
-# TODO(#222): reruns alone are a stopgap. CI (Linux) has also been seen
-# failing with the DUPLICATION mode (an item appears 2x — raw streamed
-# text AND rendered markdown both survive) which reproduces across every
-# rerun, unlike the timing/truncation mode this marker covers. That
-# points at an environment-dependent overflow-render bug in
-# ``_should_stream_more`` / ``replace_streamed_text`` at a tight (15-row)
-# viewport that is NOT fixed by retrying. Investigate and fix the
-# underlying double-render, then reassess whether this marker is still
-# needed.
-@pytest.mark.flaky(reruns=4, reruns_delay=0)
 def test_no_duplicate_when_streamed_overflows_viewport() -> None:
     """
     Stream 30 markdown items into a 15-row PTY. After the response


### PR DESCRIPTION
## Summary

Follow-up to #224. That PR made `test_no_duplicate_when_streamed_overflows_viewport` deterministic by rewriting its driver to drive `TerminalHost.output` synchronously, but the interim `@pytest.mark.flaky(reruns=4, reruns_delay=0)` safety net was left in place. This removes it.

- Removed the `@pytest.mark.flaky` decorator and its now-stale stopgap comment. The comment's timing/truncation rationale (`_drain_pty` racing the forked driver under a wall-clock deadline) no longer applies — the driver now writes all output synchronously and exits, so the capture is complete. The `TODO(#222)` duplication mode is exactly what #224's deterministic rewrite fixed.
- No product code changed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`uv run --frozen --extra dev pytest tests/frontends/sdk/test_overflow_render.py` → 2 passed; `ruff check` clean. The determinism was already proven on #224 via flake-stress (0/100 on the rewritten driver under `-n 4 --dist=worksteal` vs ~8/100 on the old driver), so reruns add no value.

Closes #222.
