### PR TITLE
ci(merge-ready): add integration checks to the merge gate

### DIFF
--- a/.github/scripts/merge-ready/required.sh
+++ b/.github/scripts/merge-ready/required.sh
@@ -2,9 +2,9 @@
 # The e2e + e2e-ui suites also gate PRs, but only run with secrets on same-repo
 # PRs (maintainer branches); fork PRs cannot read the LLM_API_KEY /
 # GATEWAY_BASE_URL secrets, so their e2e jobs skip via a workflow fork guard.
-# The e2e check names are therefore in BOTH REQUIRED (a same-repo PR must pass
-# them) and ALLOW_SKIP (a fork PR's skipped check still satisfies the gate). The
-# integration suite runs on schedule/dispatch only and is intentionally absent.
+# The e2e and integration check names are therefore in BOTH REQUIRED (a
+# same-repo PR must pass them) and ALLOW_SKIP (a fork PR's skipped check still
+# satisfies the gate).
 # Generated file -- do not hand-edit; it is replaced wholesale on every sync.
 
 REQUIRED=(
@@ -29,6 +29,9 @@ REQUIRED=(
   "E2E UI Tests (shard 0/3)"
   "E2E UI Tests (shard 1/3)"
   "E2E UI Tests (shard 2/3)"
+  "Integration (claude-sdk)"
+  "Integration (openai-agents)"
+  "Integration (codex)"
 )
 
 ALLOW_SKIP=(
@@ -52,6 +55,9 @@ ALLOW_SKIP=(
   "E2E UI Tests (shard 0/3)"
   "E2E UI Tests (shard 1/3)"
   "E2E UI Tests (shard 2/3)"
+  "Integration (claude-sdk)"
+  "Integration (openai-agents)"
+  "Integration (codex)"
 )
 
 is_allow_skip() { printf '%s\n' "${ALLOW_SKIP[@]}" | grep -qxF "$1"; }
@@ -65,6 +71,7 @@ workflow_for() {
     "Pytest ("*)             echo "CI" ;;
     "E2E Tests (shard "*)    echo "E2E Tests" ;;
     "E2E UI Tests (shard "*) echo "E2E UI Tests" ;;
+    "Integration ("*)        echo "Integration Tests" ;;
     *)                       echo "" ;;
   esac
 }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,8 +52,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Security precondition gate: on untrusted PRs every job below is held until
+  # the deterministic scan passes (see .github/workflows/security-gate.yml).
+  # Trusted authors and non-PR events pass through instantly.
+  gate:
+    uses: ./.github/workflows/security-gate.yml
+
   integration:
     name: Integration (${{ matrix.name }})
+    needs: gate
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.fork != true }}
     runs-on: ubuntu-latest
     # Per-leg ceiling. Inner test step caps at 25 min; the rest of

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -48,7 +48,7 @@ on:
   pull_request:
     types: [labeled]
   workflow_run:
-    workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests]
+    workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
     types: [completed]
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Summary
- Add `Integration (claude-sdk)`, `Integration (openai-agents)`, `Integration (codex)` to `REQUIRED` and `ALLOW_SKIP` in `required.sh`
- Add `Integration Tests` to `merge-ready.yml`'s `workflow_run` trigger so the gate re-evaluates when integration legs complete
- Add `workflow_for` mapping so `evaluate-checks.sh` can distinguish a genuine fork-skip from a missing/queued run

Same treatment as e2e: required for same-repo PRs, allow-skip for fork PRs (no LLM secrets).

Follows up on #288 which added the PR trigger to `integration.yml`.