### PR TITLE
ci: let maintainers waive the security scan via a skip-security-scan label

### DIFF
--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -16,16 +16,66 @@
 # author_association is computed by GitHub from the actor's relationship to the
 # repo at event time; it is not attacker-settable from PR contents.
 #
+# Maintainer escape hatch: an untrusted PR can be waived by the
+# `skip-security-scan` label, but ONLY when the waiver is maintainer-effective
+# -- the label is present AND the author is a maintainer, or a maintainer's
+# latest decisive review is APPROVED. Same semantics as e2e-ui-required's
+# `skip-e2e-ui-test` (and force-merge): the label alone is not enough, so a fork
+# author cannot self-waive (applying labels needs triage access anyway, and the
+# extra maintainer check is defence in depth). All state is read from the API
+# (trusted), and this script always runs from `main`, so a PR cannot edit the
+# decision. The waiver is only evaluated when MAINTAINERS is passed (the scan
+# does; the per-workflow pollers do not -- they just mirror the scan's result).
+#
 # Env in:  EVENT_NAME          (github.event_name)
 #          AUTHOR_ASSOCIATION  (github.event.pull_request.author_association)
+#          MAINTAINERS         (space-separated, from merge-ready/load-maintainers.sh;
+#                               optional -- when empty the skip label is ignored)
+#          GH_TOKEN, REPO, PR  (for the waiver lookup; needed only with MAINTAINERS)
 # Out:     `scan=true|false` and `reason=<text>` on $GITHUB_OUTPUT.
 
 set -euo pipefail
+
+SKIP_LABEL="skip-security-scan"
 
 emit() {
   echo "scan=$1" >> "$GITHUB_OUTPUT"
   echo "reason=$2" >> "$GITHUB_OUTPUT"
   echo "scan=$1 ($2)"
+}
+
+# 0 = the skip label is present AND backed by a maintainer; 1 otherwise.
+# Mirrors e2e-ui-required/check.sh cases 3-4. Fails closed on any gap.
+skip_label_effective() {
+  [[ -n "${GH_TOKEN:-}" && -n "${REPO:-}" && -n "${PR:-}" ]] || return 1
+  [[ -n "${MAINTAINERS:-}" && -n "${MAINTAINERS// /}" ]] || return 1
+
+  local has_label
+  has_label=$(gh api "repos/$REPO/pulls/$PR" \
+    --jq "[.labels[].name] | index(\"$SKIP_LABEL\") != null" 2>/dev/null || echo "false")
+  [[ "$has_label" == "true" ]] || return 1
+
+  local maint_lc author_lc approvers u_lc
+  maint_lc=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
+
+  # Author is a maintainer?
+  author_lc=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login' 2>/dev/null \
+    | tr '[:upper:]' '[:lower:]')
+  for m in $maint_lc; do
+    [[ "$m" == "$author_lc" ]] && return 0
+  done
+
+  # A maintainer's latest decisive (non-COMMENTED) review is APPROVED?
+  approvers=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+    --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login' 2>/dev/null || echo "")
+  for u in $approvers; do
+    u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
+    for m in $maint_lc; do
+      [[ "$m" == "$u_lc" ]] && return 0
+    done
+  done
+
+  return 1
 }
 
 # Only PRs carry untrusted contributor code through the gate. Every other
@@ -45,6 +95,10 @@ case "${AUTHOR_ASSOCIATION:-}" in
     emit false "trusted author (author_association=$AUTHOR_ASSOCIATION)"
     ;;
   *)
-    emit true "untrusted author (author_association=${AUTHOR_ASSOCIATION:-unknown})"
+    if skip_label_effective; then
+      emit false "maintainer-effective '$SKIP_LABEL' waiver"
+    else
+      emit true "untrusted author (author_association=${AUTHOR_ASSOCIATION:-unknown})"
+    fi
     ;;
 esac

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -21,10 +21,13 @@ name: Security Scan
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # labeled/unlabeled so applying or removing the maintainer skip label
+    # (skip-security-scan) re-runs the scan and flips this check.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
+  pull-requests: read   # read PR labels + reviews for the maintainer skip waiver
 
 concurrency:
   group: security-scan-${{ github.event.pull_request.number }}
@@ -45,14 +48,27 @@ jobs:
           ref: main             # trusted; never the PR head
           sparse-checkout: |
             .github/scripts/security-scan
+            .github/scripts/merge-ready
             .github/security
           persist-credentials: false
+
+      - name: Load maintainers
+        id: maintainers
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: bash .github/scripts/merge-ready/load-maintainers.sh
 
       - name: Trust gate
         id: gate
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # For the maintainer-effective skip-security-scan waiver (read-only).
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          MAINTAINERS: ${{ steps.maintainers.outputs.list }}
         run: |
           # Before this lands on main the scripts are absent there -- proceed
           # (fail-open) so the introducing PR is not bricked.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,3 +49,20 @@ gate.
 It is **blocking**: a finding fails the `Security Scan` check, the pollers mirror
 that failure, and the dependent CI jobs are skipped. Detectors run fail-fast, so
 a clean PR must pass every one.
+
+### Maintainer override
+
+A maintainer can waive the scan on a specific PR with the **`skip-security-scan`**
+label (same convention as `skip-e2e-ui-test`). The waiver is only honored when it
+is *maintainer-effective*: the label is present **and** the PR author is a
+maintainer, or a maintainer's latest decisive review is `APPROVED`. The label
+alone does nothing — applying labels needs triage access, and the extra
+maintainer check is defence in depth — so a fork contributor cannot self-waive.
+The label and review state are read from the API, and the decision runs from
+`should-scan.sh` on `main`, so a PR cannot edit the waiver logic.
+
+To use it: a maintainer reviews/approves the PR and applies `skip-security-scan`;
+the `Security Scan` check re-runs and passes, then the blocked CI workflows are
+re-run (or the contributor pushes) so their gate jobs see the now-green scan.
+The waiver stays effective across pushes while the maintainer approval stands —
+remove the label (or dismiss the approval) to re-enable scanning.


### PR DESCRIPTION
## What

Adds a maintainer escape hatch to the contributor security gate: the **`skip-security-scan`** label waives the scan on a specific PR, so a maintainer can unblock CI on a false positive (or an intentionally-flagged-but-trusted change) without disabling the gate.

Mirrors the existing **`skip-e2e-ui-test`** convention in `e2e-ui-required.yml` — the waiver is only honored when it is *maintainer-effective*.

## How it's safe

- **Maintainer-effective, not label-presence.** The label only takes effect when it's present **AND** the PR author is a maintainer, or a maintainer's latest decisive review is `APPROVED` (same check as `e2e-ui-required`/force-merge). A fork contributor cannot self-waive — applying labels already needs triage access, and the maintainer check is defence in depth.
- **Tamper-resistant.** Label + review state are read from the API (trusted), and the decision runs in `should-scan.sh` checked out from `main`, so a PR can't edit the waiver logic.
- **Pollers unchanged.** The waiver is only evaluated when `MAINTAINERS` is passed — the scan passes it; the per-workflow `gate` pollers don't, so they stay cheap and simply mirror the (now-green) `Security Scan` result.

## Maintainer flow

1. Review/approve the PR and apply `skip-security-scan`.
2. The `Security Scan` check re-runs (via the new `labeled` trigger) and passes.
3. Re-run the blocked CI workflows (or the contributor pushes) so their gate jobs see the green scan.

The waiver stays effective across pushes while the approval stands; remove the label or dismiss the approval to re-enable scanning.

## Files

- `should-scan.sh` — `skip_label_effective()` (label + maintainer check), gated on `MAINTAINERS`.
- `security-scan.yml` — load maintainers, pass token/PR/MAINTAINERS to the trust gate, `labeled`/`unlabeled` triggers, `pull-requests: read`, sparse-checkout merge-ready scripts.
- `SECURITY.md` — documents the override.

## Note on TOCTOU

This follows the `e2e-ui-required` model, where the waiver persists across pushes as long as the maintainer approval stands (a new commit that invalidates the approval, e.g. via branch protection dismiss-on-push, re-enables scanning). If you'd prefer the stricter "auto-clear the label on every push" behavior, that's a small follow-up.