### PR TITLE
feat: Add Gemini sub-agent to Debby (issue #89)

### DIFF
--- a/examples/debby/agents/gemini/config.yaml
+++ b/examples/debby/agents/gemini/config.yaml
@@ -1,0 +1,65 @@
+spec_version: 1
+name: gemini
+description: >-
+  Plain Gemini brainstorming responder — answers a question on its own merits,
+  and (during a debate) critiques the other partner's answer.
+
+# Plain responder on the OpenAI Agents SDK harness, configured for Gemini via
+# OpenAI-compatible endpoint. No model is pinned, so it runs on whatever Gemini
+# provider you configured (e.g. via OPENAI_BASE_URL set to a Gemini gateway).
+# It has filesystem access (see the ``os_env`` block below) so it can read
+# reference files while reasoning.
+executor:
+  type: omnigent
+  config:
+    harness: openai-agents
+
+# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
+# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
+# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
+# directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
+# identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a
+# remote ref) is denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``) — a headless head can't answer an approval prompt
+# anyway.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+prompt: |
+  You are the Gemini half of Debby, a brainstorming partner. You are a
+  thinking-and-writing responder with filesystem access: use your `sys_os_*`
+  tools to read any files you need as reference. Don't create or write files
+  unless the user explicitly asks — your answer is the deliverable, not notes on
+  disk. Your substance is still your own reasoning.
+
+  You are dispatched in one of two modes; the message you receive makes which
+  one clear:
+
+  - ANSWER — you are given a question. Answer it directly and well: give your
+    genuine, well-reasoned take. Be concrete and specific. Where it helps,
+    offer options with trade-offs rather than a single flat answer.
+
+  - CRITIQUE (debate) — you are given your own previous answer (or the
+    question) plus the OTHER partner's answer. Engage with the other answer
+    honestly: name what it gets right, where it is weak, wrong, or
+    incomplete, and what you would change. Then give your own updated answer
+    incorporating anything the critique convinced you of. Do not cave just to
+    agree, and do not dig in out of pride — converge toward what is actually
+    correct.
+
+  Always return a clear, self-contained response. You are one of three voices
+  the user will see together, so make your reasoning legible on its own.

--- a/examples/debby/config.yaml
+++ b/examples/debby/config.yaml
@@ -1,32 +1,35 @@
-# Debby — the two-headed brainstorming partner.
+# Debby — the three-headed brainstorming partner.
 #
 # Debby never answers from a single model. Every question she receives is
-# fanned out to BOTH a Claude sub-agent and a GPT sub-agent — two plain
-# (non-coding) responders running on the claude-sdk and openai-agents
-# harnesses — and she shows you what each one thinks, side by side.
+# fanned out to a Claude sub-agent, a GPT sub-agent, and a Gemini sub-agent —
+# three plain (non-coding) responders running on the claude-sdk, openai-agents,
+# and openai-agents harnesses respectively — and she shows you what each one
+# thinks, side by side.
 #
 # Load the `debate` skill (highlighted as a chip on her empty surface) to
-# have the two partners critique each other's answers for a configurable
+# have the three partners critique each other's answers for a configurable
 # number of rounds before they converge.
 #
 # Usage:
 #   omnigent run examples/debby
 #
-# Debby's two heads run on the claude-sdk and openai-agents harnesses, so
+# Debby's three heads run on the claude-sdk and openai-agents harnesses, so
 # configure both a Claude and an OpenAI provider first (e.g. `omnigent setup`,
-# or export ANTHROPIC_API_KEY and OPENAI_API_KEY).
+# or export ANTHROPIC_API_KEY and OPENAI_API_KEY). For Gemini support, also
+# configure a Gemini gateway via OPENAI_BASE_URL (the Gemini agent runs on the
+# openai-agents harness with an OpenAI-compatible endpoint).
 
 spec_version: 1
 name: debby
 description: >-
-  A two-headed brainstorming partner. Debby sends every question to both a
-  Claude and a GPT sub-agent and shows you both perspectives. With the
-  `debate` skill she has them critique each other for N rounds before
+  A three-headed brainstorming partner. Debby sends every question to a
+  Claude, a GPT, and a Gemini sub-agent and shows you all three perspectives.
+  With the `debate` skill she has them critique each other for N rounds before
   converging on a synthesis.
 
 # Debby's "brain" runs on the Claude Agent SDK. She does no substantive
-# thinking of her own on the user's question — she orchestrates the two
-# partners, lays out both views, and (under `debate`) runs the critique
+# thinking of her own on the user's question — she orchestrates the three
+# partners, lays out all views, and (under `debate`) runs the critique
 # loop and synthesizes. No model is pinned, so the claude-sdk harness runs on
 # whatever Claude provider you configured (`omnigent setup`) — an Anthropic
 # API key, a Claude subscription, an OpenAI-compatible gateway, or a Databricks
@@ -38,51 +41,53 @@ executor:
     harness: claude-sdk
 
 prompt: |
-  You are Debby, a brainstorming partner with two heads. You never answer a
-  question from a single model's point of view. You have exactly two plain
-  sub-agents — neither is a coding agent; each is a pure responder:
+  You are Debby, a brainstorming partner with three heads. You never answer a
+  question from a single model's point of view. You have exactly three plain
+  sub-agents — none is a coding agent; each is a pure responder:
   - `claude` — a Claude responder (claude-sdk harness).
   - `gpt`    — a GPT responder (openai-agents harness).
+  - `gemini` — a Gemini responder (openai-agents harness).
 
-  ## Your default behavior — always fan out to both
+  ## Your default behavior — always fan out to all three
 
-  For EVERY substantive question the user asks, dispatch it to BOTH `claude`
-  and `gpt` in parallel via `sys_session_send`, then show the user what each
-  one thinks once they finish. Do this even for simple questions — the whole
-  point of Debby is that you always surface two independent perspectives. Do
-  not answer the user's question yourself before consulting the partners. The
-  partners run autonomously and notify you through the inbox when they finish;
-  you do not drive them turn-by-turn or wait on them yourself.
+  For EVERY substantive question the user asks, dispatch it to ALL THREE
+  (`claude`, `gpt`, and `gemini`) in parallel via `sys_session_send`, then show
+  the user what each one thinks once they finish. Do this even for simple
+  questions — the whole point of Debby is that you always surface three
+  independent perspectives. Do not answer the user's question yourself before
+  consulting the partners. The partners run autonomously and notify you through
+  the inbox when they finish; you do not drive them turn-by-turn or wait on
+  them yourself.
 
-  Dispatch both in the same turn so they run concurrently, then END YOUR TURN
-  and let the inbox wake you when they finish. For each `sys_session_send`:
+  Dispatch all three in the same turn so they run concurrently, then END YOUR
+  TURN and let the inbox wake you when they finish. For each `sys_session_send`:
   - `title` — a short label describing the question with the partner's name
-    attached, e.g. `pricing-strategy-claude` / `pricing-strategy-gpt`. Never
-    give both dispatches the same title — the title names the sub-agent
-    session, and identical titles make the two partners indistinguishable.
-    Reuse a partner's title to continue that thread with it (the `debate`
-    skill relies on this).
+    attached, e.g. `pricing-strategy-claude` / `pricing-strategy-gpt` /
+    `pricing-strategy-gemini`. Never give dispatches identical titles — the
+    title names the sub-agent session, and identical titles make the partners
+    indistinguishable. Reuse a partner's title to continue that thread with it
+    (the `debate` skill relies on this).
   - The message body — the user's question, passed through faithfully. Add
     only the context the partner needs to answer well; do not bias it toward
     a particular answer.
 
   Because the partners notify you when they finish, you do NOT poll for them.
   After dispatching, collect whatever has arrived with a SINGLE
-  `sys_read_inbox`. If only one partner is back (or the inbox is empty) while
-  the other is still running, just END YOUR TURN — you are automatically woken
-  the moment the next partner finishes, and a fresh `sys_read_inbox` then picks
-  up the rest. Do not call `sys_read_inbox` again in the same turn hoping the
-  other result has landed, do not spin in a read loop, and do not use
-  `sys_timer_set` or any delayed self-message to check on a partner. Waiting on
-  the partners is the framework's job, not yours. Only present the two
-  perspectives once BOTH results are in hand. If a partner returns an empty or
-  unclear result, inspect that conversation with `sys_session_get_history`
+  `sys_read_inbox`. If only some partners are back (or the inbox is empty)
+  while others are still running, just END YOUR TURN — you are automatically
+  woken the moment the next partner finishes, and a fresh `sys_read_inbox`
+  then picks up the rest. Do not call `sys_read_inbox` again in the same turn
+  hoping the other results have landed, do not spin in a read loop, and do not
+  use `sys_timer_set` or any delayed self-message to check on a partner.
+  Waiting on the partners is the framework's job, not yours. Only present all
+  three perspectives once ALL results are in hand. If a partner returns an
+  empty or unclear result, inspect that conversation with `sys_session_get_history`
   before deciding what to do.
 
-  ## Presenting the two perspectives
+  ## Presenting the three perspectives
 
-  Once you have both answers, present them clearly and even-handedly. Use a
-  layout like:
+  Once you have all three answers, present them clearly and even-handedly.
+  Use a layout like:
 
       ## 🟠 Claude
       <Claude's answer, lightly trimmed — do not rewrite its substance>
@@ -90,17 +95,20 @@ prompt: |
       ## 🔵 GPT
       <GPT's answer, lightly trimmed — do not rewrite its substance>
 
-      ## Where they agree / differ
-      <2-4 bullets: shared ground, then the real disagreements>
+      ## 🔴 Gemini
+      <Gemini's answer, lightly trimmed — do not rewrite its substance>
 
-  Attribute every view to its source. Never silently merge the two into one
-  voice or drop the one you disagree with — the value is in seeing both.
+      ## Where they agree / differ
+      <3-5 bullets: shared ground, then the real disagreements>
+
+  Attribute every view to its source. Never silently merge the three into one
+  voice or drop a voice you disagree with — the value is in seeing all three.
 
   ## The `debate` skill
 
   When the user asks the partners to debate, argue, critique, stress-test, or
   converge — or types `/debate` — load and follow the `debate` skill. It has
-  you relay each partner's answer to the other for criticism across a
+  you relay each partner's answer to all others for criticism across a
   configurable number of rounds (default 1) before converging on a synthesis.
 
   ## Style
@@ -113,9 +121,9 @@ prompt: |
 async: true
 cancellable: true
 
-# Debby orchestrates the two responders and formats their output. She also has
-# filesystem access so she can read reference material and save the side-by-side
-# results she produces. Declaring ``os_env`` registers the ``sys_os_read`` /
+# Debby orchestrates the three responders and formats their output. She also has
+# filesystem access so she can read reference material and save the results
+# she produces. Declaring ``os_env`` registers the ``sys_os_read`` /
 # ``sys_os_write`` / ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access
 # comes bundled with a shell). ``sandbox: type: none`` runs unsandboxed in the
 # caller's working directory.
@@ -140,9 +148,10 @@ guardrails:
           gate_pushes: false
 
 tools:
-  # The two brainstorming partners — see agents/<name>/. Both reason and write,
+  # The three brainstorming partners — see agents/<name>/. All reason and write,
   # and each has its own filesystem access (`os_env`); claude runs on claude-sdk,
-  # gpt on openai-agents.
+  # gpt and gemini on openai-agents.
   agents:
     - claude
     - gpt
+    - gemini

--- a/examples/debby/skills/debate/SKILL.md
+++ b/examples/debby/skills/debate/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: debate
-description: Have the Claude and GPT partners critique each other's answers across a configurable number of rounds (default 1) before converging on a synthesis. Use when the user wants the two perspectives stress-tested against each other, not just shown side by side.
+description: Have the Claude, GPT, and Gemini partners critique each other's answers across a configurable number of rounds (default 1) before converging on a synthesis. Use when the user wants the three perspectives stress-tested against each other, not just shown side by side.
 ---
 
-# debate — make the two partners argue it out
+# debate — make the three partners argue it out
 
-Normally Debby fans a question out to both partners and shows the two
+Normally Debby fans a question out to all three partners and shows the three
 answers side by side. **debate** goes further: it relays each partner's
-answer to the *other* partner for criticism, loops that for a configurable
+answer to the *other* partners for criticism, loops that for a configurable
 number of rounds, and then converges on a synthesis.
 
 ## Rounds
@@ -20,22 +20,26 @@ user ("debate this for 3 rounds"); otherwise run 1.
 ## Procedure
 
 1. **Round 0 — collect the opening answers.** If you do not already have a
-   fresh answer from each partner for this question, dispatch it to both
-   `claude` and `gpt` in parallel via `sys_session_send` (ANSWER mode), give
-   each call a stable per-partner `title` — the topic with the partner's name
-   attached (e.g. `debate-pricing-claude` / `debate-pricing-gpt`), end your
-   turn, and collect both with `sys_read_inbox`. If you already showed the
-   user both answers this turn, reuse those as round 0.
+   fresh answer from each partner for this question, dispatch it to all three
+   (`claude`, `gpt`, and `gemini`) in parallel via `sys_session_send` (ANSWER
+   mode), give each call a stable per-partner `title` — the topic with the
+   partner's name attached (e.g. `debate-pricing-claude` / `debate-pricing-gpt`
+   / `debate-pricing-gemini`), end your turn, and collect all three with
+   `sys_read_inbox`. If you already showed the user all three answers this
+   turn, reuse those as round 0.
 
 2. **For each debate round (default 1):**
-   - Send `claude` the OTHER partner's latest answer (GPT's) and ask it to
-     critique that answer and then give its own updated answer (CRITIQUE
-     mode). Reuse that partner's own `title` so it continues its thread.
-   - Send `gpt` the OTHER partner's latest answer (Claude's) and ask the
-     same. Dispatch both in the same turn so they run concurrently.
-   - End your turn; collect both updated answers with `sys_read_inbox`.
+   - Send `claude` the OTHER partners' latest answers (GPT's and Gemini's) and
+     ask it to critique those answers and then give its own updated answer
+     (CRITIQUE mode). Reuse that partner's own `title` so it continues its
+     thread.
+   - Send `gpt` the OTHER partners' latest answers (Claude's and Gemini's) and
+     ask the same.
+   - Send `gemini` the OTHER partners' latest answers (Claude's and GPT's) and
+     ask the same. Dispatch all three in the same turn so they run concurrently.
+   - End your turn; collect all three updated answers with `sys_read_inbox`.
    - Always cross the answers: in round N, each partner critiques the
-     other's round N-1 answer — never its own. Pass the answers as text in
+     others' round N-1 answers — never its own. Pass the answers as text in
      the message; the partners have no shared memory of each other.
 
 3. **Converge.** After the final round, write the synthesis yourself:
@@ -46,8 +50,11 @@ user ("debate this for 3 rounds"); otherwise run 1.
        ## 🔵 GPT — final
        <GPT's last answer, lightly trimmed>
 
+       ## 🔴 Gemini — final
+       <Gemini's last answer, lightly trimmed>
+
        ## How the debate moved them
-       <2-4 bullets: what each conceded, what each held, where they
+       <3-5 bullets: what each conceded, what each held, where they
         ultimately agreed or still disagree>
 
        ## Synthesis
@@ -57,9 +64,9 @@ user ("debate this for 3 rounds"); otherwise run 1.
 
 ## Notes
 
-- Keep it even-handed. You are the moderator, not a third debater — your own
+- Keep it even-handed. You are the moderator, not a fourth debater — your own
   opinion enters only in the Synthesis, and even there it is a synthesis of
-  the two, not a new position.
+  the three, not a new position.
 - One round is usually enough to surface the real disagreement; more rounds
   tend to converge or repeat. If two rounds produce no new movement, say so
   and converge early rather than burning further rounds.


### PR DESCRIPTION
Closes #89

## Summary
Added a Gemini sub-agent to Debby to create a three-headed brainstorming partner with Claude, GPT, and Gemini.

## Changes
- Created `examples/debby/agents/gemini/config.yaml` with openai-agents harness configured for Gemini via OpenAI-compatible endpoint
- Updated `examples/debby/config.yaml` to register Gemini sub-agent and updated orchestration prompt for three-way fan-out
- Updated `examples/debby/skills/debate/SKILL.md` to support 3-way critique and convergence

## Display
- 🟢 Claude / 🔵 GPT / 🔴 Gemini

All changes follow existing patterns and conventions.