### PR TITLE
test(terminals): add unit tests for registry and ws_bridge

### DIFF
--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -14,17 +14,19 @@ empty list, active_conversation_ids) run regardless.
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 import threading
 from collections.abc import AsyncIterator
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.terminals import TerminalRegistry
-from omnigent.terminals.registry import conversation_link_for_id
+from omnigent.terminals.registry import TerminalListEntry, conversation_link_for_id
 
 # ── Pure bookkeeping (no tmux) ────────────────────────────────
 
@@ -448,3 +450,337 @@ async def test_shutdown_clears_all_conversations(
     # emptied with a stale key).
     assert reg_with_tmux.list_for_conversation("conv_a") == []
     assert reg_with_tmux.list_for_conversation("conv_b") == []
+
+
+# ── Additional pure-bookkeeping tests (no tmux) ─────────────
+
+
+def test_get_instance_lock_returns_none_for_unknown_triple() -> None:
+    """
+    ``get_instance_lock`` returns ``None`` for a triple that was never
+    registered. Callers treat ``None`` as "not running" and surface
+    an error to the LLM.
+    """
+    reg = TerminalRegistry()
+    assert reg.get_instance_lock("conv_nope", "bash", "s1") is None
+
+
+def test_get_instance_lock_returns_lock_after_manual_registration(tmp_path: Path) -> None:
+    """
+    After manually inserting an instance and its lock (as ``launch``
+    would), ``get_instance_lock`` returns the same lock object.
+    """
+    reg = TerminalRegistry()
+    lock = threading.Lock()
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
+    reg._instance_locks[("conv_a", "bash", "s1")] = lock
+
+    assert reg.get_instance_lock("conv_a", "bash", "s1") is lock
+
+
+def test_transfer_nonexistent_source_returns_false() -> None:
+    """
+    Transferring from a conversation that has no terminals returns
+    ``False`` without raising. This is the expected path when the
+    source conversation was already cleaned up.
+    """
+    reg = TerminalRegistry()
+    assert reg.transfer("no_such_conv", "target_conv", "bash", "s1") is False
+
+
+def test_transfer_nonexistent_terminal_in_source_returns_false(tmp_path: Path) -> None:
+    """
+    Transferring a specific terminal that doesn't exist in the source
+    conversation returns ``False``. The source conversation itself
+    exists but the named terminal does not.
+    """
+    reg = TerminalRegistry()
+    instance = TerminalInstance(
+        name="other",
+        session_key="s1",
+        socket_path=tmp_path / "other.sock",
+        private_dir=tmp_path / "other",
+        running=True,
+    )
+    reg._by_conversation["conv_a"] = {("other", "s1"): instance}
+
+    assert reg.transfer("conv_a", "conv_b", "bash", "s1") is False
+
+
+def test_transfer_cleans_up_empty_source_slot(tmp_path: Path) -> None:
+    """
+    After transferring the last terminal from a conversation, the
+    source conversation's slot is removed from ``_by_conversation``
+    entirely — not left as an empty dict.
+    """
+    reg = TerminalRegistry()
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    lock = threading.Lock()
+    reg._by_conversation["conv_old"] = {("bash", "s1"): instance}
+    reg._instance_locks[("conv_old", "bash", "s1")] = lock
+
+    reg.transfer("conv_old", "conv_new", "bash", "s1")
+
+    assert "conv_old" not in reg._by_conversation
+    assert reg.active_conversation_ids() == ["conv_new"]
+
+
+def test_conversation_link_for_id_treats_whitespace_only_as_no_base() -> None:
+    """
+    A base_url of whitespace-only is treated the same as ``None`` —
+    falls back to a relative path. This guards against config entries
+    that are accidentally blank.
+    """
+    assert conversation_link_for_id("conv_x", base_url="   ") == "/c/conv_x"
+
+
+def test_list_for_conversation_returns_terminal_list_entries(tmp_path: Path) -> None:
+    """
+    ``list_for_conversation`` returns :class:`TerminalListEntry`
+    dataclass instances with the correct fields populated.
+    """
+    reg = TerminalRegistry()
+    inst = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    reg._by_conversation["conv_a"] = {("bash", "s1"): inst}
+
+    entries = reg.list_for_conversation("conv_a")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert isinstance(entry, TerminalListEntry)
+    assert entry.terminal_name == "bash"
+    assert entry.session_key == "s1"
+    assert entry.instance is inst
+
+
+def test_list_for_conversation_snapshot_isolation(tmp_path: Path) -> None:
+    """
+    The list returned by ``list_for_conversation`` is a snapshot:
+    mutating the returned list does not affect the registry's internal
+    state.
+    """
+    reg = TerminalRegistry()
+    inst = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    reg._by_conversation["conv_a"] = {("bash", "s1"): inst}
+
+    entries = reg.list_for_conversation("conv_a")
+    entries.clear()  # mutate the returned list
+
+    # Internal state should be unchanged.
+    assert len(reg.list_for_conversation("conv_a")) == 1
+
+
+def test_conversation_link_for_id_method_delegates_to_module_function() -> None:
+    """
+    The instance method ``TerminalRegistry.conversation_link_for_id``
+    delegates to the module-level function with the registry's
+    configured base URL.
+    """
+    reg = TerminalRegistry(conversation_link_base_url=None)
+    assert reg.conversation_link_for_id("conv_abc") == "/c/conv_abc"
+
+    reg2 = TerminalRegistry(conversation_link_base_url="http://localhost:6767")
+    link = reg2.conversation_link_for_id("conv_abc")
+    assert link.startswith("http://localhost:6767")
+    assert "conv_abc" in link
+
+
+async def test_close_removes_instance_lock(tmp_path: Path) -> None:
+    """
+    After ``close``, the per-instance lock is removed so
+    ``get_instance_lock`` returns ``None``. Subsequent tool calls
+    that try to acquire the lock see "not running" rather than
+    operating on a closed tmux session.
+    """
+    reg = TerminalRegistry()
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+    instance.close = AsyncMock()  # type: ignore[method-assign]
+    lock = threading.Lock()
+    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
+    reg._instance_locks[("conv_a", "bash", "s1")] = lock
+
+    result = await reg.close("conv_a", "bash", "s1")
+
+    assert result is True
+    assert reg.get_instance_lock("conv_a", "bash", "s1") is None
+    instance.close.assert_awaited_once()
+
+
+async def test_close_with_timeout_still_returns_true(tmp_path: Path) -> None:
+    """
+    If ``instance.close()`` times out, ``close`` still returns ``True``
+    (the instance was found and removal from the registry succeeded).
+    The timeout is logged but does not propagate.
+    """
+    reg = TerminalRegistry()
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bash.sock",
+        private_dir=tmp_path / "bash",
+        running=True,
+    )
+
+    async def _hang_forever() -> None:
+        await asyncio.sleep(999)
+
+    instance.close = _hang_forever  # type: ignore[method-assign]
+    reg._by_conversation["conv_a"] = {("bash", "s1"): instance}
+    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
+
+    # The close should not hang — it uses asyncio.wait_for with _CLOSE_TIMEOUT_S.
+    # We patch _CLOSE_TIMEOUT_S to a tiny value so the test finishes quickly.
+    import omnigent.terminals.registry as reg_mod
+
+    original = reg_mod._CLOSE_TIMEOUT_S
+    reg_mod._CLOSE_TIMEOUT_S = 0.01
+    try:
+        result = await reg.close("conv_a", "bash", "s1")
+    finally:
+        reg_mod._CLOSE_TIMEOUT_S = original
+
+    assert result is True
+    assert reg.get("conv_a", "bash", "s1") is None
+
+
+async def test_cleanup_conversation_tolerates_close_exception(tmp_path: Path) -> None:
+    """
+    ``cleanup_conversation`` swallows exceptions from individual
+    ``instance.close()`` calls and continues closing the remaining
+    terminals. This ensures a wedged terminal cannot block cleanup
+    of its siblings.
+    """
+    reg = TerminalRegistry()
+    good_instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "good.sock",
+        private_dir=tmp_path / "good",
+        running=True,
+    )
+    good_instance.close = AsyncMock()  # type: ignore[method-assign]
+    bad_instance = TerminalInstance(
+        name="bash",
+        session_key="s2",
+        socket_path=tmp_path / "bad.sock",
+        private_dir=tmp_path / "bad",
+        running=True,
+    )
+
+    async def _explode() -> None:
+        raise RuntimeError("tmux gone")
+
+    bad_instance.close = _explode  # type: ignore[method-assign]
+
+    reg._by_conversation["conv_a"] = {
+        ("bash", "s1"): good_instance,
+        ("bash", "s2"): bad_instance,
+    }
+    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
+    reg._instance_locks[("conv_a", "bash", "s2")] = threading.Lock()
+
+    # Should not raise despite bad_instance.close() exploding.
+    await reg.cleanup_conversation("conv_a")
+
+    assert reg.active_conversation_ids() == []
+    # The good instance's close was still called.
+    good_instance.close.assert_awaited_once()
+
+
+async def test_shutdown_tolerates_close_exception(tmp_path: Path) -> None:
+    """
+    ``shutdown`` swallows exceptions from individual ``instance.close()``
+    calls, just like ``cleanup_conversation``. A stuck instance in one
+    conversation must not prevent cleanup of instances in other
+    conversations.
+    """
+    reg = TerminalRegistry()
+    good = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "good.sock",
+        private_dir=tmp_path / "good",
+        running=True,
+    )
+    good.close = AsyncMock()  # type: ignore[method-assign]
+    bad = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "bad.sock",
+        private_dir=tmp_path / "bad",
+        running=True,
+    )
+
+    async def _explode() -> None:
+        raise RuntimeError("tmux gone")
+
+    bad.close = _explode  # type: ignore[method-assign]
+
+    reg._by_conversation["conv_a"] = {("bash", "s1"): bad}
+    reg._by_conversation["conv_b"] = {("bash", "s1"): good}
+    reg._instance_locks[("conv_a", "bash", "s1")] = threading.Lock()
+    reg._instance_locks[("conv_b", "bash", "s1")] = threading.Lock()
+
+    await reg.shutdown()
+
+    assert reg.active_conversation_ids() == []
+    good.close.assert_awaited_once()
+
+
+def test_multiple_terminals_per_conversation(tmp_path: Path) -> None:
+    """
+    A single conversation can hold multiple terminals with different
+    names and session keys. ``list_for_conversation`` returns all of
+    them and ``get`` retrieves each individually.
+    """
+    reg = TerminalRegistry()
+    instances = {}
+    for name, key in [("bash", "s1"), ("bash", "s2"), ("python", "s1")]:
+        inst = TerminalInstance(
+            name=name,
+            session_key=key,
+            socket_path=tmp_path / f"{name}_{key}.sock",
+            private_dir=tmp_path / f"{name}_{key}",
+            running=True,
+        )
+        instances[(name, key)] = inst
+
+    reg._by_conversation["conv_a"] = dict(instances)
+
+    entries = reg.list_for_conversation("conv_a")
+    assert len(entries) == 3
+    entry_keys = {(e.terminal_name, e.session_key) for e in entries}
+    assert entry_keys == {("bash", "s1"), ("bash", "s2"), ("python", "s1")}
+
+    for (name, key), inst in instances.items():
+        assert reg.get("conv_a", name, key) is inst

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -1176,3 +1176,239 @@ async def test_forward_pty_to_ws_accepts_dynamic_coalesce_cap() -> None:
         f"were {[len(frame) for frame in ws.sent]}."
     )
     assert b"".join(ws.sent) == b"x" * ws_bridge._PTY_READ_CHUNK
+
+
+# ── Additional unit tests (no tmux required) ─────────────────
+
+
+def test_current_coalesce_limit_static_value() -> None:
+    """
+    ``_current_coalesce_limit`` returns the integer unchanged when
+    given a static cap.
+    """
+    from omnigent.terminals.ws_bridge import _current_coalesce_limit
+
+    assert _current_coalesce_limit(4096) == 4096
+
+
+def test_current_coalesce_limit_callable_invoked() -> None:
+    """
+    ``_current_coalesce_limit`` calls the callable and returns its
+    result when given a dynamic cap.
+    """
+    from omnigent.terminals.ws_bridge import _current_coalesce_limit
+
+    assert _current_coalesce_limit(lambda: 2048) == 2048
+
+
+def test_current_coalesce_limit_rejects_zero() -> None:
+    """
+    A zero cap raises ``ValueError`` — a zero cap would make the
+    frame-splitting loop infinite.
+    """
+    from omnigent.terminals.ws_bridge import _current_coalesce_limit
+
+    with pytest.raises(ValueError, match="must be positive"):
+        _current_coalesce_limit(0)
+
+
+def test_current_coalesce_limit_rejects_negative_callable() -> None:
+    """
+    A callable returning a negative value raises ``ValueError``.
+    """
+    from omnigent.terminals.ws_bridge import _current_coalesce_limit
+
+    with pytest.raises(ValueError, match="must be positive"):
+        _current_coalesce_limit(lambda: -5)
+
+
+def test_coalesce_limit_after_input_returns_large_cap_with_no_input() -> None:
+    """
+    Before any client input (``last_client_input_at=None``), the
+    coalesce cap is the full flood cap — output should stream
+    efficiently without the interactive constraint.
+    """
+    from omnigent.terminals.ws_bridge import _coalesce_limit_after_input
+
+    assert _coalesce_limit_after_input(None) == ws_bridge._WS_COALESCE_MAX_BYTES
+
+
+def test_coalesce_limit_after_input_returns_small_cap_within_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    When the last client input was within the interactive echo window,
+    the cap shrinks to the interactive size so browser sync-echo works.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.terminals.ws_bridge import _coalesce_limit_after_input
+
+    monkeypatch.setattr(ws_bridge, "_monotonic", lambda: 100.5)
+    # Input was 0.3s ago (within the 0.75s window).
+    assert _coalesce_limit_after_input(100.2) == ws_bridge._INTERACTIVE_WS_COALESCE_MAX_BYTES
+
+
+def test_coalesce_limit_after_input_returns_large_cap_after_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Once the interactive echo window has elapsed, the cap reverts to
+    the full flood cap so output floods stream efficiently again.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.terminals.ws_bridge import _coalesce_limit_after_input
+
+    monkeypatch.setattr(ws_bridge, "_monotonic", lambda: 102.0)
+    # Input was 2s ago (well past the 0.75s window).
+    assert _coalesce_limit_after_input(100.0) == ws_bridge._WS_COALESCE_MAX_BYTES
+
+
+@pytest.mark.asyncio
+async def test_tmux_session_alive_returns_false_on_spawn_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_tmux_session_alive`` returns ``False`` when ``create_subprocess_exec``
+    raises ``OSError`` (tmux binary not found). This is the conservative
+    fallback — any probe error is treated as "session dead".
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    async def _raise_oserror(*args: object, **kwargs: object) -> None:
+        raise OSError("No such file or directory")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _raise_oserror)
+    assert await _tmux_session_alive("/no/such.sock", "main") is False
+
+
+@pytest.mark.asyncio
+async def test_tmux_session_alive_returns_false_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_tmux_session_alive`` returns ``False`` when the has-session probe
+    times out (e.g. a wedged tmux server). The probe must not block the
+    bridge's teardown path.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    class _HangingProcess:
+        async def wait(self) -> int:
+            await asyncio.sleep(999)
+            return 0
+
+        def kill(self) -> None:
+            pass
+
+    async def _create_hanging(*args: object, **kwargs: object) -> _HangingProcess:
+        return _HangingProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _create_hanging)
+    # Patch the timeout to a tiny value so the test finishes quickly.
+    monkeypatch.setattr(ws_bridge, "_TMUX_HAS_SESSION_TIMEOUT_S", 0.01)
+
+    assert await _tmux_session_alive("/some.sock", "main") is False
+
+
+@pytest.mark.asyncio
+async def test_bridge_closes_ws_with_error_when_tmux_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    When ``shutil.which("tmux")`` returns ``None``, the bridge closes
+    the websocket with ``WS_CLOSE_INTERNAL_ERROR`` and returns without
+    crashing.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    close_codes: list[int] = []
+
+    class _FakeWS:
+        async def close(self, code: int = 1000, reason: str = "") -> None:
+            close_codes.append(code)
+
+    ws = _FakeWS()
+    await bridge_tmux_pty_to_websocket(
+        ws,  # type: ignore[arg-type]
+        socket_path="/nonexistent.sock",
+        tmux_target="main",
+        read_only=False,
+    )
+
+    assert close_codes == [ws_bridge.WS_CLOSE_INTERNAL_ERROR]
+
+
+@pytest.mark.asyncio
+async def test_reap_child_handles_child_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``_reap_tmux_attach_child`` exits cleanly when ``os.waitpid``
+    raises ``ChildProcessError`` (the child was already reaped by
+    another path, e.g. a signal handler).
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    def _raise_child_error(pid: int, options: int) -> tuple[int, int]:
+        raise ChildProcessError("No child processes")
+
+    monkeypatch.setattr(os, "waitpid", _raise_child_error)
+
+    # Should return without raising.
+    await _reap_tmux_attach_child(12345)
+
+
+@pytest.mark.asyncio
+async def test_forward_pty_to_ws_handles_empty_queue_then_eof() -> None:
+    """
+    When the queue receives ``None`` (EOF) as the very first item,
+    ``_forward_pty_to_ws`` returns immediately without sending
+    anything. This covers the path where the tmux attach child
+    exits before producing any output.
+    """
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+    queue.put_nowait(None)
+
+    ws = _RecordingWebSocket()
+    await asyncio.wait_for(
+        _forward_pty_to_ws(ws, queue),  # type: ignore[arg-type]
+        timeout=5.0,
+    )
+
+    assert ws.sent == []
+
+
+def test_ws_close_code_constants() -> None:
+    """
+    The WebSocket close codes are in the RFC 6455 application range
+    (4000-4999) and are distinct from each other.
+    """
+    codes = {
+        ws_bridge.WS_CLOSE_TERMINAL_NOT_FOUND,
+        ws_bridge.WS_CLOSE_TERMINAL_DETACHED,
+        ws_bridge.WS_CLOSE_INTERNAL_ERROR,
+    }
+    assert len(codes) == 3, "close codes must be distinct"
+    for code in codes:
+        assert 4000 <= code <= 4999, f"close code {code} outside RFC 6455 app range"
+
+
+def test_monotonic_returns_float() -> None:
+    """
+    ``_monotonic`` is a thin wrapper over ``time.monotonic`` that
+    returns a float. This seems trivial but the wrapper exists as
+    a test seam — verify it works as documented.
+    """
+    from omnigent.terminals.ws_bridge import _monotonic
+
+    val = _monotonic()
+    assert isinstance(val, float)
+    # Monotonic: a second call should be >= the first.
+    assert _monotonic() >= val


### PR DESCRIPTION
## Summary
- Add 15 new unit tests for `TerminalRegistry` covering instance lock lifecycle, transfer edge cases (nonexistent source, empty slot cleanup), close/cleanup/shutdown error tolerance (timeouts, exceptions), snapshot isolation, and multiple terminals per conversation
- Add 13 new unit tests for `ws_bridge` covering `_current_coalesce_limit` static/callable/invalid paths, `_coalesce_limit_after_input` interactive window transitions, `_tmux_session_alive` spawn failure and timeout handling, bridge behavior when tmux is missing, child reaper `ChildProcessError` handling, empty-queue EOF, WS close code constants, and `_monotonic` wrapper

## Test plan
- [x] All 64 non-tmux-dependent tests pass locally (`python -m pytest tests/terminals/ -v --timeout=30`)
- [x] `ruff format` and `ruff check` clean
- [ ] CI passes

This pull request and its description were written by Isaac.