### PR TITLE
feat(antigravity): offer SDK install in omnigent setup when google-antigravity is missing

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8030,25 +8030,16 @@ def _set_cursor_api_key() -> str | None:
 def _prompt_install_antigravity() -> str | None:
     """Offer to install the missing ``antigravity`` extra; return a status line.
 
-    Shown at the top of the Antigravity drill-in when the ``google-antigravity``
-    SDK is absent (it ships in an OPTIONAL pip extra, so a user can have a Gemini
-    key configured and still no SDK to run the harness). Mirrors the shape of
-    :func:`_prompt_install_harness` — a three-choice ``select``: install it now,
-    set the key anyway, or print the command — but with one deliberate
-    difference: it does NOT gate key management on the SDK. Pi can't configure
-    its credentials without its CLI, so ``_prompt_install_harness`` returns the
-    user to the picker on decline; here the ``antigravity:`` key is stored
-    independently of the SDK and is useful the moment the SDK lands, so declining
-    just falls through to the key menu.
+    Shown atop the Antigravity drill-in when the ``google-antigravity`` SDK is absent.
+    Mirrors :func:`_prompt_install_harness` — a three-choice ``select`` (install now /
+    set key anyway / print command) — but does NOT gate key management on the SDK:
+    unlike pi (which can't be configured without its CLI), the ``antigravity:`` key is
+    storable independently, so declining just falls through to the key menu. The
+    install carries no index URL (see :func:`antigravity_install_command`); on failure
+    it prints the command to run by hand.
 
-    The install runs via the safest portable mechanism (``uv pip install`` when
-    ``uv`` is present, else this interpreter's pip) and carries no index URL —
-    see :func:`antigravity_install_command`. On failure it prints the command to
-    run by hand, exactly like the CLI-harness install offer.
-
-    :returns: A status string to show as the drill-in's transient status (the
-        install result, or the printed-command note), or ``None`` when the user
-        chose to set the key anyway / Esc'd without an actionable result.
+    :returns: A status string for the drill-in's transient status (install result or
+        printed-command note), or ``None`` on set-key-anyway / Esc.
     """
     from rich.markup import escape as _rich_escape
 
@@ -8059,8 +8050,7 @@ def _prompt_install_antigravity() -> str | None:
     from omnigent.onboarding.interactive import console, select
 
     cmd = ANTIGRAVITY_EXTRA_INSTALL_COMMAND
-    # ``select`` renders option/description text through Rich markup, so the
-    # literal ``[antigravity]`` in the command must be escaped to render verbatim.
+    # ``select`` renders through Rich markup, so escape the literal ``[antigravity]``.
     cmd_markup = _rich_escape(cmd)
     choice = select(
         "Antigravity's SDK (google-antigravity) isn't installed. Install it now?",
@@ -8084,7 +8074,7 @@ def _prompt_install_antigravity() -> str | None:
             return "✓ google-antigravity installed"
         console.print(f"  [red]Install failed.[/red] Run it manually: [bold]{cmd_markup}[/bold]")
         return "✗ Install failed — set the key anyway, or install by hand"
-    if choice == 2:  # run it yourself
+    if choice == 2:
         console.print(f"  Install the antigravity extra with:\n    [bold]{cmd_markup}[/bold]")
         return None
     # choice == 1 (set key anyway) or Esc: fall through to the key menu silently.
@@ -8098,15 +8088,13 @@ def _manage_antigravity_harness() -> None:
     API key — stored in the secret store, referenced from the ``antigravity:``
     config block — mirroring how the other harnesses persist api keys.
 
-    When the optional ``google-antigravity`` SDK is missing, the drill-in first
-    offers to install it (:func:`_prompt_install_antigravity`). Unlike the
-    CLI-backed harnesses — whose drill-in *gates* on the CLI because pi/Claude/
-    Codex can't be configured without it — declining here still drops into the
-    key menu: the ``antigravity:`` key is independently storable and is useful
-    the moment the SDK is installed.
+    When the optional ``google-antigravity`` SDK is missing, the drill-in first offers
+    to install it (:func:`_prompt_install_antigravity`). Unlike the CLI-backed harnesses
+    (whose drill-in *gates* on the CLI), declining here still drops into the key menu,
+    since the ``antigravity:`` key is independently storable.
 
-    :returns: None. Side effects: may install the ``antigravity`` extra, and may
-        write the ``antigravity:`` config block and the secret store.
+    :returns: None. Side effects: may install the ``antigravity`` extra, and may write
+        the ``antigravity:`` config block and the secret store.
     """
     from omnigent.onboarding import secrets as secret_store
     from omnigent.onboarding.antigravity_auth import (
@@ -8118,10 +8106,8 @@ def _manage_antigravity_harness() -> None:
     )
     from omnigent.onboarding.interactive import select
 
-    # Offer the install once, on entry, when the SDK is absent — not on every
-    # loop iteration (that would re-prompt after each key action). The returned
-    # status seeds the menu's transient status line; declining falls through to
-    # key management rather than returning, since the key is SDK-independent.
+    # Offer the install once on entry (not per loop iteration); the returned status
+    # seeds the menu's transient status line.
     status: str | None = None
     if not antigravity_sdk_installed():
         status = _prompt_install_antigravity()
@@ -8604,15 +8590,11 @@ def _run_configure_harnesses_interactive() -> None:
         options.append(f"{'  ' if ag_key_set else '[red]✗[/] '}Antigravity")
         selectable.append(True)
         row_target.append(_ANTIGRAVITY)
-        # Unlike Cursor (whose ``cursor-sdk`` is a baseline dependency, always
-        # present), the antigravity SDK ships in an OPTIONAL extra, so a user can
-        # have a Gemini key configured and still no SDK to run the harness. Lead
-        # with that gap when the extra is missing — naming the exact install
-        # command inline (parallel to the CLI harnesses' "open to install" hint
-        # and the databricks extra hint), then still report the key status, since
-        # the key is independently storable and useful once the SDK is installed.
-        # The literal ``[antigravity]`` is escaped: the menu renders sub-lines
-        # through Rich markup, where bare brackets would parse as a tag.
+        # The antigravity SDK ships in an OPTIONAL extra (unlike Cursor's baseline
+        # ``cursor-sdk``), so a user can have a key but no SDK. Lead with that gap when
+        # the extra is missing — naming the install command inline — then still report
+        # key status. ``[antigravity]`` is escaped since the sub-lines render as Rich
+        # markup (bare brackets parse as a tag).
         ag_sub_lines: list[str] = []
         if not antigravity_sdk_installed():
             from rich.markup import escape as _rich_escape

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8027,6 +8027,70 @@ def _set_cursor_api_key() -> str | None:
     return "✓ Cursor API key stored"
 
 
+def _prompt_install_antigravity() -> str | None:
+    """Offer to install the missing ``antigravity`` extra; return a status line.
+
+    Shown at the top of the Antigravity drill-in when the ``google-antigravity``
+    SDK is absent (it ships in an OPTIONAL pip extra, so a user can have a Gemini
+    key configured and still no SDK to run the harness). Mirrors the shape of
+    :func:`_prompt_install_harness` — a three-choice ``select``: install it now,
+    set the key anyway, or print the command — but with one deliberate
+    difference: it does NOT gate key management on the SDK. Pi can't configure
+    its credentials without its CLI, so ``_prompt_install_harness`` returns the
+    user to the picker on decline; here the ``antigravity:`` key is stored
+    independently of the SDK and is useful the moment the SDK lands, so declining
+    just falls through to the key menu.
+
+    The install runs via the safest portable mechanism (``uv pip install`` when
+    ``uv`` is present, else this interpreter's pip) and carries no index URL —
+    see :func:`antigravity_install_command`. On failure it prints the command to
+    run by hand, exactly like the CLI-harness install offer.
+
+    :returns: A status string to show as the drill-in's transient status (the
+        install result, or the printed-command note), or ``None`` when the user
+        chose to set the key anyway / Esc'd without an actionable result.
+    """
+    from rich.markup import escape as _rich_escape
+
+    from omnigent.onboarding.antigravity_auth import (
+        ANTIGRAVITY_EXTRA_INSTALL_COMMAND,
+        install_antigravity_sdk,
+    )
+    from omnigent.onboarding.interactive import console, select
+
+    cmd = ANTIGRAVITY_EXTRA_INSTALL_COMMAND
+    # ``select`` renders option/description text through Rich markup, so the
+    # literal ``[antigravity]`` in the command must be escaped to render verbatim.
+    cmd_markup = _rich_escape(cmd)
+    choice = select(
+        "Antigravity's SDK (google-antigravity) isn't installed. Install it now?",
+        [
+            f"Install it now ({cmd_markup})",
+            "Set the Gemini key anyway",
+            "I'll run it myself (show the command)",
+        ],
+        descriptions=[
+            f"Runs `{cmd_markup}` (uses uv when available), then continues.",
+            "Skip the install — store the key now; the SDK can be added later.",
+            "Print the command so you can install it yourself, then continue.",
+        ],
+        default=0,
+        clear_on_exit=True,
+    )
+    if choice == 0:
+        console.print(f"  [dim]Installing the antigravity extra — running `{cmd_markup}`…[/dim]")
+        if install_antigravity_sdk():
+            console.print("  [green]✓ google-antigravity installed[/green]")
+            return "✓ google-antigravity installed"
+        console.print(f"  [red]Install failed.[/red] Run it manually: [bold]{cmd_markup}[/bold]")
+        return "✗ Install failed — set the key anyway, or install by hand"
+    if choice == 2:  # run it yourself
+        console.print(f"  Install the antigravity extra with:\n    [bold]{cmd_markup}[/bold]")
+        return None
+    # choice == 1 (set key anyway) or Esc: fall through to the key menu silently.
+    return None
+
+
 def _manage_antigravity_harness() -> None:
     """Run the level-2 loop for Antigravity: set / replace / remove its Gemini key.
 
@@ -8034,8 +8098,15 @@ def _manage_antigravity_harness() -> None:
     API key — stored in the secret store, referenced from the ``antigravity:``
     config block — mirroring how the other harnesses persist api keys.
 
-    :returns: None. Side effects: may write the ``antigravity:`` config block
-        and the secret store.
+    When the optional ``google-antigravity`` SDK is missing, the drill-in first
+    offers to install it (:func:`_prompt_install_antigravity`). Unlike the
+    CLI-backed harnesses — whose drill-in *gates* on the CLI because pi/Claude/
+    Codex can't be configured without it — declining here still drops into the
+    key menu: the ``antigravity:`` key is independently storable and is useful
+    the moment the SDK is installed.
+
+    :returns: None. Side effects: may install the ``antigravity`` extra, and may
+        write the ``antigravity:`` config block and the secret store.
     """
     from omnigent.onboarding import secrets as secret_store
     from omnigent.onboarding.antigravity_auth import (
@@ -8043,10 +8114,17 @@ def _manage_antigravity_harness() -> None:
         ANTIGRAVITY_SECRET_NAME,
         antigravity_api_key_configured,
         antigravity_api_key_ref,
+        antigravity_sdk_installed,
     )
     from omnigent.onboarding.interactive import select
 
+    # Offer the install once, on entry, when the SDK is absent — not on every
+    # loop iteration (that would re-prompt after each key action). The returned
+    # status seeds the menu's transient status line; declining falls through to
+    # key management rather than returning, since the key is SDK-independent.
     status: str | None = None
+    if not antigravity_sdk_installed():
+        status = _prompt_install_antigravity()
     while True:
         config = _load_global_config()
         key_set = antigravity_api_key_configured(config)
@@ -8410,7 +8488,9 @@ def _run_configure_harnesses_interactive() -> None:
     """
     from omnigent.onboarding.antigravity_auth import (
         ANTIGRAVITY_ENV_VARS,
+        ANTIGRAVITY_EXTRA_INSTALL_COMMAND,
         antigravity_api_key_configured,
+        antigravity_sdk_installed,
     )
     from omnigent.onboarding.configure_models import family_label
     from omnigent.onboarding.cursor_auth import cursor_api_key_configured
@@ -8524,14 +8604,32 @@ def _run_configure_harnesses_interactive() -> None:
         options.append(f"{'  ' if ag_key_set else '[red]✗[/] '}Antigravity")
         selectable.append(True)
         row_target.append(_ANTIGRAVITY)
-        ag_sub = (
+        # Unlike Cursor (whose ``cursor-sdk`` is a baseline dependency, always
+        # present), the antigravity SDK ships in an OPTIONAL extra, so a user can
+        # have a Gemini key configured and still no SDK to run the harness. Lead
+        # with that gap when the extra is missing — naming the exact install
+        # command inline (parallel to the CLI harnesses' "open to install" hint
+        # and the databricks extra hint), then still report the key status, since
+        # the key is independently storable and useful once the SDK is installed.
+        # The literal ``[antigravity]`` is escaped: the menu renders sub-lines
+        # through Rich markup, where bare brackets would parse as a tag.
+        ag_sub_lines: list[str] = []
+        if not antigravity_sdk_installed():
+            from rich.markup import escape as _rich_escape
+
+            ag_sub_lines.append(
+                f"[dim]not installed — open to install "
+                f"({_rich_escape(ANTIGRAVITY_EXTRA_INSTALL_COMMAND)})[/]"
+            )
+        ag_sub_lines.append(
             "[green]✓[/] Gemini API key configured"
             if ag_key_set
             else "[dim]no Gemini API key yet — open to add one[/]"
         )
-        options.append(f"  {ag_sub}")
-        selectable.append(False)
-        row_target.append(None)
+        for ag_sub in ag_sub_lines:
+            options.append(f"  {ag_sub}")
+            selectable.append(False)
+            row_target.append(None)
         options.append("Quit")
         selectable.append(True)
         row_target.append(_QUIT)

--- a/omnigent/onboarding/antigravity_auth.py
+++ b/omnigent/onboarding/antigravity_auth.py
@@ -24,54 +24,40 @@ from omnigent.onboarding.provider_config import load_config, resolve_secret
 # resolver agree.
 ANTIGRAVITY_SECRET_NAME = "antigravity"
 
-# The pip extra that ships the Gemini-native SDK (``google-antigravity``). It is
-# OPTIONAL — not part of the default install — so a user can configure the
-# ``antigravity:`` key in setup and still have no SDK to run the harness. The
-# install command is surfaced verbatim where setup detects the extra missing.
-# (Cursor needs no parallel: ``cursor-sdk`` is a baseline dependency.) The
-# extra name carries literal brackets, so any markup-rendered surface must
-# escape it.
+# The Gemini-native SDK (``google-antigravity``) ships in an OPTIONAL extra, so a
+# user can configure the ``antigravity:`` key in setup and still have no SDK to run
+# the harness; setup surfaces this command when the extra is missing. (Cursor needs
+# no parallel: ``cursor-sdk`` is a baseline dep.) The literal brackets must be
+# escaped on any markup-rendered surface.
 ANTIGRAVITY_EXTRA = "antigravity"
 ANTIGRAVITY_EXTRA_INSTALL_COMMAND = 'pip install "omnigent[antigravity]"'
 
 
 def antigravity_sdk_installed() -> bool:
-    """Return whether the ``google-antigravity`` SDK (the extra) is importable.
+    """Return whether the ``google-antigravity`` SDK (the optional extra) is importable.
 
-    The SDK is not part of the default install — it ships in the
-    ``antigravity`` (optional) extra. The ``harness: antigravity`` executor
-    imports it lazily on the first turn, so a user can paste a Gemini key in
-    ``omnigent setup`` and still have no SDK; setup uses this to detect that
-    and offer to install it.
-
-    Mirrors :func:`omnigent.onboarding.databricks_config.databricks_sdk_installed`:
-    uses :func:`importlib.util.find_spec` so the check never pays the cost of
-    importing the (heavy) SDK, and guards the ``ModuleNotFoundError`` that
-    ``find_spec`` raises when even the parent ``google`` namespace package is
-    absent (rather than returning ``None``).
+    Setup uses this to detect a missing SDK and offer to install it. Mirrors
+    :func:`omnigent.onboarding.databricks_config.databricks_sdk_installed`: uses
+    :func:`importlib.util.find_spec` to avoid importing the heavy SDK, and guards the
+    ``ModuleNotFoundError`` ``find_spec`` raises when the parent ``google`` namespace
+    package is absent (it raises instead of returning ``None``).
 
     :returns: ``True`` when ``google.antigravity`` is importable.
     """
     try:
         return importlib.util.find_spec("google.antigravity") is not None
     except ModuleNotFoundError:
-        # find_spec("google.antigravity") imports the parent `google` namespace
-        # package first; when even that is absent it raises instead of
-        # returning None.
+        # Raised (not None) when the parent `google` namespace package is absent.
         return False
 
 
 def antigravity_install_command() -> list[str]:
     """Return the argv that installs the ``antigravity`` extra into this env.
 
-    Prefers ``uv pip install`` when ``uv`` is on ``PATH`` (it installs into the
-    active environment correctly and is what the repo's dev/install flows use),
-    else falls back to this interpreter's own pip (``sys.executable -m pip``) so
-    the package lands in the running install rather than some other Python.
-
-    Deliberately carries **no index URL**: pip / uv pick up the user's own
-    configured index, so a private proxy is honored without ever hardcoding one
-    into committed code.
+    Prefers ``uv pip install`` when ``uv`` is on ``PATH``, else this interpreter's own
+    pip (``sys.executable -m pip``) so the package lands in the running install.
+    Deliberately carries **no index URL**: pip/uv pick up the user's own configured
+    index, so a private proxy is honored without hardcoding one into committed code.
 
     :returns: The install argv, e.g.
         ``["uv", "pip", "install", "omnigent[antigravity]"]`` or
@@ -87,21 +73,19 @@ def install_antigravity_sdk() -> bool:
     """Install the ``antigravity`` extra; return whether the SDK is now present.
 
     Shells out to :func:`antigravity_install_command` and re-checks
-    :func:`antigravity_sdk_installed`. Surfaces pip/uv's own output (no capture)
-    so a failing install is visible. Mirrors
+    :func:`antigravity_sdk_installed`. Surfaces pip/uv output (no capture) so a failing
+    install is visible. Mirrors
     :func:`omnigent.onboarding.harness_install.install_harness_cli`.
 
-    :returns: ``True`` when ``google.antigravity`` is importable after the
-        attempt; ``False`` when the install process failed to spawn, timed out,
-        or the SDK is still absent afterward.
+    :returns: ``True`` when ``google.antigravity`` is importable after the attempt;
+        ``False`` when the install failed to spawn, timed out, or the SDK is still
+        absent.
     """
     try:
         subprocess.run(antigravity_install_command(), check=False, timeout=600)
     except (OSError, subprocess.TimeoutExpired):
         return False
-    # find_spec caches negative results in ``sys.modules``-adjacent state via the
-    # import system's finders; invalidate caches so a just-installed package is
-    # seen without restarting the process.
+    # Invalidate import caches so a just-installed package is seen without a restart.
     importlib.invalidate_caches()
     return antigravity_sdk_installed()
 

--- a/omnigent/onboarding/antigravity_auth.py
+++ b/omnigent/onboarding/antigravity_auth.py
@@ -12,12 +12,99 @@ key from being mis-consumed by claude-sdk / codex / pi / openai-agents. Mirrors
 
 from __future__ import annotations
 
+import importlib.util
+import shutil
+import subprocess
+import sys
+
 from omnigent.errors import OmnigentError
 from omnigent.onboarding.provider_config import load_config, resolve_secret
 
 # Stable secret-store name (and thus ``keychain:<name>``) so setup and the
 # resolver agree.
 ANTIGRAVITY_SECRET_NAME = "antigravity"
+
+# The pip extra that ships the Gemini-native SDK (``google-antigravity``). It is
+# OPTIONAL — not part of the default install — so a user can configure the
+# ``antigravity:`` key in setup and still have no SDK to run the harness. The
+# install command is surfaced verbatim where setup detects the extra missing.
+# (Cursor needs no parallel: ``cursor-sdk`` is a baseline dependency.) The
+# extra name carries literal brackets, so any markup-rendered surface must
+# escape it.
+ANTIGRAVITY_EXTRA = "antigravity"
+ANTIGRAVITY_EXTRA_INSTALL_COMMAND = 'pip install "omnigent[antigravity]"'
+
+
+def antigravity_sdk_installed() -> bool:
+    """Return whether the ``google-antigravity`` SDK (the extra) is importable.
+
+    The SDK is not part of the default install — it ships in the
+    ``antigravity`` (optional) extra. The ``harness: antigravity`` executor
+    imports it lazily on the first turn, so a user can paste a Gemini key in
+    ``omnigent setup`` and still have no SDK; setup uses this to detect that
+    and offer to install it.
+
+    Mirrors :func:`omnigent.onboarding.databricks_config.databricks_sdk_installed`:
+    uses :func:`importlib.util.find_spec` so the check never pays the cost of
+    importing the (heavy) SDK, and guards the ``ModuleNotFoundError`` that
+    ``find_spec`` raises when even the parent ``google`` namespace package is
+    absent (rather than returning ``None``).
+
+    :returns: ``True`` when ``google.antigravity`` is importable.
+    """
+    try:
+        return importlib.util.find_spec("google.antigravity") is not None
+    except ModuleNotFoundError:
+        # find_spec("google.antigravity") imports the parent `google` namespace
+        # package first; when even that is absent it raises instead of
+        # returning None.
+        return False
+
+
+def antigravity_install_command() -> list[str]:
+    """Return the argv that installs the ``antigravity`` extra into this env.
+
+    Prefers ``uv pip install`` when ``uv`` is on ``PATH`` (it installs into the
+    active environment correctly and is what the repo's dev/install flows use),
+    else falls back to this interpreter's own pip (``sys.executable -m pip``) so
+    the package lands in the running install rather than some other Python.
+
+    Deliberately carries **no index URL**: pip / uv pick up the user's own
+    configured index, so a private proxy is honored without ever hardcoding one
+    into committed code.
+
+    :returns: The install argv, e.g.
+        ``["uv", "pip", "install", "omnigent[antigravity]"]`` or
+        ``[sys.executable, "-m", "pip", "install", "omnigent[antigravity]"]``.
+    """
+    target = f"omnigent[{ANTIGRAVITY_EXTRA}]"
+    if shutil.which("uv") is not None:
+        return ["uv", "pip", "install", target]
+    return [sys.executable, "-m", "pip", "install", target]
+
+
+def install_antigravity_sdk() -> bool:
+    """Install the ``antigravity`` extra; return whether the SDK is now present.
+
+    Shells out to :func:`antigravity_install_command` and re-checks
+    :func:`antigravity_sdk_installed`. Surfaces pip/uv's own output (no capture)
+    so a failing install is visible. Mirrors
+    :func:`omnigent.onboarding.harness_install.install_harness_cli`.
+
+    :returns: ``True`` when ``google.antigravity`` is importable after the
+        attempt; ``False`` when the install process failed to spawn, timed out,
+        or the SDK is still absent afterward.
+    """
+    try:
+        subprocess.run(antigravity_install_command(), check=False, timeout=600)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    # find_spec caches negative results in ``sys.modules``-adjacent state via the
+    # import system's finders; invalidate caches so a just-installed package is
+    # seen without restarting the process.
+    importlib.invalidate_caches()
+    return antigravity_sdk_installed()
+
 
 # The dedicated top-level config block and the field that references the key.
 ANTIGRAVITY_CONFIG_KEY = "antigravity"

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2054,7 +2054,28 @@ def test_cursor_set_api_key_non_crsr_declined_is_not_stored(isolated_config) -> 
 # ``isolated_config`` clears ambient GEMINI_API_KEY / ANTIGRAVITY_API_KEY.
 
 
-def test_antigravity_set_api_key_paste_writes_block_and_secret(isolated_config) -> None:
+@pytest.fixture()
+def _antigravity_sdk_present(monkeypatch):
+    """Force ``google-antigravity`` detection to report installed.
+
+    The key-management tests below script the Antigravity drill-in assuming no
+    install-offer. The optional ``antigravity`` extra is absent in CI, so without
+    this the drill-in's install-offer fires — consuming a scripted menu token
+    (desyncing the input) and even running a real ``uv pip install``. Patching the
+    source-module attribute is seen at every call site (it's resolved at call
+    time). Mirror of :func:`_antigravity_sdk_absent`.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed",
+        lambda: True,
+    )
+
+
+def test_antigravity_set_api_key_paste_writes_block_and_secret(
+    isolated_config, _antigravity_sdk_present
+) -> None:
     """Pasting an ``AIza`` key stores the secret + writes the ``antigravity:`` block.
 
     Proves the api-key path: the secret lands in the store (never plaintext in
@@ -2073,7 +2094,9 @@ def test_antigravity_set_api_key_paste_writes_block_and_secret(isolated_config) 
     assert secrets.load_secret("antigravity") == "AIza_test_key_123"
 
 
-def test_antigravity_adopt_env_api_key_writes_env_ref(isolated_config, monkeypatch) -> None:
+def test_antigravity_adopt_env_api_key_writes_env_ref(
+    isolated_config, monkeypatch, _antigravity_sdk_present
+) -> None:
     """Adopting an existing ``$GEMINI_API_KEY`` records an ``env:`` ref only.
 
     The env path must NOT copy the secret into the store — it points the config
@@ -2091,7 +2114,9 @@ def test_antigravity_adopt_env_api_key_writes_env_ref(isolated_config, monkeypat
     assert secrets.load_secret("antigravity") is None
 
 
-def test_antigravity_remove_api_key_drops_block_and_secret(isolated_config) -> None:
+def test_antigravity_remove_api_key_drops_block_and_secret(
+    isolated_config, _antigravity_sdk_present
+) -> None:
     """Removing a Gemini key deletes the stored secret AND drops the config block."""
     # Seed a stored key: the keychain secret + the ``antigravity:`` block.
     secrets.store_secret("antigravity", "AIza_seeded")
@@ -2110,7 +2135,9 @@ def test_antigravity_remove_api_key_drops_block_and_secret(isolated_config) -> N
     assert secrets.load_secret("antigravity") is None
 
 
-def test_antigravity_remove_does_not_delete_foreign_keychain_secret(isolated_config) -> None:
+def test_antigravity_remove_does_not_delete_foreign_keychain_secret(
+    isolated_config, _antigravity_sdk_present
+) -> None:
     """Removing antigravity drops the block but spares a shared ``keychain:<other>``.
 
     A hand-edited ``antigravity:`` block may point at a secret we don't own
@@ -2135,7 +2162,9 @@ def test_antigravity_remove_does_not_delete_foreign_keychain_secret(isolated_con
     assert secrets.load_secret("shared-gemini") == "AIza_shared_seeded"
 
 
-def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(isolated_config) -> None:
+def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(
+    isolated_config, _antigravity_sdk_present
+) -> None:
     """A non-``AIza`` paste that the user declines to force is NOT persisted.
 
     The soft prefix check warns and asks to store anyway; declining must leave

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2153,20 +2153,18 @@ def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(isolated_config
 
 
 # ── Antigravity SDK-extra install offer (the optional ``antigravity`` extra) ──
-# Unlike Cursor (``cursor-sdk`` is a baseline dep, always installed → no offer),
-# the antigravity SDK ships in an OPTIONAL extra, so a user can paste a Gemini
-# key and still have no SDK. Setup must detect that and offer to install. These
-# tests force detection absent (the SDK is actually present in the test venv).
+# The antigravity SDK ships in an OPTIONAL extra, so a user can paste a key and still
+# have no SDK; setup must detect that and offer to install. These tests force detection
+# absent (the SDK is actually present in the test venv).
 
 
 @pytest.fixture()
 def _antigravity_sdk_absent(monkeypatch):
     """Force ``google-antigravity`` detection to report missing.
 
-    Both ``_run_configure_harnesses_interactive`` (overview row) and
-    ``_manage_antigravity_harness`` (drill-in) resolve
-    ``antigravity_sdk_installed`` from the source module at call time, so
-    patching the module attribute is seen by both.
+    Both call sites (overview row + drill-in) resolve ``antigravity_sdk_installed``
+    from the source module at call time, so patching the module attribute is seen by
+    both.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     """
@@ -2181,10 +2179,8 @@ def test_antigravity_overview_surfaces_install_command_when_sdk_missing(
 ) -> None:
     """L1 overview: the Antigravity row names the extra install command when absent.
 
-    Parallel to the CLI harnesses' "not installed — open to install" sub-line and
-    the databricks extra hint. The exact ``pip install "omnigent[antigravity]"``
-    is shown (escaped so the literal brackets render). Without the SDK-detection
-    branch this line never appears.
+    The exact ``pip install "omnigent[antigravity]"`` is shown (escaped so the literal
+    brackets render). Without the SDK-detection branch this line never appears.
     """
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="q\n")
     assert result.exit_code == 0, result.output
@@ -2199,9 +2195,8 @@ def test_antigravity_drillin_offers_install_when_sdk_missing(
 ) -> None:
     """Drilling into Antigravity with the SDK absent presents the install offer.
 
-    The three-choice offer (install / set key anyway / show command) appears on
-    entry. Here the user picks "show the command" (choice 3), which prints the
-    command and falls through to the key menu, then backs out.
+    The user picks "show the command" (choice 3), which prints the command and falls
+    through to the key menu, then backs out.
     """
     # L1 5=Antigravity → install offer 3=show command → key menu q=back → L1 q.
     stdin = "\n".join(["5", "3", "q", "q"]) + "\n"
@@ -2217,11 +2212,9 @@ def test_antigravity_key_settable_when_sdk_missing(
 ) -> None:
     """The Gemini key is still storable when the SDK is absent (no hard block).
 
-    This is the deliberate divergence from pi: the ``antigravity:`` key is
-    independent of the SDK and useful the moment it's installed, so the drill-in
-    offers the install but does NOT gate key management on it. The user declines
-    the install ("set the key anyway" = choice 2), then sets the key — which must
-    persist exactly as it does with the SDK present.
+    The deliberate divergence from pi: the drill-in offers the install but does NOT
+    gate key management on it. The user declines ("set the key anyway" = choice 2),
+    then sets the key, which must persist as it does with the SDK present.
     """
     # L1 5=Antigravity → install offer 2=set key anyway → key menu 1=Set →
     # paste AIza key → key menu q=back → L1 q=quit.
@@ -2239,9 +2232,8 @@ def test_antigravity_install_now_invokes_runner_without_index(
 ) -> None:
     """Choosing "install it now" shells the install with ``omnigent[antigravity]``.
 
-    Mocks the subprocess (never really installs) and asserts the argv targets the
-    extra and carries NO hardcoded index URL / proxy — pip/uv inherit the user's
-    own config. Forces the ``uv``-absent path for a deterministic argv.
+    Mocks the subprocess and asserts the argv targets the extra and carries NO
+    hardcoded index URL / proxy. Forces the ``uv``-absent path for a deterministic argv.
     """
     import subprocess
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2150,3 +2150,118 @@ def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(isolated_config
     cfg = _config_yaml(isolated_config)
     assert "antigravity" not in cfg
     assert secrets.load_secret("antigravity") is None
+
+
+# ── Antigravity SDK-extra install offer (the optional ``antigravity`` extra) ──
+# Unlike Cursor (``cursor-sdk`` is a baseline dep, always installed → no offer),
+# the antigravity SDK ships in an OPTIONAL extra, so a user can paste a Gemini
+# key and still have no SDK. Setup must detect that and offer to install. These
+# tests force detection absent (the SDK is actually present in the test venv).
+
+
+@pytest.fixture()
+def _antigravity_sdk_absent(monkeypatch):
+    """Force ``google-antigravity`` detection to report missing.
+
+    Both ``_run_configure_harnesses_interactive`` (overview row) and
+    ``_manage_antigravity_harness`` (drill-in) resolve
+    ``antigravity_sdk_installed`` from the source module at call time, so
+    patching the module attribute is seen by both.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed",
+        lambda: False,
+    )
+
+
+def test_antigravity_overview_surfaces_install_command_when_sdk_missing(
+    isolated_config, _antigravity_sdk_absent
+) -> None:
+    """L1 overview: the Antigravity row names the extra install command when absent.
+
+    Parallel to the CLI harnesses' "not installed — open to install" sub-line and
+    the databricks extra hint. The exact ``pip install "omnigent[antigravity]"``
+    is shown (escaped so the literal brackets render). Without the SDK-detection
+    branch this line never appears.
+    """
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="q\n")
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "not installed — open to install" in out
+    # The literal command (brackets included) reaches the rendered output.
+    assert 'pip install "omnigent[antigravity]"' in out
+
+
+def test_antigravity_drillin_offers_install_when_sdk_missing(
+    isolated_config, _antigravity_sdk_absent
+) -> None:
+    """Drilling into Antigravity with the SDK absent presents the install offer.
+
+    The three-choice offer (install / set key anyway / show command) appears on
+    entry. Here the user picks "show the command" (choice 3), which prints the
+    command and falls through to the key menu, then backs out.
+    """
+    # L1 5=Antigravity → install offer 3=show command → key menu q=back → L1 q.
+    stdin = "\n".join(["5", "3", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "isn't installed" in out
+    assert 'pip install "omnigent[antigravity]"' in out
+
+
+def test_antigravity_key_settable_when_sdk_missing(
+    isolated_config, _antigravity_sdk_absent
+) -> None:
+    """The Gemini key is still storable when the SDK is absent (no hard block).
+
+    This is the deliberate divergence from pi: the ``antigravity:`` key is
+    independent of the SDK and useful the moment it's installed, so the drill-in
+    offers the install but does NOT gate key management on it. The user declines
+    the install ("set the key anyway" = choice 2), then sets the key — which must
+    persist exactly as it does with the SDK present.
+    """
+    # L1 5=Antigravity → install offer 2=set key anyway → key menu 1=Set →
+    # paste AIza key → key menu q=back → L1 q=quit.
+    stdin = "\n".join(["5", "2", "1", "AIza_key_no_sdk", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    cfg = _config_yaml(isolated_config)
+    assert cfg["antigravity"] == {"api_key_ref": "keychain:antigravity"}
+    assert secrets.load_secret("antigravity") == "AIza_key_no_sdk"
+
+
+def test_antigravity_install_now_invokes_runner_without_index(
+    isolated_config, _antigravity_sdk_absent, monkeypatch
+) -> None:
+    """Choosing "install it now" shells the install with ``omnigent[antigravity]``.
+
+    Mocks the subprocess (never really installs) and asserts the argv targets the
+    extra and carries NO hardcoded index URL / proxy — pip/uv inherit the user's
+    own config. Forces the ``uv``-absent path for a deterministic argv.
+    """
+    import subprocess
+
+    calls: list[list[str]] = []
+
+    def _run(argv: list[str], *, check: bool = False, timeout: float | None = None):
+        calls.append(argv)
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr("omnigent.onboarding.antigravity_auth.shutil.which", lambda name: None)
+    monkeypatch.setattr("omnigent.onboarding.antigravity_auth.subprocess.run", _run)
+
+    # L1 5=Antigravity → install offer 1=install now → key menu q=back → L1 q.
+    stdin = "\n".join(["5", "1", "q", "q"]) + "\n"
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
+    assert result.exit_code == 0, result.output
+
+    assert len(calls) == 1, f"expected exactly one install invocation, got {calls}"
+    argv = calls[0]
+    assert "omnigent[antigravity]" in argv
+    assert "install" in argv
+    # No index URL / proxy is baked into committed code.
+    assert not any("index" in part or "://" in part for part in argv)

--- a/tests/onboarding/test_antigravity_auth.py
+++ b/tests/onboarding/test_antigravity_auth.py
@@ -135,9 +135,8 @@ def test_antigravity_sdk_installed_false_when_namespace_absent(
 ) -> None:
     """A ``ModuleNotFoundError`` (no ``google`` parent namespace) reads as False.
 
-    ``find_spec("google.antigravity")`` imports the parent ``google`` namespace
-    first; when even that is absent it *raises* rather than returning ``None``.
-    The guard must swallow that and report not-installed (not crash setup).
+    ``find_spec`` *raises* (not ``None``) when the parent namespace is absent; the guard
+    must swallow that and report not-installed rather than crash setup.
     """
 
     def _raise(name: str) -> object:
@@ -175,8 +174,8 @@ def test_install_antigravity_sdk_runs_command_then_rechecks(
 ) -> None:
     """Shells the install argv, then reports the post-install detection verdict.
 
-    Mocks the subprocess (never really installs): the SDK "appears" only after
-    the install runs, so the function must re-check and return True.
+    The mocked SDK "appears" only after the install runs, so the function must re-check
+    and return True.
     """
     import subprocess
 

--- a/tests/onboarding/test_antigravity_auth.py
+++ b/tests/onboarding/test_antigravity_auth.py
@@ -12,12 +12,16 @@ from pathlib import Path
 import pytest
 import yaml
 
+from omnigent.onboarding import antigravity_auth
 from omnigent.onboarding import secrets as secret_store
 from omnigent.onboarding.antigravity_auth import (
     ANTIGRAVITY_SECRET_NAME,
     antigravity_api_key_configured,
     antigravity_api_key_ref,
     antigravity_api_key_settings,
+    antigravity_install_command,
+    antigravity_sdk_installed,
+    install_antigravity_sdk,
     looks_like_gemini_api_key,
     resolve_antigravity_api_key,
 )
@@ -103,3 +107,103 @@ def test_settings_shape() -> None:
     assert antigravity_api_key_settings("keychain:antigravity") == {
         "antigravity": {"api_key_ref": "keychain:antigravity"}
     }
+
+
+# ── SDK-extra detection + install (the optional ``antigravity`` extra) ────────
+
+
+def test_antigravity_sdk_installed_true_when_spec_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detection returns True when ``find_spec`` resolves ``google.antigravity``."""
+    monkeypatch.setattr(
+        antigravity_auth.importlib.util,
+        "find_spec",
+        lambda name: object(),
+    )
+    assert antigravity_sdk_installed() is True
+
+
+def test_antigravity_sdk_installed_false_when_spec_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detection returns False when ``find_spec`` returns ``None`` (extra absent)."""
+    monkeypatch.setattr(antigravity_auth.importlib.util, "find_spec", lambda name: None)
+    assert antigravity_sdk_installed() is False
+
+
+def test_antigravity_sdk_installed_false_when_namespace_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``ModuleNotFoundError`` (no ``google`` parent namespace) reads as False.
+
+    ``find_spec("google.antigravity")`` imports the parent ``google`` namespace
+    first; when even that is absent it *raises* rather than returning ``None``.
+    The guard must swallow that and report not-installed (not crash setup).
+    """
+
+    def _raise(name: str) -> object:
+        raise ModuleNotFoundError("No module named 'google'")
+
+    monkeypatch.setattr(antigravity_auth.importlib.util, "find_spec", _raise)
+    assert antigravity_sdk_installed() is False
+
+
+def test_antigravity_install_command_prefers_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ``uv`` on PATH, the install runs ``uv pip install`` — no index URL."""
+    monkeypatch.setattr(antigravity_auth.shutil, "which", lambda name: "/usr/bin/uv")
+    cmd = antigravity_install_command()
+    assert cmd == ["uv", "pip", "install", "omnigent[antigravity]"]
+    # No hardcoded index / proxy leaks into committed code.
+    assert not any("index" in part or "://" in part for part in cmd)
+
+
+def test_antigravity_install_command_falls_back_to_pip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``uv``, it falls back to this interpreter's pip — still no index."""
+    monkeypatch.setattr(antigravity_auth.shutil, "which", lambda name: None)
+    cmd = antigravity_install_command()
+    assert cmd == [
+        antigravity_auth.sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "omnigent[antigravity]",
+    ]
+    assert not any("index" in part or "://" in part for part in cmd)
+
+
+def test_install_antigravity_sdk_runs_command_then_rechecks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shells the install argv, then reports the post-install detection verdict.
+
+    Mocks the subprocess (never really installs): the SDK "appears" only after
+    the install runs, so the function must re-check and return True.
+    """
+    import subprocess
+
+    calls: list[list[str]] = []
+    state = {"installed": False}
+
+    def _run(argv: list[str], *, check: bool = False, timeout: float | None = None):
+        calls.append(argv)
+        state["installed"] = True
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(antigravity_auth.shutil, "which", lambda name: None)
+    monkeypatch.setattr(antigravity_auth.subprocess, "run", _run)
+    monkeypatch.setattr(antigravity_auth, "antigravity_sdk_installed", lambda: state["installed"])
+
+    assert install_antigravity_sdk() is True
+    assert calls == [
+        [antigravity_auth.sys.executable, "-m", "pip", "install", "omnigent[antigravity]"]
+    ]
+
+
+def test_install_antigravity_sdk_false_on_spawn_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A subprocess that can't spawn (OSError) is caught and reported as False."""
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise OSError("no pip")
+
+    monkeypatch.setattr(antigravity_auth.shutil, "which", lambda name: None)
+    monkeypatch.setattr(antigravity_auth.subprocess, "run", _boom)
+    assert install_antigravity_sdk() is False


### PR DESCRIPTION
## The gap

Antigravity's `google-antigravity` SDK is an **optional** extra
(`pip install "omnigent[antigravity]"`) — the `harness: antigravity` executor
imports it lazily on first turn, so only users of the harness need it. That
means a user can drill into **Antigravity** in `omnigent setup`, paste a Gemini
API key, and walk away with a stored key but **no SDK** to actually run the
harness. Setup never detected or surfaced that — it only ever showed the key
status.

(Cursor, by contrast, runs on `cursor-sdk`, which is a **baseline dependency**
— always installed — so it needs no install offer. This PR does not touch
cursor.)

## What this adds

Combines the two existing precedents — the pi/CLI **install-offer UX**
(`_prompt_install_harness`) and the **optional-python-extra** detection pattern
(`databricks_config.databricks_sdk_installed` + its install hint):

1. **Detection helper** — `antigravity_sdk_installed()` in `antigravity_auth.py`,
   using `importlib.util.find_spec("google.antigravity")` guarded against the
   `ModuleNotFoundError` the parent `google` namespace raises when absent. Never
   imports the heavy SDK; directly mirrors `databricks_sdk_installed()`.

2. **Overview sub-line** — in `_run_configure_harnesses_interactive`, when the
   SDK is missing the Antigravity row shows
   `not installed — open to install (pip install "omnigent[antigravity]")`,
   parallel to the CLI harnesses' "open to install" sub-line and the databricks
   hint. The existing key-status sub-line still renders.

3. **Drill-in offer** — `_prompt_install_antigravity`, shaped like
   `_prompt_install_harness` (a 3-choice `select`: **Install it now** /
   **Set the Gemini key anyway** / **show the command**). Shown once on entry to
   the Antigravity manager when the SDK is absent.

## Design decision: auto-run install (not databricks-style hint-only) + why

The prompt left the install-vs-hint choice open, noting databricks only *hints*
because auto-installing into the active venv is dicey.

**I chose to auto-run the install** (with a robust fallback), because the
headline requirement is to mirror *how pi offers to install* — and
`_prompt_install_harness` runs `npm install` for real. A hint-only flow would be
the weaker analog here. To keep it safe I made the auto-run conservative:

- **Portable mechanism**: `uv pip install "omnigent[antigravity]"` when `uv` is
  on PATH (it targets the active environment correctly and matches the repo's
  install flows), else `[sys.executable, "-m", "pip", "install",
  "omnigent[antigravity]"]` so the package lands in *this* interpreter.
- **No hardcoded index URL / Databricks proxy** in committed code — pip/uv
  inherit the user's own configured index, so a private proxy is honored without
  baking one in.
- **Graceful fallback**: on any failure (spawn error, timeout, or the SDK still
  absent after) it prints the command to run by hand, exactly like the
  CLI-harness offer, and re-checks `antigravity_sdk_installed()` after.

**Deliberate divergence from pi**: pi *gates* credential config on its CLI
(you can't configure pi creds without it), so `_prompt_install_harness` returns
the user to the picker on decline. Here the install offer does **NOT** hard-block
key management — the `antigravity:` key is independently storable and useful the
moment the SDK lands, so declining the install falls straight through to the key
menu. This is called out in a code comment on both `_prompt_install_antigravity`
and `_manage_antigravity_harness`.

## Test coverage

- `tests/onboarding/test_antigravity_auth.py`: unit tests for
  `antigravity_sdk_installed()` (spec found / `None` / `ModuleNotFoundError`
  guard), `antigravity_install_command()` (uv-preferred and pip-fallback argv,
  each asserted to carry **no** index URL), and `install_antigravity_sdk()`
  (mocked subprocess: runs the command then re-checks; OSError → False).
- `tests/cli/test_configure_models.py`: with detection forced absent
  (monkeypatched), the overview surfaces the install command; the drill-in
  presents the offer; the **key is still settable** when the SDK is absent; and
  choosing "install now" invokes the runner with `omnigent[antigravity]` and
  **no** hardcoded index (subprocess mocked — never really installs).
- All new tests fail without the change (the unit tests `ImportError` on the
  missing helpers; the CLI flow tests route through an offer the original lacks).

Targeted suite green; ruff + format + mypy clean on the changed files. (The two
pre-existing `test_kind_glyph_uniform_display_width` failures and the
`internal_beta`/`lakebox` mypy import-not-found notes reproduce on the base
branch and are unrelated to this change.)

Authored by Claude Code (an AI agent) at the repo owner's direction.