### PR TITLE
ci: trim inline comments + multi-line long commands across workflows

### DIFF
--- a/.github/workflows/ap-web-tests.yml
+++ b/.github/workflows/ap-web-tests.yml
@@ -1,14 +1,8 @@
 name: ap-web Tests
 
-# Runs `npm test` (Vitest) for the ap-web React/TypeScript frontend on
-# every non-draft PR that touches ap-web and on push to main.
-#
-# Triggers:
-#   pull_request    opened / synchronize / reopened / ready_for_review.
-#                   Only fires when ap-web/** files changed.
-#                   Draft PRs are skipped; the `ready_for_review` trigger
-#                   refires when the draft is converted.
-#   push (main)     post-merge run on the default branch.
+# Runs `npm test` (Vitest) + format check for the ap-web React/TypeScript
+# frontend on every non-draft PR that touches ap-web/** and on push to main.
+# Draft PRs are skipped; `ready_for_review` refires when the draft is converted.
 
 on:
   pull_request:
@@ -25,17 +19,14 @@ permissions:
   contents: read
 
 concurrency:
-  # PR re-syncs share a group by PR number so old runs cancel.
-  # Non-PR events (push) key by SHA so back-to-back merges to `main`
-  # each get their own run.
+  # PRs key by number (old runs cancel); push keys by SHA (each merge runs).
   group: ap-web-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  # Security precondition gate: on untrusted PRs, npm ci/test (which runs the
-  # PR's own install hooks and test code) is held until the deterministic scan
-  # passes (see .github/workflows/security-gate.yml). Trusted authors and
-  # non-PR events pass through instantly.
+  # Security precondition gate: npm ci/test runs the PR's own install hooks and
+  # test code, so untrusted PRs are held until the scan passes (security-gate.yml).
+  # Trusted authors and non-PR events pass through.
   gate:
     uses: ./.github/workflows/security-gate.yml
 
@@ -59,9 +50,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ap-web
-        # registry.npmjs.org TLS handshakes flake (ECONNRESET) on this
-        # runner pool — route npm through the Databricks proxy. The
-        # public export rewrites this URL back to the npmjs default.
+        # Pin the npm registry to the npmjs default.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/autoformat-pr.yml
+++ b/.github/workflows/autoformat-pr.yml
@@ -1,12 +1,9 @@
 name: PR Autoformat
 
-# Manual PR hygiene helper. A human comments `/autoformat` on a PR to:
-# - assign the PR author, and
-# - add missing PR-template sections without deleting the author's text.
-#
-# Security: this issue_comment workflow never checks out or executes PR
-# code. It checks out only the repository default branch script and then
-# updates PR metadata through GitHub APIs.
+# Manual PR hygiene helper: a human comments `/autoformat` to assign the PR
+# author and add missing PR-template sections without deleting the author's text.
+# This issue_comment workflow never checks out or executes PR code — it checks
+# out only the default-branch script and updates PR metadata via the API.
 
 on:
   issue_comment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,12 @@
 name: CI
 
-# Runs the unit-test pytest matrix on every non-draft PR and on push
-# to main. Tests are split across directory-based matrix groups
-# (runtime-harnesses / runtime-policies / runtime-core, server-*,
-# inner-terminal / inner-env / inner-tracing / inner-rest, tools,
-# repl-sdk, spec-llms, misc) so slow files don't bottleneck a single
-# runner. The slowest subgroups use ``--dist=worksteal`` to fan tests
-# out within a file. See the `matrix.include` block for the per-group
-# rationale.
-#
-# Triggers:
-#   pull_request    opened / synchronize / reopened / ready_for_review.
-#                   Draft PRs are skipped; the `ready_for_review`
-#                   trigger refires the workflow when the draft is
-#                   converted, so the check doesn't strand pending.
-#   push (main)     post-merge run on the default branch.
+# Unit-test pytest matrix on every non-draft PR and on push to main. Tests are
+# split across directory-based matrix groups (runtime-*, server-*, inner-rest,
+# tools, repl-sdk, spec-llms, misc) so slow files don't bottleneck one runner;
+# the slowest groups use `--dist=worksteal` to fan tests out within a file. The
+# `misc` group is a catch-all so new top-level tests/<dir>/ are picked up
+# automatically. Draft PRs are skipped (ready_for_review re-fires the workflow).
+# A `coverage-report` job combines per-shard coverage for code-coverage.yml.
 
 on:
   pull_request:
@@ -29,68 +21,41 @@ permissions:
   contents: read
 
 env:
-  # No ap-web SPA build during `uv sync` (setup.py `_build_web_ui`):
-  # this job never serves the bundle, and the hardened runner's npm has
-  # no registry mirror so the build otherwise times out ~10min on public npm.
+  # No ap-web SPA build during `uv sync`; this job never serves the bundle.
   OMNIGENT_SKIP_WEB_UI: "true"
-  # Hardened runners have no outbound network to public PyPI; route
-  # both uv and pip through the Databricks proxy. PIP_INDEX_URL is
-  # only needed if anything in the workflow shells out to pip (e.g.
-  # a pre-commit hook fetched from a remote repo); set both for
-  # parity with `lint.yml` so behaviour stays uniform.
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
 
 concurrency:
-  # PR re-syncs share a group by PR number so old runs cancel.
-  # Non-PR events (push) key by SHA so back-to-back merges to `main`
-  # each get their own run -- needed for per-commit regression
-  # visibility.
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  # Security precondition gate: on untrusted PRs every job below is held until
-  # the deterministic scan passes (see .github/workflows/security-gate.yml).
-  # Trusted authors and non-PR events pass through instantly.
+  # Security precondition gate (security-gate.yml): untrusted PRs wait for the
+  # scan; trusted authors / non-PR events pass through.
   gate:
     uses: ./.github/workflows/security-gate.yml
 
   pytest:
     name: Pytest (${{ matrix.group }})
     needs: gate
-    # Skip on draft PRs; the `ready_for_review` trigger above re-fires
-    # the workflow when the draft is converted, so this won't strand
-    # the check pending on the eventual ready-for-review state.
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
-    # 30 (was 25): headroom for the residual coverage overhead under
-    # sys.monitoring. The heaviest shard (server-rest) ran ~8 min to 98%
-    # before this; sysmon keeps it well under 30.
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Runtime is split into three matrix entries so the heavy
-          # harness/process-manager tests don't bottleneck the whole
-          # group. CPU-time breakdown (sampled from main): test_scaffold
-          # ~107s, test_process_manager ~56s, test_executor_adapter ~49s
-          # (all in ``tests/runtime/harnesses/``); test_workflow ~48s,
-          # test_telemetry ~33s, test_executor ~33s in the top level;
-          # ``tests/runtime/policies/`` totals ~85s across many small
-          # files. ``runtime-harnesses`` uses ``--dist=worksteal`` so
-          # test_scaffold's 15 tests fan out across the 8 workers
-          # instead of pinning one for 107s. No fixture in
-          # ``tests/runtime/`` is module/session-scoped, so
-          # work-stealing is safe.
           - group: runtime-harnesses
             paths: tests/runtime/harnesses
             dist: worksteal
           - group: runtime-policies
             paths: tests/runtime/policies
           - group: runtime-core
-            paths: tests/runtime --ignore=tests/runtime/harnesses --ignore=tests/runtime/policies
+            paths: >-
+              tests/runtime
+              --ignore=tests/runtime/harnesses
+              --ignore=tests/runtime/policies
             dist: worksteal
           - group: inner-rest
             paths: tests/inner
@@ -98,51 +63,46 @@ jobs:
             paths: tests/tools tests/test_errors.py
           - group: repl-sdk
             paths: tests/frontends tests/repl tests/terminals
-          # Server is split into three matrix entries. CPU-time
-          # breakdown (sampled from main, 6/2026): tests/server/
-          # integration totals ~580s, the rest of tests/server ~180s,
-          # tests/onboarding ~5s - one shard serialised the whole
-          # ~765s behind 4 workers. Each subgroup keeps ``-n 4``
-          # because 8 workers contend heavily on the hardened runner
-          # (real workflows + httpx round-trips; #104).
-          #
-          # ``server-approvals`` isolates the elicitation/permission-
-          # hook/policy-gate integration files (~95s): they park real
-          # long-polls on server-side futures and are where the #2860
-          # wedge bites, so a hang there stalls one small job instead
-          # of the whole server shard, and reruns are cheap. Kept on
-          # the default ``loadfile`` to preserve their current
-          # serialised-per-file execution.
+          # Isolates the park-on-future elicitation/permission/policy files so a
+          # wedge there stalls one small job, not the whole server shard.
           - group: server-approvals
-            paths: tests/server/integration/test_sessions_permission_request_hook.py tests/server/integration/test_sessions_elicitation_resolve_url.py tests/server/integration/test_sessions_policy_evaluate.py
+            paths: >-
+              tests/server/integration/test_sessions_permission_request_hook.py
+              tests/server/integration/test_sessions_elicitation_resolve_url.py
+              tests/server/integration/test_sessions_policy_evaluate.py
             workers: "4"
-          # ``server-integration`` runs the rest of tests/server/
-          # integration (~485s). ``--dist=worksteal`` because the
-          # biggest file (``test_sessions_endpoints`` ~160s across 125
-          # tests) would otherwise pin one worker past the shard's
-          # ~120s balanced wall time. All fixtures in
-          # ``tests/server/conftest.py`` are function-scoped, so
-          # work-stealing is safe.
+          # worksteal: the biggest file would otherwise pin one worker past the
+          # shard's balanced wall time. server/conftest fixtures are function-scoped.
           - group: server-integration
-            paths: tests/server/integration --ignore=tests/server/integration/test_sessions_permission_request_hook.py --ignore=tests/server/integration/test_sessions_elicitation_resolve_url.py --ignore=tests/server/integration/test_sessions_policy_evaluate.py
+            paths: >-
+              tests/server/integration
+              --ignore=tests/server/integration/test_sessions_permission_request_hook.py
+              --ignore=tests/server/integration/test_sessions_elicitation_resolve_url.py
+              --ignore=tests/server/integration/test_sessions_policy_evaluate.py
             workers: "4"
             dist: worksteal
-          # ``server-rest`` keeps its historical name (it stays in
-          # merge-ready's REQUIRED list) and covers everything else:
-          # tests/server outside integration/ plus tests/onboarding
-          # (~185s). The old ``--ignore`` of test_routes_agents.py was
-          # dropped - that file was deleted in #1559.
+          # Historical name; stays in merge-ready's REQUIRED list.
           - group: server-rest
             paths: tests/server --ignore=tests/server/integration tests/onboarding
             workers: "4"
           - group: spec-llms
             paths: tests/spec tests/llms
-          # Catch-all: runs everything the other groups don't already
-          # cover, so newly added top-level `tests/<dir>/` directories
-          # are picked up automatically. Sweep into a named group
-          # periodically if this gets slow.
+          # Catch-all so new top-level tests/<dir>/ are covered automatically.
           - group: misc
-            paths: tests --ignore=tests/e2e --ignore=tests/runtime --ignore=tests/inner --ignore=tests/tools --ignore=tests/test_errors.py --ignore=tests/frontends --ignore=tests/repl --ignore=tests/terminals --ignore=tests/server --ignore=tests/onboarding --ignore=tests/spec --ignore=tests/llms
+            paths: >-
+              tests
+              --ignore=tests/e2e
+              --ignore=tests/runtime
+              --ignore=tests/inner
+              --ignore=tests/tools
+              --ignore=tests/test_errors.py
+              --ignore=tests/frontends
+              --ignore=tests/repl
+              --ignore=tests/terminals
+              --ignore=tests/server
+              --ignore=tests/onboarding
+              --ignore=tests/spec
+              --ignore=tests/llms
 
     steps:
       - name: Check out repo
@@ -159,25 +119,9 @@ jobs:
           enable-cache: true
 
       - name: Install ripgrep + bubblewrap
-        # ripgrep: the `Grep` client tool prefers it and only falls
-        # back to `grep -r` when missing. The fallback omits the
-        # filename prefix on single-file searches, which fails
-        # `test_grep_smoke` (it asserts the path is in the output).
-        #
-        # bubblewrap: required by the `linux_bwrap` sandbox backend
-        # introduced in PR #79. Without `bwrap` on PATH, every test
-        # in `tests/inner/test_bwrap_sandbox.py` fails with
-        # `OSError: linux_bwrap sandbox requires the 'bwrap' binary
-        # on PATH`.
-        #
-        # apparmor sysctl: Ubuntu 24.04 ships an apparmor profile that
-        # blocks unprivileged user-namespace creation by default, so
-        # ``bwrap`` (which calls ``unshare(CLONE_NEWUSER)``) fails with
-        # ``setting up uid map: Permission denied`` even after install.
-        # Disabling the restriction at the sysctl level mirrors what
-        # the Ubuntu 22.04 runner image did implicitly. Scope is the
-        # ephemeral CI runner, so the security trade-off is bounded
-        # to the duration of one job.
+        # ripgrep: the Grep tool prefers it. bubblewrap: the linux_bwrap sandbox
+        # needs it. apparmor sysctl: Ubuntu 24.04 blocks unprivileged user
+        # namespaces that bwrap needs; scope is the ephemeral runner.
         run: |
           sudo apt-get update
           sudo apt-get install -y ripgrep bubblewrap
@@ -190,34 +134,19 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
-        # `--extra all` pulls the optional `claude-sdk` + `openai-agents`
-        # extras so unit tests that exercise harness adapters can import
-        # the underlying SDKs. Matches the install set used by `e2e.yml`.
         run: uv sync --extra all --extra dev
 
       - name: Run pytest
-        # The `force-all-tests` PR label bypasses tests/known_failures.yaml
-        # so contributors can verify that quarantined tests still need
-        # to be quarantined. Apply the label and re-run; remove to
-        # restore normal behaviour.
         shell: bash
         env:
+          # force-all-tests label bypasses tests/known_failures.yaml.
           FORCE_ALL_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'force-all-tests') }}
-          # Dump thread stacks on Python-level crash signals (SIGKILL
-          # is uncatchable, so OOM-kills still leave no trace).
           PYTHONFAULTHANDLER: "1"
-          # Per-worker fsync'd START/END/RSS logs (#426). Uploaded as
-          # artifacts so a wedged worker leaves the last test on disk.
           PYTEST_PROGRESS_LOG_DIR: artifacts/progress
           OMNIGENT_TOKEN_USAGE_JSON: artifacts/tokens-${{ matrix.group }}.json
-          # One coverage data file per shard, uploaded inside artifacts/.
-          # The code-coverage workflow downloads all shards and combines
-          # them. pytest-cov already merges the xdist workers within a shard.
           COVERAGE_FILE: artifacts/.coverage.${{ matrix.group }}
-          # Use CPython 3.12's sys.monitoring backend. The default C-trace
-          # function adds 2-5x per-line overhead, which pushed the heaviest
-          # shard (server-rest) past its timeout; sysmon cuts that to ~10-20%.
-          # We only collect line coverage (no branch), which sysmon supports.
+          # sysmon: the default C-trace coverage backend pushed the heaviest
+          # shard past its timeout; only line coverage is collected.
           COVERAGE_CORE: sysmon
         run: |
           mkdir -p artifacts artifacts/progress
@@ -226,11 +155,7 @@ jobs:
             EXTRA_ARGS=(--no-skip-known)
             echo "::notice::force-all-tests label present; bypassing tests/known_failures.yaml"
           fi
-          # ``matrix.paths`` is intentionally unquoted: it expands to
-          # multiple space-separated tokens (e.g.
-          # ``tests/runtime --ignore=tests/runtime/harnesses``), so
-          # shell word-splitting is the feature. The shellcheck
-          # disable is for that one token only.
+          # matrix.paths is unquoted on purpose: it word-splits into pytest args.
           # shellcheck disable=SC2086
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
             uv run pytest ${{ matrix.paths }} \
@@ -250,17 +175,13 @@ jobs:
           name: pytest-${{ matrix.group }}-${{ github.run_id }}
           path: artifacts/
           retention-days: 14
-          # The per-shard coverage data file is artifacts/.coverage.<group>
-          # (a dotfile); upload-artifact@v4 omits hidden files by default.
-          include-hidden-files: true
+          include-hidden-files: true  # the per-shard .coverage.<group> dotfile
 
   coverage-report:
     name: Coverage report
-    # Combines the per-shard coverage data into a `coverage-summary` artifact
-    # (total.txt + coverage.xml). This runs in the unprivileged pull_request
-    # context, so checking out + reading the PR's source is safe here; the
-    # privileged status-poster (code-coverage.yml) then only consumes the
-    # artifact and never touches the PR's code. Report-only.
+    # Combines per-shard coverage into a coverage-summary artifact. Runs in the
+    # unprivileged pull_request context (read-only); code-coverage.yml consumes
+    # the artifact and posts the status. Report-only.
     needs: pytest
     if: ${{ !cancelled() && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
@@ -298,9 +219,7 @@ jobs:
           fi
           echo "Combining ${#files[@]} shard data file(s)."
           coverage combine "${files[@]}"
-          # --ignore-errors: a plain checkout has no files generated during
-          # `uv sync` (e.g. omnigent/_build_info.py); skip those rather than
-          # exit 1 on "No source for code".
+          # --ignore-errors: a plain checkout lacks uv-sync-generated files.
           { echo "## Coverage"; echo; coverage report --format=markdown --ignore-errors; } >> "$GITHUB_STEP_SUMMARY"
           coverage xml -o coverage-summary/coverage.xml --ignore-errors
           coverage report --format=total --ignore-errors > coverage-summary/total.txt

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,21 +1,17 @@
 name: Code Coverage
 
 # Posts a report-only `Coverage` commit status from the `coverage-summary`
-# artifact produced by the CI workflow (the combine + report happen there, in
-# the unprivileged pull_request context). This job runs on workflow_run
-# (privileged: statuses:write) but deliberately does NOT check out the PR's
-# code — it only consumes the artifact — so it is not a "dangerous workflow".
-#
-# The status is always success (the % rides in the description) and is never a
-# required check, so it can't block a merge.
+# artifact produced by the CI workflow. Runs on workflow_run (privileged,
+# statuses:write) but does NOT check out PR code — it only consumes the artifact,
+# so it isn't a "dangerous workflow". The status is always success (the % rides
+# in the description) and is never required, so it can't block a merge.
 
 on:
   workflow_run:
     workflows: [CI]
     types: [completed]
 
-# Read-only at the top level (Scorecard Token-Permissions); the write
-# scopes live on the job below.
+# Read-only at the top level; write scopes live on the job below.
 permissions:
   contents: read
 
@@ -29,15 +25,13 @@ jobs:
     permissions:
       actions: read     # download the coverage-summary artifact from the CI run
       statuses: write   # post the Coverage status on the PR head SHA
-    # PR-originated CI runs only. push:main / schedule / dispatch completions
-    # have no PR head SHA worth annotating.
+    # PR-originated CI runs only; other completions have no PR head SHA.
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Data only — never the PR's code. Tolerate a missing artifact (fork-PR
-      # runs the token can't read, or CI that produced no coverage) by falling
-      # through to the no-data guard rather than painting a red check.
+      # Data only — never the PR's code. Tolerate a missing artifact (fork PRs,
+      # or CI that produced no coverage) via the no-data guard below.
       - name: Download coverage summary
         continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4

--- a/.github/workflows/e2e-ui-required.yml
+++ b/.github/workflows/e2e-ui-required.yml
@@ -1,40 +1,28 @@
 name: E2E UI Required
 
-# Required-status gate: a PR that changes ap-web/** must either ship a
-# tests/e2e_ui/** test that covers the change, or carry a maintainer-effective
-# `skip-e2e-ui-test` label. Enforces the "UI behavior change ships with a UI
-# test" policy at PR time, where the author still has the change's intent in
-# head.
+# Required-status gate: a PR that changes ap-web/** must ship a tests/e2e_ui/**
+# test covering the change or carry a maintainer-effective `skip-e2e-ui-test`
+# label. The policy verdict FAILS the job; mark `E2E UI Required` as a required
+# check in branch protection for that to block merge. Whether a change "needs a
+# test" is decided by an LLM judge (check.sh case 2), not file-presence, so
+# refactors/renames/dep-bumps/styling/test-only edits don't trip the gate and a
+# throwaway test doesn't satisfy it.
 #
-# The policy verdict (UI change without a covering test or effective waiver)
-# FAILS the job. For the failure to actually block the merge button, mark
-# `E2E UI Required` as a required status check in branch protection for main.
+# Trigger is `pull_request_target`, so the workflow + gate script run from main
+# with the base token even for fork PRs: the PR-head copy never runs (a PR can't
+# weaken the gate), and `labeled`/`unlabeled` let the skip label re-evaluate it.
 #
-# Whether the change "needs a test" is decided by an LLM judge (see
-# check.sh case 2), NOT a deterministic file-presence check -- so refactors,
-# renames, dep bumps, styling and test-only edits don't trip the gate, and a
-# trivial throwaway test doesn't satisfy it.
+# SECURITY -- the LLM judge reads the PR's (attacker-controlled) diff as TEXT and
+# sends it to the gateway with the rate-limited, revocable test token (same risk
+# profile as fork e2e). The job never checks out or runs PR-head code: it checks
+# out ONLY .github/scripts from main (pinned, no persisted credentials) and reads
+# state via the API. The judge prompt is hardened against injection and fails
+# closed; a wrong "pass" can't merge anything since the required `Maintainer
+# Approval` check + a human reviewer still gate merge.
 #
-# Trigger is `pull_request_target`, so the workflow + gate script always run
-# from the BASE branch (main), with the base token, even for fork PRs:
-#   - the PR-head copy of this file/script never runs, so a PR cannot edit
-#     the gate to weaken it (same hardening as maintainer-approval.yml);
-#   - `labeled` / `unlabeled` are included so applying the skip label
-#     re-evaluates the check and can flip it green.
-#
-# SECURITY -- the LLM judge step reads the PR's (attacker-controlled, on fork
-# PRs) diff as TEXT and sends it to the gateway with the rate-limited, revocable
-# test token (same accepted-risk profile as fork e2e). The job never checks out
-# or runs PR-head code: it checks out ONLY .github/scripts from main (pinned, no
-# persisted credentials) and reads change/label/review state via the API. The
-# judge prompt is hardened against injection and fails closed. Crucially, a
-# wrong/injected "pass" here cannot merge anything: the separate required
-# `Maintainer Approval` check still gates merge, and a maintainer reviews.
-#
-# NO `paths:` filter on purpose: a required check that is path-filtered never
-# reports on PRs that don't match, leaving the required status stuck pending
-# and blocking merge forever. Instead this always runs and the gate script
-# self-determines whether ap-web/** was touched.
+# NO `paths:` filter on purpose: a path-filtered required check never reports on
+# non-matching PRs, stranding the status pending forever. This always runs and
+# the gate script self-determines whether ap-web/** was touched.
 #
 # leak-scan-allow: pull_request_target
 on:

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -1,25 +1,16 @@
 name: E2E UI Tests
 
-# Runs the Playwright UI suite against a freshly built ap-web
-# SPA + a hello_world test agent, split across a 3-shard matrix
-# (pytest-shard, same pattern as e2e.yml) so wall-clock stays low
-# enough to gate PRs on as the suite grows. Lives in its own
-# workflow rather than as a sibling job in nightly.yml because the
-# setup (Node + npm + Playwright + SPA build) is structurally
-# disjoint from the inner-only legs and would bloat that workflow's
-# matrix.
+# Runs the Playwright UI suite against a freshly built ap-web SPA + a
+# hello_world test agent, split across a 3-shard matrix. Separate from
+# nightly.yml because the Node + Playwright + SPA-build setup is disjoint
+# from the inner-only legs.
 #
 # Triggers:
-#   pull_request        opened / synchronize / reopened /
-#                       ready_for_review. SAME-REPO PRs only; draft
-#                       PRs and fork PRs skip the job (forks run via
-#                       the fork-e2e/** push after approval, mirrored
-#                       by fork-e2e-mirror.yml).
-#   push (fork-e2e/**)  the UI suite for mirrored fork PRs -- a trusted
-#                       base-repo branch, so secrets flow.
+#   pull_request        SAME-REPO PRs only; draft / fork PRs skip the job
+#                       (forks run via the fork-e2e/** push after approval).
+#   push (fork-e2e/**)  UI suite for mirrored fork PRs (trusted, secrets flow).
 #   schedule            09:00 UTC daily, alongside nightly.yml.
-#   workflow_dispatch   manual run. Input `branch` selects a non-main
-#                       ref.
+#   workflow_dispatch   manual run. Input `branch` selects a non-main ref.
 
 on:
   pull_request:
@@ -40,55 +31,40 @@ permissions:
   contents: read
 
 concurrency:
-  # PR re-syncs share a group by PR number so old runs cancel.
-  # workflow_dispatch with a branch input shares a group so manual
-  # re-dispatches against the same branch cancel. Push and schedule
-  # events key by SHA so back-to-back merges to `main` each get
-  # their own run -- needed for per-commit regression visibility.
+  # PRs key by number, dispatch by branch (so re-runs cancel); push /
+  # schedule key by SHA so each merge to `main` gets its own run.
   group: e2e-ui-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
   cancel-in-progress: true
 
 env:
-  # No SPA build during `uv sync` (setup.py `_build_web_ui`): this
-  # workflow builds the bundle itself in a dedicated `npm ci && npm run
-  # build` step, so the setup.py build would be a redundant ~10min that
-  # also hits public npm (no registry mirror here).
+  # No SPA build during `uv sync`: this workflow builds the bundle in a
+  # dedicated step, so the setup.py build would be a redundant npm hit.
   OMNIGENT_SKIP_WEB_UI: "true"
   # Scrub harness credentials the test server must not pick up.
-  # OPENAI_API_KEY / OPENAI_BASE_URL are intentionally NOT scrubbed here
-  # — the "Run UI e2e tests" step sets them to the freshly-minted
-  # Databricks bearer + workspace serving-endpoints URL so the spawned
-  # hello_world agent (openai-agents harness against Databricks Model
-  # Serving) can authenticate. The previous shape scrubbed both and
-  # expected the agent to fall back to ~/.databrickscfg, but the SDK's
-  # default-profile lookup didn't resolve our OAuth M2M config in CI,
-  # which is what was failing the LLM calls.
+  # OPENAI_API_KEY / OPENAI_BASE_URL are NOT scrubbed here -- the "Run UI
+  # e2e tests" step sets them to the Databricks bearer + serving-endpoints
+  # URL so the spawned openai-agents hello_world agent can authenticate
+  # (the ~/.databrickscfg fallback didn't resolve our OAuth M2M in CI).
   ANTHROPIC_API_KEY: ""
   DATABRICKS_TOKEN: ""
   CODEX: ""
   CLAUDE_CODE: ""
   # Match e2e.yml's proxy choice.
   UV_INDEX_URL: https://pypi.org/simple
-  # GitHub-hosted runners default to TERM=dumb, which makes the
-  # terminal-attach test's PTY shell error out on "clear". Set a real
-  # terminfo so the spawned PTY (and any nested tools that probe TERM)
-  # can resolve clear/cursor sequences. Inherited by the agent server
-  # subprocess via the conftest's env={**os.environ, ...} plumbing.
+  # Runners default to TERM=dumb, which breaks the PTY shell's "clear".
+  # A real terminfo lets the spawned PTY resolve clear/cursor sequences;
+  # inherited by the agent server via the conftest's env plumbing.
   TERM: xterm-256color
 
 jobs:
-  # Security precondition gate: on untrusted PRs the shard setup (which checks
-  # out and runs the PR's own e2e-shard-matrix.sh) and all e2e-ui jobs are held
-  # until the deterministic scan passes (see .github/workflows/security-gate.yml).
-  # Trusted authors and non-PR events (push to fork-e2e/**, schedule, dispatch)
-  # pass through instantly.
+  # Security gate: untrusted PRs wait on the deterministic scan
+  # (security-gate.yml); trusted authors and non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
 
-  # Compute the shard matrix once. A skipped run (draft, or a fork's
-  # pull_request) yields an EMPTY matrix -> zero shard jobs -> no skipped
-  # check-runs with an unexpanded ${{ matrix.* }} name. Shared with e2e.yml
-  # via .github/scripts/ci/e2e-shard-matrix.sh (only NUM_SHARDS differs).
+  # Compute the shard matrix once. A skipped run (draft / fork pull_request)
+  # yields an EMPTY matrix -> zero shard jobs -> no skipped placeholder check.
+  # Shared with e2e.yml via e2e-shard-matrix.sh (only NUM_SHARDS differs).
   setup:
     name: setup
     needs: gate
@@ -100,10 +76,8 @@ jobs:
       - name: Check out CI scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          # Triggering ref (not pinned to main): the script must exist on the
-          # running ref, and it is not a security gate -- it only shards tests
-          # and can't expose secrets (fork pull_request has none), so the PR's
-          # own copy is fine.
+          # Triggering ref (not main): the script must exist on it, and it
+          # only shards tests -- no secrets exposure, so the PR's copy is fine.
           sparse-checkout: .github/scripts/ci
           persist-credentials: false
       - name: Compute shard matrix
@@ -117,23 +91,18 @@ jobs:
 
   e2e-ui:
     name: E2E UI Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
-    # Draft PRs and fork pull_request events resolve to an EMPTY matrix in
-    # `setup` (forks can't read the LLM_API_KEY / GATEWAY_BASE_URL secrets on a
-    # pull_request; they run via the fork-e2e/** mirror push instead), so this
-    # job produces zero shard runs for them -- and thus no skipped placeholder
-    # check. The `ready_for_review` trigger re-fires when a draft is converted.
+    # Draft / fork pull_request events resolve to an EMPTY matrix in `setup`
+    # (forks run via the fork-e2e/** mirror push), so no shard runs for them.
+    # `ready_for_review` re-fires when a draft is converted.
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
-      # One red shard shouldn't cancel siblings; we want every shard's
-      # signal so reviewers can see whether the failure is broad or
-      # localized to one chunk.
+      # One red shard shouldn't cancel siblings -- we want every shard's signal.
       fail-fast: false
       max-parallel: 3
-      # Shards from `setup`; [] when the run is skipped. Shard check names are
-      # in .github/scripts/merge-ready/required.sh -- keep in sync with the
-      # NUM_SHARDS in this workflow's setup job when changing the count.
+      # Shards from `setup`; [] when skipped. Shard check names live in
+      # merge-ready/required.sh -- keep in sync with NUM_SHARDS above.
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
@@ -171,20 +140,12 @@ jobs:
         run: uv sync --extra all --extra dev
 
       - name: Install bubblewrap + tmux
-        # The UI tests boot a real server and open terminals, which run
-        # under os_env. An agent/terminal that omits `os_env.sandbox.type`
-        # defaults to `linux_bwrap` on Linux and fails loud at runtime if
-        # `bwrap` is missing (rather than silently running unsandboxed), so
-        # the terminal never launches and the right-panel terminal assertion
-        # fails. Install `bubblewrap` like ci.yml / e2e.yml. The apparmor
-        # sysctl mirrors ci.yml: Ubuntu 24.04 blocks unprivileged user
-        # namespaces by default, which `bwrap`'s `unshare(CLONE_NEWUSER)`
-        # needs.
-        #
-        # tmux: the claude-native harness drives Claude Code through a tmux
-        # pane (omnigent/claude_native_bridge), so the native render-parity
-        # test (test_native_claude_render_parity) needs `tmux` on PATH like
-        # e2e.yml.
+        # bubblewrap: the UI tests open terminals under os_env, whose
+        # linux_bwrap backend fails loud if `bwrap` is missing. The apparmor
+        # sysctl mirrors ci.yml (Ubuntu 24.04 blocks unprivileged user
+        # namespaces, which bwrap's unshare(CLONE_NEWUSER) needs).
+        # tmux: the claude-native render-parity test drives Claude Code
+        # through a tmux pane, so `tmux` must be on PATH.
         run: |
           sudo apt-get update
           sudo apt-get install -y bubblewrap tmux
@@ -203,17 +164,10 @@ jobs:
           uv run playwright install --with-deps chromium
 
       - name: Build ap-web SPA
-        # Build BEFORE pytest. Vite's emptyOutDir clobbers the
-        # static dir, so we never want this happening under xdist
-        # workers or interleaved with the running server.
-        #
-        # The lockfile already pins the dependency tree. `--legacy-peer-deps`
-        # prevents npm from spending the whole job re-resolving the known
-        # React 19 peer-dependency conflict under @emoji-mart/react.
-        #
-        # registry.npmjs.org TLS handshakes flake (ECONNRESET) on this
-        # runner pool — route npm through the Databricks proxy. The
-        # public export rewrites this URL back to the npmjs default.
+        # Build BEFORE pytest: Vite's emptyOutDir clobbers the static dir,
+        # so never run it under xdist or alongside the live server.
+        # --legacy-peer-deps avoids re-resolving the known React 19 peer
+        # conflict under @emoji-mart/react.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
@@ -221,27 +175,15 @@ jobs:
           npm ci --legacy-peer-deps --no-audit --no-fund
           npm run build
 
-      # ----------------------------------------------------------------------
-      # Native coding-agent harness enablement. The steps below let
-      # test_native_claude_render_parity and test_native_codex_render_parity
-      # boot a real Claude Code / Codex CLI in CI, mirroring how e2e.yml /
-      # integration.yml auth those harnesses. Only the native render-parity
-      # tests depend on these; the rest of the e2e-ui suite (openai-agents)
-      # ignores them.
-      # ----------------------------------------------------------------------
+      # Native coding-agent harness enablement: the next steps let the
+      # native render-parity tests boot a real Claude Code / Codex CLI. The
+      # rest of the e2e-ui suite (openai-agents) ignores them.
       - name: Install Claude Code CLI
-        # Install claude-code 2.1.170, NOT the 2.1.124 pinned in
-        # .github/ci-deps. 2.1.124 does not recognise the hook events the
-        # native bridge configures (InstructionsLoaded / CwdChanged /
-        # FileChanged) and shows a blocking "settings values skipped" modal on
-        # startup; the injected first message lands on that modal and is lost,
-        # so no turn ever runs. 2.1.170 accepts those events and boots straight
-        # to the prompt. (The ci-deps pin drives e2e.yml's claude-sdk/codex
-        # legs; bumping it there is a separate change with wider blast radius —
-        # tracked for the permanent native-harness wiring.)
-        # --ignore-scripts blocks arbitrary postinstall; we then run claude-code's
-        # own install.cjs explicitly (audited: platform detect + same-tree hardlink
-        # of the native binary, no network/exec) and put its bin on PATH.
+        # claude-code 2.1.170, NOT the 2.1.124 in .github/ci-deps: 2.1.124
+        # doesn't recognise the hook events the native bridge configures and
+        # shows a blocking startup modal that swallows the first message.
+        # --ignore-scripts then run install.cjs explicitly (audited: platform
+        # detect + same-tree hardlink, no network/exec) and put its bin on PATH.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
@@ -251,13 +193,10 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI
-        # Install @openai/codex at the version pinned in .github/ci-deps (the
-        # same build e2e.yml's codex leg runs). `scripts: null` on the package
-        # means there is no postinstall, so --ignore-scripts is a no-op safety
-        # net; the native binary ships in the package itself and is put on PATH
-        # via node_modules/.bin. The native codex render-parity test
-        # (test_native_codex_render_parity) drives this CLI through a tmux pane
-        # (omnigent/codex_native_bridge), so `codex` must be on PATH.
+        # @openai/codex at the .github/ci-deps pin (same build as e2e.yml's
+        # codex leg). `scripts: null` means no postinstall, so --ignore-scripts
+        # is a safety no-op; the native binary ships in the package and goes on
+        # PATH for the codex render-parity test's tmux pane.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
@@ -266,18 +205,10 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Configure native-claude/codex gateway provider
-        # The runner derives each native CLI's gateway auth from omnigent
-        # provider config (claude: omnigent.claude_native.resolve_native_claude_config;
-        # codex: omnigent.codex_native_app_server.resolve_native_codex_launch).
-        # Register the Databricks gateway as the default for BOTH families so a
-        # single provider routes Claude Code (anthropic) and Codex (openai): the
-        # token reaches each CLI via an env:LLM_API_KEY ref (the runner env
-        # allowlist excludes ANTHROPIC_API_KEY / OPENAI_API_KEY), each family
-        # pins its CI model. The config uses an env: ref (not the literal token),
-        # so no secret is written to disk here. ~/.databrickscfg / DATABRICKS_BEARER
-        # are intentionally NOT written: the native paths authenticate purely from
-        # this provider config, so there's no ambient Databricks lookup to satisfy
-        # — keeping the literal token off disk.
+        # The native CLIs derive their gateway auth from omnigent provider
+        # config. Register the Databricks gateway as the default for both
+        # anthropic (Claude Code) and openai (Codex); the token reaches each
+        # CLI via an env:LLM_API_KEY ref, so no literal secret hits disk.
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
@@ -325,21 +256,11 @@ jobs:
           EOF
 
       - name: Run UI e2e tests
-        # --ui-skip-build: the SPA was already built in the previous
-        # step, so skip the fixture's own npm ci + build pass.
-        #
-        # pytest-playwright defaults --tracing/--screenshot/--video all
-        # to "off", so without these flags test-results/ stays empty
-        # and the failure-upload step has nothing to grab. retain-on-failure
-        # keeps the CI cost ~zero on green runs while giving us a full
-        # trace + video to step through when something breaks.
-        #
-        # OPENAI_API_KEY / OPENAI_BASE_URL are propagated by the
-        # conftest's live_server fixture (env={**os.environ, ...}) into
-        # the spawned `omnigent server --agent` subprocess, where the
-        # openai-agents harness picks them up as the Databricks Model
-        # Serving endpoint + bearer (see
-        # omnigent/inner/openai_agents_sdk_executor.py:387).
+        # --ui-skip-build: the SPA was built in the previous step.
+        # --tracing/--screenshot/--video default to off; retain-on-failure
+        # keeps green runs cheap while capturing artifacts on failures.
+        # OPENAI_API_KEY / OPENAI_BASE_URL flow into the spawned server via
+        # the conftest's live_server fixture for the openai-agents harness.
         env:
           OPENAI_API_KEY: ${{ env.LLM_API_KEY }}
           OPENAI_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
@@ -353,14 +274,10 @@ jobs:
           if [[ "$NIGHTLY_FULL" != "true" ]]; then
             EXTRA_ARGS+=(-m "not nightly")
           fi
-          # --splits/--group partition the suite across the matrix entries
-          # via a round-robin strided slice (see pytest_collection_modifyitems
-          # in tests/e2e_ui/conftest.py). Unlike pytest-shard's hash-bucketing
-          # -- which was blind to runtime and left one shard ~5min while
-          # others ran ~2min -- striding scatters each heavy file's cases
-          # one-per-shard, evening out wall-clock with no extra dependency
-          # and no durations file to maintain. --group is 1-indexed, so we
-          # map the 0-indexed matrix shard_id with +1.
+          # --splits/--group partition the suite via a strided slice (see
+          # pytest_collection_modifyitems in tests/e2e_ui/conftest.py), which
+          # evens out wall-clock better than pytest-shard's hash-bucketing.
+          # --group is 1-indexed, so map the 0-indexed shard_id with +1.
           uv run pytest tests/e2e_ui \
             -v --tb=long --showlocals --log-level=INFO -r a \
             --ui-skip-build \
@@ -377,13 +294,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          # Shard suffix keeps the matrix's parallel uploads from
-          # colliding on the same artifact name (v4 409s on dupes).
+          # Shard suffix avoids the matrix's parallel uploads colliding (v4
+          # 409s on dupe names).
           name: e2e-ui-playwright-${{ github.run_id }}-shard${{ matrix.shard_id }}
-          # ``playwright-report/`` is the JS-runner's HTML report dir and
-          # is never produced by pytest-playwright — left in the path
-          # list for forward-compat (``if-no-files-found: ignore`` keeps
-          # it silent when absent).
+          # `playwright-report/` is the JS-runner's HTML dir, never produced
+          # by pytest-playwright -- kept for forward-compat (ignore-if-absent).
           path: |
             test-results/
             playwright-report/
@@ -391,25 +306,18 @@ jobs:
           if-no-files-found: ignore
 
       - name: Dump Claude transcript on failure
-        # Claude Code's transcript (the JSONL with its actual API errors)
-        # lives under ~/.claude/projects, a hidden dir the absolute-path
-        # artifact glob misses. Copy it under /tmp so the server-logs upload
-        # captures it when the native test fails. Deliberately NOT copying
-        # ~/.claude.json: its apiKeyHelper embeds the gateway token, so it is
-        # never staged for upload — no credential leaves the runner.
+        # Claude Code's transcript JSONL lives under ~/.claude/projects (a
+        # hidden dir the artifact glob misses); stage it under /tmp. NOT
+        # copying ~/.claude.json: its apiKeyHelper embeds the gateway token.
         if: failure()
         run: |
           mkdir -p /tmp/claude-home-dump
           cp -r "$HOME/.claude/projects" /tmp/claude-home-dump/ 2>/dev/null || true
 
       - name: Dump Codex transcript on failure
-        # Codex's per-session rollout transcripts (the JSONL with its actual API
-        # errors) live under the bridged CODEX_HOME at
-        # ~/.omnigent/codex-native/<hash>/codex-home/sessions. Copy ONLY the
-        # *.jsonl rollouts so the server-logs upload captures them. Deliberately
-        # NOT copying config.toml: its auth command embeds the gateway token
-        # (printf %s <token>), so it is never staged for upload — no credential
-        # leaves the runner.
+        # Codex's per-session rollout JSONLs live under the bridged CODEX_HOME
+        # at ~/.omnigent/codex-native/<hash>/codex-home/sessions; stage only
+        # the *.jsonl. NOT copying config.toml: its auth command embeds the token.
         if: failure()
         run: |
           mkdir -p /tmp/codex-home-dump
@@ -422,21 +330,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: e2e-ui-server-logs-${{ github.run_id }}-shard${{ matrix.shard_id }}
-          # The conftest's ``live_server`` fixture writes server.log
-          # under ``tmp_path_factory.mktemp("e2e_ui_server")``, which
-          # resolves to ``/tmp/pytest-of-runner/pytest-*/e2e_ui_server*/``
-          # on GitHub-hosted runners. The previous glob targeted
-          # ``e2e_ui_logs*``, which never matched, so the artifact was
-          # always empty.
-          #
-          # Also grab runner.log (carries the claude-/codex-native auto-launch +
-          # auth-resolution + terminal-launch logs) and the native bridge dirs
-          # (tmux target, transcript-forward deltas) under
-          # /tmp/omnigent-<uid>/claude-native, plus the Claude / Codex
-          # transcripts staged above — all needed to triage a native
-          # render-parity failure. The codex bridge state lives under
-          # ~/.omnigent/codex-native; only its *.jsonl rollouts are staged
-          # (config.toml carries the token and is excluded).
+          # server.log + runner.log from the live_server fixture's tmp dir,
+          # plus the native bridge dirs and the Claude / Codex transcripts
+          # staged above -- all needed to triage a native render-parity failure.
           path: |
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
@@ -447,11 +343,8 @@ jobs:
           if-no-files-found: ignore
 
       - name: Surface failure artifacts on job summary
-        # GH groups artifact uploads inside the step they ran in, which
-        # means triagers have to expand the right step + scroll to find
-        # the download link. Writing to GITHUB_STEP_SUMMARY puts a flat,
-        # always-visible Markdown block at the top of the job summary
-        # page with direct links to every artifact this job produced.
+        # Write a flat, always-visible block of artifact download links to
+        # GITHUB_STEP_SUMMARY (GH otherwise buries them inside each step).
         if: failure()
         env:
           PLAYWRIGHT_URL: ${{ steps.upload_playwright.outputs.artifact-url }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,27 +1,18 @@
 name: E2E Tests
 
-# Runs the `tests/e2e/` suite, which drives real workflows against a
-# live LLM (Databricks gateway) and exercises sub-agent spawning,
-# parking, tunneled client tools, and the PATCH/GET response routes.
+# Runs the `tests/e2e/` suite against a live LLM (Databricks gateway):
+# sub-agent spawning, parking, tunneled client tools, PATCH/GET routes.
 #
 # Triggers:
-#   schedule            09:00 UTC daily (01:00 PST / 02:00 PDT,
-#                       matches nightly.yml so all cron suites land
-#                       before US working hours).
-#   workflow_dispatch   manual run. Inputs: `branch` to target a
-#                       non-main ref; `parallelism` to override the
-#                       pytest `-n` worker count (default 8).
-#   pull_request        PR-gate entry point for SAME-REPO PRs (secrets
-#                       flow). FORK PRs skip the job here (no secrets on
-#                       fork pull_request runs) and instead run via the
-#                       fork-e2e/** push below, after fork-e2e-mirror.yml
-#                       mirrors an approved / returning-contributor PR.
-#                       The four shard check names are in merge-ready.yml's
-#                       REQUIRED array so merge is blocked until all four
-#                       go green. Leans heavily on
-#                       ``tests/known_failures.yaml`` quarantines (#532).
-#   push (fork-e2e/**)  The e2e run for mirrored fork PRs -- a trusted
-#                       base-repo branch, so secrets flow.
+#   schedule            09:00 UTC daily (alongside nightly.yml).
+#   workflow_dispatch   manual run. Inputs: `branch` (non-main ref) and
+#                       `parallelism` (pytest `-n` worker count).
+#   pull_request        PR gate for SAME-REPO PRs only. Fork PRs skip
+#                       here (no secrets) and run via the fork-e2e/**
+#                       push after fork-e2e-mirror.yml mirrors them. The
+#                       four shard checks are required by merge-ready.yml.
+#   push (fork-e2e/**)  e2e run for mirrored fork PRs (trusted branch,
+#                       so secrets flow).
 
 on:
   schedule:
@@ -45,11 +36,8 @@ on:
         default: "2"
 
 concurrency:
-  # PR re-syncs share a group by PR number so old runs cancel.
-  # workflow_dispatch with a branch input shares a group so manual
-  # re-dispatches against the same branch cancel. Push and schedule
-  # events key by SHA so back-to-back merges to `main` each get
-  # their own run -- needed for per-commit regression visibility.
+  # PRs key by number, dispatch by branch (so re-runs cancel); push /
+  # schedule key by SHA so each merge to `main` gets its own run.
   group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
   cancel-in-progress: true
 
@@ -57,9 +45,8 @@ permissions:
   contents: read
 
 env:
-  # No ap-web SPA build during `uv sync` (setup.py `_build_web_ui`):
-  # this job never serves the bundle, and the hardened runner's npm has
-  # no registry mirror so the build otherwise times out ~10min on public npm.
+  # No ap-web SPA build during `uv sync`: this job never serves the
+  # bundle and the build hits public npm with no registry mirror.
   OMNIGENT_SKIP_WEB_UI: "true"
   # Never let the test server pick up the runner's own credentials.
   ANTHROPIC_API_KEY: ""
@@ -68,18 +55,14 @@ env:
   CLAUDE_CODE: ""
 
 jobs:
-  # Security precondition gate: on untrusted PRs the shard setup (which checks
-  # out and runs the PR's own e2e-shard-matrix.sh) and all e2e jobs are held
-  # until the deterministic scan passes (see .github/workflows/security-gate.yml).
-  # Trusted authors and non-PR events (push to fork-e2e/**, schedule, dispatch)
-  # pass through instantly.
+  # Security gate: untrusted PRs wait on the deterministic scan
+  # (security-gate.yml); trusted authors and non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
 
-  # Compute the shard matrix once. A skipped run (draft, or a fork's
-  # pull_request) yields an EMPTY matrix -> zero shard jobs -> no skipped
-  # check-runs with an unexpanded ${{ matrix.* }} name. Shared with e2e-ui.yml
-  # via .github/scripts/ci/e2e-shard-matrix.sh (only NUM_SHARDS differs).
+  # Compute the shard matrix once. A skipped run (draft / fork pull_request)
+  # yields an EMPTY matrix -> zero shard jobs -> no skipped placeholder check.
+  # Shared with e2e-ui.yml via e2e-shard-matrix.sh (only NUM_SHARDS differs).
   setup:
     name: setup
     needs: gate
@@ -91,10 +74,8 @@ jobs:
       - name: Check out CI scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          # Triggering ref (not pinned to main): the script must exist on the
-          # running ref, and it is not a security gate -- it only shards tests
-          # and can't expose secrets (fork pull_request has none), so the PR's
-          # own copy is fine.
+          # Triggering ref (not main): the script must exist on it, and it
+          # only shards tests -- no secrets exposure, so the PR's copy is fine.
           sparse-checkout: .github/scripts/ci
           persist-credentials: false
       - name: Compute shard matrix
@@ -107,54 +88,30 @@ jobs:
         run: bash .github/scripts/ci/e2e-shard-matrix.sh
 
   e2e:
-    # Sharded matrix. Each shard runs ~1/N of the test set, well under
-    # the wallclock budget at which the hardened runner image's
-    # CrowdStrike enforcement kills long-running jobs (see issue #426).
-    #
-    # ``max-parallel: 4`` lets all four shards run concurrently so a
-    # single wedged shard (e.g. one that gets stuck in a pty/pexpect
-    # state the runner can't recover from) doesn't block the others.
-    # The first run on max-parallel:1 demonstrated the failure mode:
-    # shard 0 hung at ~68% past its 30-min step timeout (runner agent
-    # itself wedged, even GH Actions' step-timeout enforcement
-    # couldn't cancel it), and shards 1-3 sat queued forever waiting
-    # for the slot.
-    #
-    # Each shard now runs at ``-n 2`` workers (set as the default in
-    # the workflow_dispatch input below). Net concurrent QPS against
-    # the Databricks gateway: 4 shards × 2 workers = 8 concurrent
-    # callers, which is 2x the previous single-job ``-n 4`` shape.
-    # Higher than before but well below the nightly's prior pain
-    # point (5 legs × 4 workers = 20 concurrent triggered 429s). If
-    # we trip rate limits, drop ``-n`` to 1 first; only fall back to
-    # ``max-parallel`` reduction if QPS still hurts.
+    # Sharded matrix: each shard runs ~1/N of the set, under the wallclock
+    # budget where CrowdStrike kills long jobs (#426). max-parallel:4 runs
+    # all shards concurrently so one wedged shard can't block the others.
+    # -n 2 per shard => 4 x 2 = 8 concurrent gateway calls, below the
+    # nightly's 429 pain point; drop -n before max-parallel if rate-limited.
     name: E2E Tests (shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
-    # Draft PRs and fork pull_request events resolve to an EMPTY matrix in
-    # `setup` (forks run via the fork-e2e/** mirror push instead), so this job
-    # produces zero shard runs for them -- and thus no skipped placeholder check.
+    # Draft / fork pull_request events resolve to an EMPTY matrix in `setup`
+    # (forks run via the fork-e2e/** mirror push), so no shard runs for them.
     needs: setup
     runs-on: ubuntu-latest
     strategy:
-      # One red shard shouldn't cancel siblings; we want every shard's
-      # signal so reviewers can see whether the failure is broad or
-      # localized to one chunk.
+      # One red shard shouldn't cancel siblings -- we want every shard's signal.
       fail-fast: false
       max-parallel: 4
-      # Shards from `setup` (pytest-shard splits node IDs deterministically, so
-      # a test always lands in the same shard); [] when the run is skipped.
+      # Shards from `setup` (deterministic node-ID split); [] when skipped.
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # Same-repo PRs: test the merge result. refs/pull/N/merge is the PR
-          # head merged into the base by GitHub; it is absent when the PR
-          # conflicts, so a conflicted PR fails checkout here by design
-          # (resolve conflicts first). Push events (the mirrored fork-e2e/**
-          # branches) and dispatch fall back to the branch / ref -- for
-          # fork-e2e/** that is the contributor's head commit on a trusted
-          # base-repo branch.
+          # Same-repo PRs test the merge result (refs/pull/N/merge -- absent
+          # when the PR conflicts, so a conflicted PR fails checkout by design).
+          # Push (fork-e2e/**) and dispatch fall back to the branch / ref.
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
 
       - name: Set up Python
@@ -197,32 +154,17 @@ jobs:
           uv sync --extra all --extra dev
 
       - name: Install binary dependencies
-        # `npm install` against `.github/ci-deps/package.json` (top-level
-        # versions pinned there; OSS ships no committed lock). `--ignore-scripts` blocks
-        # arbitrary postinstall code across every package, present and
-        # future. The pi harness binary is intentionally absent;
-        # pi-parametrized e2e rows skip via `skip_if_harness_cli_missing`
-        # when `pi` is missing on PATH.
+        # npm install against .github/ci-deps/package.json with
+        # --ignore-scripts to block postinstall on every package. The
+        # claude-code stub binary needs its install.cjs (audited:
+        # platform detect + same-tree hardlink, no network/exec) so we run
+        # that one explicitly; codex has no postinstall; pi is intentionally
+        # absent (its e2e rows skip via skip_if_harness_cli_missing).
         #
-        # `@anthropic-ai/claude-code` ships a 500-byte stub at
-        # `bin/claude.exe` that errors out at runtime. Its postinstall
-        # (`install.cjs`) only does platform detection plus a same-tree
-        # hardlink/copy of the native binary already pulled in via
-        # `optionalDependencies`. No network, no external execution.
-        # We run it explicitly so the carve-out is audited and visible
-        # in review, while `--ignore-scripts` still gates every other
-        # package. `@openai/codex` has `scripts: null`, so no postinstall
-        # to run there.
-        #
-        # bubblewrap: required by the `linux_bwrap` sandbox backend. An
-        # agent that omits `os_env.sandbox.type` defaults to `linux_bwrap`
-        # on Linux, and the backend fails loud at runtime if `bwrap` is
-        # not on PATH (rather than silently running unsandboxed). The e2e
-        # runner runs real agents with os_env, so it needs `bwrap` like
-        # every other workflow that exercises the sandbox (ci.yml,
-        # integration.yml, nightly.yml). The apparmor sysctl mirrors
-        # ci.yml: Ubuntu 24.04 blocks unprivileged user namespaces by
-        # default, which `bwrap`'s `unshare(CLONE_NEWUSER)` needs.
+        # bubblewrap: the linux_bwrap sandbox backend fails loud if `bwrap`
+        # is missing, and the e2e runner runs real agents with os_env. The
+        # apparmor sysctl mirrors ci.yml (Ubuntu 24.04 blocks unprivileged
+        # user namespaces, which bwrap's unshare(CLONE_NEWUSER) needs).
         working-directory: .github/ci-deps
         run: |
           sudo apt-get install -y tmux bubblewrap
@@ -235,47 +177,31 @@ jobs:
 
       - name: Run e2e tests
         timeout-minutes: 30
-        # The ``force-all-tests`` PR label bypasses
-        # ``tests/known_failures.yaml`` so contributors can verify
-        # that quarantined tests still need to be quarantined.
-        # Apply the label and re-run; remove to restore normal
-        # behaviour. Matches the ci.yml / nightly.yml pattern.
+        # The `force-all-tests` PR label bypasses tests/known_failures.yaml
+        # (matches the ci.yml / nightly.yml pattern).
         env:
-          # Cron fallback must match the workflow_dispatch default
-          # above; mismatch silently changes the gateway QPS shape.
-          # 4 shards * 2 workers = 8 concurrent, well below the
-          # nightly's prior 20-worker 429 pain point.
+          # Cron fallback must match the workflow_dispatch default above.
           PARALLELISM_INPUT: ${{ github.event.inputs.parallelism || '2' }}
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
           FORCE_ALL_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'force-all-tests') }}
-          # Scheduled / manually dispatched runs are the full pass;
-          # PR and push runs exclude @pytest.mark.nightly tests.
+          # Schedule / dispatch are the full pass; PR and push skip @nightly.
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-          # Redirect pytest's tmp_path_factory under a stable, predictable
-          # prefix so the `Upload server logs on failure` step below can
-          # find server.log / runner.log / junit.xml. The shard suffix
-          # keeps per-shard artifact paths distinct so the matrix's
-          # parallel uploads don't collide on the same prefix.
+          # Stable per-shard prefix so the upload step finds the logs / junit.
           E2E_TMP_BASE: /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}
-          # Per-xdist-worker progress log (#426). The pytest hook
-          # in tests/conftest.py fsyncs START/END per test so we
+          # Per-worker progress log (#426): fsynced START/END per test so we
           # recover the last-started test when a runner wedges.
           PYTEST_PROGRESS_LOG_DIR: /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}/progress
           OMNIGENT_TOKEN_USAGE_JSON: /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}/tokens.json
-          # Load-balance interchangeable gateway models across tests
-          # (tests/_model_pools.py). Deterministic per test nodeid;
-          # pools overridable via OMNIGENT_TEST_MODEL_POOL_*.
+          # Spread interchangeable gateway models across tests (deterministic
+          # per nodeid; tests/_model_pools.py).
           OMNIGENT_TEST_MODEL_SPREAD: '1'
-          # 2026-06-11: the workspace FMAPI quota on gpt-5-4 is far
-          # below gpt-5-5 / gpt-5-4-mini, so the tests deterministically
-          # hashed to gpt-5-4 fail on sustained 429s while their pool
-          # neighbors pass. Drain it until the tier is raised.
+          # Drain gpt-5-4 from the pool: its FMAPI quota is far below the
+          # others, so tests hashed to it fail on sustained 429s.
           OMNIGENT_TEST_MODEL_POOL_GPT: 'databricks-gpt-5-5,databricks-gpt-5-4-mini'
         run: |
-          # Validate parallelism is a positive integer before passing to pytest.
-          # Untrusted-input hardening: never interpolate GitHub expression
-          # syntax into a shell command. Bind to env and reference via "$VAR".
+          # Validate parallelism (untrusted input -- bind to env, never
+          # interpolate a GitHub expression into the shell).
           if ! [[ "$PARALLELISM_INPUT" =~ ^[1-9][0-9]?$ ]]; then
             echo "Invalid parallelism input: $PARALLELISM_INPUT (expected 1-99)" >&2
             exit 1
@@ -292,26 +218,12 @@ jobs:
             EXTRA_ARGS+=(-m "not nightly")
           fi
 
-          # --junitxml emits per-test results (with tracebacks) eagerly,
-          # so even if the wall-clock budget is exceeded again, the
-          # uploaded XML still carries diagnostics. -rfE keeps the
-          # short-result summary chars for Failures + Errors.
-          # --shard-id/--num-shards split the test node IDs evenly across
-          # matrix entries; same set of tests overall, just chunked.
-          # --timeout=180 caps any single test at 3 min. The previous
-          # shape lacked this, so one hung pexpect/REPL test would
-          # block the whole pytest session until the step's
-          # ``timeout-minutes`` killed the worker with no per-test
-          # traceback. ``--timeout_method=thread`` is more reliable
-          # than the default ``signal`` method when the test under
-          # cap forks subprocesses (our e2e fixtures spawn Omnigent servers
-          # + harness runner children), because SIGALRM doesn't reach
-          # blocked-on-pty children. See pytest-timeout README.
-          # --max-worker-restart=0 fails the shard fast when a worker
-          # is hard-killed: xdist's crashed-worker replacement under
-          # loadscope requeues already-completed scopes, which can
-          # deadlock the controller until ``timeout-minutes`` kills
-          # the step 30 minutes later (the 2026-06-11 shard-2 wedge).
+          # --junitxml emits per-test results eagerly so diagnostics survive
+          # a wall-clock overrun. --shard-id/--num-shards chunk the node IDs.
+          # --timeout=180 caps each test; --timeout-method=thread because our
+          # pty/subprocess children don't get SIGALRM. --max-worker-restart=0
+          # fails the shard fast instead of letting loadscope requeue deadlock
+          # the controller (the 2026-06-11 shard-2 wedge).
           uv run pytest tests/e2e/ \
             --llm-api-key "$LLM_API_KEY" \
             --profile default \
@@ -330,18 +242,14 @@ jobs:
             || { rc=$?; [ "$rc" -eq 5 ] && echo "::notice::No tests collected in this shard; treating as a pass." || exit "$rc"; }
 
       - name: Upload server logs on failure
-        # failure() misses step timeouts (``cancelled``), so timed-out
-        # shards (#426) would lose their junit / progress-log artifacts.
+        # cancelled() too: failure() misses step timeouts (#426).
         if: failure() || cancelled()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          # Per-shard artifact name so the matrix's parallel uploads
-          # don't collide on the same key.
+          # Per-shard name so parallel uploads don't collide.
           name: e2e-server-logs-${{ github.run_id }}-shard${{ matrix.shard_id }}
-          # Whitelist diagnostic files; basetemp also holds per-test
-          # SQLite DBs and sample-code tarballs that are large and not
-          # useful for triage. `if-no-files-found: warn` (not `ignore`)
-          # so a future broken path is loud rather than silent.
+          # Whitelist diagnostic files (basetemp also holds large per-test
+          # DBs / tarballs). `warn` not `ignore` so a broken path is loud.
           path: |
             /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}/**/server.log
             /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}/**/runner.log
@@ -350,9 +258,8 @@ jobs:
             /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}/progress/progress-*.log
           retention-days: 7
           if-no-files-found: warn
-          # The per-HOME daemon logs live under hidden `.omnigent/` dirs,
-          # which upload-artifact v4 skips by default — without this the
-          # `.omnigent/logs` whitelist line above matches nothing.
+          # Daemon logs live under hidden `.omnigent/` dirs, which v4 skips
+          # by default -- without this the `.omnigent/logs` glob matches nothing.
           include-hidden-files: true
 
       - name: Upload token usage
@@ -362,6 +269,6 @@ jobs:
           name: e2e-tokens-${{ github.run_id }}-shard${{ matrix.shard_id }}
           path: /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ matrix.shard_id }}/tokens*.json
           retention-days: 14
-          # `warn` (not `ignore`): every e2e shard makes LLM calls, so a
-          # missing tokens file means the write-through recorder broke.
+          # `warn` not `ignore`: every shard makes LLM calls, so a missing
+          # tokens file means the recorder broke.
           if-no-files-found: warn

--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -1,50 +1,20 @@
 name: Flake stress
 
-# Manually-dispatched flake-reproducer. Runs an arbitrary pytest
-# target N times in parallel on the same hardened-runner pool as
-# ci.yml, then renders a pass/fail summary on the run page. Use to:
-#
-#   1. Quantify how often a suspect test or file fails (point at
-#      ``main`` to get a baseline rate).
-#   2. Verify a fix actually closes a flake (point at the fix
-#      branch and expect 0/N failures).
-#
-# Each attempt is one independent matrix leg, so ``failures / N``
-# is the observed flake probability for the chosen target +
-# configuration. Defaults (``-n 4 --dist=worksteal``) mirror the
-# ``server-responses`` group in ci.yml, which is where the
-# original ``test_delete_response`` flake was observed (PR #580),
-# but every knob is overridable so the tool works for any future
-# flake — by file, by node-id, by parametrized case.
-#
-# Not wired to pull_request / push — workflow_dispatch only — so
-# the matrix doesn't burn runner minutes on every PR.
+# Manually-dispatched flake-reproducer (workflow_dispatch only, so it
+# doesn't burn runner minutes per PR). Runs a pytest target N times in
+# parallel on ci.yml's hardened-runner pool, then renders a pass/fail
+# summary on the run page. Each attempt is one matrix leg, so failures/N
+# is the observed flake probability for the target + config. Use it to
+# quantify a flake rate (point at main) or verify a fix (point at the fix
+# branch, expect 0/N). Defaults (-n 4 --dist=worksteal) mirror ci.yml's
+# server-responses group; every knob is overridable.
 #
 # Examples:
-#
-#   # Quantify a suspect file's flake rate on main with defaults
-#   # (20 attempts, -n 4 --dist=worksteal):
 #   gh workflow run flake-stress.yml --ref main \
 #     -f test_target=tests/server/integration/test_routes_responses.py
-#
-#   # Verify a fix branch closes the same flake (expect 0/20):
-#   gh workflow run flake-stress.yml --ref main \
-#     -f test_target=tests/server/integration/test_routes_responses.py \
-#     -f target_branch=fix-delete-response-cancels-active
-#
-#   # Inner-test flake at the inner-* group's CI config:
-#   gh workflow run flake-stress.yml --ref main \
-#     -f test_target=tests/inner/test_terminal.py \
-#     -f workers=8 -f dist=loadfile
-#
-#   # Stress one parametrized node-id solo, skipping known_failures:
 #   gh workflow run flake-stress.yml --ref main \
 #     -f test_target='tests/foo.py::test_x[case1]' \
 #     -f workers=1 -f extra_pytest_args=--no-skip-known
-#
-# Triggers:
-#   workflow_dispatch   manual run from the Actions tab or
-#                       ``gh workflow run flake-stress.yml ...``.
 
 on:
   workflow_dispatch:
@@ -77,22 +47,18 @@ permissions:
   contents: read
 
 env:
-  # No ap-web SPA build during `uv sync` (setup.py `_build_web_ui`):
-  # this job never serves the bundle, and the hardened runner's npm has
-  # no registry mirror so the build otherwise times out ~10min on public npm.
+  # No ap-web SPA build during `uv sync`: this job never serves the bundle
+  # and the hardened runner has no npm mirror (build would time out).
   OMNIGENT_SKIP_WEB_UI: "true"
-  # Hardened runners have no outbound network to public PyPI; route
-  # uv/pip through the Databricks proxy. Same as ci.yml.
+  # Pin the PyPI index for uv/pip resolution (same as ci.yml).
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
 
 jobs:
   prep:
-    # Validate inputs and turn the ``attempts`` count into a JSON
-    # array the matrix can fan out across. Matrix arrays must be
-    # known at job-graph construction time, so we synthesize the
-    # array here and the downstream job picks it up via
-    # ``fromJSON``.
+    # Validate inputs and turn ``attempts`` into a JSON array the matrix
+    # fans out across (arrays must exist at job-graph construction time;
+    # the downstream job picks it up via ``fromJSON``).
     name: Validate inputs
     runs-on: ubuntu-latest
     outputs:
@@ -108,20 +74,17 @@ jobs:
           EXTRA_ARGS: ${{ github.event.inputs.extra_pytest_args }}
         run: |
           set -euo pipefail
-          # attempts ∈ [1, 50]. 50 is a soft cap to avoid
-          # accidentally consuming the whole runner pool.
+          # attempts ∈ [1, 50]; 50 soft-caps runner-pool consumption.
           if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]?$ ]] || (( ATTEMPTS > 50 )); then
             echo "::error::attempts must be an integer in [1, 50], got '$ATTEMPTS'"
             exit 1
           fi
-          # workers ∈ [1, 32]. Above that, xdist setup tends to
-          # cost more than the parallelism returns.
+          # workers ∈ [1, 32]; above that xdist setup outweighs parallelism.
           if ! [[ "$WORKERS" =~ ^([1-9]|[12][0-9]|3[0-2])$ ]]; then
             echo "::error::workers must be 1-32, got '$WORKERS'"
             exit 1
           fi
-          # dist is an enum — reject everything else so we don't
-          # silently pass garbage to pytest.
+          # dist is an enum; reject anything else.
           case "$DIST" in
             loadfile|worksteal|loadscope|load|each|no) ;;
             *)
@@ -129,18 +92,12 @@ jobs:
               exit 1
               ;;
           esac
-          # test_target and extra_pytest_args both reach a shell.
-          # Restrict to characters that show up in legitimate pytest
-          # node-ids (paths, ``::`` separators, ``[]`` parametrize
-          # brackets, ``-`` flags) so a hostile input can't smuggle
-          # command substitution. Authorized-only workflow_dispatch
-          # already limits the threat model; belt-and-suspenders.
-          #
-          # Regex stored in a quoted variable so bash doesn't strip
-          # backslashes / glob-expand brackets before the regex engine
-          # sees the pattern. ``]`` is the first char in the class to
-          # be treated as a literal (POSIX rule); ``-`` is last so it
-          # isn't read as a range separator.
+          # test_target / extra_pytest_args reach a shell; restrict to
+          # legitimate pytest node-id chars so hostile input can't smuggle
+          # command substitution (belt-and-suspenders atop authz dispatch).
+          # Quoted so bash doesn't strip backslashes / glob-expand brackets.
+          # POSIX char-class rules: ``]`` first (literal), ``-`` last (not a
+          # range).
           allowed_chars='^[]a-zA-Z0-9./_:[ =-]+$'
           if ! [[ "$TEST_TARGET" =~ $allowed_chars ]]; then
             echo "::error::test_target contains disallowed characters; allowed: a-zA-Z0-9 . / _ : [ ] - = space"
@@ -150,7 +107,7 @@ jobs:
             echo "::error::extra_pytest_args contains disallowed characters; allowed: a-zA-Z0-9 . / _ : [ ] - = space"
             exit 1
           fi
-          # Build JSON array [1,2,...,N] for the matrix to consume.
+          # Build JSON array [1,2,...,N] for the matrix.
           ARR=$(python3 -c "import json,os; print(json.dumps(list(range(1, int(os.environ['ATTEMPTS'])+1))))")
           echo "attempts_json=$ARR" >> "$GITHUB_OUTPUT"
           echo "Will run $ATTEMPTS attempts of: $TEST_TARGET"
@@ -162,8 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
-      # Keep going after a failure so we observe the full pass/fail
-      # distribution across attempts, not just the first failure.
+      # Keep going after a failure to observe the full distribution.
       fail-fast: false
       matrix:
         attempt: ${{ fromJSON(needs.prep.outputs.attempts_json) }}
@@ -185,10 +141,8 @@ jobs:
           enable-cache: true
 
       - name: Install ripgrep + bubblewrap
-        # Some inner tests need these (Grep tool fallback,
-        # linux_bwrap sandbox). Cheap enough to always install so
-        # the tool works for inner-test flakes without a surprise
-        # import error. Apparmor sysctl mirrors ci.yml.
+        # Inner tests need these (Grep fallback, linux_bwrap sandbox);
+        # always install so inner-test flakes work. Apparmor sysctl mirrors ci.yml.
         run: |
           sudo apt-get update
           sudo apt-get install -y ripgrep bubblewrap
@@ -201,17 +155,14 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
-        # Matches ci.yml's install set. ``--extra all`` pulls
-        # claude-sdk + openai-agents so executor adapters can
-        # import their SDKs at collection time.
+        # Matches ci.yml; ``--extra all`` pulls the harness SDKs so
+        # executor adapters import at collection time.
         run: uv sync --extra all --extra dev
 
       - name: Run pytest target
-        # test_target and extra_pytest_args were validated by the
-        # prep job. Word-splitting on $TEST_TARGET and $EXTRA_ARGS
-        # is intentional — both may carry multiple tokens (paths,
-        # flags). We bind via env (not ``${{ }}`` interpolation)
-        # to avoid GitHub-expression injection at the shell layer.
+        # Inputs validated by prep. Word-splitting on $TEST_TARGET /
+        # $EXTRA_ARGS is intentional (multi-token); bound via env (not
+        # ``${{ }}``) to avoid expression injection at the shell.
         shell: bash
         env:
           TEST_TARGET: ${{ github.event.inputs.test_target }}
@@ -238,10 +189,8 @@ jobs:
           if-no-files-found: ignore
 
   summarize:
-    # Render a pass/fail summary table on the run page so a glance
-    # at the workflow run gives you the flake rate without drilling
-    # into each matrix leg. ``if: always()`` so we still summarize
-    # when some attempts failed (the common case for this tool).
+    # Render a pass/fail summary table on the run page for an at-a-glance
+    # flake rate. ``if: always()`` so failed attempts still summarize.
     name: Summarize results
     needs: repro
     if: always()
@@ -255,11 +204,8 @@ jobs:
           merge-multiple: true
 
       - name: Render summary
-        # Parse each junit XML to count pass/fail/error/skipped at
-        # the attempt level. The repro job's matrix-level conclusion
-        # already drives the visible status; this surfaces *which*
-        # tests failed and how often, which is the useful debugging
-        # artifact.
+        # Parse each junit XML per attempt to surface which tests failed
+        # and how often (the matrix conclusion already drives visible status).
         run: |
           python3 - <<'PY'
           import glob

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,22 +1,12 @@
 name: Integration Tests
 
-# Per-PR twin of nightly.yml's journey-suite matrix (tests/integration/):
-# multi-turn context retention, client-tool threading, and cross-user
-# sharing, once per wrapped harness against the real Databricks gateway.
-#
-# Burn-in status: NOT in merge-ready's REQUIRED list yet. The checks
-# report on every PR for signal; flip them to required in
-# .github/scripts/merge-ready/required.sh once they have a clean week.
-# nightly.yml remains the scheduled canary with Slack/issue notify.
-#
-# Triggers:
-#   schedule            09:30 UTC daily.
-#   pull_request        PR gate for SAME-REPO PRs (secrets flow).
-#                       Fork PRs skip (no secrets) and run via the
-#                       fork-e2e/** push after fork-e2e-mirror.yml.
-#   push (fork-e2e/**) The run for mirrored fork PRs -- trusted
-#                       base-repo branch, so secrets flow.
-#   workflow_dispatch   manual run against a branch.
+# Per-PR twin of nightly.yml's journey-suite matrix (tests/integration/),
+# once per wrapped harness against the real Databricks gateway. Burn-in:
+# NOT in merge-ready's REQUIRED list yet (reports for signal; flip in
+# .github/scripts/merge-ready/required.sh after a clean week). Triggers:
+# daily schedule, same-repo PR gate (secrets flow; fork PRs skip and run
+# via the fork-e2e/** push after fork-e2e-mirror.yml), the fork-e2e/**
+# push itself, and workflow_dispatch.
 
 on:
   schedule:
@@ -34,9 +24,8 @@ permissions:
   contents: read
 
 env:
-  # No ap-web SPA build during `uv sync` (setup.py `_build_web_ui`):
-  # this job never serves the bundle, and the hardened runner's npm has
-  # no registry mirror so the build otherwise times out ~10min on public npm.
+  # No ap-web SPA build during `uv sync`: this job never serves the bundle
+  # and the hardened runner has no npm mirror (build would time out).
   OMNIGENT_SKIP_WEB_UI: "true"
   # Never let the test server pick up the runner's own credentials.
   ANTHROPIC_API_KEY: ""
@@ -46,15 +35,13 @@ env:
   CLAUDE_CODE: ""
 
 concurrency:
-  # PR re-syncs share a group by PR number so old runs cancel; push and
-  # dispatch key by SHA / branch.
+  # Key by PR number so re-syncs cancel; push/dispatch key by SHA/branch.
   group: integration-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  # Security precondition gate: on untrusted PRs every job below is held until
-  # the deterministic scan passes (see .github/workflows/security-gate.yml).
-  # Trusted authors and non-PR events pass through instantly.
+  # Security precondition gate: untrusted PRs hold until the scan passes
+  # (see security-gate.yml); trusted authors / non-PR events pass instantly.
   gate:
     uses: ./.github/workflows/security-gate.yml
 
@@ -63,26 +50,17 @@ jobs:
     needs: gate
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.fork != true }}
     runs-on: ubuntu-latest
-    # Per-leg ceiling. Inner test step caps at 25 min; the rest of
-    # the budget covers install and the junit upload.
-    # All four legs run in parallel; longest leg gates wall-time.
+    # Per-leg ceiling; inner test step caps at 25 min, rest covers install +
+    # junit upload. Legs run in parallel; longest gates wall-time.
     timeout-minutes: 30
     strategy:
-      # Don't cancel sibling harnesses when one fails. The whole point of
-      # the matrix is to surface which harness is red without losing the
-      # signal on the others.
+      # Don't cancel sibling harnesses on failure; surface which is red.
       fail-fast: false
-      # One leg per wrapped harness, no pytest-shard splitting: the
-      # journey suite is a handful of tests per leg. Keep the
-      # ``Integration (...)`` leg-name prefix; the notify job's jq
-      # filter keys on it.
-      #
-      # Model pinning rationale:
-      # - claude-sdk on sonnet-4-6: tier 4, most TPM headroom.
-      # - codex on gpt-5-5: gpt-5-4-mini hit 429s historically.
-      # - openai-agents on gpt-5-4-mini: green there historically.
-      # OMNIGENT_TEST_MODEL_SPREAD below may rebalance within the
-      # same provider/tier pool (tests/_model_pools.py).
+      # One leg per wrapped harness, no sharding. Keep the
+      # ``Integration (...)`` leg-name prefix; the notify job's jq keys on it.
+      # Model pins: claude-sdk on sonnet-4-6 (most TPM headroom), codex on
+      # gpt-5-5 (gpt-5-4-mini hit 429s), openai-agents on gpt-5-4-mini.
+      # OMNIGENT_TEST_MODEL_SPREAD may rebalance within the pool.
       matrix:
         include:
           - name: claude-sdk
@@ -93,9 +71,7 @@ jobs:
             harness: openai-agents
             model: databricks-gpt-5-4-mini
             workers: 4
-          # codex has the least rate-limit headroom of the three legs
-          # (burn-in failures were codex-only, clustered at peak PR
-          # traffic); halve its concurrent CLI + gateway burst.
+          # codex has the least rate-limit headroom; halve its burst.
           - name: codex
             harness: codex
             model: databricks-gpt-5-5
@@ -146,12 +122,9 @@ jobs:
         run: uv sync --extra all --extra dev
 
       - name: Install binary dependencies
-        # Mirrors e2e.yml. `--ignore-scripts` blocks arbitrary postinstall
-        # hooks for every npm package; we run `claude-code`'s install.cjs
-        # explicitly (audited carve-out, no network, just a same-tree copy
-        # of the native binary already pulled in via optionalDependencies).
-        # `bubblewrap` is needed by the `linux_bwrap` sandbox backend used
-        # by tests/inner/* (same as ci.yml).
+        # Mirrors e2e.yml. `--ignore-scripts` blocks npm postinstall hooks;
+        # we run claude-code's install.cjs explicitly (audited, no network).
+        # `bubblewrap` backs the `linux_bwrap` sandbox in tests/inner/*.
         working-directory: .github/ci-deps
         run: |
           set -euo pipefail
@@ -170,38 +143,29 @@ jobs:
           HARNESS: ${{ matrix.harness }}
           MODEL: ${{ matrix.model }}
           WORKERS: ${{ matrix.workers }}
-          # Stable basetemp so the failure-upload step below can find
-          # the spawned server/runner logs.
+          # Stable basetemp so the failure-upload step can find the logs.
           INTEGRATION_TMP_BASE: /tmp/omnigent-integration-${{ github.run_id }}-${{ matrix.harness }}
-          # SDK's initialize control-request timeout in ms. Pinned here
-          # so the knob is visible alongside _CONNECT_TIMEOUT_SECONDS.
+          # SDK initialize control-request timeout (ms).
           CLAUDE_CODE_STREAM_CLOSE_TIMEOUT: '60000'
-          # Diagnostic: bypass ``create_exec_launcher`` on the
-          # claude-sdk leg to isolate whether the silent connect hang is
-          # sandbox-related. Remove once the root cause lands.
+          # Diagnostic: bypass create_exec_launcher on claude-sdk to isolate
+          # whether the silent connect hang is sandbox-related.
           OMNIGENT_CLAUDE_SDK_NO_SANDBOX: ${{ matrix.harness == 'claude-sdk' && '1' || '' }}
-          # Per-xdist-worker progress log (#426). pytest hook in
-          # tests/conftest.py fsyncs START/END per test so we recover
-          # the last-started test when a runner wedges.
+          # Per-xdist-worker progress log (#426): recovers the last-started
+          # test when a runner wedges.
           PYTEST_PROGRESS_LOG_DIR: ${{ github.workspace }}/artifacts/progress-${{ matrix.harness }}
           # Per-model call/token tally (dev/aggregate_token_usage.py).
           OMNIGENT_TOKEN_USAGE_JSON: ${{ github.workspace }}/artifacts/tokens-${{ matrix.harness }}.json
           # Load-balance interchangeable gateway models (tests/_model_pools.py).
           OMNIGENT_TEST_MODEL_SPREAD: '1'
-          # 2026-06-11: the workspace FMAPI quota on gpt-5-4 is far
-          # below gpt-5-5 / gpt-5-4-mini, so the tests deterministically
-          # hashed to gpt-5-4 fail on sustained 429s while their pool
-          # neighbors pass. Drain it until the tier is raised.
+          # gpt-5-4 FMAPI quota is far below its pool neighbors; drain it
+          # until the tier is raised so 429s don't fail hashed-to-gpt-5-4 tests.
           OMNIGENT_TEST_MODEL_POOL_GPT: 'databricks-gpt-5-5,databricks-gpt-5-4-mini'
         run: |
           set -euo pipefail
           mkdir -p artifacts "$INTEGRATION_TMP_BASE"
-          # --capture=no + --log-cli-level=INFO stream output live so
-          # the GitHub Actions log shows test progress and the
-          # executor's logs even if the step hits its 25-min timeout
-          # before pytest can render the buffered failure sections.
-          # --timeout=180 caps a single hung test with a traceback
-          # instead of letting it eat the step budget (see e2e.yml).
+          # --capture=no + --log-cli-level=INFO stream live so progress shows
+          # even if the step hits its timeout before buffered output renders.
+          # --timeout=180 caps a single hung test (see e2e.yml).
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN \
             uv run pytest tests/integration/ \
               --integration \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,9 @@
 name: Lint
 
-# Runs the project's pre-commit hooks (ruff format/check, mypy, the
-# custom anti-pattern grep hooks, etc.) on every non-draft PR and on
-# push to main. Surfaces as the `Pre-commit checks` check on PRs,
-# which is one of the REQUIRED gate entries in `merge-ready.yml`.
-#
-# Triggers:
-#   pull_request    opened / synchronize / reopened / ready_for_review.
-#                   Draft PRs are skipped; the `ready_for_review`
-#                   trigger refires the workflow when the draft is
-#                   converted, so the check doesn't strand pending.
-#   push (main)     post-merge run on the default branch.
+# Runs the project's pre-commit hooks (ruff, mypy, custom anti-pattern grep
+# hooks, etc.) on every non-draft PR and on push to main. Surfaces as the
+# `Pre-commit checks` check, a REQUIRED gate entry in merge-ready.yml. Draft PRs
+# are skipped; `ready_for_review` refires so the check doesn't strand pending.
 
 on:
   pull_request:
@@ -23,14 +16,11 @@ permissions:
   contents: read
 
 env:
-  # No ap-web SPA build during `uv sync` (setup.py `_build_web_ui`):
-  # this job never serves the bundle, and the hardened runner's npm has
-  # no registry mirror so the build otherwise times out ~10min on public npm.
+  # No ap-web SPA build during `uv sync` (setup.py _build_web_ui): this job never
+  # serves the bundle, and the build otherwise times out on public npm.
   OMNIGENT_SKIP_WEB_UI: "true"
-  # Hardened runners have no outbound network to public PyPI; route
-  # both uv and pip through the Databricks proxy so PEP-517 build
-  # backends resolve. pre-commit installs hook repos via pip (not uv),
-  # so PIP_INDEX_URL is required even when only uv is in the workflow.
+  # Route uv and pip at PyPI. pre-commit installs hook repos via pip (not uv),
+  # so PIP_INDEX_URL is needed even though the workflow only invokes uv.
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
 
@@ -39,18 +29,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Security precondition gate: on untrusted PRs lint is held until the
-  # deterministic scan passes (see .github/workflows/security-gate.yml).
-  # Trusted authors and non-PR events pass through instantly.
+  # Security precondition gate: untrusted PRs are held until the scan passes
+  # (security-gate.yml); trusted authors and non-PR events pass through.
   gate:
     uses: ./.github/workflows/security-gate.yml
 
   pre-commit:
     name: Pre-commit checks
     needs: gate
-    # Skip on draft PRs; the `ready_for_review` trigger above re-fires
-    # the workflow when the draft is converted, so this won't strand
-    # the check pending on the eventual ready-for-review state.
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -64,11 +50,9 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      # Must run BEFORE any `uv` command: `uv sync` / `uv run` re-resolve
-      # the working tree against CI's own index (pypi.org) and would
-      # rewrite a committed proxy URL to canonical, masking it from the
-      # pre-commit hook below. This checks the committed file as-is
-      # (stdlib only, no venv needed).
+      # Must run BEFORE any `uv` command: `uv sync`/`uv run` would re-resolve and
+      # rewrite a committed proxy URL to canonical, masking it. Checks the
+      # committed file as-is (stdlib only, no venv).
       - name: Check uv.lock uses the public PyPI index
         run: python scripts/normalize_uv_lock_registry.py --check uv.lock
 
@@ -84,11 +68,9 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
-        # `--locked` is the hard gate: it fails the job if `uv.lock` is
-        # out of sync with `pyproject.toml`, independent of the
-        # `uv-lock` pre-commit hook below (a bare `uv run pre-commit`
-        # would otherwise re-lock the working tree first and mask a
-        # stale committed lockfile). Fix locally with `uv lock`.
+        # `--locked` is the hard gate: fails if uv.lock is out of sync with
+        # pyproject.toml (a bare `uv run pre-commit` would re-lock first and mask
+        # a stale lockfile). Fix locally with `uv lock`.
         run: uv sync --locked --extra dev
 
       - name: Set up Node.js
@@ -100,10 +82,7 @@ jobs:
 
       - name: Install ap-web dependencies
         working-directory: ap-web
-        # registry.npmjs.org TLS handshakes flake (ECONNRESET) on this
-        # runner pool — same network policy that intercepts pypi.org —
-        # so route npm through the Databricks proxy. The public export
-        # rewrites this URL back to the npmjs default.
+        # Pin the npm registry to the npmjs default.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/maintainer-approval-rerun-run.yml
+++ b/.github/workflows/maintainer-approval-rerun-run.yml
@@ -1,12 +1,11 @@
 name: Maintainer Approval Rerun Run
 
-# Privileged half of the approval re-run relay. Triggered by the
-# completion of maintainer-approval-rerun.yml, this runs from the base
-# repo on `workflow_run`, so it gets a writable token (`actions: write`)
-# even when the underlying PR is from a fork, and is not held behind the
-# fork-approval gate. It reads the PR number recorded by the bridge and
-# re-runs the failed Maintainer Approval check on the PR head, which
-# re-evaluates the (now-present) approval and turns the check green.
+# Privileged half of the approval re-run relay. Triggered by the completion of
+# maintainer-approval-rerun.yml, this runs from the base repo on `workflow_run`,
+# so it gets a writable token (`actions: write`) even for fork PRs and isn't held
+# behind the fork-approval gate. It reads the recorded PR number and re-runs the
+# failed Maintainer Approval check on the PR head, re-evaluating the now-present
+# approval to turn the check green.
 
 on:
   workflow_run:

--- a/.github/workflows/maintainer-approval-rerun.yml
+++ b/.github/workflows/maintainer-approval-rerun.yml
@@ -1,14 +1,10 @@
 name: Maintainer Approval Rerun
 
-# Bridges a maintainer's approving review to a re-run of the Maintainer
-# Approval check. `pull_request_target` does not fire on reviews, so
-# something has to re-trigger the check when an approval lands.
-#
-# A fork PR's `pull_request_review` token is read-only AND the run is
-# held behind the fork-approval gate, so it cannot re-run a workflow
-# itself. This job therefore only records the PR number as an artifact;
-# the privileged re-run happens in maintainer-approval-rerun-run.yml,
-# which runs from the base repo on `workflow_run`.
+# Bridges a maintainer's approving review to a re-run of the Maintainer Approval
+# check (`pull_request_target` doesn't fire on reviews). A fork PR's review token
+# is read-only and held behind the fork-approval gate, so it can't re-run a
+# workflow itself; this job only records the PR number as an artifact, and the
+# privileged re-run happens in maintainer-approval-rerun-run.yml (workflow_run).
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 
 on:

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -1,33 +1,20 @@
 name: Maintainer Approval
 
-# Gates merge on a maintainer's approval. The job *is* the required
-# check: it exits non-zero until a maintainer has approved, and GitHub
-# reports that pass/fail as the `Maintainer Approval` status check
-# automatically. We do NOT post a commit status, so no `statuses: write`
-# token is needed.
+# Gates merge on a maintainer's approval. The job *is* the required check: it
+# exits non-zero until a maintainer approves, and GitHub reports that pass/fail
+# as the `Maintainer Approval` status. No commit status is posted (a fork's token
+# is read-only, so a `gh api .../statuses` POST would 403), so the check is the
+# job result instead.
 #
-# Why this matters for fork PRs: a fork's `pull_request` /
-# `pull_request_review` token is forced read-only regardless of the
-# `permissions:` block, so the old `gh api .../statuses` POST always
-# 403'd on contributor PRs. Making the check the job result sidesteps
-# the API write entirely.
+# Trigger is `pull_request_target`, so it runs from main with the base token
+# even for fork PRs: it isn't held behind the fork-PR-workflow approval gate
+# (reports immediately on open), and the PR-head copy never runs (a malicious PR
+# can't weaken the check). Safe because the job checks out nothing and runs no PR
+# code — it reads .github/MAINTAINER from main's tip (so a PR can't self-grant by
+# adding its author) and queries the API.
 #
-# Trigger is `pull_request_target`, so the workflow always runs from the
-# base branch (main) with the base repo's token, even for fork PRs:
-#   - it is not held behind the "approve fork-PR workflows" gate, so it
-#     reports immediately on open instead of sitting in action_required;
-#   - the PR-head copy of this file never runs, so a malicious PR cannot
-#     edit the check to weaken it.
-# This is safe because the job checks out nothing and runs no PR code --
-# it only reads .github/MAINTAINER from main and queries the API.
-#
-# `pull_request_target` does not fire on reviews, so an approval does
-# not re-run this check by itself. maintainer-approval-rerun.yml +
-# maintainer-approval-rerun-run.yml re-run this workflow when a
-# maintainer submits an approving review, flipping the check green.
-#
-# Why read .github/MAINTAINER from main's tip (not the PR head): a PR
-# that adds its own author to MAINTAINER must not be able to self-grant.
+# `pull_request_target` doesn't fire on reviews, so maintainer-approval-rerun.yml
+# + -rerun-run.yml re-run this workflow on an approving review to flip it green.
 
 on:
   pull_request_target:
@@ -37,8 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  # Do not cancel in-progress runs: a superseded run cancelled mid-flight
-  # leaves the check red, and queued re-evaluation is cheap.
+  # Don't cancel in-progress: a run cancelled mid-flight leaves the check red.
   group: maintainer-approval-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
@@ -68,9 +54,8 @@ jobs:
           fi
 
           CONTENT=$(echo "$CONTENT_B64" | base64 -d)
-          # Strip comments and blanks; flatten to a space-separated list.
-          # `grep -v` exits 1 with no matches; wrap so the pipeline stays
-          # 0 under pipefail and we reach the empty-list branch.
+          # Strip comments/blanks to a space-separated list. `grep -v` exits 1
+          # on no matches; wrap with `|| true` so pipefail reaches the empty branch.
           MAINTAINERS=$(echo "$CONTENT" | sed -E 's/#.*$//' | tr -s '[:space:]' '\n' | { grep -v '^$' || true; } | tr '\n' ' ')
           MAINTAINERS_LC=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
           if [[ -z "${MAINTAINERS_LC// /}" ]]; then

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -1,50 +1,24 @@
 name: Merge Ready
 
-# Posts a "Merge Ready" commit status on the PR head SHA. That status
-# is the single required check in branch protection; the REQUIRED list
-# inside this workflow defines what backs it.
-#
-# Per trigger:
-#   /merge comment   from a commenter with write access only: evaluate,
-#                    post green or red, enable GitHub auto-merge, drop a
-#                    sticky comment. Comments from users without write
-#                    access are ignored (author_association pre-filter
-#                    on the job, authoritative permission-API check
-#                    before any merge action).
-#   pull_request     skipped unless PR has `automerge` label. With
-#                    label, evaluate and post green or red. When the
-#                    `automerge` label was just added (action=labeled),
-#                    also enable GitHub auto-merge on the PR so it
-#                    merges automatically once the gate turns green.
-#   workflow_run     always evaluate. Posts green or red with the
-#                    `automerge` label. Without label, posts only
-#                    when the gate is fully green, so the PR flips
-#                    to all-green naturally after CI without flicker.
+# Posts the "Merge Ready" commit status on the PR head SHA -- the single
+# required branch-protection check, backed by the REQUIRED list inside
+# this workflow. Triggers: `/merge` comment (write-access commenter only),
+# `pull_request` labeled (acts only with `automerge`/`force-merge`), and
+# `workflow_run` on CI completion. Posted via the REST API (not the job's
+# implicit check run) so the status lands on the PR head SHA, since these
+# jobs run on the default branch.
 #
 # Labels:
-#   automerge        enable GitHub auto-merge (one-shot when label is
-#                    added) AND opt into continuous gate updates
-#                    (green AND red).
-#   force-merge      bypass: posts green regardless of CI state, but
-#                    ONLY when the PR author is a maintainer or a
-#                    maintainer has approved the PR. The maintainer
-#                    list is read at runtime from .github/MAINTAINER
-#                    at main's tip (never the PR head SHA -- a PR
-#                    that edits MAINTAINER to grant itself bypass
-#                    should not take effect until merged). When the
-#                    label is applied without maintainer involvement
-#                    and CI is also red, the workflow posts a red
-#                    status that explains why the bypass was
-#                    rejected.
-#
-# Status is posted via the REST API rather than the job's implicit
-# check run because `workflow_run` and `issue_comment` jobs execute on
-# the default branch; an explicit POST against the PR head SHA puts
-# the status on the right commit.
+#   automerge    enable GitHub auto-merge (one-shot on label add) + opt
+#                into continuous gate updates (green AND red).
+#   force-merge  bypass posting green regardless of CI, but only when the
+#                PR author is a maintainer or a maintainer approved; the
+#                list is read from .github/MAINTAINER at main's tip (never
+#                the PR head SHA). Bypass without maintainer + red CI posts
+#                a red status explaining the rejection.
 
 on:
-  # `labeled` only -- other PR events fired a skipped run on the
-  # checks panel. `workflow_run` re-evaluates on CI completion.
+  # `labeled` only; `workflow_run` re-evaluates on CI completion.
   pull_request:
     types: [labeled]
   workflow_run:
@@ -53,8 +27,7 @@ on:
   issue_comment:
     types: [created]
 
-# Read-only at the top level (Scorecard Token-Permissions); the write
-# scopes live on the job below.
+# Read-only at top level; write scopes live on the job below.
 permissions:
   contents: read
 
@@ -71,18 +44,12 @@ jobs:
       checks: read
       actions: read         # evaluate-checks.sh reads GET /actions/runs to classify missing checks
       statuses: write
-    # Fire on automerge/force-merge label adds, PR-triggered
-    # workflow_run completions, or `/merge` comments. Other label
-    # adds no longer skip-run here.
-    #
-    # workflow_run is filtered to PR-originated runs: the watched
-    # workflows' `pull_request` completions, plus the fork-e2e run
-    # which arrives as a `push` on a `fork-e2e/**` branch (the e2e
-    # suite for a mirrored fork PR -- see fork-e2e-mirror.yml). The
-    # context-resolution step below maps that branch's head SHA back
-    # to its PR. Post-merge runs on `main` (push), nightlies, and
-    # manual dispatches have no PR to post on, so they're excluded
-    # here to avoid spinning up a wasteful runner per merge.
+    # Fire on automerge/force-merge label adds, PR-originated
+    # workflow_run completions, or `/merge` comments. workflow_run is
+    # filtered to PR runs plus the fork-e2e `push` on `fork-e2e/**`
+    # (mirrored fork PR e2e -- see fork-e2e-mirror.yml; ctx step maps
+    # its head SHA back to the PR). Post-merge/nightly/dispatch runs
+    # have no PR to post on and are excluded.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -126,9 +93,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          # Passed via env (not interpolated into the script): both the JSON
-          # (PR branch names) and the comment body are author-controlled, so
-          # direct interpolation would be a shell-injection vector.
+          # Via env, not interpolated: author-controlled, so direct
+          # interpolation would be a shell-injection vector.
           WF_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -136,12 +102,9 @@ jobs:
             PR="${{ github.event.pull_request.number }}"
             SHA="${{ github.event.pull_request.head.sha }}"
           elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-            # The job `if` uses a loose contains() pre-filter (Actions
-            # expressions have no regex), so it also fires on incidental
-            # mentions like `workflows/merge-ready.yml` -- PR #288 merged on a
-            # comment that merely referenced that path. Re-validate that
-            # `/merge` appears as an actual command: a line whose first
-            # non-space token is exactly `/merge` (optionally followed by args).
+            # The job `if` contains() pre-filter also fires on incidental
+            # mentions; re-validate `/merge` as a command (first non-space
+            # token on a line is exactly `/merge`, optional args).
             if ! grep -qE '^[[:space:]]*/merge([[:space:]]|$)' <<<"$COMMENT_BODY"; then
               echo "::notice::Skipped: comment mentions '/merge' but not as a command"
               echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -153,9 +116,8 @@ jobs:
             PR=$(echo "$WF_PRS" | jq -r '.[0].number // empty')
             SHA="${{ github.event.workflow_run.head_sha }}"
             if [[ -z "$PR" ]]; then
-              # Fork-PR upstream runs leave workflow_run.pull_requests empty
-              # (GitHub omits cross-repo PR refs), so resolve the open PR from
-              # the head SHA. SHA is a commit hash from the event (no injection).
+              # Fork-PR runs leave workflow_run.pull_requests empty, so
+              # resolve the open PR from the head SHA.
               PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
                 --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true)
             fi
@@ -204,9 +166,8 @@ jobs:
           MAINTAINERS: ${{ steps.maintainers.outputs.list }}
         run: bash .github/scripts/merge-ready/force-merge-eligibility.sh
 
-      # post_red gates whether a red gate state posts a Merge Ready
-      # status. /merge needs it; automerge / force-merge opt in. Without
-      # one of those triggers we only post green so partial CI doesn't
+      # post_red gates posting a red status: /merge needs it, automerge /
+      # force-merge opt in; otherwise post green only so partial CI doesn't
       # paint red.
       - name: Determine eligibility
         id: eligible
@@ -273,10 +234,9 @@ jobs:
             -f description="$DESC" >/dev/null
           echo "Posted Merge Ready=$STATE on $SHA ($DESC)"
 
-      # Authoritative authorization for /merge: the job `if` pre-filters
-      # on author_association, but an org MEMBER may lack write on this
-      # repo, so confirm effective write access via the permission API
-      # before any merge action runs.
+      # Authoritative /merge authz: the job `if` pre-filters on
+      # author_association, but an org MEMBER may lack write here, so
+      # confirm write access via the permission API before merging.
       - name: Authorize /merge commenter
         id: authz
         if: >-

--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -1,18 +1,12 @@
-# Builds the server image and pushes it to ghcr.io/omnigent-ai/omnigent-server,
-# the image every deploy template references. ubuntu-latest, GHCR via
-# GITHUB_TOKEN.
+# Builds + pushes two images to GHCR via GITHUB_TOKEN: the server image
+# (ghcr.io/omnigent-ai/omnigent-server, referenced by every deploy template)
+# and the host image (the `host` target of the same Dockerfile,
+# ghcr.io/omnigent-ai/omnigent-host — default for `sandbox create --provider
+# modal` and server-launched managed hosts). Dockerfile ARGs default to public
+# registries, so no build-args needed.
 #
-# Also builds + pushes the Omnigent host image (the `host` target of the
-# same Dockerfile) as ghcr.io/omnigent-ai/omnigent-host with the identical
-# trigger / permission / login / tag setup — the default image for
-# `omnigent sandbox create --provider modal` and server-launched managed
-# hosts.
-#
-# The Dockerfile ARGs default to public registries, so no build-args are
-# needed. Actions are SHA-pinned per repo convention.
-#
-# First run creates the GHCR packages PRIVATE; to allow unauthenticated pulls,
-# flip them to public once in the org package settings (cannot be done in CI).
+# First run creates the GHCR packages PRIVATE; flip them to public once in the
+# org package settings to allow unauthenticated pulls (cannot be done in CI).
 name: Publish images (public)
 
 on:
@@ -33,14 +27,12 @@ on:
       - '.github/workflows/oss-publish-images.yml'
   workflow_dispatch: {}
 
-# Read-only at the top level (Scorecard Token-Permissions); the write
-# scopes live on the job(s) below.
+# Read-only at the top level; write scopes live on the job below.
 permissions:
   contents: read
 
 concurrency:
-  # Key by SHA so back-to-back merges each build; don't cancel a queued
-  # build mid-push.
+  # Key by SHA so back-to-back merges each build; don't cancel mid-push.
   group: oss-publish-images-${{ github.sha }}
   cancel-in-progress: false
 
@@ -67,11 +59,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # :latest tracks main HEAD; :sha-<short> is the immutable per-commit
-      # pin; a v* tag publishes :vX.Y.Z and re-points :latest. Server and
-      # host images share the same scheme.
-      # ref / ref_name go through env, not inline ${{ }}, so a crafted tag
-      # name cannot inject shell.
+      # :latest tracks main HEAD; :sha-<short> is the immutable per-commit pin;
+      # a v* tag publishes :vX.Y.Z and re-points :latest. Server + host images
+      # share the scheme. ref / ref_name go through env (not inline ${{ }}) so a
+      # crafted tag name can't inject shell.
       - name: Compute image tags
         id: tags
         env:
@@ -109,9 +100,8 @@ jobs:
           provenance: false
           sbom: false
 
-      # Host image: same Dockerfile, `host` target. Runs after the server
-      # build so it reuses the shared builder-stage layers from the gha
-      # cache — the host-only runtime stage is the only extra work.
+      # Host image: same Dockerfile, `host` target. Runs after the server build
+      # so it reuses the shared builder-stage layers from the gha cache.
       - name: Build and push host image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:

--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -1,38 +1,28 @@
-# A maintainer comments `/regen` on a PR to regenerate the repo's
-# lockfiles (uv.lock + ap-web/package-lock.json) against public PyPI/npm and
-# commit them ONTO that PR's branch. Complements oss-regenerate-and-smoke.yml
-# (which opens a standalone rolling PR when a maintainer dispatches it); use
-# this when the PR itself moved a dependency and you want the lock fixed in
-# place.
+# A maintainer comments `/regen` on a PR to regenerate the repo's lockfiles
+# (uv.lock + ap-web/package-lock.json) against public PyPI/npm and commit them
+# ONTO that PR's branch. Use when the PR itself moved a dependency; complements
+# oss-regenerate-and-smoke.yml (standalone rolling PR on dispatch).
 #
-# Validation is deliberately left to the PR's own CI: the push is made with a
-# GitHub App installation token (vars.OSS_REGEN_APP_ID + secrets.OSS_REGEN_APP_KEY),
-# NOT GITHUB_TOKEN, so it re-fires the PR's full check suite — including the
-# Docker build — on the new commit. A GITHUB_TOKEN push would NOT re-trigger
-# those checks (GitHub suppresses it to avoid loops), leaving stale results; an
-# App token is a distinct actor and does re-trigger. If the App is not
-# configured the push falls back to GITHUB_TOKEN: it still lands, but a
-# maintainer must re-push the branch to run CI.
+# Validation is left to the PR's own CI: the push uses a GitHub App token (NOT
+# GITHUB_TOKEN, which GitHub suppresses to avoid loops), so it re-fires the full
+# check suite on the new commit. Falls back to GITHUB_TOKEN if the App isn't
+# configured (lands, but a maintainer must re-push to run CI).
 #
-# Authorization: only maintainers listed in .github/MAINTAINER (read from main's
-# tip by merge-ready/load-maintainers.sh) may run it — the action pushes code.
-# Same-repo PRs only; pushing to a fork branch needs the fork's permission.
-#
-# Actions are SHA-pinned (trailing version comment) per the repo convention.
+# Authorization: only .github/MAINTAINER entries (read from main's tip) may run
+# it — it pushes code. Same-repo PRs only (can't push to a fork branch).
 name: OSS regenerate lockfiles on /regen comment
 
 on:
   issue_comment:
     types: [created]
 
-# Read-only at the top level (Scorecard Token-Permissions); the write
-# scopes live on the job(s) below.
+# Read-only at the top level; write scopes live on the jobs below.
 permissions:
   contents: read
 
 jobs:
-  # Cheap gate: confirm this is a `/regen` comment on a PR in the OSS repo and
-  # that the commenter is a maintainer. Exposes the PR head ref to the regen job.
+  # Gate: confirm a `/regen` comment on a PR in the OSS repo by a maintainer.
+  # Exposes the PR head ref to the regen job.
   authorize:
     permissions:
       contents: read       # checkout main for load-maintainers.sh
@@ -49,8 +39,8 @@ jobs:
       head: ${{ steps.pr.outputs.head }}
       cross: ${{ steps.pr.outputs.cross }}
     steps:
-      # Checkout main only to get load-maintainers.sh; the PR branch is checked
-      # out later (in the regen job), after authorization passes.
+      # Checkout main only for load-maintainers.sh; the PR branch is checked
+      # out later (regen job), after authorization passes.
       - name: Checkout (for the maintainer script)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -88,8 +78,7 @@ jobs:
           echo "head=$(echo "$data" | jq -r .headRefName)" >> "$GITHUB_OUTPUT"
           echo "cross=$(echo "$data" | jq -r .isCrossRepository)" >> "$GITHUB_OUTPUT"
 
-      # All ${{ }} values are passed via env: and referenced as "$VAR" rather
-      # than interpolated into the script body, to avoid expression injection.
+      # ${{ }} values pass via env: and referenced as "$VAR" to avoid injection.
       - name: Acknowledge (or reject forks)
         if: steps.authz.outputs.ok == 'true'
         env:
@@ -121,11 +110,9 @@ jobs:
       group: oss-regen-comment-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
-      # No token and no persisted credentials: the public repo needs no auth
-      # to fetch, and `uv lock` below can execute build backends the PR head
-      # chooses (sdists, [build-system] hooks in pyproject.toml) — nothing it
-      # runs should find a push token on disk. The App token is minted only
-      # after `uv lock` and enters only at the push step.
+      # No token / no persisted credentials: `uv lock` can execute PR-chosen
+      # build backends, which must not find a push token on disk. The App token
+      # is minted only after `uv lock` and enters only at the push step.
       - name: Checkout the PR branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -142,31 +129,23 @@ jobs:
         with:
           node-version: "20"
 
-      # The 7-day dependency cooldown comes from the repo's uv.toml
-      # (`exclude-newer = "P7D"`), which uv records in the lock as a
-      # relative span — so `uv sync --locked` stays consistent without
-      # this workflow injecting a cutoff. (An env-var UV_EXCLUDE_NEWER
-      # here would override the config with an absolute date and stamp
-      # it into the lock, breaking every later `uv sync --locked` that
-      # runs without the same env.)
-      # npm's 7-day cooldown lives in ap-web/.npmrc (`min-release-age=7`,
-      # the mirror of uv's `exclude-newer = "P7D"`) and is only honored by
-      # npm >= 11.10.0; node 20 ships npm 10.x, which silently ignores it.
+      # 7-day cooldown comes from uv.toml (`exclude-newer = "P7D"`), recorded as
+      # a relative span; an env-var cutoff would stamp an absolute date and break
+      # later `uv sync --locked`. npm's cooldown (ap-web/.npmrc min-release-age=7)
+      # is only honored by npm >= 11.10.0; node 20 ships npm 10.x which ignores it.
       - name: Ensure npm honors the dependency cooldown
         run: npm install -g "npm@>=11.10.0"
       # Delete package-lock.json so npm RESOLVES from scratch: min-release-age
-      # only filters candidates during resolution, and `--package-lock-only`
-      # keeps an existing in-range pin without re-applying the cooldown, so a
-      # too-fresh version already in the lock would survive a plain regen.
+      # only filters during resolution, and --package-lock-only keeps an existing
+      # in-range pin without re-applying the cooldown.
       - name: Regenerate lockfiles against public PyPI/npm
         run: |
           uv lock
           ( cd ap-web && rm -f package-lock.json && npm install --package-lock-only --no-audit --no-fund )
 
-      # Mint the App installation token only AFTER `uv lock` so untrusted PR
-      # build backends never see it, and never via the checkout (credentials
-      # stay off disk). Skipped when the App isn't configured — the push then
-      # falls back to GITHUB_TOKEN and a maintainer must re-push to run CI.
+      # Mint the App token only AFTER `uv lock` so untrusted PR build backends
+      # never see it. Skipped when the App isn't configured (push then falls back
+      # to GITHUB_TOKEN and a maintainer must re-push to run CI).
       - name: Mint App token
         id: app-token
         if: vars.OSS_REGEN_APP_ID != ''
@@ -175,12 +154,9 @@ jobs:
           app-id: ${{ vars.OSS_REGEN_APP_ID }}
           private-key: ${{ secrets.OSS_REGEN_APP_KEY }}
 
-      # All ${{ }} values are passed via env: and referenced as "$VAR" rather
-      # than interpolated into the script body — HEAD_REF is the PR author's
-      # branch name (user-influenced), so this avoids expression injection.
-      # The push token authenticates inline (scoped to this step, never written
-      # to .git/config) so the push re-triggers the PR's CI; Actions masks the
-      # secret in logs.
+      # ${{ }} values pass via env: as "$VAR" to avoid injection (HEAD_REF is a
+      # user-influenced branch name). The push token authenticates inline (scoped
+      # to this step, never in .git/config) so the push re-triggers the PR's CI.
       - name: Commit and push to the PR branch
         id: push
         env:
@@ -209,7 +185,7 @@ jobs:
           REPO: ${{ github.repository }}
           CHANGED: ${{ steps.push.outputs.changed }}
           # App token used → push re-triggers CI; skipped (GITHUB_TOKEN fallback) → it won't.
-          APP_USED: ${{ steps.app-token.conclusion == 'success' }}
+          APP_USED: ${{ steps.app-token.conclusion == 'success' }} # App token → re-triggers CI; fallback → won't
         run: |
           if [ "$CHANGED" = "true" ]; then
             base="✅ Regenerated \`uv.lock\` + \`ap-web/package-lock.json\` against public PyPI/npm and pushed to this PR."
@@ -224,8 +200,7 @@ jobs:
               --body "ℹ️ Lockfiles already current against public PyPI/npm — nothing to regenerate."
           fi
 
-      # Failure path: regen/push errored, so tell the maintainer on the PR
-      # instead of leaving them to dig through the Actions tab.
+      # Failure path: tell the maintainer on the PR instead of the Actions tab.
       - name: Comment on failure
         if: failure()
         env:

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -1,36 +1,20 @@
-# Regenerate the repo's lockfiles against PUBLIC PyPI/npm, then validate
-# the Docker build + a CLI smoke. Runs on GitHub-hosted `ubuntu-latest`
-# specifically so resolution sees the public registries directly — the
-# lockfiles must record public sources, never a mirror or proxy.
-#
-# Why this exists: sync PRs land manifest changes without lockfile updates
-# (lockfiles are regenerated, not synced), and the Dockerfile `COPY`s
-# `ap-web/package-lock.json`, so the tree is not Docker-buildable until
-# the lockfiles are (re)generated here.
-#
-# Actions are SHA-pinned (with a trailing version comment) per the repo
-# convention and the SecOps day-1 requirement; the pins match the SHAs
-# already used by sibling workflows in this repo.
+# Regenerate the repo's lockfiles against PUBLIC PyPI/npm, then validate via
+# a Docker build + CLI smoke. Runs on GitHub-hosted ubuntu-latest so resolution
+# sees public registries directly (lockfiles must record public sources, never
+# a proxy). Exists because sync PRs land manifest changes without lockfile
+# updates and the Dockerfile COPYs ap-web/package-lock.json, so the tree is not
+# Docker-buildable until lockfiles are (re)generated here. Manual-only by design
+# so timing stays in human hands; /regen on a PR covers the PR-scoped case.
 name: OSS regenerate lockfiles + smoke
 
-# Manual-only by design: a maintainer dispatches it when lockfiles need a
-# refresh (typically after a sync lands manifest changes). Automatic
-# triggers (manifest-path pushes, a weekly sweep) used to open rolling
-# regen PRs at unpredictable moments — including mid-release — so timing
-# stays in human hands; `/regen` on a PR covers the PR-scoped case.
 on:
   workflow_dispatch: {}
 
-# Read-only at the top level (Scorecard Token-Permissions); the write
-# scopes live on the job(s) below.
 permissions:
   contents: read
 
-# Serialize runs on the same ref so two overlapping dispatches don't both
-# force-push the regen branch at once.
-# cancel-in-progress is false (not true): a queued run starts AFTER the
-# prior one finishes, so it checks out the just-updated main, regenerates
-# identical lockfiles, and exits clean on "nothing to commit" — instead of
+# cancel-in-progress false: a queued run starts after the prior finishes, picks
+# up updated main, regenerates identical lockfiles, exits clean rather than
 # cancelling a run that may be mid-push.
 concurrency:
   group: oss-regenerate-${{ github.ref }}
@@ -44,9 +28,6 @@ jobs:
     # Gated to this repository; inert in forks and mirrors.
     if: github.repository == 'omnigent-ai/omnigent'
     runs-on: ubuntu-latest
-    # Bound a hung run well under GitHub's 6-hour default. The canary runs in
-    # ~3 min; 30 leaves headroom for a cold Docker build (FE compile + uv
-    # install) without letting a wedged build burn runner hours.
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -62,52 +43,35 @@ jobs:
         with:
           node-version: "20"
 
-      # 1. Regenerate uv.lock from pyproject against public PyPI. The
-      # 7-day dependency cooldown comes from the repo's uv.toml
-      # (`exclude-newer = "P7D"`), recorded in the lock as a relative
-      # span — an env-var cutoff here would instead stamp an absolute
-      # date into the lock and break later `uv sync --locked` runs.
+      # 7-day cooldown comes from uv.toml (`exclude-newer = "P7D"`), recorded as
+      # a relative span; an env-var cutoff would stamp an absolute date and break
+      # later `uv sync --locked`.
       - name: Regenerate uv.lock
         run: uv lock
 
-      # 2. Regenerate ap-web/package-lock.json against public npm. Lockfile
-      #    only (the Docker build does the full install) — fast, deterministic.
-      #    The 7-day dependency cooldown comes from ap-web/.npmrc
-      #    (`min-release-age=7`, the npm mirror of uv.toml's
-      #    `exclude-newer = "P7D"`); it is only honored by npm >= 11.10.0,
-      #    and node 20 ships npm 10.x, so install a new-enough npm first or
-      #    the cooldown is silently ignored and the lock can pin a release
-      #    too fresh for the downstream JFrog mirror to serve.
+      # npm's cooldown (ap-web/.npmrc `min-release-age=7`) is only honored by
+      # npm >= 11.10.0; node 20 ships npm 10.x which silently ignores it.
       - name: Ensure npm honors the dependency cooldown
         run: npm install -g "npm@>=11.10.0"
-      # Delete the lockfile so npm RESOLVES from scratch. `min-release-age`
-      # only filters candidates during resolution; with an existing
-      # lockfile, `npm install --package-lock-only` keeps any pin that
-      # still satisfies package.json (it prints "up to date") and never
-      # re-applies the cooldown — so a too-fresh version already in the
-      # lock would survive. A clean resolve re-picks every dep to the
-      # newest version that clears the 7-day cooldown.
+      # Delete the lockfile so npm RESOLVES from scratch: min-release-age only
+      # filters during resolution, and --package-lock-only keeps an existing
+      # in-range pin without re-applying the cooldown.
       - name: Regenerate package-lock.json
         working-directory: ap-web
         run: |
           rm -f package-lock.json
           npm install --package-lock-only --no-audit --no-fund
 
-      # 3. Validate BEFORE committing: the Docker build is the real test that
-      #    the regenerated locks + public registries produce a working image
-      #    (FE build via npm + `uv pip install -e .`, all public by default —
-      #    the Dockerfile ARGs already default to pypi.org / public npm).
+      # Validate BEFORE committing: the Docker build proves the regenerated
+      # locks + public registries produce a working image.
       - name: Docker build (FE + Python, public registries)
         run: docker build -f deploy/docker/Dockerfile -t omnigent-smoke .
 
-      # 4. CLI smoke. No secrets needed for --help; an actual agent run would
-      #    need a public LLM key (wire ${{ secrets.LLM_API_KEY }} when desired).
       - name: CLI smoke
         run: docker run --rm omnigent-smoke omnigent --help
 
-      # Mint the App installation token for the push + PR below. A distinct
-      # actor (not GITHUB_TOKEN), so the regen PR runs its own CI. Skipped when
-      # the App isn't configured — the step then falls back to GITHUB_TOKEN.
+      # App token = distinct actor (not GITHUB_TOKEN) so the regen PR runs its
+      # own CI. Skipped when the App isn't configured (falls back to GITHUB_TOKEN).
       - name: Mint App token
         id: app-token
         if: vars.OSS_REGEN_APP_ID != ''
@@ -116,17 +80,10 @@ jobs:
           app-id: ${{ vars.OSS_REGEN_APP_ID }}
           private-key: ${{ secrets.OSS_REGEN_APP_KEY }}
 
-      # 5. Persist the validated lockfiles via a PR (only if they changed and
-      #    the build above passed). A PR, not a direct push to main, so it
-      #    works once main is branch-protected. Created with a GitHub App
-      #    installation token (vars.OSS_REGEN_APP_ID + secrets.OSS_REGEN_APP_KEY)
-      #    so `gh pr create` is not blocked by the org "Allow Actions to create
-      #    PRs" restriction and the regen PR runs its own CI (an App token is a
-      #    distinct actor, so its push/PR re-triggers checks; GITHUB_TOKEN's
-      #    would not). No loop: this workflow is workflow_dispatch-only, and the
-      #    PR only touches lockfiles, so merging it never re-fires this workflow.
-      #    Falls back to GITHUB_TOKEN if the App is not configured (the step
-      #    then degrades gracefully — see the else branch below).
+      # Persist the validated lockfiles via a PR (not a direct push to main, so
+      # it works under branch protection). App token so `gh pr create` isn't
+      # blocked by the org PR-creation restriction and the PR runs its own CI;
+      # falls back to GITHUB_TOKEN if the App isn't configured.
       - name: Open lockfile-regen PR
         if: github.event_name != 'pull_request'
         env:
@@ -135,36 +92,25 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Use `git status --porcelain`, not `git diff`: on the first regen
-          # the lockfiles are UNTRACKED (the public export ships without
-          # them), and `git diff` ignores untracked files — so `git diff
-          # --quiet` would false-negative and skip the PR. --porcelain
-          # reports untracked (??) and modified files alike.
+          # --porcelain (not git diff) so first-regen UNTRACKED lockfiles count too.
           if [ -z "$(git status --porcelain -- uv.lock ap-web/package-lock.json)" ]; then
             echo "Lockfiles already current — nothing to PR."
             exit 0
           fi
-          # One rolling branch, force-pushed each run, so repeated regens
-          # update a single PR instead of spawning a new one each time.
+          # One rolling branch, force-pushed each run, so regens update a single PR.
           BRANCH="automation/oss-lockfile-regen"
           git checkout -b "$BRANCH"
           git add uv.lock ap-web/package-lock.json
           git commit -m "chore(oss): regenerate public lockfiles against public PyPI/npm"
-          # Push via the token (App, else GITHUB_TOKEN) so a refresh of an
-          # already-open PR re-triggers its CI on the synchronize event.
           git push --force "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$BRANCH"
           # An already-open PR just picks up the force-pushed update.
           if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')" ]; then
             echo "PR already open for $BRANCH — refreshed it with the latest lockfiles."
             exit 0
           fi
-          # Best-effort PR creation. The branch (with the regenerated
-          # lockfiles) is already pushed above, so the recoverable state is
-          # achieved regardless. If creation is still blocked — e.g. the PAT
-          # is unset and the GITHUB_TOKEN fallback is disallowed from creating
-          # PRs — DON'T fail the run red: print the one-liner to open it by
-          # hand and exit clean. (The `if` condition exempts gh from `set -e`,
-          # so a non-zero exit falls to the else branch instead of aborting.)
+          # Best-effort: branch is already pushed, so if PR creation is blocked
+          # don't fail red — print the manual one-liner and exit clean. (The `if`
+          # exempts gh from `set -e`, so a non-zero exit hits the else branch.)
           if gh pr create --base main --head "$BRANCH" \
               --title "chore(oss): regenerate public lockfiles against public PyPI/npm" \
               --body "Automated: regenerated uv.lock + ap-web/package-lock.json against public PyPI/npm, validated by a Docker build + omnigent --help smoke (run ${{ github.run_id }}). Merge to keep the public lockfiles current and buildable."; then

--- a/.github/workflows/oss-scorecard.yml
+++ b/.github/workflows/oss-scorecard.yml
@@ -1,21 +1,14 @@
 name: OSS Scorecard
 
-# OpenSSF Scorecard supply-chain posture scan. The job is gated to this
-# repository via `if: github.repository == 'omnigent-ai/omnigent'`, so it
-# stays inert (skipped) in forks and mirrors — no SARIF in their Security
-# tabs, no secrets required there. ubuntu-latest, GITHUB_TOKEN only.
-#
-# Results upload as SARIF to the public repo's code-scanning / Security
-# tab. Token-only for now: the Branch-Protection check needs a PAT
-# (`repo` + read:org) as repo_token to score fully; without one that one
-# check is inconclusive but every other check runs. publish_results is
-# off because the repo is private — once it goes public, flip
-# publish_results to true, add `id-token: write` to the job permissions,
-# and add the Scorecard badge to README.
+# OpenSSF Scorecard supply-chain posture scan. Gated to this repository, so it
+# stays inert in forks and mirrors. Results upload as SARIF to the repo's
+# code-scanning / Security tab. The Branch-Protection check needs a PAT (`repo`
+# + read:org) as repo_token to score fully; without one only that check is
+# inconclusive. publish_results is off while the repo is private — once public,
+# flip it to true, add `id-token: write` to the job, and add the README badge.
 
 on:
-  # Re-score whenever branch protection changes (the check Scorecard
-  # cares most about), weekly, and on push to the default branch.
+  # Re-score on branch-protection changes, weekly, and on push to main.
   branch_protection_rule:
   schedule:
     - cron: '37 4 * * 1'  # Mondays 04:37 UTC
@@ -35,12 +28,10 @@ jobs:
       contents: read
       actions: read
     steps:
-      # Scorecard's GraphQL queries (ListCommits, etc.) are not accessible to
-      # the default GITHUB_TOKEN on a PRIVATE repo — it fails with "Resource
-      # not accessible by integration". A classic PAT (repo + read:org) stored
-      # as the SCORECARD_TOKEN secret is required while the repo is private;
-      # once it's public the default token would suffice. Skip cleanly (green,
-      # no analysis) until the secret is set so this never paints a red check.
+      # Scorecard's GraphQL queries aren't accessible to the default GITHUB_TOKEN
+      # on a PRIVATE repo, so a PAT (repo + read:org) in SCORECARD_TOKEN is
+      # required until the repo is public. Skip cleanly (green) until it's set so
+      # this never paints a red check.
       - name: Check for Scorecard token
         id: gate
         env:
@@ -65,11 +56,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # PAT (repo + read:org); required for the GraphQL queries on a
-          # private repo. Set as a repo/org Actions secret on Omnigent.
+          # PAT (repo + read:org); required for GraphQL queries on a private repo.
           repo_token: ${{ secrets.SCORECARD_TOKEN }}
-          # Private repo: don't publish to the public OpenSSF API. Flip to
-          # true (and add id-token: write above) once the repo is public.
+          # Private repo: don't publish to the public OpenSSF API. Flip to true
+          # (and add id-token: write above) once the repo is public.
           publish_results: false
 
       - name: Upload SARIF to code scanning

--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -1,49 +1,31 @@
-# Build the `omnigent` release distributions — the core wheel
-# with the `ap-web` web UI bundled in, plus the `omnigent-client` and
-# `omnigent-ui-sdk` SDK wheels the core package depends on — run the
-# readiness gates, and publish all three to (Test)PyPI via OIDC Trusted
-# Publishing. The three packages version-lock together: `pip install
-# omnigent==X` must resolve `omnigent-client==X` / `omnigent-ui-sdk==X`,
-# so every release publishes all three at the same version.
-#
-# SELF-CONTAINED: it publishes straight from THIS repo. Runs on
-# GitHub-hosted `ubuntu-latest` specifically for clean, direct public
-# PyPI/npm access — releases must resolve against the public registries,
-# never a mirror or proxy.
+# Build the `omnigent` release distributions (core wheel with the ap-web
+# UI bundled in, plus the `omnigent-client` and `omnigent-ui-sdk` SDK
+# wheels it depends on), run the readiness gates, and publish all three to
+# (Test)PyPI via OIDC Trusted Publishing. The three version-lock together,
+# so every release publishes all three at the same version. Self-contained:
+# publishes straight from this repo on `ubuntu-latest` for clean public
+# PyPI/npm access (never a mirror/proxy).
 #
 # Release flow:
-#   1. Push a version tag (vX.Y.Z / vX.Y.ZrcN) -> builds + gates + publishes
-#      to **TestPyPI** automatically.
-#   2. Validate the TestPyPI release (install + smoke it).
-#   3. Manually dispatch this workflow ON THE SAME TAG with
-#      destination=pypi -> publishes the identical version to **PyPI**,
-#      behind the `pypi` environment (attach a required-reviewer rule).
+#   1. Push a version tag (vX.Y.Z / vX.Y.ZrcN) -> build + gate + publish to
+#      TestPyPI automatically.
+#   2. Validate the TestPyPI release (install + smoke).
+#   3. Manually dispatch ON THE SAME TAG with destination=pypi -> publish
+#      the identical version to PyPI, behind the protected `pypi` env.
 #
-# One-time setup (per index — pypi.org AND test.pypi.org):
-#   - Trusted Publishers for ALL THREE project names (`omnigent`,
-#     `omnigent-client`, `omnigent-ui-sdk`), each pointing at:
-#       Owner/Repository = omnigent-ai/omnigent
-#       Workflow = release-omnigent.yml
-#       Environment = test-pypi (and `pypi` for the pypi.org publishers)
-#     Unclaimed names are reserved via a "pending publisher".
-#   - GitHub environments `test-pypi` (unprotected — PR self-test runs bind
-#     to it) and `pypi` (required reviewer).
-#
-# Actions are SHA-pinned (with a trailing version comment) per the repo
-# convention and the SecOps day-1 requirement; pins match sibling workflows.
+# One-time setup (per index, pypi.org AND test.pypi.org): Trusted Publishers
+# for all three project names pointing at omnigent-ai/omnigent +
+# release-omnigent.yml + the test-pypi/pypi environment (unclaimed names
+# reserved via a pending publisher); GitHub envs test-pypi (unprotected)
+# and pypi (required reviewer). Actions are SHA-pinned per repo convention.
 name: Release omnigent (PyPI)
 
 on:
-  # NOTE: PyPI publishing has moved to the central secure-release repo
-  # (databricks/secure-public-registry-releases-eng, workflow `omnigent.yml`).
-  # The tag-push trigger is REMOVED so a version tag no longer fires this
-  # workflow — otherwise it double-publishes and collides with the secure
-  # pipeline on the same tag. This workflow is kept only as a manual fallback
-  # (workflow_dispatch) and will be deleted once the secure path has done a
-  # production release.
-  #
-  # Manual run: builds + gates always run; destination picks the index.
-  # `pypi` binds the protected `pypi` environment.
+  # PyPI publishing moved to the central secure-release repo; the tag-push
+  # trigger is REMOVED so a tag no longer double-publishes. Kept as a manual
+  # fallback only, to be deleted once the secure path has done a prod release.
+  # Manual run: build + gates always run; destination picks the index, with
+  # `pypi` binding the protected environment.
   workflow_dispatch:
     inputs:
       destination:
@@ -53,8 +35,8 @@ on:
         options:
           - test-pypi
           - pypi
-  # Keep the workflow CI-tested when it changes: build + gates run on the
-  # PR; the publish steps are condition-gated to never fire on PR events.
+  # CI-test the workflow on change: build + gates run on the PR; publish
+  # steps are condition-gated off PR events.
   pull_request:
     paths:
       - ".github/workflows/release-omnigent.yml"
@@ -73,14 +55,10 @@ jobs:
     # Gated to this repository; inert in forks and mirrors.
     if: github.repository == 'omnigent-ai/omnigent'
     runs-on: ubuntu-latest
-    # Bound a hung run well under GitHub's 6-hour default (cold npm ci + FE
-    # build + wheel builds + smoke install run in a few minutes; 30 leaves
-    # headroom).
+    # Bound a hung run under GitHub's 6-hour default (real work takes minutes).
     timeout-minutes: 30
-    # The environment binds the PyPI Trusted Publisher config. `test-pypi`
-    # stays unprotected (tag pushes and PR self-tests bind it); `pypi`
-    # carries the required-reviewer rule so a real release needs a human
-    # approval even after the manual dispatch.
+    # Environment binds the Trusted Publisher config: test-pypi unprotected,
+    # pypi gated by a required-reviewer rule for real releases.
     environment:
       name: ${{ (github.event_name == 'workflow_dispatch' && inputs.destination == 'pypi') && 'pypi' || 'test-pypi' }}
 
@@ -98,27 +76,19 @@ jobs:
         with:
           node-version: "20"
 
-      # 1. Build the web UI FIRST, into the package tree, with a CLEAN
-      #    outDir. Ordering is load-bearing: the wheel packages whatever is
-      #    on disk, so the bundle must exist BEFORE `uv build`. setuptools
-      #    never shells out to npm (JS is built as a separate step). The
-      #    `rm -rf` backstops Vite's `emptyOutDir` so stale hashed bundles
-      #    can never ride along even if that config flag regresses. `npm ci`
-      #    (not `npm install`) installs the exact locked deps for THIS
-      #    commit — which is why a release always ships the matching UI.
+      # 1. Build the web UI FIRST into the package tree, clean. Ordering is
+      #    load-bearing: the wheel packages on-disk files, so the bundle must
+      #    exist before `uv build`. `rm -rf` backstops Vite's emptyOutDir
+      #    against stale bundles; `npm ci` installs the exact locked deps.
       - name: Build web UI (clean, fresh)
         run: |
           rm -rf omnigent/server/static/web-ui
           npm --prefix ap-web ci
           npm --prefix ap-web run build # Vite outDir -> omnigent/server/static/web-ui
 
-      # 2. Tag-driven releases: the pushed tag (vX.Y.Z) must match the
-      #    version in ALL THREE pyprojects, and the core package's exact
-      #    `==` pins on its sibling SDKs must point at that same version —
-      #    a stale pin would make `pip install omnigent==X` pull a
-      #    different SDK release than the one shipped alongside it.
-      #    Skipped on PR / manual dispatch of a non-tag ref (no release tag
-      #    to compare; dispatching ON a tag still verifies).
+      # 2. Tag-driven: the tag must match the version in all three pyprojects
+      #    and the core package's `==` sibling-SDK pins, so the lockstep
+      #    contract holds. Skipped on a non-tag ref (nothing to compare).
       - name: Verify tag matches package versions
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -127,9 +97,8 @@ jobs:
           import tomllib
 
           tag = sys.argv[1]
-          # Every package must carry the tag's version, and every
-          # cross-package dependency must be an exact `==tag` pin (the
-          # lockstep contract described in the header comment).
+          # Every package carries the tag's version; every cross-package
+          # dep is an exact `==tag` pin (the lockstep contract).
           packages = {
               "pyproject.toml": ("omnigent-client", "omnigent-ui-sdk"),
               "sdks/python-client/pyproject.toml": ("omnigent",),
@@ -152,10 +121,8 @@ jobs:
               sys.exit(1)
           PY
 
-      # 3. Build sdist + wheel for all three packages from the (now
-      #    UI-populated) tree, into one dist/ that the gates and the publish
-      #    steps consume. The SDKs are plain path-deps (not a uv workspace),
-      #    so each needs its own build invocation.
+      # 3. Build sdist + wheel for all three into one dist/. The SDKs are
+      #    path-deps (not a uv workspace), so each needs its own build.
       - name: Build sdists + wheels
         run: |
           uv build --out-dir dist
@@ -167,11 +134,9 @@ jobs:
       - name: twine check
         run: uvx twine check dist/*
 
-      # 5. GATE: the built UI bundle MUST be inside the core wheel. Fails
-      #    loud if the UI is missing or empty — catches "shipped a wheel
-      #    with no UI" that pure config misses. (The SDK wheels are
-      #    `omnigent_client-*` / `omnigent_ui_sdk-*`, so the glob below
-      #    matches only the core wheel.)
+      # 5. GATE: the UI bundle must be inside the core wheel; fail loud if
+      #    missing/empty. The glob matches only the core wheel (SDK wheels
+      #    are omnigent_client-* / omnigent_ui_sdk-*).
       - name: Assert web-UI bundle shipped in the wheel
         run: |
           uv run --no-project python - <<'PY'
@@ -190,48 +155,36 @@ jobs:
           sys.exit(0 if (ui and has_index) else "WEB-UI BUNDLE MISSING FROM WHEEL")
           PY
 
-      # 6. GATE: the wheels actually install together and the CLI entry
-      #    point imports — deps resolve from public PyPI, so this also
-      #    catches a dependency that only exists on the internal proxy.
+      # 6. GATE: the wheels install together and the CLI entry point imports,
+      #    resolving deps from public PyPI (catches proxy-only deps).
       - name: Smoke-install the built wheels
         run: |
           uv venv --python 3.12 /tmp/omnigent-smoke
           uv pip install --python /tmp/omnigent-smoke/bin/python dist/*.whl
           /tmp/omnigent-smoke/bin/omnigent --version
 
-      # 7. Persist the built artifacts so the exact distributions a run
-      #    would have shipped are downloadable for inspection.
+      # 7. Persist the built artifacts for inspection.
       - name: Upload built distributions
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist-omnigent
           path: dist/
 
-      # ---------------------------------------------------------------
-      # PUBLISH — OIDC Trusted Publishing (no token anywhere; id-token:
-      # write is granted above). Attestations stay ON (the action's
-      # default): PEP 740 provenance is a trust signal for a public
-      # project.
-      # ---------------------------------------------------------------
+      # PUBLISH via OIDC Trusted Publishing (no token; id-token: write granted
+      # above). Attestations stay ON (PEP 740 provenance for a public project).
       - name: Publish to TestPyPI
-        # Tag pushes and explicit test-pypi dispatches land on TestPyPI;
-        # PR self-test runs never publish.
+        # Tag pushes + explicit test-pypi dispatches; PR runs never publish.
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.destination == 'test-pypi')
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          # TestPyPI is the retry-prone dry-run index and PyPI never allows a
-          # filename to be re-uploaded: without this, a re-run after a partial
-          # publish (e.g. one package's Trusted Publisher misconfigured)
-          # aborts on the first already-landed file and never reaches the
-          # packages that still need publishing. The real-PyPI step below
-          # deliberately omits it — a prod release must fail loud on any
-          # collision.
+          # Let a re-run skip already-landed files after a partial publish;
+          # the real-PyPI step omits this so a prod collision fails loud.
           skip-existing: true
 
       - name: Publish to PyPI
-        # Real PyPI only via a deliberate manual dispatch with
-        # destination=pypi, behind the protected `pypi` environment.
+        # Real PyPI only via deliberate dispatch with destination=pypi,
+        # behind the protected `pypi` environment.
         if: github.event_name == 'workflow_dispatch' && inputs.destination == 'pypi'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         # default repository-url is pypi.org

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -1,23 +1,16 @@
 name: Security Gate
 
-# Reusable (workflow_call) gate, called as the FIRST job of each CI workflow
-# (ci/lint/e2e/e2e-ui/ap-web tests); their real jobs declare `needs: gate`.
+# Reusable (workflow_call) gate, called as the FIRST job of each CI workflow;
+# their real jobs declare `needs: gate`. Does NOT scan — the single scan runs in
+# security-scan.yml. This poller only decides whether to let its caller proceed:
+#   - non-PR event or trusted author -> proceed immediately
+#   - untrusted PR -> wait for the `Security Scan` check on the head SHA and
+#     MIRROR its conclusion (success -> proceed; failure -> fail, skipping the
+#     dependent CI jobs).
 #
-# This job does NOT scan -- the single scan runs once in security-scan.yml and
-# produces the `Security Scan` check. This poller only decides whether to let
-# its caller proceed:
-#   - non-PR event or trusted author -> proceed immediately (no scan needed)
-#   - untrusted PR -> wait for the `Security Scan` check on the PR head SHA and
-#     MIRROR its conclusion. success -> proceed; failure -> fail, so the
-#     dependent CI jobs (needs: gate) are skipped.
-#
-# Enforcement (audit vs blocking) lives in ONE place -- GATE_BLOCKING in
-# security-scan.yml. In audit mode that scan always concludes success, so this
-# poller always proceeds; flip it to "true" and a finding fails the scan, which
-# this poller then mirrors to block dependent CI. Running the scan once instead
-# of once-per-workflow is the whole point of splitting scan from gate.
-#
-# The trust decision is read from `main` (should-scan.sh) so a PR cannot edit it.
+# Enforcement (audit vs blocking) lives in ONE place: GATE_BLOCKING in
+# security-scan.yml. Splitting scan from gate runs the scan once, not once per
+# workflow. The trust decision is read from `main` (should-scan.sh).
 
 on:
   workflow_call:
@@ -54,8 +47,7 @@ jobs:
           bash .github/scripts/security-scan/should-scan.sh
 
       - name: Wait for Security Scan result
-        # Only untrusted PRs wait; trusted authors / non-PR events already
-        # proceeded above (scan=false), so their CI is not delayed by the scan.
+        # Only untrusted PRs wait; trusted authors / non-PR events proceeded above.
         if: ${{ steps.gate.outputs.scan == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,27 +1,24 @@
 name: Security Scan
 
-# The single deterministic security scan for a PR. Runs ONCE per PR (on
-# pull_request) and produces the `Security Scan` check. The per-workflow gate
-# jobs (security-gate.yml, called by ci/lint/e2e/e2e-ui/ap-web tests) do NOT
-# re-scan -- they poll THIS check and mirror its result -- so the scan work
-# happens exactly once while still gating every CI workflow.
+# The single deterministic security scan for a PR. Runs ONCE per PR and produces
+# the `Security Scan` check; the per-workflow gate jobs (security-gate.yml) don't
+# re-scan, they poll THIS check and mirror its result, so the work happens once
+# while still gating every CI workflow.
 #
-# It only STATICALLY analyses the diff/head (semgrep, grep, diff-read) and runs
-# with NO secrets on fork PRs, so it never executes untrusted code. The scanner
-# (scripts + rules) is always checked out from `main`, while the scanned code is
-# the PR head in a separate `pr/` dir, so a PR cannot edit its own scan.
+# It only STATICALLY analyses the diff/head (semgrep, grep, diff-read) with NO
+# secrets on fork PRs, so it never executes untrusted code. The scanner is always
+# checked out from `main` and the scanned code sits in a separate `pr/` dir, so a
+# PR can't edit its own scan.
 #
 # >>> CURRENTLY NON-BLOCKING (AUDIT MODE) <<<
-# GATE_BLOCKING is "false": the detectors run and surface findings as
-# annotations + a job summary, but this job always SUCCEEDS, so the pollers see
-# success and never skip downstream CI. To ENFORCE: set GATE_BLOCKING to "true"
-# -- then a finding fails this check, the pollers mirror the failure, and the
-# dependent CI jobs are skipped (no PR-code checkout / uv sync / test). This is
-# the single enforcement switch; the pollers just mirror this check.
+# GATE_BLOCKING "false": detectors run and surface findings, but this job always
+# SUCCEEDS, so the pollers proceed. Set it to "true" to ENFORCE — a finding then
+# fails this check, the pollers mirror the failure, and dependent CI is skipped.
+# This is the single enforcement switch.
 #
-# Trust tiers (see should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR) and
-# non-PR events are not scanned; returning contributors are; first-timers are
-# held by GitHub's native fork-approval gate first.
+# Trust tiers (should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR) and non-PR
+# events aren't scanned; returning contributors are; first-timers are held by
+# GitHub's native fork-approval gate first.
 
 on:
   pull_request:
@@ -40,10 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      # Match CI: route uv at PyPI for the semgrep fetch.
+      # Route uv at PyPI for the semgrep fetch.
       UV_INDEX_URL: https://pypi.org/simple
-      # The single enforcement switch. "false" = audit (never blocks CI);
-      # "true" = blocking (a finding fails this check; pollers then skip CI).
+      # Enforcement switch: "false" = audit (never blocks); "true" = blocking.
       GATE_BLOCKING: "false"
     steps:
       - name: Check out scanner from main
@@ -63,7 +59,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
-          # Scanner is checked out from `main` so a PR cannot edit its own scan.
           # Before this lands on main the scripts are absent there -- proceed
           # (fail-open) so the introducing PR is not bricked.
           if [ ! -f .github/scripts/security-scan/should-scan.sh ]; then
@@ -132,7 +127,7 @@ jobs:
         env:
           RULES: ${{ github.workspace }}/.github/security/semgrep-rules.yml
         run: |
-          # Scan only PR-changed files that exist in the head tree, so a
+          # Scan only PR-changed files present in the head tree, so a
           # contributor is never failed for pre-existing findings.
           : > targets.txt
           while IFS= read -r f; do
@@ -150,9 +145,9 @@ jobs:
             --metrics=off --quiet $(cat targets.txt)
 
       - name: Audit summary
-        # In audit mode the detector steps above are continue-on-error, so this
-        # surfaces what WOULD have blocked without failing the job. In blocking
-        # mode a detector failure already failed the job before reaching here.
+        # Audit mode: detectors are continue-on-error, so this surfaces what
+        # WOULD have blocked without failing the job. (Blocking mode already
+        # failed before reaching here.)
         if: ${{ always() && steps.gate.outputs.scan == 'true' }}
         run: |
           findings=0


### PR DESCRIPTION
## Summary

Readability cleanup across **all 20 workflow files** (behavior-preserving). Two transformations:

1. **Multi-line long single-line commands / arg-lists** — e.g. `ci.yml`'s matrix `paths:` values (the `misc` shard's long `--ignore=…` chain) become `>-` folded block scalars, one token per line. A `>-` scalar folds back to the **identical** space-joined string passed (unquoted) to `pytest`, so no behavior change — just a readable diff. (Most other files had no such single-line lists; their long `run:` commands were already `\`-continued.)
2. **Trim inline comments** — cut verbose multi-paragraph rationale / historical narration down to terse one-liners that keep only the non-obvious *why*, and condense each file's top-of-file block to a concise behavior + caveats description. **Comment lines across the workflows: 1329 → 663.** Functional pseudo-comments (`# shellcheck disable=…`, `# leak-scan-allow: pull_request_target`) preserved verbatim. A couple of stale internal references in comments were dropped while condensing.

**Behavior preserved — verified per file.** Every workflow was checked by parsing the old (`origin/main`) and new YAML and asserting the structures are **identical** after stripping comment lines — i.e. every trigger / job / step / `${{ }}` expression / `run:` command and every folded arg-string is byte-for-byte the same. All 20 files: ✅.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Comment/formatting-only change. For each of the 20 workflows, the parsed YAML (jobs, matrix, steps, `run` scripts, `env`, `if`, `permissions`, action SHAs) is identical to `main`'s after stripping comment lines — so no executable behavior changed; only comments and line-wrapping. The repo's own CI (lint + the security gate) runs on this PR as the live check.
