### PR TITLE
fix(antigravity): enforce tool-call and LLM-phase policies

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -28,13 +28,32 @@ Streaming model:
 - Cancellation: :meth:`interrupt_session` -> ``conversation.cancel()``, which
   surfaces ``TurnCancelled``.
 
+Policy enforcement mirrors the peer SDK executors so operator guardrails apply
+to this runtime too:
+
+- TOOL_CALL phase: a registered ``PreToolCallDecideHook`` consults the
+  executor's ``_policy_evaluator`` BEFORE each tool runs. A DENY verdict blocks
+  the call (the SDK rejects it without executing the tool — for both its
+  bundled native tools and the bridged Omnigent tools, see
+  :meth:`_build_pre_tool_hook`); an ASK verdict routes through the executor's
+  ``_elicitation_handler`` (deny when none is wired). This is the
+  ``can_use_tool`` gate of :class:`~omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor`,
+  expressed through the SDK's decide-hook surface.
+- LLM_REQUEST / LLM_RESPONSE phases: :meth:`run_turn` evaluates these around
+  the model call (deny-before-spawn / deny-after-stream), matching the peer
+  executors so prompt-deny and output-block policies are honored.
+
+Both ``_policy_evaluator`` and ``_elicitation_handler`` are wired in by the
+harness ExecutorAdapter; every phase is a no-op when the evaluator is absent.
+
 Authentication is Gemini-native: a direct API key (``api_key``) or Vertex AI
 (``vertex`` + ``project`` + ``location``). The SDK has no OpenAI-compatible
 ``base_url``, so there is deliberately no gateway / Databricks routing path.
 
 SDK touchpoints are isolated in :meth:`_open_agent`, :meth:`_build_sdk_tools`,
-:meth:`_build_post_tool_hook`, and :meth:`_drive_turn`, and duck-typed to
-tolerate drift across the v0.1.x surface. Unit tests stub the SDK module.
+:meth:`_build_post_tool_hook`, :meth:`_build_pre_tool_hook`, and
+:meth:`_drive_turn`, and duck-typed to tolerate drift across the v0.1.x
+surface. Unit tests stub the SDK module.
 """
 
 from __future__ import annotations
@@ -97,6 +116,7 @@ SDKToolResult: TypeAlias = Any  # type: ignore[explicit-any]
 SDKUsage: TypeAlias = Any  # type: ignore[explicit-any]
 SDKTool: TypeAlias = Any  # type: ignore[explicit-any]
 SDKHook: TypeAlias = Any  # type: ignore[explicit-any]
+SDKHookResult: TypeAlias = Any  # type: ignore[explicit-any]
 SDKConfig: TypeAlias = Any  # type: ignore[explicit-any]
 SDKHookContext: TypeAlias = Any  # type: ignore[explicit-any]
 ToolArgs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
@@ -113,6 +133,24 @@ _ToolCallable: TypeAlias = Callable[..., Awaitable[ToolResult]]  # type: ignore[
 # sys / sub-agent / MCP tools under policy.
 ToolExecutor: TypeAlias = Callable[  # type: ignore[explicit-any]
     [str, dict[str, Any]], Awaitable[dict[str, Any]]
+]
+
+# Elicitation handler the harness ExecutorAdapter wires in. Returns whether
+# the user approves a tool call. Kept SDK-agnostic (a plain async callable) so
+# this module need not import the adapter's verdict / elicitation types —
+# mirrors :data:`omnigent.inner.claude_sdk_executor.ElicitationHandler`.
+ElicitationHandler: TypeAlias = Callable[  # type: ignore[explicit-any]
+    [str, dict[str, Any]], Awaitable[bool]
+]
+
+# Policy-evaluation callback the harness ExecutorAdapter wires in (assigns
+# ``executor._policy_evaluator``). Called with a proto-style phase string
+# (``"PHASE_TOOL_CALL"`` / ``"PHASE_LLM_REQUEST"`` / ``"PHASE_LLM_RESPONSE"``)
+# and an event-data dict; returns a verdict object exposing ``.action`` (e.g.
+# ``"POLICY_ACTION_DENY"``) and ``.reason``. Typed structurally as ``Any`` so
+# this module stays decoupled from the adapter's ``PolicyVerdictPayload``.
+PolicyEvaluator: TypeAlias = Callable[  # type: ignore[explicit-any]
+    [str, dict[str, Any]], Awaitable[Any]
 ]
 
 
@@ -357,6 +395,23 @@ class AntigravityExecutor(Executor):
         # Set by the harness ExecutorAdapter when unset; the SDK tools route
         # invocations through this to reach Omnigent's tools under policy.
         self._tool_executor: ToolExecutor | None = None
+        # Elicitation handler wired in by ExecutorAdapter. When set, a
+        # TOOL_CALL-phase ASK verdict is resolved by an async approve/deny
+        # round-trip through the Omnigent elicitation system; ``None`` until
+        # the adapter installs it (an ASK then fails closed → deny).
+        self._elicitation_handler: ElicitationHandler | None = None
+        # Policy evaluator wired in by ExecutorAdapter (assigned to
+        # ``_policy_evaluator`` when unset). Accessed via ``getattr`` at use
+        # sites — same pattern as the peer SDK executors — so every policy
+        # phase is a no-op until the adapter installs it. Declared here for
+        # discoverability; the adapter owns assignment.
+        self._policy_evaluator: PolicyEvaluator | None = None
+        # Names of the tools bridged through ``_tool_executor`` this turn (the
+        # Omnigent tools exposed as SDK callables). The pre-tool decide hook
+        # skips these — they are TOOL_CALL-gated server-side on the dispatch
+        # path — and gates everything else (chiefly the SDK's native tools).
+        # Refreshed at the start of each turn from the turn's tool set.
+        self._bridged_tool_names: frozenset[str] = frozenset()
 
     def supports_streaming(self) -> bool:
         return True
@@ -471,6 +526,28 @@ class AntigravityExecutor(Executor):
         )
         session_key = self._session_key(messages)
         prompt = _latest_user_text(messages)
+        # Names of the tools bridged through the dispatch path this turn; the
+        # pre-tool decide hook reads this to skip already-gated bridged tools.
+        self._bridged_tool_names = self._bridged_tool_name_set(tools)
+
+        # ── LLM_REQUEST policy evaluation ────────────────────────
+        # Mirror the peer executors: when the adapter wired a policy evaluator,
+        # evaluate the request before the model call (the producer's
+        # ``conversation.send()``) so a DENY aborts the turn without spawning it.
+        policy_eval = getattr(self, "_policy_evaluator", None)
+        if policy_eval is not None:
+            req_data: _StrAnyDict = {
+                "model": model,
+                "messages_count": len(messages),
+                "tools_count": len(tools),
+                "system_prompt_preview": (system_prompt[:200] if system_prompt else ""),
+                "last_user_message": prompt[:500],
+            }
+            req_verdict = await policy_eval("PHASE_LLM_REQUEST", req_data)
+            if getattr(req_verdict, "action", None) == "POLICY_ACTION_DENY":
+                deny_reason = getattr(req_verdict, "reason", None) or "no reason given"
+                yield ExecutorError(message=f"LLM call denied by policy: {deny_reason}")
+                return
 
         try:
             state, created = await self._ensure_agent(
@@ -510,6 +587,7 @@ class AntigravityExecutor(Executor):
             name=f"antigravity-turn:{session_key}",
         )
         final_text_parts: list[str] = []
+        tool_calls_count = 0
         cancelled = False
         errored = False
         try:
@@ -527,6 +605,8 @@ class AntigravityExecutor(Executor):
                     continue
                 if isinstance(item, TextChunk):
                     final_text_parts.append(item.text)
+                elif isinstance(item, ToolCallRequest):
+                    tool_calls_count += 1
                 yield item
         finally:
             state.active_queue = None
@@ -544,11 +624,31 @@ class AntigravityExecutor(Executor):
             yield TurnCancelled(reason="user_cancelled", phase="model")
             return
         usage = self._extract_usage(state.last_usage)
+        response_text = "".join(final_text_parts) or None
+
+        # ── LLM_RESPONSE policy evaluation ───────────────────────
+        # Mirror the peer executors: evaluate after the stream completes but
+        # before TurnComplete so a DENY blocks the response from being
+        # persisted / shown.
+        if policy_eval is not None:
+            resp_data: _StrAnyDict = {
+                "model": model,
+                "text_preview": (response_text[:500] if response_text else ""),
+                "tool_calls_count": tool_calls_count,
+            }
+            if usage is not None:
+                resp_data["usage"] = usage
+            resp_verdict = await policy_eval("PHASE_LLM_RESPONSE", resp_data)
+            if getattr(resp_verdict, "action", None) == "POLICY_ACTION_DENY":
+                deny_reason = getattr(resp_verdict, "reason", None) or "no reason given"
+                yield ExecutorError(message=f"LLM response denied by policy: {deny_reason}")
+                return
+
         # Notify in-process usage subscribers (and the auto-recorder) before the
         # terminal event, matching the peer SDK executors so antigravity turns
         # are not invisible to usage observers. No-op for an empty usage dict.
         _notify_usage_from_dict(model=model, usage=usage)
-        yield TurnComplete(response="".join(final_text_parts) or None, usage=usage)
+        yield TurnComplete(response=response_text, usage=usage)
 
     # ── SDK touchpoints (isolated; duck-typed; verified against v0.1.x) ──
 
@@ -805,8 +905,11 @@ class AntigravityExecutor(Executor):
         resolved model / prompt / credentials / tools / hooks and enters the
         agent's async context. Omnigent's tools are exposed as callables
         (``LocalAgentConfig.tools``) routing through :attr:`_tool_executor`, so
-        the agent runs them under policy. A ``PostToolCallHook`` surfaces a
-        :class:`ToolCallComplete` for every tool the agent runs.
+        the agent runs them under policy. Two hooks are registered: a
+        ``PreToolCallDecideHook`` that gates every tool against Omnigent's
+        TOOL_CALL policy BEFORE it runs (see :meth:`_build_pre_tool_hook`), and
+        a ``PostToolCallHook`` that surfaces a :class:`ToolCallComplete` for
+        every tool the agent runs.
 
         :param state: The session state the tool-completion hook closes over.
         :param model: The resolved model id to pin.
@@ -819,13 +922,133 @@ class AntigravityExecutor(Executor):
         sdk_tools = self._build_sdk_tools(tools)
         if sdk_tools:
             config_kwargs["tools"] = sdk_tools
-        config_kwargs["hooks"] = [self._build_post_tool_hook(antigravity, state)]
+        # The pre-tool decide hook runs first so a policy DENY blocks execution
+        # before the post-tool hook (which only observes completed calls).
+        config_kwargs["hooks"] = [
+            self._build_pre_tool_hook(antigravity),
+            self._build_post_tool_hook(antigravity, state),
+        ]
         config = self._build_local_agent_config(antigravity, model=model, kwargs=config_kwargs)
         agent = antigravity.Agent(config)
         # Agent is documented as an async context manager; enter it if so.
         if hasattr(agent, "__aenter__"):
             agent = await agent.__aenter__()
         return agent
+
+    async def _evaluate_tool_call_policy(
+        self, tool_name: str, tool_args: ToolArgs
+    ) -> tuple[bool, str]:
+        """Run a pre-execution TOOL_CALL policy evaluation for one tool call.
+
+        The policy half of the SDK's pre-tool decide gate, mirroring
+        :meth:`omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor._evaluate_tool_call_policy`.
+        Consults :attr:`_policy_evaluator` for the ``PHASE_TOOL_CALL`` phase and
+        collapses the verdict to an allow/deny pair the SDK hook can return:
+
+        - **ALLOW / no-match / no evaluator** -> ``(True, "")`` (proceed).
+        - **DENY** -> ``(False, reason)`` (the SDK rejects the call so the tool
+          never runs).
+        - **ASK** -> route through :attr:`_elicitation_handler`; ``(True, "")``
+          on approval, ``(False, reason)`` on decline or when no handler is
+          wired (fail closed). A raw ASK normally only reaches here on a
+          read-only evaluation path — the server usually collapses ASK to a
+          hard ALLOW/DENY first.
+        - **Unexpected verdict** -> ``(False, reason)`` (fail closed).
+
+        :param tool_name: The tool's wire name, e.g. ``"run_command"`` (a
+            bundled native tool) or ``"sys_shell"`` (a bridged Omnigent tool).
+        :param tool_args: The tool call's argument dict.
+        :returns: ``(allow, reason)`` — *reason* is the deny message surfaced
+            to the model (empty when *allow* is ``True``).
+        """
+        policy_eval = getattr(self, "_policy_evaluator", None)
+        if policy_eval is None:
+            return True, ""
+        verdict = await policy_eval(
+            "PHASE_TOOL_CALL",
+            {"name": tool_name, "arguments": tool_args},
+        )
+        action = getattr(verdict, "action", None)
+        if action in ("POLICY_ACTION_ALLOW", "POLICY_ACTION_UNSPECIFIED", None):
+            return True, ""
+        reason = getattr(verdict, "reason", None)
+        if action == "POLICY_ACTION_ASK":
+            ask_reason = reason or "Approval required by Omnigent TOOL_CALL policy"
+            if self._elicitation_handler is None:
+                logger.warning(
+                    "TOOL_CALL policy ASK had no elicitation handler; denying tool=%s reason=%s",
+                    tool_name,
+                    ask_reason,
+                )
+                return False, ask_reason
+            logger.info(
+                "TOOL_CALL policy requested approval tool=%s reason=%s", tool_name, ask_reason
+            )
+            if await self._elicitation_handler(tool_name, tool_args):
+                return True, ""
+            return False, ask_reason
+        if action == "POLICY_ACTION_DENY":
+            deny_reason = reason or "Denied by Omnigent TOOL_CALL policy"
+            logger.info("TOOL_CALL policy denied tool=%s reason=%s", tool_name, deny_reason)
+            return False, deny_reason
+        fail_reason = f"Unexpected Omnigent TOOL_CALL policy verdict: {action!r}"
+        logger.warning("TOOL_CALL policy failed closed tool=%s reason=%s", tool_name, fail_reason)
+        return False, fail_reason
+
+    def _build_pre_tool_hook(self, antigravity: ModuleType) -> SDKHook:
+        """Build a ``PreToolCallDecideHook`` that enforces TOOL_CALL policy.
+
+        The SDK invokes this BEFORE every tool runs with the pending
+        ``ToolCall`` and honors the returned ``HookResult``: ``allow=False``
+        rejects the call so the tool never executes — for BOTH the SDK's
+        bundled native tools (``run_command``, file ops; gated in the SDK's
+        ``_handle_tool_confirmation_request``) AND the bridged Omnigent tools
+        (gated in the SDK's ``_handle_tool_call`` before it reaches the
+        host-side runner). This is the executor's analogue of
+        claude-sdk's ``can_use_tool`` gate.
+
+        Double-evaluation guard: the bridged Omnigent tools (the ``tools`` the
+        executor exposed for this turn) route through :attr:`_tool_executor` ->
+        ``TurnContext.dispatch_tool`` -> the runner's ``ProxyMcpManager``, which
+        ALREADY enforces TOOL_CALL + TOOL_RESULT policies server-side (see
+        ``omnigent/runner/app.py`` "All tool calls go through AP:/mcp ... which
+        enforces TOOL_CALL + TOOL_RESULT policies server-side"). Re-evaluating
+        them here would double-count the same call (and could double-charge a
+        cost-budget checkpoint), so the hook SKIPS bridged tool names and only
+        gates the tools the dispatch path never sees — chiefly the SDK's
+        bundled native tools. This mirrors claude-sdk skipping its
+        ``mcp__omnigent__*`` prefix for the same reason.
+
+        Defined inline because its base class only exists once the SDK is
+        imported. Closes over the executor (``self``) so the gate reads the
+        live :attr:`_policy_evaluator` / :attr:`_elicitation_handler`.
+
+        :param antigravity: The imported ``google.antigravity`` module.
+        :returns: A ``PreToolCallDecideHook`` for ``LocalAgentConfig.hooks``.
+        """
+        executor = self
+
+        class _OmnigentToolPolicyHook(antigravity.hooks.PreToolCallDecideHook):  # type: ignore[misc, name-defined]
+            """Gates each SDK ``ToolCall`` against Omnigent's TOOL_CALL policy."""
+
+            async def run(self, context: SDKHookContext, data: SDKToolCall) -> SDKHookResult:  # noqa: ARG002 — context unused; required by hook signature
+                """Allow or deny one pending tool call before it runs.
+
+                :param context: The SDK ``OperationContext`` (unused here).
+                :param data: The SDK ``ToolCall`` about to execute.
+                :returns: A ``HookResult`` — ``allow=False`` blocks the call.
+                """
+                name = _tool_name(getattr(data, "name", None))
+                # Bridged Omnigent tools are TOOL_CALL-gated server-side on the
+                # dispatch path — don't evaluate them twice here.
+                if not name or name in executor._bridged_tool_names:
+                    return antigravity.types.HookResult(allow=True)
+                raw_args = getattr(data, "args", None)
+                args: ToolArgs = raw_args if isinstance(raw_args, dict) else {}
+                allow, reason = await executor._evaluate_tool_call_policy(name, args)
+                return antigravity.types.HookResult(allow=allow, message=reason)
+
+        return _OmnigentToolPolicyHook()
 
     def _build_post_tool_hook(
         self, antigravity: ModuleType, state: _AntigravitySessionState
@@ -882,6 +1105,24 @@ class AntigravityExecutor(Executor):
                 )
 
         return _OmnigentToolCompleteHook()
+
+    def _bridged_tool_name_set(self, tools: list[ToolSpec]) -> frozenset[str]:
+        """Return the names of the tools bridged through :attr:`_tool_executor`.
+
+        These are the Omnigent tools exposed as SDK callables for the turn —
+        exactly the names :meth:`_build_sdk_tools` would register. The pre-tool
+        decide hook uses this to skip them (they are TOOL_CALL-gated server-side
+        on the dispatch path). Returns an empty set when no executor bridge is
+        wired (the agent then runs native tools only, which the hook DOES gate).
+
+        :param tools: Omnigent tool specs for the turn.
+        :returns: The bridged tool names, or an empty set.
+        """
+        if not tools or self._tool_executor is None:
+            return frozenset()
+        return frozenset(
+            name for tool in tools if isinstance((name := tool.get("name")), str) and name
+        )
 
     def _build_sdk_tools(self, tools: list[ToolSpec]) -> list[SDKTool]:
         """Build SDK tools (plain callables) from Omnigent tool specs.

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -33,15 +33,22 @@ to this runtime too:
 
 - TOOL_CALL phase: a registered ``PreToolCallDecideHook`` consults the
   executor's ``_policy_evaluator`` BEFORE each tool runs. A DENY verdict blocks
-  the call (the SDK rejects it without executing the tool — for both its
-  bundled native tools and the bridged Omnigent tools, see
+  the call (the SDK rejects it without executing the tool — chiefly its bundled
+  native tools; bridged Omnigent tools are skipped here because they are already
+  TOOL_CALL-gated server-side on the dispatch path, see
   :meth:`_build_pre_tool_hook`); an ASK verdict routes through the executor's
-  ``_elicitation_handler`` (deny when none is wired). This is the
-  ``can_use_tool`` gate of :class:`~omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor`,
+  ``_elicitation_handler`` (deny when none is wired). The bridged skip set is
+  bound per-agent into the hook closure (not stored on the executor) and a
+  bundled native tool is gated even if its wire name collides with a bridged
+  name, so a colliding name can't bypass policy. This is the ``can_use_tool``
+  gate of :class:`~omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor`,
   expressed through the SDK's decide-hook surface.
 - LLM_REQUEST / LLM_RESPONSE phases: :meth:`run_turn` evaluates these around
   the model call (deny-before-spawn / deny-after-stream), matching the peer
-  executors so prompt-deny and output-block policies are honored.
+  executors so prompt-deny and turn-completion-block policies are honored. As
+  in the peers, response text streams live, so an LLM_RESPONSE DENY blocks
+  TurnComplete (and persistence) but does not un-send already-emitted deltas;
+  see the note at the LLM_RESPONSE block in :meth:`run_turn`.
 
 Both ``_policy_evaluator`` and ``_elicitation_handler`` are wired in by the
 harness ExecutorAdapter; every phase is a no-op when the evaluator is absent.
@@ -94,6 +101,28 @@ logger = logging.getLogger(__name__)
 
 # Default model when neither spec nor provider pins one.
 _ANTIGRAVITY_DEFAULT_MODEL = "gemini-3.5-flash"
+
+# Wire names of the SDK's bundled native tools (``BuiltinTools`` enum values),
+# used as the fallback "is this a native tool?" set when the live enum can't be
+# resolved (e.g. the SDK isn't importable, or a test stub omits it). The live
+# enum is preferred at runtime (see :func:`_native_tool_wire_names`); this
+# mirror only guards drift / absence. Kept in sync with
+# ``google.antigravity.types.BuiltinTools``.
+_NATIVE_TOOL_WIRE_NAMES: frozenset[str] = frozenset(
+    {
+        "list_directory",
+        "search_directory",
+        "find_file",
+        "view_file",
+        "create_file",
+        "edit_file",
+        "run_command",
+        "ask_question",
+        "start_subagent",
+        "generate_image",
+        "finish",
+    }
+)
 
 # Sentinel the producer pushes when the step stream is exhausted, so the
 # consumer can distinguish "turn finished" from a queued event.
@@ -305,6 +334,58 @@ def _enum_name(value: Any) -> str:  # type: ignore[explicit-any]
     return name if isinstance(name, str) else ""
 
 
+def _native_tool_wire_names(antigravity: ModuleType) -> frozenset[str]:
+    """Resolve the wire names of the SDK's bundled native tools.
+
+    Reads ``google.antigravity.types.BuiltinTools`` member ``.value``\\ s when
+    present, falling back to :data:`_NATIVE_TOOL_WIRE_NAMES` when the enum is
+    missing (e.g. a test stub) or unreadable. Used by the pre-tool decide hook
+    to keep native tools policy-gated even when a native tool's wire name
+    collides with a bridged tool name.
+
+    :param antigravity: The imported ``google.antigravity`` module (the fake
+        SDK module under test).
+    :returns: The native tool wire names, or the static fallback set.
+    """
+    builtin = getattr(getattr(antigravity, "types", None), "BuiltinTools", None)
+    if builtin is None:
+        return _NATIVE_TOOL_WIRE_NAMES
+    try:
+        names = {member.value for member in builtin if isinstance(member.value, str)}
+    except TypeError:
+        # Not iterable as an enum — fall back to the static mirror.
+        return _NATIVE_TOOL_WIRE_NAMES
+    return frozenset(names) or _NATIVE_TOOL_WIRE_NAMES
+
+
+def _is_native_tool_call(data: SDKToolCall, native_wire_names: frozenset[str]) -> bool:
+    """Whether a pending ``ToolCall`` is one of the SDK's bundled native tools.
+
+    Two independent signals, either of which marks the call native:
+
+    - **Enum-typed name** — ``ToolCall.name`` is a ``BuiltinTools`` enum member
+      for native tools and a plain ``str`` for bridged / custom callables
+      (``name: BuiltinTools | str`` in the SDK). The enum check is the precise
+      discriminator: a native call is native even if its wire name equals a
+      bridged tool's name.
+    - **Native wire name** — the resolved wire name is in *native_wire_names*.
+      Covers SDKs (and test stubs) that pass native names as plain strings.
+
+    Either signal forces the call to be policy-gated rather than skipped as a
+    bridged tool, closing the name-collision bypass.
+
+    :param data: The SDK ``ToolCall`` presented to the pre-tool hook.
+    :param native_wire_names: The native tool wire names for this agent's SDK.
+    :returns: ``True`` when the call targets a bundled native tool.
+    """
+    raw_name = getattr(data, "name", None)
+    # A ``BuiltinTools`` enum member exposes ``.value`` (the wire name) and is
+    # not a bare ``str``; bridged callables always present a bare ``str`` name.
+    if not isinstance(raw_name, str) and isinstance(getattr(raw_name, "value", None), str):
+        return True
+    return _tool_name(raw_name) in native_wire_names
+
+
 @dataclass
 class _PendingTool:
     """A tool call awaiting its completion event.
@@ -406,12 +487,6 @@ class AntigravityExecutor(Executor):
         # phase is a no-op until the adapter installs it. Declared here for
         # discoverability; the adapter owns assignment.
         self._policy_evaluator: PolicyEvaluator | None = None
-        # Names of the tools bridged through ``_tool_executor`` this turn (the
-        # Omnigent tools exposed as SDK callables). The pre-tool decide hook
-        # skips these — they are TOOL_CALL-gated server-side on the dispatch
-        # path — and gates everything else (chiefly the SDK's native tools).
-        # Refreshed at the start of each turn from the turn's tool set.
-        self._bridged_tool_names: frozenset[str] = frozenset()
 
     def supports_streaming(self) -> bool:
         return True
@@ -526,9 +601,6 @@ class AntigravityExecutor(Executor):
         )
         session_key = self._session_key(messages)
         prompt = _latest_user_text(messages)
-        # Names of the tools bridged through the dispatch path this turn; the
-        # pre-tool decide hook reads this to skip already-gated bridged tools.
-        self._bridged_tool_names = self._bridged_tool_name_set(tools)
 
         # ── LLM_REQUEST policy evaluation ────────────────────────
         # Mirror the peer executors: when the adapter wired a policy evaluator,
@@ -628,8 +700,23 @@ class AntigravityExecutor(Executor):
 
         # ── LLM_RESPONSE policy evaluation ───────────────────────
         # Mirror the peer executors: evaluate after the stream completes but
-        # before TurnComplete so a DENY blocks the response from being
-        # persisted / shown.
+        # before TurnComplete so a DENY blocks the turn from completing and the
+        # response from being persisted as a finished assistant message.
+        #
+        # Known cross-executor limitation (NOT antigravity-specific): text
+        # deltas (TextChunk) have already been yielded live during streaming
+        # above, so an LLM_RESPONSE DENY can suppress TurnComplete but cannot
+        # un-send deltas a client already received. This is the SAME shape as
+        # the peer SDK executors — ClaudeSDKExecutor.run_turn yields TextChunk
+        # per ``content_block_delta`` / per ``TextBlock`` and only evaluates
+        # PHASE_LLM_RESPONSE after the stream ends (see its "LLM_RESPONSE policy
+        # evaluation" block), and OpenAIAgentsSDKExecutor yields TextChunk per
+        # ``response.output_text.delta`` and does not gate the response phase at
+        # all. Buffering deltas until the verdict would be a true output-block
+        # gate, but it must be decided once across all streaming executors (it
+        # trades away live streaming UX), so it is deliberately NOT diverged
+        # here. The post-stream DENY still prevents the blocked turn from being
+        # recorded / acted on, matching claude-sdk.
         if policy_eval is not None:
             resp_data: _StrAnyDict = {
                 "model": model,
@@ -922,10 +1009,16 @@ class AntigravityExecutor(Executor):
         sdk_tools = self._build_sdk_tools(tools)
         if sdk_tools:
             config_kwargs["tools"] = sdk_tools
+        # Bind this agent's bridged-tool skip set into the hook below rather
+        # than reading mutable executor state at fire time: the agent (and so
+        # this hook) is rebuilt whenever the tool set changes, so the closure
+        # always holds the right names and a concurrent turn on another session
+        # can't corrupt them.
+        bridged_tool_names = self._bridged_tool_name_set(tools)
         # The pre-tool decide hook runs first so a policy DENY blocks execution
         # before the post-tool hook (which only observes completed calls).
         config_kwargs["hooks"] = [
-            self._build_pre_tool_hook(antigravity),
+            self._build_pre_tool_hook(antigravity, bridged_tool_names),
             self._build_post_tool_hook(antigravity, state),
         ]
         config = self._build_local_agent_config(antigravity, model=model, kwargs=config_kwargs)
@@ -995,7 +1088,9 @@ class AntigravityExecutor(Executor):
         logger.warning("TOOL_CALL policy failed closed tool=%s reason=%s", tool_name, fail_reason)
         return False, fail_reason
 
-    def _build_pre_tool_hook(self, antigravity: ModuleType) -> SDKHook:
+    def _build_pre_tool_hook(
+        self, antigravity: ModuleType, bridged_tool_names: frozenset[str]
+    ) -> SDKHook:
         """Build a ``PreToolCallDecideHook`` that enforces TOOL_CALL policy.
 
         The SDK invokes this BEFORE every tool runs with the pending
@@ -1014,19 +1109,34 @@ class AntigravityExecutor(Executor):
         ``omnigent/runner/app.py`` "All tool calls go through AP:/mcp ... which
         enforces TOOL_CALL + TOOL_RESULT policies server-side"). Re-evaluating
         them here would double-count the same call (and could double-charge a
-        cost-budget checkpoint), so the hook SKIPS bridged tool names and only
-        gates the tools the dispatch path never sees — chiefly the SDK's
-        bundled native tools. This mirrors claude-sdk skipping its
-        ``mcp__omnigent__*`` prefix for the same reason.
+        cost-budget checkpoint), so the hook SKIPS bridged tools and only gates
+        the tools the dispatch path never sees — chiefly the SDK's bundled
+        native tools. This mirrors claude-sdk skipping its ``mcp__omnigent__*``
+        prefix for the same reason.
+
+        Scoping (the fix for the per-turn-state bypass): *bridged_tool_names* is
+        bound into this hook's closure — NOT read from mutable executor state —
+        and a fresh hook is built each time the agent is rebuilt (the tool set
+        is part of the agent signature), so a concurrent or subsequent turn on
+        another session can't swap the skip set out from under an in-flight
+        call. The skip is also made precise so a name collision can't open a
+        hole: a call to a bundled NATIVE tool is always gated even when its wire
+        name equals a bridged tool's name. Native is detected at the call site
+        (``ToolCall.name`` is a ``BuiltinTools`` enum member, or its wire name is
+        a known native name — see :func:`_is_native_tool_call`), so only a
+        genuinely bridged call is skipped.
 
         Defined inline because its base class only exists once the SDK is
         imported. Closes over the executor (``self``) so the gate reads the
         live :attr:`_policy_evaluator` / :attr:`_elicitation_handler`.
 
         :param antigravity: The imported ``google.antigravity`` module.
+        :param bridged_tool_names: Wire names of the tools bridged through the
+            dispatch path for this agent — the only names eligible to skip.
         :returns: A ``PreToolCallDecideHook`` for ``LocalAgentConfig.hooks``.
         """
         executor = self
+        native_wire_names = _native_tool_wire_names(antigravity)
 
         class _OmnigentToolPolicyHook(antigravity.hooks.PreToolCallDecideHook):  # type: ignore[misc, name-defined]
             """Gates each SDK ``ToolCall`` against Omnigent's TOOL_CALL policy."""
@@ -1039,9 +1149,15 @@ class AntigravityExecutor(Executor):
                 :returns: A ``HookResult`` — ``allow=False`` blocks the call.
                 """
                 name = _tool_name(getattr(data, "name", None))
-                # Bridged Omnigent tools are TOOL_CALL-gated server-side on the
-                # dispatch path — don't evaluate them twice here.
-                if not name or name in executor._bridged_tool_names:
+                if not name:
+                    return antigravity.types.HookResult(allow=True)
+                # Skip ONLY a genuinely bridged call (already TOOL_CALL-gated
+                # server-side on the dispatch path). A native tool is gated here
+                # even if its wire name collides with a bridged name, so a
+                # bridged-name collision can't smuggle a native call past policy.
+                if name in bridged_tool_names and not _is_native_tool_call(
+                    data, native_wire_names
+                ):
                     return antigravity.types.HookResult(allow=True)
                 raw_args = getattr(data, "args", None)
                 args: ToolArgs = raw_args if isinstance(raw_args, dict) else {}
@@ -1109,13 +1225,15 @@ class AntigravityExecutor(Executor):
     def _bridged_tool_name_set(self, tools: list[ToolSpec]) -> frozenset[str]:
         """Return the names of the tools bridged through :attr:`_tool_executor`.
 
-        These are the Omnigent tools exposed as SDK callables for the turn —
-        exactly the names :meth:`_build_sdk_tools` would register. The pre-tool
-        decide hook uses this to skip them (they are TOOL_CALL-gated server-side
-        on the dispatch path). Returns an empty set when no executor bridge is
-        wired (the agent then runs native tools only, which the hook DOES gate).
+        These are the Omnigent tools exposed as SDK callables for the agent —
+        exactly the names :meth:`_build_sdk_tools` would register. The result is
+        bound into the pre-tool decide hook's closure (see
+        :meth:`_build_pre_tool_hook`), which skips these names for genuinely
+        bridged calls (they are TOOL_CALL-gated server-side on the dispatch
+        path). Returns an empty set when no executor bridge is wired (the agent
+        then runs native tools only, which the hook DOES gate).
 
-        :param tools: Omnigent tool specs for the turn.
+        :param tools: Omnigent tool specs for the agent being built.
         :returns: The bridged tool names, or an empty set.
         """
         if not tools or self._tool_executor is None:

--- a/tests/e2e/omnigent/test_per_harness_antigravity.py
+++ b/tests/e2e/omnigent/test_per_harness_antigravity.py
@@ -102,6 +102,21 @@ _ERROR_MARKERS: tuple[str, ...] = (
 # pin the suite forever.
 _RUN_TIMEOUT_SEC = 200
 
+_NATIVE_POLICY_BUNDLE = "antigravity_native_write_denied"
+_NATIVE_POLICY_SENTINEL_NAME = "NATIVE_WRITE_PROOF_284.txt"
+_NATIVE_POLICY_SENTINEL_CONTENT = "POLICY_BYPASS_CONFIRMED"
+
+# Substrings that mean the native-tool policy gate was not actually exercised
+# because the live run failed before reaching a tool call.
+_NATIVE_POLICY_INCONCLUSIVE_MARKERS = (
+    "code 429",
+    "exceeded your current quota",
+    "high demand",
+    "GLIBC",
+    "localharness",
+    "Failed to read length from stdout",
+)
+
 # Minimal antigravity-native agent spec. Single-file legacy form (``name`` /
 # ``prompt`` / ``executor``) — the form ``omnigent run <file>`` accepts without a
 # spec directory. No ``executor.auth`` block: the key resolves from the stored
@@ -589,3 +604,96 @@ def test_per_harness_antigravity_graceful_completion(
     # the transcript; the persisted non-error assistant reply is the observable
     # proof the session reached a clean terminal state rather than ``failed``.
     _assert_clean_assistant_reply(db_path, result, label="graceful")
+
+
+def test_per_harness_antigravity_native_write_denied(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    omnigent_credentials_env: dict[str, str],
+) -> None:
+    """A native ``create_file`` is blocked under an ``on:[tool_call]`` deny.
+
+    Runs the ``antigravity_native_write_denied`` bundle with native tools
+    enabled (``--tools coding``) and asks the agent to write a sentinel file
+    with its bundled native ``create_file`` tool. #284's pre-tool policy gate
+    must deny that native call, so the sentinel never reaches disk.
+
+    The subprocess cwd is the repo root because the bundle's policy handler is a
+    dotted module path importable from that cwd, and because the SDK's own
+    workspace-only policy allows relative writes there. That leaves Omnigent's
+    TOOL_CALL deny as the gate under test.
+    """
+    skip_reason = _antigravity_skip_reason(omnigent_python)
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    bundle = (
+        omnigent_repo_root
+        / "tests"
+        / "resources"
+        / "examples"
+        / _NATIVE_POLICY_BUNDLE
+    )
+    sentinel = omnigent_repo_root / _NATIVE_POLICY_SENTINEL_NAME
+    prompt = (
+        f"Create a new file named {_NATIVE_POLICY_SENTINEL_NAME} in the current "
+        f"directory containing the exact text: {_NATIVE_POLICY_SENTINEL_CONTENT}. "
+        "Use your native create_file tool. Then confirm whether you succeeded."
+    )
+
+    try:
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = subprocess.run(
+                [
+                    str(omnigent_python),
+                    "-m",
+                    "omnigent",
+                    "run",
+                    str(bundle),
+                    "-p",
+                    prompt,
+                    "--tools",
+                    "coding",
+                    "--no-log",
+                    "--no-session",
+                ],
+                env=omnigent_credentials_env,
+                cwd=str(omnigent_repo_root),
+                capture_output=True,
+                text=True,
+                timeout=_RUN_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired:
+            assert not sentinel.exists(), (
+                f"POLICY BYPASS: native create_file wrote {sentinel} before the "
+                f"run timed out; content={sentinel.read_text(errors='replace')!r}"
+            )
+            pytest.skip(
+                "antigravity run timed out before completing a turn; no tool "
+                "call reached the policy gate."
+            )
+
+        combined = f"{result.stdout}\n{result.stderr}"
+        if any(marker in combined for marker in _NATIVE_POLICY_INCONCLUSIVE_MARKERS):
+            pytest.skip(
+                "antigravity run inconclusive before a tool call reached the "
+                "policy gate:\n"
+                f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+            )
+
+        assert not sentinel.exists(), (
+            f"POLICY BYPASS: native create_file wrote {sentinel} under an "
+            f"on:[tool_call] deny policy. Content: "
+            f"{sentinel.read_text(errors='replace')!r}\n\n"
+            f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+        )
+
+        lowered = result.stdout.lower()
+        assert ("denied" in lowered) or ("blocked" in lowered) or ("not allowed" in lowered), (
+            "native write left no file, but the assistant did not report a "
+            "denial; the turn may have ended before calling the tool.\n\n"
+            f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+        )
+    finally:
+        sentinel.unlink(missing_ok=True)

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -4,10 +4,15 @@ Unit tests for :class:`omnigent.inner.antigravity_executor.AntigravityExecutor`.
 The fakes here mirror the real ``google.antigravity`` streaming surface the
 executor depends on: ``agent.conversation`` yields :class:`Step` objects from
 ``receive_steps()`` (text / reasoning deltas, tool calls, status, usage) as the
-turn runs, a registered ``PostToolCallHook`` fires per tool completion with a
+turn runs, a registered ``PreToolCallDecideHook`` gates each call before it
+runs, a registered ``PostToolCallHook`` fires per tool completion with a
 ``ToolResult``, and ``conversation.cancel()`` aborts a running turn. They let
-the streaming / tool-pairing / cancellation logic be tested without the SDK
-package or network.
+the streaming / tool-pairing / policy-gating / cancellation logic be tested
+without the SDK package or network.
+
+Policy tests additionally use a ``_FakePolicyEvaluator`` (scripted per-phase
+verdicts) and a ``_FakeElicitationHandler`` matching the async callables the
+harness ExecutorAdapter wires onto the executor in production.
 """
 
 from __future__ import annotations
@@ -98,6 +103,23 @@ class _FakeToolResult:
         self.exception = None
 
 
+class _FakeHookResult:
+    """Stand-in for ``google.antigravity.types.HookResult`` (allow/message)."""
+
+    def __init__(self, *, allow: bool = True, message: str = "") -> None:
+        self.allow = allow
+        self.message = message
+
+
+class _FakeSDKToolCall:
+    """Stand-in for ``google.antigravity.types.ToolCall`` (pre-tool hook data)."""
+
+    def __init__(self, name: str, args: dict[str, Any], call_id: str | None = None) -> None:
+        self.name = name
+        self.args = args
+        self.id = call_id
+
+
 class _FakeUsage:
     def __init__(self) -> None:
         self.prompt_token_count = 11
@@ -161,21 +183,58 @@ class _RaiseGeneric:
     message: str = "boom"
 
 
+@dataclass
+class _ExecToolCall:
+    """Turn-script action: run a tool through the SDK's pre-tool decide gate.
+
+    Mirrors the real ``_handle_tool_call`` flow: every registered
+    ``PreToolCallDecideHook`` is consulted with the ``ToolCall`` first; only if
+    they all allow does the tool "execute" and its ``PostToolCallHook`` fire.
+    Denied calls are recorded (and skip execution) so a test can prove the
+    policy gate blocked the tool BEFORE it ran.
+
+    :param call: The SDK ``ToolCall`` presented to the gate.
+    :param result: The ``ToolResult`` to surface via the post-tool hook when
+        the call is allowed.
+    """
+
+    call: _FakeSDKToolCall
+    result: _FakeToolResult
+
+
 # A turn script is the ordered list of actions one ``receive_steps()`` replays.
-_TurnAction = _YieldStep | _FireToolResult | _RaiseCancelled | _RaiseGeneric
+_TurnAction = _YieldStep | _FireToolResult | _ExecToolCall | _RaiseCancelled | _RaiseGeneric
 
 
 class _FakeConversation:
-    """Mirror of ``google.antigravity.conversation.Conversation`` (read paths)."""
+    """Mirror of ``google.antigravity.conversation.Conversation`` (read paths).
+
+    Splits the registered hooks by base class so the pre-tool decide hook
+    (consulted with a ``ToolCall``, returns a ``HookResult``) and the post-tool
+    hook (fired with a ``ToolResult``) are driven on their correct surfaces.
+    """
 
     def __init__(self, hooks: list[Any], scripts: collections.deque[list[_TurnAction]]) -> None:
-        self._hooks = hooks
+        self._pre_hooks = [h for h in hooks if isinstance(h, _FakePreToolCallDecideHook)]
+        self._post_hooks = [h for h in hooks if isinstance(h, _FakePostToolCallHook)]
         self._scripts = scripts
         self.sends: list[str] = []
         self.cancel_called = 0
+        # Tools the gate allowed to run / denied, by name — lets policy tests
+        # assert a denied tool never executed.
+        self.executed_tools: list[str] = []
+        self.denied_tools: list[str] = []
 
     async def send(self, prompt: Any, **_kwargs: Any) -> None:
         self.sends.append(prompt)
+
+    async def _gate_allows(self, call: _FakeSDKToolCall) -> bool:
+        """Run every pre-tool decide hook; deny if any returns ``allow=False``."""
+        for hook in self._pre_hooks:
+            res = await hook.run(SimpleNamespace(), call)
+            if not res.allow:
+                return False
+        return True
 
     async def receive_steps(self) -> Any:
         script = self._scripts.popleft() if self._scripts else []
@@ -183,8 +242,17 @@ class _FakeConversation:
             if isinstance(action, _YieldStep):
                 yield action.step
             elif isinstance(action, _FireToolResult):
-                for hook in self._hooks:
+                # Direct PostToolCallHook fire (call already past the gate).
+                for hook in self._post_hooks:
                     await hook.run(SimpleNamespace(), action.tool_result)
+            elif isinstance(action, _ExecToolCall):
+                # Full SDK flow: gate first, then execute + complete on allow.
+                if await self._gate_allows(action.call):
+                    self.executed_tools.append(action.call.name)
+                    for hook in self._post_hooks:
+                        await hook.run(SimpleNamespace(), action.result)
+                else:
+                    self.denied_tools.append(action.call.name)
             elif isinstance(action, _RaiseCancelled):
                 raise _AntigravityCancelledError("cancelled")
             elif isinstance(action, _RaiseGeneric):
@@ -243,6 +311,50 @@ class _FakePostToolCallHook:
         return None
 
 
+class _FakePreToolCallDecideHook:
+    """Sub-classable stand-in for ``hooks.PreToolCallDecideHook`` (returns HookResult)."""
+
+    async def run(self, context: Any, data: Any) -> Any:
+        return _FakeHookResult(allow=True)
+
+
+class _FakePolicyVerdict:
+    """Stand-in for the adapter's ``PolicyVerdictPayload`` (action + reason)."""
+
+    def __init__(self, action: str, reason: str | None = None) -> None:
+        self.action = action
+        self.reason = reason
+
+
+class _FakePolicyEvaluator:
+    """Scripted policy evaluator matching the executor's ``_policy_evaluator``.
+
+    Records every ``(phase, data)`` it is called with so tests can assert what
+    the executor evaluated, and returns a per-phase verdict (defaulting to
+    ALLOW for any phase without an explicit override).
+    """
+
+    def __init__(self, verdicts: dict[str, _FakePolicyVerdict] | None = None) -> None:
+        self._verdicts = verdicts or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def __call__(self, phase: str, data: dict[str, Any]) -> _FakePolicyVerdict:
+        self.calls.append((phase, data))
+        return self._verdicts.get(phase, _FakePolicyVerdict("POLICY_ACTION_ALLOW"))
+
+
+class _FakeElicitationHandler:
+    """Stand-in elicitation handler returning a fixed approve/deny decision."""
+
+    def __init__(self, approve: bool) -> None:
+        self._approve = approve
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def __call__(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
+        self.calls.append((tool_name, tool_input))
+        return self._approve
+
+
 def _install_fake_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -261,9 +373,12 @@ def _install_fake_sdk(
 
     class _FakeHooks:
         PostToolCallHook = _FakePostToolCallHook
+        PreToolCallDecideHook = _FakePreToolCallDecideHook
 
     class _FakeTypes:
         AntigravityCancelledError = _AntigravityCancelledError
+        HookResult = _FakeHookResult
+        ToolCall = _FakeSDKToolCall
 
     class _FakeModule:
         LocalAgentConfig = _FakeLocalAgentConfig
@@ -1059,9 +1174,12 @@ def _install_blocking_sdk(
 
     class _FakeHooks:
         PostToolCallHook = _FakePostToolCallHook
+        PreToolCallDecideHook = _FakePreToolCallDecideHook
 
     class _FakeTypes:
         AntigravityCancelledError = _AntigravityCancelledError
+        HookResult = _FakeHookResult
+        ToolCall = _FakeSDKToolCall
 
     class _FakeModule:
         LocalAgentConfig = _FakeLocalAgentConfig
@@ -1134,3 +1252,243 @@ async def test_interrupt_session_unknown_returns_false(monkeypatch: pytest.Monke
     _install_fake_sdk(monkeypatch, scripts=[])
     executor = AntigravityExecutor()
     assert await executor.interrupt_session("never-started") is False
+
+
+# ── Policy enforcement tests (TOOL_CALL / LLM_REQUEST / LLM_RESPONSE) ────
+
+
+def _exec_tool(name: str, args: dict[str, Any], call_id: str = "t1") -> _ExecToolCall:
+    """Build an _ExecToolCall that gates ``name`` then completes it on allow."""
+    return _ExecToolCall(
+        call=_FakeSDKToolCall(name, args, call_id=call_id),
+        result=_FakeToolResult(name, result={"ok": True}, call_id=call_id),
+    )
+
+
+async def _async_ok() -> dict[str, Any]:
+    """Minimal bridged-tool executor result used by the skip test."""
+    return {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_tool_call_policy_deny_blocks_native_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TOOL_CALL-phase DENY prevents a native tool from executing.
+
+    The pre-tool decide hook must consult the policy evaluator and return
+    ``allow=False`` so the SDK rejects the call BEFORE running it. Without the
+    hook (the bug) the tool would execute and the evaluator would never be
+    asked for PHASE_TOOL_CALL.
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="run_command blocked by operator")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": deny})
+    # ``run_command`` is a bundled NATIVE tool (not bridged), so it is not in
+    # the per-turn bridged set and the hook must gate it.
+    script: list[_TurnAction] = [
+        _exec_tool("run_command", {"command": "rm -rf /"}),
+        _text_step("done"),
+    ]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    conversation = captured["agents"][0].conversation
+    # The gate denied the call: it was recorded as denied and NEVER executed.
+    assert conversation.denied_tools == ["run_command"]
+    assert conversation.executed_tools == []
+    # The evaluator was consulted for the TOOL_CALL phase with the call args.
+    tool_phase_calls = [d for (p, d) in evaluator.calls if p == "PHASE_TOOL_CALL"]
+    assert tool_phase_calls == [{"name": "run_command", "arguments": {"command": "rm -rf /"}}]
+
+
+@pytest.mark.asyncio
+async def test_tool_call_policy_allow_runs_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ALLOW verdict lets the native tool execute (gate is not over-broad)."""
+    evaluator = _FakePolicyEvaluator()  # defaults every phase to ALLOW
+    script: list[_TurnAction] = [_exec_tool("run_command", {"command": "ls"}), _text_step("done")]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    conversation = captured["agents"][0].conversation
+    assert conversation.executed_tools == ["run_command"]
+    assert conversation.denied_tools == []
+
+
+@pytest.mark.asyncio
+async def test_tool_call_policy_skips_bridged_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bridged Omnigent tools are NOT re-evaluated here (gated server-side).
+
+    They route through the dispatch path which already enforces TOOL_CALL
+    policy; double-evaluating would double-count (and could double-charge a
+    cost budget). The hook must let them through without calling the evaluator.
+    """
+    # A DENY verdict would block the tool IF the hook evaluated it — proving the
+    # skip means asserting the tool still runs despite the deny.
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="should not be consulted")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": deny})
+    script: list[_TurnAction] = [_exec_tool("sys_shell", {"cmd": "ls"}), _text_step("done")]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    # Wire a tool executor + expose ``sys_shell`` so it is a BRIDGED tool.
+    executor._tool_executor = lambda name, args: _async_ok()
+    tool_specs = [{"name": "sys_shell", "description": "shell", "parameters": {}}]
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}], tool_specs)
+
+    conversation = captured["agents"][0].conversation
+    # Ran despite the DENY: the hook skipped the bridged tool entirely.
+    assert conversation.executed_tools == ["sys_shell"]
+    assert conversation.denied_tools == []
+    # The evaluator was never asked about the TOOL_CALL phase for this tool.
+    assert not any(p == "PHASE_TOOL_CALL" for (p, _d) in evaluator.calls)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_policy_ask_approved_runs_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TOOL_CALL ASK routes through the elicitation handler; approve -> run."""
+    ask = _FakePolicyVerdict("POLICY_ACTION_ASK", reason="approve this command?")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": ask})
+    handler = _FakeElicitationHandler(approve=True)
+    script: list[_TurnAction] = [_exec_tool("run_command", {"command": "ls"}), _text_step("done")]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    executor._elicitation_handler = handler
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    conversation = captured["agents"][0].conversation
+    assert conversation.executed_tools == ["run_command"]
+    # The elicitation handler was consulted with the tool name + args.
+    assert handler.calls == [("run_command", {"command": "ls"})]
+
+
+@pytest.mark.asyncio
+async def test_tool_call_policy_ask_declined_blocks_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TOOL_CALL ASK declined by the elicitation handler blocks the tool."""
+    ask = _FakePolicyVerdict("POLICY_ACTION_ASK")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": ask})
+    handler = _FakeElicitationHandler(approve=False)
+    script: list[_TurnAction] = [_exec_tool("run_command", {"command": "ls"}), _text_step("done")]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    executor._elicitation_handler = handler
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    conversation = captured["agents"][0].conversation
+    assert conversation.denied_tools == ["run_command"]
+    assert conversation.executed_tools == []
+
+
+@pytest.mark.asyncio
+async def test_tool_call_policy_ask_without_handler_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TOOL_CALL ASK with no elicitation handler denies (fail closed)."""
+    ask = _FakePolicyVerdict("POLICY_ACTION_ASK")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": ask})
+    script: list[_TurnAction] = [_exec_tool("run_command", {"command": "ls"}), _text_step("done")]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator  # no _elicitation_handler wired
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    conversation = captured["agents"][0].conversation
+    assert conversation.denied_tools == ["run_command"]
+    assert conversation.executed_tools == []
+
+
+@pytest.mark.asyncio
+async def test_no_policy_evaluator_does_not_gate_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no policy evaluator wired, the pre-tool hook is a no-op (tool runs)."""
+    script: list[_TurnAction] = [_exec_tool("run_command", {"command": "ls"}), _text_step("done")]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()  # _policy_evaluator stays None
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    conversation = captured["agents"][0].conversation
+    assert conversation.executed_tools == ["run_command"]
+    assert conversation.denied_tools == []
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_deny_aborts_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An LLM_REQUEST DENY aborts the turn with ExecutorError and no model call.
+
+    The gate runs before the producer is spawned, so ``conversation.send`` is
+    never reached and no agent turn runs. Without the gate (the bug) the turn
+    would proceed and stream a reply.
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="prompt contains a banned phrase")
+    evaluator = _FakePolicyEvaluator({"PHASE_LLM_REQUEST": deny})
+    # A normal turn script — it must NOT run because the request is denied first.
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("should not stream")]])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert "denied by policy" in errors[0].message
+    assert "prompt contains a banned phrase" in errors[0].message
+    # No model call: the producer never sent the prompt, and no reply streamed.
+    assert not any(isinstance(e, (TextChunk, TurnComplete)) for e in events)
+    # The agent was built lazily AFTER the request gate, so no agent exists.
+    assert captured["agents"] == []
+    # The evaluator saw the request phase; it never reached the response phase.
+    phases = [p for (p, _d) in evaluator.calls]
+    assert phases == ["PHASE_LLM_REQUEST"]
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_allow_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ALLOW request verdict lets the turn run normally (gate not over-broad)."""
+    evaluator = _FakePolicyEvaluator()  # ALLOW for every phase
+    _install_fake_sdk(monkeypatch, scripts=[[_text_step("hello")]])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    assert [e.text for e in events if isinstance(e, TextChunk)] == ["hello"]
+    assert any(isinstance(e, TurnComplete) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_llm_response_policy_deny_blocks_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An LLM_RESPONSE DENY blocks the response: ExecutorError, no TurnComplete.
+
+    Evaluated after the stream completes but before TurnComplete, so the
+    generated text is never emitted as a completed turn. Without the gate the
+    turn would complete and the (policy-violating) response would be persisted.
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="response leaked a secret")
+    evaluator = _FakePolicyEvaluator({"PHASE_LLM_RESPONSE": deny})
+    _install_fake_sdk(monkeypatch, scripts=[[_text_step("the secret is hunter2")]])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert "response denied by policy" in errors[0].message
+    assert "response leaked a secret" in errors[0].message
+    # The text streamed live (deltas can't be un-sent), but the turn must NOT
+    # complete — the DENY replaces TurnComplete with the ExecutorError.
+    assert not any(isinstance(e, TurnComplete) for e in events)
+    # Both phases were evaluated, response last, carrying the generated text.
+    phases = [p for (p, _d) in evaluator.calls]
+    assert phases == ["PHASE_LLM_REQUEST", "PHASE_LLM_RESPONSE"]
+    resp_data = next(d for (p, d) in evaluator.calls if p == "PHASE_LLM_RESPONSE")
+    assert resp_data["text_preview"] == "the secret is hunter2"

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -77,6 +77,20 @@ class _StepTarget(enum.Enum):
     ENVIRONMENT = "ENVIRONMENT"
 
 
+class _BuiltinTools(enum.Enum):
+    """Subset of ``google.antigravity.types.BuiltinTools`` (native tool names).
+
+    Members carry the SDK's wire name as their ``.value`` — the same shape the
+    executor's native-vs-bridged discriminator reads. A ``ToolCall`` whose
+    ``name`` is one of these members is a bundled native tool; bridged callables
+    present a plain ``str`` name instead.
+    """
+
+    RUN_COMMAND = "run_command"
+    VIEW_FILE = "view_file"
+    EDIT_FILE = "edit_file"
+
+
 class _AntigravityCancelledError(Exception):
     """Stand-in for ``google.antigravity.types.AntigravityCancelledError``."""
 
@@ -379,6 +393,7 @@ def _install_fake_sdk(
         AntigravityCancelledError = _AntigravityCancelledError
         HookResult = _FakeHookResult
         ToolCall = _FakeSDKToolCall
+        BuiltinTools = _BuiltinTools
 
     class _FakeModule:
         LocalAgentConfig = _FakeLocalAgentConfig
@@ -1180,6 +1195,7 @@ def _install_blocking_sdk(
         AntigravityCancelledError = _AntigravityCancelledError
         HookResult = _FakeHookResult
         ToolCall = _FakeSDKToolCall
+        BuiltinTools = _BuiltinTools
 
     class _FakeModule:
         LocalAgentConfig = _FakeLocalAgentConfig
@@ -1492,3 +1508,286 @@ async def test_llm_response_policy_deny_blocks_response(monkeypatch: pytest.Monk
     assert phases == ["PHASE_LLM_REQUEST", "PHASE_LLM_RESPONSE"]
     resp_data = next(d for (p, d) in evaluator.calls if p == "PHASE_LLM_RESPONSE")
     assert resp_data["text_preview"] == "the secret is hunter2"
+
+
+@pytest.mark.asyncio
+async def test_llm_response_deny_matches_peer_stream_then_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLM_RESPONSE is a stream-then-verdict turn-completion gate, matching the peers.
+
+    Documents (and pins) the deliberate cross-executor behaviour for FINDING 2:
+    Antigravity does NOT buffer deltas until the LLM_RESPONSE verdict — it
+    streams ``TextChunk``\\ s live and evaluates PHASE_LLM_RESPONSE only after the
+    stream ends, exactly like ``ClaudeSDKExecutor`` (which yields ``TextChunk``
+    per content-block delta and gates the response phase afterwards) and
+    ``OpenAIAgentsSDKExecutor`` (which streams ``TextChunk`` and does not gate the
+    response phase at all). So a DENY blocks TurnComplete / persistence but the
+    delta the client already saw cannot be un-sent. Buffering would diverge from
+    both peers unilaterally, so it is intentionally not done here.
+
+    This test asserts the precise observable contract: the delta IS emitted
+    (proving no buffering), it is emitted BEFORE the response verdict runs, and
+    the verdict still blocks completion.
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="blocked output")
+    evaluator = _FakePolicyEvaluator({"PHASE_LLM_RESPONSE": deny})
+    _install_fake_sdk(monkeypatch, scripts=[[_text_step("streamed-delta")]])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+
+    events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}])
+
+    # The delta WAS streamed live (not buffered/withheld pending the verdict).
+    texts = [e.text for e in events if isinstance(e, TextChunk)]
+    assert texts == ["streamed-delta"]
+    # The response verdict ran AFTER the stream produced its text (the recorded
+    # text_preview proves the evaluator saw the already-streamed content).
+    resp_data = next(d for (p, d) in evaluator.calls if p == "PHASE_LLM_RESPONSE")
+    assert resp_data["text_preview"] == "streamed-delta"
+    # The DENY still blocks turn completion: ExecutorError replaces TurnComplete.
+    assert any(isinstance(e, ExecutorError) for e in events)
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+# ── FINDING 1 regression tests: collision-safe + per-agent skip set ──────
+
+
+@pytest.mark.asyncio
+async def test_native_tool_with_bridged_name_collision_still_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native tool is policy-gated even when its name collides with a bridged tool.
+
+    Regression for the bypass: the old hook skipped any call whose bare name was
+    in the bridged set, so a bundled NATIVE tool (e.g. ``view_file``) sharing a
+    name with a bridged Omnigent tool would skip TOOL_CALL policy entirely. The
+    fix gates a native call regardless of the name collision; it must recognise
+    native via BOTH the wire-name set (string-named call) and the
+    ``BuiltinTools`` enum (enum-named call).
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="view_file blocked by operator")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": deny})
+    # Two native ``view_file`` calls that collide with the bridged name — one
+    # presented as a plain string name, one as a ``BuiltinTools`` enum member —
+    # plus a genuinely bridged ``sys_shell`` call that must still be skipped.
+    script: list[_TurnAction] = [
+        _ExecToolCall(
+            call=_FakeSDKToolCall("view_file", {"path": "/etc/passwd"}, call_id="n1"),
+            result=_FakeToolResult("view_file", result={"ok": True}, call_id="n1"),
+        ),
+        _ExecToolCall(
+            call=_FakeSDKToolCall(_BuiltinTools.VIEW_FILE, {"path": "/secrets"}, call_id="n2"),
+            result=_FakeToolResult("view_file", result={"ok": True}, call_id="n2"),
+        ),
+        _exec_tool("sys_shell", {"cmd": "ls"}, call_id="b1"),
+        _text_step("done"),
+    ]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    executor._tool_executor = lambda name, args: _async_ok()
+    # Expose BOTH names as bridged — ``view_file`` deliberately collides with the
+    # native tool, ``sys_shell`` does not.
+    tool_specs = [
+        {"name": "view_file", "description": "bridged view", "parameters": {}},
+        {"name": "sys_shell", "description": "shell", "parameters": {}},
+    ]
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}], tool_specs)
+
+    conversation = captured["agents"][0].conversation
+    # Both native ``view_file`` calls were gated and DENIED despite the bridged
+    # name collision; only the non-colliding bridged ``sys_shell`` ran. The
+    # second call's recorded name is the ``BuiltinTools`` enum member (the SDK's
+    # native-call shape), so resolve to wire names before comparing.
+    denied_wire = [getattr(n, "value", n) for n in conversation.denied_tools]
+    assert denied_wire == ["view_file", "view_file"]
+    assert conversation.executed_tools == ["sys_shell"]
+    # Policy was consulted for each native call (and only those) — the bridged
+    # ``sys_shell`` was skipped, so it never reached the evaluator. The hook
+    # passes the resolved wire name to the evaluator for both call shapes.
+    tool_phase_names = [d["name"] for (p, d) in evaluator.calls if p == "PHASE_TOOL_CALL"]
+    assert tool_phase_names == ["view_file", "view_file"]
+
+
+class _GatingBlockingConversation:
+    """Conversation that blocks mid-turn, then runs a tool through the pre-gate.
+
+    Models a turn that is provably in flight when a *second*, concurrent turn
+    runs to completion: it streams one delta, blocks on ``gate`` (so the test
+    can interleave another session's full turn), and only after release drives
+    its scripted ``ToolCall`` through every registered ``PreToolCallDecideHook``
+    — exactly as the real ``_handle_tool_call`` flow does. Whether the call ran
+    or was denied is recorded so the test can prove which bridged skip set the
+    hook consulted at fire time.
+
+    :param hooks: The agent's registered hooks (the pre-tool decide hooks are
+        consulted; others are ignored).
+    :param gate: Opened by the test once the concurrent turn has finished, so
+        this turn's tool-gate fires strictly afterwards.
+    :param call: The ``ToolCall`` to push through the gate after release.
+    """
+
+    def __init__(self, hooks: list[Any], gate: asyncio.Event, call: _FakeSDKToolCall) -> None:
+        self._pre_hooks = [h for h in hooks if isinstance(h, _FakePreToolCallDecideHook)]
+        self._gate = gate
+        self._call = call
+        self.sends: list[str] = []
+        self.cancel_called = 0
+        self.executed_tools: list[str] = []
+        self.denied_tools: list[str] = []
+
+    async def send(self, prompt: Any, **_kw: Any) -> None:
+        self.sends.append(prompt)
+
+    async def receive_steps(self) -> Any:
+        yield _FakeStep(
+            step_type=_StepType.TEXT_RESPONSE, status=_StepStatus.ACTIVE, content_delta="a-stream"
+        )
+        await self._gate.wait()  # held open until the concurrent turn completes
+        allow = True
+        for hook in self._pre_hooks:
+            res = await hook.run(SimpleNamespace(), self._call)
+            if not res.allow:
+                allow = False
+                break
+        if allow:
+            self.executed_tools.append(self._call.name)
+        else:
+            self.denied_tools.append(self._call.name)
+
+    async def cancel(self) -> None:
+        self.cancel_called += 1
+
+
+@pytest.mark.asyncio
+async def test_bridged_skip_set_not_corrupted_by_concurrent_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent turn on another session can't corrupt an in-flight hook's skip set.
+
+    Regression for the per-turn-state bypass: the skip set used to live on the
+    executor instance (``self._bridged_tool_names``) and be overwritten at the
+    START of every ``run_turn``. So while session ``a``'s turn was mid-flight
+    (its tool-gate not yet fired), a concurrent session ``b`` turn would
+    overwrite that shared set with ``b``'s names — and ``a``'s hook would then
+    consult ``b``'s set, skipping or gating the wrong tools.
+
+    Deterministic interleave: ``a`` bridges ``shared_tool`` and blocks after one
+    delta, BEFORE its gate fires. While ``a`` is parked, ``b`` (which bridges a
+    DISJOINT set NOT containing ``shared_tool``) runs to completion. Then ``a``
+    is released and gates ``shared_tool``. Correct (closure-bound) behaviour:
+    ``a``'s hook still has ``{shared_tool}`` and SKIPS it, so it runs despite the
+    DENY verdict. The old shared-state code would have ``a``'s hook read ``b``'s
+    set, gate ``shared_tool``, and wrongly DENY it.
+    """
+    # DENY everything that reaches the evaluator — so "skipped" (ran) vs "gated"
+    # (denied) is an unambiguous signal of which set the hook used.
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="should not be consulted for a")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": deny})
+
+    gate = asyncio.Event()
+    a_call = _FakeSDKToolCall("shared_tool", {"x": 1}, call_id="a1")
+    captured: dict[str, Any] = {}
+
+    class _FakeHooks:
+        PostToolCallHook = _FakePostToolCallHook
+        PreToolCallDecideHook = _FakePreToolCallDecideHook
+
+    class _FakeTypes:
+        AntigravityCancelledError = _AntigravityCancelledError
+        HookResult = _FakeHookResult
+        ToolCall = _FakeSDKToolCall
+        BuiltinTools = _BuiltinTools
+
+    # Session ``b`` uses the ordinary scripted conversation; session ``a`` uses
+    # the blocking, gate-driven one. They are told apart by the bridged tool
+    # name baked into the agent config the executor builds.
+    b_queue: collections.deque[list[_TurnAction]] = collections.deque(
+        [[_exec_tool("beta", {"y": 2}, call_id="b1")]]
+    )
+
+    class _SwitchingModule:
+        LocalAgentConfig = _FakeLocalAgentConfig
+        hooks = _FakeHooks
+        types = _FakeTypes
+
+        @staticmethod
+        def Agent(config: Any) -> Any:
+            tool_names = {
+                getattr(t, "__name__", "") for t in (getattr(config, "tools", None) or [])
+            }
+            if "shared_tool" in tool_names:
+                conv = _GatingBlockingConversation(
+                    list(getattr(config, "hooks", []) or []), gate, a_call
+                )
+                captured["conv_a"] = conv
+            else:
+                conv = _FakeConversation(list(getattr(config, "hooks", []) or []), b_queue)
+                captured["conv_b"] = conv
+
+            class _Agent:
+                def __init__(self) -> None:
+                    self._conversation = conv
+
+                @property
+                def conversation(self) -> Any:
+                    return self._conversation
+
+                async def __aenter__(self) -> Any:
+                    return self
+
+                async def __aexit__(self, *_a: object) -> None:
+                    return None
+
+            return _Agent()
+
+    monkeypatch.setattr(ag, "_ensure_antigravity_sdk", lambda: _SwitchingModule())
+
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    executor._tool_executor = lambda name, args: _async_ok()
+
+    tools_a = [{"name": "shared_tool", "description": "bridged for a", "parameters": {}}]
+    tools_b = [{"name": "beta", "description": "bridged for b", "parameters": {}}]
+
+    # Start ``a``; it streams one delta then parks on the gate (mid-flight).
+    a_collected: list[Any] = []
+    a_started = asyncio.Event()
+
+    async def _drive_a() -> None:
+        async for event in executor.run_turn(
+            [{"role": "user", "content": "a", "session_id": "a"}],
+            tools=tools_a,
+            system_prompt="sys",
+        ):
+            a_collected.append(event)
+            if isinstance(event, TextChunk):
+                a_started.set()
+
+    a_task = asyncio.create_task(_drive_a())
+    await asyncio.wait_for(a_started.wait(), timeout=5)
+
+    # With ``a`` provably parked before its gate, run ``b`` to completion. Under
+    # the old code this is the write that would clobber the shared skip set.
+    await _drain(executor, [{"role": "user", "content": "b", "session_id": "b"}], tools_b)
+
+    # Release ``a``; its tool-gate now fires and must use ``a``'s own set.
+    gate.set()
+    await asyncio.wait_for(a_task, timeout=5)
+
+    conv_a = captured["conv_a"]
+    conv_b = captured["conv_b"]
+    # ``a`` bridged ``shared_tool`` → its hook skipped it → it ran, despite the
+    # DENY. A regression to shared state would deny it (a's hook seeing b's set).
+    assert conv_a.executed_tools == ["shared_tool"]
+    assert conv_a.denied_tools == []
+    # ``b`` bridged ``beta`` → skipped → ran. Sanity that the interleaved turn
+    # behaved normally.
+    assert conv_b.executed_tools == ["beta"]
+    assert conv_b.denied_tools == []
+    # The evaluator was never consulted for ``shared_tool`` or ``beta`` — both
+    # were correctly skipped as bridged for their own session.
+    gated_names = {d["name"] for (p, d) in evaluator.calls if p == "PHASE_TOOL_CALL"}
+    assert gated_names == set()

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -128,7 +128,11 @@ class _FakeHookResult:
 class _FakeSDKToolCall:
     """Stand-in for ``google.antigravity.types.ToolCall`` (pre-tool hook data)."""
 
-    def __init__(self, name: str, args: dict[str, Any], call_id: str | None = None) -> None:
+    def __init__(
+        self, name: str | _BuiltinTools, args: dict[str, Any], call_id: str | None = None
+    ) -> None:
+        # The real SDK types ``ToolCall.name`` as ``BuiltinTools | str``: native
+        # tools arrive as the enum member, bridged callables as a plain string.
         self.name = name
         self.args = args
         self.id = call_id
@@ -235,9 +239,11 @@ class _FakeConversation:
         self.sends: list[str] = []
         self.cancel_called = 0
         # Tools the gate allowed to run / denied, by name — lets policy tests
-        # assert a denied tool never executed.
-        self.executed_tools: list[str] = []
-        self.denied_tools: list[str] = []
+        # assert a denied tool never executed. A name may be the ``BuiltinTools``
+        # enum (native call) or a ``str`` (bridged), so tests resolve via
+        # ``getattr(n, "value", n)`` before comparing.
+        self.executed_tools: list[str | _BuiltinTools] = []
+        self.denied_tools: list[str | _BuiltinTools] = []
 
     async def send(self, prompt: Any, **_kwargs: Any) -> None:
         self.sends.append(prompt)
@@ -1635,8 +1641,9 @@ class _GatingBlockingConversation:
         self._call = call
         self.sends: list[str] = []
         self.cancel_called = 0
-        self.executed_tools: list[str] = []
-        self.denied_tools: list[str] = []
+        # See ``_FakeConversation``: a recorded name may be enum or ``str``.
+        self.executed_tools: list[str | _BuiltinTools] = []
+        self.denied_tools: list[str | _BuiltinTools] = []
 
     async def send(self, prompt: Any, **_kw: Any) -> None:
         self.sends.append(prompt)
@@ -1718,6 +1725,10 @@ async def test_bridged_skip_set_not_corrupted_by_concurrent_turn(
             tool_names = {
                 getattr(t, "__name__", "") for t in (getattr(config, "tools", None) or [])
             }
+            # Either duck-typed fake conversation, by tool set; annotated wide so
+            # the two distinct branch types don't conflict (both are duck-typed
+            # SDK conversations, like the executor's ``SDKConversation`` alias).
+            conv: Any
             if "shared_tool" in tool_names:
                 conv = _GatingBlockingConversation(
                     list(getattr(config, "hooks", []) or []), gate, a_call
@@ -1791,3 +1802,265 @@ async def test_bridged_skip_set_not_corrupted_by_concurrent_turn(
     # were correctly skipped as bridged for their own session.
     gated_names = {d["name"] for (p, d) in evaluator.calls if p == "PHASE_TOOL_CALL"}
     assert gated_names == set()
+
+
+# ── Integration coverage for PR #284 (real hook + run_turn, fake SDK) ─────
+#
+# These exercise the REAL ``_build_pre_tool_hook`` / ``_evaluate_tool_call_policy``
+# + ``run_turn`` paths end-to-end against the fake SDK conversation, building
+# *alongside* the FINDING-1/2 review tests above rather than duplicating them.
+# Each is written to FAIL against the pre-fix hook (commit 2df5eac), where the
+# decide hook skipped any call whose bare name was in a single mutable
+# ``self._bridged_tool_names`` set (no native-vs-bridged discrimination, set
+# overwritten at the start of every ``run_turn``).
+
+
+@pytest.mark.asyncio
+async def test_native_collision_consulted_while_real_bridged_skipped_one_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A colliding native call is CONSULTED (ALLOW honored); a real bridged call is SKIPPED.
+
+    The companion ``test_native_tool_with_bridged_name_collision_still_gated``
+    proves a colliding native call is *denied* under a DENY verdict. This one
+    pins the other half of the #284 regression in a single turn: that the hook
+    actually *consults the policy evaluator* for the colliding native call —
+    asserted by running it under an **ALLOW** evaluator and verifying it executes
+    *because* the verdict allowed it. (A bare "did it run?" check can't tell a
+    consulted-then-allowed call from a skipped one — both run — so the
+    distinguishing signal is the recorded ``PHASE_TOOL_CALL`` consultation.)
+
+    Within the SAME turn, a genuinely bridged Omnigent tool (``sys_shell`` — a
+    non-native wire name) under the same evaluator must be SKIPPED: never
+    consulted, because it is already TOOL_CALL-gated server-side on the dispatch
+    path. The colliding ``view_file`` and the real bridged ``sys_shell`` share
+    one agent / hook / closure-bound skip set, so the asymmetric treatment is
+    exercised on a single ``_build_pre_tool_hook``.
+
+    Pre-fix, the colliding native ``view_file`` would hit ``name in
+    _bridged_tool_names`` and be skipped — never consulted — so the
+    ``PHASE_TOOL_CALL`` consultation assertion for ``view_file`` would fail
+    (zero consultations).
+    """
+    # ALLOW the native call so its execution proves consultation (not a skip).
+    evaluator = _FakePolicyEvaluator(
+        {"PHASE_TOOL_CALL": _FakePolicyVerdict("POLICY_ACTION_ALLOW")}
+    )
+    # Native ``view_file`` (string- and enum-named) collides with the bridged
+    # ``view_file`` name; ``sys_shell`` is a genuinely bridged, non-native tool.
+    script: list[_TurnAction] = [
+        _ExecToolCall(
+            call=_FakeSDKToolCall("view_file", {"path": "/a"}, call_id="n1"),
+            result=_FakeToolResult("view_file", result={"ok": True}, call_id="n1"),
+        ),
+        _ExecToolCall(
+            call=_FakeSDKToolCall(_BuiltinTools.VIEW_FILE, {"path": "/b"}, call_id="n2"),
+            result=_FakeToolResult("view_file", result={"ok": True}, call_id="n2"),
+        ),
+        _exec_tool("sys_shell", {"cmd": "ls"}, call_id="b1"),
+        _text_step("done"),
+    ]
+    captured = _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    executor._tool_executor = lambda name, args: _async_ok()
+    # Expose BOTH names as bridged — ``view_file`` deliberately collides with the
+    # native tool name; ``sys_shell`` does not.
+    tool_specs = [
+        {"name": "view_file", "description": "bridged view", "parameters": {}},
+        {"name": "sys_shell", "description": "shell", "parameters": {}},
+    ]
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}], tool_specs)
+
+    conversation = captured["agents"][0].conversation
+    # All three ran: the two native ``view_file`` calls because the evaluator
+    # ALLOWed them (proving they were gated, not skipped), and ``sys_shell``
+    # because it was skipped as genuinely bridged. Resolve enum names to wire.
+    executed_wire = [getattr(n, "value", n) for n in conversation.executed_tools]
+    assert executed_wire == ["view_file", "view_file", "sys_shell"]
+    assert conversation.denied_tools == []
+    # The evaluator was consulted ONLY for the two native ``view_file`` calls: the
+    # colliding native name did NOT bypass the gate, and the genuinely bridged
+    # ``sys_shell`` was skipped (never consulted). Pre-fix: zero consultations
+    # (``view_file`` skipped by name like ``sys_shell``).
+    tool_phase_names = [d["name"] for (p, d) in evaluator.calls if p == "PHASE_TOOL_CALL"]
+    assert tool_phase_names == ["view_file", "view_file"]
+
+
+@pytest.mark.asyncio
+async def test_llm_request_deny_never_sends_on_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An LLM_REQUEST DENY aborts before any ``conversation.send`` — and ALLOW sends.
+
+    Sharpens the request-gate contract on the producer boundary the task cares
+    about: not just "no agent built" (already covered by
+    ``test_llm_request_policy_deny_aborts_turn``) but that the SDK
+    ``Conversation`` is never asked to ``send`` the prompt on a deny, and IS on
+    an allow. Both turns run on the same executor so the ALLOW turn proves the
+    gate is not over-broad after a deny.
+
+    Pre-fix there was no LLM_REQUEST gate in ``run_turn`` at all, so the deny
+    turn would build the agent and ``send`` the prompt — failing the
+    no-send / no-agent assertions here.
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="prompt blocked")
+    deny_evaluator = _FakePolicyEvaluator({"PHASE_LLM_REQUEST": deny})
+    # One script queued: the deny turn builds NO agent (gated before
+    # ``_ensure_agent``) and consumes no script, so the allow turn's single agent
+    # draws this one. If the request gate regressed and the deny turn DID build an
+    # agent, it would steal this script and the allow turn would hang / mis-read.
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("allowed-reply")]])
+    executor = AntigravityExecutor()
+
+    # Deny turn.
+    executor._policy_evaluator = deny_evaluator
+    deny_events = await _drain(
+        executor, [{"role": "user", "content": "blocked", "session_id": "d"}]
+    )
+    errors = [e for e in deny_events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1 and "denied by policy" in errors[0].message
+    # The producer (and thus ``conversation.send``) was never reached: the gate
+    # runs before ``_ensure_agent``, so no agent — hence no conversation — exists.
+    assert captured["agents"] == []
+    assert not any(isinstance(e, (TextChunk, TurnComplete)) for e in deny_events)
+
+    # Allow turn — same executor, fresh session — proves the gate isn't sticky.
+    allow_evaluator = _FakePolicyEvaluator()
+    executor._policy_evaluator = allow_evaluator
+    allow_events = await _drain(executor, [{"role": "user", "content": "go", "session_id": "a"}])
+    assert [e.text for e in allow_events if isinstance(e, TextChunk)] == ["allowed-reply"]
+    assert any(isinstance(e, TurnComplete) for e in allow_events)
+    # Exactly one agent was ever built (for the allow turn) and its conversation
+    # received exactly the allowed prompt — the deny turn contributed no send.
+    assert len(captured["agents"]) == 1
+    assert captured["agents"][0].conversation.sends == ["go"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_turns_keep_independent_closure_bound_skip_sets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two simultaneously in-flight turns each gate against their OWN bridged set.
+
+    Complements ``test_bridged_skip_set_not_corrupted_by_concurrent_turn`` (which
+    runs turn ``b`` to completion *before* turn ``a``'s gate fires). Here BOTH
+    turns are parked with their agents (and hooks) live at the same time, and
+    their tool-gates fire only after both are built — the strongest form of the
+    isolation claim: the skip set is bound into each agent's hook closure, so two
+    concurrently-pending hooks can't read one shared mutable set.
+
+    Setup: session ``x`` bridges ``{tool_x}``; session ``y`` bridges ``{tool_y}``.
+    Each turn streams a delta, parks, then (after both are parked) drives a call
+    to its OWN bridged tool through the real ``PreToolCallDecideHook``. Under the
+    DENY evaluator, "ran" means the hook skipped it (recognised it as bridged for
+    that turn); "denied" means the hook gated it (wrong set / no skip). Correct
+    behaviour: each runs its own tool. Pre-fix, whichever ``run_turn`` last
+    overwrote ``self._bridged_tool_names`` would win, so at least one hook would
+    consult the wrong set and DENY its own bridged tool.
+
+    Also asserts the implementation has no ``_bridged_tool_names`` instance
+    attribute — pinning that the skip set is closure-bound, not stored on
+    ``self`` where a concurrent turn could clobber it.
+    """
+    deny = _FakePolicyVerdict("POLICY_ACTION_DENY", reason="own bridged tool must be skipped")
+    evaluator = _FakePolicyEvaluator({"PHASE_TOOL_CALL": deny})
+
+    gate = asyncio.Event()
+    call_x = _FakeSDKToolCall("tool_x", {"v": 1}, call_id="x1")
+    call_y = _FakeSDKToolCall("tool_y", {"v": 2}, call_id="y1")
+    captured: dict[str, Any] = {}
+
+    class _FakeHooks:
+        PostToolCallHook = _FakePostToolCallHook
+        PreToolCallDecideHook = _FakePreToolCallDecideHook
+
+    class _FakeTypes:
+        AntigravityCancelledError = _AntigravityCancelledError
+        HookResult = _FakeHookResult
+        ToolCall = _FakeSDKToolCall
+        BuiltinTools = _BuiltinTools
+
+    class _SwitchingModule:
+        LocalAgentConfig = _FakeLocalAgentConfig
+        hooks = _FakeHooks
+        types = _FakeTypes
+
+        @staticmethod
+        def Agent(config: Any) -> Any:
+            tool_names = {
+                getattr(t, "__name__", "") for t in (getattr(config, "tools", None) or [])
+            }
+            hooks = list(getattr(config, "hooks", []) or [])
+            if "tool_x" in tool_names:
+                conv = _GatingBlockingConversation(hooks, gate, call_x)
+                captured["conv_x"] = conv
+            else:
+                conv = _GatingBlockingConversation(hooks, gate, call_y)
+                captured["conv_y"] = conv
+
+            class _Agent:
+                def __init__(self) -> None:
+                    self._conversation = conv
+
+                @property
+                def conversation(self) -> Any:
+                    return self._conversation
+
+                async def __aenter__(self) -> Any:
+                    return self
+
+                async def __aexit__(self, *_a: object) -> None:
+                    return None
+
+            return _Agent()
+
+    monkeypatch.setattr(ag, "_ensure_antigravity_sdk", lambda: _SwitchingModule())
+
+    executor = AntigravityExecutor()
+    executor._policy_evaluator = evaluator
+    executor._tool_executor = lambda name, args: _async_ok()
+    # Pin the closure-bound design: no shared mutable skip attribute on ``self``.
+    assert not hasattr(executor, "_bridged_tool_names")
+
+    tools_x = [{"name": "tool_x", "description": "bridged for x", "parameters": {}}]
+    tools_y = [{"name": "tool_y", "description": "bridged for y", "parameters": {}}]
+
+    x_started = asyncio.Event()
+    y_started = asyncio.Event()
+
+    async def _drive(session: str, tools: list[dict[str, Any]], started: asyncio.Event) -> None:
+        async for event in executor.run_turn(
+            [{"role": "user", "content": session, "session_id": session}],
+            tools=tools,
+            system_prompt="sys",
+        ):
+            if isinstance(event, TextChunk):
+                started.set()
+
+    # Start BOTH turns; each streams a delta and parks on the shared gate, so
+    # both agents (and their closure-bound hooks) are live simultaneously.
+    x_task = asyncio.create_task(_drive("x", tools_x, x_started))
+    y_task = asyncio.create_task(_drive("y", tools_y, y_started))
+    await asyncio.wait_for(x_started.wait(), timeout=5)
+    await asyncio.wait_for(y_started.wait(), timeout=5)
+
+    # Release both: their tool-gates now fire concurrently, each against the set
+    # baked into its own agent's hook.
+    gate.set()
+    await asyncio.wait_for(asyncio.gather(x_task, y_task), timeout=5)
+
+    conv_x = captured["conv_x"]
+    conv_y = captured["conv_y"]
+    # Each hook skipped its OWN bridged tool (so it ran despite the DENY); neither
+    # leaked the other's set. A regression to shared mutable state would deny at
+    # least one tool here.
+    assert conv_x.executed_tools == ["tool_x"]
+    assert conv_x.denied_tools == []
+    assert conv_y.executed_tools == ["tool_y"]
+    assert conv_y.denied_tools == []
+    # The evaluator was never consulted for either bridged tool — both were
+    # correctly skipped per their own session's closure-bound set.
+    gated = {d["name"] for (p, d) in evaluator.calls if p == "PHASE_TOOL_CALL"}
+    assert gated == set()

--- a/tests/resources/examples/_shared/native_tool_policies.py
+++ b/tests/resources/examples/_shared/native_tool_policies.py
@@ -6,6 +6,58 @@ from omnigent.policies.schema import PolicyEvent, PolicyResponse
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
 
+# Native file-write tool wire names across the coding harnesses, surfaced to a
+# TOOL_CALL policy by each harness's pre-tool gate:
+#   - antigravity SDK bundled tools (``BuiltinTools``): ``create_file`` /
+#     ``edit_file`` (see
+#     ``omnigent.inner.antigravity_executor._NATIVE_TOOL_WIRE_NAMES``)
+#   - Claude Code / Codex native tools (PreToolUse hook): ``Write`` / ``Edit``
+#   - Pi native tools (lowercase, pi ``tool_call`` hook): ``write`` / ``edit``
+# This is the deny set the live bug-bash used to prove a native ``create_file``
+# bypassed an ``on:[tool_call]`` deny on pre-#284 main.
+_NATIVE_FILE_WRITE_TOOLS = frozenset(
+    {"create_file", "edit_file", "Write", "Edit", "write", "edit"}
+)
+
+
+def block_native_file_writes(event: PolicyEvent) -> PolicyResponse:
+    """
+    Deny every native file-write tool call (``create_file`` / ``edit_file`` /
+    ``Write`` / ``Edit`` / ``write`` / ``edit``) at the TOOL_CALL phase.
+
+    A harness-agnostic deny used by the antigravity policy-gating e2e
+    acceptance test: the agent's model is asked to write a sentinel file with
+    its bundled native ``create_file`` tool, and this policy must block the
+    call BEFORE it runs so nothing reaches disk. The callable self-selects
+    (returns ALLOW for every non-matching event), so no ``on:`` field is
+    required in the YAML.
+
+    The DENY verdict is what #284's ``PreToolCallDecideHook`` consults via
+    ``AntigravityExecutor._evaluate_tool_call_policy`` — on pre-#284 main the
+    native call was never routed through policy and wrote to disk regardless.
+
+    :param event: V0 event dict with ``type``, ``target``, ``data``,
+        ``context`` keys. For a tool call, ``data`` is
+        ``{"name": "<wire-name>", "arguments": {...}}``.
+    :returns: V0 decision dict — DENY for a native file-write call, ALLOW
+        otherwise.
+    """
+    if event.get("type") != "tool_call":
+        return _ALLOW
+
+    data = event.get("data")
+    tool_name: str = data.get("name", "") if isinstance(data, dict) else ""
+    if tool_name not in _NATIVE_FILE_WRITE_TOOLS:
+        return _ALLOW
+
+    return {
+        "result": "DENY",
+        "reason": (
+            f"Native file-write tool {tool_name!r} is denied by the "
+            "on:[tool_call] guardrail policy."
+        ),
+    }
+
 
 def block_bash_rm(event: PolicyEvent) -> PolicyResponse:
     """
@@ -22,7 +74,9 @@ def block_bash_rm(event: PolicyEvent) -> PolicyResponse:
         return _ALLOW
 
     data = event.get("data")
-    tool_name: str = data.get("name", "") if isinstance(data, dict) else ""
+    if not isinstance(data, dict):
+        return _ALLOW
+    tool_name: str = data.get("name", "")
     if tool_name != "Bash":
         return _ALLOW
 

--- a/tests/resources/examples/antigravity_native_write_allowed/config.yaml
+++ b/tests/resources/examples/antigravity_native_write_allowed/config.yaml
@@ -1,0 +1,26 @@
+# Antigravity native-tool policy-gating e2e bundle (ALLOW arm — positive control).
+#
+# Identical to ../antigravity_native_write_denied EXCEPT it carries NO deny
+# policy. The agent is asked to write the same sentinel file using its bundled
+# native `create_file` tool, and the file SHOULD appear on disk. This proves
+# the native tool can write when nothing blocks it — so when the DENY arm
+# leaves the file absent, the absence is attributable to the policy and not to
+# a model that simply never called the tool.
+#
+# Driven by tests/e2e/omnigent/test_per_harness_antigravity.py.
+spec_version: 1
+name: antigravity_native_write_allowed
+description: >-
+  Antigravity agent with NO write guardrail — the positive control proving the
+  native create_file tool writes to disk when policy does not block it.
+
+executor:
+  type: omnigent
+  config:
+    harness: antigravity
+    model: gemini-3.5-flash
+
+prompt: |
+  You are a coding agent. When the user asks you to create a file, use your
+  native create_file tool to write it at the exact path requested with the
+  exact content requested. Do not ask for confirmation.

--- a/tests/resources/examples/antigravity_native_write_denied/config.yaml
+++ b/tests/resources/examples/antigravity_native_write_denied/config.yaml
@@ -1,0 +1,48 @@
+# Antigravity native-tool policy-gating e2e bundle (DENY arm).
+#
+# An antigravity agent (Gemini via the google-antigravity SDK) with a single
+# guardrail policy that DENIES native file-write tool calls at the
+# `[tool_call]` phase. The agent is asked to write a sentinel file using its
+# bundled native `create_file` tool; #284's `PreToolCallDecideHook` must route
+# that native call through this policy and block it BEFORE it runs, so nothing
+# reaches disk.
+#
+# This is the regression bundle for the live bug-bash "C1" finding: on
+# pre-#284 main the native `create_file` wrote to disk EVEN UNDER this deny
+# (the native call never went through policy). #284 closes that bypass.
+#
+# Driven by tests/e2e/omnigent/test_per_harness_antigravity.py. See that test
+# for the glibc>=2.36 / dev-shim prerequisite caveat.
+spec_version: 1
+name: antigravity_native_write_denied
+description: >-
+  Antigravity agent whose native file-write tools are denied by an
+  on:[tool_call] guardrail policy (the #284 native-tool gate acceptance arm).
+
+# A real antigravity turn through the google-antigravity SDK. The SDK bundles
+# its own native tools (create_file / edit_file / run_command) into the agent
+# automatically, so the model can attempt a native file write with no extra
+# tool wiring — exactly the surface #284's pre-tool hook gates.
+executor:
+  type: omnigent
+  config:
+    harness: antigravity
+    model: gemini-3.5-flash
+
+prompt: |
+  You are a coding agent. When the user asks you to create a file, use your
+  native create_file tool to write it at the exact path requested with the
+  exact content requested. Do not ask for confirmation.
+
+# Single guardrail: deny native file-write tool calls (create_file / edit_file
+# and the peer harnesses' Write/Edit/write/edit) at the tool-call phase. The
+# handler self-selects the events it acts on, so no `on:` field is needed; it
+# is declared here to make the gated phase explicit and to mirror the
+# blast_radius `on: [tool_call]` guardrail in examples/debby/config.yaml.
+guardrails:
+  policies:
+    deny_native_file_writes:
+      type: function
+      on: [tool_call]
+      function:
+        path: tests.resources.examples._shared.native_tool_policies.block_native_file_writes


### PR DESCRIPTION
## Problem

The merged `AntigravityExecutor` installed only a **`PostToolCallHook`** — which fires *after* a tool runs and returns `None`, so it **cannot block**. Two policy gaps resulted, both relative to the claude-sdk / openai-agents peers:

- **BUG 1 (High, security):** tool calls were never evaluated against Omnigent's `TOOL_CALL` policy *before* execution. Operator DENY/ASK guardrails on shell / file / bridged tools were silently bypassed (claude-sdk gates via `can_use_tool`).
- **BUG 2 (Medium):** `run_turn` never evaluated the `LLM_REQUEST` or `LLM_RESPONSE` phases, so prompt-deny and output-block policies were ignored.

## Fix

Mirrors the peer SDK executors, expressed through the Antigravity SDK's hook surface.

### TOOL_CALL — `PreToolCallDecideHook`
Registers a `PreToolCallDecideHook` (alongside the existing post-tool hook) that consults the executor's `_policy_evaluator` for `PHASE_TOOL_CALL` **before** each tool runs:
- **DENY** → returns `HookResult(allow=False, message=reason)` so the SDK rejects the call and the tool never executes.
- **ASK** → routes through the executor's `_elicitation_handler`; approve → allow, decline / no handler wired → fail-closed deny.
- **ALLOW / no-match / no evaluator** → allow (no human interaction), preserving autonomy for un-gated tools.

This is the executor's analogue of claude-sdk's `can_use_tool` gate, collapsed into the SDK's allow/deny `HookResult`. It reuses a new `_evaluate_tool_call_policy` helper that mirrors `ClaudeSDKExecutor._evaluate_tool_call_policy`.

### LLM_REQUEST / LLM_RESPONSE — in `run_turn`
- `PHASE_LLM_REQUEST` is evaluated **before the producer is spawned**; a DENY `yield`s `ExecutorError` and returns before any model call (the agent isn't even built yet).
- `PHASE_LLM_RESPONSE` is evaluated **after the stream completes but before `TurnComplete`**; a DENY `yield`s `ExecutorError` so the response is not persisted.

The request/response data dicts and verdict handling are copied from the peer executors. Every phase is a **no-op when `_policy_evaluator` is absent** (accessed via `getattr`, same pattern as the peers). `_policy_evaluator` and `_elicitation_handler` are wired in by the harness `ExecutorAdapter`.

## Native-tool limitation: none

Investigating the SDK (`google/antigravity/connections/local/local_connection.py`) confirmed the decide hook (`HookRunner.dispatch_pre_tool_call`) gates **both** tool paths before execution:
- **Bundled native tools** (`run_command`, file ops — run in the `localharness` binary): gated in `_handle_tool_confirmation_request`; on deny the SDK sends `ToolConfirmation(accepted=False)` and the harness never runs the tool.
- **Host-side bridged tools**: gated in `_handle_tool_call`; on deny the SDK returns a denial `ToolResult` without invoking the tool runner.

So **native tools are fully pre-gateable** — there is no native-tool gap to document.

### Double-evaluation guard
Bridged Omnigent tools route through `_tool_executor` → `TurnContext.dispatch_tool` → the runner's `ProxyMcpManager`, which **already** enforces `TOOL_CALL` + `TOOL_RESULT` policies server-side. Re-evaluating them in the hook would double-count (and could double-charge a cost budget), so the hook **skips the per-turn bridged tool names** and gates everything else (chiefly the native tools). This mirrors claude-sdk skipping its `mcp__omnigent__*` prefix.

## Tests

`tests/inner/test_antigravity_executor.py` — extended the SDK fakes (pre-tool decide hook, `HookResult`, `ToolCall`, a scripted `_FakePolicyEvaluator`, a `_FakeElicitationHandler`, and an `_ExecToolCall` action that runs the gate then conditionally executes). Added coverage:
- TOOL_CALL DENY blocks a native tool (it is never executed);
- TOOL_CALL ASK approve runs / decline blocks / no-handler fails closed;
- bridged tools are **not** re-evaluated (skip guard) and still run even under a DENY verdict;
- no-evaluator and ALLOW paths still run the tool (gate not over-broad);
- LLM_REQUEST DENY aborts the turn with `ExecutorError` and **no model call** (no agent built);
- LLM_RESPONSE DENY blocks the response (`ExecutorError`, no `TurnComplete`).

Each enforcement test was verified to **fail without this change**. Full file: **38 passed**. `ruff check` / `ruff format` / `mypy` clean on the executor and tests.

This pull request and its description were written by Isaac.