### PR TITLE
ci: run the security scan once per PR (gate jobs poll the result)

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -1,28 +1,23 @@
 name: Security Gate
 
-# Reusable (workflow_call) security scan for UNTRUSTED contributor PRs. Each CI
-# workflow (ci, lint, e2e, e2e-ui, ap-web tests) calls this as its FIRST job and
-# makes its real jobs `needs: gate`. The scan only STATICALLY analyses the
-# diff/head (semgrep, grep, diff-read) and runs with NO secrets on fork PRs, so
-# it never executes untrusted code itself. The scanner (scripts + rules) is
-# always checked out from `main`, while the scanned code is the PR head in a
-# separate `pr/` dir, so a PR cannot edit its own gate to neuter it.
+# Reusable (workflow_call) gate, called as the FIRST job of each CI workflow
+# (ci/lint/e2e/e2e-ui/ap-web tests); their real jobs declare `needs: gate`.
 #
-# >>> CURRENTLY NON-BLOCKING (AUDIT MODE) <<<
-# GATE_BLOCKING is "false": the detectors run and surface findings as
-# annotations + a job summary, but the gate job always SUCCEEDS, so `needs: gate`
-# never skips downstream CI. This lets us observe the scan on real PRs before
-# enforcing. To ENFORCE: set GATE_BLOCKING to "true" below -- then a finding
-# fails the gate and skips the dependent CI jobs (no PR-code checkout / uv sync /
-# test). It is still not a merge-required check; merge stays blocked
-# transitively via the skipped required pytest/e2e checks.
+# This job does NOT scan -- the single scan runs once in security-scan.yml and
+# produces the `Security Scan` check. This poller only decides whether to let
+# its caller proceed:
+#   - non-PR event or trusted author -> proceed immediately (no scan needed)
+#   - untrusted PR -> wait for the `Security Scan` check on the PR head SHA and
+#     MIRROR its conclusion. success -> proceed; failure -> fail, so the
+#     dependent CI jobs (needs: gate) are skipped.
 #
-# Trust tiers (see should-scan.sh):
-#   - trusted (OWNER/MEMBER/COLLABORATOR) or any non-PR event -> proceed, no scan
-#   - returning contributor (CONTRIBUTOR) -> scanned
-#   - first-time contributor -> GitHub's native "approve fork workflows" repo
-#     setting already holds every workflow until a maintainer approves; once
-#     approved this gate's scan still applies (defense in depth).
+# Enforcement (audit vs blocking) lives in ONE place -- GATE_BLOCKING in
+# security-scan.yml. In audit mode that scan always concludes success, so this
+# poller always proceeds; flip it to "true" and a finding fails the scan, which
+# this poller then mirrors to block dependent CI. Running the scan once instead
+# of once-per-workflow is the whole point of splitting scan from gate.
+#
+# The trust decision is read from `main` (should-scan.sh) so a PR cannot edit it.
 
 on:
   workflow_call:
@@ -34,135 +29,56 @@ jobs:
   gate:
     name: Security Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      # Match CI: route uv at PyPI for the semgrep fetch.
-      UV_INDEX_URL: https://pypi.org/simple
-      # The single enforcement switch. "false" = audit (never blocks CI);
-      # "true" = blocking (a finding fails the gate and skips dependent jobs).
-      GATE_BLOCKING: "false"
+    timeout-minutes: 8
     steps:
-      - name: Check out scanner from main
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+      - name: Check out trust check from main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: main             # trusted; never the PR head
-          sparse-checkout: |
-            .github/scripts/security-scan
-            .github/security
+          sparse-checkout: .github/scripts/security-scan
           persist-credentials: false
 
       - name: Trust gate
         id: gate
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
-          # The scanner is checked out from `main` so a PR cannot edit its own
-          # gate. Before this gate is itself merged to main the scripts are
-          # absent there -- proceed (fail-open) so the introducing PR and any
-          # main-without-scanner state are not bricked. Once merged the scripts
-          # exist on main and this branch never runs.
+          # Before the scanner lands on main the scripts are absent there --
+          # proceed (fail-open) so the introducing PR is not bricked.
           if [ ! -f .github/scripts/security-scan/should-scan.sh ]; then
-            echo "::warning::security scanner not present on main yet; proceeding without scan (bootstrap)."
+            echo "::warning::security scanner not present on main yet; proceeding (bootstrap)."
             echo "scan=false" >> "$GITHUB_OUTPUT"
-            echo "reason=scanner absent on main (bootstrap)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           bash .github/scripts/security-scan/should-scan.sh
 
-      - name: Fetch PR diff
+      - name: Wait for Security Scan result
+        # Only untrusted PRs wait; trusted authors / non-PR events already
+        # proceeded above (scan=false), so their CI is not delayed by the scan.
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          gh pr diff "$PR" --repo "$REPO" > "$GITHUB_WORKSPACE/pr.diff"
-          gh pr diff "$PR" --repo "$REPO" --name-only > "$GITHUB_WORKSPACE/changed.txt"
-          echo "Changed files:"; cat "$GITHUB_WORKSPACE/changed.txt"
-
-      - name: Secret scan (added lines)
-        id: secret
-        if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
-        env:
-          DIFF_FILE: ${{ github.workspace }}/pr.diff
-        run: python3 .github/scripts/security-scan/secret-scan.py
-
-      - name: Sensitive-path guard
-        id: paths
-        if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
-        env:
-          CHANGED_FILES: ${{ github.workspace }}/changed.txt
-        run: bash .github/scripts/security-scan/sensitive-paths.sh
-
-      - name: Check out PR head for static analysis
-        if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}  # untrusted: only statically scanned
-          path: pr
-          persist-credentials: false
-
-      - name: Workflow misuse lint
-        id: wflint
-        if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
-        working-directory: pr
-        env:
-          CHANGED_FILES: ${{ github.workspace }}/changed.txt
-        run: python3 "$GITHUB_WORKSPACE/.github/scripts/security-scan/lint-workflow-misuse.py"
-
-      - name: Install uv
-        if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
-        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
-
-      - name: Semgrep (changed files, local rules)
-        id: semgrep
-        if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
-        env:
-          RULES: ${{ github.workspace }}/.github/security/semgrep-rules.yml
-        run: |
-          # Scan only PR-changed files that exist in the head tree, so a
-          # contributor is never failed for pre-existing findings.
-          : > targets.txt
-          while IFS= read -r f; do
-            [ -n "$f" ] && [ -f "pr/$f" ] && printf 'pr/%s\n' "$f" >> targets.txt
-          done < "$GITHUB_WORKSPACE/changed.txt"
-          if [ ! -s targets.txt ]; then
-            echo "No changed files to semgrep."; exit 0
-          fi
-          echo "Semgrep targets:"; cat targets.txt
-          # Informational pass (warnings never block).
-          uvx semgrep scan --config "$RULES" --severity=WARNING \
-            --metrics=off --quiet $(cat targets.txt) || true
-          # Gating pass: ERROR-severity rules fail the gate.
-          uvx semgrep scan --config "$RULES" --severity=ERROR --error \
-            --metrics=off --quiet $(cat targets.txt)
-
-      - name: Audit summary
-        # Always reports the scan outcome. In audit mode the detector steps above
-        # are continue-on-error, so this surfaces what WOULD have blocked without
-        # failing the job. In blocking mode a detector failure already failed the
-        # job before reaching here.
-        if: ${{ always() && steps.gate.outputs.scan == 'true' }}
-        run: |
-          findings=0
-          for o in "${{ steps.secret.outcome }}" "${{ steps.paths.outcome }}" \
-                   "${{ steps.wflint.outcome }}" "${{ steps.semgrep.outcome }}"; do
-            [ "$o" = "failure" ] && findings=1
+          echo "Untrusted PR -- waiting for the single 'Security Scan' check on $HEAD_SHA"
+          q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
+          conclusion=""
+          for _ in $(seq 1 72); do   # up to ~6 min (72 * 5s)
+            status=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .status" 2>/dev/null || echo "")
+            if [ "$status" = "completed" ]; then
+              conclusion=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .conclusion")
+              break
+            fi
+            sleep 5
           done
-          if [ "$findings" = "1" ]; then
-            echo "::warning::Security gate found issues (see annotations above). Audit mode: CI was NOT blocked. Set GATE_BLOCKING=true in security-gate.yml to enforce."
-            { echo "### 🔍 Security gate — audit mode"; echo "Findings detected; **not** blocking CI. See annotations above."; } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Security gate: no findings."
-            echo "### ✅ Security gate — audit mode: no findings" >> "$GITHUB_STEP_SUMMARY"
+          if [ -z "$conclusion" ]; then
+            echo "::warning::Security Scan check did not complete in time; proceeding (fail-open)."
+            exit 0
           fi
+          echo "Security Scan concluded: $conclusion"
+          case "$conclusion" in
+            success | skipped | neutral) exit 0 ;;
+            *) echo "::error::Security Scan did not pass ($conclusion); blocking dependent CI."; exit 1 ;;
+          esac

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,169 @@
+name: Security Scan
+
+# The single deterministic security scan for a PR. Runs ONCE per PR (on
+# pull_request) and produces the `Security Scan` check. The per-workflow gate
+# jobs (security-gate.yml, called by ci/lint/e2e/e2e-ui/ap-web tests) do NOT
+# re-scan -- they poll THIS check and mirror its result -- so the scan work
+# happens exactly once while still gating every CI workflow.
+#
+# It only STATICALLY analyses the diff/head (semgrep, grep, diff-read) and runs
+# with NO secrets on fork PRs, so it never executes untrusted code. The scanner
+# (scripts + rules) is always checked out from `main`, while the scanned code is
+# the PR head in a separate `pr/` dir, so a PR cannot edit its own scan.
+#
+# >>> CURRENTLY NON-BLOCKING (AUDIT MODE) <<<
+# GATE_BLOCKING is "false": the detectors run and surface findings as
+# annotations + a job summary, but this job always SUCCEEDS, so the pollers see
+# success and never skip downstream CI. To ENFORCE: set GATE_BLOCKING to "true"
+# -- then a finding fails this check, the pollers mirror the failure, and the
+# dependent CI jobs are skipped (no PR-code checkout / uv sync / test). This is
+# the single enforcement switch; the pollers just mirror this check.
+#
+# Trust tiers (see should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR) and
+# non-PR events are not scanned; returning contributors are; first-timers are
+# held by GitHub's native fork-approval gate first.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-scan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Match CI: route uv at PyPI for the semgrep fetch.
+      UV_INDEX_URL: https://pypi.org/simple
+      # The single enforcement switch. "false" = audit (never blocks CI);
+      # "true" = blocking (a finding fails this check; pollers then skip CI).
+      GATE_BLOCKING: "false"
+    steps:
+      - name: Check out scanner from main
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main             # trusted; never the PR head
+          sparse-checkout: |
+            .github/scripts/security-scan
+            .github/security
+          persist-credentials: false
+
+      - name: Trust gate
+        id: gate
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: |
+          # Scanner is checked out from `main` so a PR cannot edit its own scan.
+          # Before this lands on main the scripts are absent there -- proceed
+          # (fail-open) so the introducing PR is not bricked.
+          if [ ! -f .github/scripts/security-scan/should-scan.sh ]; then
+            echo "::warning::security scanner not present on main yet; proceeding without scan (bootstrap)."
+            echo "scan=false" >> "$GITHUB_OUTPUT"
+            echo "reason=scanner absent on main (bootstrap)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bash .github/scripts/security-scan/should-scan.sh
+
+      - name: Fetch PR diff
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr diff "$PR" --repo "$REPO" > "$GITHUB_WORKSPACE/pr.diff"
+          gh pr diff "$PR" --repo "$REPO" --name-only > "$GITHUB_WORKSPACE/changed.txt"
+          echo "Changed files:"; cat "$GITHUB_WORKSPACE/changed.txt"
+
+      - name: Secret scan (added lines)
+        id: secret
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        env:
+          DIFF_FILE: ${{ github.workspace }}/pr.diff
+        run: python3 .github/scripts/security-scan/secret-scan.py
+
+      - name: Sensitive-path guard
+        id: paths
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        env:
+          CHANGED_FILES: ${{ github.workspace }}/changed.txt
+        run: bash .github/scripts/security-scan/sensitive-paths.sh
+
+      - name: Check out PR head for static analysis
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # untrusted: only statically scanned
+          path: pr
+          persist-credentials: false
+
+      - name: Workflow misuse lint
+        id: wflint
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        working-directory: pr
+        env:
+          CHANGED_FILES: ${{ github.workspace }}/changed.txt
+        run: python3 "$GITHUB_WORKSPACE/.github/scripts/security-scan/lint-workflow-misuse.py"
+
+      - name: Install uv
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
+
+      - name: Semgrep (changed files, local rules)
+        id: semgrep
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
+        env:
+          RULES: ${{ github.workspace }}/.github/security/semgrep-rules.yml
+        run: |
+          # Scan only PR-changed files that exist in the head tree, so a
+          # contributor is never failed for pre-existing findings.
+          : > targets.txt
+          while IFS= read -r f; do
+            [ -n "$f" ] && [ -f "pr/$f" ] && printf 'pr/%s\n' "$f" >> targets.txt
+          done < "$GITHUB_WORKSPACE/changed.txt"
+          if [ ! -s targets.txt ]; then
+            echo "No changed files to semgrep."; exit 0
+          fi
+          echo "Semgrep targets:"; cat targets.txt
+          # Informational pass (warnings never block).
+          uvx semgrep scan --config "$RULES" --severity=WARNING \
+            --metrics=off --quiet $(cat targets.txt) || true
+          # Gating pass: ERROR-severity rules fail the scan.
+          uvx semgrep scan --config "$RULES" --severity=ERROR --error \
+            --metrics=off --quiet $(cat targets.txt)
+
+      - name: Audit summary
+        # In audit mode the detector steps above are continue-on-error, so this
+        # surfaces what WOULD have blocked without failing the job. In blocking
+        # mode a detector failure already failed the job before reaching here.
+        if: ${{ always() && steps.gate.outputs.scan == 'true' }}
+        run: |
+          findings=0
+          for o in "${{ steps.secret.outcome }}" "${{ steps.paths.outcome }}" \
+                   "${{ steps.wflint.outcome }}" "${{ steps.semgrep.outcome }}"; do
+            [ "$o" = "failure" ] && findings=1
+          done
+          if [ "$findings" = "1" ]; then
+            echo "::warning::Security scan found issues (see annotations above). Audit mode: CI was NOT blocked. Set GATE_BLOCKING=true in security-scan.yml to enforce."
+            { echo "### 🔍 Security scan — audit mode"; echo "Findings detected; **not** blocking CI. See annotations above."; } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Security scan: no findings."
+            echo "### ✅ Security scan — audit mode: no findings" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,12 +8,19 @@ credentials, tokens, or customer data in any report.
 
 ## Contributor PR security gate
 
-CI for untrusted PRs is held behind a deterministic **Security Gate** so that
+CI for untrusted PRs is held behind a deterministic security scan so that
 untrusted code is not checked out, built, or run on our runners — and the
-Actions cache is not touched — until the diff has been vetted. The gate is a
-reusable workflow (`.github/workflows/security-gate.yml`) run as the first job
-of every CI workflow (`ci`, `lint`, `e2e`, `e2e-ui`); the real jobs declare
-`needs: gate`, so a failing gate skips them entirely.
+Actions cache is not touched — until the diff has been vetted. It is split into
+two pieces so the scan work happens only **once per PR**:
+
+- **`.github/workflows/security-scan.yml`** — runs the deterministic scan once
+  on `pull_request` and produces the `Security Scan` check.
+- **`.github/workflows/security-gate.yml`** — a reusable poller run as the first
+  job (`gate`) of every CI workflow (`ci`, `lint`, `e2e`, `e2e-ui`, ap-web
+  tests); the real jobs declare `needs: gate`. It does not re-scan — for an
+  untrusted PR it waits for the `Security Scan` check and mirrors its result
+  (failure → the dependent CI jobs are skipped); trusted authors and non-PR
+  events proceed immediately.
 
 By trust tier (GitHub `author_association`):
 
@@ -32,15 +39,16 @@ CI-workflow misuse (`pull_request_target` + PR-head checkout, unpinned actions),
 and known code-execution / obfuscation patterns (semgrep, local ruleset). It
 only *statically* analyses the diff and runs with **no secrets** on fork PRs,
 and the scanner itself always runs from `main`, so a PR cannot weaken its own
-gate.
+scan.
 
-This gate is **not** a merge-required check: it gates CI, not the merge button
+This is **not** a merge-required check: it gates CI, not the merge button
 directly. When enforcing, merge stays blocked transitively (the skipped
 pytest/e2e checks are required) and `Maintainer Approval` remains the ultimate
 gate.
 
-The gate currently runs in **audit (non-blocking) mode** (`GATE_BLOCKING:
-"false"` in `security-gate.yml`): the detectors run and surface findings as
-annotations and a job summary, but the gate always succeeds, so no CI is
-blocked. Flip `GATE_BLOCKING` to `"true"` to enforce once the scan has been
-observed on real PRs.
+It currently runs in **audit (non-blocking) mode** (`GATE_BLOCKING: "false"` in
+`security-scan.yml` — the single enforcement switch): the detectors run and
+surface findings as annotations and a job summary, but the `Security Scan` check
+always succeeds, so the pollers proceed and no CI is blocked. Flip
+`GATE_BLOCKING` to `"true"` to enforce once the scan has been observed on real
+PRs.


### PR DESCRIPTION
Follow-up to #269. Eliminates the redundant N× scan: previously every gated workflow's `gate` job ran the full scan (semgrep + detectors), so it executed ~4–5× per PR.

## Change
- **`security-scan.yml`** (new): runs the deterministic scan **once** on `pull_request`, producing the `Security Scan` check. Holds the single `GATE_BLOCKING` audit/enforce switch.
- **`security-gate.yml`** (reusable `workflow_call`): now a lightweight **poller**. Trusted authors / non-PR events proceed immediately; untrusted PRs wait for the `Security Scan` check and mirror its conclusion. No re-scan.
- CI workflows (`ci`/`lint`/`e2e`/`e2e-ui`/ap-web) are **unchanged** — still `gate: uses: ./.github/workflows/security-gate.yml` + `needs: gate`.

## Result
Heavy scan runs **once** per PR; every workflow stays gated. Enforcement remains centralized in one switch (`GATE_BLOCKING` in `security-scan.yml`), still in audit (non-blocking) mode.

Note: a self-authored (trusted) PR exercises the fast pass-through path; the untrusted poll-and-wait path needs a fork PR from a non-member to fully exercise.