### PR TITLE
fix(openai-agents): handle missing databricks-sdk gracefully

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -509,14 +509,14 @@ def _get_openai_async_client(
         from .databricks_executor import _resolve_databricks_auth
 
         auth, host = _resolve_databricks_auth(profile)
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
             "The 'databricks-sdk' package is required for Databricks "
             "authentication but is not installed, and no OPENAI_API_KEY or "
             "OPENAI_BASE_URL environment variables are set. Either install "
             "the package (`pip install 'omnigent[databricks]'`) or set "
             "OPENAI_API_KEY/OPENAI_BASE_URL for non-Databricks OpenAI access."
-        )
+        ) from exc
     return AsyncOpenAI(
         base_url=base_url_override or _databricks_openai_base_url(host),
         api_key=_OPENAI_KEY_PLACEHOLDER,

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -477,7 +477,11 @@ def _get_openai_async_client(
             else:
                 raise
         except ImportError:
-            pass
+            logger.warning(
+                "databricks-sdk is not installed; cannot resolve Databricks "
+                "profile %r. Falling back to OPENAI_BASE_URL/OPENAI_API_KEY.",
+                profile,
+            )
 
     if os.environ.get("OPENAI_BASE_URL"):
         return AsyncOpenAI(
@@ -501,9 +505,18 @@ def _get_openai_async_client(
         )
 
     # No profile, no env — final fallback via ambient Databricks credentials.
-    from .databricks_executor import _resolve_databricks_auth
+    try:
+        from .databricks_executor import _resolve_databricks_auth
 
-    auth, host = _resolve_databricks_auth(profile)
+        auth, host = _resolve_databricks_auth(profile)
+    except ImportError:
+        raise ImportError(
+            "The 'databricks-sdk' package is required for Databricks "
+            "authentication but is not installed, and no OPENAI_API_KEY or "
+            "OPENAI_BASE_URL environment variables are set. Either install "
+            "the package (`pip install 'omnigent[databricks]'`) or set "
+            "OPENAI_API_KEY/OPENAI_BASE_URL for non-Databricks OpenAI access."
+        )
     return AsyncOpenAI(
         base_url=base_url_override or _databricks_openai_base_url(host),
         api_key=_OPENAI_KEY_PLACEHOLDER,

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1726,6 +1726,74 @@ def test_get_openai_client_invalid_profile_with_env_fallback_warns(monkeypatch, 
     )
 
 
+def test_get_openai_client_missing_databricks_sdk_raises_actionable_error(monkeypatch):
+    """Missing ``databricks-sdk`` with no env-var fallback gives an actionable error.
+
+    When a Databricks-hosted model is requested, ``databricks-sdk`` is not
+    installed, and no ``OPENAI_API_KEY``/``OPENAI_BASE_URL`` fallback is
+    available, the function must raise ``ImportError`` with install
+    instructions — not crash with an opaque traceback.
+
+    Regression test for https://github.com/omnigent-ai/omnigent/issues/123.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    import pytest
+
+    import omnigent.inner.databricks_executor as db_exec
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    def _import_error(*_args, **_kw):
+        raise ImportError("No module named 'databricks.sdk'")
+
+    monkeypatch.setattr(db_exec, "_resolve_databricks_auth", _import_error)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    with pytest.raises(ImportError, match="pip install"):
+        _get_openai_async_client(profile=None, model="databricks-gpt-5")
+
+
+def test_get_openai_client_missing_databricks_sdk_with_env_falls_through(
+    monkeypatch, caplog
+):
+    """Missing ``databricks-sdk`` with OPENAI_API_KEY set falls through gracefully.
+
+    When ``databricks-sdk`` is absent but env-var credentials are available,
+    the function should log a warning and return a client configured from the
+    env vars — not crash.
+
+    Regression test for https://github.com/omnigent-ai/omnigent/issues/123.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param caplog: Pytest log capture fixture.
+    """
+    import logging
+
+    import omnigent.inner.databricks_executor as db_exec
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    def _import_error(*_args, **_kw):
+        raise ImportError("No module named 'databricks.sdk'")
+
+    monkeypatch.setattr(db_exec, "_resolve_databricks_auth", _import_error)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        client = _get_openai_async_client(profile="dev", model="databricks-gpt-5")
+
+    assert any(
+        "databricks-sdk" in record.message for record in caplog.records
+    ), (
+        f"Expected a warning about missing databricks-sdk. "
+        f"Got: {[r.message for r in caplog.records]}"
+    )
+    assert client is not None
+
+
 def test_run_turn_auth_error_yields_actionable_message(monkeypatch):
     """``run_turn`` yields the actionable ``DatabricksAuthError`` message,
     not the raw ``__cause__`` string.

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1755,9 +1755,7 @@ def test_get_openai_client_missing_databricks_sdk_raises_actionable_error(monkey
         _get_openai_async_client(profile=None, model="databricks-gpt-5")
 
 
-def test_get_openai_client_missing_databricks_sdk_with_env_falls_through(
-    monkeypatch, caplog
-):
+def test_get_openai_client_missing_databricks_sdk_with_env_falls_through(monkeypatch, caplog):
     """Missing ``databricks-sdk`` with OPENAI_API_KEY set falls through gracefully.
 
     When ``databricks-sdk`` is absent but env-var credentials are available,
@@ -1785,9 +1783,7 @@ def test_get_openai_client_missing_databricks_sdk_with_env_falls_through(
     with caplog.at_level(logging.WARNING):
         client = _get_openai_async_client(profile="dev", model="databricks-gpt-5")
 
-    assert any(
-        "databricks-sdk" in record.message for record in caplog.records
-    ), (
+    assert any("databricks-sdk" in record.message for record in caplog.records), (
         f"Expected a warning about missing databricks-sdk. "
         f"Got: {[r.message for r in caplog.records]}"
     )


### PR DESCRIPTION
## Summary

- The final Databricks auth fallback in `_get_openai_async_client` crashed with an opaque `ImportError` when `databricks-sdk` was not installed and no `OPENAI_API_KEY`/`OPENAI_BASE_URL` env vars were set — silently degrading Debby to single-head mode.
- The first call site (profile-based auth) already caught `ImportError` but swallowed it silently; now it logs a warning so the fallback is visible.
- The second call site (ambient credentials fallback) did not catch `ImportError` at all; now it raises a clear, actionable error telling the user to install `omnigent[databricks]` or set env vars.

## Test plan

- [x] Added `test_get_openai_client_missing_databricks_sdk_raises_actionable_error` — verifies the actionable `ImportError` is raised when no env-var fallback exists
- [x] Added `test_get_openai_client_missing_databricks_sdk_with_env_falls_through` — verifies graceful fallthrough to `OPENAI_API_KEY` when `databricks-sdk` is absent

Closes #123