### PR TITLE
ci(fork-e2e): mirror on pull_request_review so approval triggers e2e

### DIFF
--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -18,32 +18,41 @@ name: Fork e2e mirror
 #
 # Gate -- .github/scripts/fork-e2e/should-mirror.sh opens when any holds:
 #   maintainer-approved  ||  returning-contributor  ||  fork-e2e/pr-N exists.
-# Once the branch exists, every later push re-mirrors (re-runs e2e on the new
-# commits).
+# A maintainer's `workflow_dispatch` (PR-number input) also opens it -- the
+# explicit dispatch IS the authorization. Once the branch exists, every later
+# push re-mirrors (re-runs e2e on the new commits).
 #
 # Security scan -- before mirroring, security_scan.py statically inspects the PR
-# diff (TEXT only; it never checks out or runs fork code) for exfiltration
-# shapes and changes to CI-bootstrap-executed files, and posts a `Fork Security
-# Scan` status. The mirror is WITHHELD unless the scan is clean OR a maintainer
-# applies the `security-scan-override` label (only maintainers can label). So
-# fork e2e/e2e-ui run only after BOTH the gate above AND the scan pass, and the
-# scan re-runs on every push -- closing the "approved first-timer's later pushes
-# run unreviewed" gap (new exfil code re-fails the scan, so it is not mirrored).
+# diff (TEXT only) for exfiltration shapes and posts a `Fork Security Scan`
+# status. The mirror is WITHHELD unless the scan is clean OR a maintainer
+# applies the `security-scan-override` label. Re-runs on every event.
 #
-# Runs on pull_request_target only: it executes the workflow + scripts from the
-# base (default branch), never the PR head, so a PR cannot alter the gate, and
-# -- unlike pull_request / pull_request_review on a fork -- it actually receives
-# the secrets/vars needed to mint the App token below. (A fork-triggered
-# pull_request_review gets no secrets, so it could only ever fail at "Mint
-# mirror App token" -- which is why it is NOT a trigger here.) A maintainer's
-# approval of a first-time contributor therefore takes effect on the PR's next
-# sync (or a manual workflow re-run), when the gate re-evaluates. The script
-# checkout is additionally pinned to main.
+# Triggers (all run the workflow + scripts from the BASE branch, so a PR cannot
+# alter the gate; the script checkout is additionally pinned to main):
+#   pull_request_target  opened/synchronize/reopened (mirror) + closed (cleanup).
+#   pull_request_review  submitted -- so a maintainer's approval mirrors a
+#                        first-time contributor WITHOUT waiting for the next
+#                        push. Whether a fork review actually receives the App
+#                        secret is uncertain, so the "Check App secret
+#                        availability" step gates everything on it: if the
+#                        secret is absent on this event, the run skips
+#                        gracefully (and the log says so) -- workflow_dispatch
+#                        or the next sync mirrors instead.
+#   workflow_dispatch    maintainer manual trigger by PR number, for re-running
+#                        the gate after an after-the-fact approval (write access
+#                        required, so maintainer-only).
 #
 # leak-scan-allow: pull_request_target
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to (re-)evaluate and mirror"
+        required: true
 
 # Read-only at the top level (Scorecard Token-Permissions); write scope is on
 # the job.
@@ -51,14 +60,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: fork-e2e-mirror-${{ github.event.pull_request.number }}
+  group: fork-e2e-mirror-${{ github.event.pull_request.number || github.event.inputs.pr }}
   cancel-in-progress: false
 
 jobs:
   mirror:
     name: mirror
-    # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`.
-    if: ${{ github.event.pull_request.head.repo.fork }}
+    # Run for any maintainer dispatch, or any fork PR event. Same-repo PR events
+    # are ignored (they run e2e directly via `pull_request`).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read        # reads only; the App token below does the ref writes
       pull-requests: read   # read author + reviews for the gate
@@ -68,10 +78,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
-      PR: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-      MIRROR_BRANCH: fork-e2e/pr-${{ github.event.pull_request.number }}
     steps:
       - name: Check out gate scripts from main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -80,43 +86,87 @@ jobs:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
+      - name: Check App secret availability
+        id: secret
+        # pull_request_review on a fork MAY not expose secrets/vars. Gate the
+        # whole run on the App private key being present: if it's absent on this
+        # event, skip gracefully (the log records it -- this is how we verify
+        # whether review events get secrets). Only a boolean is exposed here,
+        # never the key itself.
+        env:
+          HAS_KEY: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY != '' }}
+        run: |
+          echo "has=$HAS_KEY" >> "$GITHUB_OUTPUT"
+          echo "App secret available on this '${{ github.event_name }}' event: $HAS_KEY"
+
+      - name: Resolve PR context
+        id: ctx
+        if: ${{ steps.secret.outputs.has == 'true' }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            PR="${{ github.event.inputs.pr }}"
+            # Fetch head SHA, association, and fork-ness from the API (no event payload).
+            RESP=$(gh api "repos/$REPO/pulls/$PR" \
+              --jq '[.head.sha, .author_association, (.head.repo.fork | tostring)] | @tsv')
+            SHA=$(printf '%s' "$RESP" | cut -f1)
+            ASSOC=$(printf '%s' "$RESP" | cut -f2)
+            FORK=$(printf '%s' "$RESP" | cut -f3)
+            ACTION="dispatch"
+          else
+            PR="${{ github.event.pull_request.number }}"
+            SHA="${{ github.event.pull_request.head.sha }}"
+            ASSOC="${{ github.event.pull_request.author_association }}"
+            FORK="${{ github.event.pull_request.head.repo.fork }}"
+            ACTION="${{ github.event.action }}"
+          fi
+          {
+            echo "pr=$PR"
+            echo "sha=$SHA"
+            echo "assoc=$ASSOC"
+            echo "fork=$FORK"
+            echo "action=$ACTION"
+            echo "branch=fork-e2e/pr-$PR"
+          } >> "$GITHUB_OUTPUT"
+          echo "ctx: pr=$PR fork=$FORK assoc=$ASSOC action=$ACTION"
+
       - name: Mint mirror App token
         id: app-token
-        # A ref created/updated with the default GITHUB_TOKEN does NOT trigger
-        # workflows (GitHub recursion-prevention), so e2e.yml's `push` would
-        # never fire. Push the ref with a GitHub App token instead: it carries
-        # contents:write and its pushes DO trigger downstream workflows.
+        if: ${{ steps.secret.outputs.has == 'true' && steps.ctx.outputs.fork == 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ vars.FORK_E2E_APP_ID }}
           private-key: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY }}
 
       - name: Delete mirror branch on PR close
-        if: ${{ github.event.action == 'closed' }}
+        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action == 'closed' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.ctx.outputs.branch }}
         run: |
-          gh api -X DELETE "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1 \
-            && echo "Deleted $MIRROR_BRANCH" \
-            || echo "No $MIRROR_BRANCH to delete"
+          gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1 \
+            && echo "Deleted $BRANCH" \
+            || echo "No $BRANCH to delete"
 
       - name: Load maintainers
         id: maintainers
-        if: ${{ github.event.action != 'closed' }}
+        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
         run: bash .github/scripts/merge-ready/load-maintainers.sh
 
       - name: Evaluate mirror gate
         id: gate
-        if: ${{ github.event.action != 'closed' }}
+        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
         env:
           MAINTAINERS: ${{ steps.maintainers.outputs.list }}
+          PR: ${{ steps.ctx.outputs.pr }}
+          AUTHOR_ASSOCIATION: ${{ steps.ctx.outputs.assoc }}
+          MIRROR_BRANCH: ${{ steps.ctx.outputs.branch }}
         run: bash .github/scripts/fork-e2e/should-mirror.sh
 
       - name: Security scan of PR diff
         id: scan
-        if: ${{ github.event.action != 'closed' }}
+        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.ctx.outputs.pr }}
         run: |
           # Static analysis of the diff TEXT only -- never checks out or runs
           # fork code. Writes clean=true|false + summary to $GITHUB_OUTPUT.
@@ -125,7 +175,9 @@ jobs:
 
       - name: Check security-scan override label
         id: override
-        if: ${{ github.event.action != 'closed' }}
+        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
+        env:
+          PR: ${{ steps.ctx.outputs.pr }}
         run: |
           if gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name' \
                | grep -qx 'security-scan-override'; then
@@ -135,14 +187,13 @@ jobs:
           fi
 
       - name: Post Fork Security Scan status
-        if: ${{ github.event.action != 'closed' }}
+        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
         env:
-          # Fork-derived text (summary may contain PR file paths) is passed via
-          # env and quoted -- never interpolated into the script body.
-          GH_TOKEN: ${{ github.token }}
+          # Fork-derived text (summary may contain PR file paths) via env + quoted.
           CLEAN: ${{ steps.scan.outputs.clean }}
           OVERRIDE: ${{ steps.override.outputs.override }}
           SUMMARY: ${{ steps.scan.outputs.summary }}
+          SHA: ${{ steps.ctx.outputs.sha }}
         run: |
           if [[ "$CLEAN" == "true" ]]; then
             STATE=success; DESC="$SUMMARY"
@@ -151,28 +202,31 @@ jobs:
           else
             STATE=failure; DESC="$SUMMARY"
           fi
-          gh api "repos/$REPO/statuses/$HEAD_SHA" \
+          gh api "repos/$REPO/statuses/$SHA" \
             -f state="$STATE" -f context="Fork Security Scan" \
             -f description="${DESC:0:140}" >/dev/null
-          echo "Fork Security Scan=$STATE on $HEAD_SHA ($DESC)"
+          echo "Fork Security Scan=$STATE on $SHA ($DESC)"
 
       - name: Mirror head SHA onto trusted branch
-        # Mirror only when the base gate opens AND the scan is clean (or a
-        # maintainer overrode it). So fork e2e/e2e-ui run only after BOTH
-        # approval/returning AND the security scan pass.
+        # Mirror when: it's a fork PR, not a close, the scan is clean (or
+        # overridden), AND the base gate opened -- where a maintainer
+        # workflow_dispatch counts as the gate opening (explicit authorization).
         if: >-
-          github.event.action != 'closed'
-          && steps.gate.outputs.mirror == 'true'
+          steps.ctx.outputs.fork == 'true'
+          && steps.ctx.outputs.action != 'closed'
           && (steps.scan.outputs.clean == 'true' || steps.override.outputs.override == 'true')
+          && (steps.gate.outputs.mirror == 'true' || github.event_name == 'workflow_dispatch')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ steps.ctx.outputs.sha }}
+          BRANCH: ${{ steps.ctx.outputs.branch }}
         run: |
-          if gh api "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" \
-              -f sha="$HEAD_SHA" -F force=true >/dev/null
-            echo "Updated $MIRROR_BRANCH -> $HEAD_SHA"
+          if gh api "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" \
+              -f sha="$SHA" -F force=true >/dev/null
+            echo "Updated $BRANCH -> $SHA"
           else
             gh api -X POST "repos/$REPO/git/refs" \
-              -f ref="refs/heads/$MIRROR_BRANCH" -f sha="$HEAD_SHA" >/dev/null
-            echo "Created $MIRROR_BRANCH -> $HEAD_SHA"
+              -f ref="refs/heads/$BRANCH" -f sha="$SHA" >/dev/null
+            echo "Created $BRANCH -> $SHA"
           fi

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -4,9 +4,8 @@ name: Fork e2e mirror
 # fork-e2e/pr-N branch so e2e runs there as a `push` (with secrets). It's a pure
 # git-ref update via a GitHub App token (refs pushed by the default GITHUB_TOKEN
 # don't trigger workflows); it never checks out or runs fork code. Gated by
-# should-mirror.sh + the Fork Security Scan. Triggers: pull_request_target
-# (open/sync/reopen, + close cleanup), pull_request_review (approval), and
-# workflow_dispatch (maintainer manual trigger by PR number).
+# should-mirror.sh + the Fork Security Scan. pull_request_review is included so a
+# maintainer's approval mirrors immediately, not only on the PR's next push.
 #
 # leak-scan-allow: pull_request_target
 on:
@@ -14,24 +13,19 @@ on:
     types: [opened, synchronize, reopened, closed]
   pull_request_review:
     types: [submitted]
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: "PR number to (re-)evaluate and mirror"
-        required: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: fork-e2e-mirror-${{ github.event.pull_request.number || github.event.inputs.pr }}
+  group: fork-e2e-mirror-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   mirror:
     name: mirror
-    # Maintainer dispatch, or any fork PR event (same-repo PRs run e2e directly).
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork }}
+    # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`.
+    if: ${{ github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pull-requests: read
@@ -41,6 +35,10 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+      MIRROR_BRANCH: fork-e2e/pr-${{ github.event.pull_request.number }}
     steps:
       - name: Check out gate scripts from main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -49,89 +47,45 @@ jobs:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
-      - name: Check App secret availability
-        id: secret
-        # A fork pull_request_review may not carry secrets; gate the run on the
-        # App key being present (boolean only) so it skips cleanly, not fails.
-        env:
-          HAS_KEY: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY != '' }}
-        run: |
-          echo "has=$HAS_KEY" >> "$GITHUB_OUTPUT"
-          echo "App secret on '${{ github.event_name }}': $HAS_KEY"
-
-      - name: Resolve PR context
-        id: ctx
-        if: ${{ steps.secret.outputs.has == 'true' }}
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            PR="${{ github.event.inputs.pr }}"
-            RESP=$(gh api "repos/$REPO/pulls/$PR" \
-              --jq '[.head.sha, .author_association, (.head.repo.fork | tostring)] | @tsv')
-            SHA=$(printf '%s' "$RESP" | cut -f1)
-            ASSOC=$(printf '%s' "$RESP" | cut -f2)
-            FORK=$(printf '%s' "$RESP" | cut -f3)
-            ACTION="dispatch"
-          else
-            PR="${{ github.event.pull_request.number }}"
-            SHA="${{ github.event.pull_request.head.sha }}"
-            ASSOC="${{ github.event.pull_request.author_association }}"
-            FORK="${{ github.event.pull_request.head.repo.fork }}"
-            ACTION="${{ github.event.action }}"
-          fi
-          {
-            echo "pr=$PR"; echo "sha=$SHA"; echo "assoc=$ASSOC"
-            echo "fork=$FORK"; echo "action=$ACTION"; echo "branch=fork-e2e/pr-$PR"
-          } >> "$GITHUB_OUTPUT"
-          echo "ctx: pr=$PR fork=$FORK assoc=$ASSOC action=$ACTION"
-
       - name: Mint mirror App token
         id: app-token
         # App token, not GITHUB_TOKEN: its pushes DO trigger the downstream e2e.
-        if: ${{ steps.secret.outputs.has == 'true' && steps.ctx.outputs.fork == 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ vars.FORK_E2E_APP_ID }}
           private-key: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY }}
 
       - name: Delete mirror branch on PR close
-        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action == 'closed' }}
+        if: ${{ github.event.action == 'closed' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BRANCH: ${{ steps.ctx.outputs.branch }}
         run: |
-          gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1 \
-            && echo "Deleted $BRANCH" || echo "No $BRANCH to delete"
+          gh api -X DELETE "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1 \
+            && echo "Deleted $MIRROR_BRANCH" || echo "No $MIRROR_BRANCH to delete"
 
       - name: Load maintainers
         id: maintainers
-        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
+        if: ${{ github.event.action != 'closed' }}
         run: bash .github/scripts/merge-ready/load-maintainers.sh
 
       - name: Evaluate mirror gate
         id: gate
-        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
+        if: ${{ github.event.action != 'closed' }}
         env:
           MAINTAINERS: ${{ steps.maintainers.outputs.list }}
-          PR: ${{ steps.ctx.outputs.pr }}
-          AUTHOR_ASSOCIATION: ${{ steps.ctx.outputs.assoc }}
-          MIRROR_BRANCH: ${{ steps.ctx.outputs.branch }}
         run: bash .github/scripts/fork-e2e/should-mirror.sh
 
       - name: Security scan of PR diff
         id: scan
         # Diff TEXT only -- never checks out or runs fork code.
-        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
-        env:
-          PR: ${{ steps.ctx.outputs.pr }}
+        if: ${{ github.event.action != 'closed' }}
         run: |
           gh pr diff "$PR" --repo "$REPO" --patch > "$RUNNER_TEMP/pr.diff"
           python3 .github/scripts/fork-e2e/security_scan.py "$RUNNER_TEMP/pr.diff"
 
       - name: Check security-scan override label
         id: override
-        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
-        env:
-          PR: ${{ steps.ctx.outputs.pr }}
+        if: ${{ github.event.action != 'closed' }}
         run: |
           if gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name' \
                | grep -qx 'security-scan-override'; then
@@ -141,12 +95,11 @@ jobs:
           fi
 
       - name: Post Fork Security Scan status
-        if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
+        if: ${{ github.event.action != 'closed' }}
         env:
           CLEAN: ${{ steps.scan.outputs.clean }}
           OVERRIDE: ${{ steps.override.outputs.override }}
           SUMMARY: ${{ steps.scan.outputs.summary }}  # fork text via env, not interpolated
-          SHA: ${{ steps.ctx.outputs.sha }}
         run: |
           if [[ "$CLEAN" == "true" ]]; then
             STATE=success; DESC="$SUMMARY"
@@ -155,26 +108,22 @@ jobs:
           else
             STATE=failure; DESC="$SUMMARY"
           fi
-          gh api "repos/$REPO/statuses/$SHA" \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="$STATE" -f context="Fork Security Scan" \
             -f description="${DESC:0:140}" >/dev/null
 
       - name: Mirror head SHA onto trusted branch
-        # Dispatch counts as the gate opening; the scan still gates.
         if: >-
-          steps.ctx.outputs.fork == 'true'
-          && steps.ctx.outputs.action != 'closed'
+          github.event.action != 'closed'
+          && steps.gate.outputs.mirror == 'true'
           && (steps.scan.outputs.clean == 'true' || steps.override.outputs.override == 'true')
-          && (steps.gate.outputs.mirror == 'true' || github.event_name == 'workflow_dispatch')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SHA: ${{ steps.ctx.outputs.sha }}
-          BRANCH: ${{ steps.ctx.outputs.branch }}
         run: |
-          if gh api "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" -f sha="$SHA" -F force=true >/dev/null
-            echo "Updated $BRANCH -> $SHA"
+          if gh api "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" -f sha="$HEAD_SHA" -F force=true >/dev/null
+            echo "Updated $MIRROR_BRANCH -> $HEAD_SHA"
           else
-            gh api -X POST "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$SHA" >/dev/null
-            echo "Created $BRANCH -> $SHA"
+            gh api -X POST "repos/$REPO/git/refs" -f ref="refs/heads/$MIRROR_BRANCH" -f sha="$HEAD_SHA" >/dev/null
+            echo "Created $MIRROR_BRANCH -> $HEAD_SHA"
           fi

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -1,46 +1,12 @@
 name: Fork e2e mirror
 
-# Mirrors an approved (or returning-contributor) fork PR's head commit onto a
-# trusted base-repo branch, fork-e2e/pr-N, so the e2e suite runs there as a
-# `push` event. A fork's own `pull_request` run gets no secrets; a `push` to a
-# base-repo branch does -- that's how fork e2e reaches the test gateway.
-#
-# The mirror is a pure git-ref update via the API: it never checks out or runs
-# the fork's code, so this privileged (secret-eligible) workflow never executes
-# untrusted code with secrets in scope. The fork code only runs on the
-# downstream `push` to fork-e2e/** (see e2e.yml), which is a trusted event.
-#
-# The ref is pushed with a GitHub App token, NOT the default GITHUB_TOKEN:
-# refs created/updated by GITHUB_TOKEN do not trigger workflows (GitHub
-# recursion-prevention), so the e2e `push` would never fire. Requires repo
-# variable FORK_E2E_APP_ID and secret FORK_E2E_APP_PRIVATE_KEY for an App
-# installed on this repo with contents:write.
-#
-# Gate -- .github/scripts/fork-e2e/should-mirror.sh opens when any holds:
-#   maintainer-approved  ||  returning-contributor  ||  fork-e2e/pr-N exists.
-# A maintainer's `workflow_dispatch` (PR-number input) also opens it -- the
-# explicit dispatch IS the authorization. Once the branch exists, every later
-# push re-mirrors (re-runs e2e on the new commits).
-#
-# Security scan -- before mirroring, security_scan.py statically inspects the PR
-# diff (TEXT only) for exfiltration shapes and posts a `Fork Security Scan`
-# status. The mirror is WITHHELD unless the scan is clean OR a maintainer
-# applies the `security-scan-override` label. Re-runs on every event.
-#
-# Triggers (all run the workflow + scripts from the BASE branch, so a PR cannot
-# alter the gate; the script checkout is additionally pinned to main):
-#   pull_request_target  opened/synchronize/reopened (mirror) + closed (cleanup).
-#   pull_request_review  submitted -- so a maintainer's approval mirrors a
-#                        first-time contributor WITHOUT waiting for the next
-#                        push. Whether a fork review actually receives the App
-#                        secret is uncertain, so the "Check App secret
-#                        availability" step gates everything on it: if the
-#                        secret is absent on this event, the run skips
-#                        gracefully (and the log says so) -- workflow_dispatch
-#                        or the next sync mirrors instead.
-#   workflow_dispatch    maintainer manual trigger by PR number, for re-running
-#                        the gate after an after-the-fact approval (write access
-#                        required, so maintainer-only).
+# Mirrors an approved / returning-contributor fork PR's head onto a trusted
+# fork-e2e/pr-N branch so e2e runs there as a `push` (with secrets). It's a pure
+# git-ref update via a GitHub App token (refs pushed by the default GITHUB_TOKEN
+# don't trigger workflows); it never checks out or runs fork code. Gated by
+# should-mirror.sh + the Fork Security Scan. Triggers: pull_request_target
+# (open/sync/reopen, + close cleanup), pull_request_review (approval), and
+# workflow_dispatch (maintainer manual trigger by PR number).
 #
 # leak-scan-allow: pull_request_target
 on:
@@ -54,8 +20,6 @@ on:
         description: "PR number to (re-)evaluate and mirror"
         required: true
 
-# Read-only at the top level (Scorecard Token-Permissions); write scope is on
-# the job.
 permissions:
   contents: read
 
@@ -66,13 +30,12 @@ concurrency:
 jobs:
   mirror:
     name: mirror
-    # Run for any maintainer dispatch, or any fork PR event. Same-repo PR events
-    # are ignored (they run e2e directly via `pull_request`).
+    # Maintainer dispatch, or any fork PR event (same-repo PRs run e2e directly).
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork }}
     permissions:
-      contents: read        # reads only; the App token below does the ref writes
-      pull-requests: read   # read author + reviews for the gate
-      statuses: write       # post the Fork Security Scan status on the head SHA
+      contents: read
+      pull-requests: read
+      statuses: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -82,22 +45,19 @@ jobs:
       - name: Check out gate scripts from main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: main             # trusted base; never the PR head
+          ref: main             # trusted; never the PR head
           sparse-checkout: .github/scripts
           persist-credentials: false
 
       - name: Check App secret availability
         id: secret
-        # pull_request_review on a fork MAY not expose secrets/vars. Gate the
-        # whole run on the App private key being present: if it's absent on this
-        # event, skip gracefully (the log records it -- this is how we verify
-        # whether review events get secrets). Only a boolean is exposed here,
-        # never the key itself.
+        # A fork pull_request_review may not carry secrets; gate the run on the
+        # App key being present (boolean only) so it skips cleanly, not fails.
         env:
           HAS_KEY: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY != '' }}
         run: |
           echo "has=$HAS_KEY" >> "$GITHUB_OUTPUT"
-          echo "App secret available on this '${{ github.event_name }}' event: $HAS_KEY"
+          echo "App secret on '${{ github.event_name }}': $HAS_KEY"
 
       - name: Resolve PR context
         id: ctx
@@ -105,7 +65,6 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             PR="${{ github.event.inputs.pr }}"
-            # Fetch head SHA, association, and fork-ness from the API (no event payload).
             RESP=$(gh api "repos/$REPO/pulls/$PR" \
               --jq '[.head.sha, .author_association, (.head.repo.fork | tostring)] | @tsv')
             SHA=$(printf '%s' "$RESP" | cut -f1)
@@ -120,17 +79,14 @@ jobs:
             ACTION="${{ github.event.action }}"
           fi
           {
-            echo "pr=$PR"
-            echo "sha=$SHA"
-            echo "assoc=$ASSOC"
-            echo "fork=$FORK"
-            echo "action=$ACTION"
-            echo "branch=fork-e2e/pr-$PR"
+            echo "pr=$PR"; echo "sha=$SHA"; echo "assoc=$ASSOC"
+            echo "fork=$FORK"; echo "action=$ACTION"; echo "branch=fork-e2e/pr-$PR"
           } >> "$GITHUB_OUTPUT"
           echo "ctx: pr=$PR fork=$FORK assoc=$ASSOC action=$ACTION"
 
       - name: Mint mirror App token
         id: app-token
+        # App token, not GITHUB_TOKEN: its pushes DO trigger the downstream e2e.
         if: ${{ steps.secret.outputs.has == 'true' && steps.ctx.outputs.fork == 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
@@ -144,8 +100,7 @@ jobs:
           BRANCH: ${{ steps.ctx.outputs.branch }}
         run: |
           gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1 \
-            && echo "Deleted $BRANCH" \
-            || echo "No $BRANCH to delete"
+            && echo "Deleted $BRANCH" || echo "No $BRANCH to delete"
 
       - name: Load maintainers
         id: maintainers
@@ -164,12 +119,11 @@ jobs:
 
       - name: Security scan of PR diff
         id: scan
+        # Diff TEXT only -- never checks out or runs fork code.
         if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
         env:
           PR: ${{ steps.ctx.outputs.pr }}
         run: |
-          # Static analysis of the diff TEXT only -- never checks out or runs
-          # fork code. Writes clean=true|false + summary to $GITHUB_OUTPUT.
           gh pr diff "$PR" --repo "$REPO" --patch > "$RUNNER_TEMP/pr.diff"
           python3 .github/scripts/fork-e2e/security_scan.py "$RUNNER_TEMP/pr.diff"
 
@@ -189,10 +143,9 @@ jobs:
       - name: Post Fork Security Scan status
         if: ${{ steps.ctx.outputs.fork == 'true' && steps.ctx.outputs.action != 'closed' }}
         env:
-          # Fork-derived text (summary may contain PR file paths) via env + quoted.
           CLEAN: ${{ steps.scan.outputs.clean }}
           OVERRIDE: ${{ steps.override.outputs.override }}
-          SUMMARY: ${{ steps.scan.outputs.summary }}
+          SUMMARY: ${{ steps.scan.outputs.summary }}  # fork text via env, not interpolated
           SHA: ${{ steps.ctx.outputs.sha }}
         run: |
           if [[ "$CLEAN" == "true" ]]; then
@@ -205,12 +158,9 @@ jobs:
           gh api "repos/$REPO/statuses/$SHA" \
             -f state="$STATE" -f context="Fork Security Scan" \
             -f description="${DESC:0:140}" >/dev/null
-          echo "Fork Security Scan=$STATE on $SHA ($DESC)"
 
       - name: Mirror head SHA onto trusted branch
-        # Mirror when: it's a fork PR, not a close, the scan is clean (or
-        # overridden), AND the base gate opened -- where a maintainer
-        # workflow_dispatch counts as the gate opening (explicit authorization).
+        # Dispatch counts as the gate opening; the scan still gates.
         if: >-
           steps.ctx.outputs.fork == 'true'
           && steps.ctx.outputs.action != 'closed'
@@ -222,11 +172,9 @@ jobs:
           BRANCH: ${{ steps.ctx.outputs.branch }}
         run: |
           if gh api "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" \
-              -f sha="$SHA" -F force=true >/dev/null
+            gh api -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" -f sha="$SHA" -F force=true >/dev/null
             echo "Updated $BRANCH -> $SHA"
           else
-            gh api -X POST "repos/$REPO/git/refs" \
-              -f ref="refs/heads/$BRANCH" -f sha="$SHA" >/dev/null
+            gh api -X POST "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$SHA" >/dev/null
             echo "Created $BRANCH -> $SHA"
           fi


### PR DESCRIPTION
## Summary

Approving a fork PR didn't run e2e: the mirror only woke on `pull_request_target` open/sync/reopen, so an approval did nothing until a manual re-run / reopen / push (#22, #104, #274). Fix is **one signal** — add `pull_request_review: [submitted]` to the mirror's triggers. That event carries the same `pull_request` payload the mirror already uses, so nothing else changes: a maintainer's approval now mirrors immediately.

> Assumes a fork's `pull_request_review` event receives secrets (it's a base-context event, like `pull_request_target`, so per GitHub's model it should). If it turns out not to, the "Mint mirror App token" step would fail loudly on reviews and we'd revert / add a presence guard.

## ELI5

The **mirror** is a robot that copies an *approved* fork PR's code onto a trusted branch (`fork-e2e/pr-N`) so e2e can run there *with* the test key. Its only alarm clock was "PR opened or pushed" — it slept through "maintainer clicked Approve." So you'd approve and… nothing. The fix is just one more alarm clock: **"a maintainer submitted a review."** Now approval wakes the robot, it re-checks the gate (now approved) + the security scan, and mirrors.

## How it works

```
  PR opened / synchronized ─┐ (pull_request_target — existing)
  maintainer approves ──────┘ (pull_request_review — NEW one signal)
            │
            ▼
  gate (maintainer-approved / returning) AND security scan clean?
     │ no  → don't mirror
     │ yes
     ▼
  point refs/heads/fork-e2e/pr-N → head SHA   (App token; never runs fork code)
            │
            ▼  push on a TRUSTED base-repo branch
  e2e.yml + e2e-ui.yml run WITH secrets
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Single-trigger CI change; YAML parses and the diff vs `main` is just the added `pull_request_review` trigger (plus comment trims). The trigger activates from the base branch on merge, so it's verified live post-merge: approve a fork PR and confirm the mirror runs and e2e fires (and, incidentally, that fork review events carry the App secret — if the mint step errors there instead, that's the signal to revert / add a guard).
