### PR TITLE
fix(antigravity): stop treating it as an OpenAI-family/gateway harness

### DIFF
--- a/ap-web/src/lib/forkHarness.test.ts
+++ b/ap-web/src/lib/forkHarness.test.ts
@@ -18,6 +18,10 @@ describe("harnessFamily", () => {
     ["openai-agents", "openai"],
     ["openai-agents-sdk", "openai"],
     ["agents_sdk", "openai"],
+    // Antigravity is Gemini-native — its own family, plus alias spellings.
+    ["antigravity", "google"],
+    ["agy", "google"],
+    ["google-antigravity", "google"],
   ])("maps %s → %s", (harness, family) => {
     expect(harnessFamily(harness)).toBe(family);
   });
@@ -54,12 +58,19 @@ describe("forkTargetCarriesHistory", () => {
   // SDK targets always carry history as context, regardless of source or
   // family — including native → SDK and cross-family. A false here would
   // wrongly hide a fully-supported switch from the picker.
-  it.each([["claude-sdk"], ["claude_sdk"], ["codex"], ["openai-agents"], ["agents_sdk"]])(
-    "SDK target %s carries history",
-    (target) => {
-      expect(forkTargetCarriesHistory(target)).toBe(true);
-    },
-  );
+  it.each([
+    ["claude-sdk"],
+    ["claude_sdk"],
+    ["codex"],
+    ["openai-agents"],
+    ["agents_sdk"],
+    // Antigravity is an in-process SDK harness, so it carries history too.
+    ["antigravity"],
+    ["agy"],
+    ["google-antigravity"],
+  ])("SDK target %s carries history", (target) => {
+    expect(forkTargetCarriesHistory(target)).toBe(true);
+  });
 
   // Native targets carry from ANY source: the runner clones the source's
   // native transcript when the source is same-family native, else rebuilds

--- a/ap-web/src/lib/forkHarness.ts
+++ b/ap-web/src/lib/forkHarness.ts
@@ -18,8 +18,18 @@
 // (see _codex_rollout_records_from_session_items in omnigent/codex_native.py
 // and tests/e2e/test_host_cross_family_fork_e2e.py).
 
-/** Provider family a harness consumes, or null when unknown. */
-export function harnessFamily(harness: string | null | undefined): "anthropic" | "openai" | null {
+/**
+ * Provider family a harness consumes, or null when unknown.
+ *
+ * Antigravity is Gemini-native, so it reports its own `"google"` family —
+ * distinct from anthropic/openai. This both classifies it as a known SDK
+ * target (so `forkTargetCarriesHistory` offers it) and keeps the
+ * cross-family check honest: switching to/from antigravity is a family
+ * change, so the dialog warns that model settings reset.
+ */
+export function harnessFamily(
+  harness: string | null | undefined,
+): "anthropic" | "openai" | "google" | null {
   if (!harness) return null;
   switch (harness) {
     case "claude-native":
@@ -34,6 +44,12 @@ export function harnessFamily(harness: string | null | undefined): "anthropic" |
     case "openai-agents-sdk":
     case "agents_sdk":
       return "openai";
+    // Gemini-native SDK harness. Includes the server-emitted alias spellings
+    // (`harness_kind` returns whatever `config["harness"]` was set to).
+    case "antigravity":
+    case "agy":
+    case "google-antigravity":
+      return "google";
     default:
       return null;
   }

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -84,10 +84,11 @@ executor:
     api_key: ${GEMINI_API_KEY}     # or ANTIGRAVITY_API_KEY
 ```
 
-To route through OpenRouter / a gateway, declare a key/gateway provider in
-`~/.omnigent/config.yaml` and reference it (`auth: {type: provider, name: …}`),
-or set `auth.base_url` to the OpenAI-compatible endpoint alongside the key.
-For Databricks, use `auth: {type: databricks, profile: …}`.
+For Vertex AI, set `executor.config` `vertex: true` (plus `project` / `location`)
+and authenticate with Google Cloud ADC instead of an API key. Because the SDK
+is Gemini-native, there is no OpenAI-compatible gateway, `provider`, or
+Databricks routing for this harness — a `databricks` / `provider` auth or an
+`auth.base_url` is ignored, so do not use one.
 
 CLI flags such as `--harness` and `--model` can override or supply missing
 executor values for a run. Databricks credentials come from the spec's

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3559,8 +3559,13 @@ def _spec_used_families(agent_yaml: Path | None) -> list[str]:
     def _walk(node: AgentSpec) -> None:
         """Accumulate the surface for *node*'s harness and recurse into sub-agents."""
         harness = canonicalize_harness(node.executor.harness_kind) or node.executor.harness_kind
-        fam = harness_family(harness)
-        if fam is not None:
+        if harness == "antigravity":
+            # Antigravity is Gemini-native: its ``openai`` _HARNESS_FAMILY entry
+            # is for family-keyed lookups only (no OpenAI gateway routing), so it
+            # must NOT fold into the openai surface here — it contributes its own
+            # surface, which the header resolves to the Gemini credential.
+            families.add("antigravity")
+        elif (fam := harness_family(harness)) is not None:
             families.add(fam)
         elif harness == PI_SURFACE:
             # pi spans both model families, so it has no single family —

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -102,11 +102,15 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
 }
 
 # Preferred inline family per single-family harness (pi consumes both).
+# NB: ``antigravity`` is intentionally absent — it is Gemini-native and never
+# reaches the generic-provider entry path (_resolve_model_provider_unsafe
+# routes it to _legacy_antigravity_provider), so a lookup here would mean a
+# routing bug. Leaving it out makes that bug fail loud (KeyError) rather than
+# silently advertise OpenAI-family models the worker can never run.
 _KEY_AUTH_FAMILY: dict[str, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
     "openai-agents-sdk": OPENAI_FAMILY,
-    "antigravity": OPENAI_FAMILY,
 }
 
 # Multi-family providers (pi): anthropic first, matching _apply_provider_to_pi.
@@ -319,6 +323,15 @@ def _resolve_model_provider_unsafe(spec: Any, harness: str | None) -> ResolvedMo
     fallthrough (see :func:`_provider_from_legacy_auth`) — the builders
     diverge in which legacy auth fields they actually consume.
 
+    Antigravity is the exception: it is Gemini-native and
+    :func:`~omnigent.runtime.workflow.configure_agent_harness_with_provider`
+    rejects it, so its spawn-env builder NEVER consumes a generic
+    ``providers:`` entry. Routing it through ``_resolve_provider_for_build``
+    (which would resolve a named/default provider into an
+    :data:`~omnigent.onboarding.provider_config.OPENAI_FAMILY` entry) would
+    advertise OpenAI-family/gateway models the worker can never run, so it
+    skips step 1 and mirrors ``_build_antigravity_spawn_env`` directly.
+
     :param spec: The worker's (sub-)agent spec.
     :param harness: The worker's harness id, e.g. ``"pi"``.
     :returns: A :class:`ResolvedModelProvider`.
@@ -333,6 +346,13 @@ def _resolve_model_provider_unsafe(spec: Any, harness: str | None) -> ResolvedMo
             kind=NONE_KIND,
             detail=f"harness {harness or 'unknown'!r} has no model-provider resolution",
         )
+
+    if harness_type == "antigravity":
+        # Gemini-native: the generic-provider path is precluded by the
+        # antigravity guard in configure_agent_harness_with_provider, so the
+        # spawn-env builder only ever resolves an api_key / Vertex / ambient
+        # key. Mirror that directly and never consult _resolve_provider_for_build.
+        return _legacy_antigravity_provider(spec)
 
     entry = _resolve_provider_for_build(spec, harness_type=harness_type)  # type: ignore[arg-type]  # AgentHarnessType narrowed by the map above
     if entry is not None:
@@ -356,13 +376,11 @@ def _provider_from_legacy_auth(spec: Any, harness_type: str) -> ResolvedModelPro
     """
     if harness_type == "claude-sdk":
         return _legacy_claude_sdk_provider(spec)
-    if harness_type in ("openai-agents-sdk", "antigravity"):
-        # Both resolve spec/global ``auth:`` api-key blocks via this branch.
-        # NB: the antigravity spawn-env builder (unlike openai-agents) ignores
-        # ``config["profile"]`` — it's Gemini-native with no Databricks/gateway
-        # path — so for a profile-only antigravity spec this readout can
-        # over-report; api-key (and Vertex) specs resolve correctly.
+    if harness_type == "openai-agents-sdk":
         return _legacy_openai_agents_provider(spec)
+    # NB: antigravity never reaches here — _resolve_model_provider_unsafe
+    # routes it to _legacy_antigravity_provider directly (it is Gemini-native
+    # and shares none of the gateway/Databricks legacy auth these branches read).
     return _legacy_profile_only_provider(spec, harness_type)
 
 
@@ -468,6 +486,78 @@ def _legacy_openai_agents_provider(spec: Any) -> ResolvedModelProvider:  # type:
     if prefix is not None:
         return prefix
     return ResolvedModelProvider(kind=NONE_KIND, detail="no model provider configured")
+
+
+def _legacy_antigravity_provider(spec: Any) -> ResolvedModelProvider:  # type: ignore[explicit-any]  # structural spec stubs in tests
+    """Mirror ``_build_antigravity_spawn_env``'s Gemini-native auth resolution.
+
+    Antigravity is Gemini-native: its spawn-env builder consumes ONLY a
+    direct API key — spec ``executor.auth`` api_key (``base_url`` dropped),
+    the ``antigravity:`` config block, the legacy global ``auth:`` api_key,
+    or an ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY`` — or opts into
+    Vertex AI via ``executor.config`` vertex/project/location. It never reads
+    a ``DatabricksAuth``, ``executor.profile`` / ``config["profile"]``, or a
+    generic ``providers:`` entry, and has no OpenAI-compatible ``base_url``.
+
+    There is no Gemini model-listing endpoint wired into this catalog (and no
+    base URL to fetch from), so this always resolves to ``kind="none"`` — the
+    dispatch gate then passes the spec's model through unchanged and
+    ``sys_list_models`` reports the worker as non-enumerable rather than
+    fabricating an OpenAI-family list the worker can never run. The
+    :attr:`~ResolvedModelProvider.detail` records whether a credential was
+    found, so the readout still distinguishes a configured worker from an
+    unconfigured one.
+
+    :param spec: The worker's (sub-)agent spec.
+    :returns: A :class:`ResolvedModelProvider` with ``kind="none"``.
+    """
+    from omnigent.spec.types import ApiKeyAuth
+
+    config = spec.executor.config
+    if config.get("vertex"):
+        return ResolvedModelProvider(
+            kind=NONE_KIND,
+            detail="antigravity Vertex AI (Gemini-native; no enumerable model listing)",
+        )
+
+    spec_auth = spec.executor.auth
+    if isinstance(spec_auth, ApiKeyAuth) and spec_auth.api_key:
+        return ResolvedModelProvider(
+            kind=NONE_KIND,
+            detail="antigravity api_key auth (Gemini-native; no enumerable model listing)",
+        )
+    if spec_auth is None and _antigravity_ambient_key_present():
+        return ResolvedModelProvider(
+            kind=NONE_KIND,
+            detail="antigravity ambient Gemini key (Gemini-native; no enumerable model listing)",
+        )
+    return ResolvedModelProvider(
+        kind=NONE_KIND,
+        detail="no Gemini credential configured for the antigravity harness",
+    )
+
+
+def _antigravity_ambient_key_present() -> bool:
+    """Return whether ``_build_antigravity_spawn_env`` would find a fallback key.
+
+    Mirrors the builder's no-spec-auth fallback chain: the dedicated
+    ``antigravity:`` config block, then the legacy global ``auth:`` api_key,
+    then an ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``.
+
+    :returns: ``True`` when any of those resolves a key.
+    """
+    from omnigent.onboarding.antigravity_auth import (
+        ANTIGRAVITY_ENV_VARS,
+        resolve_antigravity_api_key,
+    )
+    from omnigent.runtime.workflow import _load_global_auth
+    from omnigent.spec.types import ApiKeyAuth
+
+    if resolve_antigravity_api_key() is not None:
+        return True
+    if isinstance(_load_global_auth(), ApiKeyAuth):
+        return True
+    return any(os.environ.get(var) for var in ANTIGRAVITY_ENV_VARS)
 
 
 def _legacy_profile_only_provider(spec: Any, harness_type: str) -> ResolvedModelProvider:  # type: ignore[explicit-any]  # structural spec stubs in tests

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -21,6 +21,10 @@ Enumeration is deterministic per provider kind:
   ``"openai-compatible"``).
 - ``subscription`` → a curated static list (source ``"static"``,
   ``verified: false`` — CLI logins expose no listing API).
+- a runnable-but-non-enumerable provider (a Gemini-native antigravity
+  worker holding a credential) → source ``"runnable"`` with an empty
+  list and a note saying the worker can run but its models cannot be
+  listed here.
 - anything unresolvable → source ``"none"`` with an explanatory note,
   which doubles as a dead-worker preflight signal.
 """
@@ -139,7 +143,8 @@ class ModelListing:
     """A worker's enumerated model list plus its provenance.
 
     :param source: Where the list came from — ``"gateway"``,
-        ``"openai-compatible"``, ``"anthropic-api"``, ``"static"``, or
+        ``"openai-compatible"``, ``"anthropic-api"``, ``"static"``,
+        ``"runnable"`` (runnable worker with no enumerable listing), or
         ``"none"``.
     :param verified: ``True`` when the list was fetched live from the
         provider; ``False`` for static/curated or empty listings.
@@ -174,6 +179,14 @@ class ResolvedModelProvider:
     :param cli: ``"claude"`` / ``"codex"`` for ``kind="subscription"``.
     :param detail: Non-secret descriptor of how the provider resolved,
         e.g. ``"provider 'openrouter'"`` — used in listing notes.
+    :param runnable: Whether a dispatch to this worker can actually run,
+        even when its models cannot be enumerated. Only meaningful for
+        ``kind="none"``: ``True`` marks a configured-but-non-enumerable
+        provider (e.g. a Gemini-native antigravity worker with an api-key
+        / Vertex / ambient credential — runnable, but with no listing
+        endpoint), distinguishing it from a genuinely unusable worker
+        (``False`` — no credential resolved). Enumerable kinds leave it
+        ``False`` since their runnability is implied by a live listing.
     """
 
     kind: str
@@ -184,6 +197,7 @@ class ResolvedModelProvider:
     auth_command: str | None = None
     cli: str | None = None
     detail: str = ""
+    runnable: bool = False
 
 
 # Unfiltered listings keyed by provider identity. TTLCache is not thread-safe
@@ -503,13 +517,18 @@ def _legacy_antigravity_provider(spec: Any) -> ResolvedModelProvider:  # type: i
     base URL to fetch from), so this always resolves to ``kind="none"`` — the
     dispatch gate then passes the spec's model through unchanged and
     ``sys_list_models`` reports the worker as non-enumerable rather than
-    fabricating an OpenAI-family list the worker can never run. The
-    :attr:`~ResolvedModelProvider.detail` records whether a credential was
-    found, so the readout still distinguishes a configured worker from an
-    unconfigured one.
+    fabricating an OpenAI-family list the worker can never run.
+
+    The :attr:`~ResolvedModelProvider.runnable` flag is what keeps that
+    "non-enumerable" honest: a worker with a credential (api-key / Vertex /
+    ambient) CAN run — it just cannot list its models — so it is marked
+    ``runnable=True`` and the listing renders as runnable-without-a-listing.
+    A worker with no Gemini credential anywhere is genuinely unusable, so it
+    stays ``runnable=False`` (the dead-worker preflight signal).
 
     :param spec: The worker's (sub-)agent spec.
-    :returns: A :class:`ResolvedModelProvider` with ``kind="none"``.
+    :returns: A :class:`ResolvedModelProvider` with ``kind="none"``;
+        ``runnable=True`` when a Gemini credential resolved.
     """
     from omnigent.spec.types import ApiKeyAuth
 
@@ -518,6 +537,7 @@ def _legacy_antigravity_provider(spec: Any) -> ResolvedModelProvider:  # type: i
         return ResolvedModelProvider(
             kind=NONE_KIND,
             detail="antigravity Vertex AI (Gemini-native; no enumerable model listing)",
+            runnable=True,
         )
 
     spec_auth = spec.executor.auth
@@ -525,11 +545,13 @@ def _legacy_antigravity_provider(spec: Any) -> ResolvedModelProvider:  # type: i
         return ResolvedModelProvider(
             kind=NONE_KIND,
             detail="antigravity api_key auth (Gemini-native; no enumerable model listing)",
+            runnable=True,
         )
     if spec_auth is None and _antigravity_ambient_key_present():
         return ResolvedModelProvider(
             kind=NONE_KIND,
             detail="antigravity ambient Gemini key (Gemini-native; no enumerable model listing)",
+            runnable=True,
         )
     return ResolvedModelProvider(
         kind=NONE_KIND,
@@ -786,6 +808,20 @@ def _listing_for_provider(
     :returns: The provider's :class:`ModelListing`.
     """
     if provider.kind == NONE_KIND:
+        if provider.runnable:
+            # Runnable, but with no listing endpoint (e.g. a Gemini-native
+            # antigravity worker holding a credential): dispatches CAN run, the
+            # models just cannot be enumerated. Report that, not "cannot run."
+            return ModelListing(
+                source="runnable",
+                verified=False,
+                models=(),
+                note=(
+                    f"{provider.detail} — dispatches to this worker can run, but "
+                    "its models cannot be enumerated here (no listing endpoint); "
+                    "pass the worker's own model id through unchanged"
+                ),
+            )
         return ModelListing(
             source=NONE_KIND,
             verified=False,

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -54,6 +54,16 @@ ANTHROPIC_FAMILY = "anthropic"
 OPENAI_FAMILY = "openai"
 _VALID_FAMILIES = (ANTHROPIC_FAMILY, OPENAI_FAMILY)
 
+# Gemini family token for the Gemini-native antigravity harness. It is
+# deliberately NOT in :data:`_VALID_FAMILIES`: no ``providers:`` entry carries
+# a ``google:`` block (antigravity's key lives in the dedicated ``antigravity:``
+# block), so this is purely a same-family marker for the fork/switch model-carry
+# decision — keeping antigravity distinct from ``openai`` there so a cross-family
+# switch correctly resets the provider-bound model id. (Matches the ``"google"``
+# vendor token used elsewhere — see ``llms/context_window.py``,
+# ``configure_models`` labels — and ``harnessFamily`` in ``ap-web``.)
+GOOGLE_FAMILY = "google"
+
 # The pi harness's *default scope*. pi is not a model family — a provider
 # entry never carries a ``pi:`` block — but defaults are scoped per harness
 # surface, and pi consumes both families, so it gets its own scope name a
@@ -129,8 +139,15 @@ _HARNESS_FAMILY: dict[str, str] = {
     # normally maps it down via _provider_harness_name; accept both spellings
     # here so callers that pass the spec/CLI spelling directly resolve too.
     "openai-agents-sdk": OPENAI_FAMILY,
-    # Antigravity is Gemini-native but routes generic-provider traffic over
-    # the OpenAI-compatible wire, so it consumes the ``openai`` family.
+    # Antigravity is Gemini-native — a direct Gemini API key or Vertex AI,
+    # never an OpenAI gateway (the antigravity guard in
+    # ``configure_agent_harness_with_provider`` rejects generic providers for
+    # it). This ``openai`` entry exists ONLY so the shared family-keyed
+    # lookups (harness install-key resolution, the SDK-readiness set) find a
+    # value; NO gateway routing occurs. Credential-readout call sites
+    # (``describe_active_credential`` and the multi-surface startup header)
+    # special-case antigravity so they don't report an OpenAI credential for
+    # this Gemini-native harness.
     "antigravity": OPENAI_FAMILY,
 }
 
@@ -146,9 +163,10 @@ _EXECUTOR_TYPE_HARNESS_ALIASES: dict[str, str] = {
 def provider_family_for_harness(harness: str | None) -> str | None:
     """Return the provider family a harness consumes, or ``None``.
 
-    Maps a harness identifier to ``"anthropic"`` / ``"openai"``. Accepts both
-    the canonical ids keyed in :data:`_HARNESS_FAMILY` and the executor-type
-    spellings :attr:`AgentSpec.harness_kind` returns for SDK harnesses
+    Maps a harness identifier to ``"anthropic"`` / ``"openai"`` /
+    ``"google"`` (Gemini-native antigravity). Accepts both the canonical ids
+    keyed in :data:`_HARNESS_FAMILY` and the executor-type spellings
+    :attr:`AgentSpec.harness_kind` returns for SDK harnesses
     (``"claude_sdk"`` → ``"claude-sdk"``, ``"agents_sdk"`` →
     ``"openai-agents"``).
 
@@ -157,14 +175,23 @@ def provider_family_for_harness(harness: str | None) -> str | None:
     a fork into a native target can carry history (same-family only): a model
     id is provider-bound, so it only transfers within the same family.
 
+    Antigravity is reported as :data:`GOOGLE_FAMILY`, NOT ``openai`` (its
+    :data:`_HARNESS_FAMILY` entry, which exists only for family-keyed config
+    lookups): it is Gemini-native, so a switch to/from it crosses provider
+    families and the provider-bound model id must reset. This mirrors
+    ``harnessFamily`` in ``ap-web/src/lib/forkHarness.ts`` so the client-side
+    reset hint and the server-side carry decision agree.
+
     :param harness: A harness id, e.g. ``"claude-native"`` or
         ``"claude_sdk"``; ``None`` returns ``None``.
-    :returns: ``"anthropic"`` / ``"openai"``, else ``None`` when the harness
-        is unknown.
+    :returns: ``"anthropic"`` / ``"openai"`` / ``"google"``, else ``None``
+        when the harness is unknown.
     """
     if harness is None:
         return None
     canonical = canonicalize_harness(harness) or harness
+    if canonical == "antigravity":
+        return GOOGLE_FAMILY
     canonical = _EXECUTOR_TYPE_HARNESS_ALIASES.get(canonical, canonical)
     return harness_family(canonical)
 
@@ -1060,6 +1087,49 @@ def _source_descriptor(family: FamilyConfig) -> str:
     )
 
 
+def _describe_antigravity_credential(
+    config: dict[str, object],
+    model_override: str | None,
+) -> ResolvedCredential | None:
+    """Describe the Gemini credential for the antigravity harness readout.
+
+    Antigravity is Gemini-native, so its credential lives in the dedicated
+    ``antigravity:`` config block (``keychain:`` / ``env:`` reference) or an
+    ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY`` — never a
+    ``providers:`` family. Mirrors the key-resolution order of
+    ``_build_antigravity_spawn_env`` (excluding per-spec Vertex / global
+    ``auth:``, which the harness-level readout can't see). The reported
+    :attr:`~ResolvedCredential.kind` is ``"key"`` with no ``family`` /
+    ``base_url`` (the SDK has no OpenAI-compatible endpoint), and the model is
+    whatever the session pinned (no provider default to fall back on).
+
+    :param config: The parsed config mapping (the ``antigravity:`` block).
+    :param model_override: The in-session ``/model`` override, or ``None``.
+    :returns: A :class:`ResolvedCredential` describing the Gemini key, or
+        ``None`` when no key is configured or ambient.
+    """
+    from omnigent.onboarding.antigravity_auth import (
+        ANTIGRAVITY_ENV_VARS,
+        antigravity_api_key_ref,
+    )
+
+    ref = antigravity_api_key_ref(config)
+    if ref is None:
+        ambient = next((var for var in ANTIGRAVITY_ENV_VARS if os.environ.get(var)), None)
+        if ambient is None:
+            return None
+        ref = f"env:{ambient}"
+    return ResolvedCredential(
+        # Literal (== KEY_KIND) so it types as ProviderKind, not bare str.
+        provider_name="antigravity",
+        kind="key",
+        family=None,
+        model=model_override,
+        source=ref,
+        base_url=None,
+    )
+
+
 def describe_active_credential(
     config: dict[str, object],
     harness: str,
@@ -1085,6 +1155,13 @@ def describe_active_credential(
     :raises OmnigentError: If the resolved provider is malformed, or more
         than one default serves the family.
     """
+    if canonicalize_harness(harness) == "antigravity":
+        # Antigravity is Gemini-native: its credential is NOT a ``providers:``
+        # entry (its family-keyed default would be the OpenAI one, which it
+        # can never use). Describe the Gemini key from the dedicated
+        # ``antigravity:`` block / ambient env var, or Vertex AI, instead.
+        return _describe_antigravity_credential(config, model_override)
+
     provider = default_provider_for_harness(config, harness)
     if provider is None:
         return None

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -1103,17 +1103,30 @@ def _describe_antigravity_credential(
     ``base_url`` (the SDK has no OpenAI-compatible endpoint), and the model is
     whatever the session pinned (no provider default to fall back on).
 
+    The configured reference is *resolved* before it is reported: a dangling
+    ``env:MISSING`` / keychain reference (whose secret no longer exists) reads
+    as not-configured, matching what ``_build_antigravity_spawn_env`` would
+    actually thread (it uses :func:`resolve_antigravity_api_key`, which omits an
+    unresolvable ref). Reporting an unresolved ref would overclaim an active
+    credential the spawn path silently drops.
+
     :param config: The parsed config mapping (the ``antigravity:`` block).
     :param model_override: The in-session ``/model`` override, or ``None``.
     :returns: A :class:`ResolvedCredential` describing the Gemini key, or
-        ``None`` when no key is configured or ambient.
+        ``None`` when no key is configured (or its reference is dangling) and
+        none is ambient.
     """
     from omnigent.onboarding.antigravity_auth import (
         ANTIGRAVITY_ENV_VARS,
         antigravity_api_key_ref,
+        resolve_antigravity_api_key,
     )
 
+    # Resolve, don't just read: a configured-but-dangling ref must not be
+    # reported as active, since the spawn path would drop it (see docstring).
     ref = antigravity_api_key_ref(config)
+    if ref is not None and resolve_antigravity_api_key(config) is None:
+        ref = None
     if ref is None:
         ambient = next((var for var in ANTIGRAVITY_ENV_VARS if os.environ.get(var)), None)
         if ambient is None:

--- a/omnigent/onboarding/wizard.py
+++ b/omnigent/onboarding/wizard.py
@@ -390,18 +390,19 @@ _CLI_HARNESSES: dict[str, dict[str, str]] = {
 
 # Pure-Python harnesses (no CLI binary needed, but require a Python package).
 # Need API credentials (env var or Databricks profile).
+#
+# NB: ``antigravity`` is intentionally absent. The supervisor sub-step routes
+# every non-``_CLI_HARNESSES`` choice through ``_prompt_openai_agents_config``,
+# which hard-codes ``harness="openai-agents"`` — offering Antigravity here
+# would silently produce an openai-agents supervisor spec. Antigravity is also
+# Gemini-native (Gemini API key or Vertex AI, never an OpenAI gateway), so it
+# needs its own credential flow before it can be offered as a supervisor.
 _API_HARNESSES: dict[str, dict[str, str]] = {
     "openai-agents": {
         "display": "OpenAI Agents",
         "description": "OpenAI API or any OpenAI-compatible endpoint",
         "package": "agents",
         "install": "pip install openai-agents",
-    },
-    "antigravity": {
-        "display": "Antigravity (Gemini)",
-        "description": "Antigravity / Gemini API key, or an OpenAI-compatible gateway",
-        "package": "google.antigravity",
-        "install": "pip install google-antigravity",
     },
 }
 

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -378,6 +378,18 @@ def _build_startup_header(
     if len(families) > 1:
         parts: list[str] = []
         for fam in families:
+            if fam == "antigravity":
+                # Gemini-native surface: resolve its dedicated credential, not a
+                # ``providers:`` family default (which would be the OpenAI one
+                # it can never use). describe_active_credential special-cases it.
+                cred = describe_active_credential(config, "antigravity")
+                if cred is None:
+                    label = "not configured"
+                else:
+                    cred_text = credential_label(cred.kind, cred.provider_name)
+                    label = f"{_header_glyph(cred.kind)} {cred_text}".strip()
+                parts.append(f"Gemini → {label}")
+                continue
             # Effective per-surface default — for the pi surface this is
             # what the pi harness would actually route through (explicit
             # pi scope, else the cross-family fallback).
@@ -4114,6 +4126,7 @@ def _build_model_readout_lines(
         ``["Active:  claude-sonnet-4-6  ·  🔑 Anthropic API Key  ·  $ANTHROPIC_API_KEY",
         "Also configured:  🧱 Databricks", "  /model <name> changes the model. …"]``.
     """
+    from omnigent.harness_aliases import canonicalize_harness
     from omnigent.onboarding.configure_models import (
         credential_label,
         kind_glyph,
@@ -4164,6 +4177,13 @@ def _build_model_readout_lines(
     # "Claude"), a key names the vendor + "API Key", Databricks names itself.
     provider_label = f"{glyph} {credential_label(cred.kind, cred.provider_name)}".strip()
     lines.append(f"Active:  {model_label}  ·  {provider_label}  ·  {cred.source}")
+
+    # Antigravity is Gemini-native: no ``providers:`` entry can serve it, so
+    # there are no in-surface provider alternatives to list (its ``openai``
+    # _HARNESS_FAMILY entry is for family-keyed lookups only). Stop after the
+    # Active line — listing OpenAI providers here would be misleading.
+    if canonicalize_harness(harness) == "antigravity":
+        return lines
 
     # List the OTHER configured providers that serve THIS harness's family,
     # so the user only sees relevant alternatives (a Codex run shouldn't list

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -379,10 +379,12 @@ _PROVIDER_HARNESS_FAMILY: dict[AgentHarnessType, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
     "openai-agents-sdk": OPENAI_FAMILY,
-    # Antigravity is Gemini-native but routes generic-provider traffic over
-    # the OpenAI-compatible wire (OpenRouter / LiteLLM / Databricks gateway),
-    # so it consumes the ``openai`` family like openai-agents-sdk.
-    "antigravity": OPENAI_FAMILY,
+    # NB: ``antigravity`` is intentionally absent. It is Gemini-native (a
+    # direct API key or Vertex AI) with no OpenAI-compatible ``base_url``, so
+    # it cannot consume a generic provider / gateway — the guard at the top of
+    # ``configure_agent_harness_with_provider`` rejects it before either reader
+    # of this map runs. Omitting it makes a future routing bug fail loud
+    # (KeyError) rather than silently route Gemini traffic over an OpenAI wire.
 }
 
 # Maps harnesses that gate the vendor-neutral gateway transport on a

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -1759,6 +1759,19 @@ def _translate_executor_from_def(
         use_responses_raw = raw_executor.get("use_responses")
         if use_responses_raw is not None:
             config["use_responses"] = bool(use_responses_raw)
+        # The antigravity harness opts into Vertex AI via
+        # ``executor.config`` vertex/project/location, which
+        # ``_build_antigravity_spawn_env`` reads to thread
+        # ``HARNESS_ANTIGRAVITY_VERTEX`` / ``_PROJECT`` / ``_LOCATION``.
+        # Like ``use_responses``, none of these are fields on the
+        # omnigent inner ExecutorSpec (the loader drops unknown keys), so
+        # recover them from the raw YAML and carry them forward — without
+        # this, the documented Vertex config shape would never reach the
+        # spawn-env builder. Each key is preserved only when present, so a
+        # non-Vertex executor's config stays untouched.
+        for _vertex_key in ("vertex", "project", "location"):
+            if _vertex_key in raw_executor:
+                config[_vertex_key] = raw_executor[_vertex_key]
         # ``auth:`` is also not in the omnigent datamodel — parse it
         # directly from the raw YAML so YAML-declared auth is not
         # silently dropped and overridden by the global config default.

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2827,6 +2827,48 @@ def test_spec_used_families_multi_vendor_directory_agent(tmp_path) -> None:
     assert _spec_used_families(root) == ["anthropic", "openai"]
 
 
+def test_spec_used_families_antigravity_is_own_surface_not_openai(tmp_path: Path) -> None:
+    """An antigravity sub-agent contributes a ``google``-native surface, not openai.
+
+    The regression this guards: ``harness_family("antigravity")`` is ``"openai"``
+    (a family-keyed lookup convenience), so the walk used to fold a Gemini-native
+    antigravity sub-agent into the ``openai`` surface. The multi-surface startup
+    header would then resolve that surface to the OpenAI provider default and
+    print an OpenAI credential for a Gemini-native worker. The walk must instead
+    contribute antigravity's own surface (``"antigravity"``), which
+    ``_build_startup_header`` special-cases to the dedicated Gemini credential.
+    """
+    root = tmp_path / "orchestrator"
+    (root / "agents" / "gemini_worker").mkdir(parents=True)
+    (root / "config.yaml").write_text(
+        "spec_version: 1\n"
+        "name: orchestrator\n"
+        "prompt: orchestrate\n"
+        "executor:\n"
+        "  type: omnigent\n"
+        "  config:\n"
+        "    harness: claude-sdk\n"
+        "tools:\n"
+        "  agents:\n"
+        "    - gemini_worker\n"
+    )
+    (root / "agents" / "gemini_worker" / "config.yaml").write_text(
+        "spec_version: 1\n"
+        "name: gemini_worker\n"
+        "prompt: work\n"
+        "executor:\n"
+        "  type: omnigent\n"
+        "  config:\n"
+        "    harness: antigravity\n"
+    )
+
+    families = _spec_used_families(root)
+    # The orchestrator's anthropic surface plus antigravity's OWN surface.
+    assert families == ["anthropic", "antigravity"]
+    # Crucially the Gemini-native worker is NOT folded into the openai surface.
+    assert "openai" not in families
+
+
 def test_spec_used_families_degrades_gracefully() -> None:
     """``_spec_used_families`` returns ``[]`` for the no-spec / standalone cases.
 

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -427,3 +427,80 @@ def test_describe_active_credential_cli_config() -> None:
     # No inline endpoint/model: both live in the CLI's own config.
     assert cred.base_url is None
     assert cred.model is None
+
+
+def test_describe_active_credential_antigravity_reports_gemini_not_openai(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The /model readout names the Gemini key for an antigravity harness.
+
+    The regression this guards: ``harness_family("antigravity")`` is
+    ``"openai"`` (a family-keyed lookup convenience), so the readout used to
+    resolve the OpenAI default provider and show an OpenAI credential for a
+    Gemini-native agent. It must instead describe the ``antigravity:`` block's
+    Gemini key — with no ``openai`` family / base_url — even when an OpenAI
+    provider is the configured default.
+    """
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    monkeypatch.setenv("MY_GEMINI", "AIza-test")
+    config = {
+        "antigravity": {"api_key_ref": "env:MY_GEMINI"},
+        "providers": {
+            "openai": {
+                "kind": "key",
+                "default": True,
+                "openai": {"base_url": "https://api.openai.com/v1", "api_key": "$OPENAI_API_KEY"},
+            }
+        },
+    }
+    cred = describe_active_credential(config, "antigravity")
+    assert cred is not None
+    assert cred.provider_name == "antigravity"
+    assert cred.kind == "key"
+    # Crucially NOT the openai family / its base_url.
+    assert cred.family is None
+    assert cred.base_url is None
+    assert cred.source == "env:MY_GEMINI"
+
+
+def test_describe_active_credential_antigravity_alias_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The readout special-case also fires for the ``agy`` alias spelling."""
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    monkeypatch.setenv("MY_GEMINI", "AIza-test")
+    config = {"antigravity": {"api_key_ref": "env:MY_GEMINI"}}
+    cred = describe_active_credential(config, "agy")
+    assert cred is not None
+    assert cred.provider_name == "antigravity"
+
+
+def test_describe_active_credential_antigravity_none_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no Gemini key (block or ambient), the antigravity readout is None."""
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    for var in ("GEMINI_API_KEY", "ANTIGRAVITY_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    assert describe_active_credential({}, "antigravity") is None
+
+
+def test_provider_family_for_harness_antigravity_is_google() -> None:
+    """Antigravity reports its own ``google`` family, not ``openai``.
+
+    The fork/switch model-carry decision (server ``_same_provider_family`` /
+    the ap-web ``harnessFamily`` reset hint) keys off this. Reporting
+    ``openai`` would (1) wrongly copy an OpenAI model id into a Gemini-native
+    agent on a codex→antigravity switch, and (2) disagree with the UI, which
+    reports ``google``. Accepts the alias spellings too.
+    """
+    from omnigent.onboarding.provider_config import GOOGLE_FAMILY
+
+    assert provider_family_for_harness("antigravity") == GOOGLE_FAMILY
+    assert provider_family_for_harness("agy") == GOOGLE_FAMILY
+    assert provider_family_for_harness("google-antigravity") == GOOGLE_FAMILY
+    # It is distinct from openai, so a codex↔antigravity switch is cross-family.
+    assert provider_family_for_harness("antigravity") != provider_family_for_harness("codex")

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -488,6 +488,50 @@ def test_describe_active_credential_antigravity_none_when_unconfigured(
     assert describe_active_credential({}, "antigravity") is None
 
 
+def test_describe_active_credential_antigravity_dangling_ref_reads_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dangling ``env:`` antigravity ref reads as NOT configured in the readout.
+
+    The regression this guards: the readout used to report an active credential
+    whenever the ``antigravity:`` block carried a reference, WITHOUT resolving
+    it. A dangling ``env:MISSING`` / keychain ref (whose secret no longer exists)
+    would then show an active Gemini credential in ``/model`` / the startup
+    header — yet ``_build_antigravity_spawn_env`` uses
+    ``resolve_antigravity_api_key`` and silently omits it, so the worker runs
+    with no key. The readout must resolve the ref first and mark it unconfigured
+    when resolution fails. With no ambient Gemini var either, the readout is
+    ``None``.
+    """
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    for var in ("GEMINI_API_KEY", "ANTIGRAVITY_API_KEY", "MISSING_GEMINI"):
+        monkeypatch.delenv(var, raising=False)
+    # The block references an env var that is not set — a dangling ref.
+    config = {"antigravity": {"api_key_ref": "env:MISSING_GEMINI"}}
+    assert describe_active_credential(config, "antigravity") is None
+
+
+def test_describe_active_credential_antigravity_dangling_ref_falls_back_to_ambient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dangling config ref does not suppress a genuinely-present ambient key.
+
+    Complement to the dangling-ref test: when the configured ref does not
+    resolve but an ambient ``GEMINI_API_KEY`` IS set, the readout reports the
+    ambient credential (mirroring the spawn-env fallback), not ``None``.
+    """
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    monkeypatch.delenv("ANTIGRAVITY_API_KEY", raising=False)
+    monkeypatch.delenv("MISSING_GEMINI", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "AIza-ambient")
+    config = {"antigravity": {"api_key_ref": "env:MISSING_GEMINI"}}
+    cred = describe_active_credential(config, "antigravity")
+    assert cred is not None
+    assert cred.source == "env:GEMINI_API_KEY"
+
+
 def test_provider_family_for_harness_antigravity_is_google() -> None:
     """Antigravity reports its own ``google`` family, not ``openai``.
 

--- a/tests/onboarding/test_wizard_supervisor.py
+++ b/tests/onboarding/test_wizard_supervisor.py
@@ -1,0 +1,62 @@
+"""Tests for the ``omnigent setup`` supervisor-harness offering (wizard.py).
+
+The supervisor sub-step (:func:`omnigent.onboarding.wizard._prompt_supervisor`)
+routes a CLI choice to :func:`_prompt_cli_supervisor_config` and EVERY other
+choice to :func:`_prompt_openai_agents_config`, which hard-codes
+``harness="openai-agents"``. So any harness offered as a supervisor that is
+neither a CLI harness nor openai-agents would silently produce an
+openai-agents spec. These tests pin that invariant — the reason antigravity
+(Gemini-native, and with no supervisor credential flow yet) is not offered.
+"""
+
+from __future__ import annotations
+
+from omnigent.onboarding import wizard
+
+
+def test_antigravity_not_offered_as_supervisor() -> None:
+    """Antigravity must not appear among the offerable supervisor harnesses.
+
+    Offering it would route through ``_prompt_openai_agents_config`` and
+    hand back an openai-agents spec for a user who picked Antigravity.
+    """
+    assert "antigravity" not in wizard._API_HARNESSES
+    assert "antigravity" not in wizard._CLI_HARNESSES
+
+
+def test_api_harness_descriptions_have_no_openai_gateway_clause_for_gemini() -> None:
+    """No offered API harness advertises an OpenAI gateway it can't use.
+
+    Specifically, the dropped antigravity entry described itself as offering
+    "an OpenAI-compatible gateway", which is false for the Gemini-native SDK.
+    """
+    assert all(
+        "antigravity" not in info["description"].lower() for info in wizard._API_HARNESSES.values()
+    )
+
+
+def test_every_offerable_api_supervisor_builds_its_own_harness() -> None:
+    """Each ``_API_HARNESSES`` entry must not silently become openai-agents.
+
+    The dispatch sends any non-CLI choice to ``_prompt_openai_agents_config``
+    (``harness="openai-agents"``). So the only API harness safe to offer today
+    is openai-agents itself; any other key would be mis-built. This guards
+    against a future re-add of a non-openai harness without a real branch.
+    """
+    for harness in wizard._API_HARNESSES:
+        assert harness == "openai-agents", (
+            f"{harness!r} is offered as a supervisor but the dispatch would build it as "
+            "'openai-agents'; add a dedicated config branch before offering it."
+        )
+
+
+def test_openai_agents_config_builder_is_pinned_to_openai_agents() -> None:
+    """The non-CLI supervisor builder still hard-codes ``openai-agents``.
+
+    This is the property that makes offering any OTHER harness here a bug —
+    documenting why the dispatch's ``else`` branch is openai-agents-only.
+    """
+    import inspect
+
+    src = inspect.getsource(wizard._prompt_openai_agents_config)
+    assert 'harness="openai-agents"' in src

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -11,6 +11,7 @@ tab) or an unrelated tool result to skip.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from prompt_toolkit.document import Document
@@ -1623,6 +1624,145 @@ def test_build_startup_header_creds_line_includes_pi_surface(tmp_path, monkeypat
     # explicit pi-scoped Databricks default, not the subscription.
     assert header.credential is not None
     assert "Databricks" in header.credential
+
+
+# ── Antigravity: Gemini-native /model + startup-header readouts ──
+
+
+def test_model_readout_antigravity_names_gemini_not_openai(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/model`` for an antigravity harness names the Gemini key, not OpenAI.
+
+    The regression this guards: ``harness_family("antigravity")`` is ``"openai"``,
+    so the readout used to resolve the OpenAI default provider and (a) show an
+    OpenAI credential on the Active line and (b) list OpenAI providers under
+    "Also configured" — for a Gemini-native agent that can never use them. Even
+    with an OpenAI provider configured as the default, the readout must name the
+    ``antigravity:`` block's Gemini key and list NO in-surface alternatives.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    monkeypatch.setenv("MY_GEMINI", "AIza-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai")
+    config = {
+        "antigravity": {"api_key_ref": "env:MY_GEMINI"},
+        "providers": {
+            "openai": {
+                "kind": "key",
+                "default": True,
+                "openai": {"base_url": "https://api.openai.com/v1", "api_key": "$OPENAI_API_KEY"},
+            }
+        },
+    }
+    lines = _build_model_readout_lines(config, "antigravity", "gemini-2.0-flash")
+    joined = "\n".join(lines)
+    assert "Active:" in lines[0]
+    assert "gemini-2.0-flash" in lines[0]
+    assert "Antigravity" in lines[0]  # the Gemini-native credential is named
+    assert "env:MY_GEMINI" in lines[0]
+    # No OpenAI credential or "Also configured" provider alternatives leak in.
+    assert "OpenAI" not in joined
+    assert "Also configured" not in joined
+
+
+def test_model_readout_antigravity_dangling_ref_reads_unconfigured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/model`` for antigravity reads NOT configured for a dangling key ref.
+
+    Mirrors what ``_build_antigravity_spawn_env`` actually threads: a dangling
+    ``env:MISSING`` ref (whose var is unset) resolves to no key, so the spawn
+    path runs with no credential. The readout must therefore show "no model
+    configured" rather than printing the dangling ref as an active credential —
+    otherwise it advertises a phantom credential the worker never receives.
+
+    An OpenAI provider is configured as the default precisely to pin the
+    regression: pre-fix, the antigravity readout resolved the family default
+    (``harness_family("antigravity") == "openai"``) and would report THAT
+    OpenAI credential as active for a Gemini-native, no-key agent. The fix
+    special-cases antigravity to its dedicated (dangling → unresolved) Gemini
+    ref, so the readout is honestly unconfigured.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai")
+    for var in ("GEMINI_API_KEY", "ANTIGRAVITY_API_KEY", "MISSING_GEMINI"):
+        monkeypatch.delenv(var, raising=False)
+    config = {
+        "antigravity": {"api_key_ref": "env:MISSING_GEMINI"},
+        "providers": {
+            "openai": {
+                "kind": "key",
+                "default": True,
+                "openai": {"base_url": "https://api.openai.com/v1", "api_key": "$OPENAI_API_KEY"},
+            }
+        },
+    }
+    lines = _build_model_readout_lines(config, "antigravity", None)
+    joined = "\n".join(lines)
+    assert "no model configured" in joined
+    # The dangling ref must NOT appear as an active credential source.
+    assert "env:MISSING_GEMINI" not in joined
+    # And crucially the OpenAI default must NOT be reported as the credential.
+    assert "OpenAI" not in joined
+
+
+def test_build_startup_header_antigravity_surface_resolves_gemini(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The multi-surface header resolves the antigravity surface to its Gemini key.
+
+    A claude-sdk brain with an antigravity sub-agent surfaces
+    ``["anthropic", "antigravity"]``. The antigravity segment must read its
+    dedicated Gemini credential ("Gemini → 🔑 Antigravity API Key"), NOT the
+    OpenAI provider default. A regression that resolved it via the plain
+    per-family lookup would render the OpenAI credential (or "openai") in the
+    Gemini segment.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MY_GEMINI", "AIza-test")
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "antigravity:\n"
+        "  api_key_ref: env:MY_GEMINI\n"
+        "providers:\n"
+        "  anth:\n"
+        "    kind: subscription\n"
+        "    cli: claude\n"
+        "    default: anthropic\n"
+    )
+    header = _build_startup_header("claude-sdk", "An agent.", ["anthropic", "antigravity"])
+    assert header.creds_line is not None
+    assert "Gemini → 🔑 Antigravity API Key" in header.creds_line
+    # The Gemini segment must not leak an OpenAI credential.
+    assert "OpenAI" not in header.creds_line
+    assert "Gemini → not configured" not in header.creds_line
+
+
+def test_build_startup_header_antigravity_surface_unconfigured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The antigravity header segment reads 'not configured' with no Gemini key.
+
+    The complement: with no Gemini credential (block ref dangling / absent and
+    no ambient var), the antigravity surface reads "Gemini → not configured"
+    rather than fabricating the OpenAI provider default.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "ANTIGRAVITY_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n  anth:\n    kind: subscription\n    cli: claude\n    default: anthropic\n"
+    )
+    header = _build_startup_header("claude-sdk", "An agent.", ["anthropic", "antigravity"])
+    assert header.creds_line is not None
+    assert "Gemini → not configured" in header.creds_line
 
 
 # ── Ctrl+O overlay: paginated conversation_items fetch ──────

--- a/tests/spec/test_omnigent_adapter.py
+++ b/tests/spec/test_omnigent_adapter.py
@@ -2190,6 +2190,81 @@ def test_use_responses_absent_omits_key_from_executor_config() -> None:
     assert "use_responses" not in spec.executor.config
 
 
+def test_antigravity_vertex_config_propagates_to_executor_config() -> None:
+    """
+    ``executor.config`` vertex/project/location in an omnigent YAML land on
+    ``spec.executor.config`` after ``agent_def_to_agent_spec``.
+
+    Like ``use_responses``, none of these are fields on the inner
+    ``ExecutorSpec`` dataclass (``omnigent.inner.datamodel``), so the omnigent
+    YAML loader silently drops them. We must read them from the raw YAML dict
+    and carry them forward explicitly.
+
+    What breaks if this fails: ``_build_antigravity_spawn_env`` finds
+    ``config.get("vertex")`` falsy, so it never sets ``HARNESS_ANTIGRAVITY_VERTEX``
+    / ``_PROJECT`` / ``_LOCATION``. The documented Vertex config shape
+    (``executor.config.vertex/project/location``) then silently does nothing for
+    users who follow the docs — the harness falls back to ambient Gemini creds.
+    """
+    agent_def, raw_yaml = _build_agent_def_with_raw_yaml()
+    raw_yaml["executor"] = {
+        "model": "gemini-2.0-flash",
+        "harness": "antigravity",
+        "vertex": True,
+        "project": "my-gcp-project",
+        "location": "us-central1",
+    }
+    spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw_yaml)
+    assert spec.executor.config.get("vertex") is True
+    assert spec.executor.config.get("project") == "my-gcp-project"
+    assert spec.executor.config.get("location") == "us-central1"
+
+
+def test_antigravity_vertex_config_reaches_spawn_env() -> None:
+    """
+    A carried-through Vertex ``executor.config`` produces the
+    ``HARNESS_ANTIGRAVITY_VERTEX`` / ``_PROJECT`` / ``_LOCATION`` spawn env.
+
+    End-to-end guard tying the adapter carry-through to the consumer: the keys
+    must not only survive translation but also reach
+    ``_build_antigravity_spawn_env``, which is what the docs promise.
+    """
+    from omnigent.runtime.workflow import _build_antigravity_spawn_env
+
+    agent_def, raw_yaml = _build_agent_def_with_raw_yaml()
+    raw_yaml["executor"] = {
+        "model": "gemini-2.0-flash",
+        "harness": "antigravity",
+        "vertex": True,
+        "project": "my-gcp-project",
+        "location": "us-central1",
+    }
+    spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw_yaml)
+    env = _build_antigravity_spawn_env(spec)
+    assert env["HARNESS_ANTIGRAVITY_VERTEX"] == "1"
+    assert env["HARNESS_ANTIGRAVITY_PROJECT"] == "my-gcp-project"
+    assert env["HARNESS_ANTIGRAVITY_LOCATION"] == "us-central1"
+
+
+def test_antigravity_vertex_config_absent_omits_keys_from_executor_config() -> None:
+    """
+    When the omnigent YAML omits vertex/project/location, none of the keys
+    appear in ``spec.executor.config`` (a non-Vertex executor stays untouched).
+
+    ``_build_antigravity_spawn_env`` keys off ``config.get("vertex")``; a missing
+    key leaves the api-key / ambient path in force.
+    """
+    agent_def, raw_yaml = _build_agent_def_with_raw_yaml()
+    raw_yaml["executor"] = {
+        "model": "gemini-2.0-flash",
+        "harness": "antigravity",
+    }
+    spec = agent_def_to_agent_spec(agent_def, raw_yaml=raw_yaml)
+    assert "vertex" not in spec.executor.config
+    assert "project" not in spec.executor.config
+    assert "location" not in spec.executor.config
+
+
 def test_unknown_policy_type_rejected_with_clear_message() -> None:
     """
     A policy with an unrecognized ``type:`` value fails with an

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -417,6 +417,126 @@ def test_resolve_provider_global_auth_consumed_by_claude_sdk_not_codex(
     assert codex.kind == "none"
 
 
+# ── Antigravity: Gemini-native, never an OpenAI-family provider ────
+
+
+def test_resolve_provider_antigravity_named_provider_does_not_overreport(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An antigravity spec naming an OpenAI provider resolves to ``none``.
+
+    The regression this guards: antigravity used to share the generic
+    ``_resolve_provider_for_build`` path, so a ``ProviderAuth`` (or a
+    configured default) resolved to an ``openai``-family ``key`` entry and
+    ``sys_list_models`` advertised OpenAI/gateway models the Gemini-native
+    spawn path can never reach (``configure_agent_harness_with_provider``
+    rejects the antigravity harness outright). It must now report ``none``.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    from omnigent.spec.types import ProviderAuth
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai")
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n"
+        "  litellm:\n"
+        "    kind: gateway\n"
+        "    openai:\n"
+        "      base_url: https://gw.example.com/v1\n"
+        "      api_key: $OPENAI_API_KEY\n",
+    )
+    spec = _worker_spec("antigravity", auth=ProviderAuth(name="litellm"))
+    provider = resolve_model_provider(spec, "antigravity")
+    assert provider.kind == "none", provider
+    assert "antigravity" in provider.detail
+
+
+def test_resolve_provider_antigravity_default_provider_does_not_overreport(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured OpenAI default never resolves for an antigravity worker.
+
+    A default ``openai`` provider must NOT be adopted by antigravity (it has
+    no spec auth), since its spawn path can't consume it.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai")
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n"
+        "  openai:\n"
+        "    kind: key\n"
+        "    default: true\n"
+        "    openai:\n"
+        "      base_url: https://api.openai.com/v1\n"
+        "      api_key: $OPENAI_API_KEY\n",
+    )
+    provider = resolve_model_provider(_worker_spec("antigravity"), "antigravity")
+    assert provider.kind == "none", provider
+
+
+def test_resolve_provider_antigravity_api_key_resolves_without_openai_family(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An antigravity spec ``api_key`` resolves to ``none`` (no listing endpoint).
+
+    The Gemini key IS the credential the spawn path threads, but there is no
+    enumerable Gemini listing endpoint, so the catalog reports ``none`` with a
+    detail that records the credential — never an ``openai`` family / base_url.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    spec = _worker_spec("antigravity", auth=ApiKeyAuth(api_key="AIza-test"))
+    provider = resolve_model_provider(spec, "antigravity")
+    assert provider.kind == "none"
+    assert provider.family is None
+    assert provider.base_url is None
+    assert "api_key" in provider.detail
+
+
+def test_resolve_provider_antigravity_vertex_resolves_to_none_with_detail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An antigravity Vertex spec reports ``none`` with a Vertex detail.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    spec = AgentSpec(
+        spec_version=1,
+        name="worker",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity", "vertex": True}),
+    )
+    provider = resolve_model_provider(spec, "antigravity")
+    assert provider.kind == "none"
+    assert "Vertex" in provider.detail
+
+
+def test_resolve_provider_antigravity_unconfigured_is_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With no Gemini credential anywhere, antigravity resolves to ``none``.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    for var in ("GEMINI_API_KEY", "ANTIGRAVITY_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    _isolate_config(monkeypatch, tmp_path, "")
+    provider = resolve_model_provider(_worker_spec("antigravity"), "antigravity")
+    assert provider.kind == "none"
+    assert "no Gemini credential" in provider.detail
+
+
 # ── Enumeration per provider kind ──────────────────────────
 
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -537,6 +537,74 @@ def test_resolve_provider_antigravity_unconfigured_is_none(
     assert "no Gemini credential" in provider.detail
 
 
+# ── Antigravity: runnable-but-non-enumerable vs. genuinely unusable ──
+
+
+def test_antigravity_api_key_listing_is_runnable_not_dead(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured antigravity (api-key) worker reads as runnable, not dead.
+
+    The regression this guards: ``_listing_for_provider`` used to render every
+    ``kind="none"`` provider — including a Gemini-native antigravity worker
+    holding a credential — as "cannot run here," telling orchestrators a valid
+    worker was unusable. A worker with an api-key CAN run; only its models are
+    non-enumerable. The listing must say so (``source="runnable"``) and never
+    emit the dead-worker signal.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    spec = _worker_spec("antigravity", auth=ApiKeyAuth(api_key="AIza-test"))
+    listing = list_models_for_worker(spec, "antigravity")
+    assert listing.source == "runnable"
+    assert listing.models == ()
+    assert "can run" in listing.note
+    assert "cannot run here" not in listing.note
+
+
+def test_antigravity_vertex_listing_is_runnable_not_dead(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured antigravity Vertex worker also reads as runnable.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    spec = AgentSpec(
+        spec_version=1,
+        name="worker",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity", "vertex": True}),
+    )
+    listing = list_models_for_worker(spec, "antigravity")
+    assert listing.source == "runnable"
+    assert listing.models == ()
+    assert "cannot run here" not in listing.note
+
+
+def test_antigravity_unconfigured_listing_reads_as_dead(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A keyless antigravity worker still reads as unusable (dead-worker signal).
+
+    The complement to the runnable cases: with no Gemini credential anywhere,
+    the worker genuinely cannot run, so the listing must keep the
+    ``source="none"`` "cannot run here" preflight signal.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    for var in ("GEMINI_API_KEY", "ANTIGRAVITY_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    _isolate_config(monkeypatch, tmp_path, "")
+    listing = list_models_for_worker(_worker_spec("antigravity"), "antigravity")
+    assert listing.source == "none"
+    assert listing.models == ()
+    assert "cannot run here" in listing.note
+
+
 # ── Enumeration per provider kind ──────────────────────────
 
 

--- a/tests/tools/builtins/test_list_models.py
+++ b/tests/tools/builtins/test_list_models.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-from omnigent.spec.types import AgentSpec
+import pytest
+
+from omnigent.spec.types import AgentSpec, ApiKeyAuth, ExecutorSpec
 from omnigent.tools.base import ToolContext
 from omnigent.tools.builtins.list_models import SysListModelsTool
 
@@ -18,6 +21,21 @@ def _make_spec() -> AgentSpec:
 
 def _ctx() -> ToolContext:
     return ToolContext(task_id="task_test", agent_id="agent_test")
+
+
+def _isolate_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the provider-config layer at an empty isolated config.
+
+    So ``catalog_for_spec`` resolves against a known-empty config (no
+    ``providers:`` default, no keyring) instead of the developer's real one.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir for the config file.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    (tmp_path / "config.yaml").write_text("")
 
 
 # ── Schema ───────────────────────────────────────────────
@@ -68,3 +86,77 @@ def test_invoke_returns_catalog(
     parsed = json.loads(result)
     assert "self" in parsed
     assert parsed["self"]["models"][0]["id"] == "gpt-4o"
+
+
+# ── End-to-end: an antigravity worker's row in the real tool payload ──
+
+
+def test_invoke_antigravity_worker_reports_runnable_not_dead_or_openai(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured antigravity sub-agent surfaces as runnable-non-enumerable.
+
+    End-to-end through the REAL ``catalog_for_spec`` (no mock): the JSON an
+    orchestrator actually receives from ``sys_list_models`` for a Gemini-native
+    antigravity worker holding an api-key must say the worker CAN run
+    (``source="runnable"``, empty models, a "can run" note) — NOT the dead-worker
+    ``source="none"`` "cannot run here" signal, and NOT a fabricated OpenAI-family
+    model list. This is the surface the dispatch-preflight reads, so the row's
+    semantics (runnable vs dead) are load-bearing.
+    """
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTIGRAVITY_API_KEY", raising=False)
+    _isolate_config(monkeypatch, tmp_path)
+    parent = AgentSpec(
+        spec_version=1,
+        name="orchestrator",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
+        sub_agents=[
+            AgentSpec(
+                spec_version=1,
+                name="gemini_worker",
+                executor=ExecutorSpec(
+                    type="omnigent",
+                    config={"harness": "antigravity"},
+                    auth=ApiKeyAuth(api_key="AIza-test"),
+                ),
+            ),
+        ],
+    )
+    payload = json.loads(SysListModelsTool(spec=parent).invoke("{}", _ctx()))
+    row = payload["gemini_worker"]
+    assert row["source"] == "runnable"
+    assert row["models"] == []
+    assert "can run" in row["note"]
+    assert "cannot run here" not in row["note"]
+
+
+def test_invoke_antigravity_unconfigured_worker_reads_dead(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A keyless antigravity sub-agent keeps the dead-worker preflight signal.
+
+    The complement to the runnable case: with no Gemini credential anywhere, the
+    worker genuinely cannot run, so its ``sys_list_models`` row must read
+    ``source="none"`` with the "cannot run here" note.
+    """
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTIGRAVITY_API_KEY", raising=False)
+    _isolate_config(monkeypatch, tmp_path)
+    parent = AgentSpec(
+        spec_version=1,
+        name="orchestrator",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-sdk"}),
+        sub_agents=[
+            AgentSpec(
+                spec_version=1,
+                name="gemini_worker",
+                executor=ExecutorSpec(type="omnigent", config={"harness": "antigravity"}),
+            ),
+        ],
+    )
+    payload = json.loads(SysListModelsTool(spec=parent).invoke("{}", _ctx()))
+    row = payload["gemini_worker"]
+    assert row["source"] == "none"
+    assert row["models"] == []
+    assert "cannot run here" in row["note"]


### PR DESCRIPTION
## Why

Antigravity is **Gemini-native**: it authenticates with a direct Gemini API key or Vertex AI and **never** routes through an OpenAI-compatible gateway or Databricks. Several small, independent issues across the merged antigravity work shared one root cause — it was being treated as an OpenAI-family / gateway harness. The `configure_agent_harness_with_provider` guard already rejects generic-provider routing for it; this PR makes the surrounding docs, wizard, catalog, comments, readout, and web UI consistent with that reality.

## Sub-fixes applied

1. **Docs** (`docs/AGENT_YAML_SPEC.md`): removed the contradictory gateway/provider/databricks instructions from the Antigravity section (it had said "no OpenAI-compatible gateway / Databricks path" and then told you to use `auth: {type: provider}` / `auth.base_url` / `auth: {type: databricks}`). Now only documents the Gemini API key and Vertex AI paths.

2. **Wizard** (`omnigent/onboarding/wizard.py`): removed `antigravity` from `_API_HARNESSES`. The supervisor sub-step special-cases only `_CLI_HARNESSES`, so picking "Antigravity" fell through to `_prompt_openai_agents_config()` and silently produced an `openai-agents` spec. Also drops the false "OpenAI-compatible gateway" clause from its description. (Deferred the alternative — a real antigravity supervisor branch with a Gemini/Vertex credential prompt — since it needs its own flow; not offering it is the safe, correct interim.)

3. **Model catalog** (`omnigent/model_catalog.py`): `_resolve_model_provider_unsafe` now special-cases antigravity to skip `_resolve_provider_for_build` (which would resolve a named/default provider into an `OPENAI_FAMILY` entry and advertise OpenAI/gateway models the worker can never run) and mirror `_build_antigravity_spawn_env` directly, reporting `kind=none` (there is no enumerable Gemini listing endpoint) with a credential-aware detail. Dropped the now-dead `antigravity` entry from `_KEY_AUTH_FAMILY` so a future routing bug fails loud.

4. **Comments / dead code** (`omnigent/runtime/workflow.py`, `omnigent/onboarding/provider_config.py`): reworded the misleading comments claiming antigravity "routes generic-provider traffic over the OpenAI-compatible wire (OpenRouter / LiteLLM / Databricks gateway)". They now state the openai-family entry exists ONLY for shared family-keyed lookups and that no gateway routing occurs. Dropped the dead `_PROVIDER_HARNESS_FAMILY["antigravity"]` entry (its only readers are precluded by the antigravity guard, so a future bypass now fails loud with a `KeyError`).

5. **Readout (L3)** (`omnigent/onboarding/provider_config.py`, `omnigent/repl/_repl.py`, `omnigent/chat.py`): `describe_active_credential`, the `/model` "Also configured" listing, and the multi-surface startup header now special-case antigravity so they report the Gemini credential (from the `antigravity:` block / ambient `GEMINI_API_KEY` / `ANTIGRAVITY_API_KEY`), or "not configured", instead of the OpenAI-family default. Verified end-to-end: a `/model` readout for an antigravity agent shows `Antigravity API Key` with no OpenAI "Also configured" line, and a mixed claude+antigravity header renders `Claude → … · Gemini → Antigravity API Key`. Chose the readout special-case over removing antigravity from `_HARNESS_FAMILY` per the lowest-risk guidance — removal would route it to the pi cross-family fallback (still anthropic/openai) and not actually fix the readout; all `_HARNESS_FAMILY` call sites (harness_readiness is SDK-gated, workflow uses a separate map, model_catalog is now special-cased) were checked.

6. **Web UI (L2)** (`ap-web/src/lib/forkHarness.ts`): `harnessFamily()` now handles `antigravity` (and the server-emitted `agy` / `google-antigravity` spellings) so the Fork/Switch dialogs offer it as an in-process SDK target like the other SDK harnesses. It reports its own `"google"` family (Gemini-native, distinct from anthropic/openai). To keep the client-side reset hint and the **server-side** fork/switch model-carry decision in agreement, `provider_family_for_harness` was made to report `GOOGLE_FAMILY` for antigravity too — so a `codex → antigravity` switch is correctly treated as cross-family and resets the provider-bound model id (it previously shared `openai` and would have copied an OpenAI model id into a Gemini-native agent).

## Tests

- Extended `tests/test_model_catalog.py` with the catalog over-report fix (named-provider, default-provider, api_key, Vertex, and unconfigured antigravity all resolve to `kind=none` with no openai family/base_url).
- Added `tests/onboarding/test_wizard_supervisor.py` pinning that antigravity is not offered as a supervisor and that the only offerable API supervisor is `openai-agents`.
- Added antigravity readout + `provider_family_for_harness` (`"google"`) tests to `tests/onboarding/test_provider_config.py`.
- Extended `ap-web/src/lib/forkHarness.test.ts` for the antigravity family + carries-history cases.

Verification: `pytest tests/onboarding/ tests/runtime/test_antigravity_spawn_env.py tests/cli/test_configure_models.py tests/test_model_catalog.py tests/repl/test_repl.py tests/cli/test_chat.py tests/server/routes/test_sessions_fork.py tests/server/routes/test_sessions_switch_agent.py tests/tools/builtins/test_list_models.py` — **all pass (747)**, plus the broader runtime/harness-readiness/antigravity suites. `ruff check` + `ruff format` clean on every changed Python file; `mypy` introduces no new errors in the changed code (pre-existing `_repl`/wizard/model_catalog errors untouched). The `ap-web` `.ts` change is source-only (not built) and was not run through vitest/oxlint, since `node_modules` is not installed and the build output is gitignored — the change is minimal (one union member + three `case` labels, matching the existing test structure).

This pull request and its description were written by Isaac.