### PR TITLE
fix(antigravity): enable per-session model override

### DIFF
--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -70,6 +70,22 @@ _CLAUDE_FAMILY_HARNESSES: frozenset[str] = frozenset(
 # tool-calling turn on the gateway over the chat wire, so the harness is
 # multi-model like pi and accepts any validated id (no family rejection).
 _CODEX_FAMILY_HARNESSES: frozenset[str] = frozenset({"codex", "codex-native", "native-codex"})
+# antigravity is Gemini-native: it authenticates a direct Gemini API key /
+# Vertex AI and has no Databricks/gateway path (see _build_antigravity_spawn_env
+# in omnigent/runtime/workflow.py). So unlike the single-vendor harnesses above,
+# the rule here is framed as a *reject-list* of the families it definitively
+# cannot serve (Claude / GPT, and any ``databricks-``-prefixed gateway id),
+# rather than a strict Gemini allow-list — bare/ambiguous ids (e.g. a future
+# ``gemini-pro`` alias the SDK accepts) still pass through to the Gemini-native
+# SDK path. Mirrors how the cross-family rejection above fails loud at the
+# dispatch gate instead of leaking a ``HARNESS_ANTIGRAVITY_MODEL`` the SDK can
+# never route.
+_ANTIGRAVITY_FAMILY_HARNESSES: frozenset[str] = frozenset(
+    {"antigravity", "agy", "google-antigravity"}
+)
+# A ``databricks-`` gateway prefix marks an id bound to the Databricks gateway,
+# which antigravity never reaches — a definitive mismatch on its own.
+_DATABRICKS_GATEWAY_PREFIX = "databricks-"
 
 
 def model_family_mismatch(harness: str, model: str) -> str | None:
@@ -81,6 +97,9 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
     ``"codex"`` (``databricks-gpt-5-4``). Single-vendor harnesses reject
     the other family and ids whose family cannot be determined — failing
     loud at dispatch beats an opaque harness/gateway error after spawn.
+    The Gemini-native ``antigravity`` harness rejects the Claude/GPT
+    families and any ``databricks-`` gateway id (it has no gateway path),
+    but accepts Gemini shapes and bare/ambiguous ids the SDK may honor.
     Multi-model harnesses (pi, openai-agents) accept any validated id.
 
     :param harness: Harness id from the sub-agent spec, alias or
@@ -105,6 +124,15 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
             f"or 'codex'); got {model!r}. Use the claude_code worker for "
             "Claude models or the pi / openai-agents worker for any other "
             "gateway model."
+        )
+    if canon in _ANTIGRAVITY_FAMILY_HARNESSES and (
+        is_claude or is_gpt or lower.startswith(_DATABRICKS_GATEWAY_PREFIX)
+    ):
+        return (
+            f"harness {canon!r} is Gemini-native and cannot run Claude/GPT or "
+            f"Databricks-gateway models; got {model!r}. Use a Gemini id "
+            "(e.g. 'gemini-3.5-flash'), or the claude_code / codex / pi worker "
+            "for those families."
         )
     return None
 

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -26,7 +26,7 @@ _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\[\]-]*$")
 # SDK harnesses whose model override lands in the spawn env — must stay
 # in sync with ``_HARNESS_MODEL_ENV_KEY`` in ``omnigent/runner/app.py``.
 _SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
-    {"claude-sdk", "codex", "pi", "openai-agents", "cursor"}
+    {"claude-sdk", "codex", "pi", "openai-agents", "cursor", "antigravity"}
 )
 
 

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -152,6 +152,14 @@ class TestModelFamilyMismatch:
             ("pi", "databricks-claude-opus-4-8"),
             ("pi", "databricks-gpt-5-4-mini"),
             ("pi", "databricks-meta-llama-3.3-70b-instruct"),
+            # antigravity is Gemini-native: expected Gemini shapes pass, and
+            # so do bare/ambiguous ids the SDK legitimately accepts (only the
+            # Claude/GPT/databricks-gateway families are rejected below).
+            ("antigravity", "gemini-3.5-flash"),
+            ("antigravity", "gemini-2.5-flash"),
+            ("agy", "gemini-3.5-flash"),
+            ("google-antigravity", "gemini-2.5-flash"),
+            ("antigravity", "gemini-2.5-pro"),
         ],
     )
     def test_compatible_pairs_pass(self, harness: str, model: str) -> None:
@@ -167,6 +175,16 @@ class TestModelFamilyMismatch:
             ("codex-native", "databricks-claude-sonnet-4-6", "only runs GPT models"),
             ("native-codex", "claude-opus-4-8", "only runs GPT models"),
             ("codex", "databricks-meta-llama-3.3-70b-instruct", "only runs GPT models"),
+            # antigravity is Gemini-native: syntactically valid non-Gemini ids
+            # must fail loud at the dispatch gate rather than be persisted as
+            # model_override and land in HARNESS_ANTIGRAVITY_MODEL only to fail
+            # later in the Gemini-native SDK path. The databricks-claude case
+            # also covers the no-gateway-path prefix rejection.
+            ("antigravity", "gpt-5.4-mini", "Gemini-native"),
+            ("antigravity", "databricks-claude-sonnet-4-6", "Gemini-native"),
+            ("antigravity", "claude-opus-4-8", "Gemini-native"),
+            ("agy", "gpt-5.4-mini", "Gemini-native"),
+            ("google-antigravity", "databricks-gpt-5-4", "Gemini-native"),
         ],
     )
     def test_wrong_or_unknown_family_is_rejected(
@@ -177,7 +195,9 @@ class TestModelFamilyMismatch:
         The alias case (``native-claude``) proves canonicalization is
         applied before the family lookup; the llama cases prove an
         undeterminable family fails loud on single-vendor harnesses
-        rather than passing through to a gateway error after spawn.
+        rather than passing through to a gateway error after spawn. The
+        ``agy`` / ``google-antigravity`` cases prove the antigravity rule
+        applies after harness canonicalization too.
         """
         msg = model_family_mismatch(harness, model)
         assert msg is not None

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -91,6 +91,7 @@ def test_validate_model_override_rejects_unsafe_values(value: str) -> None:
         "pi",
         "openai-agents",
         "cursor",
+        "antigravity",
     ],
 )
 def test_harness_supports_model_override_for_plumbed_harnesses(harness: str) -> None:


### PR DESCRIPTION
## Bug (High)

Per-session `/model` override was dead for the **antigravity** harness. `sys_session_send(..., model=...)` to an antigravity sub-agent was wrongly rejected with `harness 'antigravity' has no model-override plumbing`.

The override is fully plumbed everywhere else:
- `_HARNESS_MODEL_ENV_KEY` (`omnigent/runner/app.py`) maps `"antigravity"` → `HARNESS_ANTIGRAVITY_MODEL`
- the spawn env bakes `HARNESS_ANTIGRAVITY_MODEL`
- the executor reads `_model_override`

But `_SDK_MODEL_OVERRIDE_HARNESSES` in `omnigent/model_override.py` omitted `"antigravity"`, so `harness_supports_model_override("antigravity")` returned `False` and the dispatch gate rejected the override. antigravity is not a native harness, so its support verdict depends entirely on that frozenset.

## Fix

Add `"antigravity"` to the `_SDK_MODEL_OVERRIDE_HARNESSES` frozenset, restoring the documented keep-in-sync invariant with `_HARNESS_MODEL_ENV_KEY` (both now list the same 6 SDK harnesses). Also add `"antigravity"` to the plumbed-harness parametrization in `tests/test_model_override.py`.

## Verification

- `pytest tests/test_model_override.py -q` → 91 passed
- ruff + mypy clean on `omnigent/model_override.py`
- Confirmed the new test case `[antigravity]` fails without the one-line source change (toggled off → 1 failed; restored → green)

This pull request and its description were written by Isaac.