### PR TITLE
test: cover residual untested backend helpers

### DIFF
--- a/tests/runner/test_codex_native_launch_config.py
+++ b/tests/runner/test_codex_native_launch_config.py
@@ -1,0 +1,135 @@
+"""Tests for ``_codex_native_launch_config`` in ``omnigent/runner/app.py``.
+
+The runner fetches a session snapshot over HTTP and validates it before
+launching a runner-owned Codex terminal. Each malformed field is meant to
+fail loud with a RuntimeError rather than launch Codex with garbage; those
+guards were previously unexercised by any direct test. These tests drive the
+function with a stub async client returning controlled snapshots.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner.app import _codex_native_launch_config
+
+
+class _Resp:
+    """Minimal stand-in for an httpx response carrying a fixed status + payload."""
+
+    def __init__(self, status_code: int, payload: Any, *, json_raises: bool = False) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self._json_raises = json_raises
+
+    def json(self) -> Any:
+        if self._json_raises:
+            raise ValueError("not json")
+        return self._payload
+
+
+class _Client:
+    """Async client stub whose ``get`` returns a fixed response or raises."""
+
+    def __init__(self, resp: _Resp | None = None, raise_exc: Exception | None = None) -> None:
+        self._resp = resp
+        self._raise_exc = raise_exc
+
+    async def get(self, url: str, timeout: float | None = None) -> _Resp:
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        assert self._resp is not None
+        return self._resp
+
+
+async def _run(client: _Client | None, session_id: str = "conv_1") -> Any:
+    return await _codex_native_launch_config(session_id=session_id, server_client=client)
+
+
+@pytest.mark.asyncio
+async def test_missing_client_raises() -> None:
+    """No server client means there is no way to fetch config — fail loud."""
+    with pytest.raises(RuntimeError, match="server_client is required"):
+        await _run(None)
+
+
+@pytest.mark.asyncio
+async def test_http_error_raises() -> None:
+    """A transport error fetching the snapshot surfaces as a RuntimeError."""
+    client = _Client(raise_exc=httpx.ConnectError("boom"))
+    with pytest.raises(RuntimeError, match="Could not fetch Codex launch config"):
+        await _run(client)
+
+
+@pytest.mark.asyncio
+async def test_non_200_raises() -> None:
+    """A non-200 status is rejected and names the status in the error."""
+    client = _Client(_Resp(404, None))
+    with pytest.raises(RuntimeError, match="returned 404"):
+        await _run(client)
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_raises() -> None:
+    """A body that does not parse as JSON is rejected."""
+    client = _Client(_Resp(200, None, json_raises=True))
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        await _run(client)
+
+
+@pytest.mark.asyncio
+async def test_non_dict_snapshot_raises() -> None:
+    """A JSON array (not an object) is not a valid session snapshot."""
+    client = _Client(_Resp(200, ["not", "a", "dict"]))
+    with pytest.raises(RuntimeError, match="not a JSON object"):
+        await _run(client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("terminal_launch_args", "not-a-list", "terminal_launch_args"),
+        ("terminal_launch_args", [1, 2], "terminal_launch_args"),
+        ("model_override", "", "model_override"),
+        ("model_override", 5, "model_override"),
+        ("external_session_id", "", "external_session_id"),
+        ("workspace", "", "workspace"),
+    ],
+)
+async def test_invalid_field_raises(field: str, value: Any, match: str) -> None:
+    """Each malformed optional field is rejected with a field-specific error."""
+    client = _Client(_Resp(200, {field: value}))
+    with pytest.raises(RuntimeError, match=match):
+        await _run(client)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_parses_full_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A well-formed snapshot (with fork labels) parses into a launch config."""
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8123")
+    snapshot = {
+        "workspace": "/tmp/repo",
+        "terminal_launch_args": ["--config", "approval_policy=on-request"],
+        "model_override": "gpt-5.4-mini",
+        "external_session_id": "thread_abc",
+        "labels": {
+            "omnigent.fork.source_id": "conv_source",
+            "omnigent.fork.source_external_session_id": "thread_src",
+            "omnigent.fork.carry_history": "1",
+        },
+    }
+    cfg = await _run(_Client(_Resp(200, snapshot)))
+    assert cfg.policy_server_url == "http://127.0.0.1:8123"
+    assert cfg.terminal_launch_args == ["--config", "approval_policy=on-request"]
+    assert cfg.model_override == "gpt-5.4-mini"
+    assert cfg.external_session_id == "thread_abc"
+    assert cfg.fork_source_id == "conv_source", "Fork source id should be read from labels."
+    assert cfg.fork_source_external_id == "thread_src"
+    assert cfg.fork_carry_history is True, "carry_history label '1' should parse to True."
+    assert cfg.workspace.name == "repo", (
+        f"Workspace path should resolve from snapshot, got {cfg.workspace}."
+    )

--- a/tests/runtime/test_fetch_all_items.py
+++ b/tests/runtime/test_fetch_all_items.py
@@ -1,0 +1,96 @@
+"""Tests for ``fetch_all_items`` in ``omnigent/runtime/workflow.py``.
+
+``fetch_all_items`` drains a conversation by paginating ``list_items`` until
+``has_more`` is False, advancing the cursor to each page's ``last_id``. That
+cursor-advancement invariant is position-ordering logic that a full workflow
+integration test exercises only incidentally, so it gets a focused unit test
+here with a store stub that hands back controlled pages.
+"""
+
+from __future__ import annotations
+
+from omnigent.entities.conversation import ConversationItem, MessageData
+from omnigent.entities.pagination import PagedList
+from omnigent.runtime.workflow import fetch_all_items
+
+
+def _item(item_id: str) -> ConversationItem:
+    """Build a minimal persisted message item with the given id."""
+    return ConversationItem(
+        id=item_id,
+        type="message",
+        status="completed",
+        response_id="resp_1",
+        created_at=0,
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+    )
+
+
+class _PagedStore:
+    """A ConversationStore stub that returns pre-queued pages from ``list_items``.
+
+    Records the ``after`` cursor of each call so the test can assert the loop
+    advances the cursor to the prior page's ``last_id`` rather than re-querying
+    from the same position.
+    """
+
+    def __init__(self, pages: list[PagedList[ConversationItem]]) -> None:
+        self._pages = pages
+        self.after_calls: list[str | None] = []
+
+    def list_items(
+        self,
+        conversation_id: str,
+        limit: int = 100,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "asc",
+        type: str | None = None,
+    ) -> PagedList[ConversationItem]:
+        self.after_calls.append(after)
+        return self._pages.pop(0)
+
+
+def test_fetches_a_single_page_without_advancing() -> None:
+    """A lone page with ``has_more=False`` returns its items and stops after one call."""
+    store = _PagedStore([PagedList(data=[_item("a"), _item("b")], last_id="b", has_more=False)])
+    result = fetch_all_items(store, "conv_1")
+    assert [i.id for i in result] == ["a", "b"], "Single page items should pass through in order."
+    assert store.after_calls == [None], (
+        "One page means exactly one list_items call, starting at None."
+    )
+
+
+def test_paginates_until_has_more_is_false() -> None:
+    """Items from every page are concatenated in order and the cursor chases ``last_id``."""
+    store = _PagedStore(
+        [
+            PagedList(data=[_item("a"), _item("b")], last_id="b", has_more=True),
+            PagedList(data=[_item("c"), _item("d")], last_id="d", has_more=True),
+            PagedList(data=[_item("e")], last_id="e", has_more=False),
+        ]
+    )
+    result = fetch_all_items(store, "conv_1")
+    assert [i.id for i in result] == ["a", "b", "c", "d", "e"], (
+        "All pages should be drained into one chronological list."
+    )
+    # Each successive call advances to the previous page's last_id.
+    assert store.after_calls == [None, "b", "d"], (
+        f"Cursor must chase each page's last_id, got {store.after_calls!r}."
+    )
+
+
+def test_honors_initial_after_cursor() -> None:
+    """The starting ``after`` cursor is passed through to the first query."""
+    store = _PagedStore([PagedList(data=[_item("z")], last_id="z", has_more=False)])
+    fetch_all_items(store, "conv_1", after="msg_start")
+    assert store.after_calls[0] == "msg_start", (
+        "The initial cursor must reach the first list_items call."
+    )
+
+
+def test_empty_conversation_returns_empty_list() -> None:
+    """An empty first page yields no items and a single query."""
+    store = _PagedStore([PagedList(data=[], last_id=None, has_more=False)])
+    assert fetch_all_items(store, "conv_1") == [], "An empty conversation should drain to []."
+    assert store.after_calls == [None]

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -1,0 +1,85 @@
+"""Tests for the built-in agent bundle builders in ``omnigent/server/app.py``.
+
+The server seeds Web-UI-launchable agents (claude-native, codex-native, and
+the shipped ``debby`` / ``polly`` examples) by materializing each spec into a
+gzipped tarball at startup. These builders were previously exercised only
+transitively by the agents' e2e suites; a packaging regression (a dropped
+``config.yaml``, a spec that no longer materializes) would surface late and
+slow. These unit tests build each bundle directly and assert it is a valid,
+reproducible tarball containing the expected spec entry.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+
+import pytest
+
+from omnigent.server import app
+
+# (builder attribute, the spec entry that proves the bundle was assembled,
+# whether the source is a shipped example that a stripped deployment may omit)
+_BUILDERS = [
+    ("_build_claude_native_bundle", "claude-native-ui.yaml", False),
+    ("_build_codex_native_bundle", "codex-native-ui.yaml", False),
+    ("_build_debby_bundle", "config.yaml", True),
+    ("_build_polly_bundle", "config.yaml", True),
+]
+
+
+def _shipped_example_missing(builder: str) -> bool:
+    """Return True when ``builder``'s shipped-example source is not packaged here.
+
+    debby/polly are only seeded when their bundle ships with the wheel; a
+    generic deployment legitimately omits them. Skip rather than fail there.
+    """
+    source = {
+        "_build_debby_bundle": app._DEBBY_BUNDLE_SOURCE,
+        "_build_polly_bundle": app._POLLY_BUNDLE_SOURCE,
+    }[builder]
+    return not (source / "config.yaml").is_file()
+
+
+def _tar_members(blob: bytes) -> list[str]:
+    """Return the regular-file member names inside a gzipped tarball."""
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+        return [m.name for m in tf.getmembers() if m.isfile()]
+
+
+@pytest.mark.parametrize(("builder", "spec_entry", "shipped_example"), _BUILDERS)
+def test_bundle_builder_produces_valid_tarball(
+    builder: str, spec_entry: str, shipped_example: bool
+) -> None:
+    """Each builder returns a gzip tarball that contains the agent's spec file."""
+    if shipped_example and _shipped_example_missing(builder):
+        pytest.skip(f"{builder} source not packaged in this deployment")
+
+    blob = getattr(app, builder)()
+    assert blob, f"{builder} returned empty bytes."
+    # Must be a real gzip stream, not just arbitrary bytes.
+    assert gzip.decompress(blob), f"{builder} output is not valid gzip."
+
+    members = _tar_members(blob)
+    # arcname='.' prefixes every member with './'; match on the trailing path.
+    assert any(m.lstrip("./") == spec_entry or m.endswith("/" + spec_entry) for m in members), (
+        f"{builder} tarball is missing its spec entry {spec_entry!r}; members={members!r}."
+    )
+
+
+@pytest.mark.parametrize(("builder", "spec_entry", "shipped_example"), _BUILDERS)
+def test_bundle_builder_is_reproducible(
+    builder: str, spec_entry: str, shipped_example: bool
+) -> None:
+    """Two builds yield byte-identical tarballs (the builders are content-addressable).
+
+    Reproducibility is what lets the startup seeder refresh a row in place only
+    when the spec actually changed; a non-deterministic build would re-seed on
+    every restart.
+    """
+    if shipped_example and _shipped_example_missing(builder):
+        pytest.skip(f"{builder} source not packaged in this deployment")
+
+    fn = getattr(app, builder)
+    assert fn() == fn(), f"{builder} is not byte-for-byte reproducible across builds."


### PR DESCRIPTION
## Summary

Closes the few function-level coverage gaps left after the recent backend coverage push. Each target was previously exercised only indirectly (via slow, key-gated e2e or not at all); these add fast, direct unit tests.

- `server/app.py` bundle builders (`_build_claude_native_bundle`, `_build_codex_native_bundle`, `_build_debby_bundle`, `_build_polly_bundle`): assert each produces a valid, reproducible gzip tarball containing the agent's spec entry — catches a packaging regression (dropped `config.yaml`, spec that no longer materializes) without spinning up a server. The shipped-example builders (debby/polly) skip when their bundle is not packaged in the deployment.
- `runtime/workflow.py::fetch_all_items`: a focused unit test of the pagination cursor-advancement invariant (the loop chases each page's `last_id` until `has_more` is false), driven by a store stub with controlled pages.
- `runner/app.py::_codex_native_launch_config`: exercises every fail-loud validation branch (missing client, transport error, non-200, invalid JSON, non-dict snapshot, malformed `terminal_launch_args`/`model_override`/`external_session_id`/`workspace`) plus the happy path including fork-label parsing, via a stub async client.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Three new test files add 24 tests covering the named helpers directly. Ran `pytest tests/server/test_builtin_bundles.py tests/runtime/test_fetch_all_items.py tests/runner/test_codex_native_launch_config.py` (24 passed) plus `ruff format --check` / `ruff check` clean.