### PR TITLE
fix(antigravity): stop adopting the global OpenAI auth key + scope keychain delete

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8040,6 +8040,7 @@ def _manage_antigravity_harness() -> None:
     from omnigent.onboarding import secrets as secret_store
     from omnigent.onboarding.antigravity_auth import (
         ANTIGRAVITY_CONFIG_KEY,
+        ANTIGRAVITY_SECRET_NAME,
         antigravity_api_key_configured,
         antigravity_api_key_ref,
     )
@@ -8075,10 +8076,12 @@ def _manage_antigravity_harness() -> None:
             status = _set_antigravity_api_key()
         elif action == "remove_key":
             ref = antigravity_api_key_ref(config)
-            # Only a keychain-stored secret is ours to delete; an ``env:`` ref
-            # points at the user's own environment, so just drop the config.
-            if ref is not None and ref.startswith("keychain:"):
-                secret_store.delete_secret(ref[len("keychain:") :])
+            # Only the secret we own (``keychain:antigravity``) is ours to
+            # delete: a hand-edited block may point at a shared ``keychain:<other>``
+            # secret, and an ``env:`` ref names the user's own environment. In
+            # both of those cases just drop the config block and leave the secret.
+            if ref == f"keychain:{ANTIGRAVITY_SECRET_NAME}":
+                secret_store.delete_secret(ANTIGRAVITY_SECRET_NAME)
             _save_global_config({}, unset_keys=(ANTIGRAVITY_CONFIG_KEY,))
             status = "✓ Removed Gemini API key"
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1491,11 +1491,15 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
     Antigravity is Gemini-native with no OpenAI-compatible ``base_url``, so there
     is no gateway / ucode / Databricks path — only a direct API key or Vertex AI.
     API-key resolution (first wins): (1) spec ``executor.auth`` api_key; (2) the
-    ``antigravity:`` config block from ``omnigent setup``; (3) the legacy global
-    ``auth:`` api key; (4) an ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``.
-    Any ``base_url`` is dropped (the SDK has no such field). Vertex AI is opt-in
-    via ``executor.config`` vertex/project/location, independent of the key path.
-    A ``DatabricksAuth`` is unsupported — warned and ignored.
+    dedicated ``antigravity:`` config block from ``omnigent setup``; (3) an
+    ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``. The legacy global
+    ``auth:`` block is deliberately NOT consulted: it carries the OpenAI/gateway
+    key the other SDK harnesses inherit (an ``sk-…`` key), which the Gemini-native
+    SDK can't use — adopting it would guarantee an auth failure / mis-billing and
+    shadow the user's ambient ``GEMINI_API_KEY``. Any ``base_url`` is dropped (the
+    SDK has no such field). Vertex AI is opt-in via ``executor.config``
+    vertex/project/location, independent of the key path. A ``DatabricksAuth`` is
+    unsupported — warned and ignored.
 
     :param spec: The agent spec.
     :returns: Env-var overrides; may be empty (the wrap then uses the SDK's
@@ -1518,8 +1522,10 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
             type(spec_auth).__name__,
         )
 
-    # Spec api-key wins; with no spec auth, fall back to the configured /
-    # ambient key (see docstring). A non-api-key auth never adopts a key.
+    # Spec api-key wins; with no spec auth, fall back to the dedicated
+    # ``antigravity:`` block, then an ambient Gemini key (see docstring). The
+    # global ``auth:`` block is intentionally NOT consulted — it holds the
+    # OpenAI/gateway key the SDK can't use. A non-api-key auth never adopts a key.
     if isinstance(spec_auth, ApiKeyAuth):
         # base_url intentionally dropped — the SDK has no such field.
         env["HARNESS_ANTIGRAVITY_API_KEY"] = spec_auth.api_key
@@ -1531,11 +1537,8 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
         )
 
         stored_key = resolve_antigravity_api_key()
-        loaded = _load_global_auth()
         if stored_key is not None:
             env["HARNESS_ANTIGRAVITY_API_KEY"] = stored_key
-        elif isinstance(loaded, ApiKeyAuth):
-            env["HARNESS_ANTIGRAVITY_API_KEY"] = loaded.api_key
         else:
             for _env_var in ANTIGRAVITY_ENV_VARS:
                 if os.environ.get(_env_var):

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2110,6 +2110,31 @@ def test_antigravity_remove_api_key_drops_block_and_secret(isolated_config) -> N
     assert secrets.load_secret("antigravity") is None
 
 
+def test_antigravity_remove_does_not_delete_foreign_keychain_secret(isolated_config) -> None:
+    """Removing antigravity drops the block but spares a shared ``keychain:<other>``.
+
+    A hand-edited ``antigravity:`` block may point at a secret we don't own
+    (here ``keychain:shared-gemini``). Remove must NOT clobber that secret —
+    only the config block is dropped. Against the old over-broad delete (any
+    ``keychain:`` ref) the shared secret would have been destroyed.
+    """
+    # Seed a foreign shared secret referenced by a hand-edited block.
+    secrets.store_secret("shared-gemini", "AIza_shared_seeded")
+    config_path = os.path.join(isolated_config, "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.safe_dump({"antigravity": {"api_key_ref": "keychain:shared-gemini"}}, f)
+
+    # L1 5=Antigravity → antigravity menu 2=Remove → q back → q quit.
+    stdin = "\n".join(["5", "2", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    # Block dropped, but the secret we don't own is left intact.
+    assert "antigravity" not in cfg
+    assert secrets.load_secret("shared-gemini") == "AIza_shared_seeded"
+
+
 def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(isolated_config) -> None:
     """A non-``AIza`` paste that the user declines to force is NOT persisted.
 

--- a/tests/runtime/test_antigravity_spawn_env.py
+++ b/tests/runtime/test_antigravity_spawn_env.py
@@ -112,11 +112,22 @@ def test_api_key_auth_threads_key_only() -> None:
     assert "HARNESS_ANTIGRAVITY_GATEWAY_BASE_URL" not in env
 
 
-def test_global_api_key_used_when_spec_has_no_auth(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The global config api key is used only when the spec declares no auth."""
-    monkeypatch.setattr(wf, "_load_global_auth", lambda: ApiKeyAuth(api_key="global-key"))
+def test_global_auth_is_not_adopted_when_spec_has_no_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy global ``auth:`` key is NEVER adopted by antigravity.
+
+    The global block carries the OpenAI/gateway key the other SDK harnesses
+    inherit (an ``sk-…`` key); the Gemini-native SDK can't use it, so shipping
+    it as ``HARNESS_ANTIGRAVITY_API_KEY`` would guarantee an auth failure /
+    mis-billing. With no spec auth, no stored block, and no ambient Gemini key,
+    the builder must emit no key at all (the wrap then uses ambient/Vertex
+    creds). Against the old global-``auth:`` fallback this would have set
+    ``HARNESS_ANTIGRAVITY_API_KEY`` to the OpenAI key.
+    """
+    monkeypatch.setattr(wf, "_load_global_auth", lambda: ApiKeyAuth(api_key="sk-openai-global"))
     env = _build_antigravity_spawn_env(_make_spec(model="gemini-3-pro", auth=None))
-    assert env["HARNESS_ANTIGRAVITY_API_KEY"] == "global-key"
+    assert "HARNESS_ANTIGRAVITY_API_KEY" not in env
 
 
 def test_vertex_config_threads_project_and_location() -> None:
@@ -221,15 +232,16 @@ def test_spec_api_key_auth_wins_over_stored_key(
     assert env["HARNESS_ANTIGRAVITY_API_KEY"] == "AIza_explicit_999"
 
 
-def test_stored_key_wins_over_global_auth(
+def test_stored_key_used_and_global_auth_ignored(
     monkeypatch: pytest.MonkeyPatch, _isolate_global_config: Path
 ) -> None:
-    """The dedicated ``antigravity:`` block outranks the legacy global ``auth:``.
+    """The dedicated ``antigravity:`` block is used; the global ``auth:`` is ignored.
 
-    Both are no-auth-spec fallbacks; the Gemini-specific block is preferred so a
-    Gemini key never loses to a global ``auth:`` key meant for another harness.
+    The Gemini-specific block authenticates a no-auth spec, and a present global
+    ``auth:`` key (meant for another harness) has no influence at all. Against
+    the old behavior the global key was a fallback tier; now it is never read.
     """
-    monkeypatch.setattr(wf, "_load_global_auth", lambda: ApiKeyAuth(api_key="global-key"))
+    monkeypatch.setattr(wf, "_load_global_auth", lambda: ApiKeyAuth(api_key="sk-openai-global"))
     monkeypatch.setenv("GEMINI_KEY_SRC", "AIza_stored_123")
     _write_antigravity_config(_isolate_global_config, "env:GEMINI_KEY_SRC")
     env = _build_antigravity_spawn_env(_make_spec(model="gemini-3-pro", auth=None))
@@ -262,6 +274,23 @@ def test_ambient_gemini_key_adopted_when_no_config(
     launched with one) authenticates a no-auth spec without per-spec config.
     """
     monkeypatch.setattr(wf, "_load_global_auth", lambda: None)
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza_ambient_456")
+    env = _build_antigravity_spawn_env(_make_spec(model="gemini-3-pro", auth=None))
+    assert env["HARNESS_ANTIGRAVITY_API_KEY"] == "AIza_ambient_456"
+
+
+def test_ambient_gemini_key_wins_over_global_openai_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ambient ``GEMINI_API_KEY`` is used while a global OpenAI ``auth:`` is ignored.
+
+    This is the core credential-safety guarantee: with no spec auth and no stored
+    ``antigravity:`` block, a present global ``auth:`` (the OpenAI/gateway
+    ``sk-…`` key) must not short-circuit the user's ambient Gemini key. Against
+    the old global-``auth:`` fallback the builder would have shipped
+    ``sk-openai-global`` instead of the real Gemini key.
+    """
+    monkeypatch.setattr(wf, "_load_global_auth", lambda: ApiKeyAuth(api_key="sk-openai-global"))
     monkeypatch.setenv("GEMINI_API_KEY", "AIza_ambient_456")
     env = _build_antigravity_spawn_env(_make_spec(model="gemini-3-pro", auth=None))
     assert env["HARNESS_ANTIGRAVITY_API_KEY"] == "AIza_ambient_456"


### PR DESCRIPTION
## Summary

The Antigravity harness is Gemini-native: its SDK has no OpenAI-compatible `base_url` and authenticates only with a Gemini key (or Vertex AI). Two credential-safety bugs let the wrong secret reach (or be deleted from) it. This PR fixes both with a minimal diff.

## Bug A — global OpenAI key contaminates the Gemini SDK (High)

`_build_antigravity_spawn_env` in `omnigent/runtime/workflow.py` fell back to the legacy global `auth:` block (`_load_global_auth()`) when the spec declared no auth, shipping its `.api_key` as `HARNESS_ANTIGRAVITY_API_KEY`. That block is the OpenAI/gateway key (`sk-…`) the other SDK harnesses inherit. Shipping it to the Gemini-native SDK guarantees an auth failure or mis-billing, and it short-circuits the user's ambient `GEMINI_API_KEY`.

**Fix:** drop the global-`auth:` tier so the precedence is exactly:
1. spec `ApiKeyAuth`
2. dedicated `antigravity:` block (`resolve_antigravity_api_key`)
3. ambient `GEMINI_API_KEY` / `ANTIGRAVITY_API_KEY`

This now matches `_build_cursor_spawn_env`. The docstring is updated to drop the global-`auth:` tier and document why it is deliberately not consulted.

## Bug B — over-broad keychain delete (Low)

`_manage_antigravity_harness`'s remove path in `omnigent/cli.py` deleted whatever `keychain:<name>` the `antigravity:` block referenced, so a hand-edited block pointing at a shared secret would clobber it.

**Fix:** only delete when the ref is exactly `keychain:{ANTIGRAVITY_SECRET_NAME}` (the secret we own); otherwise just drop the config block.

## Tests

- `tests/runtime/test_antigravity_spawn_env.py`: the two tests that asserted global-`auth:` adoption now assert it is **ignored**; added a test proving an ambient `GEMINI_API_KEY` is used while a global OpenAI-style `auth:` is ignored.
- `tests/cli/test_configure_models.py`: added a test proving remove does **not** delete a foreign `keychain:<other>` secret, while the existing test still proves it **does** delete `keychain:antigravity`.
- All three new/updated tests were verified to **fail against the old behavior**.

## Verification

```
pytest tests/runtime/test_antigravity_spawn_env.py tests/cli/test_configure_models.py -k "antigravity" -q
22 passed
```

`ruff check`, `ruff format --check`, and `mypy` are clean on the changed files (no new errors; test-function annotation notes match the file's pre-existing convention).

This pull request and its description were written by Isaac.