### PR TITLE
fix(merge-ready): only run /merge when it is an actual command

### DIFF
--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -126,15 +126,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          # Passed via env (not interpolated into the script): the JSON includes
-          # PR branch names, which a same-repo author controls, so direct
-          # interpolation would be a shell-injection vector.
+          # Passed via env (not interpolated into the script): both the JSON
+          # (PR branch names) and the comment body are author-controlled, so
+          # direct interpolation would be a shell-injection vector.
           WF_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             PR="${{ github.event.pull_request.number }}"
             SHA="${{ github.event.pull_request.head.sha }}"
           elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            # The job `if` uses a loose contains() pre-filter (Actions
+            # expressions have no regex), so it also fires on incidental
+            # mentions like `workflows/merge-ready.yml` -- PR #288 merged on a
+            # comment that merely referenced that path. Re-validate that
+            # `/merge` appears as an actual command: a line whose first
+            # non-space token is exactly `/merge` (optionally followed by args).
+            if ! grep -qE '^[[:space:]]*/merge([[:space:]]|$)' <<<"$COMMENT_BODY"; then
+              echo "::notice::Skipped: comment mentions '/merge' but not as a command"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             PR="${{ github.event.issue.number }}"
             SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
           else


### PR DESCRIPTION
## Summary

PR #288 was auto-merged unintentionally. The `/merge` slash command in `merge-ready.yml` is gated by `contains(github.event.comment.body, '/merge')`, and GitHub Actions expressions have no regex — so it also fires on incidental substrings. A comment that merely referenced `.github/workflows/merge-ready.yml` (the substring `workflows/merge-ready` contains `/merge`) tripped the command, enabled auto-merge, and the green gate squash-merged the PR right away.

## Fix

Re-validate the command in the `ctx` step with a regex requiring `/merge` to be the first non-space token on a line (optionally followed by args), and skip when it isn't. The loose `contains()` stays as a cheap pre-filter (expressions can't do regex), but it no longer decides the merge.

- Comment body is passed via `env` (not interpolated) to avoid shell injection, matching the existing `WF_PRS` pattern.
- Regex: `^[[:space:]]*/merge([[:space:]]|$)`

Verified against the #288 incident comment and other incidental mentions (`/merge-ready`, mid-sentence `/merge`) — none match — while real commands (`/merge`, `  /merge`, `/merge please`, `/merge` on its own line, CRLF) still match.