### PR TITLE
fix(claude-native): stamp the live model in the policy hook

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3674,6 +3674,33 @@ def read_claude_context_state(bridge_dir: Path) -> dict[str, Any] | None:
     return parsed
 
 
+def read_claude_status_model(bridge_dir: Path) -> str | None:
+    """
+    Read the active model id from the statusLine snapshot ``context.json``.
+
+    Unlike :func:`read_claude_context_state` (which returns ``None`` unless a
+    usable ``context_window_size`` is present, since it backs the context
+    ring), this returns the model whenever the wrapper captured one — the
+    model and the window are written independently, and the cost-budget gate
+    needs the model even on a render where the window field was absent. This
+    is claude-native's race-free, gate-time source of the live ``/model``
+    selection (the analogue of the codex hook reading ``config.toml``).
+
+    :param bridge_dir: Bridge directory shared with the statusLine wrapper.
+    :returns: The model id, e.g. ``"claude-sonnet-4-6"``, or ``None`` when
+        the file is missing / unreadable / carries no model string.
+    """
+    path = bridge_dir / _CONTEXT_FILE
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    model = parsed.get("model")
+    return model if isinstance(model, str) and model else None
+
+
 def read_user_status_line_command() -> str | None:
     """
     Return the user's globally-configured statusLine shell command, if any.

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -17,6 +17,7 @@ from omnigent.claude_native_bridge import (
     read_active_session_id,
     read_bridge_id,
     read_claude_session_id,
+    read_claude_status_model,
     read_permission_hook_config,
     read_seen_claude_session_ids,
     record_hook_event,
@@ -779,6 +780,25 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     if eval_request is None:
         # Unrecognized hook event — no policy to evaluate.
         return 0
+
+    # Stamp the live model from this session's statusLine capture (the
+    # statusLine wrapper writes the active model id into ``context.json`` on
+    # every render — including right after an in-pane ``/model`` switch). This
+    # is the cost gate's source of truth at hook time, race-free, unlike the
+    # forwarder's async ``model_override`` mirror which lags a poll behind.
+    # Without it the cost-budget gate can see an unresolved model (None) and
+    # fail closed — blocking a cheap-model (sonnet/haiku) session over budget,
+    # even though only expensive tiers should be gated (the server prefers a
+    # stamped model over its own resolution; see ``PolicyEngine._inject_model``).
+    # hook_payload_to_evaluation_request always returns an event with a
+    # "context" dict, so index it directly (fail loud if that contract changes).
+    context = eval_request["event"]["context"]
+    # Stamp the harness so the over-budget message names claude-native's
+    # model-switch surface (the in-pane ``/model`` picker).
+    context["harness"] = "claude-native"
+    status_model = read_claude_status_model(bridge_dir)
+    if status_model:
+        context["model"] = status_model
 
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{url_component(session_id)}/policies/evaluate"
     try:

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1223,6 +1223,71 @@ def test_evaluate_policy_pre_tool_use_converts_and_returns_deny(
     assert captured.err == ""
 
 
+def test_evaluate_policy_stamps_live_model_from_context_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The hook stamps the statusLine-captured live model into the request.
+
+    The statusLine wrapper writes the active model id into ``context.json``
+    on every render. The hook must stamp it (and ``harness``) onto the
+    evaluation request so the cost-budget gate sees the CURRENT model at gate
+    time — not the lagging ``model_override`` mirror. Regression guard for a
+    cheap-model session getting blocked over budget because the model was
+    unresolved (None) and the gate failed closed.
+    """
+    posted: dict[str, object] = {}
+
+    class _FakeHttpxClient:
+        """Sync HTTP client stub capturing the posted EvaluationRequest."""
+
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            """Record constructor inputs. :returns: None."""
+            del headers, timeout
+
+        def __enter__(self) -> _FakeHttpxClient:
+            """:returns: This fake client."""
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            """:returns: None."""
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> object:
+            """Record the request and return an ALLOW verdict. :returns: response."""
+            import httpx
+
+            posted["json"] = json
+            return httpx.Response(
+                200,
+                text='{"result":"POLICY_ACTION_ALLOW"}',
+                request=httpx.Request("POST", url),
+            )
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
+    write_active_session_id(bridge_dir, "conv_active")
+    build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
+    # The statusLine wrapper's capture: the live model the user is on.
+    (bridge_dir / "context.json").write_text(
+        json.dumps({"model": "claude-sonnet-4-6"}), encoding="utf-8"
+    )
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {}}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    exit_code = claude_native_hook.main(["evaluate-policy", "--bridge-dir", str(bridge_dir)])
+
+    assert exit_code == 0
+    context = posted["json"]["event"]["context"]
+    # The live model + harness must ride the request so the cost gate doesn't
+    # fail closed on an unresolved model.
+    assert context["model"] == "claude-sonnet-4-6"
+    assert context["harness"] == "claude-native"
+
+
 def test_evaluate_policy_post_tool_use_converts_and_returns_context(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
The claude-native command hook posted policy evaluations **without the session's active model**, so the cost-budget gate fell back to the server's own resolution. When the async `model_override` mirror lagged (e.g. right after an in-pane `/model` switch), the gate saw an **unresolved model (`None`)** and failed **closed** — blocking a cheap-model (sonnet/haiku) session that was over budget, even though only expensive tiers (`fable`/`opus`/`gpt-5`) should be gated.

## Fix
Read the live model from the statusLine capture (`context.json`, which the statusLine wrapper rewrites on every render — including right after a `/model` switch) and stamp it (plus `harness`) onto the evaluation request, **mirroring the codex hook reading `config.toml`**. This is race-free at gate time, unlike the lagging `model_override` mirror.

- **`claude_native_bridge`**: add `read_claude_status_model()` — returns the model from `context.json` **independent of `context_window_size`** (`read_claude_context_state` returns `None` without a window, which would re-introduce the `None` gap).
- **`claude_native_hook`**: stamp `context["model"]` + `context["harness"] = "claude-native"` before POSTing.

Applies to all claude-native policy-hook events (so claude tool-call cost gating gets the live model too). Independent of #266.

Tests: new regression test asserting the model+harness are stamped onto the request; full claude-native hook + bridge suites pass.

This pull request and its description were written by Isaac.