### PR TITLE
test(e2e_ui): cover approval cards, inbox approvals, and the permissions modal

### DIFF
--- a/tests/e2e_ui/COVERAGE_GAPS.md
+++ b/tests/e2e_ui/COVERAGE_GAPS.md
@@ -1,0 +1,54 @@
+# E2E UI Test Coverage Gaps
+
+Cross-reference of user-facing features reachable from `ap-web/` against the
+existing Playwright suite under `tests/e2e_ui/`. The suite (57 files) covers the
+core journeys well — chat, sessions sidebar, files, comments, collaboration,
+render parity, fork, shells, mobile, and start-session. The items below are
+features that currently have **no e2e coverage**.
+
+## High-priority gaps (core, user-visible, untested)
+
+Status legend: ✅ now covered · ⬜ still open.
+
+| Status | Feature | Where it lives | Coverage |
+|---|---|---|---|
+| ✅ | **Approvals (in-chat card)** | `blocks/ApprovalCard.tsx` | `approvals/test_approval_card.py` — gated `git push` (blast_radius ASK) → pending card → Approve/Reject → responded state + server drains the parked prompt. New `approval_session` fixture in `conftest.py`. |
+| ✅ | **Inbox approvals** | `pages/InboxPage.tsx`, `blocks/ApprovalCard.tsx` | `approvals/test_inbox_approval.py` — pending prompt surfaces on `/inbox`, Approve there, item drains. |
+| ✅ | **Permissions modal (full surface)** | `components/PermissionsModal.tsx` | `collaboration/test_permissions_modal.py` — public toggle, copy-link, add-user grant, per-row level change, revoke; each pinned to `/permissions` REST state. (This is the "separate follow-up test" the sharing-journey docstring calls out.) |
+| ⬜ | **Exit Plan Mode review** | `blocks/ExitPlanModeReview.tsx` | Claude-native only (built-in `ExitPlanMode` tool). Needs a native-Claude session fixture (nightly, like the render-parity suites). Not yet implemented. |
+| ⬜ | **AskUserQuestion form** | `blocks/AskUserQuestionForm.tsx` | Claude-native built-in `AskUserQuestion`. Same native-session prerequisite as Exit Plan Mode. The binary-approval card is now covered; the structured-form variant is not. |
+| ⬜ | **Standalone `/approve/<id>` URL flow** | `pages/ApprovePage.tsx` | URL-mode elicitation (external approval page). Needs an elicitation published with a `url`. Not yet implemented. |
+| ⬜ | **Agent info / MCP / policies popover** | `components/AgentInfo.tsx` | MCP server badges, token/cost display, add/delete policy on a session — untested. |
+| ⬜ | **Add subagent dialog** | `shell/SubagentsPanel.tsx`, `shell/AddAgentDialog.tsx` | Navigation to subagents is tested; *spawning* one from the dialog is not. |
+
+## Medium-priority gaps
+
+| Feature | Where it lives |
+|---|---|
+| **Slash command menu** | `components/SlashCommandMenu.tsx` — typing `/` to autocomplete skills/commands |
+| **File/image attachments, paste, screenshot** | `ai-elements/prompt-input.tsx`, `attachments.tsx` — composer attachment flows |
+| **Model selector / cost-routing control** in composer | `ai-elements/model-selector.tsx`, `components/CostRoutingControl.tsx` |
+| **Code editing in Monaco / diff viewer** | `shell/MonacoCodeEditor.tsx`, `MonacoDiffViewer.tsx` — autosave is tested but diff view + direct edit isn't |
+| **Execution logs panel** | `shell/ExecutionLogsPanel.tsx` — raw JSON items + sub-agent log selector |
+| **Reconnect / resume-with-directory dialogs** | `shell/ReconnectSessionDialog.tsx`, `shell/ResumeWithDirectoryDialog.tsx` |
+| **Account menu / theme toggle** | `shell/AccountMenu.tsx`, `theme/ThemeModeMenu.tsx` |
+| **Prompt history (arrow-key recall)** | `hooks/usePromptHistory.ts` |
+| **Session archive/unarchive** | `shell/Sidebar.tsx` — pin/unpin/delete/rename tested, archive not |
+
+## Lower-priority / admin & auth gaps
+
+| Feature | Where it lives |
+|---|---|
+| **Admin: Members page** (invite, password reset, delete user) | `pages/MembersPage.tsx` |
+| **Admin: Policies page** | `pages/PoliciesPage.tsx` |
+| **Auth: Login / Register / Setup** | `pages/LoginPage.tsx`, `RegisterPage.tsx`, `SetupPage.tsx` |
+| **Voice/audio input** (mic button, transcription, audio player) | `ComposerMicButton.tsx`, `ai-elements/{transcription,audio-player,voice-selector}.tsx` |
+| **Rich message blocks** (web-preview, JSX preview, chain-of-thought, test-results, etc.) | `ai-elements/*` |
+| **Panel resize handles** | `hooks/useResizable{Panel,Sidebar,CommentsPanel}.ts` |
+
+## Well-covered areas (no action needed)
+
+Sidebar ops, fork/clone, comments (add/edit/delete/inbox/realtime/markdown+monaco
+editors), collaboration presence & realtime, render parity across 3 harnesses,
+mobile FAB/drawer, start-session config (permission mode, harness, worktree,
+folder).

--- a/tests/e2e_ui/approvals/test_approval_card.py
+++ b/tests/e2e_ui/approvals/test_approval_card.py
@@ -1,0 +1,105 @@
+"""E2E: an in-chat approval prompt renders and resolves.
+
+When a tool call trips a policy that returns ASK, the runner forwards the
+gate to the server, which publishes a ``response.elicitation_request`` the
+chat renders as an ``ApprovalCard`` (``ap-web/src/components/blocks/
+ApprovalCard.tsx``). This test drives the full loop on the openai-agents
+harness: send a turn that makes the agent attempt a gated ``git push``,
+wait for the pending card, click **Approve**, and assert the card flips to
+its "Approved" responded state and the server clears the pending prompt.
+
+The ``approval_session`` fixture (conftest) supplies an agent whose
+``blast_radius`` guardrail gates pushes; the gate fires on the *tool call*,
+so the push never has to succeed. Real LLM in the loop → nightly + a
+generous timeout, matching the other agent-driven UI suites.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+
+# The agent must boot, take a turn, and emit the gated tool call before the
+# card appears — cold-start can be slow, so allow well past the streaming
+# default but under the test's 600s ceiling.
+_AGENT_TURN_TIMEOUT_MS = 120_000
+
+
+def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
+    """Return the session snapshot's pending elicitation events (owner view)."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("pending_elicitations") or []
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(600)
+def test_approval_card_renders_and_approves(
+    page: Page,
+    approval_session: tuple[str, str],
+) -> None:
+    """Gated tool call → pending approval card → Approve → resolved."""
+    base_url, session_id = approval_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Run the command now.")
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    # The agent calls the gated push; the policy ASK surfaces a pending card.
+    card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+    expect(card).to_be_visible(timeout=_AGENT_TURN_TIMEOUT_MS)
+    expect(card.get_by_text("Approval required")).to_be_visible()
+    # The server is genuinely parked on this prompt, not just an optimistic UI.
+    assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
+
+    card.get_by_role("button", name="Approve").click()
+
+    # Card transitions to the responded "Approved" state and the parked
+    # server-side prompt drains.
+    responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
+    expect(responded).to_be_visible(timeout=30_000)
+    expect(responded.get_by_text("Approved", exact=False).first).to_be_visible()
+    _wait_for(lambda: not _pending_elicitations(base_url, session_id))
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(600)
+def test_approval_card_reject(
+    page: Page,
+    approval_session: tuple[str, str],
+) -> None:
+    """Rejecting a pending approval flips the card to the rejected state."""
+    base_url, session_id = approval_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Run the command now.")
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+    expect(card).to_be_visible(timeout=_AGENT_TURN_TIMEOUT_MS)
+    card.get_by_role("button", name="Reject").click()
+
+    responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
+    expect(responded).to_be_visible(timeout=30_000)
+    expect(responded.get_by_text("Rejected", exact=False).first).to_be_visible()
+    _wait_for(lambda: not _pending_elicitations(base_url, session_id))
+
+
+def _wait_for(predicate, *, timeout_s: float = 15.0, interval_s: float = 0.25) -> None:
+    """Poll *predicate* until truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise AssertionError("condition not met within timeout")

--- a/tests/e2e_ui/approvals/test_inbox_approval.py
+++ b/tests/e2e_ui/approvals/test_inbox_approval.py
@@ -1,0 +1,80 @@
+"""E2E: a pending approval surfaces on the /inbox page and resolves there.
+
+The Inbox page (``ap-web/src/pages/InboxPage.tsx``) gathers every pending
+``response.elicitation_request`` across the user's sessions and renders each
+as the same ``ApprovalCard`` the chat uses, with a local submit handler that
+posts the verdict to the owning session. This test raises a gated-push
+approval in a session, navigates to ``/inbox``, asserts the prompt is listed,
+approves it from the inbox, and asserts the item drains (the row's pending
+count drops to zero, so it falls out of the inbox).
+
+Driven by the same ``approval_session`` fixture as the in-chat card test;
+real LLM → nightly + generous timeout.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+_INBOX_ITEM = '[data-testid="inbox-item"]'
+_AGENT_TURN_TIMEOUT_MS = 120_000
+
+
+def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
+    """Return the session snapshot's pending elicitation events (owner view)."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("pending_elicitations") or []
+
+
+def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) -> None:
+    """Poll *predicate* until truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise AssertionError("condition not met within timeout")
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(600)
+def test_pending_approval_surfaces_and_resolves_in_inbox(
+    page: Page,
+    approval_session: tuple[str, str],
+) -> None:
+    """Gated tool call → /inbox lists the prompt → Approve there → it drains."""
+    base_url, session_id = approval_session
+
+    # Raise the approval from the chat surface, then leave it pending.
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Run the command now.")
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first).to_be_visible(
+        timeout=_AGENT_TURN_TIMEOUT_MS
+    )
+    # Confirm the server is parked before we navigate away.
+    _wait_for(lambda: bool(_pending_elicitations(base_url, session_id)))
+
+    # The inbox gathers the prompt from the session's snapshot.
+    page.goto(f"{base_url}/inbox")
+    item = page.locator(_INBOX_ITEM).first
+    expect(item).to_be_visible(timeout=30_000)
+    card = item.locator(_APPROVAL_CARD)
+    expect(card).to_be_visible()
+    expect(card.get_by_text("Approval required")).to_be_visible()
+
+    # Approve from the inbox: the verdict routes to the owning session, the
+    # server drains the prompt, and the row's pending count drops to zero so
+    # the item falls out of the inbox.
+    card.get_by_role("button", name="Approve").click()
+    _wait_for(lambda: not _pending_elicitations(base_url, session_id))
+    expect(page.locator(_INBOX_ITEM)).to_have_count(0, timeout=30_000)

--- a/tests/e2e_ui/collaboration/test_permissions_modal.py
+++ b/tests/e2e_ui/collaboration/test_permissions_modal.py
@@ -1,0 +1,128 @@
+"""UI: the Share / permissions modal interactions themselves.
+
+The sharing-journey test (``test_sharing_journey.py``) issues every grant
+through the REST API and only asserts what each identity *sees*; its
+docstring calls out the share-modal UI interaction as "a separate
+follow-up test". This is that test: it drives the modal's own controls
+(``PermissionsModal.tsx``) — the public-access switch, the copy-link
+button, the add-user grant form, the per-row level select, and revoke —
+and pins each one against the server's ``/permissions`` state so a
+silently-broken control can't pass.
+
+Single owner identity (the headerless ``local`` user, same as every other
+e2e_ui context), so no second browser is needed: every assertion is on the
+owner's own modal plus a REST read-back. No agent run — the modal only
+needs a session to exist.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+
+import httpx
+from playwright.sync_api import Page, expect
+
+# ``__public__`` is the synthetic user id the server stores for a public
+# grant (mirrors ``PUBLIC_USER`` in PermissionsModal.tsx).
+_PUBLIC_USER = "__public__"
+_LEVEL_READ = 1
+_LEVEL_EDIT = 2
+
+
+def _permissions(base_url: str, session_id: str) -> dict[str, int]:
+    """Read the session's grants as a ``{user_id: level}`` map (owner view)."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/permissions", timeout=10.0)
+    resp.raise_for_status()
+    return {p["user_id"]: p["level"] for p in resp.json()}
+
+
+def _wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 10.0,
+    interval_s: float = 0.25,
+) -> None:
+    """Poll *predicate* until it returns truthy or the deadline passes.
+
+    The modal's mutations are fire-and-forget from the UI's perspective
+    (optimistic flip + background PUT/DELETE), so a REST read-back can beat
+    the server commit. A short poll closes that race without a fixed sleep.
+    """
+    deadline = time.monotonic() + timeout_s
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            if predicate():
+                return
+        except Exception as exc:  # transient httpx blip — retry until deadline
+            last_exc = exc
+        time.sleep(interval_s)
+    if last_exc is not None:
+        raise last_exc
+    raise AssertionError("condition not met within timeout")
+
+
+def _open_share_modal(page: Page) -> None:
+    """Open the Share modal from the chat header and wait for it to mount."""
+    # Desktop viewport: the header renders a labelled Share button directly
+    # (the three-dot menu + "Share" menu item is the mobile fallback).
+    page.get_by_role("button", name="Share session").click()
+    expect(page.get_by_role("dialog")).to_be_visible()
+    expect(page.get_by_text("Share this session")).to_be_visible()
+
+
+def test_permissions_modal_controls_drive_server_state(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Public toggle, copy-link, grant, level-change and revoke all work.
+
+    Walks the whole modal surface in one session so each control is
+    pinned against the ``/permissions`` REST state it mutates.
+    """
+    base_url, session_id = seeded_session
+    grantee = "alice@ui.test"
+    page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+    page.goto(f"{base_url}/c/{session_id}")
+
+    _open_share_modal(page)
+    dialog = page.get_by_role("dialog")
+
+    # ── Public access switch: off → on creates a __public__ grant ────
+    public_switch = dialog.get_by_role("switch")
+    expect(public_switch).not_to_be_checked()
+    assert _PUBLIC_USER not in _permissions(base_url, session_id)
+    public_switch.click()
+    expect(public_switch).to_be_checked()
+    # The grant lands server-side (poll briefly: the toggle fires an async
+    # mutation, so the REST read can race the optimistic UI flip).
+    _wait_for(lambda: _permissions(base_url, session_id).get(_PUBLIC_USER) == _LEVEL_READ)
+
+    # ── Copy link: writes a shareable, session-scoped URL ────────────
+    dialog.get_by_role("button", name="Copy link").click()
+    expect(dialog.get_by_role("button", name="Copied!")).to_be_visible()
+    clipboard = page.evaluate("() => navigator.clipboard.readText()")
+    assert session_id in clipboard, f"clipboard URL {clipboard!r} missing session id"
+    assert re.search(rf"/c/{re.escape(session_id)}\b", clipboard), (
+        f"clipboard URL {clipboard!r} is not a /c/<id> session link"
+    )
+
+    # ── Grant a user at Read via the add-user form ───────────────────
+    dialog.get_by_placeholder("alice@example.com").fill(grantee)
+    dialog.get_by_role("button", name="Grant").click()
+    # The new row renders the grantee and the REST state agrees at Read.
+    expect(dialog.get_by_title(grantee)).to_be_visible()
+    _wait_for(lambda: _permissions(base_url, session_id).get(grantee) == _LEVEL_READ)
+
+    # ── Change that user's level Read → Edit via the row select ──────
+    level_select = dialog.get_by_role("combobox", name=f"Permission level for {grantee}")
+    level_select.click()
+    page.get_by_role("option", name="Edit").click()
+    _wait_for(lambda: _permissions(base_url, session_id).get(grantee) == _LEVEL_EDIT)
+
+    # ── Revoke the user: row disappears, grant is gone server-side ───
+    dialog.get_by_role("button", name="Revoke").click()
+    expect(dialog.get_by_title(grantee)).to_have_count(0)
+    _wait_for(lambda: grantee not in _permissions(base_url, session_id))

--- a/tests/e2e_ui/collaboration/test_sharing_journey.py
+++ b/tests/e2e_ui/collaboration/test_sharing_journey.py
@@ -23,6 +23,7 @@ the sidebar.
 from __future__ import annotations
 
 import json
+import subprocess
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -31,7 +32,11 @@ import httpx
 import pytest
 from playwright.sync_api import Browser, BrowserContext, Page, expect
 
-from tests.e2e_ui.conftest import _build_hello_world_bundle, _server_state
+from tests.e2e_ui.conftest import (
+    _build_hello_world_bundle,
+    _ensure_runner_online,
+    _server_state,
+)
 
 _COMPOSER = "Ask the agent anything…"
 _READONLY_PLACEHOLDER = "You have read-only access to this session"
@@ -60,13 +65,25 @@ class _SharedFixture:
 
 
 @pytest.fixture
-def shared(live_server: str) -> Iterator[_SharedFixture]:
+def shared(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[_SharedFixture]:
     """Create a ``local``-owned, runner-bound hello_world session.
 
     Mirrors ``seeded_session`` (headerless create + bind) plus a
     Bob client for the collaborator side. Teardown deletes as the
     owner (owner-only).
+
+    Respawns the shared runner first if a prior test in the shard killed
+    it (``test_stale_stream``) — otherwise the runner-bind ``PATCH`` below
+    400s ("runner is not registered"). The strided shard split
+    (``conftest.pytest_collection_modifyitems``) can place the
+    runner-killing test before this one in the same shard, so this fixture
+    must be order-independent like the conftest session fixtures. Any
+    runner this respawns is torn down with the fixture.
     """
+    respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
     suffix = uuid.uuid4().hex[:6]
     # No keep-alive pooling: these clients sit idle for minutes while
     # Playwright drives the browser, and reusing a connection the
@@ -102,6 +119,15 @@ def shared(live_server: str) -> Iterator[_SharedFixture]:
         owner.delete(f"/v1/sessions/{session_id}")
         owner.close()
         bob.close()
+        # Restore the "found" state: if we respawned the runner (a prior
+        # test had killed it), tear our copy down so it doesn't outlive us.
+        if respawned_runner is not None:
+            respawned_runner.terminate()
+            try:
+                respawned_runner.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned_runner.kill()
+                respawned_runner.wait(timeout=5)
 
 
 def _user_context(browser: Browser, email: str) -> BrowserContext:

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1238,6 +1238,129 @@ def two_agent_chat_session(
                 respawned_runner.wait(timeout=5)
 
 
+# ---------------------------------------------------------------------------
+# Approval / elicitation session (approvals suite)
+#
+# ``approval_session`` yields ``(base_url, session_id)`` for a session whose
+# agent deterministically tries a *gated* shell command, so the runner's
+# policy gate escalates an ASK to the server and the web UI renders an
+# ``ApprovalCard`` (and the same prompt surfaces on the /inbox page).
+#
+# The mechanism is the nessie ``blast_radius`` policy with ``gate_pushes:
+# true``: a plain ``git push`` is "recoverable but outward", so the policy
+# returns ASK at the TOOL_CALL phase — before the command runs — which the
+# runner forwards to ``POST /v1/sessions/{id}/policies/evaluate``. The server
+# parks the gate and publishes a ``response.elicitation_request`` the snapshot
+# replays in ``pendingElicitations``. The verdict travels back through
+# ``POST /v1/sessions/{id}/elicitations/{eid}/resolve`` (what the card's
+# Approve/Reject buttons call). ``sys_os_shell`` is registered implicitly by
+# the ``os_env`` block (no explicit ``tools`` needed).
+#
+# The prompt is explicit (mirrors ``_TERMINAL_AGENT_YAML``) because the test
+# relies on the LLM emitting the gated tool call deterministically — the gate
+# fires on the call, not on execution, so the push never has to succeed.
+# ---------------------------------------------------------------------------
+
+_APPROVAL_AGENT_NAME = "approval_probe"
+_APPROVAL_AGENT_YAML = """\
+spec_version: 1
+name: approval_probe
+prompt: |
+  You are a deterministic approval-test assistant. When the user asks you to
+  push, deploy, or "run the command", you MUST do exactly this and nothing
+  else:
+
+  1. Call sys_os_shell with command set to exactly: git push origin main
+  2. After the tool result comes back, reply with one short sentence.
+
+  Do not ask for confirmation; do not explain beforehand; do not run any
+  other command or call any other tool.
+
+executor:
+  model: databricks-gpt-5-4
+  config:
+    harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+guardrails:
+  # Generous window: the parked ASK must outlive the UI assertions.
+  ask_timeout: 300
+  policies:
+    blast_radius:
+      type: function
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          # A plain `git push` is recoverable-but-outward → ASK (vs the
+          # always-DENY catastrophic set). This is the prompt the UI renders.
+          gate_pushes: true
+"""
+
+
+@pytest.fixture
+def approval_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """Create a runner-bound session whose agent triggers an approval prompt.
+
+    Same runner-respawn + bind contract as :func:`terminal_session`. The
+    agent is registered through the strict ``config.yaml`` parser (it carries
+    ``spec_version: 1`` + ``executor.config.harness``, plus the ``os_env`` and
+    ``guardrails`` blocks that path supports — see ``examples/polly``).
+
+    :param live_server: Spawned server fixture.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``. Send a "run the command" turn to
+        raise the gated-push approval.
+    """
+    import json as _json
+
+    respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+
+    yaml_bytes = _APPROVAL_AGENT_YAML.encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        # Strict path: arcname config.yaml keeps it on the spec_version:1
+        # parser, which is the one that honors `guardrails`.
+        info = tarfile.TarInfo(name="config.yaml")
+        info.size = len(yaml_bytes)
+        tar.addfile(info, io.BytesIO(yaml_bytes))
+    create_resp = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+
+    patch_resp = httpx.patch(
+        f"{live_server}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    patch_resp.raise_for_status()
+
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned_runner is not None:
+            respawned_runner.terminate()
+            try:
+                respawned_runner.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned_runner.kill()
+                respawned_runner.wait(timeout=5)
+
+
 @pytest.fixture(autouse=True)
 def _ui_defaults() -> None:
     """

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1262,9 +1262,9 @@ def two_agent_chat_session(
 # ---------------------------------------------------------------------------
 
 _APPROVAL_AGENT_NAME = "approval_probe"
-_APPROVAL_AGENT_YAML = """\
+_APPROVAL_AGENT_YAML = f"""\
 spec_version: 1
-name: approval_probe
+name: {_APPROVAL_AGENT_NAME}
 prompt: |
   You are a deterministic approval-test assistant. When the user asks you to
   push, deploy, or "run the command", you MUST do exactly this and nothing


### PR DESCRIPTION
## What

Closes three high-priority gaps in the `ap-web` e2e UI suite. The full gap analysis (high/medium/low priority, with status) is tracked in the new `tests/e2e_ui/COVERAGE_GAPS.md`.

| Test | Covers |
|---|---|
| `approvals/test_approval_card.py` | In-chat approval card: a `blast_radius` guardrail (`gate_pushes`) trips an `ASK` on a plain `git push` at the **tool-call** phase, so the openai-agents harness raises an elicitation the chat renders as an `ApprovalCard`. Exercises both **Approve** and **Reject**, and asserts the server drains the parked prompt. |
| `approvals/test_inbox_approval.py` | The same pending prompt surfaces on `/inbox`, is approved there, and the item drains once the row's pending count drops to zero. |
| `collaboration/test_permissions_modal.py` | Drives the permissions modal's own controls — public toggle, copy-link, add-user grant, per-row level change, revoke — each pinned to the `/permissions` REST state. This is the "separate follow-up test" the `test_sharing_journey.py` docstring calls out. |

A new `approval_session` fixture in `tests/e2e_ui/conftest.py` registers an agent whose `blast_radius` guardrail gates pushes; `sys_os_shell` comes free with the agent's `os_env` block, and the gate fires on the tool *call*, so the push never has to succeed.

## Test plan

All four tests pass against a live local server (`uv run --frozen pytest tests/e2e_ui/...`):

- `test_permissions_modal_controls_drive_server_state` — deterministic, no LLM (~52s)
- `test_approval_card_renders_and_approves`, `test_approval_card_reject`, `test_pending_approval_surfaces_and_resolves_in_inbox` — drive a real LLM, so marked `@pytest.mark.nightly` + `@pytest.mark.timeout(600)` like the other agent-driven UI suites (~87s for the three)

## Still open (tracked in COVERAGE_GAPS.md)

Exit Plan Mode review, AskUserQuestion form, and the `/approve/<id>` URL flow (all need a native-Claude session fixture or a URL-mode elicitation), plus the Agent info popover and Add subagent dialog.