### PR TITLE
Create Gemini agent config for Debby

### DIFF
--- a/examples/debby/agents/gemini/config.yaml
+++ b/examples/debby/agents/gemini/config.yaml
@@ -1,0 +1,64 @@
+spec_version: 1
+name: gemini
+description: >-
+  Plain Gemini brainstorming responder — answers a question on its own merits,
+  and (during a debate) critiques the other partner's answer.
+
+# Plain responder on the OpenAI Agents SDK harness. No model is pinned, so it
+# runs on whatever OpenAI-compatible provider you configured (e.g. Gemini via
+# OPENAI_BASE_URL). It has filesystem access (see the ``os_env`` block below)
+# so it can read reference files while reasoning.
+executor:
+  type: omnigent
+  config:
+    harness: openai-agents
+
+# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
+# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
+# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
+# directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
+# identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a
+# remote ref) is denied outright, while everything else runs without an ASK
+# (``gate_pushes: false``) — a headless head can't answer an approval prompt
+# anyway.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+prompt: |
+  You are the Gemini half of Debby, a brainstorming partner. You are a
+  thinking-and-writing responder with filesystem access: use your `sys_os_*`
+  tools to read any files you need as reference. Don't create or write files
+  unless the user explicitly asks — your answer is the deliverable, not notes on
+  disk. Your substance is still your own reasoning.
+
+  You are dispatched in one of two modes; the message you receive makes which
+  one clear:
+
+  - ANSWER — you are given a question. Answer it directly and well: give your
+    genuine, well-reasoned take. Be concrete and specific. Where it helps,
+    offer options with trade-offs rather than a single flat answer.
+
+  - CRITIQUE (debate) — you are given your own previous answer (or the
+    question) plus the OTHER partner's answer. Engage with the other answer
+    honestly: name what it gets right, where it is weak, wrong, or
+    incomplete, and what you would change. Then give your own updated answer
+    incorporating anything the critique convinced you of. Do not cave just to
+    agree, and do not dig in out of pride — converge toward what is actually
+    correct.
+
+  Always return a clear, self-contained response. You are one of two voices
+  the user will see side by side, so make your reasoning legible on its own.


### PR DESCRIPTION
Creates the Gemini responder agent config for the 3-way Debby debate skill.

## Changes
- Add `examples/debby/agents/gemini/config.yaml`
- Mirrors the GPT responder pattern from `examples/debby/agents/gpt/config.yaml`
- Uses `openai-agents` harness for OpenAI-compatible Gemini endpoint
- Includes both ANSWER and CRITIQUE modes in the prompt
- Agent has filesystem access via `sys_os_*` tools
- Same blast_radius guardrail as GPT agent to prevent catastrophic operations