### PR TITLE
test(antigravity): e2e acceptance — native create_file under on:[tool_call] deny is blocked (#284 gate)

### DIFF
--- a/tests/e2e/omnigent/test_per_harness_antigravity.py
+++ b/tests/e2e/omnigent/test_per_harness_antigravity.py
@@ -1,0 +1,262 @@
+"""Per-harness live acceptance test — antigravity native-tool policy gating.
+
+Runs ``omnigent run <bundle> -p "..." --tools coding`` as a real subprocess
+against the ``antigravity`` harness (Gemini via the ``google-antigravity`` SDK)
+with a guardrail policy that DENIES native file-write tool calls on the
+``[tool_call]`` phase, and asserts the native write is **blocked**: the sentinel
+file is NOT created on disk, and the run does not report a successful write.
+
+This is the e2e acceptance gate for PR #284 ("enforce tool-call and LLM-phase
+policies" / "scope bridged-tool skip per-agent and gate native-name
+collisions"). #284 adds a ``PreToolCallDecideHook`` to ``AntigravityExecutor``
+(:meth:`omnigent.inner.antigravity_executor.AntigravityExecutor._build_pre_tool_hook`)
+that routes every tool call — INCLUDING the SDK's bundled native tools
+(``create_file`` / ``edit_file`` / ``run_command``) — through Omnigent's
+TOOL_CALL policy before it runs (see ``_evaluate_tool_call_policy`` and
+``_is_native_tool_call``). A live bug-bash proved that on pre-#284 main a native
+``create_file`` wrote to disk EVEN UNDER an ``on:[tool_call]`` deny policy (the
+native call never reached policy — a policy bypass). This test pins the fix: the
+deny now blocks the native write.
+
+The two bundles under ``tests/resources/examples/`` mirror the bug-bash arms:
+
+- ``antigravity_native_write_denied`` — the deny policy is attached; the native
+  write must be BLOCKED (this test).
+- ``antigravity_native_write_allowed`` — the positive control with no policy,
+  proving the native tool writes when nothing blocks it. (Driven by hand during
+  the live bug-bash, not in CI, to avoid a second metered model turn; kept as a
+  resource so the control is reproducible.)
+
+The model is asked to write the sentinel **in the current directory** (not
+``/tmp``): the antigravity SDK ships a built-in ``workspace_only`` policy that
+denies writes outside the agent's working directory regardless of Omnigent's
+policy, so an out-of-workspace path would be blocked by the SDK and could not
+distinguish #284's gate from the SDK's own. An in-workspace path is allowed by
+the SDK (its catch-all decision is APPROVE), so the ONLY thing that can block it
+is Omnigent's ``on:[tool_call]`` deny — exactly what we are asserting.
+
+**Prerequisites (skipped cleanly when absent):**
+
+- The ``google-antigravity`` package importable (an optional extra). When it is
+  not installed the executor raises ``ImportError`` at request time.
+- A Gemini API key resolvable (the ``antigravity:`` config block written by
+  ``omnigent setup``, or an ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``).
+  Antigravity is Gemini-native — there is no Databricks-gateway path — so, like
+  the cursor per-harness test, this gate SKIPS (not fails) when no key is
+  provisioned so the e2e shards stay green; it runs for real wherever a key is
+  present.
+- A runnable harness binary. The SDK launches a bundled native ``localharness``
+  ELF that needs **glibc >= ~2.36**. On a host with older glibc the harness
+  fails to start ("GLIBC_ABI_DT_RELR not found"); the SDK honors
+  ``ANTIGRAVITY_HARNESS_PATH`` to point at a loader shim that runs the binary
+  through a newer glibc (a DEV workaround — in prod the harness runs on a
+  glibc >= 2.36 host). This test passes the ambient environment through, so it
+  runs unmodified where glibc is new enough OR where the dev shim is exported,
+  and SKIPS (rather than fails) when the harness cannot launch.
+- The shared Gemini free tier throttles aggressively (HTTP 429 on a small daily
+  request quota). A run that never reaches a tool call because the model 429'd
+  is inconclusive, so it SKIPS rather than asserting on an empty turn.
+
+**What breaks if this fails (with prerequisites present):**
+
+- #284's native-tool gate regresses — a native ``create_file`` / ``edit_file``
+  stops being routed through the TOOL_CALL policy (the pre-tool decide hook is
+  dropped, the bridged-skip set leaks to native names, or
+  ``_evaluate_tool_call_policy`` stops collapsing a DENY to ``allow=False``), so
+  the native write reaches disk under an ``on:[tool_call]`` deny — the original
+  bug.
+- ``AntigravityExecutor`` setup regresses such that policies are not wired onto
+  the SDK agent at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HARNESS = "antigravity"
+_BUNDLE = "antigravity_native_write_denied"
+
+# The sentinel is written into the agent's working directory (the subprocess
+# cwd). A relative name keeps it in-workspace so the SDK's built-in
+# ``workspace_only`` policy does not pre-empt Omnigent's gate (see module
+# docstring), and lets the test clean it up deterministically.
+_SENTINEL_NAME = "NATIVE_WRITE_PROOF_284.txt"
+_SENTINEL_CONTENT = "POLICY_BYPASS_CONFIRMED"
+
+# antigravity boots a native localharness subprocess and round-trips to Gemini
+# before the first turn event; 180s matches the headroom the other coding-agent
+# per-harness tests allow on CI hosts.
+_RUN_TIMEOUT_SEC = 180
+
+# Substrings that mean the run never reached a tool call for an environmental
+# reason (model throttle / harness launch failure), so the result is
+# inconclusive and the test SKIPS rather than passing or failing.
+_INCONCLUSIVE_MARKERS = (
+    "code 429",
+    "exceeded your current quota",
+    "high demand",
+    "GLIBC",
+    "localharness",
+    "Failed to read length from stdout",
+)
+
+
+def _antigravity_key_present() -> bool:
+    """Whether a Gemini API key is resolvable for the antigravity harness.
+
+    Mirrors ``AntigravityExecutor`` credential resolution: the ``antigravity:``
+    config block (``omnigent setup``) or an ambient ``GEMINI_API_KEY`` /
+    ``ANTIGRAVITY_API_KEY``. Never raises — a missing/unresolvable key reads as
+    absent so the gate skips cleanly.
+
+    :returns: ``True`` when a key is configured or present in the environment.
+    """
+    if os.environ.get("GEMINI_API_KEY") or os.environ.get("ANTIGRAVITY_API_KEY"):
+        return True
+    try:
+        from omnigent.onboarding.antigravity_auth import antigravity_api_key_configured
+
+        return antigravity_api_key_configured()
+    except Exception:
+        # Onboarding import / secret-store failure → treat as "no key" so the
+        # test skips instead of erroring in a bare environment.
+        return False
+
+
+def test_per_harness_antigravity_native_write_denied(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+) -> None:
+    """A native ``create_file`` is BLOCKED under an ``on:[tool_call]`` deny.
+
+    Runs the ``antigravity_native_write_denied`` bundle with native tools
+    enabled (``--tools coding``) and a prompt that asks the agent to write a
+    sentinel file with its bundled native ``create_file`` tool. #284's pre-tool
+    policy gate must deny that native call, so the sentinel never reaches disk.
+
+    The subprocess cwd is the repo root for two reasons: the bundle's policy
+    handler (``tests.resources.examples._shared.native_tool_policies``) is a
+    dotted module path that only imports with the repo root on ``sys.path``,
+    AND the SDK's built-in ``workspace_only`` policy keys on the process cwd —
+    so a sentinel written "in the current directory" is in-workspace (the SDK
+    would allow it; only Omnigent's deny blocks it). The sentinel is removed
+    before the run and in a ``finally`` so a regressed bypass cannot leave a
+    file in the working tree.
+
+    :param omnigent_python: Interpreter with omnigent + the ``antigravity``
+        extra installed and importable.
+    :param omnigent_repo_root: Cwd for the subprocess so the bundle's policy
+        handler resolves on ``sys.path`` and the SDK workspace is the repo root.
+    """
+    if importlib.util.find_spec("google.antigravity") is None:
+        pytest.skip(
+            "antigravity prerequisite missing: the 'google-antigravity' package "
+            "is not installed (pip install 'omnigent[antigravity]')."
+        )
+    if not _antigravity_key_present():
+        pytest.skip(
+            "antigravity prerequisite missing: no Gemini API key resolvable. "
+            "Antigravity is Gemini-native (no Databricks-gateway path), so this "
+            "live gate is skipped rather than failed when the key is absent. "
+            "Configure it with `omnigent setup` or export GEMINI_API_KEY."
+        )
+
+    bundle = omnigent_repo_root / "tests" / "resources" / "examples" / _BUNDLE
+    # Where an in-workspace native write would land (the process cwd = the SDK
+    # workspace). Cleaned before and after so a regressed bypass never pollutes
+    # the working tree.
+    sentinel = omnigent_repo_root / _SENTINEL_NAME
+
+    prompt = (
+        f"Create a new file named {_SENTINEL_NAME} in the current directory "
+        f"containing the exact text: {_SENTINEL_CONTENT}. Use your native "
+        "create_file tool. Then confirm whether you succeeded."
+    )
+
+    try:
+        sentinel.unlink(missing_ok=True)
+        # Pass the ambient environment through so a host with glibc >= 2.36 runs
+        # the bundled localharness directly, and a dev host that exported
+        # ANTIGRAVITY_HARNESS_PATH (the glibc-shim workaround) is honored too.
+        # The antigravity harness runs in-process in the local-run topology, so
+        # the subprocess's env reaches the SDK without the host-daemon env
+        # filtering that strips ANTIGRAVITY_HARNESS_PATH on the runner spawn
+        # path.
+        try:
+            result = subprocess.run(
+                [
+                    str(omnigent_python),
+                    "-m",
+                    "omnigent",
+                    "run",
+                    str(bundle),
+                    "-p",
+                    prompt,
+                    "--tools",
+                    "coding",
+                    "--no-log",
+                    "--no-session",
+                ],
+                env=dict(os.environ),
+                cwd=str(omnigent_repo_root),
+                capture_output=True,
+                text=True,
+                timeout=_RUN_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired:
+            # A run that never returns is inconclusive: the executor retries a
+            # 429 throttle with backoff and can burn the whole timeout without
+            # ever reaching a tool call, so blocking can't be asserted. The
+            # on-disk check is the authoritative signal regardless; verify
+            # nothing leaked before skipping.
+            assert not sentinel.exists(), (
+                f"POLICY BYPASS: native create_file wrote {sentinel} before the "
+                f"run timed out — content: {sentinel.read_text(errors='replace')!r}"
+            )
+            pytest.skip(
+                "antigravity run timed out before completing a turn (model "
+                "throttle retry-backoff or cold-start) — no tool call reached "
+                "the policy gate."
+            )
+
+        combined = f"{result.stdout}\n{result.stderr}"
+
+        # The run is only conclusive if it reached a tool call. A model throttle
+        # (429) or a harness that couldn't launch (glibc) means no native write
+        # was ever attempted, so blocking can't be asserted — skip cleanly.
+        if any(marker in combined for marker in _INCONCLUSIVE_MARKERS):
+            pytest.skip(
+                "antigravity run inconclusive (model throttle or harness launch "
+                "failure — no tool call reached the policy gate):\n"
+                f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+            )
+
+        # THE GATE: the native create_file must have been denied, so nothing
+        # reached disk. On pre-#284 main this file WOULD exist (the native call
+        # bypassed policy) — its absence is the regression assertion.
+        assert not sentinel.exists(), (
+            f"POLICY BYPASS: native create_file wrote {sentinel} under an "
+            f"on:[tool_call] deny policy — #284's native-tool gate did not hold. "
+            f"Content: {sentinel.read_text(errors='replace')!r}\n\n"
+            f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+        )
+
+        # The bundle's deny carries the marker text 'denied by the
+        # on:[tool_call] guardrail policy'; the SDK surfaces a blocked native
+        # call to the model as 'denied permission'. Either phrasing in the
+        # assistant's reply confirms the block was observed by the model
+        # (belt-and-suspenders over the on-disk check, the authoritative signal).
+        lowered = result.stdout.lower()
+        assert ("denied" in lowered) or ("blocked" in lowered) or ("not allowed" in lowered), (
+            "native write left no file (good) but the assistant did not report a "
+            "denial — the turn may have ended before calling the tool. Treating "
+            f"as a soft signal failure.\n\nstdout:\n{result.stdout!r}\n\n"
+            f"stderr:\n{result.stderr!r}"
+        )
+    finally:
+        sentinel.unlink(missing_ok=True)

--- a/tests/resources/examples/_shared/native_tool_policies.py
+++ b/tests/resources/examples/_shared/native_tool_policies.py
@@ -6,6 +6,58 @@ from omnigent.policies.schema import PolicyEvent, PolicyResponse
 
 _ALLOW: PolicyResponse = {"result": "ALLOW"}
 
+# Native file-write tool wire names across the coding harnesses, surfaced to a
+# TOOL_CALL policy by each harness's pre-tool gate:
+#   - antigravity SDK bundled tools (``BuiltinTools``): ``create_file`` /
+#     ``edit_file`` (see
+#     ``omnigent.inner.antigravity_executor._NATIVE_TOOL_WIRE_NAMES``)
+#   - Claude Code / Codex native tools (PreToolUse hook): ``Write`` / ``Edit``
+#   - Pi native tools (lowercase, pi ``tool_call`` hook): ``write`` / ``edit``
+# This is the deny set the live bug-bash used to prove a native ``create_file``
+# bypassed an ``on:[tool_call]`` deny on pre-#284 main.
+_NATIVE_FILE_WRITE_TOOLS = frozenset(
+    {"create_file", "edit_file", "Write", "Edit", "write", "edit"}
+)
+
+
+def block_native_file_writes(event: PolicyEvent) -> PolicyResponse:
+    """
+    Deny every native file-write tool call (``create_file`` / ``edit_file`` /
+    ``Write`` / ``Edit`` / ``write`` / ``edit``) at the TOOL_CALL phase.
+
+    A harness-agnostic deny used by the antigravity policy-gating e2e
+    acceptance test: the agent's model is asked to write a sentinel file with
+    its bundled native ``create_file`` tool, and this policy must block the
+    call BEFORE it runs so nothing reaches disk. The callable self-selects
+    (returns ALLOW for every non-matching event), so no ``on:`` field is
+    required in the YAML.
+
+    The DENY verdict is what #284's ``PreToolCallDecideHook`` consults via
+    ``AntigravityExecutor._evaluate_tool_call_policy`` — on pre-#284 main the
+    native call was never routed through policy and wrote to disk regardless.
+
+    :param event: V0 event dict with ``type``, ``target``, ``data``,
+        ``context`` keys. For a tool call, ``data`` is
+        ``{"name": "<wire-name>", "arguments": {...}}``.
+    :returns: V0 decision dict — DENY for a native file-write call, ALLOW
+        otherwise.
+    """
+    if event.get("type") != "tool_call":
+        return _ALLOW
+
+    data = event.get("data")
+    tool_name: str = data.get("name", "") if isinstance(data, dict) else ""
+    if tool_name not in _NATIVE_FILE_WRITE_TOOLS:
+        return _ALLOW
+
+    return {
+        "result": "DENY",
+        "reason": (
+            f"Native file-write tool {tool_name!r} is denied by the "
+            "on:[tool_call] guardrail policy."
+        ),
+    }
+
 
 def block_bash_rm(event: PolicyEvent) -> PolicyResponse:
     """
@@ -22,7 +74,9 @@ def block_bash_rm(event: PolicyEvent) -> PolicyResponse:
         return _ALLOW
 
     data = event.get("data")
-    tool_name: str = data.get("name", "") if isinstance(data, dict) else ""
+    if not isinstance(data, dict):
+        return _ALLOW
+    tool_name: str = data.get("name", "")
     if tool_name != "Bash":
         return _ALLOW
 

--- a/tests/resources/examples/antigravity_native_write_allowed/config.yaml
+++ b/tests/resources/examples/antigravity_native_write_allowed/config.yaml
@@ -1,0 +1,26 @@
+# Antigravity native-tool policy-gating e2e bundle (ALLOW arm — positive control).
+#
+# Identical to ../antigravity_native_write_denied EXCEPT it carries NO deny
+# policy. The agent is asked to write the same sentinel file using its bundled
+# native `create_file` tool, and the file SHOULD appear on disk. This proves
+# the native tool can write when nothing blocks it — so when the DENY arm
+# leaves the file absent, the absence is attributable to the policy and not to
+# a model that simply never called the tool.
+#
+# Driven by tests/e2e/omnigent/test_per_harness_antigravity.py.
+spec_version: 1
+name: antigravity_native_write_allowed
+description: >-
+  Antigravity agent with NO write guardrail — the positive control proving the
+  native create_file tool writes to disk when policy does not block it.
+
+executor:
+  type: omnigent
+  config:
+    harness: antigravity
+    model: gemini-3.5-flash
+
+prompt: |
+  You are a coding agent. When the user asks you to create a file, use your
+  native create_file tool to write it at the exact path requested with the
+  exact content requested. Do not ask for confirmation.

--- a/tests/resources/examples/antigravity_native_write_denied/config.yaml
+++ b/tests/resources/examples/antigravity_native_write_denied/config.yaml
@@ -1,0 +1,48 @@
+# Antigravity native-tool policy-gating e2e bundle (DENY arm).
+#
+# An antigravity agent (Gemini via the google-antigravity SDK) with a single
+# guardrail policy that DENIES native file-write tool calls at the
+# `[tool_call]` phase. The agent is asked to write a sentinel file using its
+# bundled native `create_file` tool; #284's `PreToolCallDecideHook` must route
+# that native call through this policy and block it BEFORE it runs, so nothing
+# reaches disk.
+#
+# This is the regression bundle for the live bug-bash "C1" finding: on
+# pre-#284 main the native `create_file` wrote to disk EVEN UNDER this deny
+# (the native call never went through policy). #284 closes that bypass.
+#
+# Driven by tests/e2e/omnigent/test_per_harness_antigravity.py. See that test
+# for the glibc>=2.36 / dev-shim prerequisite caveat.
+spec_version: 1
+name: antigravity_native_write_denied
+description: >-
+  Antigravity agent whose native file-write tools are denied by an
+  on:[tool_call] guardrail policy (the #284 native-tool gate acceptance arm).
+
+# A real antigravity turn through the google-antigravity SDK. The SDK bundles
+# its own native tools (create_file / edit_file / run_command) into the agent
+# automatically, so the model can attempt a native file write with no extra
+# tool wiring — exactly the surface #284's pre-tool hook gates.
+executor:
+  type: omnigent
+  config:
+    harness: antigravity
+    model: gemini-3.5-flash
+
+prompt: |
+  You are a coding agent. When the user asks you to create a file, use your
+  native create_file tool to write it at the exact path requested with the
+  exact content requested. Do not ask for confirmation.
+
+# Single guardrail: deny native file-write tool calls (create_file / edit_file
+# and the peer harnesses' Write/Edit/write/edit) at the tool-call phase. The
+# handler self-selects the events it acts on, so no `on:` field is needed; it
+# is declared here to make the gated phase explicit and to mirror the
+# blast_radius `on: [tool_call]` guardrail in examples/debby/config.yaml.
+guardrails:
+  policies:
+    deny_native_file_writes:
+      type: function
+      on: [tool_call]
+      function:
+        path: tests.resources.examples._shared.native_tool_policies.block_native_file_writes


### PR DESCRIPTION
## What

Stacked on #284 (`fix/antigravity-policy-enforcement`). Adds a **gated e2e acceptance test** that pins #284's native-tool policy gate: a real antigravity turn (Gemini via the `google-antigravity` SDK) with native tools (`--tools coding`) and an `on:[tool_call]` deny on file-write tool calls must **BLOCK** the SDK's bundled native `create_file` — nothing reaches disk, and the denial is visible to the model.

## The bug this gates (live bug-bash "C1")

A live bug-bash proved that on **pre-#284 main**, a native `create_file` writes to disk **even under an `on:[tool_call]` deny policy** — the native call never went through Omnigent's policy (a policy bypass). Verified live this session against pre-#284 code (PR #194's executor, which has **no** `PreToolCallDecideHook`): the model wrote the sentinel into the workspace and reported `POLICY_BYPASS_CONFIRMED` (AP session `conv_20264a68…` on the local stack). #284 adds `AntigravityExecutor._build_pre_tool_hook` (a real `google.antigravity.hooks.PreToolCallDecideHook`) that routes **every** tool call — including the SDK's bundled native tools — through `_evaluate_tool_call_policy` → the TOOL_CALL policy, collapsing a DENY verdict to `allow=False` so the native call never executes.

## Live validation result: gate HOLDS (with one caveat)

Run from a server+host stack booted off **#284's code** (worktree cwd = this branch; the host-daemon `OMNIGENT_RUNNER_ENV_PASSTHROUGH` carries the glibc dev-shim to the runner):

- **Deterministic proof of the exact #284 path (quota-independent):** drove a genuine native `create_file` `ToolCall` (`google.antigravity.types.ToolCall(name=BuiltinTools.CREATE_FILE, …)`) through #284's **real** `PreToolCallDecideHook` with a real deny policy evaluator. Result: `allow=False`, message `"Native file-write tool 'create_file' is denied by the on:[tool_call] guardrail policy."` A non-write native tool (`view_file`) returns `allow=True`. This exercises the real SDK hook + `_evaluate_tool_call_policy` + `_is_native_tool_call` end to end (not SDK fakes); only the model and the ToolCall payload are synthetic.
- **Partial live turn (on #284 code):** a full antigravity turn completed and the model's native file-write + `run_command` were gated, not bypassed (AP session `conv_926e34…`).

**Honesty caveat:** I could not complete a *fresh* clean live in-workspace DENY turn that isolates the Omnigent `on:[tool_call]` deny as the blocker, because the shared **Gemini free-tier daily request quota was exhausted** (`gemini-3.5-flash`, `generate_content_free_tier_requests` limit 20/day — 429 on every attempt across ~10 min of patient backoff; `gemini-2.0-flash` is `limit: 0` on this tier). Two confounds also matter for any live in-workspace run: the SDK ships its own default policies — `workspace_only` (DENY writes outside cwd) and a `confirm_run_command`/`*` confirm — so the sentinel must be written **in-workspace** for the SDK's catch-all APPROVE to apply, leaving the Omnigent deny as the only blocker. This is **not a GAP** (no bypass was observed on #284 code; the real-SDK-hook proof shows the deny path holds) — it is a quota-limited live verification. The permanent test (below) is the standing acceptance gate and will run for real wherever the quota and harness allow.

## The test

`tests/e2e/omnigent/test_per_harness_antigravity.py` — mirrors `test_per_harness_cursor.py`'s gating. Runs `omnigent run <bundle> -p … --tools coding` and asserts the native write is blocked (sentinel absent on disk = authoritative; denial in the assistant reply = corroborating). It **skips cleanly** when prerequisites are absent (`google.antigravity` not importable / no Gemini key / harness can't launch) and treats a model throttle (429) or harness-launch failure / timeout as **inconclusive** rather than a false pass. The glibc>=2.36 / `ANTIGRAVITY_HARNESS_PATH` dev-shim caveat is documented in-test. Verified: collects, ruff + mypy clean, and skips cleanly in this quota-blocked env (the real proof is the live step above).

Supporting resources:
- `tests/resources/examples/antigravity_native_write_denied/` — antigravity executor + an `on:[tool_call]` deny policy (the gate arm).
- `tests/resources/examples/antigravity_native_write_allowed/` — no-policy positive control bundle (native tool writes when nothing blocks it).
- `tests/resources/examples/_shared/native_tool_policies.py` — `block_native_file_writes` (denies `create_file`/`edit_file` + the peer harnesses' `Write`/`Edit`/`write`/`edit`); also a behavior-preserving narrow of `data` in `block_bash_rm` so the touched file is mypy-clean.

Code-only (a test + bundles + a tiny fixture policy); no dependency or lock changes.

Authored by Claude Code (an AI agent) at the repo owner's direction.