### PR TITLE
test(e2e_ui): native Codex render-parity suite (CI validation)

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -340,22 +340,27 @@ jobs:
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
         run: |
-          # TEMP (revert before merge): scope this run to ONLY the native codex
-          # render-parity test so we validate the new suite + harness wiring on
-          # CI before flipping back to the full sharded e2e_ui suite. Run it on a
-          # single shard (shard 0) and treat the other shards as empty so they
-          # pass without re-running the expensive native session. -s
-          # --log-cli-level=INFO streams the runner/native logs live for triage.
-          if [[ "$SHARD_ID" != "0" ]]; then
-            echo "::notice::TEMP single-test validation runs on shard 0 only; skipping shard $SHARD_ID."
-            exit 0
+          EXTRA_ARGS=()
+          if [[ "$NIGHTLY_FULL" != "true" ]]; then
+            EXTRA_ARGS+=(-m "not nightly")
           fi
-          uv run pytest tests/e2e_ui/messages/test_native_codex_render_parity.py \
-            -v --tb=long --showlocals --log-level=INFO --log-cli-level=INFO -s -r a \
+          # --splits/--group partition the suite across the matrix entries
+          # via a round-robin strided slice (see pytest_collection_modifyitems
+          # in tests/e2e_ui/conftest.py). Unlike pytest-shard's hash-bucketing
+          # -- which was blind to runtime and left one shard ~5min while
+          # others ran ~2min -- striding scatters each heavy file's cases
+          # one-per-shard, evening out wall-clock with no extra dependency
+          # and no durations file to maintain. --group is 1-indexed, so we
+          # map the 0-indexed matrix shard_id with +1.
+          uv run pytest tests/e2e_ui \
+            -v --tb=long --showlocals --log-level=INFO -r a \
             --ui-skip-build \
+            --splits="$NUM_SHARDS" \
+            --group="$((SHARD_ID + 1))" \
             --tracing=retain-on-failure \
             --screenshot=only-on-failure \
             --video=retain-on-failure \
+            "${EXTRA_ARGS[@]}" \
             || { rc=$?; [ "$rc" -eq 5 ] && echo "::notice::No tests collected in this shard; treating as a pass." || exit "$rc"; }
 
       - name: Upload Playwright traces / videos / screenshots on failure

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -213,11 +213,12 @@ jobs:
           npm run build
 
       # ----------------------------------------------------------------------
-      # Native-claude ("Claude Code") harness enablement. The two steps below
-      # let test_native_claude_render_parity boot a real Claude Code CLI in CI,
-      # mirroring how e2e.yml / integration.yml auth the Claude harnesses. Only
-      # the native render-parity test depends on these; the rest of the e2e-ui
-      # suite (openai-agents) ignores them.
+      # Native coding-agent harness enablement. The steps below let
+      # test_native_claude_render_parity and test_native_codex_render_parity
+      # boot a real Claude Code / Codex CLI in CI, mirroring how e2e.yml /
+      # integration.yml auth those harnesses. Only the native render-parity
+      # tests depend on these; the rest of the e2e-ui suite (openai-agents)
+      # ignores them.
       # ----------------------------------------------------------------------
       - name: Install Claude Code CLI
         # Install claude-code 2.1.170, NOT the 2.1.124 pinned in
@@ -240,28 +241,49 @@ jobs:
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
-      - name: Configure native-claude gateway provider
-        # The runner derives Claude Code's gateway auth from omnigent provider
-        # config (omnigent.claude_native.resolve_native_claude_config). Register
-        # the Databricks serving-endpoints gateway as the default anthropic
-        # provider: ANTHROPIC_BASE_URL := the gateway, the token reaches Claude
-        # via a printf apiKeyHelper built from env:LLM_API_KEY (the runner env
-        # allowlist excludes ANTHROPIC_API_KEY), model := the CI Claude model.
-        # The config uses an env: ref (not the literal token), so no secret is
-        # written to disk here. ~/.databrickscfg / DATABRICKS_BEARER are
-        # intentionally NOT written: the native-claude path authenticates purely
-        # from this provider config, so there's no ambient Databricks lookup to
-        # satisfy — keeping the literal token off disk.
+      - name: Install Codex CLI
+        # Install @openai/codex at the version pinned in .github/ci-deps (the
+        # same build e2e.yml's codex leg runs). `scripts: null` on the package
+        # means there is no postinstall, so --ignore-scripts is a no-op safety
+        # net; the native binary ships in the package itself and is put on PATH
+        # via node_modules/.bin. The native codex render-parity test
+        # (test_native_codex_render_parity) drives this CLI through a tmux pane
+        # (omnigent/codex_native_bridge), so `codex` must be on PATH.
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.codex-cli" && cd "${GITHUB_WORKSPACE}/.codex-cli"
+          npm install --ignore-scripts --no-audit --no-fund @openai/codex@0.128.0-alpha.1
+          echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Configure native-claude/codex gateway provider
+        # The runner derives each native CLI's gateway auth from omnigent
+        # provider config (claude: omnigent.claude_native.resolve_native_claude_config;
+        # codex: omnigent.codex_native_app_server.resolve_native_codex_launch).
+        # Register the Databricks gateway as the default for BOTH families so a
+        # single provider routes Claude Code (anthropic) and Codex (openai): the
+        # token reaches each CLI via an env:LLM_API_KEY ref (the runner env
+        # allowlist excludes ANTHROPIC_API_KEY / OPENAI_API_KEY), each family
+        # pins its CI model. The config uses an env: ref (not the literal token),
+        # so no secret is written to disk here. ~/.databrickscfg / DATABRICKS_BEARER
+        # are intentionally NOT written: the native paths authenticate purely from
+        # this provider config, so there's no ambient Databricks lookup to satisfy
+        # — keeping the literal token off disk.
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           mkdir -p "$HOME/.omnigent"
+          # The Anthropic Messages surface and the Codex Responses surface live
+          # at different paths off the same workspace host. GATEWAY_BASE_URL is
+          # <host>/serving-endpoints (the OpenAI-compatible surface); strip that
+          # suffix to recover the bare host for the codex /ai-gateway path.
+          host="${GATEWAY_BASE_URL%/serving-endpoints}"
           cat > "$HOME/.omnigent/config.yaml" <<EOF
           providers:
             databricks-gateway:
               kind: gateway
-              default: anthropic
+              default: [anthropic, openai]
               anthropic:
                 # Databricks serves the Anthropic Messages surface at
                 # <host>/serving-endpoints/anthropic (see
@@ -279,6 +301,18 @@ jobs:
                 # 'databricks-' prefixed id).
                 models:
                   default: databricks-claude-sonnet-4-6
+              openai:
+                # Databricks serves the Codex Responses surface at
+                # <host>/ai-gateway/codex/v1 (see omnigent/inner/codex_executor.py:
+                # _databricks_codex_base_url), NOT the /serving-endpoints
+                # OpenAI-compatible surface. wire_api must be 'responses' — codex
+                # >= 0.137 rejects 'chat' at config load.
+                base_url: "${host}/ai-gateway/codex/v1"
+                api_key_ref: "env:LLM_API_KEY"
+                wire_api: responses
+                # The codex model id the e2e codex leg pins (tests/_model_pools).
+                models:
+                  default: databricks-gpt-5-4-mini
           EOF
 
       - name: Run UI e2e tests
@@ -306,27 +340,22 @@ jobs:
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
         run: |
-          EXTRA_ARGS=()
-          if [[ "$NIGHTLY_FULL" != "true" ]]; then
-            EXTRA_ARGS+=(-m "not nightly")
+          # TEMP (revert before merge): scope this run to ONLY the native codex
+          # render-parity test so we validate the new suite + harness wiring on
+          # CI before flipping back to the full sharded e2e_ui suite. Run it on a
+          # single shard (shard 0) and treat the other shards as empty so they
+          # pass without re-running the expensive native session. -s
+          # --log-cli-level=INFO streams the runner/native logs live for triage.
+          if [[ "$SHARD_ID" != "0" ]]; then
+            echo "::notice::TEMP single-test validation runs on shard 0 only; skipping shard $SHARD_ID."
+            exit 0
           fi
-          # --splits/--group partition the suite across the matrix entries
-          # via a round-robin strided slice (see pytest_collection_modifyitems
-          # in tests/e2e_ui/conftest.py). Unlike pytest-shard's hash-bucketing
-          # -- which was blind to runtime and left one shard ~5min while
-          # others ran ~2min -- striding scatters each heavy file's cases
-          # one-per-shard, evening out wall-clock with no extra dependency
-          # and no durations file to maintain. --group is 1-indexed, so we
-          # map the 0-indexed matrix shard_id with +1.
-          uv run pytest tests/e2e_ui \
-            -v --tb=long --showlocals --log-level=INFO -r a \
+          uv run pytest tests/e2e_ui/messages/test_native_codex_render_parity.py \
+            -v --tb=long --showlocals --log-level=INFO --log-cli-level=INFO -s -r a \
             --ui-skip-build \
-            --splits="$NUM_SHARDS" \
-            --group="$((SHARD_ID + 1))" \
             --tracing=retain-on-failure \
             --screenshot=only-on-failure \
             --video=retain-on-failure \
-            "${EXTRA_ARGS[@]}" \
             || { rc=$?; [ "$rc" -eq 5 ] && echo "::notice::No tests collected in this shard; treating as a pass." || exit "$rc"; }
 
       - name: Upload Playwright traces / videos / screenshots on failure
@@ -359,6 +388,20 @@ jobs:
           mkdir -p /tmp/claude-home-dump
           cp -r "$HOME/.claude/projects" /tmp/claude-home-dump/ 2>/dev/null || true
 
+      - name: Dump Codex transcript on failure
+        # Codex's per-session rollout transcripts (the JSONL with its actual API
+        # errors) live under the bridged CODEX_HOME at
+        # ~/.omnigent/codex-native/<hash>/codex-home/sessions. Copy ONLY the
+        # *.jsonl rollouts so the server-logs upload captures them. Deliberately
+        # NOT copying config.toml: its auth command embeds the gateway token
+        # (printf %s <token>), so it is never staged for upload — no credential
+        # leaves the runner.
+        if: failure()
+        run: |
+          mkdir -p /tmp/codex-home-dump
+          find "$HOME/.omnigent/codex-native" -name '*.jsonl' -print0 2>/dev/null \
+            | xargs -0 -I{} cp --parents {} /tmp/codex-home-dump/ 2>/dev/null || true
+
       - name: Upload server logs on failure
         id: upload_server_logs
         if: failure()
@@ -372,16 +415,20 @@ jobs:
           # ``e2e_ui_logs*``, which never matched, so the artifact was
           # always empty.
           #
-          # Also grab runner.log (carries the claude-native auto-launch +
-          # auth-resolution + terminal-launch logs) and the native bridge dir
+          # Also grab runner.log (carries the claude-/codex-native auto-launch +
+          # auth-resolution + terminal-launch logs) and the native bridge dirs
           # (tmux target, transcript-forward deltas) under
-          # /tmp/omnigent-<uid>/claude-native, plus the Claude transcript
-          # staged above — all needed to triage a native render-parity failure.
+          # /tmp/omnigent-<uid>/claude-native, plus the Claude / Codex
+          # transcripts staged above — all needed to triage a native
+          # render-parity failure. The codex bridge state lives under
+          # ~/.omnigent/codex-native; only its *.jsonl rollouts are staged
+          # (config.toml carries the token and is excluded).
           path: |
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
             /tmp/omnigent-*/claude-native/**
             /tmp/claude-home-dump/**
+            /tmp/codex-home-dump/**
           retention-days: 3
           if-no-files-found: ignore
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -400,15 +400,6 @@ def _spawn_runner_against_external_server(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
-        # Runner-owned Codex / Pi terminals hard-require OMNIGENT_RUNNER_WORKSPACE
-        # (the claude-native path falls back to Path.cwd(), but
-        # _codex_session_workspace / _pi_session_workspace raise without it), so
-        # the native_codex_session fixture's _auto_create_codex_terminal needs it
-        # set. Default to the repo root (the cwd claude falls back to anyway);
-        # honor an externally-provided value if one is already exported.
-        "OMNIGENT_RUNNER_WORKSPACE": os.environ.get(
-            "OMNIGENT_RUNNER_WORKSPACE", str(_REPO_ROOT)
-        ),
     }
     log_handle = open(log_path, "w")  # noqa: SIM115 — closed in finally
     proc = subprocess.Popen(
@@ -599,15 +590,6 @@ def live_server(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
-        # Runner-owned Codex / Pi terminals hard-require OMNIGENT_RUNNER_WORKSPACE
-        # (the claude-native path falls back to Path.cwd(), but
-        # _codex_session_workspace / _pi_session_workspace raise without it), so
-        # the native_codex_session fixture's _auto_create_codex_terminal needs it
-        # set. Default to the repo root (the cwd claude falls back to anyway);
-        # honor an externally-provided value if one is already exported.
-        "OMNIGENT_RUNNER_WORKSPACE": os.environ.get(
-            "OMNIGENT_RUNNER_WORKSPACE", str(_REPO_ROOT)
-        ),
     }
     runner_proc = subprocess.Popen(
         [sys.executable, "-m", "omnigent.runner._entry"],
@@ -848,15 +830,6 @@ def _ensure_runner_online(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
-        # Runner-owned Codex / Pi terminals hard-require OMNIGENT_RUNNER_WORKSPACE
-        # (the claude-native path falls back to Path.cwd(), but
-        # _codex_session_workspace / _pi_session_workspace raise without it), so
-        # the native_codex_session fixture's _auto_create_codex_terminal needs it
-        # set. Default to the repo root (the cwd claude falls back to anyway);
-        # honor an externally-provided value if one is already exported.
-        "OMNIGENT_RUNNER_WORKSPACE": os.environ.get(
-            "OMNIGENT_RUNNER_WORKSPACE", str(_REPO_ROOT)
-        ),
     }
     proc = subprocess.Popen(
         [sys.executable, "-m", "omnigent.runner._entry"],
@@ -1574,9 +1547,19 @@ def _create_native_codex_session(base_url: str, runner_id: str) -> str:
         UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
         WRAPPER_LABEL_KEY: CODEX_NATIVE_WRAPPER_VALUE,
     }
+    # Runner-owned Codex terminals hard-require a workspace: unlike the
+    # claude-native path (which falls back to Path.cwd()),
+    # _codex_session_workspace raises if neither the session's stored
+    # ``workspace`` nor OMNIGENT_RUNNER_WORKSPACE is set. Pin it on THIS
+    # session only (via metadata.workspace) rather than exporting
+    # OMNIGENT_RUNNER_WORKSPACE on the shared runner — a runner-wide value
+    # changes file-surface advertisement for every other session on the runner
+    # (it regressed the mobile file-drawer suite). The repo root is the same cwd
+    # claude falls back to, and is a valid dir on the runner's filesystem.
+    metadata = {"labels": labels, "workspace": str(_REPO_ROOT)}
     create = httpx.post(
         f"{base_url}/v1/sessions",
-        data={"metadata": _json.dumps({"labels": labels})},
+        data={"metadata": _json.dumps(metadata)},
         files={"bundle": ("codex-native-ui.tar.gz", buf.getvalue(), "application/gzip")},
         timeout=30.0,
     )

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1301,8 +1301,13 @@ def server_pid(live_server: str) -> int:
 # ``hello_world`` / ``echo_probe`` agents authenticate against), so Claude Code
 # boots non-interactively. The native render-parity suite drives this fixture.
 #
-# ``codex-native-ui`` is still not wired up here — add a sibling fixture
-# alongside that effort.
+# ``native_codex_session`` is the sibling native-CLI fixture for the
+# ``codex-native`` ("Codex") wrapper: it spins up a real Codex wrapper session —
+# the same terminal-first spec ``omnigent codex`` ships — and yields
+# ``(base_url, session_id)``. The runner auto-launches Codex in the session
+# terminal on bind (gateway auth derived from the runner's own credentials +
+# first-run pre-accept handled runner-side), exactly like the claude fixture.
+# The native codex render-parity suite drives it.
 # ---------------------------------------------------------------------------
 
 # A precise-echo agent on the openai-agents harness (same provider family as
@@ -1476,6 +1481,103 @@ def native_claude_session(
     respawned = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
     session_id = _create_native_claude_session(live_server, runner_id)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            # Escalate to SIGKILL if the runner ignores SIGTERM, so a wedged
+            # process can't raise in teardown and leak / fail unrelated tests
+            # (matching terminal_session / seeded_session_pair).
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)
+
+
+def _create_native_codex_session(base_url: str, runner_id: str) -> str:
+    """Register the ``codex-native`` wrapper agent and bind its session.
+
+    Reuses the exact terminal-first spec ``omnigent codex`` ships
+    (:func:`omnigent.codex_native._materialize_codex_agent_spec`) so the
+    fixture never drifts from production, and stamps the same wrapper /
+    terminal-first labels (``omnigent.wrapper`` + ``omnigent.ui = terminal``)
+    the CLI writes. The spec carries no ``spec_version``, so it is bundled
+    under a ``*.yaml`` arcname to route through the omnigent compat translator
+    (which preserves ``executor.harness`` + ``terminals:``); a ``config.yaml``
+    arcname would hit the strict parser and reject it.
+
+    Binding the session to the runner triggers the runner's codex-native
+    auto-bootstrap: it launches Codex in the session terminal, derives the
+    gateway auth from its own credentials, and pre-accepts the first-run
+    trust/onboarding prompts — no CLI client required. ``model=None`` lets the
+    configured provider's default model win (matching ``_build_codex_native_bundle``).
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: The token-bound runner id to bind.
+    :returns: The new session/conversation id.
+    """
+    import json as _json
+    import tempfile
+
+    from omnigent._wrapper_labels import (
+        CODEX_NATIVE_WRAPPER_VALUE,
+        UI_MODE_LABEL_KEY,
+        UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY,
+    )
+    from omnigent.codex_native import _materialize_codex_agent_spec
+
+    with tempfile.TemporaryDirectory() as _tmp:
+        spec_path = _materialize_codex_agent_spec(Path(_tmp), model=None)
+        yaml_text = spec_path.read_text()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        # Non-config.yaml arcname → omnigent compat translator (the spec has
+        # no spec_version), matching the terminal_session fixture.
+        info = tarfile.TarInfo("codex-native-ui.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    labels = {
+        UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY: CODEX_NATIVE_WRAPPER_VALUE,
+    }
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": _json.dumps({"labels": labels})},
+        files={"bundle": ("codex-native-ui.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+@pytest.fixture
+def native_codex_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session on the real ``codex-native`` ("Codex") wrapper.
+
+    The runner auto-launches Codex in the session terminal on bind (gateway
+    auth + first-run pre-accept handled runner-side), so the SPA's Terminal
+    view attaches to a live Codex TUI and its Chat view renders the same
+    canonical transcript. Drives the native codex render-parity suite.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    session_id = _create_native_codex_session(live_server, runner_id)
     try:
         yield (live_server, session_id)
     finally:

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -400,6 +400,15 @@ def _spawn_runner_against_external_server(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
+        # Runner-owned Codex / Pi terminals hard-require OMNIGENT_RUNNER_WORKSPACE
+        # (the claude-native path falls back to Path.cwd(), but
+        # _codex_session_workspace / _pi_session_workspace raise without it), so
+        # the native_codex_session fixture's _auto_create_codex_terminal needs it
+        # set. Default to the repo root (the cwd claude falls back to anyway);
+        # honor an externally-provided value if one is already exported.
+        "OMNIGENT_RUNNER_WORKSPACE": os.environ.get(
+            "OMNIGENT_RUNNER_WORKSPACE", str(_REPO_ROOT)
+        ),
     }
     log_handle = open(log_path, "w")  # noqa: SIM115 — closed in finally
     proc = subprocess.Popen(
@@ -590,6 +599,15 @@ def live_server(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
+        # Runner-owned Codex / Pi terminals hard-require OMNIGENT_RUNNER_WORKSPACE
+        # (the claude-native path falls back to Path.cwd(), but
+        # _codex_session_workspace / _pi_session_workspace raise without it), so
+        # the native_codex_session fixture's _auto_create_codex_terminal needs it
+        # set. Default to the repo root (the cwd claude falls back to anyway);
+        # honor an externally-provided value if one is already exported.
+        "OMNIGENT_RUNNER_WORKSPACE": os.environ.get(
+            "OMNIGENT_RUNNER_WORKSPACE", str(_REPO_ROOT)
+        ),
     }
     runner_proc = subprocess.Popen(
         [sys.executable, "-m", "omnigent.runner._entry"],
@@ -830,6 +848,15 @@ def _ensure_runner_online(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
+        # Runner-owned Codex / Pi terminals hard-require OMNIGENT_RUNNER_WORKSPACE
+        # (the claude-native path falls back to Path.cwd(), but
+        # _codex_session_workspace / _pi_session_workspace raise without it), so
+        # the native_codex_session fixture's _auto_create_codex_terminal needs it
+        # set. Default to the repo root (the cwd claude falls back to anyway);
+        # honor an externally-provided value if one is already exported.
+        "OMNIGENT_RUNNER_WORKSPACE": os.environ.get(
+            "OMNIGENT_RUNNER_WORKSPACE", str(_REPO_ROOT)
+        ),
     }
     proc = subprocess.Popen(
         [sys.executable, "-m", "omnigent.runner._entry"],

--- a/tests/e2e_ui/messages/test_native_codex_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_codex_render_parity.py
@@ -1,0 +1,201 @@
+r"""UI journey: a native Codex session renders parity with its TUI.
+
+The native ``codex-native`` ("Codex") wrapper is terminal-first: a real
+``codex`` CLI runs in the session terminal, the SPA's **Terminal** view
+attaches to that live TUI over a WebSocket, and the SPA's **Chat** view renders
+the SAME canonical transcript (``GET /v1/sessions/{id}/items``) the TUI prints.
+A native bridge forwards web-composer messages INTO the Codex app-server thread
+and forwards Codex's transcript back OUT as conversation items. This suite
+asserts that round-trips both ways and renders exactly once — the three
+properties the native forwarder has historically regressed on:
+
+1. **Render parity with the TUI.** Composer turns are sent through the web SPA;
+   each per-turn user marker and assistant token the SPA shows in a bubble must
+   also appear in the canonical transcript, in the same order, exactly once. The
+   transcript is what the TUI prints, so transcript parity == "renders the same
+   as the TUI".
+
+2. **A TUI-originated message surfaces in the web UI.** A turn is typed directly
+   into the Codex TUI (the embedded xterm in the Terminal view) — never through
+   the composer. The native bridge must forward it back out as a user item +
+   assistant reply, so switching to Chat shows both as bubbles and the
+   transcript carries them. This is the OUT direction the composer turns don't
+   exercise.
+
+3. **No duplicate rendering.** Every marker/token — composer- and TUI-originated
+   alike — must land in EXACTLY ONE bubble and one transcript entry. The classic
+   native-forwarder bug double-rendered a reply as both a streaming live preview
+   and the committed bubble; per-turn unique tokens make that count unambiguous.
+
+Per-turn unique markers/tokens are load-bearing for the same reasons as the
+custom-agent suite: they keep the dedup count and order checks unambiguous even
+though Codex is far chattier than the ``echo_probe`` agent (it may emit
+reasoning, tool calls, and prose around the echoed token). Every assertion
+counts *bubbles/entries containing the token*, never bubbles, so chattiness is
+fine.
+
+Requires the native-harness gateway auth the runner derives from its own
+credentials (the same gateway ``hello_world`` uses); CI exchanges Databricks
+OAuth before pytest. See ``native_codex_session`` in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+from playwright.sync_api import Page, expect
+
+# Reuse the custom-agent suite's helpers — both surfaces render from the same
+# canonical transcript, so parity / dedup / ordering are asserted identically.
+from .test_message_render_parity import (
+    _ASSISTANT,
+    _USER,
+    _WORKING,
+    _assert_no_duplicate_render,
+    _assert_transcript_parity,
+    _ensure_chat_view,
+    _send,
+    _turn_prompt,
+)
+
+_log = logging.getLogger(__name__)
+
+_TERMINAL_VIEW = '[data-testid="terminal-view"]'
+# xterm.js routes all keystrokes through a hidden helper <textarea>; focusing it
+# and typing is how a user (and Playwright) drives the embedded TUI.
+_XTERM_INPUT = ".xterm-helper-textarea"
+
+# A native Codex turn is a full agent loop (real LLM, possible tool use),
+# so it is far slower than a single custom-agent LLM call.
+_NATIVE_TURN_TIMEOUT_MS = 180_000
+# Codex boots in the terminal on bind; the auto-launch + first-run
+# pre-accept + WS attach can take a while on a cold CI runner.
+_TERMINAL_READY_TIMEOUT_MS = 120_000
+
+# Two composer turns (the IN direction) + one TUI turn (the OUT direction).
+_COMPOSER_TURNS = 2
+
+
+def _open_terminal_view(page: Page) -> None:
+    """Switch a terminal-first session to its Terminal (TUI) view.
+
+    :param page: The Playwright page, on the session's chat surface.
+    """
+    view_mode = page.get_by_role("group", name="View mode")
+    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
+    terminal_button = view_mode.get_by_role("button", name="Terminal")
+    expect(terminal_button).to_be_visible(timeout=30_000)
+    terminal_button.click()
+
+
+def _wait_terminal_connected(page: Page) -> None:
+    """Wait until the embedded xterm has attached to the live Codex TUI.
+
+    :param page: The Playwright page, on the Terminal view.
+    """
+    terminal = page.locator(_TERMINAL_VIEW).last
+    expect(terminal).to_have_attribute(
+        "data-state", "connected", timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+
+
+def _type_into_tui(page: Page, text: str) -> None:
+    """Type *text* into the embedded Codex TUI and submit with Enter.
+
+    Drives the real TUI exactly as a user would: focus the xterm input,
+    type the prompt, press Enter. This is the OUT direction — the message
+    originates in the terminal, not the web composer.
+
+    :param page: The Playwright page, on the connected Terminal view.
+    :param text: The single-line prompt to type into the TUI.
+    """
+    # Scope to the active terminal-view (not page-level) so the lookup can't
+    # focus a stray textarea from another terminal widget — matches the shell
+    # E2E test pattern.
+    xterm_input = page.locator(_TERMINAL_VIEW).last.locator(_XTERM_INPUT)
+    expect(xterm_input).to_be_attached(timeout=30_000)
+    xterm_input.focus()
+    # Type at a human-ish cadence: Codex's TUI composer can drop or
+    # reorder characters injected faster than it repaints.
+    page.keyboard.type(text, delay=15)
+    page.keyboard.press("Enter")
+
+
+@pytest.mark.timeout(900)
+def test_native_codex_message_render_parity(
+    page: Page,
+    native_codex_session: tuple[str, str],
+) -> None:
+    """Native Codex renders parity with its TUI, both ways, with no dupes.
+
+    Covers all three properties on a single (expensive to spin up) native
+    session: composer parity (IN), a TUI-originated turn surfacing in the web UI
+    (OUT), and no duplicate rendering across every turn.
+    """
+    base_url, session_id = native_codex_session
+    _log.info("native-codex session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The Terminal view proves Codex actually booted in the session terminal
+    # (the runner's codex-native auto-launch) before we send anything.
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _log.info("Codex TUI attached (terminal-view connected)")
+
+    user_markers: list[str] = []
+    assistant_tokens: list[str] = []
+
+    def _new_turn(index: int) -> tuple[str, str]:
+        nonce = uuid.uuid4().hex[:8]
+        user_marker = f"usr-{index}-{nonce}"
+        assistant_token = f"ast-{index}-{nonce}"
+        user_markers.append(user_marker)
+        assistant_tokens.append(assistant_token)
+        return user_marker, assistant_token
+
+    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
+    _ensure_chat_view(page)
+    for index in range(1, _COMPOSER_TURNS + 1):
+        user_marker, assistant_token = _new_turn(index)
+        _log.info(
+            "composer turn %d: sending (marker=%s token=%s)", index, user_marker, assistant_token
+        )
+        _send(page, _turn_prompt(index, user_marker, assistant_token))
+        # The echoed token in an assistant bubble = this turn produced its reply.
+        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+            timeout=_NATIVE_TURN_TIMEOUT_MS
+        )
+        # Fully settle (working shimmer gone) before the next send, so any
+        # transient native live-preview has collapsed into the committed bubble.
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+        expect(page.locator(_USER)).to_have_count(index, timeout=30_000)
+        _log.info("composer turn %d: settled", index)
+
+    # --- Property 2 & 3: a TUI-originated turn (OUT) surfaces in the web UI. ---
+    tui_index = _COMPOSER_TURNS + 1
+    tui_marker, tui_token = _new_turn(tui_index)
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _log.info(
+        "TUI turn %d: typing into xterm (marker=%s token=%s)", tui_index, tui_marker, tui_token
+    )
+    _type_into_tui(page, _turn_prompt(tui_index, tui_marker, tui_token))
+
+    # Back in Chat, the bridge must have forwarded the TUI turn OUT as a user
+    # item + assistant reply — both render as bubbles, exactly once.
+    _ensure_chat_view(page)
+    expect(page.locator(_ASSISTANT, has_text=tui_token).first).to_be_visible(
+        timeout=_NATIVE_TURN_TIMEOUT_MS
+    )
+    expect(page.locator(_USER, has_text=tui_marker).first).to_be_visible(timeout=30_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(page.locator(_USER)).to_have_count(len(user_markers), timeout=30_000)
+    _log.info("TUI turn %d: surfaced in web UI (user + assistant bubbles present)", tui_index)
+
+    # --- Assert all three properties over every turn. ---
+    _assert_no_duplicate_render(page, user_markers, assistant_tokens)
+    _assert_transcript_parity(base_url, session_id, user_markers, assistant_tokens)
+    _log.info("all turns verified: render parity + no-duplicate-render + transcript parity")


### PR DESCRIPTION
Adds a native Codex render-parity suite mirroring the native Claude suite from #142.

## What

- **`tests/e2e_ui/messages/test_native_codex_render_parity.py`** — drives a real `codex` ("Codex") session through the web UI and asserts the three properties the native forwarder has historically regressed on:
  1. composer turns render parity with the TUI (chat bubbles == canonical transcript);
  2. a turn typed directly into the embedded Codex TUI (xterm) surfaces in the web UI via the native bridge;
  3. no duplicate rendering of any composer- or TUI-originated message.
- **`native_codex_session` fixture** (conftest) — reuses the exact terminal-first spec `omnigent codex` ships (`_materialize_codex_agent_spec`, `model=None`) so it never drifts from production. The runner auto-launches Codex on bind (`_auto_create_codex_terminal`).
- **`e2e-ui.yml`** — installs both the Claude Code and Codex CLIs and registers the Databricks gateway as the default for BOTH families: `anthropic` for Claude, `openai` for Codex (pointing at `<host>/ai-gateway/codex/v1`, `wire_api: responses`, model `databricks-gpt-5-4-mini`). Failure-only diagnostics dump Codex's `*.jsonl` rollouts (never `config.toml`, which embeds the token).

## TEMP — revert before merge

Per the same approach as #142, the test run is temporarily scoped to **only** `test_native_codex_render_parity` (shard 0) with live log streaming, to validate the suite + harness wiring on CI before flipping back to the full sharded `e2e_ui` suite.