### PR TITLE
chore: add Copilot review instruction requiring e2e tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Copilot Code Review Instructions
+
+## E2E Test Requirement
+
+Every pull request that introduces a new feature **must** include at least one
+end-to-end (e2e) test covering the happy-path behaviour of that feature.
+
+- E2E tests live under `tests/e2e/`.
+- If a PR adds new user-facing functionality and does not add or update an e2e
+  test, flag it as a required change.
+- Bug-fix or refactor PRs that do not change observable behaviour are exempt.


### PR DESCRIPTION
## Summary
- Adds `.github/copilot-instructions.md` so Copilot code review flags PRs that introduce new features without an e2e test.
- Bug-fix and refactor PRs are exempt.

## Test plan
- [x] Verify `.github/copilot-instructions.md` is picked up by Copilot on next review request.

This pull request and its description were written by Isaac.