### PR TITLE
fix(antigravity): normalize unusable-model errors instead of leaking raw provider 404s

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -44,6 +44,7 @@ import contextlib
 import importlib
 import json
 import logging
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -265,6 +266,79 @@ def _enum_name(value: Any) -> str:  # type: ignore[explicit-any]
     """
     name = getattr(value, "name", None)
     return name if isinstance(name, str) else ""
+
+
+# A Gemini-backend "model not found" 404. The Antigravity backend answers an
+# unusable model id with the GenerativeLanguage wire error, e.g.::
+#
+#   request failed (code 404): models/gemini-bogus-xyz is not found for API
+#   version v1beta, or is not supported for generateContent. Call
+#   ModelService.ListModels to see the list of available models ...
+#
+# Matched loosely (code 404 + "is not found") so backend phrasing drift
+# (``v1beta`` -> ``v1``, ``generateContent`` -> ``streamGenerateContent``)
+# still normalizes. The raw text leaks the wire API surface
+# (``v1beta`` / ``generateContent`` / ``ListModels``) and must never reach
+# the persisted transcript — :func:`_normalize_model_error` strips it.
+_GEMINI_MODEL_NOT_FOUND_RE = re.compile(
+    r"code\s+404.*\bis not found\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _is_non_gemini_model_id(model: str) -> bool:
+    """Return ``True`` when *model* is recognizably a non-Gemini vendor id.
+
+    Mirrors the vendor-token rule in
+    :func:`omnigent.model_catalog.model_family_token` /
+    :func:`omnigent.model_override.model_family_mismatch` (Claude ids contain
+    ``"claude"``; GPT ids contain ``"gpt"`` — which also covers ``"gpt-oss"``)
+    and adds the ``"databricks-"`` gateway prefix and ``"codex"`` token. The
+    rule is mirrored rather than imported to keep this low-level executor free
+    of the ``model_catalog`` dependency graph (no inner executor imports it).
+
+    A bare unknown id (e.g. a typo'd Gemini name) returns ``False`` so it is
+    treated as a generic not-found rather than mislabelled cross-family.
+
+    :param model: The resolved model id, e.g. ``"databricks-claude-opus-4-8"``.
+    :returns: ``True`` if the id looks like another vendor's model.
+    """
+    lower = model.lower()
+    return (
+        "claude" in lower or "gpt" in lower or "codex" in lower or lower.startswith("databricks-")
+    )
+
+
+def _normalize_model_error(raw_error: str, model: str) -> str | None:
+    """Map a raw Gemini "model not found" 404 to a clean Omnigent message.
+
+    Antigravity is Gemini-only, so an unusable model id — a nonexistent
+    Gemini name or a cross-family id routed as a literal Gemini model —
+    404s at the backend. The raw provider text exposes the wire API surface
+    (``v1beta``, ``generateContent``, ``ModelService.ListModels``); returning
+    a normalized message keeps that out of the persisted transcript and
+    matches the clean, human-readable model errors the other SDK-wrap
+    executors surface (cf. the 404 ``terminal_error`` in
+    :mod:`omnigent.inner.claude_sdk_executor`).
+
+    Cross-family ids get a precise "Gemini only" message naming the offending
+    id; a genuine unknown Gemini id gets a generic not-found message. Errors
+    that are not a model-not-found 404 return ``None`` (caller keeps the raw
+    text — only the model-routing leak is normalized here).
+
+    :param raw_error: The raw ``Step.error`` string from the SDK.
+    :param model: The resolved model id pinned for this turn.
+    :returns: A normalized, leak-free message, or ``None`` when *raw_error*
+        is not a recognizable model-not-found 404.
+    """
+    if not _GEMINI_MODEL_NOT_FOUND_RE.search(raw_error or ""):
+        return None
+    if _is_non_gemini_model_id(model):
+        return f'antigravity only runs Gemini models; "{model}" is not a Gemini model'
+    return (
+        f'The selected model "{model}" was not found. It may not exist or '
+        "may not be available to this Antigravity backend."
+    )
 
 
 @dataclass
@@ -506,7 +580,7 @@ class AntigravityExecutor(Executor):
         state.interrupt_requested = False
 
         producer = asyncio.create_task(
-            self._drive_turn(state, prompt),
+            self._drive_turn(state, prompt, model),
             name=f"antigravity-turn:{session_key}",
         )
         final_text_parts: list[str] = []
@@ -552,7 +626,7 @@ class AntigravityExecutor(Executor):
 
     # ── SDK touchpoints (isolated; duck-typed; verified against v0.1.x) ──
 
-    async def _drive_turn(self, state: _AntigravitySessionState, prompt: str) -> None:
+    async def _drive_turn(self, state: _AntigravitySessionState, prompt: str, model: str) -> None:
         """Producer: drive one SDK turn, enqueuing mapped events.
 
         Sends *prompt*, then iterates ``receive_steps()`` mapping each
@@ -563,6 +637,8 @@ class AntigravityExecutor(Executor):
 
         :param state: The session state (conversation, queue, pending tools).
         :param prompt: The user text to send for this turn.
+        :param model: The resolved model id pinned for this turn, used to
+            normalize an unusable-model 404 into a clean message.
         """
         queue = state.active_queue
         assert queue is not None  # set by run_turn before spawning this task
@@ -619,9 +695,29 @@ class AntigravityExecutor(Executor):
                     # is non-retryable; plain ERROR may succeed on retry. Fall back
                     # to a generic message when the SDK reports none, so the turn
                     # isn't mis-reported as a silent empty success.
-                    message = (
-                        getattr(step, "error", "") or f"Antigravity turn failed (status={status})"
-                    )
+                    raw_error = getattr(step, "error", "") or ""
+                    # An unusable model id (nonexistent Gemini name, or a
+                    # cross-family id the Gemini-only backend can't route)
+                    # 404s with the raw GenerativeLanguage wire error. Strip
+                    # that to a clean message so the wire surface (v1beta /
+                    # generateContent / ListModels) never lands in the
+                    # persisted transcript; a bad model is config, not
+                    # transient, so it is non-retryable regardless of status.
+                    # NOTE: this normalizes the *message*; the turn still ends
+                    # ExecutorError -> status=failed. The graceful "idle" turn
+                    # the claude-native CLI bridge produces for a bad model is
+                    # a property of that native-bridge architecture, not the
+                    # SDK-wrap executor path: a normalized ExecutorError from
+                    # any SDK-wrap executor (this one and claude_sdk's 404
+                    # terminal_error alike) maps to failed via
+                    # ExecutorAdapter -> "inner executor error". Matching that
+                    # peer contract is the right cross-harness behavior here;
+                    # there is no idle escape hatch on this path to target.
+                    normalized = _normalize_model_error(raw_error, model)
+                    if normalized is not None:
+                        queue.put_nowait(ExecutorError(message=normalized, retryable=False))
+                        return
+                    message = raw_error or f"Antigravity turn failed (status={status})"
                     queue.put_nowait(ExecutorError(message=message, retryable=(status == "ERROR")))
                     return
         except asyncio.CancelledError:

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -602,6 +602,144 @@ async def test_error_step_without_message_still_fails(monkeypatch: pytest.Monkey
     assert not any(isinstance(e, TurnComplete) for e in events)
 
 
+# Raw GenerativeLanguage 404 the Antigravity backend returns for an unusable
+# model id; mirrors the bug-bash repro and carries the wire surface that must
+# not leak into the persisted transcript.
+def _raw_model_not_found_404(model: str) -> str:
+    return (
+        f"request failed (code 404): models/{model} is not found for API "
+        "version v1beta, or is not supported for generateContent. Call "
+        "ModelService.ListModels to see the list of available models and "
+        "their supported methods."
+    )
+
+
+# Wire-surface tokens that must never reach the persisted transcript.
+_WIRE_LEAK_TOKENS = ("v1beta", "ListModels", "generateContent", "models/")
+
+
+async def _model_error_for(
+    monkeypatch: pytest.MonkeyPatch, model: str, status: _StepStatus = _StepStatus.TERMINAL_ERROR
+) -> ExecutorError:
+    """Drive a turn whose terminal step carries the raw 404 for *model*."""
+    script: list[_TurnAction] = [
+        _YieldStep(
+            _FakeStep(
+                step_type=_StepType.FINISH,
+                status=status,
+                error=_raw_model_not_found_404(model),
+            )
+        ),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+    events = await _drain(
+        executor,
+        [{"role": "user", "content": "go", "session_id": "s1"}],
+        config=ExecutorConfig(model=model),
+    )
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert not any(isinstance(e, TurnComplete) for e in events)
+    return errors[0]
+
+
+@pytest.mark.asyncio
+async def test_invalid_gemini_model_404_normalized_no_wire_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nonexistent Gemini id 404 is normalized; raw wire text never leaks."""
+    script: list[_TurnAction] = [
+        _YieldStep(
+            _FakeStep(
+                step_type=_StepType.FINISH,
+                status=_StepStatus.TERMINAL_ERROR,
+                error=_raw_model_not_found_404("gemini-bogus-xyz"),
+            )
+        ),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+
+    events = await _drain(
+        executor,
+        [{"role": "user", "content": "go", "session_id": "s1"}],
+        config=ExecutorConfig(model="gemini-bogus-xyz"),
+    )
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    message = errors[0].message
+    # The wire API surface must be stripped from the persisted message.
+    for token in _WIRE_LEAK_TOKENS:
+        assert token not in message, f"raw wire token {token!r} leaked: {message!r}"
+    # A genuine unknown Gemini id is a generic not-found, not cross-family.
+    assert "gemini-bogus-xyz" in message
+    assert "not a Gemini model" not in message
+    # A bad model id is config, not transient — non-retryable.
+    assert errors[0].retryable is False
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_cross_family_gpt_id_404_names_gemini_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GPT id routed at the Gemini backend gets a precise Gemini-only message."""
+    error = await _model_error_for(monkeypatch, "gpt-4o")
+    message = error.message
+    for token in _WIRE_LEAK_TOKENS:
+        assert token not in message, f"raw wire token {token!r} leaked: {message!r}"
+    assert "only runs Gemini models" in message
+    assert "gpt-4o" in message
+    assert error.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_cross_family_databricks_claude_id_404_names_gemini_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A databricks-claude id at the Gemini backend gets the Gemini-only message."""
+    error = await _model_error_for(monkeypatch, "databricks-claude-opus-4-8")
+    message = error.message
+    for token in _WIRE_LEAK_TOKENS:
+        assert token not in message, f"raw wire token {token!r} leaked: {message!r}"
+    assert "only runs Gemini models" in message
+    assert "databricks-claude-opus-4-8" in message
+    assert error.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_non_model_error_text_preserved_not_normalized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-model-404 turn error is surfaced verbatim (only model 404s normalize)."""
+    script: list[_TurnAction] = [
+        _YieldStep(
+            _FakeStep(
+                step_type=_StepType.FINISH,
+                status=_StepStatus.ERROR,
+                error="request failed (code 503): backend overloaded, retry later",
+            )
+        ),
+    ]
+    _install_fake_sdk(monkeypatch, scripts=[script])
+    executor = AntigravityExecutor()
+
+    events = await _drain(
+        executor,
+        [{"role": "user", "content": "go", "session_id": "s1"}],
+        config=ExecutorConfig(model="gemini-3.5-flash"),
+    )
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    # Non-model errors pass through unchanged (no spurious normalization) and a
+    # plain ERROR stays retryable.
+    assert "backend overloaded" in errors[0].message
+    assert errors[0].retryable is True
+
+
 @pytest.mark.asyncio
 async def test_empty_turn_yields_turn_complete_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """A turn that streams no text ends as TurnComplete(response=None), not ''."""


### PR DESCRIPTION
## The bug (from a live bug-bash)

A live bug-bash of the Antigravity (Gemini) SDK harness found a new model-routing defect with no in-flight PR coverage (verified #290 only touches docs/catalog/UI, never the executor error path).

When an antigravity turn is pinned to an **unusable model** -- a nonexistent Gemini id (`gemini-bogus-xyz`) **or** a cross-family id (`gpt-4o`, `databricks-claude-opus-4-8`) -- the harness routes it as a literal Gemini model, the backend 404s, and `AntigravityExecutor._drive_turn` persisted the **raw provider wire error verbatim** into the transcript and marked the session `status=failed`:

```
inner executor error: ... ("request failed (code 404): models/gemini-bogus-xyz is not found
for API version v1beta ... Call ModelService.ListModels to see the list of available models ...")
```

Two problems: (a) the raw GenerativeLanguage wire surface (`v1beta`, `generateContent`, `ListModels`) leaks into the **persisted transcript**; (b) the cross-family case gives no hint that antigravity is Gemini-only.

## The fix

In the `_drive_turn` `ERROR`/`TERMINAL_ERROR` mapping (`omnigent/inner/antigravity_executor.py`):

1. **Normalize the Gemini 404.** A new `_normalize_model_error(raw_error, model)` helper detects a "model not found" 404 (matched loosely on `code 404` + `is not found`, so backend phrasing drift like `v1beta`->`v1` still normalizes) and returns a clean, **leak-free** message. The raw wire text (`v1beta` / `generateContent` / `ListModels` / `models/...`) never reaches the transcript. Non-model errors pass through unchanged.
2. **Special-case cross-family ids.** `_is_non_gemini_model_id` mirrors the existing vendor-token rule in `model_catalog.model_family_token` / `model_override.model_family_mismatch` (ids containing `claude` / `gpt` / `codex`, plus the `databricks-` gateway prefix) and emits a precise message: `antigravity only runs Gemini models; "<id>" is not a Gemini model`. The rule is **mirrored rather than imported** to keep this low-level executor off the heavier `model_catalog` dependency graph (no inner executor imports it today); the docstring cross-references the canonical rule.
3. A bad model is configuration, not a transient fault, so the normalized error is emitted **non-retryable** regardless of `ERROR` vs `TERMINAL_ERROR` status (retrying a bad model id is pointless), matching claude-sdk's own non-retryable 404 `terminal_error`.

### failed-vs-idle decision: kept `failed` (did NOT switch to `idle`)

The graceful "idle turn + clean assistant message" that claude-sdk shows for a bad model is a property of the **claude-native CLI-bridge** architecture (`codex_native_forwarder` maps `turn/completed` -> `status=idle`), not the SDK-wrap executor path. On the SDK-wrap path, a normalized `ExecutorError` from **any** executor -- this one **and** `claude_sdk_executor`'s own 404 `terminal_error` alike -- is re-raised by `ExecutorAdapter` as `"inner executor error: ..."` and the scaffold maps the resulting exception to `status=failed`. There is **no idle escape hatch** on this path to target.

So the correct cross-harness contract for an SDK-wrap executor is to **match its same-architecture peer (`claude_sdk`)**: a clean, normalized `ExecutorError` that maps to `failed`. This PR fixes the raw-leak divergence (the actionable bug) and **documents the remaining `failed`-vs-`idle` divergence in a code comment** rather than re-architecting the shared adapter (which would be out of scope and affect every SDK-wrap harness). Switching this one executor to fabricate a `TurnComplete` would diverge it from its peer and is not a contained change.

## Test coverage

Four new cases in `tests/inner/test_antigravity_executor.py`, each driving a fake `Step` carrying the raw 404:
- invalid Gemini id (`gemini-bogus-xyz`) -> generic normalized not-found, asserts **no** `v1beta` / `ListModels` / `generateContent` / `models/` substrings, non-retryable;
- cross-family `gpt-4o` -> message **names Gemini-only**, no leak, non-retryable;
- cross-family `databricks-claude-opus-4-8` -> message **names Gemini-only**, no leak, non-retryable;
- guard: a non-model `503` turn error is surfaced **verbatim** (not over-normalized) and stays retryable.

The three normalization tests fail on the base commit and pass with this change. `pytest tests/inner/test_antigravity_executor.py` is green (32 passed); ruff check + format and mypy are clean on the executor and the test.

Authored by Claude Code (an AI agent) at the repo owner's direction.
