### PR TITLE
ci: enforce the security gate on untrusted PRs (blocking mode)

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -8,9 +8,10 @@ name: Security Gate
 #     MIRROR its conclusion (success -> proceed; failure -> fail, skipping the
 #     dependent CI jobs).
 #
-# Enforcement (audit vs blocking) lives in ONE place: GATE_BLOCKING in
-# security-scan.yml. Splitting scan from gate runs the scan once, not once per
-# workflow. The trust decision is read from `main` (should-scan.sh).
+# The scan (security-scan.yml) is blocking: a finding fails the `Security Scan`
+# check, which this poller mirrors to block dependent CI. Splitting scan from
+# gate runs the scan once, not once per workflow. The trust decision is read
+# from `main` (should-scan.sh).
 
 on:
   workflow_call:
@@ -57,10 +58,13 @@ jobs:
           echo "Untrusted PR -- waiting for the single 'Security Scan' check on $HEAD_SHA"
           q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
           conclusion=""
+          details_url=""
           for _ in $(seq 1 72); do   # up to ~6 min (72 * 5s)
             status=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .status" 2>/dev/null || echo "")
             if [ "$status" = "completed" ]; then
               conclusion=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .conclusion")
+              # The scan's own run page -- where the findings/annotations live.
+              details_url=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .html_url")
               break
             fi
             sleep 5
@@ -72,5 +76,8 @@ jobs:
           echo "Security Scan concluded: $conclusion"
           case "$conclusion" in
             success | skipped | neutral) exit 0 ;;
-            *) echo "::error::Security Scan did not pass ($conclusion); blocking dependent CI."; exit 1 ;;
+            *)
+              echo "::error::Security Scan did not pass ($conclusion); dependent CI is blocked until it passes. See the findings: ${details_url:-the 'Security Scan' check on this PR}"
+              exit 1
+              ;;
           esac

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,11 +10,10 @@ name: Security Scan
 # checked out from `main` and the scanned code sits in a separate `pr/` dir, so a
 # PR can't edit its own scan.
 #
-# >>> CURRENTLY NON-BLOCKING (AUDIT MODE) <<<
-# GATE_BLOCKING "false": detectors run and surface findings, but this job always
-# SUCCEEDS, so the pollers proceed. Set it to "true" to ENFORCE — a finding then
-# fails this check, the pollers mirror the failure, and dependent CI is skipped.
-# This is the single enforcement switch.
+# Blocking: any detector that finds something fails this check; the per-workflow
+# pollers mirror the failure and skip the dependent CI jobs (no PR-code checkout
+# / uv sync / test). Detectors run fail-fast -- the first finding fails the job,
+# so a clean PR must pass every one.
 #
 # Trust tiers (should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR) and non-PR
 # events aren't scanned; returning contributors are; first-timers are held by
@@ -39,11 +38,8 @@ jobs:
     env:
       # Route uv at PyPI for the semgrep fetch.
       UV_INDEX_URL: https://pypi.org/simple
-      # Enforcement switch: "false" = audit (never blocks); "true" = blocking.
-      GATE_BLOCKING: "false"
     steps:
       - name: Check out scanner from main
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: main             # trusted; never the PR head
@@ -54,7 +50,6 @@ jobs:
 
       - name: Trust gate
         id: gate
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
@@ -71,7 +66,6 @@ jobs:
 
       - name: Fetch PR diff
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -82,24 +76,19 @@ jobs:
           echo "Changed files:"; cat "$GITHUB_WORKSPACE/changed.txt"
 
       - name: Secret scan (added lines)
-        id: secret
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           DIFF_FILE: ${{ github.workspace }}/pr.diff
         run: python3 .github/scripts/security-scan/secret-scan.py
 
       - name: Sensitive-path guard
-        id: paths
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           CHANGED_FILES: ${{ github.workspace }}/changed.txt
         run: bash .github/scripts/security-scan/sensitive-paths.sh
 
       - name: Check out PR head for static analysis
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # untrusted: only statically scanned
@@ -107,9 +96,7 @@ jobs:
           persist-credentials: false
 
       - name: Workflow misuse lint
-        id: wflint
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         working-directory: pr
         env:
           CHANGED_FILES: ${{ github.workspace }}/changed.txt
@@ -117,13 +104,10 @@ jobs:
 
       - name: Install uv
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
 
       - name: Semgrep (changed files, local rules)
-        id: semgrep
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        continue-on-error: ${{ env.GATE_BLOCKING != 'true' }}
         env:
           RULES: ${{ github.workspace }}/.github/security/semgrep-rules.yml
         run: |
@@ -143,22 +127,3 @@ jobs:
           # Gating pass: ERROR-severity rules fail the scan.
           uvx semgrep scan --config "$RULES" --severity=ERROR --error \
             --metrics=off --quiet $(cat targets.txt)
-
-      - name: Audit summary
-        # Audit mode: detectors are continue-on-error, so this surfaces what
-        # WOULD have blocked without failing the job. (Blocking mode already
-        # failed before reaching here.)
-        if: ${{ always() && steps.gate.outputs.scan == 'true' }}
-        run: |
-          findings=0
-          for o in "${{ steps.secret.outcome }}" "${{ steps.paths.outcome }}" \
-                   "${{ steps.wflint.outcome }}" "${{ steps.semgrep.outcome }}"; do
-            [ "$o" = "failure" ] && findings=1
-          done
-          if [ "$findings" = "1" ]; then
-            echo "::warning::Security scan found issues (see annotations above). Audit mode: CI was NOT blocked. Set GATE_BLOCKING=true in security-scan.yml to enforce."
-            { echo "### 🔍 Security scan — audit mode"; echo "Findings detected; **not** blocking CI. See annotations above."; } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Security scan: no findings."
-            echo "### ✅ Security scan — audit mode: no findings" >> "$GITHUB_STEP_SUMMARY"
-          fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,9 +46,6 @@ directly. When enforcing, merge stays blocked transitively (the skipped
 pytest/e2e checks are required) and `Maintainer Approval` remains the ultimate
 gate.
 
-It currently runs in **audit (non-blocking) mode** (`GATE_BLOCKING: "false"` in
-`security-scan.yml` — the single enforcement switch): the detectors run and
-surface findings as annotations and a job summary, but the `Security Scan` check
-always succeeds, so the pollers proceed and no CI is blocked. Flip
-`GATE_BLOCKING` to `"true"` to enforce once the scan has been observed on real
-PRs.
+It is **blocking**: a finding fails the `Security Scan` check, the pollers mirror
+that failure, and the dependent CI jobs are skipped. Detectors run fail-fast, so
+a clean PR must pass every one.


### PR DESCRIPTION
## What

Turns the contributor security scan from **audit** to **blocking**, and makes the gate's block message actionable.

- **`security-scan.yml`**: `GATE_BLOCKING` `"false"` → `"true"`. A finding now fails the `Security Scan` check; the per-workflow pollers mirror that failure and dependent CI (pytest/lint/e2e/ap-web) is **skipped**. Only **untrusted** PRs are scanned/blocked — trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`) and non-PR events are unaffected.
- **`security-gate.yml`**: the poller's failure message now includes the `Security Scan` run URL (`html_url`) so a developer jumps straight to the findings instead of hunting for the separate check.
- **`SECURITY.md`**: updated to describe enforcing mode.

## Proof it works

Validated end-to-end on the throwaway test PR #289 (which temporarily bypassed the author trust check and committed attacker-style payloads: a `pull_request_target` + PR-head-checkout workflow that exfiltrates `LLM_API_KEY`/`GITHUB_TOKEN` and poisons the Actions cache, a `conftest.py` with `curl | bash` secret theft, and an obfuscated `exec(base64(...))` backdoor).

Result — the scan detected it, the gate pollers mirrored the failure, and **all downstream CI was skipped**:

- Security Scan → **fail**
- `gate / Security Gate` (×5) → **fail**, e.g. https://github.com/omnigent-ai/omnigent/actions/runs/27602863523/job/81607827268
- Pre-commit / Pytest / setup → **skipping**

The poller log shows the mirror decision:
```
Security Scan concluded: failure
Security Scan did not pass (failure); blocking dependent CI.
```

## Notes

- Detection coverage (secret-scan, sensitive-paths, workflow-misuse, semgrep) was independently confirmed; the secret-*exfil* and cache-poison attacks are caught structurally by the workflow detectors, not the committed-secret scanner (correct division of labor).
- `GATE_BLOCKING` is the single switch — set back to `"false"` to return to audit mode at any time.