### PR TITLE
ci(oss-regen): run lockfile regen + smoke every 12h

### DIFF
--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -3,11 +3,13 @@
 # sees public registries directly (lockfiles must record public sources, never
 # a proxy). Exists because sync PRs land manifest changes without lockfile
 # updates and the Dockerfile COPYs ap-web/package-lock.json, so the tree is not
-# Docker-buildable until lockfiles are (re)generated here. Manual-only by design
-# so timing stays in human hands; /regen on a PR covers the PR-scoped case.
+# Docker-buildable until lockfiles are (re)generated here. Runs every 12h (and
+# on manual dispatch); opens a PR with any regenerated lockfiles.
 name: OSS regenerate lockfiles + smoke
 
 on:
+  schedule:
+    - cron: "0 */12 * * *"  # every 12 hours (00:00 / 12:00 UTC)
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary

Run `oss-regenerate-and-smoke.yml` **every 12 hours** (00:00 / 12:00 UTC), in addition to the existing manual `workflow_dispatch`. The workflow regenerates both public lockfiles (`uv.lock` + `ap-web/package-lock.json`) against public PyPI/npm, validates them via a Docker build + CLI smoke, and opens an automated PR with any changes. Scheduling it makes that the periodic safety net that keeps main's lockfiles fresh — relevant now that the on-demand `/regen` comment workflow is being removed (#305). Updated the header comment (it previously said "manual-only by design").

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Adds a `schedule:` cron to an existing workflow; no logic change to its steps. Verified the `on:` block parses with `schedule` (cron `0 */12 * * *`) + `workflow_dispatch`. The workflow already gates itself (Docker build + CLI smoke before opening the PR), so a scheduled run that produces broken lockfiles won't open a green PR.
