### PR TITLE
fix(antigravity): pass tool parameter schemas + fix tool cache key

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -395,13 +395,37 @@ class AntigravityExecutor(Executor):
 
     @staticmethod
     def _tool_signature(tools: list[ToolSpec]) -> str:
-        """Stable cache key for a tool set (names only — enough to detect change).
+        """Stable cache key for a tool set (name + description + parameters).
+
+        Keyed on the full declaration the SDK builds — name, description, and
+        ``parameters`` JSON schema — so that a change to a tool's description or
+        argument schema (not just its name) busts the cached SDK agent and the
+        model sees the new declaration. Built from a sorted, canonicalized
+        structure so it's deterministic and stable when nothing meaningful
+        changed (dict key order doesn't matter).
 
         :param tools: Omnigent tool specs for the turn.
-        :returns: Deterministic JSON string of the sorted tool names.
+        :returns: Deterministic JSON string of the sorted per-tool declarations.
         """
-        names = sorted(str(tool.get("name", "")) for tool in tools)
-        return json.dumps(names, separators=(",", ":"))
+        # Canonicalize each declaration to a string first (``sort_keys`` makes
+        # nested ``parameters`` dicts order-independent), then sort the strings.
+        # Sorting strings — not the raw tuples — avoids a ``TypeError`` from
+        # comparing un-orderable ``parameters`` values (dict vs dict / None)
+        # when two tools share a name and description.
+        declarations = sorted(
+            json.dumps(
+                [
+                    str(tool.get("name", "")),
+                    str(tool.get("description", "")),
+                    tool.get("parameters"),
+                ],
+                separators=(",", ":"),
+                sort_keys=True,
+                default=str,
+            )
+            for tool in tools
+        )
+        return json.dumps(declarations, separators=(",", ":"))
 
     async def close_session(self, session_key: str) -> None:
         """Close and drop the SDK agent for *session_key*, if any.
@@ -646,14 +670,17 @@ class AntigravityExecutor(Executor):
     ) -> None:
         """Enqueue a :class:`ToolCallRequest` for each new tool call in *step*.
 
-        Calls repeat across step transitions, so each call id is emitted once
-        and its start time recorded for the matching :class:`ToolCallComplete`.
-        Id-less calls are always emitted (can't dedupe) and get a synthetic id
-        so the completion hook can still pair them.
+        Calls repeat across step transitions, so each is emitted once. An id'd
+        call dedupes on its id; an id-less call dedupes on a stable surrogate
+        (tool name + canonical JSON of its args) and is assigned a synthetic id
+        on first sight, so a repeated id-less call reuses that id rather than
+        emitting a duplicate request. The start time is recorded for the
+        matching :class:`ToolCallComplete`.
 
         :param step: The current SDK :class:`Step`.
         :param state: The session state (records pending tools by call id).
-        :param seen_tool_ids: Call ids already emitted this turn (mutated).
+        :param seen_tool_ids: Surrogate keys already emitted this turn (mutated)
+            — a real call id for id'd calls, or ``name + args`` for id-less ones.
         """
         queue = state.active_queue
         if queue is None:
@@ -662,16 +689,45 @@ class AntigravityExecutor(Executor):
             name = _tool_name(getattr(call, "name", None))
             if not name:
                 continue
-            raw_id = getattr(call, "id", None)
-            call_id = raw_id if isinstance(raw_id, str) and raw_id else uuid.uuid4().hex
-            if isinstance(raw_id, str) and raw_id:
-                if call_id in seen_tool_ids:
-                    continue
-                seen_tool_ids.add(call_id)
             raw_args = getattr(call, "args", None)
             args: ToolArgs = raw_args if isinstance(raw_args, dict) else {}
+            raw_id = getattr(call, "id", None)
+            # An id'd call dedupes on (and pairs by) its real id; an id-less call
+            # dedupes on a content surrogate and gets a synthetic id so the
+            # completion hook can still pair it.
+            if isinstance(raw_id, str) and raw_id:
+                surrogate = raw_id
+                call_id = raw_id
+            else:
+                surrogate = self._idless_surrogate(name, args)
+                call_id = uuid.uuid4().hex
+            # Skip a repeat of an already-seen call (same id, or same name+args
+            # for the id-less case) rather than re-emitting the request.
+            if surrogate in seen_tool_ids:
+                continue
+            seen_tool_ids.add(surrogate)
             state.pending_tools[call_id] = _PendingTool(name=name, started=time.monotonic())
             queue.put_nowait(ToolCallRequest(name=name, args=args, metadata={"call_id": call_id}))
+
+    @staticmethod
+    def _idless_surrogate(name: str, args: ToolArgs) -> str:
+        """Build a stable dedupe key for an id-less tool call.
+
+        The SDK re-emits the same call across step transitions; without an id
+        to dedupe on, repeated emissions of the same call (same tool name and
+        arguments) would each surface a :class:`ToolCallRequest`. This pairs
+        the name with a canonical (key-sorted) JSON render of the args so two
+        emissions of the same logical call collapse to one key.
+
+        :param name: The tool's wire name.
+        :param args: The call's argument dict.
+        :returns: A surrogate key string ``"<name>:<canonical-args-json>"``.
+        """
+        try:
+            args_json = json.dumps(args, sort_keys=True, separators=(",", ":"), default=str)
+        except TypeError:
+            args_json = repr(args)
+        return f"{name}:{args_json}"
 
     def _complete_pending_from_step(
         self, step: SDKStep, state: _AntigravitySessionState, status: str
@@ -803,10 +859,12 @@ class AntigravityExecutor(Executor):
 
         Isolated SDK touchpoint. Builds a ``LocalAgentConfig`` from the
         resolved model / prompt / credentials / tools / hooks and enters the
-        agent's async context. Omnigent's tools are exposed as callables
-        (``LocalAgentConfig.tools``) routing through :attr:`_tool_executor`, so
-        the agent runs them under policy. A ``PostToolCallHook`` surfaces a
-        :class:`ToolCallComplete` for every tool the agent runs.
+        agent's async context. Omnigent's tools are exposed via
+        ``LocalAgentConfig.tools`` (schema-bearing ``ToolWithSchema`` wrappers
+        when the spec has a ``parameters`` schema, else bare callables) routing
+        through :attr:`_tool_executor`, so the agent runs them under policy. A
+        ``PostToolCallHook`` surfaces a :class:`ToolCallComplete` for every tool
+        the agent runs.
 
         :param state: The session state the tool-completion hook closes over.
         :param model: The resolved model id to pin.
@@ -816,7 +874,7 @@ class AntigravityExecutor(Executor):
         """
         antigravity = _ensure_antigravity_sdk()
         config_kwargs: _StrAnyDict = {"system_instructions": system_prompt or None}
-        sdk_tools = self._build_sdk_tools(tools)
+        sdk_tools = self._build_sdk_tools(antigravity, tools)
         if sdk_tools:
             config_kwargs["tools"] = sdk_tools
         config_kwargs["hooks"] = [self._build_post_tool_hook(antigravity, state)]
@@ -883,21 +941,29 @@ class AntigravityExecutor(Executor):
 
         return _OmnigentToolCompleteHook()
 
-    def _build_sdk_tools(self, tools: list[ToolSpec]) -> list[SDKTool]:
-        """Build SDK tools (plain callables) from Omnigent tool specs.
+    def _build_sdk_tools(self, antigravity: ModuleType, tools: list[ToolSpec]) -> list[SDKTool]:
+        """Build SDK tools from Omnigent tool specs, with explicit arg schemas.
 
-        The SDK introspects each callable's ``__name__`` / ``__doc__`` for its
-        function declaration. Each routes through :attr:`_tool_executor`, so
-        the agent reaches Omnigent's tool registry under policy. Returns ``[]``
-        when there are no tools or no executor bridge yet (the agent then runs
-        with its native + MCP tools only).
+        Each tool becomes an async callable (``__name__`` / ``__doc__`` set)
+        routing through :attr:`_tool_executor`, so the agent reaches Omnigent's
+        tool registry under policy. When the spec carries a ``parameters`` JSON
+        schema, the callable is wrapped in the SDK's ``ToolWithSchema`` so the
+        model sees the argument shapes (the SDK uses the explicit schema
+        verbatim, bypassing signature introspection); otherwise the bare
+        callable is registered and the SDK introspects its (empty) signature.
+        Returns ``[]`` when there are no tools or no executor bridge yet (the
+        agent then runs with its native + MCP tools only).
 
+        :param antigravity: The imported ``google.antigravity`` module (source
+            of the ``ToolWithSchema`` explicit-schema wrapper).
         :param tools: Omnigent tool specs (``name`` / ``description`` /
             ``parameters``).
-        :returns: A list of named async callables, or ``[]``.
+        :returns: A list of SDK tools (``ToolWithSchema`` or bare callables),
+            or ``[]``.
         """
         if not tools or self._tool_executor is None:
             return []
+        schema_wrapper = self._tool_with_schema_cls(antigravity)
         sdk_tools: list[SDKTool] = []
         for tool in tools:
             name = tool.get("name")
@@ -905,16 +971,45 @@ class AntigravityExecutor(Executor):
                 continue
             description = tool.get("description")
             description = description if isinstance(description, str) else ""
-            sdk_tools.append(self._make_tool_callable(name, description))
+            callable_tool = self._make_tool_callable(name, description)
+            parameters = tool.get("parameters")
+            if schema_wrapper is not None and isinstance(parameters, dict) and parameters:
+                # Pass the spec's JSON schema straight through; the SDK uses it
+                # as the tool's declaration so the model knows each argument.
+                sdk_tools.append(schema_wrapper(callable_tool, parameters))
+            else:
+                sdk_tools.append(callable_tool)
         return sdk_tools
+
+    @staticmethod
+    def _tool_with_schema_cls(antigravity: ModuleType) -> type | None:
+        """Resolve the SDK's ``ToolWithSchema`` explicit-schema wrapper class.
+
+        Isolated SDK touchpoint, duck-typed to tolerate v0.1.x drift: the
+        wrapper lives at ``antigravity.tools.tool_runner.ToolWithSchema`` and
+        pairs a callable with an explicit ``input_schema`` that
+        ``callable_to_tool_proto`` serializes verbatim into the tool
+        declaration. Returns ``None`` when the SDK doesn't expose it, in which
+        case the caller registers bare callables (the SDK then introspects the
+        signature, the pre-schema behavior).
+
+        :param antigravity: The imported ``google.antigravity`` module.
+        :returns: The ``ToolWithSchema`` class, or ``None`` when unavailable.
+        """
+        tools_mod = getattr(antigravity, "tools", None)
+        runner_mod = getattr(tools_mod, "tool_runner", None)
+        wrapper = getattr(runner_mod, "ToolWithSchema", None)
+        return wrapper if isinstance(wrapper, type) else None
 
     def _make_tool_callable(self, tool_name: str, description: str) -> _ToolCallable:
         """Build a named async callable the SDK can register as a tool.
 
         Accepts the SDK's arg shape (kwargs, a single dict, or a JSON string)
         and forwards to :attr:`_tool_executor`. Its ``__name__`` / ``__doc__``
-        are set so the SDK's function-declaration introspection picks up the
-        name and description.
+        are set so the SDK picks up the name and description; the argument
+        schema is supplied separately by :meth:`_build_sdk_tools` wrapping this
+        callable in ``ToolWithSchema`` (the SDK only introspects the bare
+        callable's signature when no explicit schema is provided).
 
         :param tool_name: The Omnigent tool name, e.g. ``"sys_shell"``.
         :param description: Human-readable tool description for the model.

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -22,9 +22,11 @@ Streaming model:
   ``status``, ``usage_metadata``), ending once the turn goes idle. A producer
   task drives ``send()`` + ``receive_steps()`` and feeds a per-turn
   :class:`asyncio.Queue`; :meth:`run_turn` drains it and yields mapped events.
-- Tool *requests* derive from ``Step.tool_calls`` (deduped by call id); tool
-  *completions* (with payload, error, duration) arrive via a registered
-  ``PostToolCallHook`` and pair back by call id.
+- Tool *requests* derive from ``Step.tool_calls`` (an id'd call deduped by its
+  id, an id-less call deduped only while in flight); tool *completions* (with
+  payload, error, duration) arrive via a registered ``PostToolCallHook`` and
+  pair back by call id, or — for an id-less result — to the oldest in-flight
+  id-less call of the same name.
 - Cancellation: :meth:`interrupt_session` -> ``conversation.cancel()``, which
   surfaces ``TurnCancelled``.
 
@@ -274,10 +276,16 @@ class _PendingTool:
     :param name: The tool's wire name, e.g. ``"sys_shell"``.
     :param started: ``time.monotonic()`` at :class:`ToolCallRequest` emit,
         used to compute ``ToolCallComplete.duration_ms``.
+    :param surrogate: For an *id-less* call, the content surrogate (tool name +
+        canonical args) holding its in-flight dedupe slot in
+        ``_AntigravitySessionState.active_idless``; ``None`` for an id'd call.
+        On completion the slot is freed so a genuinely new id-less call with
+        identical name + args later in the turn is not swallowed as a repeat.
     """
 
     name: str
     started: float
+    surrogate: str | None = None
 
 
 @dataclass
@@ -296,8 +304,16 @@ class _AntigravitySessionState:
     :param agent_signature: ``(model, system_prompt, tool_signature)`` key; a
         change forces an agent rebuild. A model change thus resets the SDK
         conversation — fine since mid-session model switches are rare.
-    :param pending_tools: Open tool calls keyed by call id, populated on
-        :class:`ToolCallRequest` and drained by the ``PostToolCallHook``.
+    :param pending_tools: Open tool calls keyed by call id (real id for id'd
+        calls, synthetic id for id-less ones), populated on
+        :class:`ToolCallRequest` and drained by the ``PostToolCallHook`` (or the
+        terminal-step fallback).
+    :param active_idless: In-flight id-less calls, mapping the content surrogate
+        (tool name + canonical args) to the synthetic call id assigned on first
+        sight. An id-less call's dedupe slot lives here only while the call is
+        in flight; its completion frees the slot, so repeated step emissions of
+        the *same* in-flight call collapse to one request while a genuinely new
+        id-less call with identical name + args later in the turn still emits.
     :param active_queue: The current turn's event queue (the
         ``PostToolCallHook`` enqueues completions here), or ``None`` between
         turns.
@@ -311,6 +327,7 @@ class _AntigravitySessionState:
     conversation: SDKConversation = None
     agent_signature: tuple[str, str, str] | None = field(default=None)
     pending_tools: dict[str, _PendingTool] = field(default_factory=dict)
+    active_idless: dict[str, str] = field(default_factory=dict)
     active_queue: _EventQueue | None = field(default=None)
     last_usage: SDKUsage = None
     interrupt_requested: bool = False
@@ -526,6 +543,7 @@ class AntigravityExecutor(Executor):
         event_queue: _EventQueue = asyncio.Queue()
         state.active_queue = event_queue
         state.pending_tools.clear()
+        state.active_idless.clear()
         state.last_usage = None
         state.interrupt_requested = False
 
@@ -591,6 +609,9 @@ class AntigravityExecutor(Executor):
         queue = state.active_queue
         assert queue is not None  # set by run_turn before spawning this task
         conversation = state.conversation
+        # Real ids already emitted this turn, deduping an id'd call re-emitted
+        # across step transitions. Id-less calls dedupe separately (and only
+        # while in flight) via ``state.active_idless``.
         seen_tool_ids: set[str] = set()
         try:
             await conversation.send(prompt)
@@ -670,17 +691,32 @@ class AntigravityExecutor(Executor):
     ) -> None:
         """Enqueue a :class:`ToolCallRequest` for each new tool call in *step*.
 
-        Calls repeat across step transitions, so each is emitted once. An id'd
-        call dedupes on its id; an id-less call dedupes on a stable surrogate
-        (tool name + canonical JSON of its args) and is assigned a synthetic id
-        on first sight, so a repeated id-less call reuses that id rather than
-        emitting a duplicate request. The start time is recorded for the
+        The SDK re-emits the same call across step transitions (dispatch →
+        execution → result), so each logical call is emitted once. An id'd call
+        dedupes on (and pairs by) its real id via *seen_tool_ids*.
+
+        An id-less call (``ToolCall.id is None`` — e.g. the SDK's sub-agent
+        completions) has no id to dedupe on, so it gets a synthetic id and its
+        content surrogate (tool name + canonical args) is recorded in
+        ``state.active_idless`` *only while it is in flight*. A repeat emission
+        of that same in-flight call finds its surrogate still live and is
+        skipped; the surrogate is freed the moment the call completes (see
+        :meth:`_match_idless_pending`, used by both completion paths). This
+        deliberately mirrors how far the SDK's own ``receive_chunks`` dedupes —
+        it never collapses *distinct* id-less calls — so a genuinely new id-less
+        call with identical name + args later in the turn still emits its own
+        request and keeps a paired completion, rather than being swallowed by a
+        turn-wide ``name + args`` key. (Two distinct id-less calls with
+        identical args that overlap *before* the first completes still collapse;
+        the SDK gives no id to tell them apart mid-flight, so the in-flight slot
+        is the tightest unambiguous scope.) The start time is recorded for the
         matching :class:`ToolCallComplete`.
 
         :param step: The current SDK :class:`Step`.
-        :param state: The session state (records pending tools by call id).
-        :param seen_tool_ids: Surrogate keys already emitted this turn (mutated)
-            — a real call id for id'd calls, or ``name + args`` for id-less ones.
+        :param state: The session state (records pending tools by call id and
+            in-flight id-less surrogates).
+        :param seen_tool_ids: Real call ids already emitted this turn (mutated);
+            id-less calls dedupe via ``state.active_idless`` instead.
         """
         queue = state.active_queue
         if queue is None:
@@ -692,32 +728,39 @@ class AntigravityExecutor(Executor):
             raw_args = getattr(call, "args", None)
             args: ToolArgs = raw_args if isinstance(raw_args, dict) else {}
             raw_id = getattr(call, "id", None)
-            # An id'd call dedupes on (and pairs by) its real id; an id-less call
-            # dedupes on a content surrogate and gets a synthetic id so the
-            # completion hook can still pair it.
             if isinstance(raw_id, str) and raw_id:
-                surrogate = raw_id
+                # An id'd call dedupes on (and pairs by) its real id.
+                if raw_id in seen_tool_ids:
+                    continue
+                seen_tool_ids.add(raw_id)
+                surrogate: str | None = None
                 call_id = raw_id
             else:
+                # An id-less call dedupes on its content surrogate, but only
+                # while in flight — skip a repeat of a still-open call, else
+                # treat it as a new call and reopen the slot.
                 surrogate = self._idless_surrogate(name, args)
+                if surrogate in state.active_idless:
+                    continue
                 call_id = uuid.uuid4().hex
-            # Skip a repeat of an already-seen call (same id, or same name+args
-            # for the id-less case) rather than re-emitting the request.
-            if surrogate in seen_tool_ids:
-                continue
-            seen_tool_ids.add(surrogate)
-            state.pending_tools[call_id] = _PendingTool(name=name, started=time.monotonic())
+                state.active_idless[surrogate] = call_id
+            state.pending_tools[call_id] = _PendingTool(
+                name=name, started=time.monotonic(), surrogate=surrogate
+            )
             queue.put_nowait(ToolCallRequest(name=name, args=args, metadata={"call_id": call_id}))
 
     @staticmethod
     def _idless_surrogate(name: str, args: ToolArgs) -> str:
-        """Build a stable dedupe key for an id-less tool call.
+        """Build the in-flight dedupe key for an id-less tool call.
 
         The SDK re-emits the same call across step transitions; without an id
-        to dedupe on, repeated emissions of the same call (same tool name and
-        arguments) would each surface a :class:`ToolCallRequest`. This pairs
-        the name with a canonical (key-sorted) JSON render of the args so two
-        emissions of the same logical call collapse to one key.
+        to dedupe on, repeated emissions of the same in-flight call (same tool
+        name and arguments) would each surface a :class:`ToolCallRequest`. This
+        pairs the name with a canonical (key-sorted) JSON render of the args so
+        repeated emissions of one logical call collapse to one key. The key is
+        only treated as "seen" while the call is in flight (it lives in
+        ``state.active_idless`` and is freed on completion), so a later distinct
+        id-less call with identical name + args is not mistaken for a repeat.
 
         :param name: The tool's wire name.
         :param args: The call's argument dict.
@@ -729,19 +772,53 @@ class AntigravityExecutor(Executor):
             args_json = repr(args)
         return f"{name}:{args_json}"
 
+    @staticmethod
+    def _match_idless_pending(
+        state: _AntigravitySessionState, name: str
+    ) -> tuple[str, _PendingTool] | None:
+        """Pop the oldest in-flight id-less pending call of *name* and free it.
+
+        An id-less completion (a ``ToolResult`` with no id — e.g. a sub-agent
+        result) carries no id to pair on, so it's matched to the earliest-opened
+        in-flight id-less call of the same tool name (FIFO). Removes that entry
+        from ``state.pending_tools`` and frees its surrogate slot in
+        ``state.active_idless``, so a later id-less call with identical name +
+        args is treated as new rather than a repeat.
+
+        Relies on ``dict`` preserving insertion order: ``pending_tools`` is
+        populated in emit order, so the first id-less match of *name* is the
+        oldest open call.
+
+        :param state: The session state (its ``pending_tools`` / ``active_idless``
+            are drained).
+        :param name: The completing tool's wire name.
+        :returns: The popped ``(call_id, _PendingTool)``, or ``None`` when no
+            in-flight id-less call of that name remains (already completed).
+        """
+        for call_id, pending in state.pending_tools.items():
+            if pending.surrogate is not None and pending.name == name:
+                state.pending_tools.pop(call_id, None)
+                state.active_idless.pop(pending.surrogate, None)
+                return call_id, pending
+        return None
+
     def _complete_pending_from_step(
         self, step: SDKStep, state: _AntigravitySessionState, status: str
     ) -> None:
         """Close any still-pending tool calls in a terminal ``TOOL_CALL`` step.
 
         Fallback for when the ``PostToolCallHook`` doesn't fire for a call. The
-        hook pops a completed call from ``state.pending_tools``, so an id still
+        hook pops a completed call from ``state.pending_tools``, so a call still
         present here wasn't completed by it — emit a :class:`ToolCallComplete`
-        (without the payload, which only the hook carries). Popping here makes
-        a later hook fire for the same id a no-op, so it completes once.
+        (without the payload, which only the hook carries). An id'd call is
+        matched by its real id; an id-less call is matched to the oldest
+        in-flight id-less call of the same name (and its surrogate freed) via
+        :meth:`_match_idless_pending`. Popping here makes a later hook fire for
+        the same call a no-op, so it completes once.
 
         :param step: The terminal ``TOOL_CALL`` step.
-        :param state: The session state (its ``pending_tools`` is drained).
+        :param state: The session state (its ``pending_tools`` / ``active_idless``
+            are drained).
         :param status: The step's status name, e.g. ``"ERROR"`` / ``"DONE"``.
         """
         queue = state.active_queue
@@ -758,11 +835,17 @@ class AntigravityExecutor(Executor):
             error = None
         for call in getattr(step, "tool_calls", None) or []:
             raw_id = getattr(call, "id", None)
-            # id-less calls can't be matched to a pending entry; the hook is
-            # their only completion path.
-            if not (isinstance(raw_id, str) and raw_id):
-                continue
-            pending = state.pending_tools.pop(raw_id, None)
+            if isinstance(raw_id, str) and raw_id:
+                call_id = raw_id
+                pending = state.pending_tools.pop(raw_id, None)
+            else:
+                # No id to pair on: match the oldest in-flight id-less call of
+                # this name (FIFO), freeing its in-flight surrogate slot.
+                name = _tool_name(getattr(call, "name", None))
+                matched = self._match_idless_pending(state, name) if name else None
+                if matched is None:
+                    continue  # already completed by the PostToolCallHook
+                call_id, pending = matched
             if pending is None:
                 continue  # already completed by the PostToolCallHook
             duration_ms = (time.monotonic() - pending.started) * 1000
@@ -773,7 +856,7 @@ class AntigravityExecutor(Executor):
                     result=None,
                     error=error,
                     duration_ms=duration_ms,
-                    metadata={"call_id": raw_id},
+                    metadata={"call_id": call_id},
                 )
             )
 
@@ -891,10 +974,12 @@ class AntigravityExecutor(Executor):
         """Build a ``PostToolCallHook`` that emits :class:`ToolCallComplete`.
 
         The SDK invokes this after every tool call with a ``ToolResult``; the
-        hook pairs it to the originating :class:`ToolCallRequest` via
-        ``state.pending_tools[id]`` (for duration) and enqueues a
-        :class:`ToolCallComplete`. Defined inline because its base only exists
-        once the SDK is imported.
+        hook pairs it to the originating :class:`ToolCallRequest` (for duration
+        and call id) and enqueues a :class:`ToolCallComplete`. An id'd result
+        pairs by its real id; an id-less result (e.g. a sub-agent completion)
+        pairs to the oldest in-flight id-less call of the same name (FIFO) via
+        :meth:`_match_idless_pending`. Defined inline because its base only
+        exists once the SDK is imported.
 
         :param antigravity: The imported ``google.antigravity`` module.
         :param state: The session state (queue + pending-tool table) the hook
@@ -915,19 +1000,39 @@ class AntigravityExecutor(Executor):
                 if queue is None:
                     return
                 raw_id = getattr(data, "id", None)
-                call_id = raw_id if isinstance(raw_id, str) and raw_id else None
-                pending = state.pending_tools.pop(call_id, None) if call_id else None
-                # For an id'd call, a missing pending entry means the step-stream
-                # fallback already completed it — skip to avoid a double emit.
-                if call_id is not None and pending is None:
-                    return
-                name = _tool_name(getattr(data, "name", None)) or (pending.name if pending else "")
-                duration_ms = (time.monotonic() - pending.started) * 1000 if pending else 0.0
+                result_name = _tool_name(getattr(data, "name", None))
+                if isinstance(raw_id, str) and raw_id:
+                    call_id: str | None = raw_id
+                    pending = state.pending_tools.pop(raw_id, None)
+                    # For an id'd call, a missing pending entry means the
+                    # step-stream fallback already completed it — skip the
+                    # double emit.
+                    if pending is None:
+                        return
+                else:
+                    # An id-less result carries no id to pair on; match it to the
+                    # oldest in-flight id-less call of the same name (FIFO),
+                    # freeing its surrogate so a later identical call re-emits.
+                    matched = (
+                        AntigravityExecutor._match_idless_pending(state, result_name)
+                        if result_name
+                        else None
+                    )
+                    # A missing match means the step-stream fallback already
+                    # closed it — skip to avoid a double emit.
+                    if matched is None:
+                        return
+                    call_id, pending = matched
+                name = result_name or pending.name
+                duration_ms = (time.monotonic() - pending.started) * 1000
                 result = getattr(data, "result", None)
                 error = getattr(data, "error", None)
                 classification = classify_tool_result(result)
                 status = ToolCallStatus.ERROR if error else classification.status
                 message = error or (classification.error or None)
+                # call_id is always set here (both branches above return early
+                # when no pending call matches), so the completion is paired —
+                # an id-less call to its synthetic id, an id'd call to its id.
                 queue.put_nowait(
                     ToolCallComplete(
                         name=name,
@@ -935,7 +1040,7 @@ class AntigravityExecutor(Executor):
                         result=result,
                         error=message,
                         duration_ms=duration_ms,
-                        metadata={"call_id": call_id} if call_id else {},
+                        metadata={"call_id": call_id},
                     )
                 )
 

--- a/tests/e2e/omnigent/test_per_harness_antigravity_tool_schema.py
+++ b/tests/e2e/omnigent/test_per_harness_antigravity_tool_schema.py
@@ -1,0 +1,217 @@
+"""Per-harness live e2e — antigravity bridged-tool *parameter schema* reaches the model.
+
+Runs a real ``omnigent run <spec> -p "..."`` one-shot against the in-process
+``antigravity`` harness (Gemini-native ``google-antigravity`` SDK), where the
+spec declares a bridged ``type: function`` tool whose ``parameters`` JSON schema
+has TWO **required** structured args (a string ``player`` and an integer
+``score``). The prompt asks the model to record a specific score, and the test
+asserts the bridged tool actually ran with the **correct populated args** — the
+recorded player + score round-trip back into the assistant's reply.
+
+This is the end-to-end gate for the headline fix in PR #279: the Antigravity
+executor now passes each bridged Omnigent tool's ``parameters`` JSON schema to
+the SDK via its ``ToolWithSchema(fn, input_schema)`` wrapper, so Gemini sees the
+argument shapes instead of guessing. Before that fix the SDK only received the
+tool's name + description with an empty arg schema, so the model could not
+reliably populate ``player`` / ``score`` and the structured round-trip would not
+appear. The full path exercised: CLI parse -> spec materialize -> Omnigent
+server boot -> local runner -> :class:`AntigravityExecutor` building a
+schema-bearing ``ToolWithSchema`` and driving a persistent SDK ``Agent`` ->
+bridged tool dispatch through the Omnigent tool registry (under policy) -> the
+``PostToolCallHook`` completion -> the ``-p`` one-shot printer.
+
+**Prerequisites (skipped — not failed — when absent so e2e shards stay green):**
+- The ``google.antigravity`` package importable (a Gemini-native SDK).
+- A resolvable Gemini API key (``antigravity_api_key_configured()`` — the
+  dedicated ``antigravity:`` block in ``~/.omnigent/config.yaml``). The SDK is
+  Gemini-native: there is no Databricks-gateway path, so this gate does NOT use
+  ``omnigent_credentials_env`` / ``patched_databrickscfg`` (mirrors the cursor
+  per-harness test). It runs for real wherever a key is configured.
+
+**glibc / harness-binary caveat (DEV HOSTS):** the SDK spawns a bundled native
+``localharness`` binary that needs glibc >= 2.36. On an older host (e.g. the
+glibc-2.31 dev box) set ``ANTIGRAVITY_HARNESS_PATH`` to a loader-shim wrapping
+the bundled binary through a newer glibc; the subprocess inherits it via
+``os.environ``. Where the host glibc is new enough the var is unnecessary. This
+caveat is environmental only — it does not affect what the fix validates.
+
+**What breaks if this fails (with prerequisites present):**
+- The schema-passing regresses: ``_build_sdk_tools`` stops wrapping a
+  ``parameters``-bearing tool in ``ToolWithSchema`` (or the SDK drops the
+  ``ToolWithSchema`` API), so Gemini no longer sees the arg shapes and the
+  structured ``player`` / ``score`` round-trip disappears.
+- ``AntigravityExecutor`` regresses on the bridged-tool dispatch / completion
+  path, or the ``-p`` one-shot path stops printing the assistant reply.
+
+**Rate limits:** a shared free-tier Gemini key can return HTTP 429 / 503
+(quota / high demand). Those are transient infra conditions, not fix failures,
+so the test treats a model-provider rate-limit / overload error as a skip
+rather than a hard failure (it asserts hard on any *other* non-zero exit).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# The bridged tool's dotted callable — an in-tree fixture importable from the
+# repo-root cwd (the subprocess runs there, as the conftest documents). Its
+# ``parameters`` schema below mirrors the function's (player: str, score: int).
+_TOOL_CALLABLE = "tests.resources.examples._shared.score_tool.record_score"
+
+# Specific values the model must populate into the structured args; both have
+# to appear in the reply for the round-trip to prove the schema reached Gemini.
+_PLAYER = "Ada"
+_SCORE = 42
+_PROMPT = f"Player {_PLAYER} scored {_SCORE} points. Record it."
+
+# The only Gemini model with non-zero free-tier quota on the dev key; the SDK
+# default is also a gemini-* flash model, so leaving it unpinned is fine, but
+# pinning keeps the test deterministic across SDK default bumps.
+_MODEL = "gemini-3.5-flash"
+
+# A real Gemini round-trip plus a tool call; 180s matches the other
+# slow-harness per-harness gates' headroom on CI hosts.
+_RUN_TIMEOUT_SEC = 180
+
+# Substrings that mark a transient provider rate-limit / overload (HTTP 429 /
+# 503) rather than a fix regression — skip on these so a saturated shared
+# free-tier key never reds the shard.
+# Lowercased: matched against ``combined.lower()`` below.
+_RATE_LIMIT_MARKERS = (
+    "code 429",
+    "code 503",
+    "resource_exhausted",
+    "quota",
+    "high demand",
+    "rate limit",
+)
+
+
+def _spec_yaml() -> str:
+    """Build the agent spec: a bridged FUNCTION tool with a structured schema.
+
+    :returns: A ``config.yaml`` body declaring ``record_score`` with two
+        required args (``player`` / ``score``) — the schema under test.
+    """
+    return textwrap.dedent(
+        f"""\
+        spec_version: 1
+        name: score_recorder
+        prompt: |
+          You record game scores. When the user reports a score, call the
+          record_score tool exactly once with the player's name and their
+          integer score, then confirm what you recorded in one short sentence.
+        executor:
+          type: omnigent
+          config:
+            harness: antigravity
+          model: {_MODEL}
+        tools:
+          record_score:
+            type: function
+            description: "Record a player's score in the leaderboard."
+            callable: {_TOOL_CALLABLE}
+            parameters:
+              type: object
+              properties:
+                player:
+                  type: string
+                  description: "The player's name."
+                score:
+                  type: integer
+                  description: "The integer score to record."
+              required: [player, score]
+        """
+    )
+
+
+def test_per_harness_antigravity_bridged_tool_schema(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    tmp_path: Path,
+) -> None:
+    """A bridged tool's ``parameters`` schema reaches Gemini and is filled correctly.
+
+    :param omnigent_python: Interpreter with omnigent + ``google.antigravity``
+        installed and importable.
+    :param omnigent_repo_root: Cwd for the subprocess so the spec's dotted
+        ``callable`` (the in-tree fixture) resolves on sys.path.
+    :param tmp_path: Per-test dir holding the materialized spec directory.
+    """
+    if importlib.util.find_spec("google.antigravity") is None:
+        pytest.skip(
+            "antigravity prerequisite missing: the 'google.antigravity' SDK is not "
+            "installed (Gemini-native harness)."
+        )
+    # Import lazily — only meaningful once the SDK package is present.
+    from omnigent.onboarding.antigravity_auth import antigravity_api_key_configured
+
+    if not antigravity_api_key_configured():
+        pytest.skip(
+            "antigravity prerequisite missing: no resolvable Gemini API key. The "
+            "antigravity harness authenticates Gemini-natively (a dedicated "
+            "'antigravity:' block in ~/.omnigent/config.yaml; it does NOT reuse the "
+            "Databricks-gateway auth), so this live gate is skipped rather than "
+            "failed when the key is absent."
+        )
+
+    spec_dir = tmp_path / "score_recorder"
+    spec_dir.mkdir()
+    (spec_dir / "config.yaml").write_text(_spec_yaml())
+
+    # The SDK reads its Gemini key from the keychain/config and may need
+    # ANTIGRAVITY_HARNESS_PATH on older-glibc dev hosts (see module docstring),
+    # so pass the full environment through.
+    result = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(spec_dir),
+            "-p",
+            _PROMPT,
+            "--no-log",
+            "--no-session",
+        ],
+        env=dict(os.environ),
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+    combined = f"{result.stdout}\n{result.stderr}"
+    if result.returncode != 0:
+        if any(marker in combined.lower() for marker in _RATE_LIMIT_MARKERS):
+            pytest.skip(
+                "antigravity live turn hit a transient provider rate-limit / overload "
+                f"(429 / 503) on the shared free-tier key — not a fix regression.\n\n{combined}"
+            )
+        pytest.fail(
+            f"antigravity run exited {result.returncode}.\n\n"
+            f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+        )
+
+    reply = result.stdout
+    # The structured-arg round-trip: the model could only populate BOTH the
+    # string player and the integer score because the SDK received the tool's
+    # parameters schema. The bridged callable echoes them, and the agent's
+    # confirming sentence reflects both — so both must appear in the reply.
+    assert _PLAYER in reply, (
+        f"player {_PLAYER!r} not in the assistant reply — the structured arg did not "
+        f"round-trip, so the bridged tool likely was not invoked with the schema.\n\n"
+        f"stdout:\n{reply!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    assert re.search(rf"\b{_SCORE}\b", reply), (
+        f"score {_SCORE} not in the assistant reply — the integer arg did not "
+        f"round-trip, so the bridged tool likely was not invoked with the schema.\n\n"
+        f"stdout:\n{reply!r}\n\nstderr:\n{result.stderr!r}"
+    )

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -243,6 +243,25 @@ class _FakePostToolCallHook:
         return None
 
 
+class _FakeToolWithSchema:
+    """Mirror of ``google.antigravity.tools.tool_runner.ToolWithSchema``.
+
+    Pairs a callable with an explicit JSON ``input_schema`` (mirroring the real
+    wrapper's positional ``(fn, input_schema)`` constructor and ``__call__``
+    that forwards kwargs), so tests can assert the executor passes the spec's
+    ``parameters`` through as the model-facing schema.
+    """
+
+    def __init__(self, fn: Any, input_schema: dict[str, Any]) -> None:
+        self.fn = fn
+        self.input_schema = input_schema
+        self.__name__ = fn.__name__
+        self.__doc__ = fn.__doc__
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        return await self.fn(**kwargs)
+
+
 def _install_fake_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -265,10 +284,17 @@ def _install_fake_sdk(
     class _FakeTypes:
         AntigravityCancelledError = _AntigravityCancelledError
 
+    class _FakeToolRunner:
+        ToolWithSchema = _FakeToolWithSchema
+
+    class _FakeTools:
+        tool_runner = _FakeToolRunner
+
     class _FakeModule:
         LocalAgentConfig = _FakeLocalAgentConfig
         hooks = _FakeHooks
         types = _FakeTypes
+        tools = _FakeTools
 
         @staticmethod
         def Agent(config: Any) -> _FakeAgent:
@@ -318,6 +344,73 @@ def test_latest_user_text_prefers_last_user_message() -> None:
         {"role": "user", "content": [{"type": "text", "text": "second"}]},
     ]
     assert _latest_user_text(messages) == "second"
+
+
+def test_tool_signature_tracks_params_and_description() -> None:
+    """The agent cache key changes on a params/description change, stable otherwise.
+
+    The signature keys the per-session SDK agent cache; if it ignored a tool's
+    ``parameters`` / ``description`` (the old name-only behavior), a schema or
+    description edit would not bust the cache and the model would keep the stale
+    declaration. It must also be stable across equivalent specs (dict key order,
+    re-serialization).
+    """
+    sig = AntigravityExecutor._tool_signature
+    base = [
+        {
+            "name": "sys_shell",
+            "description": "Run a shell command",
+            "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}},
+        }
+    ]
+
+    # Identical content (with reordered dict keys) → identical signature.
+    reordered = [
+        {
+            "parameters": {"properties": {"cmd": {"type": "string"}}, "type": "object"},
+            "description": "Run a shell command",
+            "name": "sys_shell",
+        }
+    ]
+    assert sig(base) == sig(reordered)
+
+    # A changed parameters schema busts the key.
+    changed_params = [
+        {
+            "name": "sys_shell",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"cmd": {"type": "string"}, "timeout": {"type": "integer"}},
+            },
+        }
+    ]
+    assert sig(base) != sig(changed_params)
+
+    # A changed description busts the key (name + params unchanged).
+    changed_desc = [
+        {
+            "name": "sys_shell",
+            "description": "Run a shell command (with a timeout)",
+            "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}},
+        }
+    ]
+    assert sig(base) != sig(changed_desc)
+
+    # Tool order doesn't matter (sorted), but the set of tools does.
+    two_a = [base[0], {"name": "sys_read", "description": "d", "parameters": {}}]
+    two_b = [{"name": "sys_read", "description": "d", "parameters": {}}, base[0]]
+    assert sig(two_a) == sig(two_b)
+    assert sig(base) != sig(two_a)
+
+    # Two tools sharing a name and description but differing only by parameters
+    # must not raise (the declarations are sorted as strings, not as tuples with
+    # un-orderable dict/None tail elements) — and still produce a stable key.
+    same_name = [
+        {"name": "t", "description": "d", "parameters": {"properties": {"a": {}}}},
+        {"name": "t", "description": "d", "parameters": None},
+    ]
+    assert sig(same_name) == sig(list(reversed(same_name)))
 
 
 @pytest.mark.asyncio
@@ -556,6 +649,56 @@ async def test_tool_request_deduped_across_steps(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_idless_tool_request_deduped_across_steps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A repeated id-less tool call (same name + args) yields exactly one request.
+
+    Id-less calls can't dedupe on an id, so the executor keys them on a content
+    surrogate (tool name + canonical args). The SDK re-emits the same call
+    across step transitions; without the surrogate each emission would surface a
+    duplicate :class:`ToolCallRequest`.
+    """
+    call = _FakeToolCall("sys_shell", {"cmd": "ls"}, call_id=None)
+    script: list[_TurnAction] = [
+        _tool_call_step(call, status=_StepStatus.ACTIVE),
+        _tool_call_step(call, status=_StepStatus.DONE),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    requests = [e for e in events if isinstance(e, ToolCallRequest)]
+    # 1, not 2: the content surrogate collapses the two id-less emissions of the
+    # same logical call into a single request.
+    assert len(requests) == 1
+    assert requests[0].name == "sys_shell"
+    assert requests[0].args == {"cmd": "ls"}
+
+
+@pytest.mark.asyncio
+async def test_idless_tool_requests_distinct_args_not_deduped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two id-less calls to the same tool with different args are both emitted.
+
+    Guards against the surrogate over-collapsing: distinct argument payloads are
+    distinct logical calls and must each surface a request.
+    """
+    script: list[_TurnAction] = [
+        _tool_call_step(_FakeToolCall("sys_shell", {"cmd": "ls"}, call_id=None)),
+        _tool_call_step(_FakeToolCall("sys_shell", {"cmd": "pwd"}, call_id=None)),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    requests = [e for e in events if isinstance(e, ToolCallRequest)]
+    assert len(requests) == 2
+    assert {r.args["cmd"] for r in requests} == {"ls", "pwd"}
+
+
+@pytest.mark.asyncio
 async def test_terminal_error_step_yields_executor_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """A TERMINAL_ERROR step surfaces an ExecutorError and suppresses TurnComplete."""
     script: list[_TurnAction] = [
@@ -721,19 +864,94 @@ async def test_sys_tools_exposed_as_callables_routing_through_executor(
     sdk_tools = captured["configs"][0].tools
     assert sdk_tools is not None and len(sdk_tools) == 1
     sdk_tool = sdk_tools[0]
-    # LocalAgentConfig.tools is list[Callable]; the SDK reads __name__/__doc__.
-    assert callable(sdk_tool)
+    # The tool reaches the SDK as a ToolWithSchema wrapper; the SDK reads its
+    # __name__/__doc__ for the declaration and invokes it with kwargs.
     assert sdk_tool.__name__ == "sys_shell"
     assert sdk_tool.__doc__ == "Run a shell command"
-
-    # Invoking the callable (kwargs form) routes back through the bridge.
+    # Invoking the wrapper (kwargs form, how the SDK calls it) routes through
+    # the bridge.
     assert await sdk_tool(cmd="ls") == {"ok": True}
-    # Single-dict argument form also works (SDK arg-shape tolerance).
-    assert await sdk_tool({"cmd": "pwd"}) == {"ok": True}
+    # The underlying bridge callable still tolerates the SDK's other arg shapes
+    # (single dict, JSON string) — unchanged by the schema wrapper.
+    bridge_callable = sdk_tool.fn
+    assert await bridge_callable({"cmd": "pwd"}) == {"ok": True}
+    assert await bridge_callable('{"cmd": "whoami"}') == {"ok": True}
     assert calls == [
         {"name": "sys_shell", "args": {"cmd": "ls"}},
         {"name": "sys_shell", "args": {"cmd": "pwd"}},
+        {"name": "sys_shell", "args": {"cmd": "whoami"}},
     ]
+
+
+@pytest.mark.asyncio
+async def test_tool_parameters_reach_sdk_declaration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bridged tool's ``parameters`` JSON schema reaches the SDK tool declaration.
+
+    Without this the executor registered a bare callable carrying only
+    name/description, so the model never saw the argument shapes and had to
+    guess them. The SDK's ``ToolWithSchema`` wrapper exposes the schema verbatim
+    via ``.input_schema``; this asserts the spec's ``parameters`` land there.
+    """
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
+    executor = AntigravityExecutor()
+
+    async def _fake_tool_executor(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    executor._tool_executor = _fake_tool_executor
+
+    schema = {
+        "type": "object",
+        "properties": {"cmd": {"type": "string"}, "timeout": {"type": "integer"}},
+        "required": ["cmd"],
+    }
+    tool_specs = [
+        {"name": "sys_shell", "description": "Run a shell command", "parameters": schema}
+    ]
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}], tool_specs)
+
+    sdk_tools = captured["configs"][0].tools
+    assert sdk_tools is not None and len(sdk_tools) == 1
+    sdk_tool = sdk_tools[0]
+    # Wrapped in ToolWithSchema: name/doc preserved AND the parameters schema is
+    # attached as input_schema (what callable_to_tool_proto serializes for the
+    # model), not discarded.
+    assert sdk_tool.__name__ == "sys_shell"
+    assert sdk_tool.__doc__ == "Run a shell command"
+    assert sdk_tool.input_schema == schema
+    # The wrapped callable still routes through the bridge (kwargs form).
+    assert await sdk_tool(cmd="ls") == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_tool_without_parameters_registers_bare_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool with no ``parameters`` schema falls back to a bare callable.
+
+    The SDK then introspects the callable's signature (the pre-schema path);
+    the executor must not wrap an empty/absent schema in ToolWithSchema.
+    """
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
+    executor = AntigravityExecutor()
+
+    async def _fake_tool_executor(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    executor._tool_executor = _fake_tool_executor
+
+    await _drain(
+        executor,
+        [{"role": "user", "content": "go", "session_id": "s1"}],
+        [{"name": "ping", "description": "no-arg tool", "parameters": {}}],
+    )
+
+    sdk_tool = captured["configs"][0].tools[0]
+    # Bare callable: it carries name/doc but is NOT a ToolWithSchema wrapper.
+    assert callable(sdk_tool)
+    assert not hasattr(sdk_tool, "input_schema")
+    assert sdk_tool.__name__ == "ping"
 
 
 @pytest.mark.asyncio
@@ -1063,10 +1281,17 @@ def _install_blocking_sdk(
     class _FakeTypes:
         AntigravityCancelledError = _AntigravityCancelledError
 
+    class _FakeToolRunner:
+        ToolWithSchema = _FakeToolWithSchema
+
+    class _FakeTools:
+        tool_runner = _FakeToolRunner
+
     class _FakeModule:
         LocalAgentConfig = _FakeLocalAgentConfig
         hooks = _FakeHooks
         types = _FakeTypes
+        tools = _FakeTools
 
         @staticmethod
         def Agent(config: Any) -> _BlockingAgent:

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import asyncio
 import collections
 import enum
+import importlib.util
+import json
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -1008,6 +1010,92 @@ async def test_tool_parameters_reach_sdk_declaration(monkeypatch: pytest.MonkeyP
     assert sdk_tool.input_schema == schema
     # The wrapped callable still routes through the bridge (kwargs form).
     assert await sdk_tool(cmd="ls") == {"ok": True}
+
+
+# Skip the real-SDK serialization gate when ``google.antigravity`` isn't
+# installed (it's an optional, Gemini-native dependency). Unlike the fake-SDK
+# tests above, this one drives the *actual* SDK so it can only run with the
+# package present.
+_requires_real_sdk = pytest.mark.skipif(
+    importlib.util.find_spec("google.antigravity") is None,
+    reason="google.antigravity SDK not importable (optional Gemini-native dependency)",
+)
+
+
+@_requires_real_sdk
+@pytest.mark.asyncio
+async def test_parameters_schema_reaches_sdk_tool_proto() -> None:
+    """Headline (#279): a bridged tool's ``parameters`` survive the real SDK serialization.
+
+    The fake-SDK test above proves ``_build_sdk_tools`` *attaches* the schema as
+    ``ToolWithSchema.input_schema``. This goes one layer deeper against the
+    **real** ``google.antigravity`` SDK: it feeds the executor's actual
+    ``_build_sdk_tools`` output through the SDK's own
+    ``callable_to_tool_proto`` — the exact serializer that builds the tool
+    declaration Gemini sees — and asserts the emitted
+    ``parameters_json_schema`` carries the declared properties and ``required``
+    list, NOT the degenerate empty ``{"type": "OBJECT"}``.
+
+    This is the deterministic proof that needs no live model: pre-#279
+    ``_build_sdk_tools`` returned a bare ``_invoke(*args, **kwargs)`` callable,
+    which ``callable_to_tool_proto`` runs through ``FunctionDeclaration``
+    signature introspection — yielding ``{"type": "OBJECT"}`` because the
+    bridge callable has no typed parameters (the negative half of this test
+    asserts exactly that). The fix wraps the callable in ``ToolWithSchema`` so
+    the serializer takes the explicit-schema branch and emits the spec's schema
+    verbatim.
+    """
+    import google.antigravity as antigravity
+    from google.antigravity.connections.local import local_connection
+    from google.antigravity.tools.tool_runner import ToolWithSchema
+
+    executor = AntigravityExecutor()
+
+    async def _fake_tool_executor(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    executor._tool_executor = _fake_tool_executor
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "player": {"type": "string", "description": "The player's name."},
+            "score": {"type": "integer", "description": "The integer score."},
+        },
+        "required": ["player", "score"],
+    }
+    sdk_tools = executor._build_sdk_tools(
+        antigravity,
+        [{"name": "record_score", "description": "Record a score.", "parameters": schema}],
+    )
+
+    # Build path: the schema-bearing spec is wrapped in the real SDK
+    # ToolWithSchema (not a bare callable).
+    assert len(sdk_tools) == 1
+    assert isinstance(sdk_tools[0], ToolWithSchema)
+
+    # Serialize through the SDK's own proto builder — the code path that
+    # produces the tool declaration sent to Gemini.
+    proto = local_connection.callable_to_tool_proto(sdk_tools[0])
+    assert proto.name == "record_score"
+    emitted = json.loads(proto.parameters_json_schema)
+    # The full structured schema reaches the proto — properties + required —
+    # NOT the empty {"type": "OBJECT"} the pre-fix bare callable produced.
+    assert emitted != {"type": "OBJECT"}
+    assert set(emitted.get("properties", {})) == {"player", "score"}
+    assert emitted.get("required") == ["player", "score"]
+    assert emitted["properties"]["score"]["type"] == "integer"
+
+    # Negative half — proves the assertion above is load-bearing and the empty
+    # schema is exactly what the *pre-fix* path emits. A bare bridge callable
+    # (what _build_sdk_tools returned before #279, reproduced here via the same
+    # _make_tool_callable factory) serializes to the degenerate {"type":
+    # "OBJECT"} because callable_to_tool_proto then falls back to signature
+    # introspection of _invoke(*args, **kwargs), which has no typed params.
+    bare_callable = executor._make_tool_callable("record_score", "Record a score.")
+    assert not isinstance(bare_callable, ToolWithSchema)
+    bare_proto = local_connection.callable_to_tool_proto(bare_callable)
+    assert json.loads(bare_proto.parameters_json_schema) == {"type": "OBJECT"}
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -558,7 +558,7 @@ async def test_tool_result_payload_error_classified_error(monkeypatch: pytest.Mo
 
 @pytest.mark.asyncio
 async def test_tool_call_without_id_still_completes(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An id-less tool call still emits one request and one (unpaired) completion."""
+    """An id-less tool call emits one request and one completion paired by name."""
     script: list[_TurnAction] = [
         _tool_call_step(_FakeToolCall("sys_shell", {"cmd": "ls"}, call_id=None)),
         _FireToolResult(_FakeToolResult("sys_shell", result={"ok": True}, call_id=None)),
@@ -570,14 +570,17 @@ async def test_tool_call_without_id_still_completes(monkeypatch: pytest.MonkeyPa
 
     requests = [e for e in events if isinstance(e, ToolCallRequest)]
     completes = [e for e in events if isinstance(e, ToolCallComplete)]
-    # Exactly one of each: the request gets a synthetic id (so it's still shown);
-    # the id-less completion can't pair back, so its metadata is empty and it
-    # falls back to the ToolResult's own name. The tool must still "close".
+    # Exactly one of each. The id-less request gets a synthetic id; the id-less
+    # completion (no ToolResult.id) pairs back to the only in-flight id-less call
+    # of that name, so it carries that synthetic call_id and a real duration.
     assert len(requests) == 1
     assert len(completes) == 1
     assert completes[0].name == "sys_shell"
-    assert completes[0].metadata == {}
-    assert completes[0].duration_ms == 0.0
+    synthetic_id = requests[0].metadata["call_id"]
+    assert synthetic_id  # a synthetic id was assigned
+    assert completes[0].metadata == {"call_id": synthetic_id}
+    assert completes[0].result == {"ok": True}
+    assert completes[0].duration_ms >= 0.0
 
 
 @pytest.mark.asyncio
@@ -696,6 +699,89 @@ async def test_idless_tool_requests_distinct_args_not_deduped(
     requests = [e for e in events if isinstance(e, ToolCallRequest)]
     assert len(requests) == 2
     assert {r.args["cmd"] for r in requests} == {"ls", "pwd"}
+
+
+@pytest.mark.asyncio
+async def test_idless_distinct_calls_identical_args_each_paired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two distinct id-less calls with identical name + args each emit a paired request.
+
+    Regression for the over-dedupe the review flagged: the id-less surrogate was
+    turn-scoped on ``name + args``, so a *second* genuinely-distinct id-less call
+    with identical name and args later in the same turn was swallowed — one
+    request would show while the second completion was left unpaired. Scoping the
+    surrogate to the in-flight lifecycle (freed on completion) lets the model
+    legitimately call ``sys_shell(cmd="ls")`` twice in one turn: each call's
+    dispatch reopens the freed slot, so two requests surface and each pairs to its
+    own completion. (The SDK's own ``receive_chunks`` likewise never collapses
+    distinct id-less calls.)
+    """
+    ls = {"cmd": "ls"}
+    script: list[_TurnAction] = [
+        # First call: dispatched (re-emitted across two steps → still one
+        # request), then completed by the hook — which frees the surrogate.
+        _tool_call_step(_FakeToolCall("sys_shell", ls, call_id=None)),
+        _tool_call_step(_FakeToolCall("sys_shell", ls, call_id=None)),
+        _FireToolResult(_FakeToolResult("sys_shell", result={"n": 1}, call_id=None)),
+        # Second, genuinely-distinct call with identical name + args, issued
+        # after the first finished. The freed slot must let it through.
+        _tool_call_step(_FakeToolCall("sys_shell", ls, call_id=None)),
+        _FireToolResult(_FakeToolResult("sys_shell", result={"n": 2}, call_id=None)),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    requests = [e for e in events if isinstance(e, ToolCallRequest)]
+    completes = [e for e in events if isinstance(e, ToolCallComplete)]
+    # TWO requests, not one: the repeated in-flight emission of the first call is
+    # still deduped (two dispatch steps → one request), but the second distinct
+    # call after completion is NOT swallowed.
+    assert len(requests) == 2
+    assert all(r.name == "sys_shell" and r.args == ls for r in requests)
+    # Each request got its own synthetic id.
+    req_ids = [r.metadata["call_id"] for r in requests]
+    assert req_ids[0] != req_ids[1]
+    # TWO completions, each paired (by synthetic id) to its originating request —
+    # FIFO by name, so the first completion pairs to the first request. Pre-fix,
+    # the second completion was unpaired (empty metadata) since its request never
+    # emitted.
+    assert len(completes) == 2
+    assert [c.metadata["call_id"] for c in completes] == req_ids
+    assert [c.result for c in completes] == [{"n": 1}, {"n": 2}]
+
+
+@pytest.mark.asyncio
+async def test_idless_surrogate_freed_for_next_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An id-less call's surrogate doesn't leak across turns on the same session.
+
+    The in-flight surrogate table is cleared per turn, so an identical id-less
+    call on a later turn of the same session still emits its own request even if
+    the prior turn's call was never explicitly completed.
+    """
+    ls = {"cmd": "ls"}
+    turn_one: list[_TurnAction] = [
+        _tool_call_step(_FakeToolCall("sys_shell", ls, call_id=None)),
+        # No completion this turn — the surrogate stays "in flight" until the
+        # per-turn reset clears it.
+        _text_step("one"),
+    ]
+    turn_two: list[_TurnAction] = [
+        _tool_call_step(_FakeToolCall("sys_shell", ls, call_id=None)),
+        _text_step("two"),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[turn_one, turn_two])
+    executor = AntigravityExecutor()
+
+    events_one = await _drain(executor, [{"role": "user", "content": "a", "session_id": "s1"}])
+    events_two = await _drain(executor, [{"role": "user", "content": "b", "session_id": "s1"}])
+
+    # One request per turn: clearing active_idless at turn start means the second
+    # turn's identical call isn't mistaken for the first turn's still-open one.
+    assert len([e for e in events_one if isinstance(e, ToolCallRequest)]) == 1
+    assert len([e for e in events_two if isinstance(e, ToolCallRequest)]) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/resources/examples/_shared/score_tool.py
+++ b/tests/resources/examples/_shared/score_tool.py
@@ -1,0 +1,27 @@
+"""Bridged FUNCTION-tool fixture for the antigravity tool-schema e2e gate.
+
+``record_score`` takes two REQUIRED structured args — a string ``player`` and an
+integer ``score`` — declared as an explicit ``parameters`` JSON schema in the
+e2e spec. It exists so a live antigravity turn can prove the schema reached the
+model: the model can only populate both args when the SDK was handed the tool's
+``parameters`` (PR #279) — otherwise the schema is empty and there are no arg
+shapes to fill. The callable echoes the args back so the assistant's confirming
+reply reflects the recorded values.
+
+Referenced as the dotted ``callable``
+``tests.resources.examples._shared.score_tool.record_score`` from
+``tests/e2e/omnigent/test_per_harness_antigravity_tool_schema.py``.
+"""
+
+from __future__ import annotations
+
+
+def record_score(player: str, score: int) -> dict[str, object]:
+    """Record a player's score.
+
+    :param player: The player's name.
+    :param score: The integer score to record.
+    :returns: An echo payload confirming what was recorded
+        (``{"recorded": True, "player": <player>, "score": <score>}``).
+    """
+    return {"recorded": True, "player": player, "score": int(score)}


### PR DESCRIPTION
## Summary

Three tool-schema bugs in the merged Google Antigravity harness executor (`omnigent/inner/antigravity_executor.py`, from #194):

1. **Blind tool calls (medium).** Bridged Omnigent tools were registered carrying only `__name__` / `__doc__` — the tool's `parameters` JSON schema was discarded, so the model got no argument schema and had to guess each tool's arg shape. Now each bridged tool is wrapped in the SDK's `ToolWithSchema(fn, input_schema)` (at `google.antigravity.tools.tool_runner`), whose `input_schema` `callable_to_tool_proto` serializes verbatim into the tool declaration — bypassing signature introspection. Tools with no usable `parameters` (or when the SDK doesn't expose the wrapper) fall back to the prior bare-callable path, so nothing regresses. The bridge callable still tolerates the SDK's kwargs / single-dict / JSON-string arg shapes.

2. **Stale agent cache (medium).** `_tool_signature` keyed the per-session SDK agent cache on tool **names only**, so a change to a tool's `description` or `parameters` did not invalidate the cached agent and the model kept the old declaration. The key now covers each tool's name + description + canonical (key-sorted) `parameters`. Declarations are canonicalized to strings before sorting, which also fixes a latent `TypeError` when two tools share a name/description but differ in `parameters` (dict vs dict / `None` are not orderable).

3. **Duplicate emits (low).** Id-less tool calls were not deduped (only id'd ones were), so a repeated id-less call across step transitions emitted duplicate `ToolCallRequest`s. They now dedupe on a stable surrogate (tool name + canonical JSON of args), with a synthetic id assigned only on first sight.

## Tests

In `tests/inner/test_antigravity_executor.py` (existing SDK fakes, extended with a `ToolWithSchema` fake):

- a bridged tool's `parameters` reach the SDK tool declaration's `input_schema` (+ a no-schema bare-callable fallback guard);
- `_tool_signature` changes when a tool's params or description change and is stable otherwise (incl. a same-name/different-params guard against the sort `TypeError`);
- a repeated id-less call emits exactly one `ToolCallRequest` (+ a distinct-args negative guard so the surrogate doesn't over-collapse).

Each fails without the corresponding change. Full file: `33 passed`. `ruff check` / `ruff format` / `mypy` clean on the executor.

## Notes

The SDK *does* accept an explicit schema (`ToolWithSchema` → `parameters_json_schema`), so no signature-synthesis fallback was needed. The wrapper is resolved duck-typed (`antigravity.tools.tool_runner.ToolWithSchema`) and degrades to bare callables if a future SDK version drops it.

This pull request and its description were written by Isaac.