### PR TITLE
ci: scan-gate the fork-e2e mirror push (untrusted code meets secrets)

### DIFF
--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -27,7 +27,17 @@
 # decision. The waiver is only evaluated when MAINTAINERS is passed (the scan
 # does; the per-workflow pollers do not -- they just mirror the scan's result).
 #
+# Fork-e2e mirror: a fork PR's head commit is mirrored onto fork-e2e/pr-N so
+# e2e/e2e-ui run there as a `push` WITH the gateway secrets -- the one place
+# untrusted code meets secrets. That commit is byte-identical to the PR head, so
+# the `Security Scan` check already ran on it during the PR's pull_request event.
+# We therefore re-engage the gate on a fork-e2e/** push (scan=true) so the poller
+# MIRRORS that pre-computed result before any secret-bearing job runs, instead of
+# waving the push through as a "trusted" non-PR event. Any other push (main) is
+# genuinely trusted.
+#
 # Env in:  EVENT_NAME          (github.event_name)
+#          REF                 (github.ref; only needed to spot fork-e2e/** push)
 #          AUTHOR_ASSOCIATION  (github.event.pull_request.author_association)
 #          MAINTAINERS         (space-separated, from merge-ready/load-maintainers.sh;
 #                               optional -- when empty the skip label is ignored)
@@ -78,12 +88,24 @@ skip_label_effective() {
   return 1
 }
 
-# Only PRs carry untrusted contributor code through the gate. Every other
-# trigger -- push to main / fork-e2e/** (the mirror branch only exists after a
-# returning-contributor / maintainer-approval gate), schedule, dispatch -- is a
-# trusted context, so proceed without scanning.
+# PRs carry untrusted contributor code through the gate directly. A fork-e2e/**
+# push is the mirrored PR head running WITH secrets, so it must mirror that
+# commit's already-computed Security Scan result (handled by the poller). Every
+# other trigger -- push to main, schedule, dispatch -- is a trusted context.
 case "${EVENT_NAME:-}" in
   pull_request | pull_request_target) ;;
+  push)
+    case "${REF:-}" in
+      refs/heads/fork-e2e/*)
+        emit true "fork-e2e mirror push; mirror the PR's Security Scan result"
+        exit 0
+        ;;
+      *)
+        emit false "non-PR push (${REF:-unknown}); trusted context"
+        exit 0
+        ;;
+    esac
+    ;;
   *)
     emit false "non-PR event (${EVENT_NAME:-unknown}); trusted context"
     exit 0

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -3,10 +3,12 @@ name: Security Gate
 # Reusable (workflow_call) gate, called as the FIRST job of each CI workflow;
 # their real jobs declare `needs: gate`. Does NOT scan — the single scan runs in
 # security-scan.yml. This poller only decides whether to let its caller proceed:
-#   - non-PR event or trusted author -> proceed immediately
+#   - trusted author or trusted non-PR event -> proceed immediately
 #   - untrusted PR -> wait for the `Security Scan` check on the head SHA and
 #     MIRROR its conclusion (success -> proceed; failure -> fail, skipping the
 #     dependent CI jobs).
+#   - fork-e2e/** push (a mirrored fork PR running WITH secrets) -> mirror the
+#     same `Security Scan` check, looked up on the pushed commit (== PR head).
 #
 # The scan (security-scan.yml) is blocking: a finding fails the `Security Scan`
 # check, which this poller mirrors to block dependent CI. Splitting scan from
@@ -36,6 +38,7 @@ jobs:
         id: gate
         env:
           EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
           # Before the scanner lands on main the scripts are absent there --
@@ -48,14 +51,17 @@ jobs:
           bash .github/scripts/security-scan/should-scan.sh
 
       - name: Wait for Security Scan result
-        # Only untrusted PRs wait; trusted authors / non-PR events proceeded above.
+        # Only untrusted PRs and fork-e2e mirror pushes wait; trusted authors /
+        # trusted non-PR events proceeded above. For a PR the SHA is the PR head;
+        # for a fork-e2e/** push it is the mirrored commit (identical to the PR
+        # head), where the `Security Scan` check already ran on the PR event.
         if: ${{ steps.gate.outputs.scan == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          echo "Untrusted PR -- waiting for the single 'Security Scan' check on $HEAD_SHA"
+          echo "Untrusted run -- waiting for the single 'Security Scan' check on $HEAD_SHA"
           q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
           conclusion=""
           details_url=""

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,13 @@ two pieces so the scan work happens only **once per PR**:
   (failure → the dependent CI jobs are skipped); trusted authors and non-PR
   events proceed immediately.
 
+The fork-e2e mirror (`fork-e2e-mirror.yml`) pushes a fork PR's head commit to a
+`fork-e2e/**` branch so `e2e`/`e2e-ui` run there **with secrets**. That push is
+the one place untrusted code meets secrets, so the gate does **not** wave it
+through as a trusted push: it mirrors the `Security Scan` result of the pushed
+commit (which is byte-identical to the PR head, where the scan already ran), and
+skips the secret-bearing e2e jobs if the scan did not pass.
+
 By trust tier (GitHub `author_association`):
 
 - **Trusted** (`OWNER` / `MEMBER` / `COLLABORATOR`) and all non-PR events


### PR DESCRIPTION
## The gap

`fork-e2e-mirror.yml` itself runs **no** PR code (it checks out only `main` and does a pure git-ref update), so it doesn't need a gate. But its purpose is to push a fork PR's head commit to `fork-e2e/pr-N`, which triggers **`e2e.yml` and `e2e-ui.yml` as a `push` event — running the fork's untrusted code WITH the gateway secrets.**

The gate's `should-scan.sh` treated every non-PR event as trusted:

```
push → "non-PR event; trusted context" → scan=false → proceed, no scan
```

So the **secret-bearing** mirrored run sailed through unscanned, while the *no-secret* `pull_request` e2e was gated. Backwards from what you'd want — this is the highest-value place to enforce the scan.

## The fix (cheap — the result already exists)

The mirrored commit is **byte-identical to the PR head**, so the `Security Scan` check already ran on that exact SHA during the PR's `pull_request` event. The push gate just needs to *read* it:

- **`should-scan.sh`** — a `fork-e2e/**` push now yields `scan=true` (new `REF` env); other pushes (e.g. `main`) stay trusted.
- **`security-gate.yml`** — pass `REF` to the trust gate, and look the `Security Scan` result up on `github.sha` (the pushed commit) when there's no PR context.
- **`SECURITY.md`** — documents that mirrored fork e2e honors the scan.

Both `e2e` and `e2e-ui` inherit this through the shared reusable gate — no per-workflow change. A red scan on the PR head now skips the secret-bearing mirrored e2e jobs too.

## Notes

- The poller still **fail-opens** if the scan result is absent after ~6 min (matches existing behavior); the mirror is independently gated by `should-mirror.sh` (returning-contributor / maintainer-approval).
- Touches `should-scan.sh` + `security-gate.yml`, which #301 and #319 also touch — last to merge needs a trivial rebase.