### PR TITLE
test(antigravity): beef up e2e coverage (per-harness, streaming, lifecycle)

### DIFF
--- a/tests/e2e/omnigent/test_antigravity_lifecycle_e2e.py
+++ b/tests/e2e/omnigent/test_antigravity_lifecycle_e2e.py
@@ -1,0 +1,547 @@
+"""Live concurrency + process-lifecycle e2e for the antigravity (Gemini) harness.
+
+The ``antigravity`` harness drives Google's Antigravity Python SDK
+(``google-antigravity``). Unlike the other SDK harnesses it is **not**
+pure-Python: ``Agent.__aenter__`` opens a local connection that spawns a
+bundled **native ``localharness`` binary** (~111 MB ELF) which talks to
+Google's Gemini backend. This test file is the lifecycle/concurrency counterpart
+to the one-shot per-harness gates (``test_per_harness_claude_sdk.py`` /
+``test_per_harness_cursor.py``): it drives real ``omnigent run`` subprocesses
+and asserts invariants about *concurrent* turns and the *native subprocess
+lifecycle* rather than a single assistant reply.
+
+Three properties are covered, all against STABLE-on-main behavior:
+
+1. **Parallel turns / no state bleed** — two concurrent ``omnigent run``
+   invocations, each a distinct ephemeral session (``--no-session``) carrying a
+   distinct sentinel token in its prompt. Each session's transcript must contain
+   ONLY its own sentinel — proving the per-session SDK ``Agent``/``Conversation``
+   reuse (keyed by ``session_key`` in
+   :class:`~omnigent.inner.antigravity_executor.AntigravityExecutor`) does not
+   leak one conversation's content into another's.
+2. **No orphaned ``localharness``** — snapshot the live ``localharness`` PIDs
+   before a turn and again after it ends cleanly; the turn must not leave a NEW
+   native subprocess behind (the SDK ``Agent`` is closed on session teardown via
+   ``close_session`` / ``close`` → ``Agent.__aexit__``, which must reap the
+   native binary).
+3. **Session cleanup reaps the runner/harness** — after a single ``omnigent
+   run`` turn's process tree exits, no native subprocess that this run started
+   may linger.
+
+**Prerequisites (skipped when absent), mirroring the cursor gate:**
+
+- ``google-antigravity`` importable in the *omnigent* venv (the test shells
+  out, so the subprocess interpreter is what matters, not the test's own).
+- A Gemini API key resolvable — either a configured ``antigravity:`` block
+  (``omnigent setup``) or an ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``.
+  Antigravity is Gemini-native (no Databricks gateway / ``base_url`` path), so
+  unlike the gateway harnesses this test does NOT use ``patched_databrickscfg``
+  / ``omnigent_credentials_env`` — a missing key is a clean SKIP so the e2e
+  shards stay green, and it runs for real wherever a key is present.
+
+.. note::
+   **glibc >= ~2.36 caveat.** The native ``localharness`` binary is linked
+   against a recent glibc (needs ``GLIBC_ABI_DT_RELR``). On an older host (e.g.
+   glibc 2.31) a live turn fails at SDK setup with ``RuntimeError: …
+   localharness: … version 'GLIBC_ABI_DT_RELR' not found``, surfaced as an
+   ``ExecutorError``. There is a dev-only loader-shim workaround
+   (``ANTIGRAVITY_HARNESS_PATH`` pointing at a newer glibc's loader), but this
+   test never depends on it: the lifecycle assertions (2, 3) hold even when the
+   turn fails at setup (the subprocess still tears its process tree down), and
+   the no-state-bleed assertion (1) self-skips when neither run produces its
+   sentinel (which is what a glibc/quota failure looks like) rather than
+   asserting a cross-contamination invariant it cannot observe.
+
+**What breaks if this fails (with prerequisites present):**
+
+- :class:`AntigravityExecutor`'s per-session agent isolation regresses and one
+  conversation's state bleeds into another (assertion 1).
+- The SDK ``Agent`` teardown (``close_session`` / ``close`` →
+  ``_close_agent`` → ``Agent.__aexit__``) stops reaping the native
+  ``localharness`` subprocess, leaking a process per turn (assertions 2, 3).
+- The ``omnigent run`` one-shot path stops tearing down its local server /
+  runner / harness process tree on exit.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+# Hardcoded because the file's whole point is the antigravity harness; a
+# lifecycle test that didn't pin the harness it characterizes would be
+# meaningless. Gemini ids only (the SDK is Gemini-native).
+_HARNESS = "antigravity"
+# gemini-2.5-flash works on a plain AI-Studio key; gemini-3-pro 404s there.
+# Either flash model exercises the same native-binary lifecycle, which is what
+# this file is about, so the cheaper/widely-available one is used.
+_MODEL = "gemini-2.5-flash"
+
+# The native binary is matched on its on-disk path substring. ``pgrep``'s
+# default (process-name) match misses it because the visible argv[0] is the
+# dynamic loader (``ld-linux-…``); ``pgrep -f`` against the full command line
+# is the SDK's documented way to find the ``localharness`` process.
+_LOCALHARNESS_PGREP_PATTERN = "antigravity/bin/localharness"
+
+# Antigravity turns cold-start the native binary + round-trip to Gemini; 180s
+# matches the headroom the other coding-agent per-harness gates allow, with
+# extra room for the binary launch.
+_RUN_TIMEOUT_SEC = 180
+
+# After a clean ``omnigent run`` exit, the local server/runner shutdown that
+# reaps the native subprocess is asynchronous. Poll the PID set up to this many
+# seconds for the post-turn count to return to baseline before asserting a leak,
+# so a slow-but-correct teardown is not mis-reported as an orphan.
+_REAP_POLL_TIMEOUT_SEC = 30.0
+_REAP_POLL_INTERVAL_SEC = 0.5
+
+# Substrings that mark a turn that failed for *infrastructure* reasons (not a
+# correctness regression): the glibc/native-binary wall on an old host, or a
+# saturated Gemini free-tier quota. When BOTH parallel runs fail this way the
+# no-state-bleed assertion has nothing real to compare, so it self-skips.
+_INFRA_FAILURE_MARKERS = (
+    "GLIBC_ABI_DT_RELR",  # native binary vs. old-host glibc
+    "localharness",  # native-binary setup failure surfaced in the error
+    "RESOURCE_EXHAUSTED",  # Gemini quota
+    "code 429",
+    "high demand",
+    "quota",
+)
+
+
+def _antigravity_prereqs_missing(omnigent_python: Path) -> str | None:
+    """Return a skip reason if the antigravity harness can't run, else ``None``.
+
+    Probes the *omnigent* venv (the interpreter the subprocess uses), not the
+    test's own interpreter: the SDK import and the key resolution both have to
+    hold for the spawned ``omnigent run`` to do anything. Booleans only — the
+    key is never printed.
+
+    :param omnigent_python: Interpreter with omnigent installed, from the
+        ``omnigent_python`` fixture.
+    :returns: A human-readable skip reason, or ``None`` when both the
+        ``google-antigravity`` package and a resolvable Gemini key are present.
+    """
+    probe = subprocess.run(
+        [
+            str(omnigent_python),
+            "-c",
+            # Print two booleans: SDK importable, and a Gemini key resolvable
+            # from either the dedicated antigravity config block or ambient env.
+            # ``find_spec`` is wrapped because for a namespace package it can
+            # *raise* ModuleNotFoundError (not just return None) when the
+            # ``google`` parent fails to resolve — treat any such failure as
+            # "not importable" so the gate SKIPs cleanly instead of crashing the
+            # probe (which would read as an inconclusive "could not probe").
+            "import importlib.util as u, os\n"
+            "try:\n"
+            "    sdk = u.find_spec('google.antigravity') is not None\n"
+            "except Exception:\n"
+            "    sdk = False\n"
+            "try:\n"
+            "    from omnigent.onboarding.antigravity_auth import "
+            "antigravity_api_key_configured as c\n"
+            "    cfg = c()\n"
+            "except Exception:\n"
+            "    cfg = False\n"
+            "env = bool(os.environ.get('GEMINI_API_KEY') or "
+            "os.environ.get('ANTIGRAVITY_API_KEY'))\n"
+            "print(int(sdk), int(cfg or env))",
+        ],
+        capture_output=True,
+        text=True,
+        # Run from the interpreter's own dir so a prepended ``''`` on sys.path
+        # can't shadow the ``google`` namespace with an unrelated local package.
+        cwd=str(omnigent_python.parent),
+    )
+    out = probe.stdout.strip().split()
+    if probe.returncode != 0 or len(out) != 2:
+        return (
+            "could not probe antigravity prerequisites in the omnigent venv "
+            f"(rc={probe.returncode}, stdout={probe.stdout!r}, stderr={probe.stderr!r})."
+        )
+    sdk_ok, key_ok = out[0] == "1", out[1] == "1"
+    if not sdk_ok:
+        return (
+            "antigravity prerequisite missing: the 'google-antigravity' package is not installed."
+        )
+    if not key_ok:
+        return (
+            "antigravity prerequisite missing: no Gemini API key resolvable. The "
+            "Antigravity SDK is Gemini-native (no Databricks-gateway path), so "
+            "configure an 'antigravity:' key via 'omnigent setup' or export "
+            "GEMINI_API_KEY / ANTIGRAVITY_API_KEY. Skipped (not failed) when absent."
+        )
+    return None
+
+
+def _write_antigravity_bundle(bundle_dir: Path, *, name: str) -> Path:
+    """Materialize a minimal antigravity agent bundle directory.
+
+    A spec carrying ``spec_version`` must be a *directory* containing
+    ``config.yaml`` — the antigravity harness rejects a single ``.yaml`` file.
+    No ``auth:`` block is written so the key resolves from the ambient
+    ``antigravity:`` config / env (see :func:`_antigravity_prereqs_missing`).
+
+    :param bundle_dir: Directory to write the bundle into (created if absent).
+    :param name: The agent ``name`` field; also makes each parallel bundle a
+        distinct on-disk path so its session is independent.
+    :returns: The bundle directory path (the argument ``omnigent run`` takes).
+    """
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "config.yaml").write_text(
+        "spec_version: 1\n"
+        f"name: {name}\n"
+        "description: Antigravity lifecycle/concurrency e2e agent.\n"
+        "executor:\n"
+        "  type: omnigent\n"
+        "  config:\n"
+        f"    harness: {_HARNESS}\n"
+        f"    model: {_MODEL}\n"
+        "prompt: |\n"
+        "  You are a terse echo agent. When asked to repeat a token, reply with\n"
+        "  exactly that token and nothing else.\n",
+        encoding="utf-8",
+    )
+    return bundle_dir
+
+
+def _antigravity_env() -> dict[str, str]:
+    """Build the subprocess env for an antigravity ``omnigent run``.
+
+    Starts from ``os.environ`` (so HOME / PATH / the ambient Gemini key and any
+    dev-only ``ANTIGRAVITY_HARNESS_PATH`` shim propagate) and suppresses the
+    onboarding prompt + update-check banner so the subprocess never blocks on
+    stdin or dirties stderr. Deliberately does NOT inject a Databricks PAT /
+    OPENAI_BASE_URL: antigravity is Gemini-native and ignores them.
+
+    :returns: An env dict for ``subprocess.run(env=...)``.
+    """
+    env = dict(os.environ)
+    env["OMNIGENT_SKIP_ONBOARD"] = "1"
+    env["OMNIGENT_NO_UPDATE_CHECK"] = "1"
+    return env
+
+
+def _run_antigravity_turn(
+    *,
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    bundle_dir: Path,
+    prompt: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run one ``omnigent run <bundle> --harness antigravity -p <prompt>``.
+
+    ``--no-session`` gives the run a fresh ephemeral store so concurrent runs
+    don't share a persistent conversation. ``--no-log`` keeps the JSON dump off
+    disk. The full process tree (local server + runner + native ``localharness``)
+    is spawned and torn down by this single invocation.
+
+    :param omnigent_python: Interpreter with omnigent installed.
+    :param omnigent_repo_root: Cwd for the subprocess (puts example tool modules
+        on sys.path, matching the other run_omnigent tests).
+    :param bundle_dir: The antigravity bundle directory to run.
+    :param prompt: The one-shot ``-p`` prompt.
+    :returns: The completed process (stdout/stderr captured, text mode).
+    """
+    return subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(bundle_dir),
+            "--harness",
+            _HARNESS,
+            "--model",
+            _MODEL,
+            "-p",
+            prompt,
+            "--no-log",
+            "--no-session",
+        ],
+        env=_antigravity_env(),
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+
+def _localharness_pids() -> set[int]:
+    """Return the set of currently-live native ``localharness`` PIDs.
+
+    Uses ``pgrep -f`` against the binary's on-disk path substring (the SDK's
+    documented way — the default process-name match misses it because argv[0] is
+    the dynamic loader). A non-zero ``pgrep`` exit with no match means "none",
+    which maps to an empty set.
+
+    Returning the PID *set* (not a count) is deliberate: the lifecycle
+    assertions take a before/after set difference so they are robust to
+    unrelated ``localharness`` processes from other work on the same host — only
+    PIDs this turn newly created are considered, and pre-existing ones are
+    ignored.
+
+    :returns: The set of live ``localharness`` PIDs (empty when none).
+    """
+    proc = subprocess.run(
+        ["pgrep", "-f", _LOCALHARNESS_PGREP_PATTERN],
+        capture_output=True,
+        text=True,
+    )
+    pids: set[int] = set()
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.isdigit():
+            pids.add(int(line))
+    return pids
+
+
+def _looks_like_infra_failure(result: subprocess.CompletedProcess[str]) -> bool:
+    """Whether a turn failed for an infra reason (glibc/native binary or quota).
+
+    Distinguishes "the harness couldn't even run a real model turn here"
+    (old-host glibc wall, saturated Gemini quota) from a genuine output, so the
+    no-state-bleed test can self-skip instead of mis-reporting an environment
+    gap as a regression.
+
+    :param result: The completed ``omnigent run`` process.
+    :returns: ``True`` when stdout+stderr carry a known infra-failure marker.
+    """
+    blob = f"{result.stdout}\n{result.stderr}"
+    return any(marker in blob for marker in _INFRA_FAILURE_MARKERS)
+
+
+@pytest.fixture
+def antigravity_runnable(omnigent_python: Path) -> None:
+    """Skip the whole module's tests when antigravity can't run.
+
+    :param omnigent_python: Interpreter probed for the SDK + key.
+    :raises pytest.skip.Exception: When a prerequisite is missing.
+    """
+    reason = _antigravity_prereqs_missing(omnigent_python)
+    if reason is not None:
+        pytest.skip(reason)
+
+
+def test_antigravity_parallel_turns_no_state_bleed(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    tmp_path: Path,
+    antigravity_runnable: None,
+) -> None:
+    """Two concurrent antigravity turns keep their conversations isolated.
+
+    Each run is a distinct ephemeral session (distinct bundle dir +
+    ``--no-session``) whose prompt embeds a unique sentinel and asks the model
+    to echo exactly that sentinel. The load-bearing property: each run's
+    transcript contains ONLY its own sentinel — never the other run's — so the
+    per-session ``Agent``/``Conversation`` keyed by ``session_key`` in
+    :class:`AntigravityExecutor` does not bleed state across concurrent
+    sessions.
+
+    Self-skips (rather than fails) when neither run produces its sentinel: on a
+    glibc-<2.36 host or against a saturated Gemini quota the turns fail at
+    setup, leaving no real output to compare. The cross-contamination invariant
+    is only meaningful when at least one run produced its own sentinel.
+
+    :param omnigent_python: Interpreter with omnigent + google-antigravity.
+    :param omnigent_repo_root: Cwd for the subprocesses.
+    :param tmp_path: Per-test scratch dir for the two bundles.
+    :param antigravity_runnable: Skip-guard (SDK + key present).
+    """
+    # Distinct, lowercase, punctuation-free sentinels so an exact substring
+    # match is unambiguous and the model echoes them verbatim. Fresh per run
+    # (uuid) so a popular fixture word can't be "recovered" from training data.
+    sentinel_a = "sentinel" + uuid.uuid4().hex[:12]
+    sentinel_b = "sentinel" + uuid.uuid4().hex[:12]
+
+    bundle_a = _write_antigravity_bundle(tmp_path / "agy-a", name="agy_lifecycle_a")
+    bundle_b = _write_antigravity_bundle(tmp_path / "agy-b", name="agy_lifecycle_b")
+
+    def _prompt(sentinel: str) -> str:
+        return f"Repeat exactly this token and nothing else: {sentinel}"
+
+    results: dict[str, subprocess.CompletedProcess[str]] = {}
+
+    def _worker(key: str, bundle: Path, sentinel: str) -> None:
+        results[key] = _run_antigravity_turn(
+            omnigent_python=omnigent_python,
+            omnigent_repo_root=omnigent_repo_root,
+            bundle_dir=bundle,
+            prompt=_prompt(sentinel),
+        )
+
+    threads = [
+        threading.Thread(target=_worker, args=("a", bundle_a, sentinel_a)),
+        threading.Thread(target=_worker, args=("b", bundle_b, sentinel_b)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        # Each subprocess already has its own _RUN_TIMEOUT_SEC; the join just
+        # needs to outlast that so a hung subprocess surfaces as its own
+        # TimeoutExpired rather than a silent deadlock here.
+        t.join(timeout=_RUN_TIMEOUT_SEC + 30)
+
+    assert set(results) == {"a", "b"}, (
+        f"a parallel antigravity worker did not finish; got results for {sorted(results)}."
+    )
+    out_a = results["a"].stdout.lower()
+    out_b = results["b"].stdout.lower()
+
+    produced_own_sentinel = sentinel_a in out_a or sentinel_b in out_b
+    if not produced_own_sentinel:
+        # Neither turn emitted real model output — only an infra failure makes
+        # the no-bleed invariant unobservable, so require that signature before
+        # skipping (otherwise a genuine "no output" regression would hide here).
+        infra = _looks_like_infra_failure(results["a"]) or _looks_like_infra_failure(results["b"])
+        reason = (
+            "both parallel antigravity turns produced no sentinel"
+            + (
+                " (infra failure: glibc<2.36 native-binary wall or saturated Gemini quota)"
+                if infra
+                else ""
+            )
+            + f". stdout_a={results['a'].stdout!r} stderr_a={results['a'].stderr!r} "
+            f"stdout_b={results['b'].stdout!r} stderr_b={results['b'].stderr!r}"
+        )
+        if infra:
+            pytest.skip(reason)
+        pytest.fail(reason)
+
+    # The isolation invariant: no run's transcript carries the OTHER run's
+    # sentinel. Checked per-run so a one-directional bleed is still caught even
+    # when only one run produced output.
+    assert sentinel_b not in out_a, (
+        f"state bleed: run A's transcript contains run B's sentinel {sentinel_b!r}. "
+        f"Concurrent antigravity sessions are sharing conversation state. "
+        f"stdout_a={results['a'].stdout!r}"
+    )
+    assert sentinel_a not in out_b, (
+        f"state bleed: run B's transcript contains run A's sentinel {sentinel_a!r}. "
+        f"Concurrent antigravity sessions are sharing conversation state. "
+        f"stdout_b={results['b'].stdout!r}"
+    )
+
+
+def test_antigravity_no_orphaned_localharness(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    tmp_path: Path,
+    antigravity_runnable: None,
+) -> None:
+    """A clean antigravity turn leaves no NEW native ``localharness`` behind.
+
+    Snapshots the live ``localharness`` PID set before the turn, runs one turn,
+    then polls until the post-turn set returns to baseline (allowing for an
+    asynchronous shutdown). The assertion is on the set DIFFERENCE — PIDs this
+    turn created that are still alive — so unrelated ``localharness`` processes
+    from other work on the host (which are in the baseline) never affect it.
+
+    A leaked PID here means the SDK ``Agent`` teardown
+    (``close_session`` / ``close`` → ``_close_agent`` → ``Agent.__aexit__``)
+    stopped reaping the native subprocess, so every turn would leak one.
+
+    Holds even when the turn fails at setup (glibc/quota): a turn that never
+    spawned the binary creates no new PID, and a turn that spawned it before
+    failing must still reap it on teardown.
+
+    :param omnigent_python: Interpreter with omnigent + google-antigravity.
+    :param omnigent_repo_root: Cwd for the subprocess.
+    :param tmp_path: Per-test scratch dir for the bundle.
+    :param antigravity_runnable: Skip-guard (SDK + key present).
+    """
+    bundle = _write_antigravity_bundle(tmp_path / "agy-orphan", name="agy_lifecycle_orphan")
+
+    baseline_pids = _localharness_pids()
+
+    result = _run_antigravity_turn(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        bundle_dir=bundle,
+        prompt="Repeat exactly this token and nothing else: pong",
+    )
+
+    # Poll for the new-PID set to drain to empty; teardown of the local
+    # server/runner that reaps the binary is asynchronous to the CLI exit.
+    leaked = _localharness_pids() - baseline_pids
+    deadline = _REAP_POLL_TIMEOUT_SEC
+    waited = 0.0
+    while leaked and waited < deadline:
+        time.sleep(_REAP_POLL_INTERVAL_SEC)
+        waited += _REAP_POLL_INTERVAL_SEC
+        leaked = _localharness_pids() - baseline_pids
+
+    assert not leaked, (
+        f"antigravity turn leaked {len(leaked)} native localharness subprocess(es) "
+        f"(PIDs {sorted(leaked)}) that were not in the pre-turn baseline and did not "
+        f"exit within {deadline:.0f}s of the run completing. The SDK Agent teardown "
+        f"is not reaping the native binary on session cleanup.\n\n"
+        f"run stdout:\n{result.stdout!r}\n\nrun stderr:\n{result.stderr!r}"
+    )
+
+
+def test_antigravity_session_cleanup_reaps_runner(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    tmp_path: Path,
+    antigravity_runnable: None,
+) -> None:
+    """After a turn's process tree exits, its native subprocess is reaped.
+
+    A single ``omnigent run`` turn owns a self-contained process tree (local
+    server → runner → native ``localharness``). Once the CLI process exits, that
+    tree must be torn down: no ``localharness`` PID this run created may survive.
+    Asserts on the before/after PID set difference (robust to unrelated host
+    processes) after polling for an async teardown.
+
+    Note (deliberately the *weaker, true* invariant): a separate bug-bash found
+    a "session DELETE leaves the runner alive" leak, but it reproduces on the
+    claude-sdk harness too — i.e. it is shared session-infra behavior, not an
+    antigravity-specific contract. This test therefore does NOT exercise an
+    explicit ``DELETE /v1/sessions/{id}`` and assert reaping (which would be a
+    known shared-infra failure). It asserts the antigravity-relevant invariant
+    that is true on main: a *clean turn end* (the ``-p`` one-shot exiting)
+    returns the native-subprocess set to baseline. The CLI process exiting 0 is
+    the clean-turn-end signal; the PID-diff is the reaping check.
+
+    :param omnigent_python: Interpreter with omnigent + google-antigravity.
+    :param omnigent_repo_root: Cwd for the subprocess.
+    :param tmp_path: Per-test scratch dir for the bundle.
+    :param antigravity_runnable: Skip-guard (SDK + key present).
+    """
+    bundle = _write_antigravity_bundle(tmp_path / "agy-cleanup", name="agy_lifecycle_cleanup")
+
+    baseline_pids = _localharness_pids()
+
+    result = _run_antigravity_turn(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        bundle_dir=bundle,
+        prompt="Repeat exactly this token and nothing else: bye",
+    )
+
+    # The CLI process has already exited here (subprocess.run returned). Its
+    # process tree teardown is what must reap the native binary; poll for the
+    # new-PID set to drain so a slow-but-correct shutdown isn't a false leak.
+    survivors = _localharness_pids() - baseline_pids
+    waited = 0.0
+    while survivors and waited < _REAP_POLL_TIMEOUT_SEC:
+        time.sleep(_REAP_POLL_INTERVAL_SEC)
+        waited += _REAP_POLL_INTERVAL_SEC
+        survivors = _localharness_pids() - baseline_pids
+
+    assert not survivors, (
+        f"after the antigravity run's process tree exited, {len(survivors)} native "
+        f"localharness subprocess(es) (PIDs {sorted(survivors)}) started by this run "
+        f"were still alive after {_REAP_POLL_TIMEOUT_SEC:.0f}s. A clean turn end must "
+        f"reap the per-conversation runner/harness; this is a lingering-process leak.\n\n"
+        f"run stdout:\n{result.stdout!r}\n\nrun stderr:\n{result.stderr!r}"
+    )

--- a/tests/e2e/omnigent/test_antigravity_streaming_e2e.py
+++ b/tests/e2e/omnigent/test_antigravity_streaming_e2e.py
@@ -1,0 +1,473 @@
+"""Per-harness live characterization — antigravity (Gemini) SDK streaming fidelity.
+
+Drives the ``antigravity`` harness end-to-end through the production
+``/v1/sessions`` flow — register an inline Omnigent agent
+(``executor.harness: antigravity``) → create + runner-bind a session →
+``POST /v1/sessions/{id}/events`` → poll the session to idle — then asserts over
+the *persisted transcript items* (``GET /v1/sessions/{id}/items``), NOT stdout
+chrome. This exercises the full producer/consumer path in
+:mod:`omnigent.inner.antigravity_executor`: ``conversation.send`` →
+``receive_steps()`` → the MODEL→USER ``content_delta`` mapping onto
+:class:`TextChunk` → the terminal :class:`TurnComplete` whose accumulated text
+the runner persists as an assistant ``message`` item.
+
+Scope is deliberately narrow: **streaming / output fidelity** of stable behavior
+already on ``main`` (this branch is cut from ``main``). It covers three things a
+streamed text channel can silently corrupt:
+
+1. **Long output** is not truncated or duplicated — the per-delta accumulation
+   in ``run_turn`` (``final_text_parts.append`` then ``"".join(...)``) must
+   neither drop a tail nor replay a block.
+2. **Unicode fidelity** — emoji / CJK / accented text round-trips byte-exact
+   through ``content_delta`` concatenation and JSON (de)serialization, with no
+   mojibake (``Ã©``), replacement char (``�``), or double-encoding.
+3. **Reasoning-heavy task** — a step-by-step prompt still yields a coherent,
+   non-empty final answer (we assert the answer sentinel, not the reasoning
+   internals, which the harness maps separately as :class:`ReasoningChunk`).
+
+**Gating (mirrors the cursor per-harness test):** the antigravity harness is
+Gemini-native — it authenticates with a Gemini / Antigravity API key and has NO
+Databricks-gateway path — so this test SKIPS (rather than fails) when its
+prerequisites are absent, keeping the e2e shards green where no Gemini key is
+provisioned. It runs for real wherever the prerequisites are present:
+
+- ``google.antigravity`` (the ``google-antigravity`` package) is importable, and
+- a Gemini key is configured (``antigravity_api_key_configured()``) or present
+  ambiently as ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``.
+
+.. note::
+   **glibc caveat.** The Antigravity SDK launches a bundled native
+   ``localharness`` binary linked against a recent glibc (it needs
+   ``GLIBC_ABI_DT_RELR``), so a turn only *completes* on a host with
+   glibc ≳ 2.36. On an older host (e.g. glibc 2.31) the turn fails at native
+   setup with ``version 'GLIBC_ABI_DT_RELR' not found`` and the session goes
+   ``failed`` — that is an environment gap, not a regression in the code under
+   test. The gate above mirrors cursor's (package + key) and deliberately does
+   NOT probe glibc; on a glibc-2.31 dev box point the SDK at a loader-shim via
+   ``ANTIGRAVITY_HARNESS_PATH`` (dev-only) to run the untouched binary under a
+   newer loader. CI runs this on a glibc-≥2.36 host.
+
+**What breaks if this fails (with prerequisites present):**
+- ``AntigravityExecutor`` regresses (the ``Step`` → :class:`TextChunk` mapping,
+  the per-turn text accumulation in ``run_turn``, or the MODEL→USER source/target
+  filter that keeps the echoed prompt out of the assistant reply).
+- ``_build_antigravity_spawn_env`` stops resolving the Gemini key into
+  ``HARNESS_ANTIGRAVITY_API_KEY`` for a spec with no ``executor.auth``.
+- The sessions dispatch path stops persisting the streamed assistant text into
+  ``conversation_items`` faithfully (truncation, duplication, or re-encoding).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.onboarding.antigravity_auth import antigravity_api_key_configured
+from tests.e2e.conftest import (
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    send_user_message_to_session,
+    upload_agent,
+)
+
+# Gemini id that runs on a plain AI-Studio key. ``gemini-3-pro`` 404s without
+# Pro access, so the suite pins a Flash model; left un-rewritten (the harness is
+# Gemini-native — a Databricks model map / profile stamp would break it).
+_MODEL = "gemini-3.5-flash"
+_HARNESS = "antigravity"
+
+# A turn cold-starts the native binary, round-trips to Google's backend, and
+# (for the long-output case) streams a multi-paragraph reply. 240s matches the
+# headroom the other live session smokes allow without letting a hung run pin
+# the suite forever.
+_RUN_TIMEOUT_SEC = 240.0
+
+
+def _antigravity_skip_reason() -> str | None:
+    """Return why the antigravity harness can't run for real, or ``None``.
+
+    Mirrors the cursor per-harness gate's spirit: the harness is Gemini-native
+    (no Databricks-gateway fallback), so when its prerequisites are absent the
+    suite SKIPS rather than fails — CI shards without a provisioned Gemini key
+    stay green, and the test runs for real wherever a key is present.
+
+    Two prerequisites, both probed against the *running* interpreter (the e2e
+    server + runner the ``live_server`` fixture spawns with ``sys.executable``
+    are this same interpreter):
+
+    1. ``google.antigravity`` is importable (the ``google-antigravity`` extra).
+    2. A Gemini key is configured (the dedicated ``antigravity:`` config block)
+       or present ambiently as ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY`` —
+       which ``_build_antigravity_spawn_env`` threads into the harness as
+       ``HARNESS_ANTIGRAVITY_API_KEY`` for a spec with no ``executor.auth``.
+
+    This gate intentionally does NOT probe glibc (see the module docstring's
+    note): on a glibc-<2.36 host the prerequisites read as present and the turn
+    fails at native-binary setup — surfaced by the per-turn terminal-status
+    assertion as an environment gap, not masked as a silent skip.
+
+    :returns: A skip-reason string when a prerequisite is missing, else ``None``.
+    """
+    if importlib.util.find_spec("google.antigravity") is None:
+        return (
+            "antigravity prerequisite missing: the 'google-antigravity' package "
+            "is not importable. Install it with: pip install 'omnigent[antigravity]'."
+        )
+    key_present = antigravity_api_key_configured() or bool(
+        os.environ.get("GEMINI_API_KEY") or os.environ.get("ANTIGRAVITY_API_KEY")
+    )
+    if not key_present:
+        return (
+            "antigravity prerequisite missing: no Gemini key configured. The "
+            "Antigravity SDK requires one (there is no login flow); configure it "
+            "via 'omni setup' (Antigravity) or export GEMINI_API_KEY / "
+            "ANTIGRAVITY_API_KEY. Skipped (not failed) so CI shards without a key "
+            "stay green."
+        )
+    return None
+
+
+# Skip the whole module at COLLECTION time when the harness can't run. This must
+# precede fixture setup: the live-server stack here is session-scoped (and the
+# e2e suite's own ``--llm-api-key`` gate lives on a session fixture), and
+# higher-scoped fixtures resolve before any function-scoped skip-guard could
+# fire — so a function-level gate would surface as a fixture ERROR instead of a
+# clean SKIP when a prerequisite is absent. ``allow_module_level`` runs the gate
+# before any of that, yielding a clean skip with no server/runner spawned.
+_SKIP_REASON = _antigravity_skip_reason()
+if _SKIP_REASON is not None:
+    pytest.skip(_SKIP_REASON, allow_module_level=True)
+
+
+def _write_antigravity_agent_yaml(tmp_path: Path, *, prompt: str) -> Path:
+    """Write a minimal single-file ``harness: antigravity`` Omnigent bundle.
+
+    Deliberately carries NO ``executor.auth`` and NO Databricks ``profile``: the
+    harness resolves its Gemini key Gemini-natively (configured ``antigravity:``
+    block, then ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``) — a global
+    ``auth:`` / profile would be the OpenAI-gateway key the SDK can't use. The
+    bundle is uploaded with ``rewrite_model_for_databricks=False`` so the Gemini
+    model id and ``antigravity`` harness pass through unmangled.
+
+    :param tmp_path: Per-test temp dir to materialize the bundle directory in.
+    :param prompt: The agent's system prompt (per-test, so each scenario can
+        steer the model toward a deterministic, assertable shape).
+    :returns: The bundle directory to hand to :func:`upload_agent`.
+    """
+    agent_dir = tmp_path / "antigravity-streaming-agent"
+    agent_dir.mkdir()
+    (agent_dir / "antigravity-streaming-agent.yaml").write_text(
+        "\n".join(
+            [
+                "name: antigravity-streaming-agent",
+                "description: Live streaming/output-fidelity probe for the antigravity harness.",
+                "executor:",
+                f"  harness: {_HARNESS}",
+                f"  model: {_MODEL}",
+                "prompt: |",
+                *(f"  {line}" for line in prompt.splitlines()),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return agent_dir
+
+
+def _run_one_shot(
+    http_client: httpx.Client,
+    *,
+    runner_id: str,
+    agent_name: str,
+    user_text: str,
+) -> str:
+    """Run one antigravity turn through a fresh runner-bound session.
+
+    Creates a session, posts *user_text*, and polls to terminal — asserting the
+    turn completed (a ``failed`` status surfaces the error, e.g. the glibc
+    native-binary failure on an old host, instead of masquerading as empty
+    output).
+
+    :param http_client: HTTP client pointed at the live server.
+    :param runner_id: The live runner id to bind the session to.
+    :param agent_name: The registered antigravity agent's name.
+    :param user_text: The user prompt for this turn.
+    :returns: The session id (so the caller can read ``/items``).
+    """
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=runner_id
+    )
+    response_id = send_user_message_to_session(
+        http_client, session_id=session_id, content=user_text
+    )
+    body = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=response_id,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+    assert body["status"] == "completed", (
+        f"antigravity turn did not complete: status={body['status']!r}, "
+        f"error={body.get('error')!r}. A 'failed' status with a "
+        f"GLIBC_ABI_DT_RELR error means the host's glibc is < 2.36 (the SDK's "
+        f"native binary can't load) — an environment gap, not a code "
+        f"regression. output={body.get('output')!r}"
+    )
+    return session_id
+
+
+def _assistant_text_from_items(http_client: httpx.Client, session_id: str) -> str:
+    """Concatenate assistant ``output_text`` from ``GET /v1/sessions/{id}/items``.
+
+    Reads the persisted transcript (the durable record the production session
+    flow commits), NOT stdout, so the assertions characterize what the harness
+    actually streamed and stored. The items endpoint returns the flat
+    Responses-style item shape — assistant text lives in ``message`` items with
+    ``role == "assistant"`` whose ``content`` carries ``output_text`` blocks
+    (see ``omnigent/server/API.md`` § List Conversation Items).
+
+    :param http_client: HTTP client pointed at the live server.
+    :param session_id: The session/conversation id to read.
+    :returns: The assistant text, ``"\\n"``-joined across any assistant messages
+        in the turn (empty string if none).
+    """
+    resp = http_client.get(f"/v1/sessions/{session_id}/items", params={"limit": 1000})
+    resp.raise_for_status()
+    items: list[dict[str, Any]] = resp.json()["data"]
+    parts: list[str] = []
+    for item in items:
+        if item.get("type") != "message" or item.get("role") != "assistant":
+            continue
+        for block in item.get("content", []):
+            if block.get("type") == "output_text":
+                text = block.get("text")
+                if text:
+                    parts.append(text)
+    return "\n".join(parts)
+
+
+def _max_repeated_run(text: str, *, block: int) -> int:
+    """Return the largest count of any *block*-char substring repeated in *text*.
+
+    A cheap duplication detector: a streamed reply that double-appended a chunk
+    shows up as a long substring occurring far more than the prose would warrant.
+    Samples non-overlapping windows so it stays linear on long replies.
+
+    :param text: The text to scan.
+    :param block: Window size in characters; large enough that natural prose
+        rarely repeats a window verbatim.
+    :returns: The max occurrence count of any sampled window (1 when nothing
+        repeats; >= 2 indicates a verbatim repeat of a *block*-sized span).
+    """
+    if len(text) < block:
+        return 1
+    counts: dict[str, int] = {}
+    best = 1
+    for start in range(0, len(text) - block + 1, block):
+        window = text[start : start + block]
+        counts[window] = counts.get(window, 0) + 1
+        best = max(best, counts[window])
+    return best
+
+
+# ─── Tests ───────────────────────────────────────────────────
+
+
+def test_antigravity_long_output_not_truncated_or_duplicated(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    tmp_path: Path,
+) -> None:
+    """A long multi-paragraph reply streams in full — not truncated, not duplicated.
+
+    The model is steered to emit six numbered sections, each ending in a unique
+    ``[SECT-k-END]`` sentinel. Asserting every sentinel survives proves nothing
+    was dropped from the head or tail of the streamed text; a length floor
+    proves the reply is genuinely substantial; and a verbatim-repeat check
+    proves the per-delta accumulation didn't replay a block. Together these
+    characterize ``run_turn``'s ``final_text_parts`` accumulation over a long
+    ``content_delta`` stream.
+    """
+    sentinels = [f"[SECT-{k}-END]" for k in range(1, 7)]
+    section_lines = "\n".join(
+        f"- Section {k}: at least four full sentences, then end the section with "
+        f"the exact marker {sent}"
+        for k, sent in enumerate(sentinels, start=1)
+    )
+    agent_name = upload_agent(
+        http_client,
+        _write_antigravity_agent_yaml(
+            tmp_path,
+            prompt=(
+                "You are a thorough technical writer. When asked for a multi-section "
+                "explanation, write every requested section in full, each as its own "
+                "paragraph, and place each section's exact end-marker on its own line. "
+                "Never abbreviate, summarize, or skip a section."
+            ),
+        ),
+        rewrite_model_for_databricks=False,
+    )
+    session_id = _run_one_shot(
+        http_client,
+        runner_id=live_runner_id,
+        agent_name=agent_name,
+        user_text=(
+            "Write a detailed explanation of how a CPU cache hierarchy works, "
+            "organized into exactly these six sections (keep them in order):\n"
+            f"{section_lines}\n"
+            "Write each section fully before moving to the next."
+        ),
+    )
+
+    text = _assistant_text_from_items(http_client, session_id)
+
+    # Not truncated: every section's end-marker survived the stream. A dropped
+    # tail (the classic truncation bug) loses the later markers first.
+    missing = [s for s in sentinels if s not in text]
+    assert not missing, (
+        f"long-output reply is missing section markers {missing} — the streamed "
+        f"text was truncated before the end. Got {len(text)} chars:\n{text!r}"
+    )
+
+    # Substantial: six full sections clear this floor comfortably; an empty /
+    # one-line reply (a streaming or accumulation regression) does not.
+    assert len(text) >= 800, (
+        f"long-output reply is only {len(text)} chars; expected a substantial "
+        f"multi-section answer (>= 800). Reply:\n{text!r}"
+    )
+
+    # Not duplicated: no 80-char window recurs verbatim. A double-appended delta
+    # block would push some window's count to >= 2.
+    repeats = _max_repeated_run(text, block=80)
+    assert repeats < 2, (
+        f"long-output reply repeats an 80-char block {repeats}x — the stream "
+        f"likely double-appended a chunk. Reply:\n{text!r}"
+    )
+
+
+def test_antigravity_unicode_fidelity_round_trips(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    tmp_path: Path,
+) -> None:
+    """Emoji + CJK + accented text round-trips byte-exact into the transcript.
+
+    The model is asked to echo a fixed payload verbatim on its own line. We
+    assert each non-ASCII fragment appears EXACTLY in the persisted item text —
+    catching mojibake (``café`` → ``cafÃ©``), the replacement char ``\\ufffd``,
+    and double-encoding, any of which would corrupt the ``content_delta``
+    concatenation or the JSON (de)serialization on the way into
+    ``conversation_items``.
+    """
+    # One emoji (incl. a ZWJ sequence + skin-tone modifier), CJK, and accents.
+    fragments = ["café", "naïve façade", "日本語のテキスト", "中文字符", "🚀", "👩‍🚀", "👍🏽"]
+    payload = " | ".join(fragments)
+    agent_name = upload_agent(
+        http_client,
+        _write_antigravity_agent_yaml(
+            tmp_path,
+            prompt=(
+                "You echo text exactly as given, preserving every character including "
+                "emoji, CJK, and accents. Never transliterate, escape, or normalize."
+            ),
+        ),
+        rewrite_model_for_databricks=False,
+    )
+    session_id = _run_one_shot(
+        http_client,
+        runner_id=live_runner_id,
+        agent_name=agent_name,
+        user_text=(
+            "Repeat the following text back to me EXACTLY, character for character, "
+            "on a single line, with no additional commentary, quotes, or code "
+            f"fences:\n{payload}"
+        ),
+    )
+
+    text = _assistant_text_from_items(http_client, session_id)
+
+    # No corruption signatures anywhere in the persisted text.
+    assert "�" not in text, (
+        f"transcript contains the Unicode replacement char (\\ufffd) — bytes were "
+        f"lost or mis-decoded in the stream. Reply:\n{text!r}"
+    )
+    # ``Ã`` is the tell-tale lead byte of UTF-8 mis-decoded as Latin-1 (e.g.
+    # ``é`` → ``Ã©``); none of our intended fragments contain it.
+    assert "Ã" not in text and "â€" not in text, (
+        f"transcript shows mojibake / double-encoding (e.g. 'Ã©' for 'é') — a "
+        f"decode/encode mismatch corrupted the non-ASCII text. Reply:\n{text!r}"
+    )
+    # Each intended fragment must survive verbatim.
+    missing = [frag for frag in fragments if frag not in text]
+    assert not missing, (
+        f"these unicode fragments did not round-trip into the transcript: "
+        f"{missing}. The harness must preserve emoji/CJK/accents byte-exact. "
+        f"Reply:\n{text!r}"
+    )
+
+
+def test_antigravity_reasoning_heavy_task_final_answer(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    tmp_path: Path,
+) -> None:
+    """A step-by-step task yields a coherent, non-empty final answer.
+
+    A small arithmetic word problem elicits multi-step reasoning; the model is
+    told to end with ``FINAL ANSWER: <n>``. We assert the answer sentinel with
+    the correct value is present and the reply is non-trivial — characterizing
+    that the harness streams a usable final answer for a reasoning-heavy turn.
+    We deliberately do NOT assert on the reasoning internals (the harness maps
+    ``thinking_delta`` onto :class:`ReasoningChunk` separately, and whether/how
+    much reasoning surfaces is model- and config-dependent — over-specifying it
+    would make the test flaky without testing output fidelity).
+    """
+    agent_name = upload_agent(
+        http_client,
+        _write_antigravity_agent_yaml(
+            tmp_path,
+            prompt=(
+                "You are a careful problem solver. Work through the problem step by "
+                "step, then state the result on a final line in the exact form "
+                "'FINAL ANSWER: <number>'."
+            ),
+        ),
+        rewrite_model_for_databricks=False,
+    )
+    # 3 crates * 4 boxes * 6 widgets = 72; +5 spares = 77. A unique integer the
+    # model is very unlikely to emit except as the correct result.
+    session_id = _run_one_shot(
+        http_client,
+        runner_id=live_runner_id,
+        agent_name=agent_name,
+        user_text=(
+            "A warehouse has 3 crates. Each crate holds 4 boxes, and each box holds "
+            "6 widgets. There are also 5 loose spare widgets on a shelf. How many "
+            "widgets are in the warehouse in total? Show your reasoning step by "
+            "step, then end with a line 'FINAL ANSWER: <number>'."
+        ),
+    )
+
+    text = _assistant_text_from_items(http_client, session_id)
+
+    # Coherent + non-empty: a reasoning-heavy reply is more than a bare token.
+    assert len(text.strip()) >= 20, (
+        f"reasoning-task reply is too short to be a coherent answer "
+        f"({len(text.strip())} chars): {text!r}"
+    )
+    # The final answer surfaced with the correct value. ``77`` (not ``72``) also
+    # confirms the model accounted for the spares — i.e. the streamed reply
+    # carries the genuine end-of-reasoning result, not a truncated mid-step.
+    assert "FINAL ANSWER" in text, (
+        f"reply is missing the requested 'FINAL ANSWER:' line — the final-answer "
+        f"text didn't stream into the transcript. Reply:\n{text!r}"
+    )
+    assert "77" in text, (
+        f"reply's final answer is not 77 (3*4*6 + 5); the reasoning result is "
+        f"wrong or its tail was dropped from the stream. Reply:\n{text!r}"
+    )

--- a/tests/e2e/omnigent/test_per_harness_antigravity.py
+++ b/tests/e2e/omnigent/test_per_harness_antigravity.py
@@ -1,0 +1,591 @@
+"""Per-harness live characterization test — antigravity (Gemini) SDK harness.
+
+Runs ``omnigent run <spec> --harness antigravity ...`` as a real subprocess and
+asserts structural invariants over the persisted **conversation transcript**
+(not stdout): a non-empty, non-error assistant reply; a pinned + default Gemini
+model both complete; multi-turn history is retained across a ``--continue``
+resume (the #278 plain-text history seeding); and the happy path exits 0 with a
+non-error transcript. This is the end-to-end gate for the antigravity harness:
+the full path from CLI parse -> spec materialize -> ``_build_antigravity_spawn_env``
+threading ``HARNESS_ANTIGRAVITY_*`` -> the ``antigravity`` harness wrap ->
+:class:`AntigravityExecutor` driving the in-process ``google.antigravity`` SDK
+(``conversation.send`` -> ``receive_steps()`` -> mapped ``ExecutorEvent``\\ s) ->
+``TurnComplete`` -> the conversation store.
+
+Unlike the other per-harness e2e tests (claude-sdk / codex / openai-agents / pi),
+the antigravity harness is **Gemini-native**: the SDK has no OpenAI-compatible
+``base_url`` and there is deliberately no Databricks-gateway path, so this test
+does NOT use ``patched_databrickscfg`` / ``omnigent_credentials_env``'s gateway
+URL — it authenticates purely from the configured / ambient Gemini key. This
+mirrors :mod:`tests.e2e.omnigent.test_per_harness_cursor` (the other
+backend-native SDK harness): because a Gemini key is not provisioned on CI, the
+test **skips** (rather than fails) when no key is present, so the e2e shards stay
+green; it runs for real wherever a key is configured.
+
+**Prerequisites (skipped cleanly when absent):**
+- ``google.antigravity`` importable in the Omnigent venv (the ``antigravity``
+  extra — ``pip install 'omnigent[antigravity]'``).
+- A Gemini / Antigravity API key configured (a stored ``antigravity:`` config
+  block resolvable via
+  :func:`omnigent.onboarding.antigravity_auth.antigravity_api_key_configured`,
+  or an ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``). The SDK *requires*
+  a key — there is no login flow.
+
+**glibc / dev-shim caveat:** the SDK spawns a bundled native ``localharness``
+binary linked against a recent glibc (needs ``GLIBC_ABI_DT_RELR``), so a live
+turn only succeeds on hosts with **glibc >= ~2.36**. On an older dev box the turn
+fails at setup with ``RuntimeError: ... localharness: ... version
+'GLIBC_ABI_DT_RELR' not found`` unless ``ANTIGRAVITY_HARNESS_PATH`` points at a
+loader-shim that runs the untouched bundled binary through a newer glibc's
+loader. This gate intentionally does NOT probe glibc (CI runners are modern); it
+is documented here so a glibc-2.31 dev run that fails the live turn is
+recognized as the host, not a harness regression.
+
+**What breaks if this fails (with prerequisites present):**
+- :class:`AntigravityExecutor` regresses (the ``Step`` -> ``ExecutorEvent``
+  translation, the ``custom_tools`` bridge, per-session agent reuse, the
+  ``LocalAgentConfig`` field filtering, or the Gemini-native auth threading).
+- ``_build_antigravity_spawn_env`` stops resolving the configured / ambient
+  Gemini key into ``HARNESS_ANTIGRAVITY_API_KEY`` (#277 regression), or stops
+  threading ``--model`` into ``HARNESS_ANTIGRAVITY_MODEL`` (#276 regression).
+- The ``google-antigravity`` SDK contract changes (``Agent`` / ``Conversation``
+  / ``receive_steps`` shape).
+- ``--continue`` stops seeding prior-turn history onto a fresh antigravity
+  session (#278 regression — the SDK has no history-injection API, so prior
+  turns are replayed as a plain-text ``"Conversation so far: ..."`` prefix).
+- ``omnigent.cli``'s ``run`` one-shot / interactive paths stop persisting the
+  assistant reply, or harness dispatch for ``antigravity`` regresses.
+
+**Scope note (stable-on-main behaviors only):** this file is authored off
+``main`` (#194 + #276/#277/#278). It deliberately does NOT assert tool-parameter
+schemas (#279), policy enforcement (#284), the model catalog (#290), or error
+normalization (#297) — those land with their own PRs and are tested there.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from omnigent.entities.conversation import MessageData
+
+_HARNESS = "antigravity"
+
+# A valid Gemini id the harness pins for the model-selection test. ``gemini-3-pro``
+# 404s on a plain AI-Studio key, so the suite stays on the flash tier:
+# ``gemini-2.5-flash`` is the explicit pin; the harness default is
+# ``gemini-3.5-flash`` (resolved by ``AntigravityExecutor`` when no model is set).
+_PINNED_MODEL = "gemini-2.5-flash"
+_DEFAULT_MODEL = "gemini-3.5-flash"
+
+# Minimum assistant-text length. A reply longer than ~10 chars proves the turn
+# produced a genuine model response (not an empty turn or a one-token stub).
+_MIN_ASSISTANT_CHARS = 10
+
+# Substrings that betray an error item / failed turn rather than a real reply.
+# The antigravity executor surfaces failures as an ``ExecutorError`` whose
+# message is prefixed "Antigravity ... failed"; a glibc / model / egress failure
+# lands here. Matched case-insensitively against the joined transcript text.
+_ERROR_MARKERS: tuple[str, ...] = (
+    "antigravity turn failed",
+    "antigravity agent setup failed",
+    "glibc_abi_dt_relr",
+    "traceback (most recent call last)",
+)
+
+# Subprocess timeout per ``omnigent run`` invocation. The antigravity SDK boots
+# a native subprocess and round-trips to the Gemini backend, so cold turns take
+# ~10-60s; 200s keeps headroom on a contended CI host without letting a hung run
+# pin the suite forever.
+_RUN_TIMEOUT_SEC = 200
+
+# Minimal antigravity-native agent spec. Single-file legacy form (``name`` /
+# ``prompt`` / ``executor``) — the form ``omnigent run <file>`` accepts without a
+# spec directory. No ``executor.auth`` block: the key resolves from the stored
+# ``antigravity:`` config / ambient ``GEMINI_API_KEY`` via
+# ``_build_antigravity_spawn_env``. The model is pinned per-test via ``--model``
+# (an empty ``executor`` would default to the harness's ``gemini-3.5-flash``).
+_AGENT_YAML = """\
+name: antigravity_per_harness_e2e
+prompt: |
+  You are a terse test assistant. Answer in as few words as possible, but
+  always answer in a complete sentence of at least a few words.
+
+executor:
+  harness: antigravity
+"""
+
+
+def _antigravity_skip_reason(omnigent_python: Path) -> str | None:
+    """Return a skip reason when the antigravity prerequisites are absent.
+
+    Mirrors the cursor harness gate: the antigravity harness talks only to
+    Google's Gemini backend (no Databricks-gateway path), and CI does not
+    provision a Gemini key, so an absent prerequisite is a clean **skip** rather
+    than a failure — keeping the e2e shards green while the test runs for real
+    wherever a key is configured.
+
+    Both prerequisites are probed in the *Omnigent venv* interpreter (the one the
+    subprocess uses), not the current pytest interpreter, because the test shells
+    out: the SDK import and the key-config resolution must hold *there*.
+
+    :param omnigent_python: Interpreter the ``omnigent`` subprocess will use.
+    :returns: A human-readable skip reason, or ``None`` when both the
+        ``google.antigravity`` SDK and a usable Gemini key are present.
+    """
+    probe = subprocess.run(
+        [
+            str(omnigent_python),
+            "-c",
+            # Booleans only — never print the key. ``antigravity_api_key_configured``
+            # resolves a stored ``antigravity:`` block; the ambient env vars are the
+            # SDK's direct fallback (and what ``_build_antigravity_spawn_env`` adopts).
+            "import importlib.util, os, sys;"
+            "have_sdk = importlib.util.find_spec('google.antigravity') is not None;"
+            "from omnigent.onboarding.antigravity_auth import "
+            "antigravity_api_key_configured as cfg, ANTIGRAVITY_ENV_VARS;"
+            "have_key = cfg() or any(os.environ.get(v) for v in ANTIGRAVITY_ENV_VARS);"
+            "sys.stdout.write(f'{int(have_sdk)}{int(have_key)}')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0:
+        # The probe itself failed to import the onboarding module — treat as a
+        # missing/installation-broken prerequisite and skip with the detail.
+        return (
+            "antigravity prerequisite probe failed in the Omnigent venv "
+            f"(exit {probe.returncode}): {probe.stderr.strip()[:400]!r}"
+        )
+    flags = probe.stdout.strip()
+    have_sdk = flags[:1] == "1"
+    have_key = flags[1:2] == "1"
+    if not have_sdk:
+        return (
+            "antigravity prerequisite missing: the 'google.antigravity' SDK is "
+            "not importable in the Omnigent venv (install the 'antigravity' "
+            "extra: pip install 'omnigent[antigravity]')."
+        )
+    if not have_key:
+        return (
+            "antigravity prerequisite missing: no Gemini API key configured. The "
+            "Antigravity SDK requires a key (no login flow); configure an "
+            "'antigravity:' block via 'omni setup' or export GEMINI_API_KEY / "
+            "ANTIGRAVITY_API_KEY. Skipped (not failed) because CI does not "
+            "provision a Gemini key — this Gemini-native harness has no "
+            "Databricks-gateway fallback."
+        )
+    return None
+
+
+@pytest.fixture
+def antigravity_spec(tmp_path: Path) -> Path:
+    """Materialize the minimal antigravity agent spec and return its path.
+
+    :param tmp_path: Per-test temp dir.
+    :returns: Path to the written ``agent.yaml``.
+    """
+    spec_path = tmp_path / "agent.yaml"
+    spec_path.write_text(_AGENT_YAML, encoding="utf-8")
+    return spec_path
+
+
+def _antigravity_env(base_env: dict[str, str], home: Path) -> dict[str, str]:
+    """Build the subprocess env for an antigravity run.
+
+    Starts from the shared ``omnigent_credentials_env`` (so PATH, the onboarding
+    suppression knobs, and the worktree ``PYTHONPATH`` propagate) but isolates
+    ``$HOME`` and the Omnigent state/config roots into the test's temp dir, so
+    the persistent conversation store this test reads (``$HOME/.omnigent/chat.db``)
+    is private and the run never threads onto an unrelated prior conversation.
+
+    The gateway-oriented ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` keys inherited
+    from the base env are irrelevant to this harness (the SDK has no
+    ``base_url``); the Gemini key is resolved by ``_build_antigravity_spawn_env``
+    from the configured ``antigravity:`` block / ambient env, which survives the
+    ``HOME`` swap because the ambient ``GEMINI_API_KEY`` (when set) is carried in
+    ``base_env`` and the keychain is process-global.
+
+    :param base_env: The ``omnigent_credentials_env`` fixture dict.
+    :param home: Per-test fake ``$HOME``.
+    :returns: A fresh env dict for ``subprocess.run(env=...)``.
+    """
+    env = dict(base_env)
+    env["HOME"] = str(home)
+    env["OMNIGENT_CONFIG_HOME"] = str(home / ".omnigent")
+    env["OMNIGENT_DATA_DIR"] = str(home / ".omnigent")
+    return env
+
+
+def _assistant_transcript_texts(db_path: Path) -> list[str]:
+    """Return every assistant message text block from the persistent store.
+
+    Reads the conversation transcript directly from the SQLite store the
+    subprocess wrote, rather than scraping the CLI's stdout — the transcript is
+    the durable record of what the harness actually produced. Mirrors
+    ``_conversation_texts`` in
+    :mod:`tests.e2e.omnigent.test_server_remote_omnigent_autonomous_flows`, but
+    filtered to assistant-authored messages so the assertions can't be satisfied
+    by the echoed user prompt.
+
+    :param db_path: Path to ``$HOME/.omnigent/chat.db``.
+    :returns: Assistant message texts across every conversation in the store.
+    """
+    # Lazy import: the conversation store pulls in SQLAlchemy, and keeping it out
+    # of module import time means a skipped test (no SDK / key) never pays for it.
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    store = SqlAlchemyConversationStore(f"sqlite:///{db_path}")
+    texts: list[str] = []
+    convs = store.list_conversations(limit=50)
+    for conv in convs.data:
+        page = store.list_items(conversation_id=conv.id, limit=500)
+        for item in page.data:
+            if item.type != "message" or not isinstance(item.data, MessageData):
+                continue
+            if item.data.role != "assistant":
+                continue
+            for block in item.data.content or []:
+                if not isinstance(block, dict):
+                    continue
+                text = block.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+    return texts
+
+
+def _run_one_shot(
+    *,
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    spec_path: Path,
+    env: dict[str, str],
+    prompt: str,
+    model: str | None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a one-shot ``omnigent run <spec> --harness antigravity -p <prompt>``.
+
+    Session-backed (no ``--no-session``) so the turn is persisted to
+    ``$HOME/.omnigent/chat.db`` for transcript inspection and so a later
+    ``--continue`` can thread onto it.
+
+    :param omnigent_python: Interpreter from the ``omnigent_python`` fixture.
+    :param omnigent_repo_root: Cwd for the subprocess (repo root on sys.path).
+    :param spec_path: Path to the antigravity agent YAML.
+    :param env: Subprocess env (HOME-isolated, Gemini-keyed).
+    :param prompt: The ``-p`` prompt for this turn.
+    :param model: Gemini model to pin via ``--model``; ``None`` uses the harness
+        default (``gemini-3.5-flash``).
+    :returns: The completed process (stdout/stderr captured for diagnostics).
+    """
+    argv = [
+        str(omnigent_python),
+        "-m",
+        "omnigent",
+        "run",
+        str(spec_path),
+        "--harness",
+        _HARNESS,
+    ]
+    if model is not None:
+        argv += ["--model", model]
+    argv += ["-p", prompt, "--no-log"]
+    return subprocess.run(
+        argv,
+        env=env,
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+
+def _assert_clean_assistant_reply(
+    db_path: Path,
+    result: subprocess.CompletedProcess[str],
+    *,
+    label: str,
+) -> str:
+    """Assert the run exited 0 and persisted a non-empty, non-error reply.
+
+    The single shared post-condition for the happy-path turns: graceful exit,
+    plus a transcript whose assistant text is long enough to be a real reply and
+    free of the executor's error markers (a failed antigravity turn surfaces as
+    a ``failed`` session + an error item, never a silent empty success).
+
+    :param db_path: The session store the run wrote.
+    :param result: The completed ``omnigent run`` process.
+    :param label: Short label for failure messages, e.g. ``"smoke"``.
+    :returns: The joined assistant transcript text (for callers that assert more).
+    """
+    assert result.returncode == 0, (
+        f"antigravity {label} run exited {result.returncode}.\n\n"
+        f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    texts = _assistant_transcript_texts(db_path)
+    joined = "\n".join(texts).strip()
+    assert len(joined) >= _MIN_ASSISTANT_CHARS, (
+        f"antigravity {label}: assistant transcript shorter than "
+        f"{_MIN_ASSISTANT_CHARS} chars; got {joined!r}. The turn produced no "
+        f"real reply.\n\nstdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    lowered = joined.lower()
+    matched = [marker for marker in _ERROR_MARKERS if marker in lowered]
+    assert not matched, (
+        f"antigravity {label}: assistant transcript looks like an error item "
+        f"(matched {matched}), not a real reply: {joined!r}\n\n"
+        f"stderr:\n{result.stderr!r}"
+    )
+    return joined
+
+
+def test_per_harness_antigravity_smoke(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    omnigent_credentials_env: dict[str, str],
+    antigravity_spec: Path,
+    tmp_path: Path,
+) -> None:
+    """A real antigravity turn returns a non-empty, non-error assistant reply.
+
+    The end-to-end smoke gate: one ``omnigent run --harness antigravity -p``
+    against the harness default model. Asserts over the persisted transcript
+    (not stdout) that the assistant reply is >= ~10 chars and not an error
+    string, and that the process exited 0.
+
+    :param omnigent_python: Interpreter with omnigent + the antigravity SDK.
+    :param omnigent_repo_root: Cwd for the subprocess.
+    :param omnigent_credentials_env: Base env (PATH / onboarding-suppression /
+        worktree PYTHONPATH); the Gemini key resolves independently of the
+        Databricks gateway keys it also carries.
+    :param antigravity_spec: Materialized antigravity agent YAML.
+    :param tmp_path: Per-test temp dir (also the fake ``$HOME``).
+    """
+    skip_reason = _antigravity_skip_reason(omnigent_python)
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    env = _antigravity_env(omnigent_credentials_env, fake_home)
+
+    result = _run_one_shot(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        spec_path=antigravity_spec,
+        env=env,
+        prompt="Reply in one short sentence that you are ready.",
+        model=None,
+    )
+    _assert_clean_assistant_reply(fake_home / ".omnigent" / "chat.db", result, label="smoke")
+
+
+@pytest.mark.parametrize(
+    "model",
+    [_PINNED_MODEL, _DEFAULT_MODEL],
+    ids=["pinned-2.5-flash", "default-3.5-flash"],
+)
+def test_per_harness_antigravity_model_selection(
+    model: str,
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    omnigent_credentials_env: dict[str, str],
+    antigravity_spec: Path,
+    tmp_path: Path,
+) -> None:
+    """A turn pinned to a valid Gemini id completes (and so does the default).
+
+    Exercises ``--model`` threading through ``_build_antigravity_spawn_env`` ->
+    ``HARNESS_ANTIGRAVITY_MODEL`` for an explicit ``gemini-2.5-flash`` pin, and
+    the harness's resolved ``gemini-3.5-flash`` default. Both must exit 0 and
+    persist a non-error assistant reply. Stays on the flash tier deliberately —
+    ``gemini-3-pro`` 404s on a plain AI-Studio key.
+
+    :param model: The Gemini id under test (parametrized).
+    :param omnigent_python: Interpreter with omnigent + the antigravity SDK.
+    :param omnigent_repo_root: Cwd for the subprocess.
+    :param omnigent_credentials_env: Base subprocess env.
+    :param antigravity_spec: Materialized antigravity agent YAML.
+    :param tmp_path: Per-test temp dir (also the fake ``$HOME``).
+    """
+    skip_reason = _antigravity_skip_reason(omnigent_python)
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    env = _antigravity_env(omnigent_credentials_env, fake_home)
+
+    result = _run_one_shot(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        spec_path=antigravity_spec,
+        env=env,
+        prompt="Name any primary color in one short sentence.",
+        model=model,
+    )
+    _assert_clean_assistant_reply(
+        fake_home / ".omnigent" / "chat.db", result, label=f"model={model}"
+    )
+
+
+def test_per_harness_antigravity_multi_turn_history_retention(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    omnigent_credentials_env: dict[str, str],
+    antigravity_spec: Path,
+    tmp_path: Path,
+) -> None:
+    """Turn 2 (``--continue``) references a nonce only turn 1 saw (#278).
+
+    The antigravity SDK has no history-injection API, so #278 seeds prior turns
+    onto a fresh/rebuilt session as a plain-text ``"Conversation so far: ..."``
+    prefix. This is the integration test for that path: turn 1 (one-shot ``-p``)
+    plants a unique nonce into the persistent store; turn 2 (interactive REPL
+    ``--continue`` on the same store, with the recall prompt piped on stdin and
+    ``/quit`` terminating it) must recover the nonce — proving the prior turn's
+    text reached the model on the resumed session. The recall prompt does NOT
+    contain the nonce, so the only way turn 2 can produce it is via the seeded
+    history.
+
+    The proof reads turn 2's **assistant transcript items** for the nonce, not
+    stdout, keeping it consistent with the other assertions here.
+
+    :param omnigent_python: Interpreter with omnigent + the antigravity SDK.
+    :param omnigent_repo_root: Cwd for the subprocess.
+    :param omnigent_credentials_env: Base subprocess env.
+    :param antigravity_spec: Materialized antigravity agent YAML.
+    :param tmp_path: Per-test temp dir (also the fake ``$HOME``).
+    """
+    skip_reason = _antigravity_skip_reason(omnigent_python)
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    env = _antigravity_env(omnigent_credentials_env, fake_home)
+    db_path = fake_home / ".omnigent" / "chat.db"
+    # Fresh per-run nonce so a parallel run can't leak it, and so the model can't
+    # "recover" a popular fixture word from its training data instead of history.
+    nonce = "nonce" + uuid.uuid4().hex[:12]
+
+    # ── Turn 1: plant the nonce (one-shot -p, session-backed).
+    plant = _run_one_shot(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        spec_path=antigravity_spec,
+        env=env,
+        prompt=(
+            f"Remember the magic word {nonce}. Reply with one short sentence "
+            f"that includes exactly that word."
+        ),
+        model=_PINNED_MODEL,
+    )
+    plant_text = _assert_clean_assistant_reply(db_path, plant, label="plant")
+    # Pre-condition: the model actually echoed the nonce in turn 1. Without this,
+    # turn 2's recovery would be meaningless (it could echo a nonce it never saw).
+    assert nonce in plant_text.lower(), (
+        f"turn 1 did not echo the nonce {nonce!r}; assistant text={plant_text!r}. "
+        f"The multi-turn recovery check below would be meaningless."
+    )
+    assert db_path.is_file(), (
+        f"persistent store not created at {db_path} — turn 1 ran ephemerally, so "
+        f"--continue in turn 2 would have nothing to thread onto."
+    )
+
+    # ── Turn 2: recover the nonce via interactive REPL --continue. The CLI
+    # rejects --continue + -p, so the recall prompt is piped on stdin and /quit
+    # ends the REPL. The prompt deliberately omits the nonce.
+    recall_prompt = (
+        "What is the magic word I asked you to remember? Reply with one short "
+        "sentence that includes exactly that word."
+    )
+    recall = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(antigravity_spec),
+            "--harness",
+            _HARNESS,
+            "--model",
+            _PINNED_MODEL,
+            "--no-log",
+            "--continue",
+        ],
+        env=env,
+        cwd=str(omnigent_repo_root),
+        input=f"{recall_prompt}\n/quit\n",
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+    assert recall.returncode == 0, (
+        f"turn 2 (--continue) exited {recall.returncode}.\n\n"
+        f"stdout:\n{recall.stdout!r}\n\nstderr:\n{recall.stderr!r}"
+    )
+    # The load-bearing assertion: the nonce appears in an assistant transcript
+    # item written after turn 1. Turn 2's reply is the newest assistant text, but
+    # turn 1's reply also contained the nonce, so a stricter check (that the nonce
+    # appears in MORE than one assistant message) confirms turn 2 reproduced it
+    # rather than the assertion merely re-reading turn 1's persisted reply.
+    texts = _assistant_transcript_texts(db_path)
+    nonce_hits = sum(1 for text in texts if nonce in text.lower())
+    assert nonce_hits >= 2, (
+        f"nonce {nonce!r} appears in {nonce_hits} assistant message(s); expected "
+        f">= 2 (turn 1's echo + turn 2's recovery). --continue failed to seed "
+        f"turn 1's history onto the resumed antigravity session (#278).\n\n"
+        f"assistant texts:\n{texts!r}\n\n"
+        f"turn 2 stdout:\n{recall.stdout!r}\n\nturn 2 stderr:\n{recall.stderr!r}"
+    )
+
+
+def test_per_harness_antigravity_graceful_completion(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    omnigent_credentials_env: dict[str, str],
+    antigravity_spec: Path,
+    tmp_path: Path,
+) -> None:
+    """The happy path exits 0 and the parent session is not ``failed``.
+
+    Distinct from the smoke test: this asserts the *graceful-completion*
+    invariant — a clean exit and a transcript free of error markers, i.e. the
+    session did not end in the ``failed`` state the executor uses for a glibc /
+    model / egress failure (which would surface as an ``ExecutorError`` item, not
+    a normal assistant reply). Together with the smoke test's content check this
+    pins both "a reply came back" and "the turn completed cleanly".
+
+    :param omnigent_python: Interpreter with omnigent + the antigravity SDK.
+    :param omnigent_repo_root: Cwd for the subprocess.
+    :param omnigent_credentials_env: Base subprocess env.
+    :param antigravity_spec: Materialized antigravity agent YAML.
+    :param tmp_path: Per-test temp dir (also the fake ``$HOME``).
+    """
+    skip_reason = _antigravity_skip_reason(omnigent_python)
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    env = _antigravity_env(omnigent_credentials_env, fake_home)
+    db_path = fake_home / ".omnigent" / "chat.db"
+
+    result = _run_one_shot(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        spec_path=antigravity_spec,
+        env=env,
+        prompt="Reply with one short friendly sentence.",
+        model=None,
+    )
+    # _assert_clean_assistant_reply already checks exit 0 + no error markers in
+    # the transcript; the persisted non-error assistant reply is the observable
+    # proof the session reached a clean terminal state rather than ``failed``.
+    _assert_clean_assistant_reply(db_path, result, label="graceful")


### PR DESCRIPTION
## Summary

Antigravity was the only SDK harness without a per-harness e2e file (claude_sdk / codex / cursor / openai_agents_sdk / pi all have one) and was excluded from the live no-AGENT matrix (Gemini-native, no Databricks gateway). This adds **11 gated e2e tests** across three files, modeled on the existing per-harness tests + the `antigravity-sdk-e2e-dev` skill:

- `tests/e2e/omnigent/test_per_harness_antigravity.py` (5) — smoke, valid-model selection (pinned `gemini-2.5-flash` + default `gemini-3.5-flash`), multi-turn history retention, graceful completion. Asserts over the conversation transcript, not stdout.
- `tests/e2e/omnigent/test_antigravity_streaming_e2e.py` (3) — long output (no truncation/duplication), unicode/CJK/emoji fidelity (no mojibake), reasoning-heavy final answer. Asserts over `GET /v1/sessions/{id}/items`.
- `tests/e2e/omnigent/test_antigravity_lifecycle_e2e.py` (3) — parallel turns / no cross-session state bleed, no orphaned `localharness` after a turn, runner cleanup.

Scoped to **stable-on-main** behavior — deliberately does not assert the in-flight fixes (#279 tool schemas / #284 policy / #290 catalog / #297 error normalization), which carry their own tests.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

11 gated e2e tests. Validated locally by `pytest --collect-only` (all 11 collect), `ruff check`, `ruff format --check`, and `mypy` (all clean). Each file gates (skips) cleanly when `google-antigravity` or a Gemini key is absent, mirroring the cursor per-harness gating; the glibc>=2.36 native-binary requirement is documented in each module docstring. Live turns require real Gemini quota + a glibc>=2.36 host, so they run for real in CI — on the dev host the capped smokes confirmed the full stack is reached (harness dispatched, glibc shim booted the binary, Gemini key authenticated) before the shared free-tier 429 / dev-host glibc 2.31 stopped the turn.

_Authored by Claude Code (an AI agent) at the repo owner's direction._