### PR TITLE
feat(sandbox): add E2B sandbox provider

### DIFF
--- a/ap-web/src/lib/capabilities.ts
+++ b/ap-web/src/lib/capabilities.ts
@@ -132,6 +132,7 @@ const _SANDBOX_PROVIDER_NAMES: Record<string, string> = {
   modal: "Modal",
   lakebox: "Databricks",
   daytona: "Daytona",
+  e2b: "E2B",
 };
 
 /**

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -75,6 +75,9 @@ deploy/
 ├── islo/              ← Islo sandbox-provider guide (gateway credential
 │   └── README.md         injection); NOT a server deploy target.
 │
+├── e2b/               ← E2B sandbox-provider guide (boots from a pre-built
+│   └── README.md         E2B template); NOT a server deploy target.
+│
 └── docker/            ← common Docker image + compose stack
     ├── Dockerfile         multi-stage slim image (node web build → python builder → runtime)
     ├── docker-compose.yaml   omnigent + postgres for any Docker host
@@ -195,13 +198,13 @@ omnigent run path/to/agent.yaml --server https://your-host
 
 Don't want a laptop to be the host? Run the host in a cloud sandbox instead.
 
-**From the CLI (Modal, Daytona, or Islo).** Install the provider extra when
-needed (`pip install 'omnigent[modal]'` or `'omnigent[daytona]'`; Islo uses the
-built-in HTTP client), authenticate (`modal token new`, `DAYTONA_API_KEY`, or
-`ISLO_API_KEY`), then:
+**From the CLI (Modal, Daytona, Islo, or E2B).** Install the provider extra when
+needed (`pip install 'omnigent[modal]'`, `'omnigent[daytona]'`, or
+`'omnigent[e2b]'`; Islo uses the built-in HTTP client), authenticate
+(`modal token new`, `DAYTONA_API_KEY`, `ISLO_API_KEY`, or `E2B_API_KEY`), then:
 
 ```bash
-omnigent sandbox create --provider modal     # or --provider daytona / islo
+omnigent sandbox create --provider modal     # or --provider daytona / islo / e2b
 omnigent sandbox connect --provider modal --sandbox-id <id> --server https://your-host
 ```
 
@@ -209,9 +212,12 @@ omnigent sandbox connect --provider modal --sandbox-id <id> --server https://you
 > Modal caps sandbox lifetime at 24 hours. Re-run `create` + `connect` to
 > roll the host onto a fresh sandbox. Daytona and Islo have no Omnigent-imposed
 > lifetime cap; Daytona free-tier orgs restrict egress to an allowlist; see
-> [`daytona/README.md`](daytona/README.md) for the relay workaround.
+> [`daytona/README.md`](daytona/README.md) for the relay workaround. E2B
+> shares Modal's 24-hour cap **and** boots from a pre-built E2B *template*
+> rather than a registry image — build it once first; see
+> [`e2b/README.md`](e2b/README.md).
 
-**Server-managed (Modal, Daytona, or Islo).** With *managed hosts*, creating a
+**Server-managed (Modal, Daytona, Islo, or E2B).** With *managed hosts*, creating a
 session with `"host_type": "managed"` (e.g.
 `POST /v1/sessions {"agent_id": ..., "host_type": "managed"}`) makes the
 server provision a sandbox, start a host in it, and run the session there.
@@ -228,7 +234,7 @@ sandbox:
 Modal credentials come from the server's environment (`MODAL_TOKEN_ID` /
 `MODAL_TOKEN_SECRET`, or a mounted `~/.modal.toml`), not the config file.
 Daytona reads `DAYTONA_API_KEY`; Islo reads `ISLO_API_KEY` (and optional
-`ISLO_BASE_URL`) from the server environment.
+`ISLO_BASE_URL`); E2B reads `E2B_API_KEY` from the server environment.
 Each sandbox authenticates back with a server-minted, per-launch token, so
 no user credentials ever enter the sandbox.
 

--- a/deploy/e2b/README.md
+++ b/deploy/e2b/README.md
@@ -40,11 +40,13 @@ e2b auth login                # one-time, authenticates the E2B CLI too
 > **Lifetime is capped and cannot be disabled.** An E2B sandbox carries a
 > single timeout (default 5 minutes; account maximum **24 h on Pro, 1 h on
 > Hobby**) with no "never expire" option. Omnigent requests the 24 h
-> maximum at creation and re-extends it on every reconnect, but a managed
-> session outliving the cap relies on the dead-sandbox relaunch path (same
-> posture as Modal's 24 h limit). A **Pro account** is recommended for
-> anything beyond short demos — on Hobby, `provision` requests 24 h and
-> E2B clamps it to 1 h.
+> maximum at creation, but E2B **rejects** (does not clamp) a request above
+> the account cap, so `provision` automatically **retries clamped to the
+> account's maximum** (e.g. 1 h on Hobby) — verified live. Set
+> `OMNIGENT_E2B_MAX_LIFETIME_S` to request a specific lifetime and skip the
+> retry. A managed session outliving the cap relies on the dead-sandbox
+> relaunch path (same posture as Modal's 24 h limit), so a **Pro account**
+> is recommended for anything beyond short demos.
 
 ## Build the host template (one time)
 
@@ -238,16 +240,19 @@ Modal guide.
   couldn't dial back to `server_url`. Confirm it's a public HTTPS URL
   reachable from E2B's cloud (not `localhost`), and check
   `/tmp/omnigent-host.log` inside the sandbox.
-- **Sandbox stops after ~1 hour** — you're on a Hobby account (1 h cap).
-  Upgrade to Pro for the 24 h maximum, or expect the dead-sandbox
-  relaunch path to re-provision on the next message.
+- **Sandbox stops after ~1 hour** — you're on a Hobby account (1 h cap);
+  `provision` auto-clamps to it (you'll see a one-line warning). Upgrade
+  to Pro for the 24 h maximum, or expect the dead-sandbox relaunch path to
+  re-provision on the next message.
 
 ## Lifecycle notes
 
-- **Hard lifetime cap, no idle-stop disable.** `provision` requests the
-  24 h Pro maximum and `keep_alive` re-extends a live sandbox to it on
-  reconnect, but there is no never-expire option. A managed session past
-  the cap is replaced by the dead-sandbox relaunch path (same as Modal).
+- **Hard lifetime cap, no idle-stop disable.** `provision` requests
+  `OMNIGENT_E2B_MAX_LIFETIME_S` (default the 24 h Pro maximum); E2B rejects
+  a request above the account cap, so creation retries clamped to it (e.g.
+  1 h on Hobby). `keep_alive` re-extends a live sandbox on reconnect, but
+  there is no never-expire option — a managed session past the cap is
+  replaced by the dead-sandbox relaunch path (same as Modal).
 - **Templates, not registry images.** See
   [Build the host template](#build-the-host-template-one-time). Resources
   (vCPU / memory) are fixed when the template is built — pass
@@ -264,3 +269,4 @@ Modal guide.
 | `E2B_API_KEY` | CLI machine / server | E2B API credentials (required) |
 | `OMNIGENT_E2B_TEMPLATE` | CLI machine / server | E2B template name to provision from (`sandbox.e2b.template` takes precedence; default `omnigent-host`) |
 | `OMNIGENT_E2B_SANDBOX_ENV` | CLI machine / server | Comma-separated launcher-side env var names to inject (`sandbox.e2b.env` takes precedence for managed) |
+| `OMNIGENT_E2B_MAX_LIFETIME_S` | CLI machine / server | Requested sandbox lifetime in seconds (default 24 h); creation auto-clamps to the account cap if exceeded |

--- a/deploy/e2b/README.md
+++ b/deploy/e2b/README.md
@@ -219,12 +219,18 @@ Modal guide.
   isolation between Omnigent users rides on E2B's sandbox boundaries, and
   the shared key can enumerate and kill any user's sandbox. Scope the
   account to this workload.
-- **The launch token's lifetime is ~25 h.** E2B sandboxes share Modal's
-  24 h hard cap, so the per-launch host token outlives the sandbox by an
-  hour to re-authenticate the tunnel across reconnects. A leaked token is
-  replayable against the server for that window; a relaunch mints a fresh
-  one. Deployments injecting their own launcher can set a shorter
-  `token_ttl_s` on `ManagedSandboxConfig`.
+- **The launch token's lifetime is ~25 h, derived from the *requested*
+  lifetime.** E2B sandboxes share Modal's 24 h hard cap, so the per-launch
+  host token outlives the sandbox by an hour to re-authenticate the tunnel
+  across reconnects. The TTL is computed from `OMNIGENT_E2B_MAX_LIFETIME_S`
+  (default 24 h) at server start, so it bounds the *longest possible*
+  sandbox. On a capped account where `provision` clamps the sandbox shorter
+  (e.g. Hobby's 1 h), the token over-covers the now-shorter sandbox — safe
+  for re-auth, but a leaked token is replayable for the full window. To
+  tighten this, **set `OMNIGENT_E2B_MAX_LIFETIME_S` to your account cap** so
+  the token TTL tracks the granted lifetime (or set a shorter `token_ttl_s`
+  on a directly-constructed `ManagedSandboxConfig`). A relaunch mints a
+  fresh token.
 - **Sandbox URLs are public by default.** E2B exposes sandbox ports via
   public `*.e2b.app` URLs; Omnigent never opens one (the host dials *out*
   to your server), but be aware nothing in a sandbox should bind a

--- a/deploy/e2b/README.md
+++ b/deploy/e2b/README.md
@@ -1,0 +1,266 @@
+# Omnigent on E2B
+
+[E2B](https://e2b.dev) sandboxes give you disposable cloud machines for
+running Omnigent hosts, two ways:
+
+- **CLI-launched**: `omnigent sandbox create` / `connect` provisions a
+  sandbox from your terminal, ships your local checkout into it, and
+  registers it as a host with your server.
+- **Server-managed**: the server provisions a sandbox automatically when
+  a session is created with `"host_type": "managed"` and terminates it
+  when the session is deleted.
+
+> [!IMPORTANT]
+> **E2B boots from a pre-built *template*, not a registry image.** Unlike
+> the Modal / Daytona / CoreWeave launchers — which pull
+> `ghcr.io/omnigent-ai/omnigent-host` directly — E2B cannot start an
+> arbitrary registry image at create time. You must first build the
+> Omnigent host image into an E2B template (a one-time step, below); the
+> launcher's `template` field then names *that template*, not a
+> `ghcr.io/...` reference. This is the one real difference from the other
+> sandbox providers. This directory is **not** a server deploy target.
+
+## Prerequisites
+
+```bash
+pip install 'omnigent[e2b]'   # installs the e2b SDK extra
+npm i -g @e2b/cli             # the E2B CLI, for building the template
+```
+
+Create an API key in the [E2B dashboard](https://e2b.dev/dashboard) and
+make it available where the launcher runs — your shell for the CLI flow,
+the **server** process for managed sandboxes:
+
+```bash
+export E2B_API_KEY=e2b_…
+e2b auth login                # one-time, authenticates the E2B CLI too
+```
+
+> [!NOTE]
+> **Lifetime is capped and cannot be disabled.** An E2B sandbox carries a
+> single timeout (default 5 minutes; account maximum **24 h on Pro, 1 h on
+> Hobby**) with no "never expire" option. Omnigent requests the 24 h
+> maximum at creation and re-extends it on every reconnect, but a managed
+> session outliving the cap relies on the dead-sandbox relaunch path (same
+> posture as Modal's 24 h limit). A **Pro account** is recommended for
+> anything beyond short demos — on Hobby, `provision` requests 24 h and
+> E2B clamps it to 1 h.
+
+## Build the host template (one time)
+
+E2B builds a template from a Dockerfile whose base image must be
+**Debian-based** and **single-stage**. The Omnigent host image
+(`python:slim`, Debian) satisfies both — so the template Dockerfile is a
+one-liner that layers nothing on top of the published image:
+
+```bash
+mkdir -p omnigent-e2b && cd omnigent-e2b
+cat > e2b.Dockerfile <<'EOF'
+# Single-stage, Debian-based — both E2B requirements. The host image
+# already bakes the full omnigent install plus git / tmux / curl, so
+# nothing else is needed here.
+FROM ghcr.io/omnigent-ai/omnigent-host:latest
+EOF
+
+e2b template build --name omnigent-host --dockerfile e2b.Dockerfile
+```
+
+`omnigent-host` is the default template name the launcher looks for
+([`DEFAULT_E2B_TEMPLATE`](../../omnigent/onboarding/sandboxes/e2b.py)), so
+a deployment that uses that name needs no further config. Use a different
+name (or pin a `:sha-<short>` host image) and point the launcher at it
+with `sandbox.e2b.template` / `OMNIGENT_E2B_TEMPLATE`.
+
+To run your own host image, build the `host` target of
+[`deploy/docker/Dockerfile`](../docker/Dockerfile)
+(`--platform linux/amd64`), push it anywhere E2B can pull from, and `FROM`
+that ref in `e2b.Dockerfile` instead. Rebuild the template whenever the
+host image changes (the CLI flow still overlays your *local* wheels on
+top per-sandbox, so day-to-day code changes don't need a template
+rebuild).
+
+## CLI-launched sandboxes
+
+Provision a sandbox and ship your local checkout into it:
+
+```bash
+omnigent sandbox create --provider e2b
+```
+
+This starts a sandbox from the `omnigent-host` template, builds wheels
+from your local checkout, and overlays them on top — so the sandbox runs
+*your* code, not whatever the template was built from. Then register it
+as a host with your server:
+
+```bash
+omnigent sandbox connect --provider e2b \
+  --sandbox-id <id-printed-by-create> \
+  --server https://your-host
+```
+
+`connect` runs `omnigent host` inside the sandbox and holds the
+connection open in your terminal — Ctrl-C tears it down (and kills the
+remote process; E2B exposes a real kill handle). New sessions targeting
+that host now run in the sandbox.
+
+Running multiple sandboxes against one server? Pass a unique
+`--host-name <label>` to each `connect` — the server keys hosts on
+(owner, name), and sandboxes that share a hostname collide.
+
+Sandboxes are disposable. When your code changes, create a new one — and
+delete the old one (via the [dashboard](https://e2b.dev/dashboard) or
+`e2b sandbox kill <id>`), though E2B also reaps it automatically at its
+timeout.
+
+To inject LLM/git credentials into a CLI-launched sandbox, set
+`OMNIGENT_E2B_SANDBOX_ENV` in your shell to a comma-separated list of
+variable names (e.g. `ANTHROPIC_API_KEY,GIT_TOKEN`) before running
+`create` — the named variables are copied from your environment into the
+sandbox at provision time.
+
+> [!NOTE]
+> E2B has no local→sandbox port forward (it exposes sandbox ports
+> *outward* via public URLs only). The interactive in-sandbox
+> `omnigent login` / App OAuth step is therefore skipped automatically
+> (as on Modal / Daytona): use E2B with servers that don't require
+> in-sandbox App auth, or authenticate via injected credentials (below).
+
+## Server-managed sandboxes
+
+Add a `sandbox:` section to the server config (`omnigent server -c
+config.yaml`, or `<data_dir>/config.yaml`):
+
+```yaml
+sandbox:
+  provider: e2b
+  server_url: https://your-host    # public URL sandboxes dial back to
+```
+
+`server_url` must be reachable *from E2B's cloud* — a public HTTPS URL,
+not `localhost`. Sessions created with `host_type: "managed"` (the API
+call or the Web UI's New Sandbox option) then run on a fresh E2B sandbox;
+the create returns immediately and provisioning happens in the
+background, exactly like the [Modal managed
+flow](../modal/README.md#server-managed-sandboxes) — including repository
+workspaces, the first-message rendezvous, and dead-sandbox relaunch.
+
+Optional `e2b:` settings:
+
+```yaml
+sandbox:
+  provider: e2b
+  server_url: https://your-host
+  e2b:
+    template: omnigent-host          # E2B template NAME (default: omnigent-host)
+    env: [OPENAI_API_KEY, ANTHROPIC_API_KEY, GIT_TOKEN]
+```
+
+> [!NOTE]
+> `sandbox.e2b.template` is an **E2B template name** (built above), not a
+> registry image reference — the field that holds a `ghcr.io/...` ref on
+> the other providers. Omit it to use the default `omnigent-host`
+> template.
+
+## Credentials for the sandbox (LLM keys, git tokens)
+
+`sandbox.e2b.env` lists the **names** of variables to copy from the
+**server's own environment** into every sandbox at provision time (passed
+to `Sandbox.create(envs=…)`). Values never live in the config file — set
+them where the server runs:
+
+```bash
+export OPENAI_API_KEY=sk-…       # on the server
+export GIT_TOKEN=github_pat_…    # private-repo clone/fetch/push
+```
+
+```yaml
+sandbox:
+  provider: e2b
+  server_url: https://your-host
+  e2b:
+    env: [OPENAI_API_KEY, GIT_TOKEN]
+```
+
+A listed name that is **not** set in the server's environment fails the
+launch loudly (it would otherwise surface much later as an opaque harness
+auth failure inside the sandbox).
+
+Which variables to inject — providers, gateways, subscriptions, git — is
+identical to Modal; see the [variable table and per-plan
+recipes](../modal/README.md#llm-credentials-for-managed-sandboxes) and
+[git credentials](../modal/README.md#git-credentials-private-repositories).
+The in-sandbox host forwards the same standard set to its runners, and
+`OMNIGENT_RUNNER_ENV_PASSTHROUGH` (as an injected variable) names any
+extras.
+
+The same env-injection also carries **credentials for connecting to the
+server itself**, for a host that authenticates its dial-back with user
+credentials instead of a launch token. Managed launches never need this:
+the server injects a per-launch host token automatically. But a
+[CLI-launched](#cli-launched-sandboxes) host does when the server requires
+authentication — name the keys (e.g. `DATABRICKS_HOST` +
+`DATABRICKS_TOKEN`) in `OMNIGENT_E2B_SANDBOX_ENV` before `create`. See
+[Connecting to an authenticated
+server](../modal/README.md#connecting-to-an-authenticated-server) in the
+Modal guide.
+
+## Security considerations
+
+- **Injected credentials reach E2B's control plane.** `sandbox.e2b.env`
+  values are sent to E2B's API as literal sandbox env vars. Prefer
+  **scoped, short-lived** credentials: a fine-grained PAT limited to the
+  repos a session needs, a gateway token over a root provider key.
+  (Modal's launcher attaches named Modal secrets, so its values stay in
+  Modal's secret store — a stronger posture; same trade-off as the
+  Daytona provider.)
+- **All managed sandboxes share one E2B account + API key.** Cross-user
+  isolation between Omnigent users rides on E2B's sandbox boundaries, and
+  the shared key can enumerate and kill any user's sandbox. Scope the
+  account to this workload.
+- **The launch token's lifetime is ~25 h.** E2B sandboxes share Modal's
+  24 h hard cap, so the per-launch host token outlives the sandbox by an
+  hour to re-authenticate the tunnel across reconnects. A leaked token is
+  replayable against the server for that window; a relaunch mints a fresh
+  one. Deployments injecting their own launcher can set a shorter
+  `token_ttl_s` on `ManagedSandboxConfig`.
+- **Sandbox URLs are public by default.** E2B exposes sandbox ports via
+  public `*.e2b.app` URLs; Omnigent never opens one (the host dials *out*
+  to your server), but be aware nothing in a sandbox should bind a
+  service expecting it to be private without E2B's access-token gating.
+
+## Troubleshooting
+
+- **"E2B sandbox creation failed: template '…' is unavailable"** — the
+  host image was never built into an E2B template, or the name doesn't
+  match. Run the [template build](#build-the-host-template-one-time) with
+  `--name omnigent-host` (or set `sandbox.e2b.template` to your name).
+- **"managed host did not come online within 120s"** — the sandbox
+  couldn't dial back to `server_url`. Confirm it's a public HTTPS URL
+  reachable from E2B's cloud (not `localhost`), and check
+  `/tmp/omnigent-host.log` inside the sandbox.
+- **Sandbox stops after ~1 hour** — you're on a Hobby account (1 h cap).
+  Upgrade to Pro for the 24 h maximum, or expect the dead-sandbox
+  relaunch path to re-provision on the next message.
+
+## Lifecycle notes
+
+- **Hard lifetime cap, no idle-stop disable.** `provision` requests the
+  24 h Pro maximum and `keep_alive` re-extends a live sandbox to it on
+  reconnect, but there is no never-expire option. A managed session past
+  the cap is replaced by the dead-sandbox relaunch path (same as Modal).
+- **Templates, not registry images.** See
+  [Build the host template](#build-the-host-template-one-time). Resources
+  (vCPU / memory) are fixed when the template is built — pass
+  `--cpu-count` / `--memory-mb` to `e2b template build` — not at sandbox
+  create time.
+- **Custom images** require rebuilding the template: `FROM` your image in
+  `e2b.Dockerfile` and `e2b template build` it, then set
+  `sandbox.e2b.template` / `OMNIGENT_E2B_TEMPLATE`.
+
+## Environment variable reference
+
+| Variable | Where it's read | Purpose |
+|---|---|---|
+| `E2B_API_KEY` | CLI machine / server | E2B API credentials (required) |
+| `OMNIGENT_E2B_TEMPLATE` | CLI machine / server | E2B template name to provision from (`sandbox.e2b.template` takes precedence; default `omnigent-host`) |
+| `OMNIGENT_E2B_SANDBOX_ENV` | CLI machine / server | Comma-separated launcher-side env var names to inject (`sandbox.e2b.env` takes precedence for managed) |

--- a/omnigent/inner/banner.py
+++ b/omnigent/inner/banner.py
@@ -38,20 +38,21 @@ def _ansi_truecolor_fg(hex_rgb: str) -> str:
 
 
 def _display_width(text: str) -> int:
-    """Terminal display width of *text*, counting VS16 emoji as 2 cells.
+    """Terminal display width of *text*.
 
-    :func:`rich.cells.cell_len` under-counts an emoji forced to its wide
-    presentation by a trailing VARIATION SELECTOR-16 (U+FE0F) — e.g. the
-    cli-config ``⚙️`` glyph — as a single cell, while modern terminals
-    render it as two. Adding one cell per VS16 makes the banner box border
-    line up under such a glyph instead of drifting one column right.
+    :func:`rich.cells.cell_len` (rich >= 14, which omnigent requires) counts
+    an emoji forced to its wide presentation by a trailing VARIATION
+    SELECTOR-16 (U+FE0F) — e.g. the cli-config ``⚙️`` glyph — as the two
+    cells modern terminals render, so it already aligns the banner box.
+    (rich < 14 under-counted such glyphs as one cell and needed a ``+1 per
+    VS16`` correction; under rich 14 that correction became a double-count.)
 
     :param text: The string to measure, e.g. ``"⚙️ my-gateway"``.
     :returns: The estimated terminal column width, e.g. ``13``.
     """
     from rich.cells import cell_len
 
-    return cell_len(text) + text.count("\N{VARIATION SELECTOR-16}")
+    return cell_len(text)
 
 
 @dataclass(frozen=True)

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -52,9 +52,9 @@ from omnigent.onboarding.provider_config import (
 # The ADMISSION TICKETS glyph (subscription) carries a VARIATION SELECTOR-16 so
 # terminals render it as a 2-cell emoji (matching 🔑 / 🌐 / 🧱 and the 🎟️ in
 # README.oss.md) instead of a cramped 1-cell text glyph — that VS16, not extra
-# padding, is what aligns the subscription label with the wider glyphs. (NB:
-# rich.cells.cell_len under-counts a VS16 emoji as 1 cell; the banner box
-# corrects for that — see omnigent.inner.banner._display_width.)
+# padding, is what aligns the subscription label with the wider glyphs.
+# (rich >= 14's cell_len counts such a VS16-forced wide emoji as 2 cells —
+# see omnigent.inner.banner._display_width.)
 _KIND_GLYPH: dict[str, str] = {
     KEY_KIND: "\N{KEY}",
     SUBSCRIPTION_KIND: "\N{ADMISSION TICKETS}\N{VARIATION SELECTOR-16}",

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -62,6 +62,9 @@ _LAUNCHERS: dict[str, str] = {
     # `omnigent[cwsandbox]` extra), imported lazily like modal/daytona.
     "cwsandbox": "omnigent.onboarding.sandboxes.cwsandbox:CWSandboxLauncher",
     "islo": "omnigent.onboarding.sandboxes.islo:IsloSandboxLauncher",
+    # E2B (https://e2b.dev) via the official `e2b` SDK (the
+    # `omnigent[e2b]` extra), imported lazily like modal/daytona.
+    "e2b": "omnigent.onboarding.sandboxes.e2b:E2BSandboxLauncher",
 }
 
 

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import contextlib
 import os
 import queue
+import re
 import shlex
 import threading
 from collections.abc import Sequence
@@ -90,12 +91,26 @@ DEFAULT_E2B_TEMPLATE: str = "omnigent-host"
 deployment that followed the guide works without extra config. Override
 with the ``template`` field or :data:`TEMPLATE_ENV_VAR`."""
 
-MAX_SANDBOX_LIFETIME_S: int = 24 * 60 * 60
-"""Sandbox ``timeout`` requested at creation and re-asserted by
-:meth:`keep_alive` — E2B's Pro-plan maximum (24 hours). The SDK default
-is only 300 s and there is no never-expire option, so this must be passed
-explicitly; on a Hobby account the account max is 1 hour and E2B clamps
-or rejects a larger request (see ``deploy/e2b/README.md``)."""
+MAX_LIFETIME_ENV_VAR: str = "OMNIGENT_E2B_MAX_LIFETIME_S"
+"""Environment variable overriding the requested sandbox lifetime in
+seconds (default :data:`_DEFAULT_MAX_LIFETIME_S`, 24 h). E2B caps lifetime
+per account — 24 h on Pro, 1 h on Hobby — and the SDK default is only
+300 s with no never-expire option, so the timeout is always passed
+explicitly. E2B *rejects* (does not clamp) a request above the account
+cap, so :meth:`E2BSandboxLauncher.provision` retries clamped to the cap;
+set this to the account maximum to skip that retry."""
+
+_DEFAULT_MAX_LIFETIME_S: int = 24 * 60 * 60  # E2B Pro-plan maximum
+# Fallback cap used when E2B rejects the requested lifetime but its error
+# doesn't state the limit — E2B's Hobby maximum (1 h).
+_HOBBY_FALLBACK_LIFETIME_S: int = 60 * 60
+# Token TTL slack: the managed launch-token must outlive the sandbox so a
+# live sandbox can re-authenticate its tunnel across reconnects.
+_TOKEN_TTL_SLACK_S: int = 3600
+
+# Matches E2B's "Timeout cannot be greater than N hours" 400 rejection so
+# provision() can retry clamped to the account's actual cap.
+_TIMEOUT_REJECTED_RE = re.compile(r"greater than\s+(\d+)\s*hour", re.IGNORECASE)
 
 # E2B caps each command at 60 s by default; 0 disables that per-command
 # limit (the SDK documents "Using 0 will not limit the command connection
@@ -105,6 +120,55 @@ _COMMAND_NO_TIMEOUT: int = 0
 # Resources (vCPU / memory) are baked into the E2B TEMPLATE at build time,
 # not passed to Sandbox.create(), so there are no _SANDBOX_CPU / _MEMORY
 # constants here — sizing lives in the template (see deploy/e2b/README.md).
+
+
+def resolve_max_lifetime_s() -> int:
+    """
+    Resolve the requested sandbox lifetime in seconds.
+
+    :data:`MAX_LIFETIME_ENV_VAR` overrides the 24 h default.
+
+    :returns: The lifetime to request at sandbox creation.
+    :raises click.ClickException: When the env override is not a number.
+    """
+    raw = os.environ.get(MAX_LIFETIME_ENV_VAR)
+    if raw is None:
+        return _DEFAULT_MAX_LIFETIME_S
+    try:
+        return int(float(raw))
+    except ValueError as exc:
+        raise click.ClickException(
+            f"{MAX_LIFETIME_ENV_VAR} must be a number of seconds"
+        ) from exc
+
+
+def managed_token_ttl_s() -> int:
+    """
+    Launch-token TTL for the managed path, derived from (and always above)
+    the sandbox lifetime so the token outlives the sandbox across tunnel
+    reconnects.
+
+    :returns: The token lifetime in seconds.
+    """
+    return resolve_max_lifetime_s() + _TOKEN_TTL_SLACK_S
+
+
+def _lifetime_cap_from_error(message: str) -> int | None:
+    """
+    Extract the account's max lifetime (seconds) from E2B's
+    timeout-too-large 400 rejection.
+
+    :param message: The SDK exception's string form, e.g.
+        ``"400: Timeout cannot be greater than 1 hours"``.
+    :returns: The cap in seconds (``3600`` for the example), or ``None``
+        when the error is not that rejection (so the caller re-raises it).
+    """
+    match = _TIMEOUT_REJECTED_RE.search(message)
+    if match:
+        return int(match.group(1)) * 3600
+    if "Timeout cannot be greater than" in message:
+        return _HOBBY_FALLBACK_LIFETIME_S
+    return None
 
 
 def _ensure_sdk() -> None:
@@ -373,12 +437,14 @@ class E2BSandboxLauncher(SandboxLauncher):
         """
         Create a new E2B sandbox from the host template.
 
-        The sandbox is created at E2B's Pro-plan maximum lifetime
-        (24 hours); the SDK default is only 300 s and there is no
-        never-expire option, so the timeout is passed explicitly. The
-        sandbox lives until the managed-session machinery terminates it
-        or the timeout lapses (a managed host outliving 24 h relies on
-        the dead-sandbox relaunch path).
+        The sandbox is created at the requested lifetime
+        (:func:`resolve_max_lifetime_s`, default E2B's 24 h Pro maximum);
+        the SDK default is only 300 s and there is no never-expire option,
+        so the timeout is passed explicitly. E2B *rejects* a request above
+        the account cap (e.g. a Hobby account's 1 h), so creation retries
+        once clamped to that cap. The sandbox lives until the managed-
+        session machinery terminates it or the timeout lapses (a managed
+        host outliving the cap relies on the dead-sandbox relaunch path).
 
         :param name: Human-readable label, e.g. ``"managed-a1b2c3d4"``.
             Recorded as sandbox metadata; the returned id is the
@@ -388,18 +454,37 @@ class E2BSandboxLauncher(SandboxLauncher):
             template that has not been built yet).
         """
         _ensure_sdk()
-        from e2b import Sandbox
-        from e2b.exceptions import SandboxException, TemplateException
-
         template = self._resolved_template()
         env_vars = self._resolve_sandbox_env()
         click.echo(f"▸ Creating E2B sandbox '{name}' from template '{template}'")
+        sandbox = self._create_sandbox(template, resolve_max_lifetime_s(), name, env_vars)
+        sandbox_id = sandbox.sandbox_id
+        self._sandboxes[sandbox_id] = sandbox
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
+
+    def _create_sandbox(
+        self, template: str, timeout: int, name: str, env_vars: dict[str, str]
+    ) -> Sandbox:
+        """
+        Create one sandbox, retrying once clamped to the account's cap if
+        E2B rejects the requested lifetime as too large.
+
+        :param template: E2B template name to boot from.
+        :param timeout: Requested lifetime in seconds.
+        :param name: Human-readable label (recorded as metadata).
+        :param env_vars: Resolved env vars to inject (empty for none).
+        :returns: The created sandbox handle.
+        :raises click.ClickException: If creation fails for any reason
+            other than a clampable timeout rejection.
+        """
+        from e2b import Sandbox
+        from e2b.exceptions import SandboxException, TemplateException
+
+        metadata = {"omnigent-name": name}
         try:
-            sandbox = Sandbox.create(
-                template=template,
-                timeout=MAX_SANDBOX_LIFETIME_S,
-                metadata={"omnigent-name": name},
-                envs=env_vars or None,
+            return Sandbox.create(
+                template=template, timeout=timeout, metadata=metadata, envs=env_vars or None
             )
         except TemplateException as exc:
             # The most common first-run failure: the host image was never
@@ -412,14 +497,27 @@ class E2BSandboxLauncher(SandboxLauncher):
                 f"({exc})"
             ) from exc
         except SandboxException as exc:
-            # SDK boundary: surface the provider's reason (quota, auth, …)
-            # as the launcher-contract error type so the managed-launch
-            # 502 carries it verbatim instead of a generic "internal error".
+            cap = _lifetime_cap_from_error(str(exc))
+            if cap is None or cap >= timeout:
+                # SDK boundary: surface the provider's reason (quota, auth,
+                # …) as the launcher-contract error type so the managed-
+                # launch 502 carries it verbatim, not a generic message.
+                raise click.ClickException(f"E2B sandbox creation failed: {exc}") from exc
+        # The requested lifetime exceeds this account's maximum (e.g. a
+        # Hobby account's 1 h cap vs the 24 h default) and E2B rejected it
+        # rather than clamping — retry once at the cap.
+        click.secho(
+            f"  → requested {timeout // 3600}h lifetime exceeds this E2B account's "
+            f"maximum ({cap // 3600}h); retrying clamped to it (set "
+            f"{MAX_LIFETIME_ENV_VAR} to request a specific lifetime).",
+            fg="yellow",
+        )
+        try:
+            return Sandbox.create(
+                template=template, timeout=cap, metadata=metadata, envs=env_vars or None
+            )
+        except SandboxException as exc:
             raise click.ClickException(f"E2B sandbox creation failed: {exc}") from exc
-        sandbox_id = sandbox.sandbox_id
-        self._sandboxes[sandbox_id] = sandbox
-        click.echo(f"  → created {sandbox_id}")
-        return sandbox_id
 
     def attach(self, sandbox_id: str) -> None:
         """
@@ -440,21 +538,23 @@ class E2BSandboxLauncher(SandboxLauncher):
 
     def keep_alive(self, sandbox_id: str) -> None:
         """
-        Re-extend the sandbox timeout to the 24 h maximum.
+        Re-extend the sandbox timeout to the requested lifetime.
 
         E2B exposes no idle-autostop to disable and no never-expire
         option, so the best available keep-alive is to set the timeout to
-        the account maximum, measured from now. Soft-fail per the
-        launcher contract: a rejected setting (e.g. a Hobby account whose
-        max is 1 h) warns rather than aborting the bootstrap.
+        the requested maximum (:func:`resolve_max_lifetime_s`), measured
+        from now. Soft-fail per the launcher contract: a rejected setting
+        (e.g. a Hobby account whose max is below the request) warns rather
+        than aborting the bootstrap.
 
         :param sandbox_id: The sandbox to configure.
         """
         from e2b.exceptions import SandboxException
 
+        lifetime = resolve_max_lifetime_s()
         handle = self._resolve(sandbox_id)
         try:
-            handle.set_timeout(MAX_SANDBOX_LIFETIME_S)
+            handle.set_timeout(lifetime)
         except SandboxException as exc:
             click.secho(
                 f"  → warning: could not extend the lifetime of '{sandbox_id}' "
@@ -462,9 +562,11 @@ class E2BSandboxLauncher(SandboxLauncher):
                 fg="yellow",
             )
         else:
+            # set_timeout clamps to the account cap silently (unlike create,
+            # which rejects), so report the REQUEST rather than claim a grant.
             click.echo(
-                f"  → lifetime extended to {MAX_SANDBOX_LIFETIME_S // 3600}h "
-                "(E2B has no idle-stop disable; re-extended on reconnect)."
+                f"  → requested a {lifetime // 3600}h lifetime extension "
+                "(capped at the account maximum; E2B has no idle-stop disable)."
             )
 
     def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -170,6 +170,40 @@ def _lifetime_cap_from_error(message: str) -> int | None:
     return None
 
 
+def _is_missing_template_error(message: str) -> bool:
+    """
+    Whether an E2B creation error indicates a missing/unknown template.
+
+    A template that was never built (or is misnamed) surfaces as a plain
+    ``SandboxException`` — ``"404: template '<name>' not found"`` — NOT a
+    ``TemplateException`` (which the SDK reserves for an incompatible/old
+    template). This is the most common first-run failure, so the launcher
+    detects it to point the operator at the build step.
+
+    :param message: The SDK exception's string form.
+    :returns: ``True`` for a missing-template error.
+    """
+    low = message.lower()
+    return "template" in low and ("not found" in low or "404" in low)
+
+
+def _template_build_hint(template: str, exc: Exception) -> click.ClickException:
+    """
+    Build the error that points the operator at the E2B template build
+    step — for both a missing template and an incompatible one.
+
+    :param template: The template name that failed to resolve.
+    :param exc: The underlying SDK exception (appended verbatim).
+    :returns: The launcher-contract error to raise.
+    """
+    return click.ClickException(
+        f"E2B sandbox creation failed: template '{template}' is unavailable or "
+        "incompatible. Build the Omnigent host image into an E2B template first "
+        "(`e2b template build` — see deploy/e2b/README.md), or set the correct "
+        f"template via sandbox.e2b.template / {TEMPLATE_ENV_VAR}. ({exc})"
+    )
+
+
 def _ensure_sdk() -> None:
     """
     Verify the E2B SDK is importable, with an install hint when not.
@@ -280,8 +314,11 @@ class _E2BRemoteProcess(RemoteProcess):
             # a transport error — CommandExitException IS a CommandResult,
             # so carry its exit code rather than raising.
             self._returncode = exc.exit_code
-        except BaseException as exc:
-            # Any other failure is a transport error surfaced from wait().
+        except Exception as exc:
+            # Any other failure is a transport error surfaced from wait();
+            # catch Exception (not BaseException) so KeyboardInterrupt /
+            # SystemExit still propagate. The finally below always runs, so
+            # the sentinel is queued regardless.
             self._error = exc
         finally:
             self._lines.put(None)
@@ -477,29 +514,38 @@ class E2BSandboxLauncher(SandboxLauncher):
             other than a clampable timeout rejection.
         """
         from e2b import Sandbox
-        from e2b.exceptions import SandboxException, TemplateException
+        from e2b.exceptions import AuthenticationException, SandboxException, TemplateException
 
         metadata = {"omnigent-name": name}
         try:
             return Sandbox.create(
                 template=template, timeout=timeout, metadata=metadata, envs=env_vars or None
             )
-        except TemplateException as exc:
-            # The most common first-run failure: the host image was never
-            # built into an E2B template. Point at the build step.
+        except AuthenticationException as exc:
+            # A bad/expired key (HTTP 401) raises AuthenticationException,
+            # which does NOT extend SandboxException — catch it explicitly so
+            # it surfaces as a credential hint instead of escaping raw.
             raise click.ClickException(
-                f"E2B sandbox creation failed: template '{template}' is unavailable. "
-                "Build the Omnigent host image into an E2B template first "
-                "(`e2b template build` — see deploy/e2b/README.md), or set the "
-                f"correct template via sandbox.e2b.template / {TEMPLATE_ENV_VAR}. "
-                f"({exc})"
+                "E2B authentication failed — check E2B_API_KEY (create a key at "
+                f"https://e2b.dev/dashboard). ({exc})"
             ) from exc
+        except TemplateException as exc:
+            # TemplateException is reserved for an incompatible/old template,
+            # not a missing one (that's a generic SandboxException, below).
+            raise _template_build_hint(template, exc) from exc
         except SandboxException as exc:
             cap = _lifetime_cap_from_error(str(exc))
-            if cap is None or cap >= timeout:
-                # SDK boundary: surface the provider's reason (quota, auth,
-                # …) as the launcher-contract error type so the managed-
-                # launch 502 carries it verbatim, not a generic message.
+            if cap is not None and cap < timeout:
+                pass  # account-cap rejection → fall through to the clamp-retry
+            elif _is_missing_template_error(str(exc)):
+                # The most common first-run failure: the host image was never
+                # built into an E2B template (E2B returns "404: template … not
+                # found" as a plain SandboxException). Point at the build step.
+                raise _template_build_hint(template, exc) from exc
+            else:
+                # SDK boundary: surface the provider's reason (quota, …) as the
+                # launcher-contract error type so the managed-launch 502 carries
+                # it verbatim, not a generic message.
                 raise click.ClickException(f"E2B sandbox creation failed: {exc}") from exc
         # The requested lifetime exceeds this account's maximum (e.g. a
         # Hobby account's 1 h cap vs the 24 h default) and E2B rejected it
@@ -560,8 +606,9 @@ class E2BSandboxLauncher(SandboxLauncher):
                 fg="yellow",
             )
         else:
-            # set_timeout clamps to the account cap silently (unlike create,
-            # which rejects), so report the REQUEST rather than claim a grant.
+            # set_timeout accepts an over-cap request without raising (unlike
+            # create, which rejects it — verified live on a capped account),
+            # so report the REQUEST rather than claim a grant.
             click.echo(
                 f"  → requested a {lifetime // 3600}h lifetime extension "
                 "(capped at the account maximum; E2B has no idle-stop disable)."
@@ -652,7 +699,14 @@ class E2BSandboxLauncher(SandboxLauncher):
 
         handle = self._resolve(sandbox_id)
         try:
-            process = handle.commands.run(f"bash -lc {shlex.quote(command)}", background=True)
+            # timeout=0 disables the SDK's default 60s per-command cap — this
+            # backs exec_foreground, which holds `omnigent host` open for the
+            # whole session; the cap would otherwise tear it down after 60s.
+            process = handle.commands.run(
+                f"bash -lc {shlex.quote(command)}",
+                background=True,
+                timeout=_COMMAND_NO_TIMEOUT,
+            )
         except SandboxException as exc:
             raise click.ClickException(
                 f"Could not start a streaming command on sandbox '{sandbox_id}': {exc}"

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -117,9 +117,8 @@ _TIMEOUT_REJECTED_RE = re.compile(r"greater than\s+(\d+)\s*hour", re.IGNORECASE)
 # time"). A wheel install or git clone must not be killed mid-run.
 _COMMAND_NO_TIMEOUT: int = 0
 
-# Resources (vCPU / memory) are baked into the E2B TEMPLATE at build time,
-# not passed to Sandbox.create(), so there are no _SANDBOX_CPU / _MEMORY
-# constants here — sizing lives in the template (see deploy/e2b/README.md).
+# No _SANDBOX_CPU / _MEMORY constants: E2B bakes resources into the template
+# at build time, not at Sandbox.create() (see deploy/e2b/README.md).
 
 
 def resolve_max_lifetime_s() -> int:
@@ -264,9 +263,8 @@ class _E2BRemoteProcess(RemoteProcess):
         Unlike Modal / Islo (whose handles expose no kill), E2B's
         ``CommandHandle.kill`` really stops the remote process, so this
         is a true teardown. Idempotent and best-effort: a process that
-        already exited is left alone.
+        already exited is left alone, and close() never raises.
         """
-        # Best-effort teardown — close() must never raise.
         with contextlib.suppress(Exception):
             self._handle.kill()
 
@@ -649,7 +647,7 @@ class E2BSandboxLauncher(SandboxLauncher):
         :returns: Handle over the streaming process.
         :raises click.ClickException: When the command cannot be started.
         """
-        del pty  # combined output comes from routing both callbacks to one queue
+        del pty  # unused (see docstring)
         from e2b.exceptions import SandboxException
 
         handle = self._resolve(sandbox_id)

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -136,9 +136,7 @@ def resolve_max_lifetime_s() -> int:
     try:
         return int(float(raw))
     except ValueError as exc:
-        raise click.ClickException(
-            f"{MAX_LIFETIME_ENV_VAR} must be a number of seconds"
-        ) from exc
+        raise click.ClickException(f"{MAX_LIFETIME_ENV_VAR} must be a number of seconds") from exc
 
 
 def managed_token_ttl_s() -> int:
@@ -652,8 +650,7 @@ class E2BSandboxLauncher(SandboxLauncher):
         _echo_lines(stderr, err=True)
         if check and returncode != 0:
             raise click.ClickException(
-                f"Remote command failed on sandbox '{sandbox_id}' "
-                f"(exit {returncode}): {command}"
+                f"Remote command failed on sandbox '{sandbox_id}' (exit {returncode}): {command}"
             )
         return RemoteCommandResult(returncode=returncode, stdout=stdout, stderr=stderr)
 

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -1,0 +1,628 @@
+"""
+E2B sandbox launcher.
+
+Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
+for `E2B <https://e2b.dev>`_ sandboxes on top of the official ``e2b``
+Python SDK. Same posture as the Modal, Daytona, and CoreWeave launchers:
+the SDK is an optional dependency (``pip install 'omnigent[e2b]'``)
+imported lazily, so the provider can be listed and the module probed
+without it.
+
+Supports both server-managed hosts (``host_type="managed"`` sessions)
+and the CLI bootstrap flow. The one unsupported primitive is
+``forward_local_port``: E2B only exposes sandbox ports OUTWARD via a
+public URL (``sandbox.get_host(port)``) — there is no local→sandbox
+path — so the in-sandbox Databricks App OAuth flow doesn't apply and
+managed hosts authenticate with a server-minted launch token instead.
+
+Notes that shape this launcher:
+
+- **Templates, not registry images.** Unlike every other launcher, E2B
+  cannot boot an arbitrary registry image at create time — it boots from
+  a pre-built E2B *template*. The Omnigent host image must therefore be
+  built into an E2B template out-of-band (``e2b template build`` from the
+  host Dockerfile; see ``deploy/e2b/README.md``) and the launcher's
+  ``template`` field names that template — it is NOT a
+  ``ghcr.io/...`` reference. The wheel-overlay path
+  (:meth:`wheel_install_command`) still applies because the template is
+  built FROM the same host image (omnigent ``0.1.0`` baked).
+- **Hard lifetime cap, no idle-stop disable.** E2B sandboxes carry a
+  single timeout (default 300 s, account-max 24 h on Pro / 1 h on Hobby)
+  with no "never expire" option. :meth:`provision` requests the 24 h max;
+  :meth:`keep_alive` can only re-extend a live sandbox to that max. A
+  managed host outliving the cap relies on the dead-sandbox relaunch path
+  (same posture as Modal's 24 h cap).
+- **API-key auth.** ``E2B_API_KEY`` is read from the CLI/server process
+  environment by the SDK, 12-factor — like the other providers' keys.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import queue
+import shlex
+import threading
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, ClassVar
+
+import click
+
+from omnigent.onboarding.sandboxes.base import (
+    RemoteCommandResult,
+    RemoteProcess,
+    SandboxLauncher,
+    host_image_wheel_install_command,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from e2b import CommandHandle, Sandbox
+
+
+# ── Constants ──────────────────────────────────────────
+
+API_KEY_ENV_VAR: str = "E2B_API_KEY"
+"""E2B API key, read from the CLI/server process environment by the SDK.
+Create one at https://e2b.dev/dashboard."""
+
+TEMPLATE_ENV_VAR: str = "OMNIGENT_E2B_TEMPLATE"
+"""Environment variable overriding :data:`DEFAULT_E2B_TEMPLATE` — the
+NAME (or id) of the pre-built E2B template the Omnigent host image was
+built into (``e2b template build``). NOT a registry image reference:
+E2B boots from templates, not arbitrary images."""
+
+SANDBOX_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_E2B_SANDBOX_ENV"
+"""Comma-separated server-process environment variable NAMES whose
+values are injected into every sandbox this launcher creates — typically
+the harness LLM credentials (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``,
+gateway base URLs, …) and ``GIT_TOKEN`` that the in-sandbox host forwards
+to runners. Names, not values: the values are read from the server's own
+environment at provision time, so secrets never live in config files.
+The server's managed-host config (``sandbox.e2b.env``) takes precedence
+when set."""
+
+DEFAULT_E2B_TEMPLATE: str = "omnigent-host"
+"""Default E2B template name. Matches the ``--name`` the
+``deploy/e2b/README.md`` walkthrough builds the host template with, so a
+deployment that followed the guide works without extra config. Override
+with the ``template`` field or :data:`TEMPLATE_ENV_VAR`."""
+
+MAX_SANDBOX_LIFETIME_S: int = 24 * 60 * 60
+"""Sandbox ``timeout`` requested at creation and re-asserted by
+:meth:`keep_alive` — E2B's Pro-plan maximum (24 hours). The SDK default
+is only 300 s and there is no never-expire option, so this must be passed
+explicitly; on a Hobby account the account max is 1 hour and E2B clamps
+or rejects a larger request (see ``deploy/e2b/README.md``)."""
+
+# E2B caps each command at 60 s by default; 0 disables that per-command
+# limit (the SDK documents "Using 0 will not limit the command connection
+# time"). A wheel install or git clone must not be killed mid-run.
+_COMMAND_NO_TIMEOUT: int = 0
+
+# Resources (vCPU / memory) are baked into the E2B TEMPLATE at build time,
+# not passed to Sandbox.create(), so there are no _SANDBOX_CPU / _MEMORY
+# constants here — sizing lives in the template (see deploy/e2b/README.md).
+
+
+def _ensure_sdk() -> None:
+    """
+    Verify the E2B SDK is importable, with an install hint when not.
+
+    Called at the top of every launcher entry point because the SDK is
+    an optional dependency — the base ``omnigent`` install does not
+    pull it in.
+
+    :raises click.ClickException: When the ``e2b`` package is not
+        installed.
+    """
+    try:
+        import e2b  # noqa: F401  # presence probe only
+    except ImportError as exc:
+        raise click.ClickException(
+            "The E2B SDK is required for the 'e2b' sandbox provider. "
+            "Install it with `pip install 'omnigent[e2b]'`, then set "
+            "E2B_API_KEY (create a key at https://e2b.dev/dashboard)."
+        ) from exc
+
+
+def _echo_lines(stream: str, *, err: bool = False) -> None:
+    """
+    Echo a captured remote output stream line-by-line, dropping
+    pure-whitespace lines.
+
+    :param stream: Captured stdout or stderr from a remote command.
+    :param err: When ``True``, write to stderr (used for the captured
+        stderr stream).
+    """
+    for line in stream.splitlines():
+        if line.strip():
+            click.echo(line, err=err)
+
+
+class _E2BRemoteProcess(RemoteProcess):
+    """
+    Thread-backed :class:`RemoteProcess` over an E2B background command.
+
+    E2B delivers a background command's output through ``on_stdout`` /
+    ``on_stderr`` callbacks rather than a readable stream, so a worker
+    thread drives ``CommandHandle.wait`` with both callbacks feeding one
+    queue — the queue is the combined-output stream the
+    :class:`RemoteProcess` contract wants.
+    """
+
+    def __init__(self, handle: CommandHandle) -> None:
+        """
+        Wrap a running background command handle.
+
+        :param handle: Handle returned by
+            ``sandbox.commands.run(..., background=True)``.
+        """
+        self._handle = handle
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._returncode: int | None = None
+        self._error: BaseException | None = None
+        # Materialize the iterator once so repeated `lines` reads resume
+        # the same stream (the RemoteProcess contract).
+        self._line_iter: Iterator[str] = self._iter_lines()
+        self._thread = threading.Thread(target=self._run, name="e2b-remote-process", daemon=True)
+        self._thread.start()
+
+    @property
+    def lines(self) -> Iterator[str]:
+        """
+        Iterator over the command's combined stdout/stderr lines (same
+        object on every access).
+
+        :returns: Line iterator draining the shared output queue.
+        """
+        return self._line_iter
+
+    def wait(self) -> int:
+        """
+        Block until the command finishes and return its exit code.
+
+        :returns: The command's exit code.
+        :raises click.ClickException: When the command failed to run at
+            the transport level (as opposed to merely exiting non-zero).
+        """
+        self._thread.join()
+        if self._error is not None:
+            raise click.ClickException(str(self._error)) from self._error
+        return self._returncode if self._returncode is not None else 1
+
+    def close(self) -> None:
+        """
+        Terminate the command if it is still running.
+
+        Unlike Modal / Islo (whose handles expose no kill), E2B's
+        ``CommandHandle.kill`` really stops the remote process, so this
+        is a true teardown. Idempotent and best-effort: a process that
+        already exited is left alone.
+        """
+        # Best-effort teardown — close() must never raise.
+        with contextlib.suppress(Exception):
+            self._handle.kill()
+
+    def _run(self) -> None:
+        """Drive the handle to completion, feeding output into the queue."""
+        from e2b import CommandExitException
+
+        try:
+            result = self._handle.wait(on_stdout=self._enqueue, on_stderr=self._enqueue)
+            self._returncode = result.exit_code
+        except CommandExitException as exc:
+            # A non-zero exit is a normal outcome the caller inspects, not
+            # a transport error — CommandExitException IS a CommandResult,
+            # so carry its exit code rather than raising.
+            self._returncode = exc.exit_code
+        except BaseException as exc:
+            # Any other failure is a transport error surfaced from wait().
+            self._error = exc
+        finally:
+            self._lines.put(None)
+
+    def _iter_lines(self) -> Iterator[str]:
+        """Yield queued output lines until the terminating sentinel."""
+        while True:
+            item = self._lines.get()
+            if item is None:
+                return
+            yield item
+
+    def _enqueue(self, text: str) -> None:
+        """Split a callback chunk into newline-terminated lines and queue them."""
+        for line in text.splitlines(keepends=True):
+            self._lines.put(line)
+        if text and not text.endswith(("\n", "\r")):
+            self._lines.put("\n")
+
+
+class E2BSandboxLauncher(SandboxLauncher):
+    """
+    :class:`SandboxLauncher` for E2B sandboxes, over the ``e2b`` SDK.
+
+    All transport rides the SDK: ``Sandbox.create`` / ``connect`` /
+    ``kill`` for lifecycle, ``sandbox.commands.run`` for commands (a
+    ``bash -lc`` wrap applies login PATH), ``sandbox.files.write`` for
+    file shipping, and a background command for the foreground attach.
+    Handles are cached per sandbox id to avoid a server round-trip on
+    every primitive.
+    """
+
+    provider: ClassVar[str] = "e2b"
+    # E2B exposes sandbox ports OUTWARD only (get_host(port) → public
+    # URL); there is no local→sandbox path for the App OAuth callback.
+    supports_local_port_forward: ClassVar[bool] = False
+
+    def __init__(self, *, template: str | None = None, env: Sequence[str] | None = None) -> None:
+        """
+        Initialize the launcher.
+
+        :param template: Optional E2B template NAME (or id) to provision
+            sandboxes from — the server's managed-host
+            ``sandbox.e2b.template`` config. This is an E2B template the
+            Omnigent host image was built into (``e2b template build``),
+            NOT a registry image reference. ``None`` resolves
+            :data:`TEMPLATE_ENV_VAR` and falls back to
+            :data:`DEFAULT_E2B_TEMPLATE`.
+        :param env: Optional names of server-process environment
+            variables to inject into every sandbox, e.g.
+            ``["OPENAI_API_KEY", "GIT_TOKEN"]`` — the server's
+            managed-host ``sandbox.e2b.env`` config. ``None`` resolves
+            :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR` (comma-separated)
+            and falls back to no injected env.
+        """
+        self._template_ref = template
+        self._env_names = tuple(env) if env is not None else None
+        self._sandboxes: dict[str, Sandbox] = {}
+
+    def _resolved_template(self) -> str:
+        """
+        Resolve the E2B template name: explicit constructor value wins,
+        then :data:`TEMPLATE_ENV_VAR`, then :data:`DEFAULT_E2B_TEMPLATE`.
+
+        :returns: The template name to pass to ``Sandbox.create``.
+        """
+        return self._template_ref or os.environ.get(TEMPLATE_ENV_VAR) or DEFAULT_E2B_TEMPLATE
+
+    def _resolve(self, sandbox_id: str) -> Sandbox:
+        """
+        Return the cached handle for *sandbox_id*, connecting on first
+        use.
+
+        :param sandbox_id: E2B sandbox id, e.g. ``"i1a2b3c4..."``.
+        :returns: The sandbox handle.
+        :raises click.ClickException: When the SDK is not installed or
+            the sandbox does not exist (e.g. reaped after its timeout).
+        """
+        # The CLI connect flow reaches primitives without a prepare()
+        # preflight — keep the missing-SDK error the friendly install hint.
+        _ensure_sdk()
+        from e2b import Sandbox
+        from e2b.exceptions import NotFoundException
+
+        handle = self._sandboxes.get(sandbox_id)
+        if handle is None:
+            try:
+                handle = Sandbox.connect(sandbox_id)
+            except NotFoundException as exc:
+                raise click.ClickException(
+                    f"E2B sandbox '{sandbox_id}' not found — it may have passed its "
+                    "lifetime cap. Managed sessions provision a replacement on the "
+                    "next message; for a CLI host create a fresh one with "
+                    "`omnigent sandbox create --provider e2b`."
+                ) from exc
+            self._sandboxes[sandbox_id] = handle
+        return handle
+
+    def _resolve_sandbox_env(self) -> dict[str, str]:
+        """
+        Resolve the env vars to inject into created sandboxes.
+
+        Explicit constructor names win; otherwise
+        :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR` (comma-separated)
+        applies; an empty resolution injects nothing. Values come from
+        the server's own environment — a configured name that is unset
+        there fails loud (an operator listed a credential the deployment
+        never provided; silently launching without it would surface much
+        later as an opaque harness auth failure).
+
+        :returns: Name → value mapping for ``Sandbox.create(envs=…)``.
+        :raises click.ClickException: When a configured name is not set
+            in the server process environment.
+        """
+        if self._env_names is not None:
+            names: Sequence[str] = self._env_names
+        else:
+            names = [
+                name.strip()
+                for name in os.environ.get(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+                if name.strip()
+            ]
+        resolved: dict[str, str] = {}
+        for name in names:
+            value = os.environ.get(name)
+            if value is None:
+                raise click.ClickException(
+                    f"sandbox env passthrough names '{name}' but it is not set "
+                    "in the server's environment — set it (or remove it from "
+                    f"sandbox.e2b.env / {SANDBOX_ENV_PASSTHROUGH_ENV_VAR})."
+                )
+            resolved[name] = value
+        return resolved
+
+    def prepare(self) -> None:
+        """
+        Local preflight: the E2B SDK must be installed and an API key
+        available.
+
+        :raises click.ClickException: When the SDK is missing or
+            ``E2B_API_KEY`` is not set.
+        """
+        _ensure_sdk()
+        if not os.environ.get(API_KEY_ENV_VAR):
+            raise click.ClickException(
+                "No E2B credentials found. Create an API key at "
+                "https://e2b.dev/dashboard and set E2B_API_KEY."
+            )
+
+    def provision(self, name: str) -> str:
+        """
+        Create a new E2B sandbox from the host template.
+
+        The sandbox is created at E2B's Pro-plan maximum lifetime
+        (24 hours); the SDK default is only 300 s and there is no
+        never-expire option, so the timeout is passed explicitly. The
+        sandbox lives until the managed-session machinery terminates it
+        or the timeout lapses (a managed host outliving 24 h relies on
+        the dead-sandbox relaunch path).
+
+        :param name: Human-readable label, e.g. ``"managed-a1b2c3d4"``.
+            Recorded as sandbox metadata; the returned id is the
+            canonical reference.
+        :returns: The E2B sandbox id.
+        :raises click.ClickException: If provisioning fails (including a
+            template that has not been built yet).
+        """
+        _ensure_sdk()
+        from e2b import Sandbox
+        from e2b.exceptions import SandboxException, TemplateException
+
+        template = self._resolved_template()
+        env_vars = self._resolve_sandbox_env()
+        click.echo(f"▸ Creating E2B sandbox '{name}' from template '{template}'")
+        try:
+            sandbox = Sandbox.create(
+                template=template,
+                timeout=MAX_SANDBOX_LIFETIME_S,
+                metadata={"omnigent-name": name},
+                envs=env_vars or None,
+            )
+        except TemplateException as exc:
+            # The most common first-run failure: the host image was never
+            # built into an E2B template. Point at the build step.
+            raise click.ClickException(
+                f"E2B sandbox creation failed: template '{template}' is unavailable. "
+                "Build the Omnigent host image into an E2B template first "
+                "(`e2b template build` — see deploy/e2b/README.md), or set the "
+                f"correct template via sandbox.e2b.template / {TEMPLATE_ENV_VAR}. "
+                f"({exc})"
+            ) from exc
+        except SandboxException as exc:
+            # SDK boundary: surface the provider's reason (quota, auth, …)
+            # as the launcher-contract error type so the managed-launch
+            # 502 carries it verbatim instead of a generic "internal error".
+            raise click.ClickException(f"E2B sandbox creation failed: {exc}") from exc
+        sandbox_id = sandbox.sandbox_id
+        self._sandboxes[sandbox_id] = sandbox
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
+
+    def attach(self, sandbox_id: str) -> None:
+        """
+        Validate that an existing sandbox is still running.
+
+        :param sandbox_id: The sandbox to attach to.
+        :raises click.ClickException: When the sandbox is missing or has
+            terminated (E2B sandboxes are reaped at their timeout).
+        """
+        click.echo(f"▸ Reusing existing E2B sandbox '{sandbox_id}'")
+        handle = self._resolve(sandbox_id)
+        if not handle.is_running():
+            raise click.ClickException(
+                f"E2B sandbox '{sandbox_id}' is not running (it may have passed its "
+                "lifetime cap). Create a fresh one with "
+                "`omnigent sandbox create --provider e2b`."
+            )
+
+    def keep_alive(self, sandbox_id: str) -> None:
+        """
+        Re-extend the sandbox timeout to the 24 h maximum.
+
+        E2B exposes no idle-autostop to disable and no never-expire
+        option, so the best available keep-alive is to set the timeout to
+        the account maximum, measured from now. Soft-fail per the
+        launcher contract: a rejected setting (e.g. a Hobby account whose
+        max is 1 h) warns rather than aborting the bootstrap.
+
+        :param sandbox_id: The sandbox to configure.
+        """
+        from e2b.exceptions import SandboxException
+
+        handle = self._resolve(sandbox_id)
+        try:
+            handle.set_timeout(MAX_SANDBOX_LIFETIME_S)
+        except SandboxException as exc:
+            click.secho(
+                f"  → warning: could not extend the lifetime of '{sandbox_id}' "
+                f"({exc}); the sandbox will stop at its current timeout.",
+                fg="yellow",
+            )
+        else:
+            click.echo(
+                f"  → lifetime extended to {MAX_SANDBOX_LIFETIME_S // 3600}h "
+                "(E2B has no idle-stop disable; re-extended on reconnect)."
+            )
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        """
+        Run a shell command in the sandbox and capture its output.
+
+        ``bash -lc`` wraps the command so login PATH applies. E2B caps
+        each command at 60 s by default; the per-command timeout is
+        disabled here so installs / clones aren't killed mid-run.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely.
+        :param check: When ``True``, raise on non-zero exit.
+        :returns: Exit code plus captured stdout/stderr.
+        :raises click.ClickException: If the command could not be
+            executed, or *check* is ``True`` and it exited non-zero.
+        """
+        from e2b import CommandExitException
+        from e2b.exceptions import SandboxException
+
+        handle = self._resolve(sandbox_id)
+        wrapped = f"bash -lc {shlex.quote(command)}"
+        try:
+            result = handle.commands.run(wrapped, timeout=_COMMAND_NO_TIMEOUT)
+            returncode, stdout, stderr = result.exit_code, result.stdout, result.stderr
+        except CommandExitException as exc:
+            # E2B raises on non-zero exit; the exception IS a CommandResult,
+            # so read its captured output/code rather than treating it as a
+            # transport failure (which would break check=False callers).
+            returncode, stdout, stderr = exc.exit_code, exc.stdout, exc.stderr
+        except SandboxException as exc:
+            # SDK boundary: a stopped/deleted sandbox or daemon outage must
+            # surface its provider reason through the launcher contract.
+            raise click.ClickException(
+                f"Remote command failed to execute on sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        _echo_lines(stdout)
+        _echo_lines(stderr, err=True)
+        if check and returncode != 0:
+            raise click.ClickException(
+                f"Remote command failed on sandbox '{sandbox_id}' "
+                f"(exit {returncode}): {command}"
+            )
+        return RemoteCommandResult(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
+        """
+        Copy a local file into the sandbox via the SDK's filesystem API.
+
+        :param sandbox_id: Target sandbox.
+        :param local_path: Local file to read.
+        :param remote_path: Absolute destination path on the sandbox,
+            e.g. ``"/tmp/oa-wheels.tgz"``.
+        :raises click.ClickException: If the transfer fails.
+        """
+        from e2b.exceptions import SandboxException
+
+        handle = self._resolve(sandbox_id)
+        try:
+            handle.files.write(remote_path, local_path.read_bytes())
+        except SandboxException as exc:
+            raise click.ClickException(
+                f"File upload to sandbox '{sandbox_id}' failed: {exc}"
+            ) from exc
+
+    def stream_exec(self, sandbox_id: str, command: str, *, pty: bool = False) -> RemoteProcess:
+        """
+        Spawn a command in the sandbox and stream its combined output
+        line by line.
+
+        E2B background commands deliver stdout and stderr through
+        separate callbacks; the wrapping :class:`_E2BRemoteProcess`
+        routes both into one queue, so the *pty* flag is unused — the
+        output is already combined either way (mirrors the Islo
+        launcher).
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely.
+        :param pty: Accepted for the contract; unused (see above).
+        :returns: Handle over the streaming process.
+        :raises click.ClickException: When the command cannot be started.
+        """
+        del pty  # combined output comes from routing both callbacks to one queue
+        from e2b.exceptions import SandboxException
+
+        handle = self._resolve(sandbox_id)
+        try:
+            process = handle.commands.run(f"bash -lc {shlex.quote(command)}", background=True)
+        except SandboxException as exc:
+            raise click.ClickException(
+                f"Could not start a streaming command on sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        return _E2BRemoteProcess(process)
+
+    def exec_foreground(self, sandbox_id: str, command: str) -> int:
+        """
+        Run *command* in the sandbox, echoing its output to the local
+        terminal until it exits; Ctrl-C kills the remote process and
+        re-raises.
+
+        ``TERM`` is forced to ``xterm-256color`` for the same reason as
+        the other launchers: native harnesses spawn tmux, which refuses
+        to start under a dumb/unset TERM. ``exec`` replaces the wrapping
+        shell so the streamed command's own exit code is reported.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to execute remotely, e.g.
+            ``"omnigent host --server https://…"``.
+        :returns: The remote command's exit code.
+        :raises KeyboardInterrupt: Re-raised after killing the remote
+            process when the user detaches with Ctrl-C.
+        """
+        process = self.stream_exec(sandbox_id, f"TERM=xterm-256color exec {command}", pty=True)
+        try:
+            for line in process.lines:
+                click.echo(line, nl=False)
+            return process.wait()
+        except KeyboardInterrupt:
+            click.echo("\n  → detaching; stopping the remote process")
+            # E2B's command handle exposes a real kill, so this genuinely
+            # tears the remote process down (unlike Modal / Islo).
+            process.close()
+            raise
+
+    def wheel_install_command(self, remote_tgz_path: str) -> str:
+        """
+        Remote command that overlays the shipped wheels onto the host
+        template — see
+        :func:`~omnigent.onboarding.sandboxes.base.host_image_wheel_install_command`
+        for the flag rationale. Applies because the E2B template is built
+        FROM the prebaked host image (omnigent ``0.1.0`` baked).
+
+        :param remote_tgz_path: Sandbox path of the shipped tarball,
+            e.g. ``"/tmp/oa-wheels.tgz"``.
+        :returns: Shell command string for :meth:`run`.
+        """
+        return host_image_wheel_install_command(remote_tgz_path)
+
+    def terminate(self, sandbox_id: str) -> None:
+        """
+        Kill a sandbox, releasing its compute.
+
+        Idempotent from the caller's perspective: a sandbox that no
+        longer exists (already killed or aged past its timeout) is
+        treated as success — the desired end state holds.
+
+        :param sandbox_id: The sandbox to kill.
+        """
+        _ensure_sdk()
+        from e2b import Sandbox
+        from e2b.exceptions import NotFoundException
+
+        try:
+            # Static kill resolves the id directly (no need to connect a
+            # cached handle first); returns False for an already-gone
+            # sandbox, which is the desired end state.
+            Sandbox.kill(sandbox_id)
+        except NotFoundException:
+            pass  # already gone — success
+        finally:
+            self._sandboxes.pop(sandbox_id, None)

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -157,13 +157,6 @@ DAYTONA_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # as Daytona for long-lived hosts and stale-token cleanup.
 ISLO_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 
-# Launch-token lifetime for the YAML e2b path. E2B sandboxes share
-# Modal's 24h hard cap (no never-expire option), so mirror Modal: the
-# cap plus an hour of slack, letting a live sandbox always re-authenticate
-# its tunnel across reconnects while a token from a long-dead sandbox
-# expires. A relaunch (dead-host path past the cap) mints a fresh token.
-E2B_MANAGED_TOKEN_TTL_S = 25 * 3600
-
 # The cwsandbox launch-token TTL is NOT a constant: CW Sandbox's lifetime is
 # operator-overridable (OMNIGENT_CWSANDBOX_MAX_LIFETIME_S), so the TTL is
 # derived from the resolved lifetime at parse time via
@@ -626,10 +619,15 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
         )
         token_ttl_s = ISLO_MANAGED_TOKEN_TTL_S
     elif provider == "e2b":
+        from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s
+
         launcher_factory = _e2b_launcher_factory(
             _parse_e2b_template(raw), _parse_provider_env(raw, "e2b")
         )
-        token_ttl_s = E2B_MANAGED_TOKEN_TTL_S
+        # Derived from OMNIGENT_E2B_MAX_LIFETIME_S so the token always
+        # outlives the (operator-overridable) sandbox lifetime — mirrors
+        # the cwsandbox path.
+        token_ttl_s = managed_token_ttl_s()
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -121,10 +121,10 @@ _logger = logging.getLogger(__name__)
 # ManagedSandboxConfig directly are not constrained by either set —
 # their launcher factory IS the support.)
 SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
-    {"lakebox", "modal", "daytona", "cwsandbox", "islo"}
+    {"lakebox", "modal", "daytona", "cwsandbox", "islo", "e2b"}
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
-    {"modal", "daytona", "cwsandbox", "islo"}
+    {"modal", "daytona", "cwsandbox", "islo", "e2b"}
 )
 
 # How long a managed launch waits for the sandboxed host to register
@@ -156,6 +156,13 @@ DAYTONA_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # deleted by managed-session teardown; use the same 7-day policy bound
 # as Daytona for long-lived hosts and stale-token cleanup.
 ISLO_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# Launch-token lifetime for the YAML e2b path. E2B sandboxes share
+# Modal's 24h hard cap (no never-expire option), so mirror Modal: the
+# cap plus an hour of slack, letting a live sandbox always re-authenticate
+# its tunnel across reconnects while a token from a long-dead sandbox
+# expires. A relaunch (dead-host path past the cap) mints a fresh token.
+E2B_MANAGED_TOKEN_TTL_S = 25 * 3600
 
 # The cwsandbox launch-token TTL is NOT a constant: CW Sandbox's lifetime is
 # operator-overridable (OMNIGENT_CWSANDBOX_MAX_LIFETIME_S), so the TTL is
@@ -618,6 +625,11 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             disk_gb=_parse_provider_positive_int(raw, "islo", "disk_gb"),
         )
         token_ttl_s = ISLO_MANAGED_TOKEN_TTL_S
+    elif provider == "e2b":
+        launcher_factory = _e2b_launcher_factory(
+            _parse_e2b_template(raw), _parse_provider_env(raw, "e2b")
+        )
+        token_ttl_s = E2B_MANAGED_TOKEN_TTL_S
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -858,6 +870,71 @@ def _parse_cwsandbox_env(raw: dict[str, object]) -> list[str] | None:
             "environment variable NAMES to inject, e.g. ['ANTHROPIC_API_KEY', 'GIT_TOKEN']"
         )
     return [name.strip() for name in env]
+
+
+def _e2b_launcher_factory(
+    template: str | None,
+    env: list[str] | None,
+) -> Callable[[], SandboxLauncher]:
+    """
+    Build the launcher factory for the YAML ``provider: e2b`` path.
+
+    :param template: E2B template NAME the Omnigent host image was built
+        into (``e2b template build``), or ``None`` to use the launcher's
+        env-var fallback / the default template. Unlike the other
+        providers' ``image`` field this is NOT a registry reference —
+        E2B boots from templates (see
+        :class:`omnigent.onboarding.sandboxes.e2b.E2BSandboxLauncher`).
+    :param env: Names of server-process environment variables (harness
+        LLM credentials, gateway URLs, ``GIT_TOKEN``) injected into
+        every sandbox, e.g. ``["OPENAI_API_KEY", "GIT_TOKEN"]``, or
+        ``None`` to resolve from the launcher's env-var fallback /
+        inject nothing.
+    :returns: A factory producing parameterized E2B launchers.
+    """
+
+    def _build() -> SandboxLauncher:
+        """Construct the E2B launcher (lazy SDK import inside)."""
+        from omnigent.onboarding.sandboxes.e2b import E2BSandboxLauncher
+
+        return E2BSandboxLauncher(template=template, env=env)
+
+    return _build
+
+
+def _parse_e2b_template(raw: dict[str, object]) -> str | None:
+    """
+    Extract and validate the e2b template from the ``sandbox`` dict.
+
+    ``sandbox.e2b.template`` names the pre-built E2B template the
+    Omnigent host image was built into — NOT a registry image reference
+    (the wording every other provider's ``image`` field uses), because
+    E2B cannot boot an arbitrary registry image. OPTIONAL — when absent,
+    the launcher resolves :data:`~omnigent.onboarding.sandboxes.e2b.TEMPLATE_ENV_VAR`
+    then the default template. A present-but-malformed value fails loud.
+
+    :param raw: The raw ``sandbox`` mapping (provider already known to
+        be ``"e2b"``).
+    :returns: The validated template name, or ``None`` to use the
+        launcher's fallback / default.
+    :raises ValueError: When ``sandbox.e2b`` is present but not a
+        mapping, or ``sandbox.e2b.template`` is present but not a
+        non-empty string.
+    """
+    section = _parse_provider_section(raw, "e2b")
+    if section is None:
+        return None
+    template = section.get("template")
+    if template is None:
+        return None
+    if not isinstance(template, str) or not template.strip():
+        raise ValueError(
+            "server config 'sandbox.e2b.template' must be the NAME of a pre-built "
+            "E2B template the omnigent host image was built into (e.g. "
+            "'omnigent-host'; see deploy/e2b/README.md) — NOT a registry image "
+            "reference (omit it to use the default template)"
+        )
+    return template.strip()
 
 
 def _islo_launcher_factory(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",
-    # <15 (was <14): the `e2b` extra's SDK (>=2.26) needs rich>=14.
-    "rich>=13.0,<15",
+    # >=14: the `e2b` extra's SDK (>=2.26) needs rich>=14 (was >=13,<14).
+    "rich>=14,<15",
     "prompt_toolkit>=3.0,<4",
     "mcp>=1.0,<2",
     "starlette>=0.27,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",
-    "rich>=13.0,<14",
+    # <15 (was <14): the `e2b` extra's SDK (>=2.26) needs rich>=14.
+    "rich>=13.0,<15",
     "prompt_toolkit>=3.0,<4",
     "mcp>=1.0,<2",
     "starlette>=0.27,<1",
@@ -119,7 +120,7 @@ cwsandbox = ["cwsandbox>=0.24,<1"]
 # E2B sandbox launcher (`omnigent sandbox --provider e2b` and
 # server-managed `sandbox.provider: e2b`).
 # Same lazy-import posture as above.
-e2b = ["e2b>=2,<3"]
+e2b = ["e2b>=2.26,<3"]
 # MLflow tracing is opt-in: tracing is disabled by default and the
 # server degrades gracefully when mlflow is absent, so the (heavy) mlflow
 # dependency only installs for users who want it (`omnigent[tracing]`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ daytona = ["daytona>=0.180,<1"]
 # server-managed `sandbox.provider: cwsandbox`).
 # Same lazy-import posture as above. Pre-1.0 SDK: pin minor.
 cwsandbox = ["cwsandbox>=0.24,<1"]
+# E2B sandbox launcher (`omnigent sandbox --provider e2b` and
+# server-managed `sandbox.provider: e2b`).
+# Same lazy-import posture as above.
+e2b = ["e2b>=2,<3"]
 # MLflow tracing is opt-in: tracing is disabled by default and the
 # server degrades gracefully when mlflow is absent, so the (heavy) mlflow
 # dependency only installs for users who want it (`omnigent[tracing]`).
@@ -475,6 +479,12 @@ ignore_missing_imports = true
 # posture as modal above.
 [[tool.mypy.overrides]]
 module = "cwsandbox.*"
+ignore_missing_imports = true
+
+# e2b is an optional dep (the `e2b` extra); same lazy-import posture as
+# modal above.
+[[tool.mypy.overrides]]
+module = "e2b.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -674,15 +674,15 @@ def test_kind_glyph_uniform_display_width(kind: str) -> None:
 
     Proves the "ticket looks cramped" fix comes from the subscription
     glyph's VARIATION SELECTOR-16 (which makes ADMISSION TICKETS a 2-cell
-    emoji like 🔑 / 🌐 / 🧱), not ad-hoc padding. Width is measured the way
-    the banner box measures it — ``cell_len`` plus one cell per VS16 —
-    because ``rich.cells.cell_len`` itself under-counts a VS16 emoji as 1
-    cell. A regression that dropped the VS16 (or a glyph) yields width != 2.
+    emoji like 🔑 / 🌐 / 🧱), not ad-hoc padding. Width is measured via the
+    banner box's own ``_display_width`` (rich >= 14 ``cell_len``, which counts
+    a VS16-forced wide emoji as the two cells terminals render). A regression
+    that dropped the VS16 (or a glyph) yields width != 2.
     """
-    from rich.cells import cell_len
+    from omnigent.inner.banner import _display_width
 
     g = kind_glyph(kind)
-    width = cell_len(g) + g.count("\ufe0f")
+    width = _display_width(g)
     assert width == 2, f"glyph for {kind!r} should be 2 display cells; got {width} ({g!r})."
 
 

--- a/tests/e2e/integrations/deploy/e2b/e2b_smoke_test.py
+++ b/tests/e2e/integrations/deploy/e2b/e2b_smoke_test.py
@@ -17,7 +17,7 @@ build``; see deploy/e2b/README.md) to smoke the real host template too.
 
     pip install 'omnigent[e2b]'
     export E2B_API_KEY=e2b_...
-    python tests/e2e/integrations/deploy/e2b/smoke_test.py [--template NAME] [--keep]
+    python tests/e2e/integrations/deploy/e2b/e2b_smoke_test.py [--template NAME] [--keep]
 
 Exit code 0 = every primitive worked; 1 = a check failed; 2 = setup error.
 """

--- a/tests/e2e/integrations/deploy/e2b/smoke_test.py
+++ b/tests/e2e/integrations/deploy/e2b/smoke_test.py
@@ -33,8 +33,8 @@ import time
 # omnigent package) isn't importable rather than a raw traceback.
 try:
     from omnigent.onboarding.sandboxes.e2b import (
-        MAX_SANDBOX_LIFETIME_S,
         E2BSandboxLauncher,
+        resolve_max_lifetime_s,
     )
 except ImportError as exc:  # pragma: no cover - environment guard
     print(f"ERROR: cannot import the launcher ({exc}).", file=sys.stderr)
@@ -122,7 +122,7 @@ def main() -> int:
 
         print("\n[6/8] keep_alive (set_timeout to max) + attach (connect + is_running)")
         launcher.keep_alive(sandbox_id)  # soft-fail; must not raise
-        _check(failures, True, f"keep_alive extended (target {MAX_SANDBOX_LIFETIME_S // 3600}h)")
+        _check(failures, True, f"keep_alive extended (target {resolve_max_lifetime_s() // 3600}h)")
         # Fresh launcher to force a real Sandbox.connect (not the cached handle).
         E2BSandboxLauncher(template=args.template).attach(sandbox_id)
         _check(failures, True, "attach validated a running sandbox")

--- a/tests/e2e/integrations/deploy/e2b/smoke_test.py
+++ b/tests/e2e/integrations/deploy/e2b/smoke_test.py
@@ -141,7 +141,7 @@ def main() -> int:
         print("\n[8/8] public egress (outbound HTTPS from inside)")
         egress = launcher.run(
             sandbox_id,
-            "python3 -c \"import urllib.request as u; "
+            'python3 -c "import urllib.request as u; '
             "print(u.urlopen('https://api.github.com', timeout=15).status)\"",
             check=False,
         )

--- a/tests/e2e/integrations/deploy/e2b/smoke_test.py
+++ b/tests/e2e/integrations/deploy/e2b/smoke_test.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Smoke test for the E2B sandbox provider.
+
+Drives the REAL :class:`~omnigent.onboarding.sandboxes.e2b.E2BSandboxLauncher`
+against a live E2B sandbox to validate every primitive the managed-host /
+CLI-bootstrap flows rely on: provision -> run (incl. the non-zero-exit
+``CommandExitException`` path) -> put + read-back -> keep_alive ->
+stream_exec (combined output) -> attach -> public egress -> terminate
+(idempotent). This is the test that actually exercises the E2B SDK calls
+the launcher makes, end to end.
+
+By default it boots from E2B's stock ``base`` template, so it needs NO
+pre-built omnigent host template — it validates the launcher's SDK wiring
+in isolation. Pass ``--template omnigent-host`` (after ``e2b template
+build``; see deploy/e2b/README.md) to smoke the real host template too.
+
+    pip install 'omnigent[e2b]'
+    export E2B_API_KEY=e2b_...
+    python tests/e2e/integrations/deploy/e2b/smoke_test.py [--template NAME] [--keep]
+
+Exit code 0 = every primitive worked; 1 = a check failed; 2 = setup error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+# The launcher lazy-imports the e2b SDK; surface a clean hint if it (or the
+# omnigent package) isn't importable rather than a raw traceback.
+try:
+    from omnigent.onboarding.sandboxes.e2b import (
+        MAX_SANDBOX_LIFETIME_S,
+        E2BSandboxLauncher,
+    )
+except ImportError as exc:  # pragma: no cover - environment guard
+    print(f"ERROR: cannot import the launcher ({exc}).", file=sys.stderr)
+    print("Run from the repo root with omnigent installed.", file=sys.stderr)
+    raise SystemExit(2) from exc
+
+
+def _check(failures: list[str], ok: bool, label: str) -> None:
+    """Record and print one check result."""
+    print(f"    {'✓' if ok else '✗'} {label}", flush=True)
+    if not ok:
+        failures.append(label)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--template",
+        default="base",
+        help="E2B template to boot from (default: E2B's stock 'base'; pass "
+        "'omnigent-host' to smoke the real host template once built).",
+    )
+    parser.add_argument("--keep", action="store_true", help="don't terminate at the end")
+    args = parser.parse_args()
+
+    if not os.environ.get("E2B_API_KEY"):
+        print("ERROR: set E2B_API_KEY (https://e2b.dev/dashboard)", file=sys.stderr)
+        return 2
+
+    # A sentinel env var we inject at provision and read back from inside the
+    # sandbox — exercises the env-passthrough path (resolved from THIS process
+    # env by name, exactly like the server forwards its own environment).
+    marker_name = "OMNIGENT_E2B_SMOKE_MARKER"
+    marker_value = f"smoke-{int(time.time())}"
+    os.environ[marker_name] = marker_value
+
+    launcher = E2BSandboxLauncher(template=args.template, env=[marker_name])
+    name = f"smoke-{int(time.time())}"
+    print(f"▸ E2B launcher smoke  template={args.template}  tag={name}")
+
+    sandbox_id: str | None = None
+    failures: list[str] = []
+    try:
+        print("\n[1/8] prepare (SDK + credentials)")
+        launcher.prepare()
+        _check(failures, True, "prepare passed")
+
+        print("\n[2/8] provision")
+        sandbox_id = launcher.provision(name)
+        _check(failures, bool(sandbox_id), f"provisioned sandbox_id={sandbox_id}")
+
+        print("\n[3/8] run: exit code, output, and env passthrough")
+        result = launcher.run(sandbox_id, f'echo "$HOME"; printf %s "${marker_name}"', check=True)
+        _check(failures, result.returncode == 0, "run exit code 0")
+        _check(failures, result.stdout.strip() != "", "run captured stdout")
+        _check(failures, marker_value in result.stdout, "injected env var visible inside sandbox")
+
+        print("\n[4/8] run: non-zero exit (CommandExitException path)")
+        # E2B raises CommandExitException on non-zero exit — the launcher must
+        # catch it and surface the code/streams rather than letting it escape.
+        failed = launcher.run(sandbox_id, "echo to-stderr >&2; exit 7", check=False)
+        _check(failures, failed.returncode == 7, "non-zero exit surfaced as returncode 7")
+        _check(failures, "to-stderr" in failed.stderr, "stderr captured on failing command")
+
+        print("\n[5/8] put: ship a binary file and read it back")
+        import tempfile
+        from pathlib import Path
+
+        payload = b"e2b-omnigent-smoke\x00\x01binary\n"
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(payload)
+            local = Path(tmp.name)
+        try:
+            launcher.put(sandbox_id, local, "/tmp/oa-smoke.bin")
+        finally:
+            local.unlink(missing_ok=True)
+        readback = launcher.run(sandbox_id, "base64 -w0 /tmp/oa-smoke.bin", check=True)
+        import base64
+
+        _check(
+            failures,
+            base64.b64decode(readback.stdout.strip()) == payload,
+            "uploaded file bytes match read-back",
+        )
+
+        print("\n[6/8] keep_alive (set_timeout to max) + attach (connect + is_running)")
+        launcher.keep_alive(sandbox_id)  # soft-fail; must not raise
+        _check(failures, True, f"keep_alive extended (target {MAX_SANDBOX_LIFETIME_S // 3600}h)")
+        # Fresh launcher to force a real Sandbox.connect (not the cached handle).
+        E2BSandboxLauncher(template=args.template).attach(sandbox_id)
+        _check(failures, True, "attach validated a running sandbox")
+
+        print("\n[7/8] stream_exec: combined stdout+stderr line stream")
+        proc = launcher.stream_exec(sandbox_id, "echo out-line; echo err-line >&2")
+        streamed = "".join(proc.lines)
+        code = proc.wait()
+        _check(failures, code == 0, "stream_exec wait() exit code 0")
+        _check(
+            failures,
+            "out-line" in streamed and "err-line" in streamed,
+            "stream_exec merged stdout and stderr",
+        )
+
+        print("\n[8/8] public egress (outbound HTTPS from inside)")
+        egress = launcher.run(
+            sandbox_id,
+            "python3 -c \"import urllib.request as u; "
+            "print(u.urlopen('https://api.github.com', timeout=15).status)\"",
+            check=False,
+        )
+        _check(failures, "200" in egress.stdout, "outbound HTTPS reached api.github.com")
+
+    except Exception as exc:
+        failures.append(f"FATAL: {type(exc).__name__}: {exc}")
+    finally:
+        if sandbox_id is not None and not args.keep:
+            print("\n[cleanup] terminate (idempotent)")
+            try:
+                launcher.terminate(sandbox_id)
+                # A second terminate of an already-killed sandbox must be a no-op.
+                launcher.terminate(sandbox_id)
+                print(f"    ✓ terminated {sandbox_id} (and second call was a no-op)")
+            except Exception as exc:
+                print(f"    WARNING: cleanup failed for {sandbox_id}: {exc}")
+        elif sandbox_id is not None:
+            print(f"\n[cleanup] --keep set; leaving {sandbox_id} running")
+
+    print("\n" + "=" * 60)
+    if failures:
+        print("SMOKE TEST FAILED:")
+        for f in failures:
+            print(f"  ✗ {f}")
+        return 1
+    print("SMOKE TEST PASSED — every E2B launcher primitive works against a live sandbox.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/onboarding/sandboxes/test_e2b.py
+++ b/tests/onboarding/sandboxes/test_e2b.py
@@ -12,10 +12,13 @@ import pytest
 
 from omnigent.onboarding.sandboxes.base import SandboxCapabilityError
 from omnigent.onboarding.sandboxes.e2b import (
+    _HOBBY_FALLBACK_LIFETIME_S,
     DEFAULT_E2B_TEMPLATE,
     SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
     TEMPLATE_ENV_VAR,
     E2BSandboxLauncher,
+    _is_missing_template_error,
+    _lifetime_cap_from_error,
     resolve_max_lifetime_s,
 )
 
@@ -36,6 +39,11 @@ class _NotFoundException(_SandboxException):
 
 
 class _TemplateException(_SandboxException):
+    pass
+
+
+class _AuthenticationException(Exception):
+    # Mirrors the real class: extends Exception, NOT SandboxException.
     pass
 
 
@@ -74,13 +82,18 @@ class _State:
     stream_result: _FakeCommandResult = field(default_factory=_FakeCommandResult)
     running: bool = True
     connect_missing: bool = False
+    connect_calls: list[str] = field(default_factory=list)
     kill_missing: bool = False
+    kill_raises: bool = False
     set_timeout_raises: bool = False
     create_raises: BaseException | None = None
     # When set, create() rejects (like E2B's 400) any timeout above this many
     # seconds, reporting the cap in hours — drives the clamp-and-retry test.
     reject_timeout_over: int | None = None
     handle_killed: bool = False
+    # When set, a background command's wait() raises this — drives the
+    # stream transport-error path.
+    stream_wait_raises: BaseException | None = None
 
 
 class _FakeCommandHandle:
@@ -93,6 +106,8 @@ class _FakeCommandHandle:
             on_stdout(result.stdout)
         if on_stderr is not None and result.stderr:
             on_stderr(result.stderr)
+        if self._state.stream_wait_raises is not None:
+            raise self._state.stream_wait_raises
         if result.exit_code != 0:
             raise _CommandExitException(
                 stdout=result.stdout, stderr=result.stderr, exit_code=result.exit_code
@@ -100,6 +115,8 @@ class _FakeCommandHandle:
         return result
 
     def kill(self) -> bool:
+        if self._state.kill_raises:
+            raise _SandboxException("already exited")
         self._state.handle_killed = True
         return True
 
@@ -155,6 +172,7 @@ class _FakeSandbox:
 
     @classmethod
     def connect(cls, sandbox_id: str, **kwargs) -> _FakeSandbox:
+        cls._state.connect_calls.append(sandbox_id)
         if cls._state.connect_missing:
             raise _NotFoundException(sandbox_id)
         return cls(sandbox_id)
@@ -188,6 +206,7 @@ def sdk(monkeypatch: pytest.MonkeyPatch) -> _State:
     exc.SandboxException = _SandboxException  # type: ignore[attr-defined]
     exc.NotFoundException = _NotFoundException  # type: ignore[attr-defined]
     exc.TemplateException = _TemplateException  # type: ignore[attr-defined]
+    exc.AuthenticationException = _AuthenticationException  # type: ignore[attr-defined]
     mod.exceptions = exc  # type: ignore[attr-defined]
 
     monkeypatch.setitem(sys.modules, "e2b", mod)
@@ -254,9 +273,27 @@ def test_provision_env_passthrough_missing_var_fails_loud(sdk: _State) -> None:
         E2BSandboxLauncher(env=["NOT_SET_ANYWHERE"]).provision("x")
 
 
-def test_provision_template_unavailable_points_at_build(sdk: _State) -> None:
-    sdk.create_raises = _TemplateException("not found")
+def test_provision_incompatible_template_points_at_build(sdk: _State) -> None:
+    # TemplateException is the SDK's incompatible/old-envd template signal.
+    sdk.create_raises = _TemplateException("envd version too old")
     with pytest.raises(click.ClickException, match="e2b template build"):
+        E2BSandboxLauncher().provision("x")
+
+
+def test_provision_missing_template_points_at_build(sdk: _State) -> None:
+    # A missing/unbuilt template is a PLAIN SandboxException ("404: template
+    # '…' not found"), not TemplateException — the most common first-run
+    # failure must still surface the build hint.
+    sdk.create_raises = _SandboxException("404: template 'omnigent-host' not found")
+    with pytest.raises(click.ClickException, match="e2b template build"):
+        E2BSandboxLauncher().provision("x")
+
+
+def test_provision_auth_error_is_friendly(sdk: _State) -> None:
+    # AuthenticationException does NOT extend SandboxException; it must still
+    # surface as a credential hint, not escape raw.
+    sdk.create_raises = _AuthenticationException("401: invalid api key")
+    with pytest.raises(click.ClickException, match="E2B_API_KEY"):
         E2BSandboxLauncher().provision("x")
 
 
@@ -281,6 +318,56 @@ def test_provision_env_override_skips_retry(sdk: _State, monkeypatch: pytest.Mon
     sdk.reject_timeout_over = 3600
     E2BSandboxLauncher().provision("x")
     assert [call["timeout"] for call in sdk.create_calls] == [3600]
+
+
+def test_provision_reraises_when_cap_not_below_request(sdk: _State) -> None:
+    # A timeout rejection whose parsed cap (48h) is NOT below the 24h request
+    # must surface as an error with NO second create attempt (no blind retry).
+    sdk.create_raises = _SandboxException("400: Timeout cannot be greater than 48 hours")
+    with pytest.raises(click.ClickException, match="E2B sandbox creation failed"):
+        E2BSandboxLauncher().provision("x")
+    assert len(sdk.create_calls) == 1
+
+
+def test_provision_clamp_retry_also_failing_surfaces_error(sdk: _State) -> None:
+    # First create rejects over-cap (→ clamp), and the clamped retry also
+    # fails — provision must surface a ClickException after exactly 2 attempts.
+    sdk.create_raises = _SandboxException("400: Timeout cannot be greater than 1 hours")
+    with pytest.raises(click.ClickException, match="E2B sandbox creation failed"):
+        E2BSandboxLauncher().provision("x")
+    assert len(sdk.create_calls) == 2
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("400: Timeout cannot be greater than 1 hours", 3600),  # regex path
+        ("400: Timeout cannot be greater than 24 hours", 24 * 3600),  # regex path
+        ("Timeout cannot be greater than", _HOBBY_FALLBACK_LIFETIME_S),  # unparsed fallback
+        ("404: template 'x' not found", None),  # unrelated → re-raise
+    ],
+)
+def test_lifetime_cap_from_error_branches(message: str, expected: int | None) -> None:
+    assert _lifetime_cap_from_error(message) == expected
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("404: template 'omnigent-host' not found", True),
+        ("Template 'x' Not Found", True),  # case-insensitive
+        ("400: Timeout cannot be greater than 1 hours", False),
+        ("429: rate limited", False),
+    ],
+)
+def test_is_missing_template_error(message: str, expected: bool) -> None:
+    assert _is_missing_template_error(message) is expected
+
+
+def test_resolve_max_lifetime_rejects_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_E2B_MAX_LIFETIME_S", "soon")
+    with pytest.raises(click.ClickException, match="must be a number of seconds"):
+        resolve_max_lifetime_s()
 
 
 # ── run ─────────────────────────────────────────────────────
@@ -379,7 +466,8 @@ def test_stream_exec_combines_output_and_returns_stable_iterator(sdk: _State) ->
     sdk.stream_result = _FakeCommandResult(stdout="out\n", stderr="err\n", exit_code=0)
     process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "do-thing")
     # The lines property must return the same iterator across accesses.
-    assert process.lines is process.lines
+    first_access = process.lines
+    assert process.lines is first_access
     assert list(process.lines) == ["out\n", "err\n"]
     assert process.wait() == 0
 
@@ -401,6 +489,93 @@ def test_exec_foreground_echoes_and_returns_exit_code(
     # TERM is forced and the command is exec'd inside the login shell.
     foreground_cmd = sdk.run_calls[-1]["cmd"]
     assert "TERM=xterm-256color exec omnigent host" in foreground_cmd
+
+
+def test_stream_exec_disables_per_command_timeout(sdk: _State) -> None:
+    # The streaming path backs the long-lived foreground host; it must disable
+    # the SDK's default 60s per-command cap (timeout=0), like run() does.
+    E2BSandboxLauncher().stream_exec("sb-e2b-1", "omnigent host")
+    assert sdk.run_calls[-1]["background"] is True
+    assert sdk.run_calls[-1]["timeout"] == 0
+
+
+def test_stream_exec_wait_surfaces_transport_error(sdk: _State) -> None:
+    # A non-CommandExit failure from wait() (daemon outage) is a transport
+    # error: wait() must re-raise it as a ClickException.
+    sdk.stream_wait_raises = _SandboxException("daemon connection lost")
+    process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "do-thing")
+    list(process.lines)  # drain to the sentinel
+    with pytest.raises(click.ClickException, match="daemon connection lost"):
+        process.wait()
+
+
+def test_stream_exec_nonzero_exit_returns_code_without_raising(sdk: _State) -> None:
+    # A non-zero stream exit is a normal outcome the caller inspects: wait()
+    # RETURNS the code (contrast with run(), which raises when check=True).
+    sdk.stream_result = _FakeCommandResult(stdout="x\n", exit_code=5)
+    process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "false")
+    assert list(process.lines) == ["x\n"]
+    assert process.wait() == 5
+
+
+def test_stream_exec_close_swallows_kill_error(sdk: _State) -> None:
+    # close() is best-effort and must never raise, even if kill() errors.
+    sdk.kill_raises = True
+    process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "do-thing")
+    process.wait()
+    process.close()  # must not raise
+    process.close()  # idempotent
+
+
+def test_stream_exec_appends_newline_to_partial_final_chunk(sdk: _State) -> None:
+    # A callback chunk with no trailing newline still yields a newline-
+    # terminated combined stream (the RemoteProcess contract).
+    sdk.stream_result = _FakeCommandResult(stdout="partial", exit_code=0)
+    process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "do-thing")
+    assert "".join(process.lines) == "partial\n"
+    assert process.wait() == 0
+
+
+def test_exec_foreground_kills_on_keyboard_interrupt(
+    sdk: _State, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Ctrl-C during the attach must kill the remote process (real close())
+    # and re-raise.
+    closed: list[bool] = []
+
+    class _Interrupting:
+        @property
+        def lines(self):
+            raise KeyboardInterrupt
+
+        def wait(self) -> int:
+            return 0
+
+        def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(
+        E2BSandboxLauncher, "stream_exec", lambda self, sid, cmd, *, pty=False: _Interrupting()
+    )
+    with pytest.raises(KeyboardInterrupt):
+        E2BSandboxLauncher().exec_foreground("sb-e2b-1", "omnigent host")
+    assert closed == [True]
+
+
+def test_resolve_caches_handle_across_primitives(sdk: _State) -> None:
+    # Two primitives on the same id connect once (cached handle).
+    launcher = E2BSandboxLauncher()
+    launcher.run("sb-e2b-1", "a")
+    launcher.run("sb-e2b-1", "b")
+    assert sdk.connect_calls == ["sb-e2b-1"]
+
+
+def test_provision_caches_handle_so_run_skips_connect(sdk: _State) -> None:
+    # provision caches the created sandbox; a follow-up run reuses it (no connect).
+    launcher = E2BSandboxLauncher()
+    sandbox_id = launcher.provision("x")
+    launcher.run(sandbox_id, "echo hi")
+    assert sdk.connect_calls == []
 
 
 # ── wheel install + capability surface ──────────────────────

--- a/tests/onboarding/sandboxes/test_e2b.py
+++ b/tests/onboarding/sandboxes/test_e2b.py
@@ -13,10 +13,10 @@ import pytest
 from omnigent.onboarding.sandboxes.base import SandboxCapabilityError
 from omnigent.onboarding.sandboxes.e2b import (
     DEFAULT_E2B_TEMPLATE,
-    MAX_SANDBOX_LIFETIME_S,
     SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
     TEMPLATE_ENV_VAR,
     E2BSandboxLauncher,
+    resolve_max_lifetime_s,
 )
 
 # ── Fake e2b SDK ────────────────────────────────────────────
@@ -65,6 +65,7 @@ class _State:
     """Shared recorder for assertions."""
 
     create_kwargs: dict = field(default_factory=dict)
+    create_calls: list[dict] = field(default_factory=list)
     run_calls: list[dict] = field(default_factory=list)
     written: list[tuple[str, bytes]] = field(default_factory=list)
     killed: list[str] = field(default_factory=list)
@@ -76,6 +77,9 @@ class _State:
     kill_missing: bool = False
     set_timeout_raises: bool = False
     create_raises: BaseException | None = None
+    # When set, create() rejects (like E2B's 400) any timeout above this many
+    # seconds, reporting the cap in hours — drives the clamp-and-retry test.
+    reject_timeout_over: int | None = None
     handle_killed: bool = False
 
 
@@ -140,8 +144,13 @@ class _FakeSandbox:
     @classmethod
     def create(cls, **kwargs) -> _FakeSandbox:
         cls._state.create_kwargs = kwargs
+        cls._state.create_calls.append(kwargs)
         if cls._state.create_raises is not None:
             raise cls._state.create_raises
+        cap = cls._state.reject_timeout_over
+        if cap is not None and kwargs.get("timeout", 0) > cap:
+            # Mirror E2B's 400 rejection of an over-cap lifetime.
+            raise _SandboxException(f"400: Timeout cannot be greater than {cap // 3600} hours")
         return cls()
 
     @classmethod
@@ -212,7 +221,7 @@ def test_prepare_raises_install_hint_when_sdk_missing(monkeypatch: pytest.Monkey
 def test_provision_uses_default_template_and_max_timeout(sdk: _State) -> None:
     assert E2BSandboxLauncher().provision("managed-x") == "sb-e2b-1"
     assert sdk.create_kwargs["template"] == DEFAULT_E2B_TEMPLATE
-    assert sdk.create_kwargs["timeout"] == MAX_SANDBOX_LIFETIME_S
+    assert sdk.create_kwargs["timeout"] == resolve_max_lifetime_s()
     assert sdk.create_kwargs["metadata"] == {"omnigent-name": "managed-x"}
     # No env configured → nothing injected.
     assert sdk.create_kwargs["envs"] is None
@@ -255,6 +264,23 @@ def test_provision_sandbox_error_surfaces_reason(sdk: _State) -> None:
     sdk.create_raises = _SandboxException("quota exceeded")
     with pytest.raises(click.ClickException, match="quota exceeded"):
         E2BSandboxLauncher().provision("x")
+
+
+def test_provision_clamps_lifetime_when_account_cap_rejects(sdk: _State) -> None:
+    # E2B rejects (HTTP 400) — not clamps — a lifetime above the account cap
+    # (e.g. Hobby's 1h vs the 24h default). provision must retry clamped to it.
+    sdk.reject_timeout_over = 3600  # 1h cap
+    assert E2BSandboxLauncher().provision("x") == "sb-e2b-1"
+    timeouts = [call["timeout"] for call in sdk.create_calls]
+    assert timeouts == [resolve_max_lifetime_s(), 3600]  # requested 24h, retried at 1h
+
+
+def test_provision_env_override_skips_retry(sdk: _State, monkeypatch: pytest.MonkeyPatch) -> None:
+    # With the lifetime pinned to the account cap, provision succeeds first try.
+    monkeypatch.setenv("OMNIGENT_E2B_MAX_LIFETIME_S", "3600")
+    sdk.reject_timeout_over = 3600
+    E2BSandboxLauncher().provision("x")
+    assert [call["timeout"] for call in sdk.create_calls] == [3600]
 
 
 # ── run ─────────────────────────────────────────────────────
@@ -323,7 +349,7 @@ def test_resolve_missing_sandbox_is_friendly(sdk: _State) -> None:
 
 def test_keep_alive_extends_to_max(sdk: _State) -> None:
     E2BSandboxLauncher().keep_alive("sb-e2b-1")
-    assert sdk.set_timeouts == [MAX_SANDBOX_LIFETIME_S]
+    assert sdk.set_timeouts == [resolve_max_lifetime_s()]
 
 
 def test_keep_alive_soft_fails(sdk: _State) -> None:

--- a/tests/onboarding/sandboxes/test_e2b.py
+++ b/tests/onboarding/sandboxes/test_e2b.py
@@ -1,0 +1,397 @@
+"""Tests for :mod:`omnigent.onboarding.sandboxes.e2b`."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes.base import SandboxCapabilityError
+from omnigent.onboarding.sandboxes.e2b import (
+    DEFAULT_E2B_TEMPLATE,
+    MAX_SANDBOX_LIFETIME_S,
+    SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
+    TEMPLATE_ENV_VAR,
+    E2BSandboxLauncher,
+)
+
+# ── Fake e2b SDK ────────────────────────────────────────────
+#
+# The SDK is an optional dependency the test env may not install, and
+# real Sandbox objects only exist server-side — so these are hand-rolled
+# stubs injected via sys.modules, resolving the launcher's function-local
+# `from e2b import ...` / `from e2b.exceptions import ...`.
+
+
+class _SandboxException(Exception):
+    pass
+
+
+class _NotFoundException(_SandboxException):
+    pass
+
+
+class _TemplateException(_SandboxException):
+    pass
+
+
+class _CommandExitException(_SandboxException):
+    """Mirrors the real class: a SandboxException that also carries the result."""
+
+    def __init__(
+        self, *, stdout: str = "", stderr: str = "", exit_code: int = 1, error: str | None = None
+    ) -> None:
+        super().__init__(f"Command exited with code {exit_code} and error:\n{stderr}")
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+        self.error = error
+
+
+@dataclass
+class _FakeCommandResult:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+    error: str | None = None
+
+
+@dataclass
+class _State:
+    """Shared recorder for assertions."""
+
+    create_kwargs: dict = field(default_factory=dict)
+    run_calls: list[dict] = field(default_factory=list)
+    written: list[tuple[str, bytes]] = field(default_factory=list)
+    killed: list[str] = field(default_factory=list)
+    set_timeouts: list[int] = field(default_factory=list)
+    exec_result: _FakeCommandResult = field(default_factory=_FakeCommandResult)
+    stream_result: _FakeCommandResult = field(default_factory=_FakeCommandResult)
+    running: bool = True
+    connect_missing: bool = False
+    kill_missing: bool = False
+    set_timeout_raises: bool = False
+    create_raises: BaseException | None = None
+    handle_killed: bool = False
+
+
+class _FakeCommandHandle:
+    def __init__(self, state: _State) -> None:
+        self._state = state
+
+    def wait(self, on_stdout=None, on_stderr=None, on_pty=None) -> _FakeCommandResult:
+        result = self._state.stream_result
+        if on_stdout is not None and result.stdout:
+            on_stdout(result.stdout)
+        if on_stderr is not None and result.stderr:
+            on_stderr(result.stderr)
+        if result.exit_code != 0:
+            raise _CommandExitException(
+                stdout=result.stdout, stderr=result.stderr, exit_code=result.exit_code
+            )
+        return result
+
+    def kill(self) -> bool:
+        self._state.handle_killed = True
+        return True
+
+
+class _FakeCommands:
+    def __init__(self, state: _State) -> None:
+        self._state = state
+
+    def run(self, cmd: str, *, timeout=None, background: bool = False):
+        self._state.run_calls.append({"cmd": cmd, "timeout": timeout, "background": background})
+        if background:
+            return _FakeCommandHandle(self._state)
+        result = self._state.exec_result
+        if result.exit_code != 0:
+            raise _CommandExitException(
+                stdout=result.stdout, stderr=result.stderr, exit_code=result.exit_code
+            )
+        return result
+
+
+class _FakeFiles:
+    def __init__(self, state: _State) -> None:
+        self._state = state
+
+    def write(self, path: str, data: bytes):
+        self._state.written.append((path, data))
+        return object()  # WriteInfo stand-in
+
+
+class _FakeSandbox:
+    _state: _State
+
+    def __init__(self, sandbox_id: str = "sb-e2b-1") -> None:
+        self._sandbox_id = sandbox_id
+        self.commands = _FakeCommands(self._state)
+        self.files = _FakeFiles(self._state)
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._sandbox_id
+
+    @classmethod
+    def create(cls, **kwargs) -> _FakeSandbox:
+        cls._state.create_kwargs = kwargs
+        if cls._state.create_raises is not None:
+            raise cls._state.create_raises
+        return cls()
+
+    @classmethod
+    def connect(cls, sandbox_id: str, **kwargs) -> _FakeSandbox:
+        if cls._state.connect_missing:
+            raise _NotFoundException(sandbox_id)
+        return cls(sandbox_id)
+
+    @staticmethod
+    def kill(sandbox_id: str, **kwargs) -> bool:
+        if _FakeSandbox._state.kill_missing:
+            raise _NotFoundException(sandbox_id)
+        _FakeSandbox._state.killed.append(sandbox_id)
+        return True
+
+    def is_running(self, request_timeout=None) -> bool:
+        return self._state.running
+
+    def set_timeout(self, timeout: int, **kwargs) -> None:
+        if self._state.set_timeout_raises:
+            raise _SandboxException("rejected")
+        self._state.set_timeouts.append(timeout)
+
+
+@pytest.fixture()
+def sdk(monkeypatch: pytest.MonkeyPatch) -> _State:
+    state = _State()
+    _FakeSandbox._state = state
+
+    mod = types.ModuleType("e2b")
+    mod.Sandbox = _FakeSandbox  # type: ignore[attr-defined]
+    mod.CommandExitException = _CommandExitException  # type: ignore[attr-defined]
+    mod.CommandResult = _FakeCommandResult  # type: ignore[attr-defined]
+    exc = types.ModuleType("e2b.exceptions")
+    exc.SandboxException = _SandboxException  # type: ignore[attr-defined]
+    exc.NotFoundException = _NotFoundException  # type: ignore[attr-defined]
+    exc.TemplateException = _TemplateException  # type: ignore[attr-defined]
+    mod.exceptions = exc  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "e2b", mod)
+    monkeypatch.setitem(sys.modules, "e2b.exceptions", exc)
+    monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+    monkeypatch.delenv(TEMPLATE_ENV_VAR, raising=False)
+    monkeypatch.delenv(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, raising=False)
+    return state
+
+
+# ── prepare ─────────────────────────────────────────────────
+
+
+def test_prepare_requires_api_key(sdk: _State, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("E2B_API_KEY")
+    with pytest.raises(click.ClickException, match="E2B_API_KEY"):
+        E2BSandboxLauncher().prepare()
+
+
+def test_prepare_raises_install_hint_when_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A None entry in sys.modules makes `import e2b` raise ImportError.
+    monkeypatch.setitem(sys.modules, "e2b", None)
+    monkeypatch.setenv("E2B_API_KEY", "k")
+    with pytest.raises(click.ClickException, match=r"pip install 'omnigent\[e2b\]'"):
+        E2BSandboxLauncher().prepare()
+
+
+# ── provision ───────────────────────────────────────────────
+
+
+def test_provision_uses_default_template_and_max_timeout(sdk: _State) -> None:
+    assert E2BSandboxLauncher().provision("managed-x") == "sb-e2b-1"
+    assert sdk.create_kwargs["template"] == DEFAULT_E2B_TEMPLATE
+    assert sdk.create_kwargs["timeout"] == MAX_SANDBOX_LIFETIME_S
+    assert sdk.create_kwargs["metadata"] == {"omnigent-name": "managed-x"}
+    # No env configured → nothing injected.
+    assert sdk.create_kwargs["envs"] is None
+
+
+def test_provision_template_resolution_order(sdk: _State, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TEMPLATE_ENV_VAR, "env-template")
+    E2BSandboxLauncher(template="explicit-template").provision("x")
+    assert sdk.create_kwargs["template"] == "explicit-template"
+
+
+def test_provision_template_from_env_when_no_explicit(
+    sdk: _State, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TEMPLATE_ENV_VAR, "env-template")
+    E2BSandboxLauncher().provision("x")
+    assert sdk.create_kwargs["template"] == "env-template"
+
+
+def test_provision_env_passthrough_from_server_env(
+    sdk: _State, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-123")
+    E2BSandboxLauncher(env=["ANTHROPIC_API_KEY"]).provision("x")
+    assert sdk.create_kwargs["envs"] == {"ANTHROPIC_API_KEY": "sk-ant-123"}
+
+
+def test_provision_env_passthrough_missing_var_fails_loud(sdk: _State) -> None:
+    with pytest.raises(click.ClickException, match="NOT_SET_ANYWHERE"):
+        E2BSandboxLauncher(env=["NOT_SET_ANYWHERE"]).provision("x")
+
+
+def test_provision_template_unavailable_points_at_build(sdk: _State) -> None:
+    sdk.create_raises = _TemplateException("not found")
+    with pytest.raises(click.ClickException, match="e2b template build"):
+        E2BSandboxLauncher().provision("x")
+
+
+def test_provision_sandbox_error_surfaces_reason(sdk: _State) -> None:
+    sdk.create_raises = _SandboxException("quota exceeded")
+    with pytest.raises(click.ClickException, match="quota exceeded"):
+        E2BSandboxLauncher().provision("x")
+
+
+# ── run ─────────────────────────────────────────────────────
+
+
+def test_run_returns_separate_streams_and_exit_code(sdk: _State) -> None:
+    sdk.exec_result = _FakeCommandResult(stdout="hi\n", stderr="warn\n", exit_code=0)
+    result = E2BSandboxLauncher().run("sb-e2b-1", "echo hi")
+    assert result.returncode == 0
+    assert result.stdout == "hi\n"
+    assert result.stderr == "warn\n"
+    # Per-command timeout disabled so long jobs aren't killed at 60s.
+    assert sdk.run_calls[0]["timeout"] == 0
+    assert sdk.run_calls[0]["background"] is False
+
+
+def test_run_handles_nonzero_exit_via_exception(sdk: _State) -> None:
+    # E2B raises CommandExitException on non-zero exit; the launcher must
+    # catch it, surface the captured output, and honor check.
+    sdk.exec_result = _FakeCommandResult(stdout="boom\n", stderr="bad\n", exit_code=3)
+    launcher = E2BSandboxLauncher()
+    with pytest.raises(click.ClickException, match="exit 3"):
+        launcher.run("sb-e2b-1", "false")
+    unchecked = launcher.run("sb-e2b-1", "false", check=False)
+    assert unchecked.returncode == 3
+    assert unchecked.stdout == "boom\n"
+    assert unchecked.stderr == "bad\n"
+
+
+def test_run_wraps_command_in_login_bash(sdk: _State) -> None:
+    E2BSandboxLauncher().run("sb-e2b-1", "echo hi")
+    assert sdk.run_calls[0]["cmd"].startswith("bash -lc ")
+
+
+# ── put ─────────────────────────────────────────────────────
+
+
+def test_put_writes_bytes(sdk: _State, tmp_path: Path) -> None:
+    local = tmp_path / "wheels.tgz"
+    local.write_bytes(b"binary\x00data")
+    E2BSandboxLauncher().put("sb-e2b-1", local, "/tmp/wheels.tgz")
+    assert sdk.written == [("/tmp/wheels.tgz", b"binary\x00data")]
+
+
+# ── attach ──────────────────────────────────────────────────
+
+
+def test_attach_accepts_running_sandbox(sdk: _State) -> None:
+    E2BSandboxLauncher().attach("sb-e2b-1")  # must not raise
+
+
+def test_attach_rejects_stopped_sandbox(sdk: _State) -> None:
+    sdk.running = False
+    with pytest.raises(click.ClickException, match="not running"):
+        E2BSandboxLauncher().attach("sb-e2b-1")
+
+
+def test_resolve_missing_sandbox_is_friendly(sdk: _State) -> None:
+    sdk.connect_missing = True
+    with pytest.raises(click.ClickException, match="not found"):
+        E2BSandboxLauncher().run("gone", "echo hi")
+
+
+# ── keep_alive ──────────────────────────────────────────────
+
+
+def test_keep_alive_extends_to_max(sdk: _State) -> None:
+    E2BSandboxLauncher().keep_alive("sb-e2b-1")
+    assert sdk.set_timeouts == [MAX_SANDBOX_LIFETIME_S]
+
+
+def test_keep_alive_soft_fails(sdk: _State) -> None:
+    sdk.set_timeout_raises = True
+    E2BSandboxLauncher().keep_alive("sb-e2b-1")  # warns, must not raise
+    assert sdk.set_timeouts == []
+
+
+# ── terminate ───────────────────────────────────────────────
+
+
+def test_terminate_kills_sandbox(sdk: _State) -> None:
+    E2BSandboxLauncher().terminate("sb-e2b-1")
+    assert sdk.killed == ["sb-e2b-1"]
+
+
+def test_terminate_swallows_not_found(sdk: _State) -> None:
+    sdk.kill_missing = True
+    E2BSandboxLauncher().terminate("already-gone")  # must not raise
+    assert sdk.killed == []
+
+
+# ── streaming ───────────────────────────────────────────────
+
+
+def test_stream_exec_combines_output_and_returns_stable_iterator(sdk: _State) -> None:
+    sdk.stream_result = _FakeCommandResult(stdout="out\n", stderr="err\n", exit_code=0)
+    process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "do-thing")
+    # The lines property must return the same iterator across accesses.
+    assert process.lines is process.lines
+    assert list(process.lines) == ["out\n", "err\n"]
+    assert process.wait() == 0
+
+
+def test_stream_exec_close_kills_remote_handle(sdk: _State) -> None:
+    process = E2BSandboxLauncher().stream_exec("sb-e2b-1", "do-thing")
+    process.wait()
+    process.close()
+    assert sdk.handle_killed is True
+
+
+def test_exec_foreground_echoes_and_returns_exit_code(
+    sdk: _State, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sdk.stream_result = _FakeCommandResult(stdout="line-1\n", exit_code=0)
+    code = E2BSandboxLauncher().exec_foreground("sb-e2b-1", "omnigent host")
+    assert code == 0
+    assert "line-1" in capsys.readouterr().out
+    # TERM is forced and the command is exec'd inside the login shell.
+    foreground_cmd = sdk.run_calls[-1]["cmd"]
+    assert "TERM=xterm-256color exec omnigent host" in foreground_cmd
+
+
+# ── wheel install + capability surface ──────────────────────
+
+
+def test_wheel_install_command_overlays_wheels(sdk: _State) -> None:
+    cmd = E2BSandboxLauncher().wheel_install_command("/tmp/oa-wheels.tgz")
+    assert "tar xzf /tmp/oa-wheels.tgz" in cmd
+    assert "--force-reinstall" in cmd
+    assert "--no-deps" in cmd
+
+
+def test_capability_surface() -> None:
+    launcher = E2BSandboxLauncher()
+    assert launcher.provider == "e2b"
+    # CLI-bootstrap stays at the base default; no local port forward.
+    assert launcher.supports_cli_bootstrap is True
+    assert launcher.supports_local_port_forward is False
+    with pytest.raises(SandboxCapabilityError, match="cannot forward a local port"):
+        launcher.forward_local_port("sb-e2b-1", 8022)

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -405,6 +405,10 @@ def install_fake_e2b_launcher(
         """Stand-in constructor recording the construction wiring."""
         fake.template = template
         fake.env = env
+        # Report the e2b provider so managed-host teardown's provider match
+        # (launcher.provider vs host.sandbox_provider) exercises the real path
+        # instead of the FakeSandboxLauncher default ("modal").
+        fake.provider = "e2b"  # type: ignore[misc]  # shadow the ClassVar per-instance
         return fake
 
     monkeypatch.setattr(e2b_mod, "E2BSandboxLauncher", _ctor)

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -181,6 +181,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         # constructed the launcher with (captured by the
         # ctor-monkeypatch shims).
         self.image: str | None = None
+        self.template: str | None = None
         self.secrets: list[str] | None = None
         self.env: list[str] | None = None
         self.base_url: str | None = None
@@ -382,6 +383,31 @@ def install_fake_islo_launcher(
         return fake
 
     monkeypatch.setattr(islo_mod, "IsloSandboxLauncher", _ctor)
+
+
+def install_fake_e2b_launcher(
+    monkeypatch: Any,  # pytest.MonkeyPatch — Any avoids importing pytest in a helpers module
+    fake: FakeSandboxLauncher,
+) -> None:
+    """
+    Substitute the fake for ``E2BSandboxLauncher`` at its public seam.
+
+    The managed flow constructs ``E2BSandboxLauncher(template=…, env=…)``;
+    the shim records the template name and env names on the fake and
+    hands the fake back, so production code runs unmodified against it.
+
+    :param monkeypatch: The test's ``pytest.MonkeyPatch``.
+    :param fake: The fake launcher to substitute.
+    """
+    import omnigent.onboarding.sandboxes.e2b as e2b_mod
+
+    def _ctor(*, template: str | None = None, env: list[str] | None = None) -> FakeSandboxLauncher:
+        """Stand-in constructor recording the construction wiring."""
+        fake.template = template
+        fake.env = env
+        return fake
+
+    monkeypatch.setattr(e2b_mod, "E2BSandboxLauncher", _ctor)
 
 
 async def wait_for_completion(

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -11,11 +11,11 @@ from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from omnigent.db.utils import now_epoch
+from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s as e2b_managed_token_ttl_s
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
 from omnigent.server.managed_hosts import (
     DAYTONA_MANAGED_TOKEN_TTL_S,
-    E2B_MANAGED_TOKEN_TTL_S,
     ISLO_MANAGED_TOKEN_TTL_S,
     MODAL_MANAGED_TOKEN_TTL_S,
     ManagedSandboxConfig,
@@ -287,7 +287,7 @@ def test_parse_valid_e2b_config_builds_parameterized_factory(
     )
     assert cfg is not None
     assert cfg.server_url == "https://srv.example.com"
-    assert cfg.token_ttl_s == E2B_MANAGED_TOKEN_TTL_S
+    assert cfg.token_ttl_s == e2b_managed_token_ttl_s()
     assert cfg.managed_launch_supported is True
     assert cfg.provider == "e2b"
     fake = FakeSandboxLauncher()

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -15,6 +15,7 @@ from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
 from omnigent.server.managed_hosts import (
     DAYTONA_MANAGED_TOKEN_TTL_S,
+    E2B_MANAGED_TOKEN_TTL_S,
     ISLO_MANAGED_TOKEN_TTL_S,
     MODAL_MANAGED_TOKEN_TTL_S,
     ManagedSandboxConfig,
@@ -34,6 +35,7 @@ from tests.server.helpers import (
     FakeSandboxLauncher,
     HostStartInvocation,
     install_fake_daytona_launcher,
+    install_fake_e2b_launcher,
     install_fake_islo_launcher,
     install_fake_modal_launcher,
 )
@@ -262,6 +264,66 @@ def test_parse_islo_without_section_defaults(
     assert fake.vcpus is None
     assert fake.memory_mb is None
     assert fake.disk_gb is None
+
+
+def test_parse_valid_e2b_config_builds_parameterized_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The documented e2b YAML shape parses into a config whose factory
+    constructs E2B launchers carrying the configured template name and
+    env-passthrough names, with the e2b token TTL (24h cap → mirror
+    Modal's 25h token lifetime).
+    """
+    cfg = parse_sandbox_config(
+        {
+            "provider": "e2b",
+            "server_url": "https://srv.example.com/",
+            "e2b": {
+                "template": "omnigent-host",
+                "env": ["OPENAI_API_KEY", "GIT_TOKEN"],
+            },
+        }
+    )
+    assert cfg is not None
+    assert cfg.server_url == "https://srv.example.com"
+    assert cfg.token_ttl_s == E2B_MANAGED_TOKEN_TTL_S
+    assert cfg.managed_launch_supported is True
+    assert cfg.provider == "e2b"
+    fake = FakeSandboxLauncher()
+    install_fake_e2b_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.template == "omnigent-host"
+    assert fake.env == ["OPENAI_API_KEY", "GIT_TOKEN"]
+
+
+def test_parse_e2b_without_section_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    `provider: e2b` + `server_url` is a complete config: template and
+    env are optional and reach the launcher as None (its own env-var
+    fallbacks / default-template apply).
+    """
+    cfg = parse_sandbox_config({"provider": "e2b", "server_url": "https://s.example.com"})
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_e2b_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.template is None
+    assert fake.env is None
+
+
+def test_parse_e2b_template_rejects_non_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A present-but-malformed e2b template fails loud at parse time."""
+    with pytest.raises(ValueError, match=r"sandbox\.e2b\.template"):
+        parse_sandbox_config(
+            {
+                "provider": "e2b",
+                "server_url": "https://s.example.com",
+                "e2b": {"template": ""},
+            }
+        )
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -2832,7 +2832,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.4.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "rich", specifier = ">=13.0,<15" },
+    { name = "rich", specifier = ">=14,<15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "starlette", specifier = ">=0.27,<1" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ cwsandbox = "2026-06-12T00:00:00Z"
 [[package]]
 name = "absl-py"
 version = "2.4.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
@@ -27,7 +27,7 @@ wheels = [
 [[package]]
 name = "aiofiles"
 version = "24.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
@@ -36,7 +36,7 @@ wheels = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
@@ -45,7 +45,7 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.14.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "aiohttp-retry"
 version = "2.9.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
@@ -157,7 +157,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.4.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -170,7 +170,7 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.18.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
@@ -184,7 +184,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -193,7 +193,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -202,7 +202,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.13.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -215,7 +215,7 @@ wheels = [
 [[package]]
 name = "argon2-cffi"
 version = "23.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argon2-cffi-bindings" },
 ]
@@ -227,7 +227,7 @@ wheels = [
 [[package]]
 name = "argon2-cffi-bindings"
 version = "25.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
@@ -258,7 +258,7 @@ wheels = [
 [[package]]
 name = "asgiref"
 version = "3.11.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
@@ -267,7 +267,7 @@ wheels = [
 [[package]]
 name = "ast-serialize"
 version = "0.5.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
@@ -307,7 +307,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "26.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
@@ -316,7 +316,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -325,7 +325,7 @@ wheels = [
 [[package]]
 name = "boto3"
 version = "1.43.25"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
@@ -339,7 +339,7 @@ wheels = [
 [[package]]
 name = "botocore"
 version = "1.43.25"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -353,7 +353,7 @@ wheels = [
 [[package]]
 name = "bracex"
 version = "2.6"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
@@ -362,7 +362,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "6.2.6"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
@@ -371,7 +371,7 @@ wheels = [
 [[package]]
 name = "cbor2"
 version = "6.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/75/af/473c241e41c142ea06ebef8d1f660fa6ff928fb97210e7bec8ee5974f8cd/cbor2-6.1.2.tar.gz", hash = "sha256:6b43037a66947dee5af0abb1a4c3a13b3abac5a4a3f32f9771efbbcd030fd909", size = 86760, upload-time = "2026-06-02T19:01:29.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/0c/a857b6ca032282b564cf25de18ad92fe0614e8b3fa3422eb10e32a873939/cbor2-6.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b158d3ff9d9dce70eeb09786a6e518e3cb0ecb927fd23e9a0f7fc4b175c01a", size = 409592, upload-time = "2026-06-02T19:00:44.556Z" },
@@ -411,7 +411,7 @@ wheels = [
 [[package]]
 name = "cel-expr-python"
 version = "0.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/bb/3a9f008001e86a4995d5e68785d0afc78debee9d69faf97b11bd3135a9f2/cel_expr_python-0.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d98c2b821c921e41965c54688fe23bef26742f0a138a75e3928359bd2090b183", size = 11771428, upload-time = "2026-06-01T17:23:41.57Z" },
     { url = "https://files.pythonhosted.org/packages/87/12/1309c203a38c573549a393475fb9a503b543f551618f59a74a4632a0a544/cel_expr_python-0.1.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:671b230b2fefdc621d5038ae7d9ccff651c12a9913137b03a6cf78556fba0f94", size = 17007730, upload-time = "2026-06-01T17:23:43.614Z" },
@@ -426,7 +426,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.5.20"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
@@ -435,7 +435,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -492,7 +492,7 @@ wheels = [
 [[package]]
 name = "cfgv"
 version = "3.5.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -501,7 +501,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.7"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
@@ -574,7 +574,7 @@ wheels = [
 [[package]]
 name = "claude-agent-sdk"
 version = "0.2.94"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
@@ -592,7 +592,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.1.8"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -604,7 +604,7 @@ wheels = [
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
@@ -613,7 +613,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -622,7 +622,7 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -688,7 +688,7 @@ wheels = [
 [[package]]
 name = "coverage"
 version = "7.14.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
@@ -772,7 +772,7 @@ wheels = [
 [[package]]
 name = "cryptography"
 version = "48.0.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
@@ -825,7 +825,7 @@ wheels = [
 [[package]]
 name = "cursor-sdk"
 version = "0.1.7"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
@@ -841,7 +841,7 @@ wheels = [
 [[package]]
 name = "cwsandbox"
 version = "0.24.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -855,7 +855,7 @@ wheels = [
 [[package]]
 name = "cycler"
 version = "0.12.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
@@ -864,7 +864,7 @@ wheels = [
 [[package]]
 name = "databricks-ai-bridge"
 version = "0.19.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "databricks-sdk" },
     { name = "databricks-vectorsearch" },
@@ -883,7 +883,7 @@ wheels = [
 [[package]]
 name = "databricks-mcp"
 version = "0.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "databricks-ai-bridge" },
     { name = "databricks-sdk" },
@@ -898,7 +898,7 @@ wheels = [
 [[package]]
 name = "databricks-sdk"
 version = "0.115.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
@@ -912,7 +912,7 @@ wheels = [
 [[package]]
 name = "databricks-vectorsearch"
 version = "0.66"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
     { name = "mlflow-skinny" },
@@ -926,7 +926,7 @@ wheels = [
 [[package]]
 name = "daytona"
 version = "0.184.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -957,7 +957,7 @@ wheels = [
 [[package]]
 name = "daytona-api-client"
 version = "0.184.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -972,7 +972,7 @@ wheels = [
 [[package]]
 name = "daytona-api-client-async"
 version = "0.184.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -988,7 +988,7 @@ wheels = [
 [[package]]
 name = "daytona-toolbox-api-client"
 version = "0.184.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -1003,7 +1003,7 @@ wheels = [
 [[package]]
 name = "daytona-toolbox-api-client-async"
 version = "0.184.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -1019,7 +1019,7 @@ wheels = [
 [[package]]
 name = "deprecated"
 version = "1.3.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
@@ -1031,7 +1031,7 @@ wheels = [
 [[package]]
 name = "deprecation"
 version = "2.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1043,7 +1043,7 @@ wheels = [
 [[package]]
 name = "distlib"
 version = "0.4.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/8d/873e9252ea2c0e0c857884e0a2899ec43ade132345df1925ef24cbe64f18/distlib-0.4.2.tar.gz", hash = "sha256:baeb401c90f27acd15c4861ae0847d1e731c27ac3dbf4210643ba61fa1e813db", size = 614914, upload-time = "2026-06-08T16:24:15.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/aa891c893821d4d127292ed66c6940d1d715894bd5a0ce048056bc641773/distlib-0.4.2-py2.py3-none-any.whl", hash = "sha256:ca4cb11e5d746b5ec13c199cbf19ae27a241f89702b54e153a74332955446067", size = 470510, upload-time = "2026-06-08T16:24:13.208Z" },
@@ -1052,7 +1052,7 @@ wheels = [
 [[package]]
 name = "distro"
 version = "1.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
@@ -1061,7 +1061,7 @@ wheels = [
 [[package]]
 name = "docker"
 version = "7.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
@@ -1075,7 +1075,7 @@ wheels = [
 [[package]]
 name = "dockerfile-parse"
 version = "2.0.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
@@ -1084,7 +1084,7 @@ wheels = [
 [[package]]
 name = "e2b"
 version = "2.26.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "dockerfile-parse" },
@@ -1106,7 +1106,7 @@ wheels = [
 [[package]]
 name = "execnet"
 version = "2.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
@@ -1115,7 +1115,7 @@ wheels = [
 [[package]]
 name = "fastapi"
 version = "0.136.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -1131,7 +1131,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.29.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
@@ -1140,7 +1140,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "3.1.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
@@ -1157,7 +1157,7 @@ wheels = [
 [[package]]
 name = "flask-cors"
 version = "6.0.5"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
@@ -1170,7 +1170,7 @@ wheels = [
 [[package]]
 name = "fonttools"
 version = "4.63.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
@@ -1211,7 +1211,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
@@ -1300,7 +1300,7 @@ wheels = [
 [[package]]
 name = "ftfy"
 version = "6.3.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -1312,7 +1312,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -1324,7 +1324,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.50"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -1336,7 +1336,7 @@ wheels = [
 [[package]]
 name = "google-antigravity"
 version = "0.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "google-genai" },
@@ -1357,7 +1357,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.53.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
@@ -1375,7 +1375,7 @@ requests = [
 [[package]]
 name = "google-genai"
 version = "2.8.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -1396,7 +1396,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -1408,7 +1408,7 @@ wheels = [
 [[package]]
 name = "graphene"
 version = "3.4.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphql-core" },
     { name = "graphql-relay" },
@@ -1423,7 +1423,7 @@ wheels = [
 [[package]]
 name = "graphql-core"
 version = "3.2.11"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/90/f2aff026ab4aebd80eb71905106a0885f4cfde85dcf965543f45bed0d9ee/graphql_core-3.2.11.tar.gz", hash = "sha256:e7e156d10beb127cab5c89ff0da71416fc73d27c484a4757d3b2d35633774802", size = 528407, upload-time = "2026-06-05T13:45:22.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl", hash = "sha256:0b3e35ff41e9adba53021ab0cef475eb18f57c7f53f0f2ca55567fbf3c537ea0", size = 214879, upload-time = "2026-06-05T13:45:21.245Z" },
@@ -1432,7 +1432,7 @@ wheels = [
 [[package]]
 name = "graphql-relay"
 version = "3.2.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphql-core" },
 ]
@@ -1444,7 +1444,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.5.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
@@ -1511,7 +1511,7 @@ wheels = [
 [[package]]
 name = "griffelib"
 version = "2.0.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
@@ -1520,7 +1520,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.81.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -1561,7 +1561,7 @@ wheels = [
 [[package]]
 name = "grpclib"
 version = "0.4.9"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h2" },
     { name = "multidict" },
@@ -1574,7 +1574,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "26.0.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1586,7 +1586,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -1595,7 +1595,7 @@ wheels = [
 [[package]]
 name = "h2"
 version = "4.3.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
@@ -1608,7 +1608,7 @@ wheels = [
 [[package]]
 name = "hpack"
 version = "4.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
@@ -1617,7 +1617,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -1630,7 +1630,7 @@ wheels = [
 [[package]]
 name = "httptools"
 version = "0.8.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
@@ -1666,7 +1666,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -1681,7 +1681,7 @@ wheels = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
@@ -1690,7 +1690,7 @@ wheels = [
 [[package]]
 name = "httpx-ws"
 version = "0.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpcore" },
@@ -1705,7 +1705,7 @@ wheels = [
 [[package]]
 name = "huey"
 version = "3.0.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/01/5f0fb711585af22412baee31a9a6a88975c33a58c57ec618e09be20bcc88/huey-3.0.1.tar.gz", hash = "sha256:83ca54fa77c4ee27349393212fc13088142244f491be903f620a9e46e8fca4ce", size = 253328, upload-time = "2026-05-14T15:35:02.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/37/1056e57ffb9d0fa1b859e02c9e5f7cf1e8276c8f5b610050e2a755f5c060/huey-3.0.1-py3-none-any.whl", hash = "sha256:5de8ff852021da670efe8d4d78db8719c0255ebbde0772766a0114f997ea61f6", size = 86331, upload-time = "2026-05-14T15:35:01.314Z" },
@@ -1714,7 +1714,7 @@ wheels = [
 [[package]]
 name = "hyperframe"
 version = "6.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
@@ -1723,7 +1723,7 @@ wheels = [
 [[package]]
 name = "identify"
 version = "2.6.19"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
@@ -1732,7 +1732,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.18"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
@@ -1741,7 +1741,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "9.0.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -1753,7 +1753,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -1762,7 +1762,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -1771,7 +1771,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -1783,7 +1783,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
@@ -1792,7 +1792,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.5.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -1804,7 +1804,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -1813,7 +1813,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -1825,7 +1825,7 @@ wheels = [
 [[package]]
 name = "jiter"
 version = "0.15.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
@@ -1897,7 +1897,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
@@ -1906,7 +1906,7 @@ wheels = [
 [[package]]
 name = "joblib"
 version = "1.5.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
@@ -1915,7 +1915,7 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.26.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
@@ -1930,7 +1930,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -1942,7 +1942,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.7.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
@@ -1959,7 +1959,7 @@ wheels = [
 [[package]]
 name = "kiwisolver"
 version = "1.5.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
@@ -2045,7 +2045,7 @@ wheels = [
 [[package]]
 name = "librt"
 version = "0.11.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
@@ -2105,7 +2105,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.12"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2117,7 +2117,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.2.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -2129,7 +2129,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
@@ -2192,7 +2192,7 @@ wheels = [
 [[package]]
 name = "matplotlib"
 version = "3.10.9"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "contourpy" },
     { name = "cycler" },
@@ -2246,7 +2246,7 @@ wheels = [
 [[package]]
 name = "mcp"
 version = "1.27.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
@@ -2271,7 +2271,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -2280,7 +2280,7 @@ wheels = [
 [[package]]
 name = "mlflow"
 version = "3.13.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
@@ -2311,7 +2311,7 @@ wheels = [
 [[package]]
 name = "mlflow-skinny"
 version = "3.13.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2342,7 +2342,7 @@ wheels = [
 [[package]]
 name = "mlflow-tracing"
 version = "3.13.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "databricks-sdk" },
@@ -2361,7 +2361,7 @@ wheels = [
 [[package]]
 name = "modal"
 version = "1.4.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cbor2" },
@@ -2385,7 +2385,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "11.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
@@ -2394,7 +2394,7 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.7.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
@@ -2493,7 +2493,7 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "2.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ast-serialize" },
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -2537,7 +2537,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -2546,7 +2546,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "2.22.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
@@ -2555,7 +2555,7 @@ wheels = [
 [[package]]
 name = "nodeenv"
 version = "1.10.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
@@ -2564,7 +2564,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.6"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
@@ -2625,7 +2625,7 @@ wheels = [
 [[package]]
 name = "obstore"
 version = "0.8.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -2882,7 +2882,7 @@ requires-dist = [
 [[package]]
 name = "openai"
 version = "2.41.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -2901,7 +2901,7 @@ wheels = [
 [[package]]
 name = "openai-agents"
 version = "0.17.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mcp" },
@@ -2920,7 +2920,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.42.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -2932,7 +2932,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-distro"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -2946,7 +2946,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.42.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
@@ -2958,7 +2958,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.42.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -2976,7 +2976,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.42.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "opentelemetry-api" },
@@ -2994,7 +2994,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -3009,7 +3009,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-aiohttp-client"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3025,7 +3025,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "opentelemetry-api" },
@@ -3041,7 +3041,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3057,7 +3057,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3073,7 +3073,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents-v2"
 version = "0.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3088,7 +3088,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.42.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -3100,7 +3100,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.42.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -3114,7 +3114,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
@@ -3127,7 +3127,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-util-genai"
 version = "0.4b0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3141,7 +3141,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-util-http"
 version = "0.63b1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/d8/7bf5e4cec0578ac3c28c18eb7b88f34279139cbc8c568d6aa02b9c5ae53e/opentelemetry_util_http-0.63b1.tar.gz", hash = "sha256:ba1268f00922ee522dba2ae38458060f99486e7385a8056985901ca9685adfff", size = 11102, upload-time = "2026-05-21T16:36:56.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/f1/34e047e8f6a3c67e5220acf1af7b9f62868c25d77791bca74457bd2180a6/opentelemetry_util_http-0.63b1-py3-none-any.whl", hash = "sha256:6284194028c59cd439f8acfe388145069a6127f11dc077e1344a2094adacc3f8", size = 8205, upload-time = "2026-05-21T16:36:09.736Z" },
@@ -3150,7 +3150,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "25.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
@@ -3159,7 +3159,7 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
@@ -3206,7 +3206,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "1.1.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
@@ -3215,7 +3215,7 @@ wheels = [
 [[package]]
 name = "pexpect"
 version = "4.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess" },
 ]
@@ -3227,7 +3227,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.2.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
@@ -3296,7 +3296,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.10.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
@@ -3305,7 +3305,7 @@ wheels = [
 [[package]]
 name = "playwright"
 version = "1.60.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
@@ -3324,7 +3324,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -3333,7 +3333,7 @@ wheels = [
 [[package]]
 name = "pre-commit"
 version = "4.6.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
     { name = "identify" },
@@ -3349,7 +3349,7 @@ wheels = [
 [[package]]
 name = "prettytable"
 version = "3.17.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3361,7 +3361,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3373,7 +3373,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.5.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
@@ -3467,7 +3467,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.6"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
@@ -3482,7 +3482,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.2.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
@@ -3510,7 +3510,7 @@ wheels = [
 [[package]]
 name = "psycopg"
 version = "3.3.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
@@ -3528,7 +3528,7 @@ binary = [
 [[package]]
 name = "psycopg-binary"
 version = "3.3.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
     { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
@@ -3568,7 +3568,7 @@ wheels = [
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
@@ -3577,7 +3577,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "24.0.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
@@ -3620,7 +3620,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
@@ -3629,7 +3629,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "3.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
@@ -3650,7 +3650,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.13.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -3665,7 +3665,7 @@ wheels = [
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3740,7 +3740,7 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.14.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -3754,7 +3754,7 @@ wheels = [
 [[package]]
 name = "pyee"
 version = "13.0.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3766,7 +3766,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
@@ -3775,7 +3775,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.13.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
@@ -3789,7 +3789,7 @@ crypto = [
 [[package]]
 name = "pyparsing"
 version = "3.3.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
@@ -3798,7 +3798,7 @@ wheels = [
 [[package]]
 name = "pyte"
 version = "0.8.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3810,7 +3810,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "9.0.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -3826,7 +3826,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "1.4.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -3839,7 +3839,7 @@ wheels = [
 [[package]]
 name = "pytest-base-url"
 version = "2.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "requests" },
@@ -3852,7 +3852,7 @@ wheels = [
 [[package]]
 name = "pytest-cov"
 version = "7.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
@@ -3866,7 +3866,7 @@ wheels = [
 [[package]]
 name = "pytest-playwright"
 version = "0.8.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "playwright" },
     { name = "pytest" },
@@ -3881,7 +3881,7 @@ wheels = [
 [[package]]
 name = "pytest-rerunfailures"
 version = "16.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pytest" },
@@ -3894,7 +3894,7 @@ wheels = [
 [[package]]
 name = "pytest-shard"
 version = "0.1.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -3906,7 +3906,7 @@ wheels = [
 [[package]]
 name = "pytest-timeout"
 version = "2.4.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -3918,7 +3918,7 @@ wheels = [
 [[package]]
 name = "pytest-xdist"
 version = "3.8.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
@@ -3931,7 +3931,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -3943,7 +3943,7 @@ wheels = [
 [[package]]
 name = "python-discovery"
 version = "1.4.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
@@ -3956,7 +3956,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.2.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
@@ -3965,7 +3965,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.32"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
@@ -3974,7 +3974,7 @@ wheels = [
 [[package]]
 name = "python-slugify"
 version = "8.0.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "text-unidecode" },
 ]
@@ -3986,7 +3986,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2026.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
@@ -3995,7 +3995,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "312"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
     { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
@@ -4014,7 +4014,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -4023,7 +4023,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
@@ -4069,7 +4069,7 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.37.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
@@ -4083,7 +4083,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2026.5.9"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
@@ -4171,7 +4171,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.34.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -4186,7 +4186,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "14.3.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -4199,7 +4199,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "2026.5.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
@@ -4309,7 +4309,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.15.16"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
@@ -4334,7 +4334,7 @@ wheels = [
 [[package]]
 name = "s3transfer"
 version = "0.18.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
@@ -4346,7 +4346,7 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.9.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
@@ -4385,7 +4385,7 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.17.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -4446,7 +4446,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.5.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "jeepney" },
@@ -4459,7 +4459,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -4468,7 +4468,7 @@ wheels = [
 [[package]]
 name = "skops"
 version = "0.14.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
@@ -4484,7 +4484,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
@@ -4493,7 +4493,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -4502,7 +4502,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "2.0.50"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
@@ -4543,7 +4543,7 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.5"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
@@ -4552,7 +4552,7 @@ wheels = [
 [[package]]
 name = "sse-starlette"
 version = "3.4.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
@@ -4565,7 +4565,7 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.52.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -4578,7 +4578,7 @@ wheels = [
 [[package]]
 name = "synchronicity"
 version = "0.12.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4590,7 +4590,7 @@ wheels = [
 [[package]]
 name = "tabulate"
 version = "0.10.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
@@ -4599,7 +4599,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "9.1.4"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
@@ -4608,7 +4608,7 @@ wheels = [
 [[package]]
 name = "text-unidecode"
 version = "1.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
@@ -4617,7 +4617,7 @@ wheels = [
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
@@ -4626,7 +4626,7 @@ wheels = [
 [[package]]
 name = "tiktoken"
 version = "0.13.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
@@ -4673,7 +4673,7 @@ wheels = [
 [[package]]
 name = "toml"
 version = "0.10.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
@@ -4682,7 +4682,7 @@ wheels = [
 [[package]]
 name = "tomlkit"
 version = "0.15.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
@@ -4691,7 +4691,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.68.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -4703,7 +4703,7 @@ wheels = [
 [[package]]
 name = "types-certifi"
 version = "2021.10.8.3"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
@@ -4712,7 +4712,7 @@ wheels = [
 [[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260518"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
@@ -4721,7 +4721,7 @@ wheels = [
 [[package]]
 name = "types-requests"
 version = "2.33.0.20260518"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
@@ -4733,7 +4733,7 @@ wheels = [
 [[package]]
 name = "types-toml"
 version = "0.10.8.20260518"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
@@ -4742,7 +4742,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -4751,7 +4751,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4763,7 +4763,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2026.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
@@ -4772,7 +4772,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.7.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
@@ -4781,7 +4781,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.49.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
@@ -4805,7 +4805,7 @@ standard = [
 [[package]]
 name = "uvloop"
 version = "0.22.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
@@ -4837,7 +4837,7 @@ wheels = [
 [[package]]
 name = "virtualenv"
 version = "21.4.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
@@ -4852,7 +4852,7 @@ wheels = [
 [[package]]
 name = "waitress"
 version = "3.0.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
@@ -4861,7 +4861,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.2.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -4947,7 +4947,7 @@ wheels = [
 [[package]]
 name = "wcmatch"
 version = "10.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
@@ -4959,7 +4959,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.8.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
@@ -4968,7 +4968,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "16.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
@@ -5013,7 +5013,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "3.1.8"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -5025,7 +5025,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "2.2.1"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
@@ -5089,7 +5089,7 @@ wheels = [
 [[package]]
 name = "wsproto"
 version = "1.3.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
 ]
@@ -5101,7 +5101,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.24.2"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -5183,7 +5183,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "4.1.0"
-source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ cwsandbox = "2026-06-12T00:00:00Z"
 [[package]]
 name = "absl-py"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
@@ -27,7 +27,7 @@ wheels = [
 [[package]]
 name = "aiofiles"
 version = "24.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
@@ -36,7 +36,7 @@ wheels = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
@@ -45,7 +45,7 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "aiohttp-retry"
 version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
@@ -157,7 +157,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "frozenlist" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -170,7 +170,7 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.18.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
@@ -184,7 +184,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -193,7 +193,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -202,7 +202,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -215,7 +215,7 @@ wheels = [
 [[package]]
 name = "argon2-cffi"
 version = "23.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "argon2-cffi-bindings" },
 ]
@@ -227,7 +227,7 @@ wheels = [
 [[package]]
 name = "argon2-cffi-bindings"
 version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cffi" },
 ]
@@ -258,7 +258,7 @@ wheels = [
 [[package]]
 name = "asgiref"
 version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
@@ -267,7 +267,7 @@ wheels = [
 [[package]]
 name = "ast-serialize"
 version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
@@ -307,7 +307,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
@@ -316,7 +316,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -325,7 +325,7 @@ wheels = [
 [[package]]
 name = "boto3"
 version = "1.43.25"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
@@ -339,7 +339,7 @@ wheels = [
 [[package]]
 name = "botocore"
 version = "1.43.25"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -351,9 +351,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
@@ -362,7 +371,7 @@ wheels = [
 [[package]]
 name = "cbor2"
 version = "6.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/75/af/473c241e41c142ea06ebef8d1f660fa6ff928fb97210e7bec8ee5974f8cd/cbor2-6.1.2.tar.gz", hash = "sha256:6b43037a66947dee5af0abb1a4c3a13b3abac5a4a3f32f9771efbbcd030fd909", size = 86760, upload-time = "2026-06-02T19:01:29.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/0c/a857b6ca032282b564cf25de18ad92fe0614e8b3fa3422eb10e32a873939/cbor2-6.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b158d3ff9d9dce70eeb09786a6e518e3cb0ecb927fd23e9a0f7fc4b175c01a", size = 409592, upload-time = "2026-06-02T19:00:44.556Z" },
@@ -402,7 +411,7 @@ wheels = [
 [[package]]
 name = "cel-expr-python"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/bb/3a9f008001e86a4995d5e68785d0afc78debee9d69faf97b11bd3135a9f2/cel_expr_python-0.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d98c2b821c921e41965c54688fe23bef26742f0a138a75e3928359bd2090b183", size = 11771428, upload-time = "2026-06-01T17:23:41.57Z" },
     { url = "https://files.pythonhosted.org/packages/87/12/1309c203a38c573549a393475fb9a503b543f551618f59a74a4632a0a544/cel_expr_python-0.1.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:671b230b2fefdc621d5038ae7d9ccff651c12a9913137b03a6cf78556fba0f94", size = 17007730, upload-time = "2026-06-01T17:23:43.614Z" },
@@ -417,7 +426,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.5.20"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
@@ -426,7 +435,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -483,7 +492,7 @@ wheels = [
 [[package]]
 name = "cfgv"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -492,7 +501,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
@@ -565,7 +574,7 @@ wheels = [
 [[package]]
 name = "claude-agent-sdk"
 version = "0.2.94"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
@@ -583,7 +592,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -595,7 +604,7 @@ wheels = [
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
@@ -604,7 +613,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -613,7 +622,7 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -679,7 +688,7 @@ wheels = [
 [[package]]
 name = "coverage"
 version = "7.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
@@ -763,7 +772,7 @@ wheels = [
 [[package]]
 name = "cryptography"
 version = "48.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
@@ -816,7 +825,7 @@ wheels = [
 [[package]]
 name = "cursor-sdk"
 version = "0.1.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "httpx" },
 ]
@@ -832,7 +841,7 @@ wheels = [
 [[package]]
 name = "cwsandbox"
 version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -846,7 +855,7 @@ wheels = [
 [[package]]
 name = "cycler"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
@@ -855,7 +864,7 @@ wheels = [
 [[package]]
 name = "databricks-ai-bridge"
 version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "databricks-sdk" },
     { name = "databricks-vectorsearch" },
@@ -874,7 +883,7 @@ wheels = [
 [[package]]
 name = "databricks-mcp"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "databricks-ai-bridge" },
     { name = "databricks-sdk" },
@@ -889,7 +898,7 @@ wheels = [
 [[package]]
 name = "databricks-sdk"
 version = "0.115.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
@@ -903,7 +912,7 @@ wheels = [
 [[package]]
 name = "databricks-vectorsearch"
 version = "0.66"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "deprecation" },
     { name = "mlflow-skinny" },
@@ -917,7 +926,7 @@ wheels = [
 [[package]]
 name = "daytona"
 version = "0.184.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -948,7 +957,7 @@ wheels = [
 [[package]]
 name = "daytona-api-client"
 version = "0.184.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -963,7 +972,7 @@ wheels = [
 [[package]]
 name = "daytona-api-client-async"
 version = "0.184.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -979,7 +988,7 @@ wheels = [
 [[package]]
 name = "daytona-toolbox-api-client"
 version = "0.184.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -994,7 +1003,7 @@ wheels = [
 [[package]]
 name = "daytona-toolbox-api-client-async"
 version = "0.184.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -1010,7 +1019,7 @@ wheels = [
 [[package]]
 name = "deprecated"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
@@ -1022,7 +1031,7 @@ wheels = [
 [[package]]
 name = "deprecation"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1034,7 +1043,7 @@ wheels = [
 [[package]]
 name = "distlib"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/8d/873e9252ea2c0e0c857884e0a2899ec43ade132345df1925ef24cbe64f18/distlib-0.4.2.tar.gz", hash = "sha256:baeb401c90f27acd15c4861ae0847d1e731c27ac3dbf4210643ba61fa1e813db", size = 614914, upload-time = "2026-06-08T16:24:15.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/aa891c893821d4d127292ed66c6940d1d715894bd5a0ce048056bc641773/distlib-0.4.2-py2.py3-none-any.whl", hash = "sha256:ca4cb11e5d746b5ec13c199cbf19ae27a241f89702b54e153a74332955446067", size = 470510, upload-time = "2026-06-08T16:24:13.208Z" },
@@ -1043,7 +1052,7 @@ wheels = [
 [[package]]
 name = "distro"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
@@ -1052,7 +1061,7 @@ wheels = [
 [[package]]
 name = "docker"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
@@ -1064,9 +1073,40 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.26.0"
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/e5/3bea1524a51f569844965ceb3f9672dd4aaae2c6bbfa3011692aab6b0250/e2b-2.26.0.tar.gz", hash = "sha256:e140aec56c29a34706cdaf1bbe4dc1858ac38c7bed87145795019cf321866a2f", size = 163073, upload-time = "2026-06-06T06:43:58.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9e/5b4edc5ed8b0e84147291087fbd2e0762e9188c121637fb43b5f839d40ab/e2b-2.26.0-py3-none-any.whl", hash = "sha256:55cdb88b30d3026084fff862275815d88ffd37665814f73f09beea9c057de5bc", size = 309648, upload-time = "2026-06-06T06:43:57.583Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
@@ -1075,7 +1115,7 @@ wheels = [
 [[package]]
 name = "fastapi"
 version = "0.136.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -1091,7 +1131,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.29.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
@@ -1100,7 +1140,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
@@ -1117,7 +1157,7 @@ wheels = [
 [[package]]
 name = "flask-cors"
 version = "6.0.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
@@ -1130,7 +1170,7 @@ wheels = [
 [[package]]
 name = "fonttools"
 version = "4.63.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
@@ -1171,7 +1211,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
@@ -1260,7 +1300,7 @@ wheels = [
 [[package]]
 name = "ftfy"
 version = "6.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -1272,7 +1312,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -1284,7 +1324,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.50"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -1296,7 +1336,7 @@ wheels = [
 [[package]]
 name = "google-antigravity"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "google-genai" },
@@ -1317,7 +1357,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.53.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
@@ -1335,7 +1375,7 @@ requests = [
 [[package]]
 name = "google-genai"
 version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -1356,7 +1396,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -1368,7 +1408,7 @@ wheels = [
 [[package]]
 name = "graphene"
 version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "graphql-core" },
     { name = "graphql-relay" },
@@ -1383,7 +1423,7 @@ wheels = [
 [[package]]
 name = "graphql-core"
 version = "3.2.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/90/f2aff026ab4aebd80eb71905106a0885f4cfde85dcf965543f45bed0d9ee/graphql_core-3.2.11.tar.gz", hash = "sha256:e7e156d10beb127cab5c89ff0da71416fc73d27c484a4757d3b2d35633774802", size = 528407, upload-time = "2026-06-05T13:45:22.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl", hash = "sha256:0b3e35ff41e9adba53021ab0cef475eb18f57c7f53f0f2ca55567fbf3c537ea0", size = 214879, upload-time = "2026-06-05T13:45:21.245Z" },
@@ -1392,7 +1432,7 @@ wheels = [
 [[package]]
 name = "graphql-relay"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "graphql-core" },
 ]
@@ -1404,7 +1444,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
@@ -1471,7 +1511,7 @@ wheels = [
 [[package]]
 name = "griffelib"
 version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
@@ -1480,7 +1520,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.81.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -1521,7 +1561,7 @@ wheels = [
 [[package]]
 name = "grpclib"
 version = "0.4.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "h2" },
     { name = "multidict" },
@@ -1534,7 +1574,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "26.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1546,7 +1586,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -1555,7 +1595,7 @@ wheels = [
 [[package]]
 name = "h2"
 version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
@@ -1568,7 +1608,7 @@ wheels = [
 [[package]]
 name = "hpack"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
@@ -1577,7 +1617,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -1590,7 +1630,7 @@ wheels = [
 [[package]]
 name = "httptools"
 version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
@@ -1626,7 +1666,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -1641,7 +1681,7 @@ wheels = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
@@ -1650,7 +1690,7 @@ wheels = [
 [[package]]
 name = "httpx-ws"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpcore" },
@@ -1665,7 +1705,7 @@ wheels = [
 [[package]]
 name = "huey"
 version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/01/5f0fb711585af22412baee31a9a6a88975c33a58c57ec618e09be20bcc88/huey-3.0.1.tar.gz", hash = "sha256:83ca54fa77c4ee27349393212fc13088142244f491be903f620a9e46e8fca4ce", size = 253328, upload-time = "2026-05-14T15:35:02.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/37/1056e57ffb9d0fa1b859e02c9e5f7cf1e8276c8f5b610050e2a755f5c060/huey-3.0.1-py3-none-any.whl", hash = "sha256:5de8ff852021da670efe8d4d78db8719c0255ebbde0772766a0114f997ea61f6", size = 86331, upload-time = "2026-05-14T15:35:01.314Z" },
@@ -1674,7 +1714,7 @@ wheels = [
 [[package]]
 name = "hyperframe"
 version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
@@ -1683,7 +1723,7 @@ wheels = [
 [[package]]
 name = "identify"
 version = "2.6.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
@@ -1692,7 +1732,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
@@ -1701,7 +1741,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -1713,7 +1753,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -1722,7 +1762,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -1731,7 +1771,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -1743,7 +1783,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
@@ -1752,7 +1792,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -1764,7 +1804,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -1773,7 +1813,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -1785,7 +1825,7 @@ wheels = [
 [[package]]
 name = "jiter"
 version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
@@ -1857,7 +1897,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
@@ -1866,7 +1906,7 @@ wheels = [
 [[package]]
 name = "joblib"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
@@ -1875,7 +1915,7 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
@@ -1890,7 +1930,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -1902,7 +1942,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
@@ -1919,7 +1959,7 @@ wheels = [
 [[package]]
 name = "kiwisolver"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
@@ -2005,7 +2045,7 @@ wheels = [
 [[package]]
 name = "librt"
 version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
@@ -2065,7 +2105,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2077,7 +2117,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -2089,7 +2129,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
@@ -2152,7 +2192,7 @@ wheels = [
 [[package]]
 name = "matplotlib"
 version = "3.10.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "contourpy" },
     { name = "cycler" },
@@ -2206,7 +2246,7 @@ wheels = [
 [[package]]
 name = "mcp"
 version = "1.27.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
@@ -2231,7 +2271,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -2240,7 +2280,7 @@ wheels = [
 [[package]]
 name = "mlflow"
 version = "3.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
@@ -2271,7 +2311,7 @@ wheels = [
 [[package]]
 name = "mlflow-skinny"
 version = "3.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2302,7 +2342,7 @@ wheels = [
 [[package]]
 name = "mlflow-tracing"
 version = "3.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "databricks-sdk" },
@@ -2321,7 +2361,7 @@ wheels = [
 [[package]]
 name = "modal"
 version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cbor2" },
@@ -2345,7 +2385,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "11.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
@@ -2354,7 +2394,7 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
@@ -2453,7 +2493,7 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "ast-serialize" },
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -2497,7 +2537,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -2506,7 +2546,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "2.22.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
@@ -2515,7 +2555,7 @@ wheels = [
 [[package]]
 name = "nodeenv"
 version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
@@ -2524,7 +2564,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
@@ -2585,7 +2625,7 @@ wheels = [
 [[package]]
 name = "obstore"
 version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -2718,6 +2758,9 @@ dev = [
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
+e2b = [
+    { name = "e2b" },
+]
 modal = [
     { name = "modal" },
 ]
@@ -2745,6 +2788,7 @@ requires-dist = [
     { name = "databricks-sdk", marker = "extra == 'all'", specifier = ">=0.56.0,<1" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.56.0,<1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.180,<1" },
+    { name = "e2b", marker = "extra == 'e2b'", specifier = ">=2.26,<3" },
     { name = "fastapi", specifier = ">=0.100,<1" },
     { name = "filelock", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "ftfy", specifier = ">=6.0" },
@@ -2788,7 +2832,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.4.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "rich", specifier = ">=13.0,<14" },
+    { name = "rich", specifier = ">=13.0,<15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "starlette", specifier = ">=0.27,<1" },
@@ -2797,7 +2841,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "modal", "daytona", "cwsandbox", "tracing", "agents-sdk", "antigravity", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "modal", "daytona", "cwsandbox", "e2b", "tracing", "agents-sdk", "antigravity", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"
@@ -2838,7 +2882,7 @@ requires-dist = [
 [[package]]
 name = "openai"
 version = "2.41.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -2857,7 +2901,7 @@ wheels = [
 [[package]]
 name = "openai-agents"
 version = "0.17.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mcp" },
@@ -2876,7 +2920,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -2888,7 +2932,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-distro"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -2902,7 +2946,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
@@ -2914,7 +2958,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -2932,7 +2976,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "opentelemetry-api" },
@@ -2950,7 +2994,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -2965,7 +3009,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-aiohttp-client"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -2981,7 +3025,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "opentelemetry-api" },
@@ -2997,7 +3041,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3013,7 +3057,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3029,7 +3073,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents-v2"
 version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3044,7 +3088,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -3056,7 +3100,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -3070,7 +3114,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
@@ -3083,7 +3127,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-util-genai"
 version = "0.4b0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -3097,7 +3141,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-util-http"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/d8/7bf5e4cec0578ac3c28c18eb7b88f34279139cbc8c568d6aa02b9c5ae53e/opentelemetry_util_http-0.63b1.tar.gz", hash = "sha256:ba1268f00922ee522dba2ae38458060f99486e7385a8056985901ca9685adfff", size = 11102, upload-time = "2026-05-21T16:36:56.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/f1/34e047e8f6a3c67e5220acf1af7b9f62868c25d77791bca74457bd2180a6/opentelemetry_util_http-0.63b1-py3-none-any.whl", hash = "sha256:6284194028c59cd439f8acfe388145069a6127f11dc077e1344a2094adacc3f8", size = 8205, upload-time = "2026-05-21T16:36:09.736Z" },
@@ -3106,7 +3150,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
@@ -3115,7 +3159,7 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
@@ -3162,7 +3206,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
@@ -3171,7 +3215,7 @@ wheels = [
 [[package]]
 name = "pexpect"
 version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "ptyprocess" },
 ]
@@ -3183,7 +3227,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
@@ -3252,7 +3296,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
@@ -3261,7 +3305,7 @@ wheels = [
 [[package]]
 name = "playwright"
 version = "1.60.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
@@ -3280,7 +3324,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -3289,7 +3333,7 @@ wheels = [
 [[package]]
 name = "pre-commit"
 version = "4.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cfgv" },
     { name = "identify" },
@@ -3305,7 +3349,7 @@ wheels = [
 [[package]]
 name = "prettytable"
 version = "3.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3317,7 +3361,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3329,7 +3373,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
@@ -3423,7 +3467,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
@@ -3438,7 +3482,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
@@ -3466,7 +3510,7 @@ wheels = [
 [[package]]
 name = "psycopg"
 version = "3.3.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
@@ -3484,7 +3528,7 @@ binary = [
 [[package]]
 name = "psycopg-binary"
 version = "3.3.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
     { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
@@ -3524,7 +3568,7 @@ wheels = [
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
@@ -3533,7 +3577,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "24.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
@@ -3576,7 +3620,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
@@ -3585,7 +3629,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -3597,7 +3641,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
@@ -3606,7 +3650,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.13.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -3621,7 +3665,7 @@ wheels = [
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3696,7 +3740,7 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -3710,7 +3754,7 @@ wheels = [
 [[package]]
 name = "pyee"
 version = "13.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3722,7 +3766,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
@@ -3731,7 +3775,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
@@ -3745,7 +3789,7 @@ crypto = [
 [[package]]
 name = "pyparsing"
 version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
@@ -3754,7 +3798,7 @@ wheels = [
 [[package]]
 name = "pyte"
 version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3766,7 +3810,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "9.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -3782,7 +3826,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -3795,7 +3839,7 @@ wheels = [
 [[package]]
 name = "pytest-base-url"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "requests" },
@@ -3808,7 +3852,7 @@ wheels = [
 [[package]]
 name = "pytest-cov"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
@@ -3822,7 +3866,7 @@ wheels = [
 [[package]]
 name = "pytest-playwright"
 version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "playwright" },
     { name = "pytest" },
@@ -3837,7 +3881,7 @@ wheels = [
 [[package]]
 name = "pytest-rerunfailures"
 version = "16.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pytest" },
@@ -3850,7 +3894,7 @@ wheels = [
 [[package]]
 name = "pytest-shard"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -3862,7 +3906,7 @@ wheels = [
 [[package]]
 name = "pytest-timeout"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -3874,7 +3918,7 @@ wheels = [
 [[package]]
 name = "pytest-xdist"
 version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
@@ -3887,7 +3931,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -3899,7 +3943,7 @@ wheels = [
 [[package]]
 name = "python-discovery"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
@@ -3912,7 +3956,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
@@ -3921,7 +3965,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.32"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
@@ -3930,7 +3974,7 @@ wheels = [
 [[package]]
 name = "python-slugify"
 version = "8.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "text-unidecode" },
 ]
@@ -3942,7 +3986,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2026.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
@@ -3951,7 +3995,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "312"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
     { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
@@ -3970,7 +4014,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -3979,7 +4023,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
@@ -4025,7 +4069,7 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
@@ -4039,7 +4083,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2026.5.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
@@ -4127,7 +4171,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.34.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -4141,21 +4185,21 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "13.9.4"
-source = { registry = "https://pypi.org/simple" }
+version = "14.3.4"
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
 name = "rpds-py"
 version = "2026.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
@@ -4265,7 +4309,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.15.16"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
@@ -4290,7 +4334,7 @@ wheels = [
 [[package]]
 name = "s3transfer"
 version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "botocore" },
 ]
@@ -4302,7 +4346,7 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
@@ -4341,7 +4385,7 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -4402,7 +4446,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "jeepney" },
@@ -4415,7 +4459,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -4424,7 +4468,7 @@ wheels = [
 [[package]]
 name = "skops"
 version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
@@ -4440,7 +4484,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
@@ -4449,7 +4493,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -4458,7 +4502,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "2.0.50"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
@@ -4499,7 +4543,7 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
@@ -4508,7 +4552,7 @@ wheels = [
 [[package]]
 name = "sse-starlette"
 version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
@@ -4521,7 +4565,7 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.52.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -4534,7 +4578,7 @@ wheels = [
 [[package]]
 name = "synchronicity"
 version = "0.12.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4546,7 +4590,7 @@ wheels = [
 [[package]]
 name = "tabulate"
 version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
@@ -4555,7 +4599,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
@@ -4564,7 +4608,7 @@ wheels = [
 [[package]]
 name = "text-unidecode"
 version = "1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
@@ -4573,7 +4617,7 @@ wheels = [
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
@@ -4582,7 +4626,7 @@ wheels = [
 [[package]]
 name = "tiktoken"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
@@ -4629,7 +4673,7 @@ wheels = [
 [[package]]
 name = "toml"
 version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
@@ -4638,7 +4682,7 @@ wheels = [
 [[package]]
 name = "tomlkit"
 version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
@@ -4647,7 +4691,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.68.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -4659,7 +4703,7 @@ wheels = [
 [[package]]
 name = "types-certifi"
 version = "2021.10.8.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
@@ -4668,7 +4712,7 @@ wheels = [
 [[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260518"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
@@ -4677,7 +4721,7 @@ wheels = [
 [[package]]
 name = "types-requests"
 version = "2.33.0.20260518"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
@@ -4689,7 +4733,7 @@ wheels = [
 [[package]]
 name = "types-toml"
 version = "0.10.8.20260518"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
@@ -4698,7 +4742,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -4707,7 +4751,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4719,7 +4763,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2026.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
@@ -4728,7 +4772,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
@@ -4737,7 +4781,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.49.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
@@ -4761,7 +4805,7 @@ standard = [
 [[package]]
 name = "uvloop"
 version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
@@ -4793,7 +4837,7 @@ wheels = [
 [[package]]
 name = "virtualenv"
 version = "21.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
@@ -4808,7 +4852,7 @@ wheels = [
 [[package]]
 name = "waitress"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
@@ -4817,7 +4861,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -4901,9 +4945,21 @@ wheels = [
 ]
 
 [[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
@@ -4912,7 +4968,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
@@ -4957,7 +5013,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "3.1.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -4969,7 +5025,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
@@ -5033,7 +5089,7 @@ wheels = [
 [[package]]
 name = "wsproto"
 version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "h11" },
 ]
@@ -5045,7 +5101,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.24.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -5127,7 +5183,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },


### PR DESCRIPTION
Add an E2B (https://e2b.dev) sandbox launcher alongside the existing modal/daytona/cwsandbox/islo providers, supporting both the CLI bootstrap flow (`omnigent sandbox --provider e2b create/connect`) and server-managed hosts (`sandbox.provider: e2b`).

Modeled on the cwsandbox/islo launchers. Every SandboxLauncher primitive maps to the official `e2b` SDK: Sandbox.create/connect/kill for lifecycle, commands.run for commands (catching CommandExitException), files.write for file shipping, and a background command for the foreground attach (with a callback-fed queue, like Islo). supports_local_port_forward stays False (E2B exposes ports outward only), so the in-sandbox App OAuth step is auto-skipped.

Two E2B-specific wrinkles vs. the other providers:
- Boots from a pre-built E2B *template*, not a registry image. The `image`-equivalent config is `sandbox.e2b.template` (an E2B template name); deploy/e2b/README.md documents the one-time `e2b template build` from the host Dockerfile.
- Hard 24h lifetime cap (Pro) with no idle-stop disable: provision requests the 24h max, keep_alive re-extends, and the token TTL mirrors Modal's 25h.

Wiring: registry entry, `omnigent[e2b]` extra + mypy override, server provider sets + parse dispatch + token TTL, frontend label, and the deploy docs. Adds unit tests for the launcher and managed-host config parsing.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
