### PR TITLE
fix(test): address unaddressed review comments from merged test PRs

### DIFF
--- a/tests/server/integration/test_accounts_auth_e2e.py
+++ b/tests/server/integration/test_accounts_auth_e2e.py
@@ -136,17 +136,23 @@ def setup_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
 @pytest_asyncio.fixture()
 async def client(accounts_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
     """Async HTTP client wired to the pre-seeded accounts app."""
+    from omnigent.db.utils import clear_engine_cache
+
     transport = httpx.ASGITransport(app=accounts_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
+    clear_engine_cache()
 
 
 @pytest_asyncio.fixture()
 async def setup_client(setup_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
     """Async HTTP client wired to the needs-setup accounts app."""
+    from omnigent.db.utils import clear_engine_cache
+
     transport = httpx.ASGITransport(app=setup_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
+    clear_engine_cache()
 
 
 # ── Helpers ───────────────────────────────────────────────
@@ -304,7 +310,7 @@ async def test_invite_and_register_flow(
         json={"is_admin": False},
         headers=admin_headers,
     )
-    assert invite_resp.status_code == 200
+    assert invite_resp.status_code == 200, invite_resp.text
     invite_body = invite_resp.json()
     token = invite_body["token"]
     assert "register_url" in invite_body
@@ -318,7 +324,7 @@ async def test_invite_and_register_flow(
             "password": "bob-pw-123456",
         },
     )
-    assert reg_resp.status_code == 200
+    assert reg_resp.status_code == 200, reg_resp.text
     reg_body = reg_resp.json()
     assert reg_body["user"]["id"] == "bob"
     assert reg_body["user"]["is_admin"] is False
@@ -336,12 +342,14 @@ async def test_invite_requires_admin(
     invite_resp = await client.post(
         "/auth/invite", json={"is_admin": False}, headers=admin_headers
     )
+    assert invite_resp.status_code == 200, invite_resp.text
     token = invite_resp.json()["token"]
 
-    await client.post(
+    reg_resp = await client.post(
         "/auth/register",
         json={"invite": token, "username": "bob", "password": "bob-pw-123456"},
     )
+    assert reg_resp.status_code == 200, reg_resp.text
 
     # Login as non-admin bob.
     bob_cookies = await _login(client, "bob", "bob-pw-123456")
@@ -427,11 +435,13 @@ async def test_non_admin_cannot_list_users(
     invite_resp = await client.post(
         "/auth/invite", json={"is_admin": False}, headers=admin_headers
     )
+    assert invite_resp.status_code == 200, invite_resp.text
     token = invite_resp.json()["token"]
-    await client.post(
+    reg_resp = await client.post(
         "/auth/register",
         json={"invite": token, "username": "bob", "password": "bob-pw-123456"},
     )
+    assert reg_resp.status_code == 200, reg_resp.text
 
     bob_cookies = await _login(client, "bob", "bob-pw-123456")
     bob_headers = _cookie_header(bob_cookies)
@@ -496,7 +506,9 @@ async def test_magic_link_is_single_use(
     cookies = await _login(client, _ADMIN_USERNAME, _ADMIN_PASSWORD)
     headers = _cookie_header(cookies)
 
-    redeem_url = (await client.post("/auth/magic", headers=headers)).json()["redeem_url"]
+    mint_resp = await client.post("/auth/magic", headers=headers)
+    assert mint_resp.status_code == 200, mint_resp.text
+    redeem_url = mint_resp.json()["redeem_url"]
     parsed = urlparse(redeem_url)
     path_q = f"{parsed.path}?{parsed.query}"
 

--- a/tests/server/integration/test_comments_rest_e2e.py
+++ b/tests/server/integration/test_comments_rest_e2e.py
@@ -145,7 +145,7 @@ async def test_full_crud_lifecycle(
         },
         headers=headers,
     )
-    assert c1_resp.status_code == 200
+    assert c1_resp.status_code == 200, c1_resp.text
     c1 = c1_resp.json()
     assert c1["status"] == "draft"
     assert c1["path"] == "src/foo.py"
@@ -160,7 +160,7 @@ async def test_full_crud_lifecycle(
         },
         headers=headers,
     )
-    assert c2_resp.status_code == 200
+    assert c2_resp.status_code == 200, c2_resp.text
     c2 = c2_resp.json()
 
     # ── List all ─────────────────────────────────────────────────────
@@ -244,9 +244,9 @@ async def test_comment_on_nonexistent_session_returns_404(
         },
         headers=headers,
     )
-    # The permission check fires before the comment store, so the user
-    # gets a 403 (no grant) or 404 (session not found) — either is fine.
-    assert resp.status_code in {403, 404}
+    # The permission check fires before the comment store — the user
+    # has no grant for this session, so they get a 404.
+    assert resp.status_code == 404
 
 
 async def test_send_formats_multifile_message_with_anchors(
@@ -258,47 +258,47 @@ async def test_send_formats_multifile_message_with_anchors(
     headers = {"X-Forwarded-Email": ALICE}
 
     # Comment with anchor_content on file A
-    c1 = (
-        await auth_client.post(
-            f"/v1/sessions/{session_id}/comments",
-            json={
-                "path": "src/alpha.py",
-                "body": "Rename variable",
-                "start_index": 10,
-                "end_index": 25,
-                "anchor_content": "old_var_name",
-            },
-            headers=headers,
-        )
-    ).json()
+    c1_resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/comments",
+        json={
+            "path": "src/alpha.py",
+            "body": "Rename variable",
+            "start_index": 10,
+            "end_index": 25,
+            "anchor_content": "old_var_name",
+        },
+        headers=headers,
+    )
+    assert c1_resp.status_code == 200, c1_resp.text
+    c1 = c1_resp.json()
 
     # Comment without anchor_content on file B
-    c2 = (
-        await auth_client.post(
-            f"/v1/sessions/{session_id}/comments",
-            json={
-                "path": "src/beta.py",
-                "body": "Add docstring",
-                "start_index": 0,
-                "end_index": 8,
-            },
-            headers=headers,
-        )
-    ).json()
+    c2_resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/comments",
+        json={
+            "path": "src/beta.py",
+            "body": "Add docstring",
+            "start_index": 0,
+            "end_index": 8,
+        },
+        headers=headers,
+    )
+    assert c2_resp.status_code == 200, c2_resp.text
+    c2 = c2_resp.json()
 
     # Comment on file A again (should group with the first)
-    c3 = (
-        await auth_client.post(
-            f"/v1/sessions/{session_id}/comments",
-            json={
-                "path": "src/alpha.py",
-                "body": "Fix indentation",
-                "start_index": 50,
-                "end_index": 60,
-            },
-            headers=headers,
-        )
-    ).json()
+    c3_resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/comments",
+        json={
+            "path": "src/alpha.py",
+            "body": "Fix indentation",
+            "start_index": 50,
+            "end_index": 60,
+        },
+        headers=headers,
+    )
+    assert c3_resp.status_code == 200, c3_resp.text
+    c3 = c3_resp.json()
 
     send_resp = await auth_client.post(
         f"/v1/sessions/{session_id}/comments/send",
@@ -396,7 +396,7 @@ async def test_session_list_includes_comments_fingerprint(
     assert target2[0]["comments_updated_at"] == comment["updated_at"]
 
     # Add a second comment and verify count bumps
-    await auth_client.post(
+    add_resp2 = await auth_client.post(
         f"/v1/sessions/{session_id}/comments",
         json={
             "path": "src/main.py",
@@ -406,6 +406,7 @@ async def test_session_list_includes_comments_fingerprint(
         },
         headers=headers,
     )
+    assert add_resp2.status_code == 200, add_resp2.text
     list_resp3 = await auth_client.get("/v1/sessions", headers=headers)
     items3 = list_resp3.json()["data"]
     target3 = [s for s in items3 if s["id"] == session_id]

--- a/tests/server/integration/test_hosts_management_e2e.py
+++ b/tests/server/integration/test_hosts_management_e2e.py
@@ -1,14 +1,16 @@
 """Integration tests for host management edge cases.
 
-Covers gaps not exercised by test_hosts_api.py or test_hosts_filesystem.py:
+Covers 8 gaps not exercised by test_hosts_api.py or test_hosts_filesystem.py:
 
 - ``GET /v1/runners`` returns empty when no runners are connected.
 - ``GET /v1/runners/{id}/status`` returns offline for an unknown runner.
+- ``GET /v1/runners/{id}/status`` omits error field for unconnected runners.
 - ``GET /v1/hosts/{id}`` response shape includes the ``runners`` field.
 - ``POST /v1/hosts/{id}/runners`` with missing ``session_id`` returns 422.
-- ``GET /v1/hosts/{id}/filesystem/{path}`` with offline host returns 409.
-- ``GET /v1/hosts`` returns offline after the host's ``last_seen_at``
+- ``POST /v1/hosts/{id}/runners`` with missing ``workspace`` returns 422.
+- ``GET /v1/hosts`` returns offline after the host's ``updated_at``
   exceeds the liveness window (stale host detection).
+- ``GET /v1/hosts/{id}`` returns offline status for an offline host.
 """
 
 from __future__ import annotations
@@ -209,25 +211,29 @@ async def test_list_hosts_stale_host_reported_offline(
     # Verify it initially shows as online.
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/v1/hosts")
+    assert resp.status_code == 200, resp.text
     hosts = resp.json()["hosts"]
     assert len(hosts) == 1
     assert hosts[0]["status"] == "online"
 
-    # Manually backdate last_seen_at to simulate a crashed host.
+    # Manually backdate updated_at to simulate a crashed host.
     # The liveness window is typically 60-120s; setting it 10 minutes
     # in the past guarantees it exceeds any reasonable window.
-    from sqlalchemy import text
+    from sqlalchemy import update
+    from sqlalchemy.orm import Session
+
+    from omnigent.db.db_models import SqlHost
 
     stale_time = int(time.time()) - 600
-    with host_store._engine.connect() as conn:
-        conn.execute(
-            text("UPDATE hosts SET updated_at = :ts WHERE host_id = :hid"),
-            {"ts": stale_time, "hid": "host_stale"},
+    with Session(host_store._engine) as session:
+        session.execute(
+            update(SqlHost).where(SqlHost.host_id == "host_stale").values(updated_at=stale_time)
         )
-        conn.commit()
+        session.commit()
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/v1/hosts")
+    assert resp.status_code == 200, resp.text
     hosts = resp.json()["hosts"]
     assert len(hosts) == 1
     assert hosts[0]["host_id"] == "host_stale"

--- a/tests/server/integration/test_oidc_auth_e2e.py
+++ b/tests/server/integration/test_oidc_auth_e2e.py
@@ -33,7 +33,6 @@ pytestmark = pytest.mark.asyncio
 
 _TEST_SECRET = b"a" * 32
 _GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token"
-_GITHUB_EMAILS_ENDPOINT = "https://api.github.com/user/emails"
 
 
 def _make_oidc_config() -> OIDCConfig:
@@ -63,7 +62,7 @@ def _build_oidc_app() -> httpx.ASGITransport:
 
     config = _make_oidc_config()
     auth_provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
-    admin_list = AdminList(Path("/dev/null"))
+    admin_list = AdminList(Path("/tmp/nonexistent-admin-list.txt"))
 
     router = create_auth_router(
         auth_provider=auth_provider,
@@ -302,15 +301,19 @@ async def test_logout_clears_cookie_and_redirects() -> None:
 
     assert resp.status_code == 302
     assert resp.headers["location"] == "/"
-    # The session cookie should be cleared (max-age=0 or deleted).
-    cookie_header = resp.headers.get("set-cookie", "")
-    assert "ap_session" in cookie_header
+    # The session cookie should be cleared with Max-Age=0 deletion semantics.
+    set_cookie_headers = resp.headers.get_list("set-cookie")
+    session_cookies = [h for h in set_cookie_headers if "ap_session" in h]
+    assert session_cookies, "expected a Set-Cookie header for ap_session"
+    assert any("Max-Age=0" in h for h in session_cookies), (
+        f"expected Max-Age=0 deletion cookie; got {session_cookies}"
+    )
 
 
 # ── 6. Expired ticket eviction ─────────────────────────────────────
 
 
-def test_evict_expired_tickets_removes_old_entries() -> None:
+async def test_evict_expired_tickets_removes_old_entries() -> None:
     """_evict_expired_tickets removes tickets older than the TTL."""
     tickets: dict[str, _CliTicket] = {
         "fresh": _CliTicket(created_at=time.time()),
@@ -325,7 +328,7 @@ def test_evict_expired_tickets_removes_old_entries() -> None:
     assert "also_expired" not in tickets
 
 
-def test_evict_expired_tickets_noop_when_all_fresh() -> None:
+async def test_evict_expired_tickets_noop_when_all_fresh() -> None:
     """_evict_expired_tickets is a no-op when no tickets are expired."""
     tickets: dict[str, _CliTicket] = {
         "a": _CliTicket(created_at=time.time()),

--- a/tests/server/integration/test_policy_ask_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_ask_lifecycle_e2e.py
@@ -62,7 +62,8 @@ def policy_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
     store, so the session policy CRUD routes are not mounted. This
     fixture adds one so ``POST /v1/sessions/{id}/policies`` and the
     evaluate endpoint's ``get_policy_store()`` both see session-attached
-    policies.
+    policies. The runtime-global ``_policy_store`` is wired separately
+    in the ``client`` fixture via monkeypatch.
 
     :param runtime_init: Fixture that initializes the runtime with a
         mock LLM.
@@ -238,10 +239,9 @@ async def test_ask_policy_approve_flow(
     session_id = await _create_session(client, agent["id"])
     await _attach_ask_policy(client, session_id)
 
+    drain = asyncio.create_task(_drain_elicitation_id(session_id))
+    evaluate = None
     try:
-        # Subscribe to the stream before triggering evaluation so the
-        # elicitation event is not missed.
-        drain = asyncio.create_task(_drain_elicitation_id(session_id))
         await asyncio.sleep(0.05)
 
         # The evaluate POST parks until the verdict arrives.
@@ -276,6 +276,10 @@ async def test_ask_policy_approve_flow(
         assert resp.status_code == 200, resp.text
         assert resp.json()["result"] == "POLICY_ACTION_ALLOW"
     finally:
+        for task in [drain, evaluate]:
+            if task is not None and not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
 
 
@@ -295,8 +299,9 @@ async def test_ask_policy_refuse_flow(
     session_id = await _create_session(client, agent["id"])
     await _attach_ask_policy(client, session_id)
 
+    drain = asyncio.create_task(_drain_elicitation_id(session_id))
+    evaluate = None
     try:
-        drain = asyncio.create_task(_drain_elicitation_id(session_id))
         await asyncio.sleep(0.05)
 
         evaluate = asyncio.create_task(
@@ -321,4 +326,8 @@ async def test_ask_policy_refuse_flow(
         body = resp.json()
         assert body["result"] == "POLICY_ACTION_DENY"
     finally:
+        for task in [drain, evaluate]:
+            if task is not None and not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
         pending_elicitations.reset_for_tests()

--- a/tests/server/integration/test_policy_ask_yaml_tools_e2e.py
+++ b/tests/server/integration/test_policy_ask_yaml_tools_e2e.py
@@ -17,7 +17,6 @@ which is the standard pattern for always-ASK gates in agent YAML.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from typing import Any
 
 import httpx
@@ -208,7 +207,9 @@ async def test_input_ask_yaml_approve(
         assert verdict.status_code == 202, verdict.text
 
         # The message POST should now return — ALLOW means the message
-        # was forwarded (not denied synchronously).
+        # was forwarded past the policy layer (not denied synchronously).
+        # It may then fail with 503 (no runner bound) — that still proves
+        # the ASK gate approved the message through.
         resp = await asyncio.wait_for(message_task, timeout=5.0)
         body = resp.json()
         assert body.get("denied") is not True, f"approved INPUT ASK should not deny; got {body}"
@@ -216,8 +217,7 @@ async def test_input_ask_yaml_approve(
         for task in [drain_task, message_task if "message_task" in dir() else None]:
             if task is not None and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await task
+                await asyncio.gather(task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
 
 
@@ -273,12 +273,14 @@ async def test_input_ask_yaml_refuse(
         body = resp.json()
         assert body.get("denied") is True, f"declined INPUT ASK should deny; got {body}"
         assert "reason" in body, f"deny verdict missing reason: {body}"
+        assert "Confirm this message before processing" in body["reason"], (
+            f"expected exact ASK reason in deny verdict; got {body['reason']!r}"
+        )
     finally:
         for task in [drain_task, message_task if "message_task" in dir() else None]:
             if task is not None and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await task
+                await asyncio.gather(task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
 
 
@@ -333,6 +335,5 @@ async def test_tool_call_ask_yaml_approve(
         for task in [drain_task, evaluate_task if "evaluate_task" in dir() else None]:
             if task is not None and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await task
+                await asyncio.gather(task, return_exceptions=True)
         pending_elicitations.reset_for_tests()

--- a/tests/server/integration/test_policy_composition_e2e.py
+++ b/tests/server/integration/test_policy_composition_e2e.py
@@ -3,9 +3,11 @@
 Verifies the PolicyEngine's composition semantics through the
 ``POST /v1/sessions/{id}/policies/evaluate`` endpoint:
 
-- DENY takes precedence over ASK on the same phase.
+- DENY takes precedence over ASK on the same phase (engine
+  short-circuits on the first DENY).
 - Removing a DENY policy lets ASK fire on re-evaluation.
-- Two DENY policies both contribute their reasons.
+- Two DENY policies: the first in declaration order short-circuits,
+  so only its reason is surfaced.
 - ALLOW does not override DENY.
 
 Uses ``make_fixed_action_callable`` factories injected via
@@ -141,11 +143,11 @@ async def test_deny_takes_precedence_over_ask(
 ) -> None:
     """When DENY and ASK policies both fire, DENY short-circuits.
 
-    The engine iterates policies in order; a DENY result ends
-    evaluation immediately (POLICIES.md section 4). Even if an ASK
-    policy is declared, the DENY fires first and no elicitation
-    prompt is shown. If this regresses, the endpoint would return
-    ASK or park for approval instead of returning DENY.
+    The engine iterates policies in declaration order; a DENY result
+    ends evaluation immediately. Even if an ASK policy is declared,
+    the DENY fires first and no elicitation prompt is shown. If this
+    regresses, the endpoint would return ASK or park for approval
+    instead of returning DENY.
     """
     _install_policies(
         monkeypatch,
@@ -183,19 +185,11 @@ async def test_ask_fires_when_deny_removed(
 
     This complements test 1: after removing the DENY policy, the
     ASK policy is no longer shadowed and fires. The evaluate
-    endpoint parks for approval on TOOL_CALL ASK, so we verify the
-    behavior by checking that the response does NOT return
-    POLICY_ACTION_DENY. Since the gate parks, we expect either a
-    timeout or a long-poll — but for this test we simply verify
-    with a non-blocking phase (using a short-lived request that
-    we can cancel). Instead, we just test that ASK-only doesn't
-    produce DENY — the ASK gate parking is covered by dedicated
+    endpoint parks for approval on TOOL_CALL, so we use
+    ``PHASE_LLM_RESPONSE`` (a non-blocking phase where ASK is
+    returned directly without gate parking) to observe the ASK
+    result. The ASK gate parking flow is covered by the dedicated
     elicitation tests.
-
-    As a simpler alternative: re-evaluate with only the ASK policy.
-    The endpoint parks for approval on TOOL_CALL, but we can use
-    PHASE_LLM_RESPONSE (a non-blocking phase) to see ASK returned
-    directly.
     """
     _install_policies(
         monkeypatch,
@@ -238,10 +232,9 @@ async def test_two_deny_policies_first_reason_visible(
     """With two DENY policies, the first one's reason is surfaced.
 
     The engine short-circuits on the first DENY in declaration
-    order (POLICIES.md section 4). The deciding policy's reason
-    is carried in the verdict. This tests that multiple DENY
-    policies compose correctly — the second never fires because
-    the first already short-circuited.
+    order. The deciding policy's reason is carried in the verdict.
+    This tests that multiple DENY policies compose correctly — the
+    second never fires because the first already short-circuited.
     """
     _install_policies(
         monkeypatch,
@@ -266,7 +259,7 @@ async def test_two_deny_policies_first_reason_visible(
     # is the one that surfaces.
     assert "Alpha deny reason" in body.get("reason", ""), (
         f"Expected the first DENY policy's reason; got {body.get('reason')!r}. "
-        "The engine should short-circuit on the first DENY in YAML order."
+        "The engine should short-circuit on the first DENY in declaration order."
     )
 
 

--- a/tests/server/integration/test_policy_contextual_labels_e2e.py
+++ b/tests/server/integration/test_policy_contextual_labels_e2e.py
@@ -6,8 +6,8 @@ Verifies the realistic scenario where a policy monitors conversation state
 
 - A condition-gated DENY policy that fires only when ``tainted: "1"`` is set.
 - Label writes via PATCH persist across evaluations.
-- The condition gate correctly skips when the label is absent and fires
-  when the label is present.
+- The condition gate correctly skips when the label is at its initial value
+  (``"0"``) and fires when updated to the matching value (``"1"``).
 - Labels survive across multiple evaluation rounds (simulating multi-turn
   conversations).
 
@@ -47,22 +47,6 @@ def _deny_all_tool_calls(event: dict[str, Any]) -> dict[str, Any]:
     return {
         "result": "DENY",
         "reason": "Conversation is tainted from a prior turn.",
-    }
-
-
-def _allow_and_taint(event: dict[str, Any]) -> dict[str, Any]:
-    """
-    Policy that ALLOWs every tool call and writes ``tainted: "1"``.
-
-    Simulates a policy that detects a trigger condition and writes
-    a label to mark the conversation for downstream gates.
-
-    :param event: V0 event dict.
-    :returns: ALLOW with ``set_labels`` carrying the taint marker.
-    """
-    return {
-        "result": "ALLOW",
-        "set_labels": {"tainted": "1"},
     }
 
 
@@ -111,17 +95,17 @@ def _tool_call_request(tool_name: str = "Bash") -> dict[str, Any]:
 # ── Tests ──────────────────────────────────────────────────
 
 
-async def test_condition_gate_skips_when_label_absent(
+async def test_condition_gate_skips_when_label_at_initial_value(
     client: httpx.AsyncClient,
 ) -> None:
     """
-    A condition-gated DENY policy is skipped when its label condition
-    does not match the session's current labels.
+    A condition-gated DENY policy is skipped when the label is at its
+    initial value (``"0"``), which does not match the condition.
 
-    This is turn 1 of the multi-turn scenario: the conversation has not
-    yet been tainted, so the condition ``tainted: "1"`` does not match
-    and the policy is skipped entirely. The evaluate endpoint returns
-    ALLOW.
+    This is turn 1 of the multi-turn scenario: the label ``tainted``
+    starts at its declared ``initial: "0"`` value, so the condition
+    ``tainted: "1"`` does not match and the policy is skipped entirely.
+    The evaluate endpoint returns ALLOW.
     """
     agent = await create_test_agent(
         client,

--- a/tests/server/integration/test_policy_deny_lifecycle_e2e.py
+++ b/tests/server/integration/test_policy_deny_lifecycle_e2e.py
@@ -163,7 +163,7 @@ async def _attach_deny_policy(
     :param factory_params: Override factory params if needed.
     :returns: The created policy id.
     """
-    params = factory_params or {"action": "deny", "reason": reason}
+    params = {"action": "deny", "reason": reason} if factory_params is None else factory_params
     resp = await client.post(
         f"/v1/sessions/{session_id}/policies",
         json={
@@ -251,11 +251,15 @@ async def test_deny_policy_lifecycle(
     resp_allowed = await _send_user_message(
         policy_client, session_id, "Hello, this should go through."
     )
-    body = resp_allowed.json()
     # After policy removal the message must NOT be denied by policy.
     # It may return 202 (queued) or 503 (no runner bound) — both prove
-    # the policy layer allowed it through. A synchronous DENY verdict
-    # ({"denied": true}) would mean the policy is still active.
+    # the policy layer allowed it through.
+    assert resp_allowed.status_code in {202, 503}, (
+        f"expected 202 or 503 after policy removal; "
+        f"got {resp_allowed.status_code} {resp_allowed.text}"
+    )
+    body = resp_allowed.json()
+    # A synchronous DENY verdict ({"denied": true}) would mean the policy is still active.
     assert body.get("denied") is not True, f"message was denied after policy removal; got {body}"
 
     # ── Step 6: verify the policy list is empty ──
@@ -300,6 +304,9 @@ async def test_deny_policy_only_blocks_matching_phase(
     # May return 202 (queued) or 503 (no runner) — both prove the
     # policy layer allowed it through; only {"denied": true} is a failure.
     resp = await _send_user_message(policy_client, session_id, "Hello, this should go through.")
+    assert resp.status_code in {202, 503}, (
+        f"expected 202 or 503; got {resp.status_code} {resp.text}"
+    )
     body = resp.json()
     assert body.get("denied") is not True, (
         f"tool_call-only DENY policy incorrectly blocked an input message; got {body}"

--- a/tests/server/integration/test_policy_deny_yaml_tools_e2e.py
+++ b/tests/server/integration/test_policy_deny_yaml_tools_e2e.py
@@ -32,41 +32,7 @@ from tests.server.helpers import create_test_agent
 pytestmark = pytest.mark.asyncio
 
 
-# ── Policy callables ────────────────────────────────────────
-
-
-def _deny_echo_tool(event: dict[str, Any]) -> dict[str, Any]:
-    """
-    Policy that denies ``echo`` tool calls.
-
-    :param event: V0 event dict.
-    :returns: DENY for echo tool calls, ALLOW otherwise.
-    """
-    if event.get("type") != "tool_call":
-        return {"result": "ALLOW"}
-    data = event.get("data")
-    tool = data.get("name", "") if isinstance(data, dict) else ""
-    if tool == "echo":
-        return {
-            "result": "DENY",
-            "reason": "echo tool is blocked by YAML policy.",
-        }
-    return {"result": "ALLOW"}
-
-
-def _deny_all_requests(event: dict[str, Any]) -> dict[str, Any]:
-    """
-    Policy that denies all request-phase events.
-
-    :param event: V0 event dict.
-    :returns: DENY for request events, ALLOW otherwise.
-    """
-    if event.get("type") == "request":
-        return {
-            "result": "DENY",
-            "reason": "All input is blocked by request-phase policy.",
-        }
-    return {"result": "ALLOW"}
+_MAKE_FIXED = "omnigent.policies.function.make_fixed_action_callable"
 
 
 # ── Helpers ─────────────────────────────────────────────────
@@ -131,8 +97,15 @@ async def test_deny_on_specific_tool_call(
             "policies": {
                 "deny_echo": {
                     "type": "function",
+                    "on": ["tool_call"],
                     "function": {
-                        "path": f"{__name__}._deny_echo_tool",
+                        "path": _MAKE_FIXED,
+                        "arguments": {
+                            "action": "deny",
+                            "reason": "echo tool is blocked by YAML policy.",
+                            "on_phases": ["tool_call"],
+                            "on_tools": ["echo"],
+                        },
                     },
                 },
             },
@@ -163,8 +136,8 @@ async def test_deny_does_not_block_other_tools(
     tools through.
 
     A tool call to ``grep`` must return ALLOW because the policy
-    callable only inspects ``echo``. If the policy over-fires, this
-    test catches it.
+    is scoped to ``on_tools: ["echo"]``. If the policy over-fires,
+    this test catches it.
     """
     agent = await create_test_agent(
         client,
@@ -172,8 +145,15 @@ async def test_deny_does_not_block_other_tools(
             "policies": {
                 "deny_echo": {
                     "type": "function",
+                    "on": ["tool_call"],
                     "function": {
-                        "path": f"{__name__}._deny_echo_tool",
+                        "path": _MAKE_FIXED,
+                        "arguments": {
+                            "action": "deny",
+                            "reason": "echo tool is blocked by YAML policy.",
+                            "on_phases": ["tool_call"],
+                            "on_tools": ["echo"],
+                        },
                     },
                 },
             },
@@ -217,8 +197,14 @@ async def test_deny_on_request_phase_blocks_input(
             "policies": {
                 "deny_all_input": {
                     "type": "function",
+                    "on": ["request"],
                     "function": {
-                        "path": f"{__name__}._deny_all_requests",
+                        "path": _MAKE_FIXED,
+                        "arguments": {
+                            "action": "deny",
+                            "reason": "All input is blocked by request-phase policy.",
+                            "on_phases": ["request"],
+                        },
                     },
                 },
             },

--- a/tests/server/integration/test_sessions_elicitation_api.py
+++ b/tests/server/integration/test_sessions_elicitation_api.py
@@ -20,7 +20,6 @@ real parked elicitations without duplicating the hook machinery.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 
 import httpx
 import pytest
@@ -75,8 +74,7 @@ async def test_get_pending_elicitation_shape(client: httpx.AsyncClient) -> None:
     finally:
         if not hook_task.done():
             hook_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await hook_task
+            await asyncio.gather(hook_task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
 
 
@@ -149,8 +147,7 @@ async def test_get_after_resolution_returns_resolved(
     finally:
         if not hook_task.done():
             hook_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await hook_task
+            await asyncio.gather(hook_task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
 
 
@@ -205,8 +202,7 @@ async def test_post_resolve_already_resolved_is_idempotent(
     finally:
         if not hook_task.done():
             hook_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await hook_task
+            await asyncio.gather(hook_task, return_exceptions=True)
         pending_elicitations.reset_for_tests()
 
 


### PR DESCRIPTION
## Summary
- Address unaddressed review comments from merged test PRs #164, #217, #219, #220, #235, #244, #245, #248, #249, #250, #251 across 11 integration test files
- Replace bare `await` in finally blocks with `asyncio.gather(return_exceptions=True)`, remove unused imports (`contextlib`, `_GITHUB_EMAILS_ENDPOINT`, `_allow_and_taint`)
- Add engine cache cleanup (`clear_engine_cache`) in accounts auth fixture teardown
- Assert HTTP status codes before calling `.json()` on responses across all files
- Replace raw SQL with ORM `update()` using `SqlHost` model in hosts management tests
- Use `make_fixed_action_callable` with `on_phases`/`on_tools` params instead of custom self-filtering callables in YAML policy tests
- Fix docstrings/comments: "label absent" to "label at initial value", "YAML order" to "declaration order", remove POLICIES.md references, match actual test count
- Replace `Path("/dev/null")` with nonexistent path for `AdminList`, fix logout cookie assertion to check `Max-Age=0` with `get_list()`
- Make sync eviction tests async (module has `pytestmark = pytest.mark.asyncio`)
- Change `assert resp.status_code in {403, 404}` to `== 404` in comments test
- Fix `factory_params or {...}` to explicit `is None` check
- Add try/finally cleanup for background evaluate/drain tasks in ASK lifecycle tests

## Test plan
- [x] All 11 modified test files pass locally (`pytest -x -q` on each)
- [x] `ruff format` and `ruff check` pass clean

This pull request and its description were written by Isaac.