### PR TITLE
fix(ap-web): drop fork-of-fork clones from the new-session agent picker

### DIFF
--- a/ap-web/src/components/AgentInfo.test.tsx
+++ b/ap-web/src/components/AgentInfo.test.tsx
@@ -373,6 +373,15 @@ describe("agentDisplayLabel", () => {
     expect(agentDisplayLabel("codex-native-ui (switch conv_ab12)")).toBe("Codex");
   });
 
+  it("strips EVERY clone layer of a fork-of-a-fork before resolving", () => {
+    // A fork of a fork nests suffixes. A single-layer strip would leave
+    // "pi-native-ui (fork conv_a)" — no native match → the raw slug leaks
+    // into the model picker. agentRootName peels every layer to the root.
+    expect(agentDisplayLabel("pi-native-ui (fork conv_a) (fork conv_b)")).toBe("Pi");
+    expect(agentDisplayLabel("claude-native-ui (fork conv_a) (switch conv_b)")).toBe("Claude");
+    expect(agentDisplayLabel("polly (fork conv_a) (fork conv_b)")).toBe("Polly");
+  });
+
   it("capitalizes non-native names and strips their clone suffix", () => {
     expect(agentDisplayLabel("polly")).toBe("Polly");
     expect(agentDisplayLabel("polly (fork conv_ab12)")).toBe("Polly");

--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -24,7 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import { coercePolicyParams } from "@/lib/policyParams";
-import { agentBaseName } from "@/lib/forkHarness";
+import { agentRootName } from "@/lib/forkHarness";
 import { nativeCodingAgentForAgentName } from "@/lib/nativeCodingAgents";
 import { useChatStore } from "@/store/chatStore";
 
@@ -34,15 +34,16 @@ import { useChatStore } from "@/store/chatStore";
  * ``"polly"`` → ``"Polly"``). Keeps the chat surfaces consistent with
  * the new-chat picker's capitalization.
  *
- * Strips the `" (fork <id>)"` / `" (switch <id>)"` suffix the fork/switch
- * routes append to a cloned agent's name before resolving, so a clone of
- * a native wrapper (e.g. `"pi-native-ui (fork conv_ab12)"`) still maps to
- * its display name ("Pi") instead of falling through to the capitalized
- * raw slug ("Pi-native-ui …"). Mirrors how `useAvailableAgents` and the
- * fork/switch pickers already match clones back to their base agent.
+ * Strips EVERY `" (fork <id>)"` / `" (switch <id>)"` suffix the fork/switch
+ * routes append to a cloned agent's name before resolving (a fork of a fork
+ * nests them), so a clone of a native wrapper (e.g.
+ * `"pi-native-ui (fork conv_a) (fork conv_b)"`) still maps to its display
+ * name ("Pi") instead of falling through to the capitalized raw slug
+ * ("Pi-native-ui (fork conv_a) …"). Mirrors how `useAvailableAgents` and the
+ * fork/switch pickers match clones back to their root agent.
  */
 export function agentDisplayLabel(name: string): string {
-  const baseName = agentBaseName(name);
+  const baseName = agentRootName(name);
   const nativeAgent = nativeCodingAgentForAgentName(baseName);
   if (nativeAgent?.key === "claude") return "Claude";
   return nativeAgent?.displayName ?? capitalizeAgentName(baseName);

--- a/ap-web/src/hooks/useAvailableAgents.test.tsx
+++ b/ap-web/src/hooks/useAvailableAgents.test.tsx
@@ -259,6 +259,18 @@ describe("useAvailableAgents", () => {
             agent_id: "ag_clone",
             agent_name: "claude-native-ui (fork conv_9)",
           },
+          // A fork OF A fork of the built-in — nested clone suffixes. A
+          // single-layer strip leaves "claude-native-ui (fork conv_9)"
+          // (not a built-in name), so the clone leaks into the picker;
+          // once enriched its claude-native harness resolves to the
+          // "Claude Code" display name, surfacing as a DUPLICATE of the
+          // built-in. agentRootName peels every layer so it drops by
+          // name before it is ever enriched.
+          {
+            id: "conv_6",
+            agent_id: "ag_clone2",
+            agent_name: "claude-native-ui (fork conv_9) (fork conv_10)",
+          },
           // Genuinely custom agent; survives and is enriched below.
           { id: "conv_3", agent_id: "ag_doc", agent_name: "doc-writer" },
           // Same custom agent on an older session — deduped by id, and
@@ -277,13 +289,26 @@ describe("useAvailableAgents", () => {
         harness: "claude-sdk",
         skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
       }),
+      // Reached only if the fork-of-fork leaks (i.e. the fix regressed):
+      // its claude-native harness would resolve to "Claude Code", proving
+      // the leak renders as a duplicate built-in. With the fix conv_6 is
+      // dropped before enrichment, so this mock is never hit.
+      "/v1/sessions/conv_6/agent": mockResponse({
+        id: "ag_clone2",
+        object: "agent",
+        name: "claude-native-ui (fork conv_9) (fork conv_10)",
+        harness: "claude-native",
+        skills: [],
+      }),
     });
 
     const { result } = renderHook(() => useAvailableAgents(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    // One built-in + one custom. ag_clone or ag_native appearing twice
-    // means shadow-dropping regressed; ag_doc missing means kind=any
+    // One built-in + one custom. A second "Claude Code" row (from
+    // ag_clone/ag_clone2 leaking) means shadow-dropping regressed —
+    // ag_clone2 specifically guards the nested fork-of-fork case that
+    // surfaces as a duplicate built-in; ag_doc missing means kind=any
     // discovery broke; two ag_doc rows mean the by-id dedup broke.
     expect(result.current.data).toEqual([
       {

--- a/ap-web/src/hooks/useAvailableAgents.ts
+++ b/ap-web/src/hooks/useAvailableAgents.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
-import { agentBaseName } from "@/lib/forkHarness";
+import { agentRootName } from "@/lib/forkHarness";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import {
   nativeCodingAgentForAgentName,
@@ -168,8 +168,10 @@ async function enrichSessionAgent(scanned: ScannedSessionAgent): Promise<Availab
  *
  * Session-discovered agents that shadow a built-in are dropped: by id
  * (most sessions bind a built-in's agent row directly) and by clone
- * base name (fork/switch create per-session rows named
- * `"<builtin> (fork <id>)"`). What survives is genuinely custom —
+ * ROOT name (fork/switch create per-session rows named
+ * `"<builtin> (fork <id>)"`, and a fork of a fork nests them —
+ * `agentRootName` peels every layer so multi-fork clones still match).
+ * What survives is genuinely custom —
  * ad-hoc uploaded agents that were previously invisible to the picker.
  * Surviving custom agents are then collapsed by base name, keeping the
  * newest session's row: a custom agent launched repeatedly from a local
@@ -195,7 +197,11 @@ async function fetchAvailableAgents(): Promise<AvailableAgent[]> {
   // identical-name rows are indistinguishable in the picker anyway.
   const customByName = new Map<string, ScannedSessionAgent>();
   for (const agent of scanned) {
-    const base = agentBaseName(agent.agentName);
+    // Peel EVERY clone layer, not just one: a fork of a fork is named
+    // `"<builtin> (fork ag_a) (fork ag_b)"`, and a single-layer strip
+    // leaves `"<builtin> (fork ag_a)"` — which is not a built-in name, so
+    // the clone would slip past the shadow check and pollute the picker.
+    const base = agentRootName(agent.agentName);
     if (builtinIds.has(agent.agentId) || builtinNames.has(base)) continue;
     if (!customByName.has(base)) customByName.set(base, agent);
   }

--- a/ap-web/src/lib/forkHarness.test.ts
+++ b/ap-web/src/lib/forkHarness.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   agentBaseName,
+  agentRootName,
   harnessFamily,
   isNativeHarness,
   forkTargetCarriesHistory,
@@ -115,5 +116,29 @@ describe("agentBaseName", () => {
     // Fork-of-a-fork names accumulate suffixes; one call removes one
     // layer (callers compare against catalogs of single-layer names).
     expect(agentBaseName("polly (fork conv_a) (switch conv_b)")).toBe("polly (fork conv_a)");
+  });
+});
+
+describe("agentRootName", () => {
+  it("returns a plain name unchanged", () => {
+    expect(agentRootName("claude-native-ui")).toBe("claude-native-ui");
+  });
+
+  it("peels a single clone layer", () => {
+    expect(agentRootName("claude-native-ui (fork ag_3a9fa87)")).toBe("claude-native-ui");
+  });
+
+  it("peels every layer of a fork-of-a-fork", () => {
+    // Where agentBaseName stops after one layer, agentRootName recurses to
+    // the root so a multi-fork clone of a built-in still matches the
+    // built-in catalog (and is dropped by the agent picker).
+    expect(agentRootName("claude-native-ui (fork ag_a) (fork ag_b)")).toBe("claude-native-ui");
+    expect(agentRootName("polly (fork conv_a) (switch conv_b)")).toBe("polly");
+  });
+
+  it("leaves interior or non-clone parentheses alone", () => {
+    // Only trailing clone markers are peeled — user-chosen parens survive.
+    expect(agentRootName("my-agent (beta)")).toBe("my-agent (beta)");
+    expect(agentRootName("agent (fork pun) helper")).toBe("agent (fork pun) helper");
   });
 });

--- a/ap-web/src/lib/forkHarness.test.ts
+++ b/ap-web/src/lib/forkHarness.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  agentBaseName,
   agentRootName,
   harnessFamily,
   isNativeHarness,
@@ -92,46 +91,20 @@ describe("forkTargetCarriesHistory", () => {
   });
 });
 
-describe("agentBaseName", () => {
-  it("returns a plain name unchanged", () => {
-    expect(agentBaseName("claude-native-ui")).toBe("claude-native-ui");
-  });
-
-  it("strips a fork suffix", () => {
-    expect(agentBaseName("claude-native-ui (fork conv_ab12)")).toBe("claude-native-ui");
-  });
-
-  it("strips a switch suffix", () => {
-    expect(agentBaseName("nessie (switch conv_9f3c)")).toBe("nessie");
-  });
-
-  it("leaves interior or non-clone parentheses alone", () => {
-    // Only the exact trailing " (fork <id>)" / " (switch <id>)" shape is a
-    // clone marker — user-chosen names with parens must not be mangled.
-    expect(agentBaseName("my-agent (beta)")).toBe("my-agent (beta)");
-    expect(agentBaseName("agent (fork pun) helper")).toBe("agent (fork pun) helper");
-  });
-
-  it("strips only the outermost suffix when a clone was itself cloned", () => {
-    // Fork-of-a-fork names accumulate suffixes; one call removes one
-    // layer (callers compare against catalogs of single-layer names).
-    expect(agentBaseName("polly (fork conv_a) (switch conv_b)")).toBe("polly (fork conv_a)");
-  });
-});
-
 describe("agentRootName", () => {
   it("returns a plain name unchanged", () => {
     expect(agentRootName("claude-native-ui")).toBe("claude-native-ui");
   });
 
-  it("peels a single clone layer", () => {
+  it("peels a single fork or switch layer", () => {
     expect(agentRootName("claude-native-ui (fork ag_3a9fa87)")).toBe("claude-native-ui");
+    expect(agentRootName("nessie (switch conv_9f3c)")).toBe("nessie");
   });
 
   it("peels every layer of a fork-of-a-fork", () => {
-    // Where agentBaseName stops after one layer, agentRootName recurses to
-    // the root so a multi-fork clone of a built-in still matches the
-    // built-in catalog (and is dropped by the agent picker).
+    // A single-layer strip would stop at "claude-native-ui (fork ag_a)";
+    // agentRootName recurses to the root so a multi-fork clone of a built-in
+    // still matches the built-in catalog (and is dropped by the agent picker).
     expect(agentRootName("claude-native-ui (fork ag_a) (fork ag_b)")).toBe("claude-native-ui");
     expect(agentRootName("polly (fork conv_a) (switch conv_b)")).toBe("polly");
   });

--- a/ap-web/src/lib/forkHarness.ts
+++ b/ap-web/src/lib/forkHarness.ts
@@ -93,3 +93,28 @@ export function forkTargetCarriesHistory(targetHarness: string | null | undefine
 export function agentBaseName(name: string): string {
   return name.replace(/ \((?:fork|switch) [^)]+\)$/, "");
 }
+
+/**
+ * The base name behind ANY chain of fork/switch clone suffixes.
+ *
+ * {@link agentBaseName} removes a single trailing `(fork <id>)` /
+ * `(switch <id>)` layer, but a fork of a fork accumulates them — e.g.
+ * `"claude-native-ui (fork ag_a) (fork ag_b)"`. Callers that compare a
+ * clone's name against a single-layer catalog (the agent picker dropping
+ * session agents that shadow a built-in) must peel EVERY layer, otherwise
+ * a multi-layer clone of a built-in strips to `"claude-native-ui (fork
+ * ag_a)"`, fails the built-in-name match, and leaks into the picker as a
+ * spurious "custom" agent.
+ *
+ * @param name - An agent name, possibly with nested clone suffixes.
+ * @returns The root base name with all clone suffixes removed.
+ */
+export function agentRootName(name: string): string {
+  let prev: string;
+  let cur = name;
+  do {
+    prev = cur;
+    cur = agentBaseName(cur);
+  } while (cur !== prev);
+  return cur;
+}

--- a/ap-web/src/lib/forkHarness.ts
+++ b/ap-web/src/lib/forkHarness.ts
@@ -82,29 +82,37 @@ export function forkTargetCarriesHistory(targetHarness: string | null | undefine
 }
 
 /**
- * Strip the `" (fork <id>)"` / `" (switch <id>)"` suffix the fork/switch
- * routes append to an agent's name when cloning it, so a clone can be
- * matched back to the agent it was cloned from by name.
+ * Strip ONE trailing `" (fork <id>)"` / `" (switch <id>)"` suffix.
+ *
+ * Internal one-layer primitive for {@link agentRootName}; not exported,
+ * because a fork of a fork stacks these suffixes and every caller that
+ * matches a clone name back to its origin (built-in catalog, native-label
+ * map, switch-dialog dedup) wants the FULLY rooted name. Reaching for a
+ * single-layer strip is the footgun that lets a multi-fork clone slip the
+ * match — so callers use `agentRootName`, never this.
  *
  * @param name - An agent name, e.g. `"claude-native-ui (fork conv_ab12)"`.
- * @returns The base name, e.g. `"claude-native-ui"`. Names without a
- *   clone suffix are returned unchanged.
+ * @returns The name with one clone suffix removed.
  */
-export function agentBaseName(name: string): string {
+function agentBaseName(name: string): string {
   return name.replace(/ \((?:fork|switch) [^)]+\)$/, "");
 }
 
 /**
- * The base name behind ANY chain of fork/switch clone suffixes.
+ * The root agent name behind ANY chain of fork/switch clone suffixes.
  *
- * {@link agentBaseName} removes a single trailing `(fork <id>)` /
- * `(switch <id>)` layer, but a fork of a fork accumulates them — e.g.
- * `"claude-native-ui (fork ag_a) (fork ag_b)"`. Callers that compare a
- * clone's name against a single-layer catalog (the agent picker dropping
- * session agents that shadow a built-in) must peel EVERY layer, otherwise
- * a multi-layer clone of a built-in strips to `"claude-native-ui (fork
- * ag_a)"`, fails the built-in-name match, and leaks into the picker as a
- * spurious "custom" agent.
+ * The fork/switch routes clone a bound agent as `"<name> (fork <id>)"`, and
+ * a fork of a fork accumulates them — e.g. `"claude-native-ui (fork ag_a)
+ * (fork ag_b)"`. This peels EVERY layer to the root, so a clone (however
+ * deep) still matches the agent it derives from by name.
+ *
+ * Use this for ALL clone-name → catalog matching: the new-session picker
+ * dropping session agents that shadow a built-in (`useAvailableAgents`),
+ * the in-session model-picker / agent-info label (`agentDisplayLabel`), and
+ * the switch-agent dialog excluding the current agent's origin. A
+ * single-layer strip would leave `"claude-native-ui (fork ag_a)"`, miss the
+ * match, and surface the clone as a spurious "custom" agent / duplicate
+ * built-in / raw suffixed label.
  *
  * @param name - An agent name, possibly with nested clone suffixes.
  * @returns The root base name with all clone suffixes removed.

--- a/ap-web/src/shell/SwitchAgentDialog.test.tsx
+++ b/ap-web/src/shell/SwitchAgentDialog.test.tsx
@@ -121,6 +121,28 @@ describe("SwitchAgentDialog", () => {
     expect(screen.getByTestId("switch-agent-option-ag_claude_native")).toBeInTheDocument();
   });
 
+  it("excludes the origin built-in and labels it for a fork-of-a-fork clone", () => {
+    // A fork of a fork nests suffixes: "claude (fork …) (fork …)". A
+    // single-layer strip would leave "claude (fork …)" — not a built-in
+    // name — so the origin would wrongly be offered AND the current label
+    // would show the raw suffixed slug. agentRootName peels to "claude".
+    setAgents({
+      id: "ag_src_clone2",
+      name: "claude (fork ag_a) (fork ag_b)",
+      harness: "claude-sdk",
+    });
+    renderDialog();
+
+    // Current-agent label resolves to the origin built-in's display name,
+    // not the raw "claude (fork ag_a)" a one-layer strip would leave.
+    expect(screen.getByTestId("switch-agent-current")).toHaveTextContent("Claude");
+
+    openAgentSelect();
+    // The origin built-in (claude → ag_claude_sdk) is still excluded.
+    expect(screen.queryByTestId("switch-agent-option-ag_claude_sdk")).not.toBeInTheDocument();
+    expect(screen.getByTestId("switch-agent-option-ag_claude_native")).toBeInTheDocument();
+  });
+
   it("submit is disabled until a target is chosen", () => {
     renderDialog();
     // No selection yet → the Switch button is disabled, so a stray click

--- a/ap-web/src/shell/SwitchAgentDialog.tsx
+++ b/ap-web/src/shell/SwitchAgentDialog.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { switchSessionAgent } from "@/lib/sessionsApi";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { useSessionAgent } from "@/hooks/useAgents";
-import { agentBaseName, forkTargetCarriesHistory, harnessFamily } from "@/lib/forkHarness";
+import { agentRootName, forkTargetCarriesHistory, harnessFamily } from "@/lib/forkHarness";
 
 // "" means no target chosen yet. It must be empty (not a sentinel like
 // "__none__"): Radix only renders the trigger placeholder when the controlled
@@ -68,20 +68,21 @@ export function SwitchAgentDialog({
   const { data: agents } = useAvailableAgents({ enabled: open });
   const { data: currentAgent } = useSessionAgent(open ? sessionId : null);
 
-  // The bound agent stripped of any " (fork <id>)" / " (switch <id>)" suffix
-  // the fork/switch routes append when cloning, so a clone of a built-in
-  // still matches that built-in by name and is excluded below.
+  // The bound agent stripped of EVERY " (fork <id>)" / " (switch <id>)"
+  // suffix the fork/switch routes append when cloning (a fork of a fork
+  // nests them), so a clone of a built-in — however deep — still matches
+  // that built-in by name and is excluded below.
   const currentAgentName = currentAgent?.name ?? null;
-  const currentAgentBaseName = currentAgentName ? agentBaseName(currentAgentName) : null;
+  const currentAgentRootName = currentAgentName ? agentRootName(currentAgentName) : null;
 
   // Friendly label for the currently-bound agent, shown as the trigger's
   // default (greyed) so the box isn't blank and the user sees what they're on.
   // Prefer the matching built-in's display_name (e.g. "nessie" → "Nessie");
   // fall back to the bound agent's own (suffix-stripped) name.
   const currentDisplay =
-    (agents ?? []).find((a) => a.name === currentAgentName || a.name === currentAgentBaseName)
+    (agents ?? []).find((a) => a.name === currentAgentName || a.name === currentAgentRootName)
       ?.display_name ??
-    currentAgentBaseName ??
+    currentAgentRootName ??
     currentAgentName;
 
   // Targets, excluding the session's own agent (switching to it is a no-op)
@@ -92,7 +93,7 @@ export function SwitchAgentDialog({
     (a) =>
       a.id !== currentAgent?.id &&
       a.name !== currentAgentName &&
-      a.name !== currentAgentBaseName &&
+      a.name !== currentAgentRootName &&
       forkTargetCarriesHistory(a.harness),
   );
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -762,3 +762,137 @@ async def _drive_add_worktree(base_url: str, session_id: str) -> None:
             assert body.get("git") == {"branch_name": "feature/login", "base_branch": "main"}, body
         finally:
             await browser.close()
+
+
+# Session-bound agents the discovery scan returns. Both clone names below root
+# to the built-in "claude-native-ui", so the picker must drop both; the fork of
+# a fork (two nested suffixes) is the case a single-layer strip missed.
+_SINGLE_FORK_NAME = "claude-native-ui (fork ag_aaa11111)"
+_FORK_OF_FORK_NAME = "claude-native-ui (fork ag_aaa11111) (fork ag_bbb22222)"
+
+
+def _fork_scan_body() -> str:
+    """Stub body for the ``GET /v1/sessions?kind=any`` agent-discovery scan.
+
+    Returns four session-bound agents that exercise every branch of the
+    picker's shadow-dropping: the built-in's own row (dropped by id), a single
+    fork and a fork-of-fork of the built-in (both dropped by rooted name), and
+    one genuinely custom agent (must survive).
+    """
+    return json.dumps(
+        {
+            "object": "list",
+            "data": [
+                # Binds the built-in's own agent row — dropped by id.
+                {
+                    "id": "conv_native",
+                    "agent_id": "ag_claude_e2e",
+                    "agent_name": "claude-native-ui",
+                },
+                # Single fork of the built-in — dropped by name (one layer).
+                {"id": "conv_f1", "agent_id": "ag_fork1", "agent_name": _SINGLE_FORK_NAME},
+                # Fork of a fork — the regression: dropped only if EVERY clone
+                # layer is stripped before the built-in-name check.
+                {"id": "conv_ff", "agent_id": "ag_forkfork", "agent_name": _FORK_OF_FORK_NAME},
+                # A genuinely custom agent — must SURVIVE and be offered.
+                {"id": "conv_doc", "agent_id": "ag_doc", "agent_name": "doc-writer"},
+            ],
+            "has_more": False,
+        }
+    )
+
+
+def test_start_session_picker_drops_fork_of_fork_shadows(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The landing picker hides fork-of-fork clones of a built-in agent.
+
+    The picker (``useAvailableAgents``) merges the built-in list
+    (``GET /v1/agents``) with session-scoped agents discovered by scanning the
+    caller's sessions (``GET /v1/sessions?kind=any``), dropping any discovered
+    agent whose clone name roots back to a built-in. A fork of a fork nests two
+    clone suffixes — ``"claude-native-ui (fork …) (fork …)"`` — so a single-
+    layer strip leaves ``"claude-native-ui (fork …)"``, which is not a built-in
+    name, and the clone leaked into the picker as a SECOND "Claude Code" row.
+
+    This drives that regression end to end against the rendered picker: only
+    the real built-in Claude Code and a genuinely custom agent are offered;
+    both the single-fork and the fork-of-fork clones are dropped.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_fork_of_fork_dedup(base_url, session_id))
+
+
+async def _drive_fork_of_fork_dedup(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                # Sole built-in: claude-native-ui, display "Claude Code".
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_agents_body()
+                )
+
+            async def handle_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_fork_scan_body()
+                )
+
+            async def handle_enrich(route: Route) -> None:
+                # Only the surviving custom agent reaches the per-agent enrich
+                # fetch — the dropped shadows never get here.
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "id": "ag_doc",
+                            "object": "agent",
+                            "name": "doc-writer",
+                            "description": "Documentation specialist",
+                            "harness": "claude-sdk",
+                            "skills": [],
+                        }
+                    ),
+                )
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            # kind=any returns the fork + custom session-bound agents; the bare
+            # conversation-list GET still falls through to the real server.
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_scan)
+            # Per-agent enrich fetch for whichever agent survives the dedup.
+            await page.route(re.compile(r"/v1/sessions/[^/]+/agent$"), handle_enrich)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Open the agent picker dropdown.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+
+            # The real built-in Claude Code is offered...
+            await expect(
+                page.get_by_test_id("new-chat-landing-agent-ag_claude_e2e")
+            ).to_be_visible(timeout=30_000)
+            # ...the genuinely custom agent survives...
+            await expect(page.get_by_test_id("new-chat-landing-agent-ag_doc")).to_be_visible()
+            # ...and BOTH fork clones of the built-in are dropped. Pre-fix the
+            # fork-of-fork (ag_forkfork) rendered as a duplicate "Claude Code".
+            await expect(page.get_by_test_id("new-chat-landing-agent-ag_fork1")).to_have_count(0)
+            await expect(page.get_by_test_id("new-chat-landing-agent-ag_forkfork")).to_have_count(
+                0
+            )
+            # Exactly two options total: the built-in + the one custom agent —
+            # no duplicate "Claude Code" sneaks in via a leaked clone.
+            await expect(page.get_by_role("menuitem")).to_have_count(2)
+        finally:
+            await browser.close()


### PR DESCRIPTION
## Problem

The new-session agent picker (`useAvailableAgents`) lists built-in agents from `GET /v1/agents` and merges in session-scoped agents discovered by scanning the caller's recent sessions (`GET /v1/sessions?kind=any`). Session agents that merely *shadow* a built-in are dropped by matching their clone base name against the built-in names — a fork of `claude-native-ui` is named `claude-native-ui (fork ag_a)`, whose base name (`claude-native-ui`) is a built-in, so it's hidden.

But `agentBaseName` strips only a **single** trailing `(fork|switch <id>)` layer. A **fork of a fork** nests the suffixes — `claude-native-ui (fork ag_a) (fork ag_b)` — so a one-layer strip yields `claude-native-ui (fork ag_a)`, which is *not* a built-in name. Multi-layer clones of a built-in therefore slip past the shadow check and surface in the picker as spurious "custom" agents.

Observed in practice: two `Claude Code` rows (each backing a "Fork of Fork of …" session) appeared in the picker, while every single-fork clone was correctly hidden.

## Fix

Add `agentRootName`, which applies `agentBaseName` to a fixed point (peels *every* nested clone layer), and use it for the picker's shadow/dedup check. A fork-of-fork of a built-in now collapses to the built-in name and is dropped; forks of a genuine custom agent still collapse to a single picker row.

## Tests

Before:
<img width="1909" height="924" alt="Screenshot 2026-06-16 at 2 35 07 PM" src="https://github.com/user-attachments/assets/b5400bca-314f-4b54-8be8-79dbbbfdde5f" />

After:
<img width="1728" height="866" alt="Screenshot 2026-06-16 at 1 12 17 PM" src="https://github.com/user-attachments/assets/d69f0fc0-1e81-492e-abb1-6bfd95b21196" />


- `forkHarness.test.ts`: new `agentRootName` suite — plain name, single layer, nested fork-of-fork, non-clone parentheses left intact.
- `useAvailableAgents.test.tsx`: the "drops built-in shadows" test gains a nested `(fork …) (fork …)` row that must not surface.
- `npx vitest run` over both files: **57 passing**. `tsc --noEmit`, `oxlint`, and `prettier --check` all clean.

This pull request and its description were written by Isaac.
