### PR TITLE
fix(antigravity): seed full history on fresh/rebuilt SDK sessions

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -51,6 +51,7 @@ from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any, TypeAlias
 
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.spec.types import RetryPolicy
 
 from .executor import (
@@ -180,6 +181,63 @@ def _content_to_text(content: Any) -> str:  # type: ignore[explicit-any]
                     parts.append(text)
         return "\n".join(parts)
     return json.dumps(content)
+
+
+def _render_prior_history(prior: list[Message]) -> str:
+    """Render prior conversation turns as a plain-text transcript prefix.
+
+    Used to seed a FRESH SDK conversation (a new ``session_key`` or a
+    rebuilt agent) with the history it would otherwise lose. The SDK's
+    ``Conversation`` accumulates history only from steps it streams — it
+    exposes no API to inject prior turns, and ``send()`` triggers a model
+    turn — so the prior turns ride into the single ``send()`` of the next
+    turn as a context prefix rather than as native step history.
+
+    .. note::
+       Only ``user`` / ``assistant`` text is replayed. Tool calls and tool
+       results are not reconstructed into the SDK's native tool-call history
+       (the SDK has no surface to inject them); they appear, if at all, only
+       as whatever text the assistant turns carried. This is a deliberate,
+       documented limitation of the no-history-API fallback.
+
+    :param prior: The conversation messages preceding the latest user turn
+        (``messages[:-1]``), as Omnigent role/content dicts.
+    :returns: A transcript prefix like ``"Conversation so far:\\nuser: …\\n
+        assistant: …"``, or ``""`` when no prior user/assistant text exists.
+    """
+    lines: list[str] = []
+    for message in prior:
+        role = str(message.get("role", "")).strip()
+        # Only user/assistant turns carry replayable conversational text;
+        # tool/system bookkeeping rows are skipped (see the note above).
+        if role not in ("user", "assistant"):
+            continue
+        text = _content_to_text(message.get("content"))
+        if not text:
+            continue
+        lines.append(f"{role}: {text}")
+    if not lines:
+        return ""
+    return "Conversation so far:\n" + "\n".join(lines)
+
+
+def _seed_prompt(prior: list[Message], latest_user_text: str) -> str:
+    """Combine a prior-history prefix with the latest user text for one ``send``.
+
+    On a fresh SDK conversation the prior turns and the latest user input are
+    delivered together in the single ``send()`` the turn already makes, so the
+    fresh backend sees the history as context for the turn it is about to run.
+
+    :param prior: Messages preceding the latest user turn (``messages[:-1]``).
+    :param latest_user_text: The newest user input for this turn (may be ``""``).
+    :returns: ``latest_user_text`` unchanged when there is no replayable prior
+        history; otherwise the transcript prefix followed by the latest input
+        under a ``user:`` label so the model can tell them apart.
+    """
+    prefix = _render_prior_history(prior)
+    if not prefix:
+        return latest_user_text
+    return f"{prefix}\n\nRespond to the latest user message:\nuser: {latest_user_text}"
 
 
 def _tool_name(raw_name: Any) -> str:  # type: ignore[explicit-any]
@@ -415,7 +473,7 @@ class AntigravityExecutor(Executor):
         prompt = _latest_user_text(messages)
 
         try:
-            state = await self._ensure_agent(
+            state, created = await self._ensure_agent(
                 session_key,
                 model=model,
                 system_prompt=system_prompt,
@@ -428,6 +486,18 @@ class AntigravityExecutor(Executor):
             logger.exception("Antigravity agent construction failed")
             yield ExecutorError(message=f"Antigravity agent setup failed: {exc}", retryable=False)
             return
+
+        # A FRESH agent (new session, or a model/system-prompt/tools rebuild —
+        # e.g. after a server restart) starts with an empty SDK conversation, so
+        # it would otherwise lose all prior turns. Seed the prior history
+        # (``messages[:-1]``) into this turn's single ``send()`` as a context
+        # prefix — the SDK exposes no history-injection API and ``send()``
+        # triggers a turn, so riding the prefix into the next prompt is the only
+        # way to replay it without spawning extra model turns. A REUSED agent
+        # already holds this history in its live conversation; re-seeding would
+        # duplicate it, so we leave its prompt as the latest user text alone.
+        if created:
+            prompt = _seed_prompt(messages[:-1], prompt)
 
         event_queue: _EventQueue = asyncio.Queue()
         state.active_queue = event_queue
@@ -474,6 +544,10 @@ class AntigravityExecutor(Executor):
             yield TurnCancelled(reason="user_cancelled", phase="model")
             return
         usage = self._extract_usage(state.last_usage)
+        # Notify in-process usage subscribers (and the auto-recorder) before the
+        # terminal event, matching the peer SDK executors so antigravity turns
+        # are not invisible to usage observers. No-op for an empty usage dict.
+        _notify_usage_from_dict(model=model, usage=usage)
         yield TurnComplete(response="".join(final_text_parts) or None, usage=usage)
 
     # ── SDK touchpoints (isolated; duck-typed; verified against v0.1.x) ──
@@ -674,7 +748,7 @@ class AntigravityExecutor(Executor):
         model: str,
         system_prompt: str,
         tools: list[ToolSpec],
-    ) -> _AntigravitySessionState:
+    ) -> tuple[_AntigravitySessionState, bool]:
         """Return the session state with a current SDK agent + conversation.
 
         Rebuilds the agent when the model, system prompt, or tool set changes;
@@ -686,8 +760,14 @@ class AntigravityExecutor(Executor):
         :param model: The resolved model id to pin, e.g. ``"gemini-3.5-flash"``.
         :param system_prompt: The agent's system instructions.
         :param tools: Omnigent tool specs to expose to the agent.
-        :returns: The session's :class:`_AntigravitySessionState`, with
-            ``agent`` and ``conversation`` populated.
+        :returns: ``(state, created)`` — the session's
+            :class:`_AntigravitySessionState` (with ``agent`` /
+            ``conversation`` populated) and ``created``, which is ``True``
+            when a FRESH SDK agent was opened (a brand-new session or a
+            signature-forced rebuild) and ``False`` when an existing live
+            agent was reused. A fresh agent's SDK conversation starts empty,
+            so the caller must seed prior history into it; a reused agent
+            already holds that history and must NOT be re-seeded.
         """
         signature = (model, system_prompt, self._tool_signature(tools))
         state = self._session_states.get(session_key)
@@ -696,7 +776,7 @@ class AntigravityExecutor(Executor):
             self._session_states[session_key] = state
 
         if state.agent is not None and state.agent_signature == signature:
-            return state
+            return state, False
 
         if state.agent is not None:
             await self._close_agent(state.agent)
@@ -709,7 +789,7 @@ class AntigravityExecutor(Executor):
         state.agent = agent
         state.conversation = agent.conversation
         state.agent_signature = signature
-        return state
+        return state, True
 
     async def _open_agent(
         self,

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -34,6 +34,7 @@ from omnigent.inner.executor import (
     TurnCancelled,
     TurnComplete,
 )
+from omnigent.llms._usage_observer import add_observer
 
 # ── Fakes mirroring the real SDK streaming shapes ───────────────────────
 
@@ -765,6 +766,152 @@ async def test_agent_reused_across_turns_same_session(monkeypatch: pytest.Monkey
     # the cached agent (and its SDK conversation state) was reused.
     assert len(captured["agents"]) == 1
     assert captured["agents"][0].conversation.sends == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_fresh_session_replays_prior_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A FRESH agent seeds prior user/assistant turns into its first send().
+
+    Models a rebuilt/restarted session: the turn arrives with prior history but
+    the SDK conversation is brand new (and the SDK has no history-injection
+    API). The prior turns must ride into the single send() as a context prefix,
+    so the agent doesn't lose them. Without the seeding fix the agent would only
+    ever see the latest user text.
+    """
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("reply")]])
+    executor = AntigravityExecutor()
+
+    messages = [
+        {"role": "user", "content": "what is 2+2?", "session_id": "s1"},
+        {"role": "assistant", "content": "4", "session_id": "s1"},
+        {"role": "user", "content": "and times 3?", "session_id": "s1"},
+    ]
+    await _drain(executor, messages)
+
+    # One agent, one send. That send must carry the prior turns AND the latest
+    # user text — not just the latest text (the pre-fix behavior).
+    sends = captured["agents"][0].conversation.sends
+    assert len(sends) == 1
+    seeded = sends[0]
+    assert "what is 2+2?" in seeded  # prior user turn replayed
+    assert "assistant: 4" in seeded  # prior assistant turn replayed
+    assert "and times 3?" in seeded  # latest user input still present
+    # The latest input is not the whole prompt — proves a prefix was prepended.
+    assert seeded != "and times 3?"
+
+
+@pytest.mark.asyncio
+async def test_rebuilt_session_replays_history_after_signature_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model switch rebuilds the agent; the rebuild re-seeds prior history.
+
+    A signature change (model/system-prompt/tools) discards the live SDK
+    conversation, so the *rebuilt* agent is fresh and must be re-seeded with the
+    history it just lost — the same context-loss bug a server restart causes.
+    """
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("a")], [_text_step("b")]])
+    executor = AntigravityExecutor(model="gemini-3-pro")
+
+    await _drain(executor, [{"role": "user", "content": "first", "session_id": "s1"}])
+    # Second turn carries the accumulated history AND switches model, forcing a
+    # rebuild of the (now fresh) agent.
+    second = [
+        {"role": "user", "content": "first", "session_id": "s1"},
+        {"role": "assistant", "content": "answer one", "session_id": "s1"},
+        {"role": "user", "content": "second", "session_id": "s1"},
+    ]
+    await _drain(executor, second, config=ExecutorConfig(model="gemini-3-flash"))
+
+    # Two agents (model changed). The rebuilt agent's first send must replay the
+    # prior turns, not just the latest "second".
+    assert len(captured["agents"]) == 2
+    rebuilt_sends = captured["agents"][1].conversation.sends
+    assert len(rebuilt_sends) == 1
+    assert "first" in rebuilt_sends[0]
+    assert "assistant: answer one" in rebuilt_sends[0]
+    assert "second" in rebuilt_sends[0]
+
+
+@pytest.mark.asyncio
+async def test_reused_session_does_not_reseed_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A REUSED agent must NOT re-seed history (it already holds it).
+
+    The live SDK conversation accumulated the prior turns itself, so re-seeding
+    on reuse would duplicate them. The second turn's send must be exactly the
+    latest user text, with no transcript prefix.
+    """
+    captured = _install_fake_sdk(
+        monkeypatch, scripts=[[_text_step("one-reply")], [_text_step("two-reply")]]
+    )
+    executor = AntigravityExecutor()
+
+    await _drain(executor, [{"role": "user", "content": "one", "session_id": "s1"}])
+    # Second turn on the same session/signature reuses the agent. It carries the
+    # prior turn in its messages, but the reused conversation already has it.
+    second = [
+        {"role": "user", "content": "one", "session_id": "s1"},
+        {"role": "assistant", "content": "one-reply", "session_id": "s1"},
+        {"role": "user", "content": "two", "session_id": "s1"},
+    ]
+    await _drain(executor, second)
+
+    assert len(captured["agents"]) == 1  # reused, not rebuilt
+    # The reused turn's send is the bare latest text — no "Conversation so far:"
+    # prefix and no duplicated prior turn.
+    sends = captured["agents"][0].conversation.sends
+    assert sends == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_usage_observer_notified_on_turn_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The usage observer is notified with the turn's tokens before TurnComplete.
+
+    Peers notify in-process usage subscribers on every turn; without the fix,
+    antigravity turns fire nothing, so observers see no usage for them.
+    """
+    script: list[_TurnAction] = [
+        _text_step("hi"),
+        _YieldStep(
+            _FakeStep(
+                step_type=_StepType.FINISH, status=_StepStatus.DONE, usage_metadata=_FakeUsage()
+            )
+        ),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor(model="gemini-3-pro")
+
+    seen: list[dict[str, Any]] = []
+
+    def _observer(
+        *, model: str | None, input_tokens: int, output_tokens: int, total_tokens: int
+    ) -> None:
+        seen.append(
+            {
+                "model": model,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": total_tokens,
+            }
+        )
+
+    remove = add_observer(_observer)
+    try:
+        events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+    finally:
+        remove()
+
+    # Exactly one notification, carrying the model and the mapped token counts
+    # from the turn's UsageMetadata (_FakeUsage: prompt=11, candidates=7, total=18).
+    assert len(seen) == 1
+    assert seen[0] == {
+        "model": "gemini-3-pro",
+        "input_tokens": 11,
+        "output_tokens": 7,
+        "total_tokens": 18,
+    }
+    # The notification accompanies a normal TurnComplete.
+    assert any(isinstance(e, TurnComplete) for e in events)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The merged Google Antigravity harness executor (`omnigent/inner/antigravity_executor.py`, PR #194) has two gaps relative to its peers (`openai_agents_sdk_executor`, `claude_sdk_executor`):

**Bug 1 — context loss (High).** `run_turn` sent only `_latest_user_text(messages)` to `conversation.send()`. When `_ensure_agent` builds a **fresh** agent — a new `session_key` (e.g. after a server restart) or a rebuild forced by a model / system-prompt / tools change — the SDK conversation starts empty and never receives the prior turns, so the agent loses all history. The OpenAI-Agents and Claude SDK executors both replay full history when (re)building a session.

**Bug 2 — usage observer (Low).** `run_turn` never notified the usage observer before `TurnComplete`, so in-process usage subscribers (and the `OMNIGENT_TOKEN_USAGE_JSON` auto-recorder) saw nothing for antigravity turns.

## Fix

The Antigravity SDK exposes **no history-injection API**: `Connection.send()` maps the prompt to a single `InputEvent` and triggers a model turn, and `LocalAgentConfig` has no inline-history field (only a backend-side `conversation_id` resume that a genuine rebuild/restart cannot use). So, mirroring the Claude SDK executor's fallback (`_build_prompt(resume_session=...)`):

1. `_ensure_agent` now returns `(state, created)`, reporting whether it opened a **fresh** agent (new session or signature-forced rebuild) vs. reused a live one.
2. When `created`, `run_turn` seeds the prior history (`messages[:-1]`) as a plain-text transcript prefix into the single `send()` the turn already makes, so the fresh backend sees the history as context for the turn it is about to run. A **reused** agent already holds the history in its live conversation and is **not** re-seeded (avoids duplication).
3. `notify_from_dict(model=, usage=)` is called immediately before `yield TurnComplete(...)`, matching the peers.

**Limitation (documented in code):** only `user` / `assistant` text is replayed. Tool calls and tool results are not reconstructed into the SDK's native step history (the SDK has no surface to inject them). This is the best replay the SDK allows.

## Tests

Added to `tests/inner/test_antigravity_executor.py` using the existing fakes (asserting on the fake conversation's recorded `send`s and via a registered usage observer):

- a fresh session replays prior user/assistant turns into its first `send`;
- a signature-rebuilt session (model switch) re-seeds the history it lost;
- a reused session does **not** re-seed;
- the usage observer is notified with the turn's tokens on `TurnComplete`.

Each behavior-changing test fails without the change. Full file: 32 passed. `ruff check` / `ruff format` / `mypy` clean on the executor.

This pull request and its description were written by Isaac.