### PR TITLE
feat(harness): add GitHub Copilot SDK harness

### DIFF
--- a/.claude/skills/copilot-sdk-e2e-dev/SKILL.md
+++ b/.claude/skills/copilot-sdk-e2e-dev/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: copilot-sdk-e2e-dev
+description: Spin up a live local Omnigent server and exercise the GitHub Copilot SDK harness end-to-end — build copilot agents, run real turns, smoke-test, and bug-bash. Load when developing, testing, or debugging the copilot harness (omnigent/inner/copilot_executor.py, copilot_harness.py, omnigent/onboarding/copilot_auth.py) or its auth / model / tool-bridge behavior.
+---
+
+# Copilot SDK harness: end-to-end dev & testing
+
+The `copilot` harness drives the **GitHub Copilot SDK** (`github-copilot-sdk`,
+imported as `copilot`) — a persistent `CopilotClient` + `CopilotSession` per
+Omnigent conversation — and bridges Omnigent's `sys_*` tools into Copilot as SDK
+`Tool`s. The Python SDK **bundles the Copilot CLI binary it drives** as a backing
+server, so there is no separate `@github/copilot` install. This skill is the
+proven recipe for running it **for real** against a live local server — not just
+the unit tests.
+
+> The harness runs as a **local runner** from your current checkout, so
+> `omni run <bundle> --server <url>` exercises exactly the code you're on.
+
+## Prerequisites (check these first)
+
+1. **You're on the branch you want to test.** The copilot harness is an
+   optional extra — install it (without disturbing other extras) with
+   `uv sync --frozen --extra dev --extra copilot`. NB: a bare
+   `uv run --frozen --extra dev` re-syncs the venv and **prunes** the copilot
+   SDK; for live testing call `.venv/bin/omni` / `.venv/bin/python` directly and
+   avoid `uv run` mid-session.
+2. **The SDK is installed:**
+   `.venv/bin/python -c "import copilot; print(copilot.__file__)"`.
+3. **A GitHub token with Copilot access is configured.** Copilot needs a
+   fine-grained PAT with the "Copilot Requests" permission, or an OAuth token
+   from the GitHub CLI / Copilot CLI app (classic `ghp_` PATs are rejected).
+   Verify (booleans only — never print the token):
+   ```bash
+   .venv/bin/python -c "from omnigent.onboarding.copilot_auth import copilot_github_token_configured; import os; print('config:', copilot_github_token_configured(), 'env:', bool(os.environ.get('GH_TOKEN') or os.environ.get('COPILOT_GITHUB_TOKEN')))"
+   ```
+   If both are `False`, run `omni setup` and register a Copilot token, or
+   `export GH_TOKEN=$(gh auth token)` (when `gh` is logged into an account with
+   Copilot). Check the account's entitlement with
+   `gh api /copilot_internal/user` (look for `chat_enabled`/`cli_enabled`).
+4. **Network egress to GitHub's Copilot backend.** A turn that hangs or fails to
+   connect on a locked-down host is usually egress, not a harness bug.
+
+## Step 1 — start a local server
+
+```bash
+cd /path/to/omnigent
+.venv/bin/omni server --port 7788 --no-open    # foreground; or `omni server start` for detached
+curl -s http://127.0.0.1:7788/health           # {"status":"ok"}
+```
+
+Use the URL below as `$SERVER`.
+
+## Step 2 — build a copilot agent bundle
+
+A spec with `spec_version` **must be a directory containing `config.yaml`** —
+not a single `.yaml` file. Minimal copilot agent:
+
+```bash
+mkdir -p /tmp/copilot-dev
+cat > /tmp/copilot-dev/config.yaml <<'YAML'
+spec_version: 1
+name: copilot-dev
+description: Copilot SDK dev/test agent.
+executor:
+  type: omnigent
+  config:
+    harness: copilot
+    # model: gpt-5-mini      # optional; omit for Copilot auto-select
+prompt: |
+  You are a terse test agent. Answer in as few words as possible.
+YAML
+```
+
+For sub-agents, tools, guardrails/policies, copy the field shapes from
+`examples/polly/config.yaml` and `examples/debby/config.yaml`. (Declare policies
+under `guardrails.policies:` — a top-level `policies:` key is silently dropped on
+the `spec_version` + `config.yaml` path.)
+
+## Step 3 — run a turn (and smoke-test)
+
+```bash
+SERVER=http://127.0.0.1:7788
+timeout 280 .venv/bin/omni run /tmp/copilot-dev \
+  -p "Reply with exactly the single word: PONG" \
+  --server "$SERVER" 2>&1
+```
+
+A healthy run prints connection lines then the reply (`PONG`). If that works,
+the full stack is good: token, egress, bundled CLI, harness.
+
+- **Shell / file tools:** add `--tools coding`.
+- **Specific model:** add `--model gpt-5-mini` (or `claude-haiku-4.5`, `auto`).
+
+## Targeted scenarios
+
+| Goal | How |
+|------|-----|
+| Native tools (shell/edit/read) | `--tools coding`, prompt to create→read→edit a file; confirm it actually touches disk |
+| Bridged `sys_*` / sub-agent dispatch | declare a sub-agent (harness `copilot` so auth is satisfied), prompt the parent to delegate — exercises the SDK `Tool` async-handler bridge into `_tool_executor` |
+| Model routing | run the same bundle with several `--model` values; an unknown id fails **loud**, a `databricks-*` id is dropped to auto with a warning |
+| LLM-phase policy | add a guardrail that denies a keyword; confirm `PHASE_LLM_REQUEST`/`PHASE_LLM_RESPONSE` blocks it |
+| Concurrency / leaks | fire several `omni run … &` at once; then `pgrep -af "copilot/bin/copilot"` to check for orphaned bundled-CLI subprocesses |
+
+## Gotchas (these cost real time)
+
+1. **`config.yaml`'s `server:` defaults to a *remote* server.** Omitting
+   `--server` sends your turn to that remote deploy — which may be **stale** and
+   reject the copilot harness with `executor.config.harness: must be one of […]`.
+   **Always pass `--server http://127.0.0.1:<port>`.** (If a *local* server
+   rejects `copilot`, it's running stale code — restart it from your checkout.)
+2. **A spec with `spec_version` must be a directory + `config.yaml`**, never a
+   single `.yaml` file.
+3. **Copilot needs a GitHub token** (fine-grained PAT w/ Copilot Requests, or a
+   gh/Copilot-CLI OAuth token). Resolution precedence: spec `executor.auth`
+   (api_key) > stored `copilot:` config block (`omni setup`) > ambient
+   `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`. Classic `ghp_` rejected.
+4. **No Databricks gateway.** Copilot talks only to GitHub's backend, so a
+   `databricks-*` model is silently resolved to Copilot's auto-select — it will
+   *not* route through the AI Gateway like claude-sdk/codex/pi.
+5. **Use a model id from the account's catalog.** free_limited offers `auto`,
+   `claude-haiku-4.5`, `gpt-5-mini`. Run `.venv/bin/python` + `client.list_models()`
+   to discover the live set; an unknown id fails loud (server-side failed session).
+6. **Turns take 30–90s** — always wrap in `timeout 280`.
+7. **Never print/echo the GitHub token** in logs or commands.
+
+## Code & tests
+
+- **Executor (SDK bridge):** `omnigent/inner/copilot_executor.py`
+- **Wrap (HARNESS_COPILOT_* env → executor):** `omnigent/inner/copilot_harness.py`
+- **Auth / token resolution:** `omnigent/onboarding/copilot_auth.py`
+- **Spawn env:** `_build_copilot_spawn_env` in `omnigent/runtime/workflow.py`
+
+```bash
+uv run --frozen --extra dev python -m pytest \
+  tests/inner/test_copilot_executor.py \
+  tests/inner/test_copilot_harness.py \
+  tests/runtime/test_copilot_spawn_env.py \
+  tests/onboarding/test_copilot_auth.py -q
+```
+
+## Bug-bash (fan out)
+
+To stress the harness, run several scenario probes in parallel — each builds a
+bundle and runs real turns against the same `$SERVER`, then reports what broke.
+Highest-value targets: the `Tool` async-handler bridge (hangs / lost tool
+results / errors reported as success), model routing, policy enforcement,
+streamed-output rendering, and orphaned bundled-CLI processes after teardown.
+Cross-check the AP API (`GET /v1/sessions/{id}/items`) — a start failure can exit
+0 with empty stdout while the server records a `failed` session.
+
+## Known sharp edges (found via live bug-bash — "as of this writing")
+
+- **Native tools bypass `on:[tool_call]` policies and aren't recorded.** Copilot's
+  built-in `create`/`view`/`edit`/`bash` run inside the SDK, so an
+  `on:[tool_call]` DENY guardrail (e.g. `blast_radius`) never sees them, and they
+  leave no `function_call` item in the transcript (only streamed narration).
+  **Bridged `sys_*` tools ARE gated and recorded.** Gate Copilot's built-ins at
+  the LLM phase (`PHASE_LLM_REQUEST`/`RESPONSE`, which fire) or via the OS-env
+  sandbox — not `on:[tool_call]`. (Same shape as the cursor harness.)
+- **Copilot fails loud (unlike cursor's swallowed start failures).** Bad token,
+  empty/invalid model, and unknown model ids all exit non-zero with a clear error
+  AND a server-side failed session + error item — verified, not swallowed.
+- **`omni run -p` against an async orchestrator exits after the dispatch turn**,
+  so a delegated sub-agent's final answer is persisted server-side but may not
+  reach stdout in one-shot mode. Read the session over the AP API to see it.
+- **Non-graceful exit can orphan the bundled CLI.** Graceful teardown reaps it
+  (`client.stop()`); after a `SIGKILL`/hard-exit, sweep
+  `pgrep -af "copilot/bin/copilot"`.
+
+## Cleanup
+
+```bash
+.venv/bin/omni server stop        # or kill the foreground `omni server`
+rm -rf /tmp/copilot-dev           # remove scratch bundles
+pgrep -af "copilot/bin/copilot"   # confirm no orphaned bundled-CLI subprocesses linger
+```

--- a/.claude/skills/copilot-sdk-e2e-dev/SKILL.md
+++ b/.claude/skills/copilot-sdk-e2e-dev/SKILL.md
@@ -101,6 +101,44 @@ the full stack is good: token, egress, bundled CLI, harness.
 | LLM-phase policy | add a guardrail that denies a keyword; confirm `PHASE_LLM_REQUEST`/`PHASE_LLM_RESPONSE` blocks it |
 | Concurrency / leaks | fire several `omni run … &` at once; then `pgrep -af "copilot/bin/copilot"` to check for orphaned bundled-CLI subprocesses |
 
+## Running polly (or any orchestrator) on a copilot brain
+
+The copilot harness can serve as an **async orchestrator** brain (polly / debby),
+not just a standalone agent — it dispatches to sub-agents via the bridged
+`sys_*` tools and synthesizes their results. Two ways to exercise it:
+
+**1. Committed regression guard (brain smoke).**
+`tests/e2e/test_polly_copilot_e2e.py` boots a local server from your checkout and
+runs `examples/polly` with `--harness copilot --model auto`, asserting the brain
+boots and replies. It is **skipped** unless a Copilot token is configured (so CI
+without one skips it). Run it with:
+
+```bash
+.venv/bin/python -m pytest -o addopts="" tests/e2e/test_polly_copilot_e2e.py -v
+```
+
+**2. Full orchestration (dispatch → collect → synthesize).** Use the
+`polly-e2e-dev` driver (in the internal `agent-framework` clone) — it boots a
+local server, polls the AP API, auto-answers elicitations, and asserts the
+fan-out. Drive the brain on copilot with `--brain-harness copilot`, and **always
+pass a Copilot-catalog `--brain-model`** (`auto`, `claude-haiku-4.5`,
+`gpt-5-mini`): the driver's default `--brain-model` is a Claude id that Copilot
+(no Databricks gateway) can't route. From the agent-framework clone:
+
+```bash
+.venv/bin/python .claude/skills/polly-e2e-dev/polly_driver.py \
+  --local --code-dir <this-worktree> \
+  --cuj smoke --brain-harness copilot --brain-model auto      # brain only
+# --cuj fanout  …  and  --cuj review-pr --repo omnigent-ai/omnigent --pr <n>  …
+#   exercise real sub-agent dispatch (claude_code + codex) under a copilot brain.
+```
+
+All three CUJs (smoke / fanout / review-pr) pass on a copilot brain (verified
+live: fanout dispatched 8 sub-agents, 8/8 OK + a synthesis). Note `omni run -p`
+exits after the dispatch turn (the brain parks until woken), so a sub-agent's
+final answer lands server-side — read it over the AP API
+(`GET /v1/sessions/{id}/items`, child sessions), not just stdout.
+
 ## Gotchas (these cost real time)
 
 1. **`config.yaml`'s `server:` defaults to a *remote* server.** Omitting

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ omnigent run examples/scribe/
 omnigent run examples/polly/ --harness pi
 omnigent run examples/debby/ --harness openai-agents
 omnigent run examples/polly/ --harness cursor  # Cursor CLI (needs cursor-agent + CURSOR_API_KEY)
+omnigent run examples/polly/ --harness copilot # GitHub Copilot SDK (needs a GitHub token w/ Copilot, e.g. GH_TOKEN)
 ```
 
 **🐙 Polly** is a multi-agent coding orchestrator who writes no code herself.
@@ -375,7 +376,7 @@ name: my_agent
 prompt: You are a helpful data analyst.
 
 executor:
-  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor, cursor-native, openai-agents, pi, pi-native, antigravity, qwen
+  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor, cursor-native, openai-agents, pi, pi-native, antigravity, qwen, copilot
 
 tools:
   # A local Python function (schema auto-generated from the signature)

--- a/ap-web/src/lib/agentLabels.ts
+++ b/ap-web/src/lib/agentLabels.ts
@@ -20,6 +20,7 @@ export const BRAIN_HARNESS_LABELS: Record<string, string> = {
   cursor: "Cursor",
   pi: "Pi",
   antigravity: "Antigravity",
+  copilot: "Copilot",
 };
 
 /**

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -49,7 +49,7 @@ resolved from the YAML file's directory.
 
 ```yaml
 executor:
-  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, pi, antigravity, qwen, ...
+  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, pi, antigravity, qwen, copilot, ...
   model: databricks-claude-opus-4-7
   auth:
     type: databricks
@@ -82,6 +82,31 @@ executor:
   auth:
     type: api_key
     api_key: ${GEMINI_API_KEY}     # or ANTIGRAVITY_API_KEY
+```
+
+### GitHub Copilot
+
+`harness: copilot` runs the agent through the
+[GitHub Copilot SDK](https://pypi.org/project/github-copilot-sdk/)
+(`pip install "omnigent[copilot]"`). The SDK bundles the Copilot CLI it drives
+as a backing server, so no separate CLI install is needed. Like cursor and
+antigravity it talks only to GitHub's Copilot backend — there is no Databricks
+gateway / `auth.type: databricks` path. Authenticate with a **GitHub token** that
+carries Copilot access: a fine-grained PAT with the "Copilot Requests"
+permission, or an OAuth token from the GitHub CLI (`gh auth token`) / Copilot
+CLI. Resolution: spec `auth.api_key` → a token registered via `omnigent setup`
+(the `copilot:` config block) → ambient `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` /
+`GITHUB_TOKEN`. Choose a Copilot model id (e.g. `claude-haiku-4.5`, `gpt-5-mini`,
+or omit for auto-select) rather than a `databricks-*` id. Classic `ghp_` PATs are
+not accepted by Copilot.
+
+```yaml
+executor:
+  harness: copilot             # alias: github-copilot
+  model: claude-haiku-4.5      # a Copilot model id; omit for auto-select
+  auth:
+    type: api_key
+    api_key: ${GH_TOKEN}       # a GitHub token with Copilot access
 ```
 
 To route through OpenRouter / a gateway, declare a key/gateway provider in

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9384,6 +9384,115 @@ def _manage_goose_harness() -> None:
             status = None
 
 
+def _manage_copilot_harness() -> None:
+    """Run the level-2 loop for Copilot: manage its GitHub token.
+
+    Copilot runs via the ``github-copilot-sdk`` package and authenticates against
+    GitHub's Copilot backend with a GitHub token — the SDK requires one and it
+    has no provider/gateway family. So this manages exactly that credential:
+    set / replace / remove a token stored in the omnigent secret store, mirroring
+    how cursor / antigravity persist theirs (the secret in the store, a
+    ``keychain:``/``env:`` reference in ``~/.omnigent/config.yaml``).
+
+    :returns: None. Side effects: may write the ``copilot:`` block of
+        ``~/.omnigent/config.yaml`` and the secret store.
+    """
+    from omnigent.onboarding import secrets as secret_store
+    from omnigent.onboarding.copilot_auth import (
+        COPILOT_CONFIG_KEY,
+        COPILOT_SECRET_NAME,
+        copilot_github_token_configured,
+        copilot_github_token_ref,
+    )
+    from omnigent.onboarding.interactive import select
+
+    status: str | None = None
+    while True:
+        config = _load_global_config()
+        token_set = copilot_github_token_configured(config)
+
+        rows: list[_HarnessMenuRow] = [
+            _HarnessMenuRow(
+                "Replace GitHub token" if token_set else "Set GitHub token",
+                action="set_key",
+            )
+        ]
+        if token_set:
+            rows.append(_HarnessMenuRow("Remove GitHub token", action="remove_key"))
+        rows.append(_HarnessMenuRow("← Back", action="back"))
+
+        header = (
+            "Copilot — GitHub token configured" if token_set else "Copilot — no GitHub token yet"
+        )
+        idx = select(header, [r.label for r in rows], clear_on_exit=True, status=status)
+        if idx < 0:  # Esc / q
+            return
+        action = rows[idx].action
+        if action == "back":
+            return
+        if action == "set_key":
+            status = _set_copilot_github_token()
+        elif action == "remove_key":
+            ref = copilot_github_token_ref(config)
+            # Only the secret we own (``keychain:copilot``) is ours to delete: a
+            # hand-edited block may point at a shared ``keychain:<other>`` secret,
+            # and an ``env:`` ref names the user's own environment. In both of
+            # those cases just drop the config block and leave the secret.
+            if ref == f"keychain:{COPILOT_SECRET_NAME}":
+                secret_store.delete_secret(COPILOT_SECRET_NAME)
+            _save_global_config({}, unset_keys=(COPILOT_CONFIG_KEY,))
+            status = "✓ Removed Copilot GitHub token"
+
+
+def _set_copilot_github_token() -> str | None:
+    """Prompt for and store a Copilot GitHub token; return a status line.
+
+    Offers an existing ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``
+    first (recorded as an ``env:`` ref, so the secret stays in the environment),
+    else reads it with a hidden prompt and stores it under ``keychain:copilot``.
+    The token shape is checked softly (a classic ``ghp_`` PAT — which Copilot
+    rejects — or a wrong paste is flagged but can be forced). The token is never
+    echoed.
+
+    :returns: A status string for the menu, or ``None`` if the user aborted.
+    """
+    from omnigent.onboarding import secrets as secret_store
+    from omnigent.onboarding.copilot_auth import (
+        COPILOT_SECRET_NAME,
+        COPILOT_TOKEN_ENV_VARS,
+        copilot_github_token_settings,
+        looks_like_github_copilot_token,
+    )
+    from omnigent.onboarding.interactive import prompt_text
+
+    detected_var = next((v for v in COPILOT_TOKEN_ENV_VARS if os.environ.get(v)), None)
+    if detected_var is not None and click.confirm(
+        f"Detected {detected_var} in the environment — use it?", default=True
+    ):
+        detected = os.environ[detected_var]
+        if not looks_like_github_copilot_token(detected) and not click.confirm(
+            f"${detected_var} doesn't look like a Copilot-capable GitHub token "
+            "(github_pat_/gho_). Use it anyway?",
+            default=False,
+        ):
+            return None
+        _save_global_config(copilot_github_token_settings(f"env:{detected_var}"))
+        return f"✓ Copilot GitHub token set (from ${detected_var})"
+
+    pasted = prompt_text("GitHub token with Copilot access", hide_input=True).strip()
+    if not pasted:
+        return None
+    if not looks_like_github_copilot_token(pasted) and not click.confirm(
+        "That doesn't look like a Copilot-capable GitHub token (github_pat_/gho_). "
+        "Store it anyway?",
+        default=False,
+    ):
+        return None
+    secret_store.store_secret(COPILOT_SECRET_NAME, pasted)
+    _save_global_config(copilot_github_token_settings(f"keychain:{COPILOT_SECRET_NAME}"))
+    return "✓ Copilot GitHub token stored"
+
+
 def _manage_credential(provider: str, family: str) -> str | None:
     """Run the level-3 loop for one credential: make default / remove.
 
@@ -9908,6 +10017,10 @@ def _run_configure_harnesses_interactive() -> None:
         antigravity_sdk_installed,
     )
     from omnigent.onboarding.configure_models import family_label
+    from omnigent.onboarding.copilot_auth import (
+        COPILOT_TOKEN_ENV_VARS,
+        copilot_github_token_configured,
+    )
     from omnigent.onboarding.cursor_auth import (
         CURSOR_EXTRA_INSTALL_COMMAND,
         cursor_api_key_configured,
@@ -9915,6 +10028,7 @@ def _run_configure_harnesses_interactive() -> None:
     )
     from omnigent.onboarding.goose_auth import goose_config_summary
     from omnigent.onboarding.harness_install import (
+        COPILOT_KEY,
         CURSOR_KEY,
         GOOSE_KEY,
         OPENCODE_KEY,
@@ -10161,6 +10275,24 @@ def _run_configure_harnesses_interactive() -> None:
         options.append(f"  {goose_sub}")
         selectable.append(False)
         row_target.append(None)
+        # Copilot (GitHub Copilot SDK, no provider family): like Cursor, readiness
+        # is just whether a GitHub token with Copilot access is configured (the
+        # ``copilot:`` block or an ambient ``COPILOT_GITHUB_TOKEN``/``GH_TOKEN``/
+        # ``GITHUB_TOKEN``); its drill-in manages that token.
+        copilot_token_set = copilot_github_token_configured(config) or any(
+            os.environ.get(v) for v in COPILOT_TOKEN_ENV_VARS
+        )
+        options.append(f"{'  ' if copilot_token_set else '[red]✗[/] '}Copilot")
+        selectable.append(True)
+        row_target.append(COPILOT_KEY)
+        copilot_sub = (
+            "[green]✓[/] GitHub token configured"
+            if copilot_token_set
+            else "[dim]no GitHub token yet — open to add one[/]"
+        )
+        options.append(f"  {copilot_sub}")
+        selectable.append(False)
+        row_target.append(None)
         options.append("Quit")
         selectable.append(True)
         row_target.append(_QUIT)
@@ -10175,6 +10307,8 @@ def _run_configure_harnesses_interactive() -> None:
         target = row_target[idx]
         if target == CURSOR_KEY:
             _manage_cursor_harness()
+        elif target == COPILOT_KEY:
+            _manage_copilot_harness()
         elif target in families:
             _manage_harness_providers(target)
         elif target == _ANTIGRAVITY:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4899,7 +4899,7 @@ def resume(
 _HARNESS_CHOICES_HELP = (
     "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
     "'cursor', "
-    "'openai-agents', 'open-responses', 'pi', 'antigravity', 'qwen', or 'goose'"
+    "'openai-agents', 'open-responses', 'pi', 'antigravity', 'qwen', 'goose', or 'copilot'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
 _RUN_HARNESS_HELP = (

--- a/omnigent/harness_aliases.py
+++ b/omnigent/harness_aliases.py
@@ -25,6 +25,9 @@ HARNESS_ALIASES: dict[str, str] = {
     # (there is no separate SDK ``opencode`` harness, so the bare name is free).
     "opencode": "opencode-native",
     "native-opencode": "opencode-native",
+    # User-facing spelling for the GitHub Copilot SDK harness; the canonical id
+    # is "copilot" (matches the registry / workflow type).
+    "github-copilot": "copilot",
 }
 
 # Canonical native-CLI harness spellings. These harnesses type messages into

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -1,0 +1,767 @@
+"""CopilotExecutor: run agents through the GitHub Copilot SDK (``github-copilot-sdk``).
+
+Drives GitHub Copilot via :mod:`copilot` (the ``github-copilot-sdk`` package) —
+one persistent :class:`copilot.CopilotClient` + :class:`copilot.CopilotSession`
+per Omnigent conversation, created once and reused turn to turn. Each
+``run_turn`` issues one ``session.send_and_wait`` and translates the session's
+streamed :class:`copilot.SessionEvent` objects into ExecutorEvents:
+assistant text deltas → :class:`TextChunk`, reasoning deltas →
+:class:`ReasoningChunk`, tool execution → :class:`ToolCallRequest` /
+:class:`ToolCallComplete`, completing on ``ASSISTANT_TURN_END`` /
+``SESSION_IDLE`` (when ``send_and_wait`` returns).
+
+Crucially, Omnigent's spec-declared tools (``sys_session_send`` et al.) are
+bridged into Copilot **in-process** via the SDK's ``tools``: each
+:class:`~omnigent.inner.executor.ToolSpec` becomes a :class:`copilot.Tool`
+whose async ``handler`` routes back to the executor's ``_tool_executor`` — the
+same pattern the claude-sdk / cursor harnesses use. So a Copilot agent can call
+``sys_*``, orchestrate sub-agents, and respect policies, i.e. full first-party
+parity. Unlike cursor's daemon-thread bridge, the Copilot SDK awaits tool
+handlers *in its own event loop* (``CopilotSession._execute_tool_and_respond``),
+so the bridged handler is a plain coroutine that ``await``\\s ``_tool_executor``
+directly — no ``run_coroutine_threadsafe`` hop.
+
+Auth: a **GitHub token** that carries Copilot access — a fine-grained PAT with
+the "Copilot Requests" permission, or an OAuth token from the GitHub CLI (``gh``)
+/ Copilot CLI app. Resolved from a spec ``api_key`` or the ambient
+``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN`` (the same precedence
+the bundled CLI uses). Classic ``ghp_`` tokens are not accepted by Copilot.
+
+Requirements:
+    The ``github-copilot-sdk`` package must be installed (it bundles the
+    Copilot CLI binary it drives as a backing server). Installed via the
+    ``copilot`` extra; imported lazily so a missing install surfaces as a
+    request-time error, not an app-boot crash.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+
+from .datamodel import OSEnvSpec
+from .executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    ReasoningChunk,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
+    ToolSpec,
+    TurnComplete,
+    classify_tool_result,
+)
+
+logger = logging.getLogger(__name__)
+
+# Omnigent's bridged-tool callback: (tool_name, args) -> awaitable result.
+# Installed by the runtime adapter (see ``_executor_adapter``); mirrors the
+# claude-sdk / cursor executors' ``ToolExecutor``.
+ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # type: ignore[explicit-any]
+
+# Ambient GitHub-token env vars, in the precedence the Copilot CLI/SDK itself
+# honors (``copilot login --help``): a fine-grained PAT with the "Copilot
+# Requests" permission, or an OAuth token from the gh / Copilot CLI app.
+GITHUB_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+# Upper bound (seconds) on one ``send_and_wait``. The SDK default is 60s, far
+# too short for an agentic turn (sub-agent dispatches, long tool calls), so we
+# pass a generous finite bound: a wedged turn surfaces a timeout error instead
+# of hanging forever. The runner enforces its own per-turn timeout on top.
+_SEND_TIMEOUT_S = 3600.0
+
+
+def _resolve_model(model: str | None) -> str | None:
+    """Resolve the Copilot model id, dropping ids Copilot can't honor.
+
+    The Copilot SDK accepts only ids in the account's catalog (``auto``,
+    ``claude-haiku-4.5``, ``gpt-5-mini``, ...), so a gateway-routed model id
+    (carried by a spec authored for another harness) falls back to Copilot's
+    own auto-select (``None`` → the SDK picks). ``None`` likewise lets the SDK
+    choose.
+    """
+    if not model or model.startswith(("databricks-", "databricks/")):
+        if model:
+            # Warn, not debug: the requested model is silently NOT honored, and
+            # a debug line is invisible in the harness subprocess — so a user who
+            # pinned a non-Copilot model would otherwise have no idea it was dropped.
+            logger.warning(
+                "CopilotExecutor: requested model %r is not a Copilot model id; "
+                "falling back to Copilot's auto-select.",
+                model,
+            )
+        return None
+    return model
+
+
+def _tools_fingerprint(tools: list[ToolSpec]) -> str:
+    """A stable fingerprint of the tool set (names + parameter schemas).
+
+    ``tools`` are fixed at session creation, so a changed tool set must
+    invalidate the persistent session — otherwise removed tools stay callable
+    and newly-added tools are missing for the rest of the conversation.
+    """
+    entries = sorted(
+        (str(t.get("name", "")), json.dumps(t.get("parameters"), sort_keys=True, default=str))
+        for t in tools
+    )
+    return json.dumps(entries)
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+
+def _extract_text(msg: Message) -> str:
+    """Extract plain text content from a message dict."""
+    content = msg.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return " ".join(parts)
+    return str(content)
+
+
+def _latest_user_text(messages: list[Message]) -> str:
+    """Return the text of the latest user message (multimodal parts joined)."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return _extract_text(msg)
+    return ""
+
+
+def _build_copilot_prompt(messages: list[Message], *, is_first_turn: bool) -> str:
+    """Build the prompt text for a ``send_and_wait``.
+
+    The SDK session persists conversation history across ``send`` calls and the
+    Omnigent system prompt is delivered separately (``system_message``), so on
+    the first turn any prior history (e.g. a ``pass_history=True`` sub-agent that
+    handed a single user message plus assistant / tool context) is serialized for
+    context. On subsequent turns the session already holds the history, so only
+    the latest user message is sent.
+
+    :returns: The prompt string (empty when there is nothing to send).
+    """
+    if is_first_turn and len(messages) > 1:
+        lines = ["Conversation so far:"]
+        for msg in messages:
+            role = str(msg.get("role") or "user").replace("_", " ")
+            lines.append(f"{role}: {_extract_text(msg)}")
+        lines.append("")
+        lines.append(
+            "Respond to the latest user message, using the conversation above as context."
+        )
+        return "\n".join(lines)
+    return _latest_user_text(messages)
+
+
+# ---------------------------------------------------------------------------
+# Bridged-tool result encoding
+# ---------------------------------------------------------------------------
+
+
+def _encode_tool_result(result: Any) -> Any:  # type: ignore[explicit-any]
+    """Encode a bridged-tool result as a :class:`copilot.ToolResult`.
+
+    A dict carrying a truthy ``error`` or ``blocked`` is a dispatch failure or a
+    policy block (the shapes ``_bridge_one_dispatch`` / the policy layer return):
+    surface it as a ``failure`` result so the Copilot model sees the failure —
+    parity with the claude-sdk / cursor handlers. Everything else is a success:
+    a ``str`` is passed through; anything else is JSON-encoded.
+    """
+    from copilot import ToolResult  # lazy: optional dependency
+
+    if isinstance(result, dict) and (result.get("error") or result.get("blocked")):
+        text = json.dumps(result, default=str)
+        return ToolResult(text_result_for_llm=text, result_type="failure", error=text)
+    if isinstance(result, str):
+        return ToolResult(text_result_for_llm=result)
+    try:
+        text = json.dumps(result, default=str)
+    except (TypeError, ValueError):
+        text = str(result)
+    return ToolResult(text_result_for_llm=text)
+
+
+# ---------------------------------------------------------------------------
+# CopilotExecutor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CopilotSessionState:
+    """Per-Omnigent-conversation SDK session state."""
+
+    client: Any = None  # copilot.CopilotClient
+    session: Any = None  # copilot.CopilotSession
+    system_prompt: str | None = None
+    model: str | None = None
+    tools_fingerprint: str | None = None
+    has_sent_prompt: bool = False
+    # call_id -> tool name, populated on TOOL_EXECUTION_START so the matching
+    # TOOL_EXECUTION_COMPLETE (which carries only the id) can name its tool.
+    call_names: dict[str, str] = field(default_factory=dict)
+
+
+class CopilotExecutor(Executor):
+    """Execute agent turns via a persistent GitHub Copilot SDK session."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        model: str | None = None,
+        github_token: str | None = None,
+        bundle_dir: Path | None = None,
+        agent_name: str | None = None,
+        skills_filter: str | list[str] = "all",
+    ) -> None:
+        """Create a CopilotExecutor.
+
+        :param cwd: Working directory the Copilot session operates in. ``None``
+            falls back to ``os_env.cwd`` then the process cwd.
+        :param os_env: Optional OS environment / sandbox spec (its ``cwd`` is
+            used when *cwd* is unset).
+        :param model: Copilot model id (e.g. ``"claude-haiku-4.5"``); a
+            gateway-routed id or ``None`` falls back to Copilot's auto-select.
+        :param github_token: GitHub token carrying Copilot access. ``None``
+            falls back to ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` /
+            ``GITHUB_TOKEN`` in the environment.
+        :param bundle_dir: Reserved for future skill wiring; unused in v1.
+        :param agent_name: Optional agent name (reserved for parity).
+        :param skills_filter: Accepted for parity; copilot has no skill
+            mechanism wired here.
+        """
+        self._cwd = cwd or (os_env.cwd if os_env is not None else None)
+        self._os_env_spec = os_env
+        self._model_override = model
+        self._github_token = github_token or _ambient_github_token()
+        self._bundle_dir = bundle_dir
+        self._agent_name = agent_name
+        self._skills_filter = skills_filter
+        self._session_states: dict[str, _CopilotSessionState] = {}
+        # Installed by the runtime adapter; routes a bridged-tool call back into
+        # Omnigent's session (policy gating, sub-agent dispatch, logging).
+        self._tool_executor: ToolExecutor | None = None
+        # Installed by the runtime adapter; evaluates PHASE_LLM_REQUEST /
+        # PHASE_LLM_RESPONSE policies (the same round-trip pi / claude-sdk /
+        # cursor use). ``None`` on single-process / pre-turn paths (no-op).
+        self._policy_evaluator: Callable[[str, dict[str, Any]], Awaitable[Any]] | None = None
+
+    def supports_streaming(self) -> bool:
+        return True
+
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    def handles_tools_internally(self) -> bool:
+        # Bridged tools execute in-band via the SDK tool handler (which calls
+        # ``_tool_executor``), so the runtime adapter must NOT re-dispatch the
+        # observed tool events — same contract as claude-sdk / cursor.
+        return True
+
+    def supports_live_message_queue(self) -> bool:
+        # The SDK exposes no confirmed mid-turn steer wired here, so a message
+        # can't be injected into a running turn.
+        return False
+
+    def _session_key(self, messages: list[Message]) -> str:
+        if messages:
+            last = messages[-1]
+            if last.get("session_id"):
+                return str(last["session_id"])
+            meta = last.get("metadata", {})
+            if isinstance(meta, dict) and meta.get("session_id"):
+                return str(meta["session_id"])
+        return "__default__"
+
+    # -- tool bridge --------------------------------------------------------
+
+    def _make_tools(self, tools: list[ToolSpec]) -> list[Any]:  # type: ignore[explicit-any]
+        """Build the SDK ``tools`` list from Omnigent ToolSpecs.
+
+        Each tool's async ``handler`` is awaited by the SDK in its own event
+        loop, so it bridges straight into ``_tool_executor`` — no thread hop.
+        ``skip_permission=True`` because Omnigent's policy layer (and the
+        ``_tool_executor`` round-trip) already governs these tools; the SDK
+        permission prompt would be redundant and would stall a headless turn.
+        """
+        from copilot import Tool  # lazy: optional dependency
+
+        built: list[Any] = []  # type: ignore[explicit-any]
+        for spec in tools:
+            name = spec.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            params = spec.get("parameters")
+            built.append(
+                Tool(
+                    name=name,
+                    description=spec.get("description") or "",
+                    handler=self._make_handler(name),
+                    parameters=params
+                    if isinstance(params, dict)
+                    else {"type": "object", "properties": {}},
+                    skip_permission=True,
+                )
+            )
+        return built
+
+    def _make_handler(self, tool_name: str) -> Callable[[Any], Awaitable[Any]]:  # type: ignore[explicit-any]
+        """Build an async ``handler`` that bridges a Copilot tool call to Omnigent.
+
+        Awaited by the SDK in its event loop, so it ``await``\\s the main-loop
+        ``_tool_executor`` directly. Any exception becomes a tool *failure*
+        result rather than propagating into the SDK turn.
+        """
+
+        async def handler(invocation: Any) -> Any:  # type: ignore[explicit-any]
+            from copilot import ToolResult  # lazy: optional dependency
+
+            if self._tool_executor is None:
+                return ToolResult(
+                    text_result_for_llm=(
+                        f"Tool {tool_name!r} is unavailable: no tool executor wired."
+                    ),
+                    result_type="failure",
+                    error="no tool executor wired",
+                )
+            raw_args = getattr(invocation, "arguments", None)
+            args = _coerce_args(raw_args)
+            try:
+                result = await self._tool_executor(tool_name, dict(args))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — surface as a tool failure
+                return ToolResult(
+                    text_result_for_llm=f"Tool {tool_name!r} failed: {exc}",
+                    result_type="failure",
+                    error=str(exc),
+                )
+            return _encode_tool_result(result)
+
+        return handler
+
+    # -- session lifecycle --------------------------------------------------
+
+    async def _ensure_session(
+        self,
+        state: _CopilotSessionState,
+        model: str | None,
+        tools: list[ToolSpec],
+        system_prompt: str,
+    ) -> None:
+        """Start the SDK client and create the session if not already live.
+
+        On any bring-up failure the partially-started client is stopped before
+        propagating, so a bad token / launch error can't orphan the bundled
+        CLI subprocess.
+        """
+        if state.session is not None:
+            return
+        try:
+            from copilot import CopilotClient, PermissionHandler
+        except ImportError as exc:
+            raise ImportError(
+                "CopilotExecutor requires the 'github-copilot-sdk' package. "
+                "Install it with: uv pip install github-copilot-sdk "
+                "(or `pip install 'omnigent[copilot]'`)."
+            ) from exc
+
+        # The Copilot SDK rejects a relative working_directory ("Directory path
+        # must be absolute"), and a spec / os_env can hand us a relative cwd
+        # (e.g. ``.``), so always resolve to an absolute path.
+        cwd = os.path.abspath(self._cwd or os.getcwd())
+        client = CopilotClient(
+            github_token=self._github_token,
+            working_directory=cwd,
+            log_level="error",
+        )
+        await client.start()
+        try:
+            # ``append`` keeps Copilot's own operating instructions (how to use
+            # its built-in tools) and layers the Omnigent agent's system prompt
+            # on top — a ``replace`` would strip the tool-use guidance the model
+            # relies on. ``None`` when the spec carries no system prompt.
+            system_message = (
+                {"mode": "append", "content": system_prompt} if system_prompt else None
+            )
+            session = await client.create_session(
+                model=model,
+                streaming=True,
+                system_message=system_message,
+                tools=self._make_tools(tools) or None,
+                on_permission_request=PermissionHandler.approve_all,
+                working_directory=cwd,
+            )
+        except BaseException:
+            await _safe_stop(client)
+            raise
+        state.client = client
+        state.session = session
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        session_key = self._session_key(messages)
+        model = _resolve_model((config.model if config else None) or self._model_override)
+        tools_fp = _tools_fingerprint(tools)
+        state = self._session_states.setdefault(session_key, _CopilotSessionState())
+
+        # System prompt, model, and tool set are all fixed at session creation,
+        # so a change to any of them means a fresh session (otherwise a changed
+        # tool set would leave the initial ``tools`` stale for the conversation).
+        if state.session is not None and (
+            state.system_prompt != system_prompt
+            or state.model != model
+            or state.tools_fingerprint != tools_fp
+        ):
+            await self._close_state(state)
+            state = _CopilotSessionState()
+            self._session_states[session_key] = state
+        is_first_turn = not state.has_sent_prompt
+        state.system_prompt = system_prompt
+        state.model = model
+        state.tools_fingerprint = tools_fp
+
+        try:
+            await self._ensure_session(state, model, tools, system_prompt)
+        except Exception as exc:  # noqa: BLE001 — surfaced as ExecutorError (CancelledError propagates)
+            await self.close_session(session_key)
+            yield ExecutorError(message=f"Failed to start copilot-sdk session: {exc}")
+            return
+
+        prompt = _build_copilot_prompt(messages, is_first_turn=is_first_turn)
+        if not prompt:
+            yield TurnComplete(response=None)
+            return
+
+        # PHASE_LLM_REQUEST policy (parity with claude-sdk / cursor / pi):
+        # evaluate before the LLM call so a DENY blocks it. No-op when unwired.
+        policy_eval = self._policy_evaluator
+        if policy_eval is not None:
+            req_verdict = await policy_eval(
+                "PHASE_LLM_REQUEST",
+                {
+                    "model": model or "auto",
+                    "messages_count": sum(1 for m in messages if m.get("role") == "user") or 1,
+                    "tools_count": len(tools),
+                    "system_prompt_preview": system_prompt[:200] if system_prompt else "",
+                    "last_user_message": _latest_user_text(messages)[:500],
+                },
+            )
+            if getattr(req_verdict, "action", "") == "POLICY_ACTION_DENY":
+                reason = getattr(req_verdict, "reason", "") or "no reason given"
+                yield ExecutorError(message=f"LLM call denied by policy: {reason}")
+                return
+
+        state.has_sent_prompt = True
+        session = state.session
+
+        # Stream the session's events into a queue from the SDK's ``on`` callback
+        # (invoked in the SDK loop), then drain-and-translate them here while the
+        # ``send_and_wait`` task runs. Unsubscribe + drain when the send completes.
+        queue: asyncio.Queue[Any] = asyncio.Queue()  # type: ignore[explicit-any]
+
+        def _on_event(event: Any) -> None:  # type: ignore[explicit-any]
+            queue.put_nowait(event)
+
+        unsubscribe = session.on(_on_event)
+        send_task: asyncio.Task[Any] = asyncio.ensure_future(  # type: ignore[explicit-any]
+            session.send_and_wait(prompt, timeout=_SEND_TIMEOUT_S)
+        )
+
+        response_text = ""
+        tool_calls = 0
+        usage_acc: dict[str, int] = {}
+        usage_model: str | None = None
+        turn_error: str | None = None
+        # A tool call between two assistant text blocks means they are distinct
+        # narration segments (pre- vs post-tool); insert a paragraph break so
+        # they don't render as one run-on string. Streamed deltas of a single
+        # response (no tool between) still concatenate seamlessly.
+        separate_next_text = False
+
+        async def _drain(event: Any) -> AsyncIterator[ExecutorEvent]:  # type: ignore[explicit-any]
+            nonlocal response_text, tool_calls, separate_next_text, usage_model, turn_error
+            etype = str(getattr(event, "type", ""))
+            data = _event_data(event)
+            if etype.endswith("ASSISTANT_MESSAGE_DELTA"):
+                text = str(data.get("deltaContent") or "")
+                if text:
+                    if separate_next_text and response_text:
+                        trailing = len(response_text) - len(response_text.rstrip("\n"))
+                        leading = len(text) - len(text.lstrip("\n"))
+                        if trailing + leading < 2:
+                            text = "\n" * (2 - trailing - leading) + text
+                    separate_next_text = False
+                    response_text += text
+                    yield TextChunk(text=text)
+            elif etype.endswith("ASSISTANT_REASONING_DELTA"):
+                text = str(data.get("deltaContent") or "")
+                if text:
+                    yield ReasoningChunk(delta=text, event_type="reasoning_text")
+            elif etype.endswith("TOOL_EXECUTION_START"):
+                name = str(data.get("toolName") or "tool")
+                call_id = data.get("toolCallId")
+                if call_id:
+                    state.call_names[str(call_id)] = name
+                tool_calls += 1
+                separate_next_text = True
+                yield ToolCallRequest(
+                    name=name,
+                    args=_coerce_args(data.get("arguments")),
+                    metadata={"call_id": call_id},
+                )
+            elif etype.endswith("TOOL_EXECUTION_COMPLETE"):
+                call_id = data.get("toolCallId")
+                name = state.call_names.get(str(call_id), "tool") if call_id else "tool"
+                result = data.get("result")
+                classification = classify_tool_result(result)
+                status = classification.status
+                error = classification.error or None
+                if data.get("success") is False or data.get("error"):
+                    status = ToolCallStatus.ERROR
+                    error = error or str(data.get("error") or "tool call failed")
+                separate_next_text = True
+                yield ToolCallComplete(
+                    name=name,
+                    status=status,
+                    result=result,
+                    error=error,
+                    metadata={"call_id": call_id},
+                )
+            elif etype.endswith("ASSISTANT_USAGE"):
+                usage_model = data.get("model") or usage_model
+                _accumulate_usage(usage_acc, data)
+            elif etype.endswith(("SESSION_ERROR", "MODEL_CALL_FAILURE")):
+                turn_error = str(
+                    data.get("message") or data.get("errorMessage") or "copilot session error"
+                )
+
+        try:
+            while True:
+                getter: asyncio.Task[Any] = asyncio.ensure_future(queue.get())  # type: ignore[explicit-any]
+                done, _pending = await asyncio.wait(
+                    {getter, send_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+                if getter in done:
+                    event = getter.result()
+                    async for ev in _drain(event):
+                        yield ev
+                else:
+                    getter.cancel()
+                if send_task.done():
+                    # The turn ended — drain whatever is still queued, then stop.
+                    while not queue.empty():
+                        async for ev in _drain(queue.get_nowait()):
+                            yield ev
+                    break
+            final_event = send_task.result()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — the SDK turn failed mid-stream
+            await self.close_session(session_key)
+            yield ExecutorError(message=f"copilot-sdk turn failed: {exc}", retryable=True)
+            return
+        finally:
+            unsubscribe()
+            if not send_task.done():
+                send_task.cancel()
+
+        if turn_error and not response_text:
+            await self.close_session(session_key)
+            yield ExecutorError(message=f"copilot-sdk run error: {turn_error}", retryable=True)
+            return
+
+        # Prefer the streamed text (which carries the paragraph breaks inserted
+        # above); fall back to the final ASSISTANT_MESSAGE content only when
+        # nothing streamed (e.g. a tool-only turn).
+        final = response_text or _final_message_text(final_event) or None
+
+        # PHASE_LLM_RESPONSE policy (parity with the peer harnesses).
+        if policy_eval is not None:
+            resp_verdict = await policy_eval(
+                "PHASE_LLM_RESPONSE",
+                {
+                    "model": model or "auto",
+                    "text_preview": response_text[:500] if response_text else "",
+                    "tool_calls_count": tool_calls,
+                },
+            )
+            if getattr(resp_verdict, "action", "") == "POLICY_ACTION_DENY":
+                reason = getattr(resp_verdict, "reason", "") or "no reason given"
+                yield ExecutorError(message=f"LLM response denied by policy: {reason}")
+                return
+
+        usage = _finalize_usage(usage_acc)
+        if usage is not None:
+            _notify_usage_from_dict(model=usage_model or model or "copilot", usage=usage)
+        yield TurnComplete(response=final, usage=usage)
+
+    async def _close_state(self, state: _CopilotSessionState) -> None:
+        if state.session is not None:
+            await _safe_stop(state.session)
+            state.session = None
+        if state.client is not None:
+            await _safe_stop(state.client)
+            state.client = None
+        state.call_names.clear()
+
+    async def close_session(self, session_key: str) -> None:
+        state = self._session_states.pop(session_key, None)
+        if state is not None:
+            await self._close_state(state)
+
+    async def interrupt_session(self, session_key: str) -> bool:
+        state = self._session_states.get(session_key)
+        if state is None:
+            return False
+        # Drop the session so the next turn starts a fresh one — mirrors the
+        # cursor / pi executors (a resumed turn would bypass the runner's
+        # interrupt marker).
+        try:
+            await self.close_session(session_key)
+            return True
+        except Exception as exc:  # noqa: BLE001 — close failures surface as False
+            logger.debug("CopilotExecutor: close after interrupt failed: %s", exc)
+            return False
+
+    async def close(self) -> None:
+        for key in list(self._session_states.keys()):
+            await self.close_session(key)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ambient_github_token() -> str | None:
+    """Return the first set ambient GitHub token, in CLI precedence order."""
+    for var in GITHUB_TOKEN_ENV_VARS:
+        value = os.environ.get(var)
+        if value:
+            return value
+    return None
+
+
+def _coerce_args(raw: Any) -> dict[str, Any]:  # type: ignore[explicit-any]
+    """Coerce a tool-call ``arguments`` payload to a dict.
+
+    The SDK delivers arguments as a parsed dict, but tolerate a JSON string (or
+    anything else) by best-effort parsing, falling back to an empty mapping.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _event_data(event: Any) -> dict[str, Any]:  # type: ignore[explicit-any]
+    """Return an event's ``data`` payload as a (camelCase-keyed) dict.
+
+    Uses ``to_dict()`` (the wire form) so reads are schema-stable across the
+    SDK's snake_case attributes vs. camelCase wire keys.
+    """
+    try:
+        payload = event.to_dict()
+    except Exception:  # noqa: BLE001 — fall back to attribute access below
+        payload = None
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, dict):
+            return data
+    data_attr = getattr(event, "data", None)
+    if isinstance(data_attr, dict):
+        return data_attr
+    return {}
+
+
+def _final_message_text(event: Any) -> str:  # type: ignore[explicit-any]
+    """Extract the aggregate assistant text from the final ASSISTANT_MESSAGE event."""
+    if event is None:
+        return ""
+    content = _event_data(event).get("content")
+    return content if isinstance(content, str) else ""
+
+
+def _accumulate_usage(acc: dict[str, int], data: dict[str, Any]) -> None:  # type: ignore[explicit-any]
+    """Sum the token counts from one ASSISTANT_USAGE event into *acc*.
+
+    Copilot emits one usage event per underlying model call, so a turn with
+    tool round-trips reports usage several times; we accumulate.
+    """
+    mapping = {
+        "inputTokens": "input_tokens",
+        "outputTokens": "output_tokens",
+        "cacheReadTokens": "cache_read_input_tokens",
+    }
+    for wire_key, usage_key in mapping.items():
+        value = data.get(wire_key)
+        if isinstance(value, (int, float)):
+            acc[usage_key] = acc.get(usage_key, 0) + int(value)
+
+
+def _finalize_usage(acc: dict[str, int]) -> dict[str, Any] | None:  # type: ignore[explicit-any]
+    """Build the TurnComplete usage dict from accumulated counts, or ``None``."""
+    if not acc:
+        return None
+    usage: dict[str, Any] = dict(acc)  # type: ignore[explicit-any]
+    usage["total_tokens"] = usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+    return usage
+
+
+async def _safe_stop(obj: Any) -> None:  # type: ignore[explicit-any]
+    """Best-effort async teardown of a ``copilot`` client / session.
+
+    :class:`copilot.CopilotClient` exposes ``stop()`` (terminates the bundled
+    CLI subprocess it launched); :class:`copilot.CopilotSession` exposes
+    ``disconnect()``. Prefer ``stop`` then ``disconnect``; a teardown failure
+    must not mask the original error or leave the closer raising.
+    """
+    closer = (
+        getattr(obj, "stop", None)
+        or getattr(obj, "disconnect", None)
+        or getattr(obj, "aclose", None)
+        or getattr(obj, "close", None)
+    )
+    if closer is None:
+        return
+    try:
+        result = closer()
+        if asyncio.iscoroutine(result):
+            await result
+    except Exception as exc:  # noqa: BLE001 — best-effort teardown
+        logger.debug("CopilotExecutor: stop failed: %s", exc)

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -21,6 +21,16 @@ handlers *in its own event loop* (``CopilotSession._execute_tool_and_respond``),
 so the bridged handler is a plain coroutine that ``await``\\s ``_tool_executor``
 directly — no ``run_coroutine_threadsafe`` hop.
 
+Known limitation — Copilot's **native** tools (its own ``create`` / ``view`` /
+``edit`` / ``bash``) run *inside* the SDK and never flow through Omnigent's
+bridged-tool dispatch, so (a) they are NOT gated by ``on:[tool_call]`` policies
+(e.g. ``blast_radius``) and (b) they leave no ``function_call`` item in the
+persisted transcript — only the streamed narration is recorded. This mirrors the
+cursor harness's built-in tools. Bridged ``sys_*`` tools ARE policy-gated and
+recorded. Don't rely on ``on:[tool_call]`` guardrails to constrain Copilot's
+built-in file/shell tools; gate at the LLM phase (``PHASE_LLM_REQUEST`` /
+``PHASE_LLM_RESPONSE``, which DO fire) or via the OS-env sandbox instead.
+
 Auth: a **GitHub token** that carries Copilot access — a fine-grained PAT with
 the "Copilot Requests" permission, or an OAuth token from the GitHub CLI (``gh``)
 / Copilot CLI app. Resolved from a spec ``api_key`` or the ambient
@@ -399,8 +409,13 @@ class CopilotExecutor(Executor):
             working_directory=cwd,
             log_level="error",
         )
-        await client.start()
         try:
+            # ``start()`` is inside the try: it spawns the bundled Copilot CLI
+            # subprocess *before* connecting/verifying, and the SDK's own error
+            # path re-raises without terminating that subprocess — only
+            # ``client.stop()`` reaps it. So a start failure (bad token, version
+            # skew) must still hit ``_safe_stop`` below, or it orphans the CLI.
+            await client.start()
             # ``append`` keeps Copilot's own operating instructions (how to use
             # its built-in tools) and layers the Omnigent agent's system prompt
             # on top — a ``replace`` would strip the tool-use guidance the model
@@ -595,7 +610,14 @@ class CopilotExecutor(Executor):
             if not send_task.done():
                 send_task.cancel()
 
-        if turn_error and not response_text:
+        # Surface a mid-turn error event (``SESSION_ERROR`` / ``MODEL_CALL_FAILURE``)
+        # whenever the turn did NOT produce a successful final message — even if
+        # some text streamed first. Reporting a failed turn as a clean
+        # ``TurnComplete`` with partial text would mask the failure (a turn that
+        # errored after partial output would look successful). A real final
+        # ASSISTANT_MESSAGE (``final_event`` set) means the SDK completed the turn,
+        # so a stray earlier event is not treated as fatal.
+        if turn_error and final_event is None:
             await self.close_session(session_key)
             yield ExecutorError(message=f"copilot-sdk run error: {turn_error}", retryable=True)
             return

--- a/omnigent/inner/copilot_executor.py
+++ b/omnigent/inner/copilot_executor.py
@@ -557,13 +557,14 @@ class CopilotExecutor(Executor):
             elif etype.endswith("TOOL_EXECUTION_COMPLETE"):
                 call_id = data.get("toolCallId")
                 name = state.call_names.get(str(call_id), "tool") if call_id else "tool"
-                result = data.get("result")
+                result = _unwrap_tool_result(data.get("result"))
                 classification = classify_tool_result(result)
                 status = classification.status
                 error = classification.error or None
-                if data.get("success") is False or data.get("error"):
+                raw_error = data.get("error")
+                if data.get("success") is False or raw_error:
                     status = ToolCallStatus.ERROR
-                    error = error or str(data.get("error") or "tool call failed")
+                    error = error or _unwrap_tool_error(raw_error) or "tool call failed"
                 separate_next_text = True
                 yield ToolCallComplete(
                     name=name,
@@ -729,6 +730,50 @@ def _event_data(event: Any) -> dict[str, Any]:  # type: ignore[explicit-any]
     if isinstance(data_attr, dict):
         return data_attr
     return {}
+
+
+# SDK ``ToolExecutionCompleteResult.to_dict`` wraps the payload as
+# ``{"content": ..., "contents": [...], "detailedContent": ..., "uiResource": ...}``
+# and ``ToolExecutionCompleteError.to_dict`` as ``{"message": ..., "code": ...}``.
+_TOOL_RESULT_WRAPPER_KEYS = ("content", "contents", "detailedContent", "uiResource")
+
+
+def _unwrap_tool_result(raw: Any) -> Any:  # type: ignore[explicit-any]
+    """Unwrap the SDK ``ToolExecutionCompleteResult`` wrapper to its content payload.
+
+    A ``TOOL_EXECUTION_COMPLETE`` ``result`` arrives in wire form as a wrapper
+    dict (``{"content": ..., "detailedContent": ..., ...}``). Carry the bare
+    content downstream (classification, tracing, the persisted ``ToolCallComplete``
+    result) rather than the wrapper — matching the bare-payload convention the
+    peer executors use. Only a recognized wrapper shape is unwrapped, so an
+    Omnigent-convention result (e.g. ``{"blocked": True}``) passes through
+    untouched for :func:`classify_tool_result`.
+    """
+    if isinstance(raw, dict) and any(k in raw for k in _TOOL_RESULT_WRAPPER_KEYS):
+        for key in ("content", "detailedContent"):
+            value = raw.get(key)
+            if value is not None:
+                return value
+    return raw
+
+
+def _unwrap_tool_error(raw: Any) -> str | None:  # type: ignore[explicit-any]
+    """Extract the message from the SDK's structured tool error.
+
+    A failed ``TOOL_EXECUTION_COMPLETE`` ``error`` arrives as
+    ``{"message": ..., "code": ...}`` (``ToolExecutionCompleteError.to_dict``);
+    surface the ``message`` rather than the dict's Python repr (which would leak
+    ``"{'message': ..., 'code': ...}"`` into the tool error shown to the
+    model / recorded on the span). A bare string passes through; anything else
+    yields ``None`` so the caller can fall back to a generic message.
+    """
+    if isinstance(raw, dict):
+        message = raw.get("message")
+        if isinstance(message, str) and message:
+            return message
+    if isinstance(raw, str) and raw:
+        return raw
+    return None
 
 
 def _final_message_text(event: Any) -> str:  # type: ignore[explicit-any]

--- a/omnigent/inner/copilot_harness.py
+++ b/omnigent/inner/copilot_harness.py
@@ -1,0 +1,145 @@
+"""
+``harness: copilot`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"copilot"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.copilot_executor.CopilotExecutor`, which drives
+a persistent GitHub Copilot SDK (``github-copilot-sdk``) session. Mirrors the
+cursor / antigravity wraps' env-var config flow.
+
+Like cursor and antigravity, copilot has NO gateway / Databricks-profile env
+vars: the Copilot SDK talks only to GitHub's Copilot backend (authenticated by a
+GitHub token) and has no custom API base-URL override, so there is nothing for
+the workflow layer to route through the Databricks AI gateway.
+
+Env vars read at startup:
+
+- ``HARNESS_COPILOT_MODEL``: Copilot model id, e.g. ``"claude-haiku-4.5"`` or
+  ``"gpt-5-mini"``. ``None`` lets Copilot auto-select. A ``databricks-*`` id
+  (from a spec authored for another harness) is dropped by the executor.
+- ``HARNESS_COPILOT_CWD``: working directory the session operates in.
+  ``None`` falls back to ``os_env.cwd`` then the process cwd.
+- ``HARNESS_COPILOT_GITHUB_TOKEN``: GitHub token carrying Copilot access, used
+  as the SDK ``github_token``. ``None`` falls back to an inherited
+  ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``.
+- ``HARNESS_COPILOT_OS_ENV``: JSON-encoded :class:`OSEnvSpec` (its ``cwd`` is
+  used when ``HARNESS_COPILOT_CWD`` is unset). Defaults to
+  ``caller_process + sandbox=none``.
+- ``HARNESS_COPILOT_SKILLS_FILTER``: JSON ``str | list[str]`` (parity;
+  copilot has no skill mechanism wired here). Defaults to ``"all"``.
+- ``HARNESS_COPILOT_BUNDLE_DIR`` / ``HARNESS_COPILOT_AGENT_NAME``:
+  reserved for future use.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from omnigent.inner.copilot_executor import CopilotExecutor
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+_ENV_MODEL = "HARNESS_COPILOT_MODEL"
+_ENV_CWD = "HARNESS_COPILOT_CWD"
+_ENV_GITHUB_TOKEN = "HARNESS_COPILOT_GITHUB_TOKEN"
+_ENV_OS_ENV = "HARNESS_COPILOT_OS_ENV"
+_ENV_SKILLS_FILTER = "HARNESS_COPILOT_SKILLS_FILTER"
+_ENV_BUNDLE_DIR = "HARNESS_COPILOT_BUNDLE_DIR"
+_ENV_AGENT_NAME = "HARNESS_COPILOT_AGENT_NAME"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """Resolve the inner-executor :class:`OSEnvSpec` from :data:`_ENV_OS_ENV`.
+
+    Decodes the JSON-encoded dict Omnigent serialized via
+    :func:`dataclasses.asdict`. When the env var is missing or malformed, falls
+    back to ``caller_process + sandbox=none`` — matches the cursor/codex/pi
+    wraps' default for specs without an ``os_env:`` block.
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env", _ENV_OS_ENV, exc
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _resolve_skills_filter() -> str | list[str]:
+    """Resolve ``skills_filter`` from :data:`_ENV_SKILLS_FILTER` (defaults ``"all"``)."""
+    raw = os.environ.get(_ENV_SKILLS_FILTER, "").strip()
+    if not raw:
+        return "all"
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _logger.warning(
+            "%s is not valid JSON (%s); falling back to 'all'", _ENV_SKILLS_FILTER, exc
+        )
+        return "all"
+    if isinstance(decoded, str) and decoded in ("all", "none"):
+        return decoded
+    if isinstance(decoded, list) and all(isinstance(s, str) for s in decoded):
+        return decoded
+    _logger.warning(
+        "%s decoded to unsupported shape %r; falling back to 'all'", _ENV_SKILLS_FILTER, decoded
+    )
+    return "all"
+
+
+def _build_copilot_executor() -> Executor:
+    """Construct a :class:`CopilotExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first turn, so a
+    missing ``github-copilot-sdk`` install surfaces as a request-time error
+    rather than an app-boot crash.
+
+    :raises ImportError: If the ``github-copilot-sdk`` package isn't installed.
+    """
+    bundle_dir_raw = os.environ.get(_ENV_BUNDLE_DIR, "").strip()
+    bundle_dir = Path(bundle_dir_raw) if bundle_dir_raw else None
+    return CopilotExecutor(
+        cwd=os.environ.get(_ENV_CWD) or None,
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL) or None,
+        github_token=os.environ.get(_ENV_GITHUB_TOKEN) or None,
+        bundle_dir=bundle_dir,
+        agent_name=os.environ.get(_ENV_AGENT_NAME, "").strip() or None,
+        skills_filter=_resolve_skills_filter(),
+    )
+
+
+def create_app() -> FastAPI:
+    """Build the copilot harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(executor_factory=_build_copilot_executor)
+    return adapter.build()

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -26,7 +26,7 @@ _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\[\]-]*$")
 # SDK harnesses whose model override lands in the spawn env — must stay
 # in sync with ``_HARNESS_MODEL_ENV_KEY`` in ``omnigent/runner/app.py``.
 _SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
-    {"claude-sdk", "codex", "pi", "openai-agents", "cursor", "antigravity", "qwen", "goose"}
+    {"claude-sdk", "codex", "pi", "openai-agents", "cursor", "antigravity", "qwen", "goose", "copilot"}
 )
 
 

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -26,7 +26,17 @@ _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\[\]-]*$")
 # SDK harnesses whose model override lands in the spawn env — must stay
 # in sync with ``_HARNESS_MODEL_ENV_KEY`` in ``omnigent/runner/app.py``.
 _SDK_MODEL_OVERRIDE_HARNESSES: frozenset[str] = frozenset(
-    {"claude-sdk", "codex", "pi", "openai-agents", "cursor", "antigravity", "qwen", "goose", "copilot"}
+    {
+        "claude-sdk",
+        "codex",
+        "pi",
+        "openai-agents",
+        "cursor",
+        "antigravity",
+        "qwen",
+        "goose",
+        "copilot",
+    }
 )
 
 

--- a/omnigent/onboarding/copilot_auth.py
+++ b/omnigent/onboarding/copilot_auth.py
@@ -1,0 +1,134 @@
+"""GitHub Copilot token storage for ``omnigent setup`` and the runtime.
+
+Copilot is deliberately outside the anthropic/openai provider-family + gateway
+machinery (see :func:`omnigent.runtime.workflow._build_copilot_spawn_env`): the
+GitHub Copilot SDK (``github-copilot-sdk``) talks only to GitHub's Copilot
+backend, authenticated by a **GitHub token** — never the Databricks AI gateway.
+It therefore has no ``providers:`` family entry, but a user should still be able
+to register a Copilot token once through ``omnigent setup`` rather than
+exporting it in every shell.
+
+This module is that home. The token is stored exactly like the api-key
+providers' secrets — in the omnigent secret store (OS keychain, else a ``0600``
+JSON file; see :mod:`omnigent.onboarding.secrets`) — and referenced from a
+dedicated top-level ``copilot:`` block in ``~/.omnigent/config.yaml``::
+
+    copilot:
+      github_token_ref: keychain:copilot   # or env:GH_TOKEN
+
+The reference is resolved with the same :func:`resolve_secret` resolver the
+provider families use. A dedicated block (rather than the shared global
+``auth:`` block) is required because ``auth:`` is the *gateway* credential the
+SDK harnesses inherit when their spec declares no auth — a Copilot token parked
+there would be mis-consumed by claude-sdk / codex / pi / openai-agents.
+
+Accepted token types mirror what the Copilot CLI/SDK honors: a fine-grained PAT
+(``github_pat_``) with the "Copilot Requests" permission, or an OAuth token from
+the GitHub CLI (``gho_``) / Copilot CLI app. Classic PATs (``ghp_``) are NOT
+accepted by Copilot.
+"""
+
+from __future__ import annotations
+
+from omnigent.errors import OmnigentError
+from omnigent.onboarding.provider_config import load_config, resolve_secret
+
+# The secret-store name (and thus ``keychain:<name>``) under which a Copilot
+# GitHub token is stored — stable so the setup flow and the resolver agree.
+COPILOT_SECRET_NAME = "copilot"
+
+# The dedicated top-level config block and the field that references the token.
+COPILOT_CONFIG_KEY = "copilot"
+_TOKEN_REF_FIELD = "github_token_ref"
+_TOKEN_FIELD = "github_token"
+
+# Ambient GitHub-token env vars, in the precedence the Copilot CLI/SDK honors.
+COPILOT_TOKEN_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+# Token-shape prefixes Copilot accepts. The check is deliberately *soft* — a
+# user may force a non-matching value through — so a future prefix change can
+# never lock anyone out of their own token. Classic ``ghp_`` PATs are excluded
+# because Copilot rejects them.
+_GITHUB_TOKEN_PREFIXES = ("github_pat_", "gho_", "ghu_", "ghs_")
+
+
+def looks_like_github_copilot_token(value: str) -> bool:
+    """Return whether *value* has the shape of a Copilot-capable GitHub token.
+
+    :param value: A pasted/typed candidate token, e.g. ``"gho_AbC123"`` or
+        ``"github_pat_..."``.
+    :returns: ``True`` when *value* starts with a known Copilot-capable prefix
+        (a fine-grained PAT or an OAuth token); ``False`` for an empty string or
+        a classic ``ghp_`` PAT (which Copilot rejects).
+    """
+    return value.startswith(_GITHUB_TOKEN_PREFIXES)
+
+
+def copilot_github_token_ref(config: dict[str, object] | None = None) -> str | None:
+    """Return the configured Copilot GitHub-token secret reference, if any.
+
+    Reads the dedicated ``copilot:`` block of the global config. Both the
+    ``github_token_ref`` (``keychain:`` / ``env:``) and an inline ``github_token``
+    (``$VAR`` / literal) shapes are accepted so a hand-edited config works too;
+    ``github_token_ref`` wins when both are present.
+
+    :param config: A pre-loaded config mapping; ``None`` loads
+        ``~/.omnigent/config.yaml`` via :func:`load_config`.
+    :returns: The secret reference, e.g. ``"keychain:copilot"`` or
+        ``"env:GH_TOKEN"``, or ``None`` when no Copilot token is configured.
+    """
+    cfg = load_config() if config is None else config
+    block = cfg.get(COPILOT_CONFIG_KEY)
+    if not isinstance(block, dict):
+        return None
+    ref = block.get(_TOKEN_REF_FIELD) or block.get(_TOKEN_FIELD)
+    return ref if isinstance(ref, str) and ref else None
+
+
+def resolve_copilot_github_token(config: dict[str, object] | None = None) -> str | None:
+    """Resolve the configured Copilot GitHub token to its plaintext value, softly.
+
+    Looks up the ``copilot:`` block's secret reference and resolves it via
+    :func:`resolve_secret`. Unlike :func:`resolve_secret`, this **never raises**:
+    a missing block or an unresolvable reference (deleted keychain entry, unset
+    env var) returns ``None`` so the caller — the copilot spawn-env builder and
+    the setup readout — can fall back to an inherited ``GH_TOKEN`` instead of
+    crashing a run.
+
+    :param config: A pre-loaded config mapping; ``None`` loads the global config.
+    :returns: The plaintext GitHub token, or ``None`` when none is configured or
+        it cannot be resolved.
+    """
+    ref = copilot_github_token_ref(config)
+    if ref is None:
+        return None
+    try:
+        return resolve_secret(ref)
+    except OmnigentError:
+        return None
+
+
+def copilot_github_token_configured(config: dict[str, object] | None = None) -> bool:
+    """Return whether a usable Copilot GitHub token is configured.
+
+    ``True`` only when the ``copilot:`` block names a reference **and** it
+    resolves — a dangling reference reads as not-configured so the setup readout
+    never claims a credential the runtime can't actually use.
+
+    :param config: A pre-loaded config mapping; ``None`` loads the global config.
+    :returns: ``True`` when a Copilot GitHub token is configured and resolvable.
+    """
+    return resolve_copilot_github_token(config) is not None
+
+
+def copilot_github_token_settings(ref: str) -> dict[str, object]:
+    """Build the ``{"copilot": {...}}`` settings dict that records *ref*.
+
+    Handed to :func:`omnigent.cli._save_global_config` (a shallow update, so it
+    replaces the whole ``copilot:`` block) to persist the reference.
+
+    :param ref: The secret reference to record, e.g. ``"keychain:copilot"`` or
+        ``"env:GH_TOKEN"``.
+    :returns: ``{"copilot": {"github_token_ref": ref}}``.
+    """
+    return {COPILOT_CONFIG_KEY: {_TOKEN_REF_FIELD: ref}}

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -67,6 +67,13 @@ OPENCODE_KEY = "opencode"
 # ``install_hint``, not a ``package``.
 GOOSE_KEY = "goose"
 
+# Copilot runs in-process via the ``github-copilot-sdk`` package, which bundles
+# the Copilot CLI binary it drives — so, like cursor, there is no separately
+# installed CLI to gate on; readiness is whether a GitHub token resolves (see
+# :func:`omnigent.onboarding.harness_readiness.harness_is_configured`). The key
+# is kept here purely as the canonical harness id the readiness layer shares.
+COPILOT_KEY = "copilot"
+
 
 @dataclass(frozen=True)
 class HarnessInstallSpec:

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -28,6 +28,7 @@ import os
 
 from omnigent.harness_aliases import HARNESS_ALIASES, canonicalize_harness
 from omnigent.onboarding.harness_install import (
+    COPILOT_KEY,
     CURSOR_KEY,
     GOOSE_KEY,
     OPENCODE_KEY,
@@ -169,6 +170,22 @@ def harness_is_configured(harness: str) -> bool:
         from omnigent.onboarding.cursor_auth import cursor_api_key_configured
 
         return cursor_api_key_configured() or bool(os.environ.get("CURSOR_API_KEY"))
+    if canonical == COPILOT_KEY:
+        # Copilot runs in-process via the ``github-copilot-sdk`` package (the
+        # SDK bundles the CLI binary it drives, so there is no separate binary to
+        # gate on) and authenticates against GitHub's Copilot backend with a
+        # GitHub token. So, like cursor, readiness is whether a token is
+        # resolvable — one stored by ``omnigent setup`` (the ``copilot:`` config
+        # block — see :mod:`omnigent.onboarding.copilot_auth`) or inherited from
+        # the environment. A bad / Copilot-less token surfaces at run time.
+        from omnigent.onboarding.copilot_auth import (
+            COPILOT_TOKEN_ENV_VARS,
+            copilot_github_token_configured,
+        )
+
+        return copilot_github_token_configured() or any(
+            os.environ.get(var) for var in COPILOT_TOKEN_ENV_VARS
+        )
     if (
         canonical not in _HARNESS_FAMILY
         and canonical not in _PI_HARNESSES
@@ -205,4 +222,5 @@ def configured_harness_map() -> dict[str, bool]:
     spellings.update(_QWEN_HARNESSES)
     spellings.add(CURSOR_KEY)
     spellings.add(GOOSE_KEY)  # headless Goose (``goose acp``) gates on the goose binary
+    spellings.add(COPILOT_KEY)
     return {spelling: harness_is_configured(spelling) for spelling in spellings}

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -14459,6 +14459,7 @@ _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     "antigravity": "HARNESS_ANTIGRAVITY_MODEL",
     "qwen": "HARNESS_QWEN_MODEL",
     "goose": "HARNESS_GOOSE_MODEL",
+    "copilot": "HARNESS_COPILOT_MODEL",
 }
 
 
@@ -14491,6 +14492,7 @@ def _build_spawn_env_from_spec(
             _build_antigravity_spawn_env,
             _build_claude_sdk_spawn_env,
             _build_codex_spawn_env,
+            _build_copilot_spawn_env,
             _build_cursor_spawn_env,
             _build_goose_spawn_env,
             _build_openai_agents_sdk_spawn_env,
@@ -14514,6 +14516,8 @@ def _build_spawn_env_from_spec(
             env = _build_qwen_spawn_env(spec, workdir=workdir)
         elif harness == "goose":
             env = _build_goose_spawn_env(spec, workdir=workdir)
+        elif harness == "copilot":
+            env = _build_copilot_spawn_env(spec, workdir=workdir)
         else:
             # Native terminal harnesses and unknown harnesses build env elsewhere.
             return None

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -98,6 +98,12 @@ _HARNESS_MODULES: dict[str, str] = {
     # ``opencode`` is accepted as a friendly alias for the canonical
     # ``opencode-native`` (there is no separate SDK ``opencode`` harness).
     "opencode": "omnigent.inner.opencode_native_harness",
+    # GitHub Copilot SDK harness wrap. See omnigent/inner/copilot_harness.py.
+    # In-process SDK harness (``github-copilot-sdk``), like cursor / antigravity:
+    # the SDK bundles the Copilot CLI binary it drives as a backing server, so
+    # Omnigent spawns no separately-installed CLI. Authenticates against GitHub's
+    # Copilot backend with a GitHub token (no Databricks gateway).
+    "copilot": "omnigent.inner.copilot_harness",
 }
 
 __all__ = ["_HARNESS_MODULES"]

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1705,6 +1705,79 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
     return env
 
 
+def _build_copilot_spawn_env(
+    spec: AgentSpec,
+    *,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """
+    Build the ``HARNESS_COPILOT_*`` env-var dict the copilot harness wrap reads.
+
+    Maps spec.executor fields → the ``HARNESS_COPILOT_*`` env vars defined in
+    ``omnigent/inner/copilot_harness.py``. Like the cursor / antigravity
+    builders there is NO gateway or Databricks-profile resolution: the GitHub
+    Copilot SDK talks only to GitHub's Copilot backend (a GitHub token) and has
+    no custom API base-URL override, so it never routes through the Databricks
+    AI gateway. That is also why copilot is intentionally absent from
+    :data:`AgentHarnessType` and the gateway/ucode dicts above.
+
+    Auth: an explicit ``executor.auth: {type: api_key, api_key: ...}`` carries
+    the GitHub token, forwarded as ``HARNESS_COPILOT_GITHUB_TOKEN`` (the copilot
+    harness passes it to the SDK as its ``github_token``). When the spec declares
+    no auth at all, a GitHub token registered once via ``omnigent setup`` (the
+    dedicated ``copilot:`` config block — see
+    :mod:`omnigent.onboarding.copilot_auth`) is used instead, so a user need not
+    export it in every shell. With neither, the harness falls back to an
+    inherited ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN`` — a
+    ``DatabricksAuth`` profile does not apply to copilot and is ignored.
+
+    :param spec: The agent spec.
+    :param workdir: The bundle's on-disk path, threaded as
+        ``HARNESS_COPILOT_BUNDLE_DIR``.
+    :returns: A dict of env-var overrides for
+        :meth:`HarnessProcessManager.get_client(env=...)`.
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_COPILOT_MODEL"] = model
+    # Auth precedence: an explicit api-key auth on the spec wins (its ``api_key``
+    # is the GitHub token); with NO spec auth at all, fall back to a token
+    # registered once via ``omnigent setup`` (the dedicated ``copilot:`` config
+    # block), else an ambient ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` /
+    # ``GITHUB_TOKEN``. A Databricks / provider auth has no copilot equivalent
+    # and never silently adopts a stored or ambient copilot token.
+    if isinstance(spec.executor.auth, ApiKeyAuth):
+        env["HARNESS_COPILOT_GITHUB_TOKEN"] = spec.executor.auth.api_key
+    elif spec.executor.auth is None:
+        # Imported lazily — the onboarding layer pulls in the secret store /
+        # keyring, which the hot spawn-env path shouldn't import eagerly.
+        from omnigent.onboarding.copilot_auth import (
+            COPILOT_TOKEN_ENV_VARS,
+            resolve_copilot_github_token,
+        )
+
+        stored_token = resolve_copilot_github_token()
+        if stored_token is not None:
+            env["HARNESS_COPILOT_GITHUB_TOKEN"] = stored_token
+        else:
+            for _env_var in COPILOT_TOKEN_ENV_VARS:
+                if os.environ.get(_env_var):
+                    env["HARNESS_COPILOT_GITHUB_TOKEN"] = os.environ[_env_var]
+                    break
+    # Always set so the wrap doesn't fall back to ``"all"`` and override an
+    # explicit ``skills: none`` from the spec (parity with the peer builders).
+    env["HARNESS_COPILOT_SKILLS_FILTER"] = json.dumps(spec.skills_filter)
+    if spec.name:
+        env["HARNESS_COPILOT_AGENT_NAME"] = spec.name
+    if workdir is not None:
+        env["HARNESS_COPILOT_BUNDLE_DIR"] = str(workdir)
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_COPILOT_OS_ENV"] = os_env_payload
+    return env
+
+
 def _serialize_os_env(value: OSEnvSpec | None) -> str | None:
     """
     Encode an :class:`OSEnvSpec` for the wrap's env-var input.

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -84,6 +84,7 @@ OMNIGENT_HARNESSES = frozenset(
         "claude-sdk",
         "codex",
         "codex-native",
+        "copilot",
         "cursor",
         "cursor-native",
         "goose",
@@ -108,6 +109,7 @@ OMNIGENT_HARNESS_ALIASES = frozenset(
         "qwen-code",
         "opencode",
         "native-opencode",
+        "github-copilot",
     }
 )
 _OMNIGENT_ACCEPTED_HARNESSES = OMNIGENT_HARNESSES | OMNIGENT_HARNESS_ALIASES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,11 @@ agents-sdk = [
 # harness module imports the SDK lazily on first turn, so only users of the
 # harness need this extra. Early SDK (v0.1.x) — pin minor.
 antigravity = ["google-antigravity>=0.1,<1"]
+# GitHub Copilot SDK harness (`harness: copilot`). Optional: the harness module
+# imports the SDK lazily on first turn, so only users of the harness need this
+# extra. The wheel bundles the Copilot CLI binary it drives (~90MB), which is
+# why it is not part of the baseline install. Pin major.
+copilot = ["github-copilot-sdk>=1,<2"]
 # Cursor SDK harness (`harness: cursor`). Optional like antigravity: the
 # harness imports the cursor-sdk lazily on first turn, so only `--harness
 # cursor` users need this extra (`omnigent[cursor]`). Was a baseline dependency;

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -155,6 +155,13 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     Gemini-native and its SDK launches a native binary needing a modern
     glibc.
 
+    ``copilot`` is excluded for the same reason as ``cursor`` / ``antigravity``:
+    the GitHub Copilot SDK authenticates with a GitHub token and talks only to
+    GitHub's Copilot backend (no Databricks gateway path), so ``_build_copilot_spawn_env``
+    emits none of the shared ``HARNESS_<H>_GATEWAY`` / profile probe vars this
+    matrix drives. Its live round-trip is covered by the gated
+    ``tests/e2e/test_polly_copilot_e2e.py`` and the ``copilot-sdk-e2e-dev`` skill.
+
     ``cursor-native`` is excluded for the union of both reasons above.
 
     ``qwen`` is excluded because it does not follow the shared
@@ -182,6 +189,7 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
         "cursor",
         "cursor-native",
         "antigravity",
+        "copilot",
         "qwen",
         "goose",
         "goose-native",

--- a/tests/e2e/test_polly_copilot_e2e.py
+++ b/tests/e2e/test_polly_copilot_e2e.py
@@ -1,0 +1,159 @@
+"""Gated real-network e2e: polly's orchestrator brain on the GitHub Copilot SDK.
+
+Unlike the mock-LLM smoke in ``test_polly_e2e.py`` (which swaps polly's brain to
+``openai-agents`` against a fake server), the Copilot SDK talks only to GitHub's
+Copilot backend, so this exercises the REAL harness. It is **skipped** unless a
+Copilot-capable GitHub token is resolvable — the ``copilot:`` config block
+written by ``omnigent setup``, or an ambient ``COPILOT_GITHUB_TOKEN`` /
+``GH_TOKEN`` / ``GITHUB_TOKEN`` — so CI without a token skips it, mirroring how
+the harness probes skip when a CLI binary is absent from ``PATH``.
+
+It boots a throwaway local server from this working tree (which carries polly's
+in-tree ``omnigent.inner.nessie.policies`` guardrails, resolved server-side) and
+runs the real ``examples/polly`` bundle with its orchestrator brain overridden
+to ``--harness copilot``. The committed assertion is a brain-only smoke (boots +
+coherent reply). The full dispatch→collect→synthesize orchestration loop on a
+copilot brain is exercised by the ``copilot-sdk-e2e-dev`` skill's polly driver
+(smoke / fanout / review-pr CUJs), which additionally needs the sub-agent CLIs.
+
+Run manually (with a Copilot token configured)::
+
+    pytest tests/e2e/test_polly_copilot_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.test_polly_e2e import (
+    _MIN_REPLY_CHARS,
+    _POLLY,
+    _REPO,
+    _SERVER_BOOT_TIMEOUT_SEC,
+    _free_port,
+    _wait_for_health,
+)
+
+# A real Copilot turn (network round-trip to GitHub's backend + bundled-CLI
+# spin-up) is slower than the mock path; give it a generous one-shot bound.
+_COPILOT_RUN_TIMEOUT_SEC = 280
+
+
+def _copilot_token_available() -> bool:
+    """Return whether a Copilot-capable GitHub token is resolvable on this host."""
+    try:
+        from omnigent.onboarding.copilot_auth import (
+            COPILOT_TOKEN_ENV_VARS,
+            copilot_github_token_configured,
+        )
+    except Exception:  # pragma: no cover - defensive: copilot auth module missing
+        return False
+    if copilot_github_token_configured():
+        return True
+    return any(os.environ.get(var) for var in COPILOT_TOKEN_ENV_VARS)
+
+
+pytestmark = pytest.mark.skipif(
+    not _copilot_token_available(),
+    reason=(
+        "no Copilot-capable GitHub token configured "
+        "(copilot: config block or COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN)"
+    ),
+)
+
+
+@pytest.fixture
+def local_polly_server_real(tmp_path: Path) -> Iterator[str]:
+    """Boot a throwaway local ``omnigent server`` from this working tree.
+
+    Unlike ``test_polly_e2e.local_polly_server`` this does NOT strip the
+    developer's credentials — the Copilot harness needs the real GitHub token to
+    reach GitHub's backend. Own sqlite DB + artifact dir under ``tmp_path`` keep
+    it isolated from the developer's real state.
+
+    :param tmp_path: pytest-provided per-test temp dir for the DB + artifacts.
+    :yields: The base URL of the running server, e.g. ``"http://127.0.0.1:8811"``.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{tmp_path / 'polly_copilot_e2e.db'}",
+            "--artifact-location",
+            str(tmp_path / "artifacts"),
+        ],
+        cwd=str(_REPO),
+        env={**os.environ, "OMNIGENT_SKIP_ONBOARD": "1", "OMNIGENT_NO_UPDATE_CHECK": "1"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_health(base_url, time.monotonic() + _SERVER_BOOT_TIMEOUT_SEC)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_polly_brain_on_copilot_boots_and_responds(local_polly_server_real: str) -> None:
+    """polly with a ``--harness copilot`` brain boots and returns a coherent reply.
+
+    Runs the real ``examples/polly`` bundle with its orchestrator brain
+    overridden to the Copilot SDK harness (``--harness copilot --model auto``)
+    against the local server, and asserts exit 0 + a non-trivial reply. This is
+    the regression guard that the Copilot SDK harness can serve as polly's brain
+    end-to-end: GitHub token resolution, egress, the bundled Copilot CLI, the
+    harness wrap, and server-side guardrail resolution all working together. A
+    blank reply or non-zero exit means the copilot brain can't drive polly.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "run",
+            str(_POLLY),
+            "--server",
+            local_polly_server_real,
+            "--harness",
+            "copilot",
+            "--model",
+            "auto",
+            "-p",
+            "In one short sentence, what are you and how do you handle a coding task?",
+        ],
+        cwd=str(_REPO),
+        env={**os.environ, "OMNIGENT_SKIP_ONBOARD": "1", "OMNIGENT_NO_UPDATE_CHECK": "1"},
+        capture_output=True,
+        text=True,
+        timeout=_COPILOT_RUN_TIMEOUT_SEC,
+    )
+    assert result.returncode == 0, (
+        f"polly(copilot) run exited {result.returncode}\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    reply = result.stdout.strip()
+    assert len(reply) >= _MIN_REPLY_CHARS, (
+        f"polly(copilot) produced no/short reply ({len(reply)} chars): {reply!r}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -1,0 +1,494 @@
+"""Tests for :class:`omnigent.inner.copilot_executor.CopilotExecutor`.
+
+The copilot harness drives the GitHub Copilot SDK (``github-copilot-sdk``,
+imported as ``copilot``). The SDK is replaced with an injected fake module (so
+no real backing CLI, GitHub token, or network is needed), letting us exercise
+the ``SessionEvent`` → ExecutorEvent mapping, the tool bridge into
+``_tool_executor``, persistent-session reuse across turns, the ``databricks-*``
+model fallback, usage accumulation, and the failure/lifecycle paths. Live
+end-to-end coverage (a real Copilot model invoking a bridged tool) lives in the
+gated e2e test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from omnigent.inner.copilot_executor import (
+    CopilotExecutor,
+    _accumulate_usage,
+    _ambient_github_token,
+    _build_copilot_prompt,
+    _coerce_args,
+    _encode_tool_result,
+    _event_data,
+    _finalize_usage,
+    _resolve_model,
+)
+from omnigent.inner.executor import (
+    ExecutorError,
+    Message,
+    ReasoningChunk,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
+    TurnComplete,
+)
+
+
+def _user(content: str, session_id: str = "conv1") -> Message:
+    return {"role": "user", "content": content, "session_id": session_id}
+
+
+def _ev(name: str, **data: Any) -> tuple[str, dict[str, Any]]:
+    """A scripted (event-type-name, data) pair."""
+    return (name, data)
+
+
+# ---------------------------------------------------------------------------
+# Fake copilot SDK
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    def __init__(self, name: str, data: dict[str, Any]) -> None:
+        self.type = f"SessionEventType.{name}"
+        self._data = data
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.type, "data": dict(self._data)}
+
+
+class _FakeSession:
+    def __init__(self, state: dict[str, Any]) -> None:
+        self._state = state
+        self._handlers: list[Any] = []
+
+    def on(self, handler: Any) -> Any:
+        self._handlers.append(handler)
+
+        def unsub() -> None:
+            if handler in self._handlers:
+                self._handlers.remove(handler)
+
+        self._state["unsub_calls"] = self._state.get("unsub_calls", 0)
+        return _Unsub(self, handler)
+
+    async def send_and_wait(self, prompt: str, *, timeout: float = 60.0) -> Any:
+        self._state["sent"].append(prompt)
+        await asyncio.sleep(0)
+        scripts: list[list[tuple[str, dict[str, Any]]]] = self._state["turn_scripts"]
+        script = scripts.pop(0) if scripts else []
+        final = None
+        for name, data in script:
+            event = _FakeEvent(name, data)
+            for handler in list(self._handlers):
+                handler(event)
+            if event.type.endswith("ASSISTANT_MESSAGE"):
+                final = event
+        return final
+
+    async def disconnect(self) -> None:
+        self._state["session_closed"] += 1
+
+    def abort(self) -> None:
+        self._state["aborted"] += 1
+
+
+class _Unsub:
+    def __init__(self, session: _FakeSession, handler: Any) -> None:
+        self._session = session
+        self._handler = handler
+
+    def __call__(self) -> None:
+        self._session._state["unsub_calls"] = self._session._state.get("unsub_calls", 0) + 1
+        if self._handler in self._session._handlers:
+            self._session._handlers.remove(self._handler)
+
+
+class _PermissionHandler:
+    approve_all = "approve_all"
+
+
+def _install_fake_copilot(
+    monkeypatch: pytest.MonkeyPatch,
+    turn_scripts: list[list[tuple[str, dict[str, Any]]]] | None = None,
+    *,
+    create_exc: Exception | None = None,
+) -> dict[str, Any]:
+    """Install a fake ``copilot`` module; return a capture dict.
+
+    *turn_scripts* is one list of scripted events per ``send_and_wait`` call.
+    """
+    state: dict[str, Any] = {
+        "client_kwargs": [],
+        "create_kwargs": [],
+        "sent": [],
+        "started": 0,
+        "client_closed": 0,
+        "session_closed": 0,
+        "aborted": 0,
+        "turn_scripts": list(turn_scripts or []),
+    }
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            state["client_kwargs"].append(kwargs)
+
+        async def start(self) -> None:
+            state["started"] += 1
+
+        async def stop(self) -> None:
+            state["client_closed"] += 1
+
+        async def create_session(self, **kwargs: Any) -> _FakeSession:
+            state["create_kwargs"].append(kwargs)
+            if create_exc is not None:
+                raise create_exc
+            return _FakeSession(state)
+
+    class _Tool:
+        def __init__(
+            self,
+            name: str,
+            description: str,
+            handler: Any = None,
+            parameters: Any = None,
+            overrides_built_in_tool: bool = False,
+            skip_permission: bool = False,
+        ) -> None:
+            self.name = name
+            self.description = description
+            self.handler = handler
+            self.parameters = parameters
+            self.skip_permission = skip_permission
+
+    class _ToolResult:
+        def __init__(
+            self,
+            text_result_for_llm: str = "",
+            result_type: str = "success",
+            error: str | None = None,
+            **_: Any,
+        ) -> None:
+            self.text_result_for_llm = text_result_for_llm
+            self.result_type = result_type
+            self.error = error
+
+    module = types.ModuleType("copilot")
+    module.CopilotClient = _FakeClient  # type: ignore[attr-defined]
+    module.Tool = _Tool  # type: ignore[attr-defined]
+    module.ToolResult = _ToolResult  # type: ignore[attr-defined]
+    module.PermissionHandler = _PermissionHandler  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "copilot", module)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no SDK needed)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_passthrough_and_databricks_drop() -> None:
+    assert _resolve_model(None) is None
+    assert _resolve_model("claude-haiku-4.5") == "claude-haiku-4.5"
+    assert _resolve_model("databricks-claude-opus-4-8") is None
+
+
+def test_build_prompt_first_turn_history_and_latest() -> None:
+    # Multi-message first turn serializes history.
+    msgs = [_user("first"), {"role": "assistant", "content": "ok"}, _user("second")]
+    prompt = _build_copilot_prompt(msgs, is_first_turn=True)
+    assert "Conversation so far:" in prompt and "second" in prompt
+    # Single message: just the latest user text.
+    assert _build_copilot_prompt([_user("hi")], is_first_turn=True) == "hi"
+    assert _build_copilot_prompt([_user("again")], is_first_turn=False) == "again"
+
+
+def test_coerce_args() -> None:
+    assert _coerce_args({"a": 1}) == {"a": 1}
+    assert _coerce_args('{"a": 1}') == {"a": 1}
+    assert _coerce_args("not json") == {}
+    assert _coerce_args(None) == {}
+    assert _coerce_args("[1,2]") == {}  # non-dict json
+
+
+def test_event_data_reads_to_dict() -> None:
+    assert _event_data(_FakeEvent("ASSISTANT_MESSAGE_DELTA", {"deltaContent": "x"})) == {
+        "deltaContent": "x"
+    }
+
+
+def test_usage_accumulation_and_finalize() -> None:
+    acc: dict[str, int] = {}
+    _accumulate_usage(acc, {"inputTokens": 10, "outputTokens": 5, "cacheReadTokens": 2})
+    _accumulate_usage(acc, {"inputTokens": 3, "outputTokens": 1})
+    usage = _finalize_usage(acc)
+    assert usage == {
+        "input_tokens": 13,
+        "output_tokens": 6,
+        "cache_read_input_tokens": 2,
+        "total_tokens": 19,
+    }
+    assert _finalize_usage({}) is None
+
+
+def test_ambient_github_token_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    assert _ambient_github_token() is None
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_c")
+    monkeypatch.setenv("GH_TOKEN", "gho_b")
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_a")
+    assert _ambient_github_token() == "gho_a"
+
+
+def test_capabilities() -> None:
+    ex = CopilotExecutor()
+    assert ex.supports_streaming() is True
+    assert ex.supports_tool_calling() is True
+    assert ex.handles_tools_internally() is True
+    assert ex.supports_live_message_queue() is False
+
+
+# ---------------------------------------------------------------------------
+# Tool-result encoding + bridge (needs the fake ToolResult)
+# ---------------------------------------------------------------------------
+
+
+def test_encode_tool_result_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_copilot(monkeypatch)
+    ok = _encode_tool_result("plain text")
+    assert ok.text_result_for_llm == "plain text" and ok.result_type == "success"
+    err = _encode_tool_result({"error": "boom"})
+    assert err.result_type == "failure" and "boom" in err.error
+    blocked = _encode_tool_result({"blocked": True, "reason": "policy"})
+    assert blocked.result_type == "failure"
+    js = _encode_tool_result({"value": 1})
+    assert js.result_type == "success" and "value" in js.text_result_for_llm
+
+
+@pytest.mark.asyncio
+async def test_bridged_tool_handler_routes_to_tool_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_copilot(monkeypatch)
+    ex = CopilotExecutor()
+    seen: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_exec(name: str, args: dict[str, Any]) -> Any:
+        seen.append((name, args))
+        return {"ok": True}
+
+    ex._tool_executor = fake_exec
+    handler = ex._make_handler("sys_session_send")
+    invocation = types.SimpleNamespace(arguments={"x": 1}, tool_call_id="c1")
+    result = await handler(invocation)
+    assert seen == [("sys_session_send", {"x": 1})]
+    assert result.result_type == "success"
+
+
+@pytest.mark.asyncio
+async def test_bridged_tool_handler_surfaces_exception_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_copilot(monkeypatch)
+    ex = CopilotExecutor()
+
+    async def boom(name: str, args: dict[str, Any]) -> Any:
+        raise RuntimeError("kaboom")
+
+    ex._tool_executor = boom
+    handler = ex._make_handler("sys_x")
+    result = await handler(types.SimpleNamespace(arguments={}, tool_call_id="c"))
+    assert result.result_type == "failure" and "kaboom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# run_turn (fake SDK)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_turn_streams_text_reasoning_and_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("ASSISTANT_REASONING_DELTA", deltaContent="thinking…"),
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="PO"),
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="NG"),
+                _ev("ASSISTANT_USAGE", model="claude-haiku-4.5", inputTokens=10, outputTokens=2),
+                _ev("ASSISTANT_MESSAGE", content="PONG"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    texts = [e.text for e in events if isinstance(e, TextChunk)]
+    reasoning = [e for e in events if isinstance(e, ReasoningChunk)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert "".join(texts) == "PONG"
+    assert reasoning and reasoning[0].delta == "thinking…"
+    assert completes and completes[0].response == "PONG"
+    assert completes[0].usage == {
+        "input_tokens": 10,
+        "output_tokens": 2,
+        "total_tokens": 12,
+    }
+    # github_token threaded to the client; unsubscribed after the turn.
+    assert state["client_kwargs"][0]["github_token"] == "gho_x"
+    assert state["unsub_calls"] >= 1
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_tool_call_request_and_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev(
+                    "TOOL_EXECUTION_START",
+                    toolName="sys_session_send",
+                    toolCallId="c1",
+                    arguments={"to": "x"},
+                ),
+                _ev("TOOL_EXECUTION_COMPLETE", toolCallId="c1", success=True, result="done"),
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="ok"),
+                _ev("ASSISTANT_MESSAGE", content="ok"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    reqs = [e for e in events if isinstance(e, ToolCallRequest)]
+    comps = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert reqs and reqs[0].name == "sys_session_send" and reqs[0].args == {"to": "x"}
+    assert comps and comps[0].name == "sys_session_send"
+    assert comps[0].status != ToolCallStatus.ERROR
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_tool_complete_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("TOOL_EXECUTION_START", toolName="sys_x", toolCallId="c1"),
+                _ev(
+                    "TOOL_EXECUTION_COMPLETE",
+                    toolCallId="c1",
+                    success=False,
+                    error="tool blew up",
+                ),
+                _ev("ASSISTANT_MESSAGE", content="done"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    comps = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert comps and comps[0].status == ToolCallStatus.ERROR and "tool blew up" in comps[0].error
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_session_error_no_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_copilot(
+        monkeypatch,
+        [[_ev("SESSION_ERROR", message="model exploded")]],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert errors and "model exploded" in errors[0].message
+
+
+@pytest.mark.asyncio
+async def test_session_reused_across_turns(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [
+            [_ev("ASSISTANT_MESSAGE", content="one")],
+            [_ev("ASSISTANT_MESSAGE", content="two")],
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    _ = [e async for e in ex.run_turn([_user("first")], [], "SYS")]
+    _ = [e async for e in ex.run_turn([_user("second")], [], "SYS")]
+    # One create_session for two same-config turns.
+    assert len(state["create_kwargs"]) == 1
+    assert state["sent"] == ["first", "second"]
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_session_restart_on_system_prompt_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [
+            [_ev("ASSISTANT_MESSAGE", content="one")],
+            [_ev("ASSISTANT_MESSAGE", content="two")],
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    _ = [e async for e in ex.run_turn([_user("first")], [], "SYS-A")]
+    _ = [e async for e in ex.run_turn([_user("second")], [], "SYS-B")]
+    # System prompt changed → fresh session created, old client stopped.
+    assert len(state["create_kwargs"]) == 2
+    assert state["client_closed"] >= 1
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_system_message_and_model_threaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(monkeypatch, [[_ev("ASSISTANT_MESSAGE", content="ok")]])
+    ex = CopilotExecutor(github_token="gho_x", model="databricks-claude-opus-4-8")
+    _ = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    kwargs = state["create_kwargs"][0]
+    # databricks-* model dropped to None (auto-select).
+    assert kwargs["model"] is None
+    # system prompt delivered as an append-mode system_message.
+    assert kwargs["system_message"] == {"mode": "append", "content": "SYS"}
+    assert kwargs["on_permission_request"] == _PermissionHandler.approve_all
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_relative_cwd_resolved_to_absolute(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The Copilot SDK rejects a relative working_directory; a spec / os_env can
+    # hand us ``.``, so the executor must resolve it to an absolute path.
+    state = _install_fake_copilot(monkeypatch, [[_ev("ASSISTANT_MESSAGE", content="ok")]])
+    ex = CopilotExecutor(github_token="gho_x", cwd=".")
+    _ = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    client_wd = state["client_kwargs"][0]["working_directory"]
+    session_wd = state["create_kwargs"][0]["working_directory"]
+    import os as _os
+
+    assert _os.path.isabs(client_wd) and _os.path.isabs(session_wd)
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_failure_surfaces_executor_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_copilot(monkeypatch, [], create_exc=RuntimeError("bad token"))
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert errors and "bad token" in errors[0].message

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -121,6 +121,7 @@ def _install_fake_copilot(
     turn_scripts: list[list[tuple[str, dict[str, Any]]]] | None = None,
     *,
     create_exc: Exception | None = None,
+    start_exc: Exception | None = None,
 ) -> dict[str, Any]:
     """Install a fake ``copilot`` module; return a capture dict.
 
@@ -143,6 +144,8 @@ def _install_fake_copilot(
 
         async def start(self) -> None:
             state["started"] += 1
+            if start_exc is not None:
+                raise start_exc
 
         async def stop(self) -> None:
             state["client_closed"] += 1
@@ -492,3 +495,41 @@ async def test_ensure_session_failure_surfaces_executor_error(
     events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
     errors = [e for e in events if isinstance(e, ExecutorError)]
     assert errors and "bad token" in errors[0].message
+
+
+@pytest.mark.asyncio
+async def test_start_failure_stops_client_no_orphan(monkeypatch: pytest.MonkeyPatch) -> None:
+    # client.start() spawns the bundled CLI subprocess before connecting; a
+    # start failure must still call client.stop() (via _safe_stop) so that
+    # subprocess is reaped, not orphaned.
+    state = _install_fake_copilot(monkeypatch, [], start_exc=RuntimeError("start blew up"))
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert errors and "start blew up" in errors[0].message
+    # The started client was stopped (subprocess reaped), not leaked.
+    assert state["started"] == 1
+    assert state["client_closed"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_error_after_partial_text_is_not_masked(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A SESSION_ERROR / MODEL_CALL_FAILURE after partial text streamed, with no
+    # successful final ASSISTANT_MESSAGE, must surface as an ExecutorError — not
+    # a clean TurnComplete carrying the partial text (which would mask the
+    # failure).
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="partial..."),
+                _ev("MODEL_CALL_FAILURE", errorMessage="model call failed mid-stream"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert errors and "model call failed mid-stream" in errors[0].message
+    assert not completes  # the turn is failed, not reported complete

--- a/tests/inner/test_copilot_executor.py
+++ b/tests/inner/test_copilot_executor.py
@@ -31,6 +31,7 @@ from omnigent.inner.copilot_executor import (
     _resolve_model,
 )
 from omnigent.inner.executor import (
+    ExecutorConfig,
     ExecutorError,
     Message,
     ReasoningChunk,
@@ -66,9 +67,10 @@ class _FakeEvent:
 
 
 class _FakeSession:
-    def __init__(self, state: dict[str, Any]) -> None:
+    def __init__(self, state: dict[str, Any], send_exc: Exception | None = None) -> None:
         self._state = state
         self._handlers: list[Any] = []
+        self._send_exc = send_exc
 
     def on(self, handler: Any) -> Any:
         self._handlers.append(handler)
@@ -83,6 +85,9 @@ class _FakeSession:
     async def send_and_wait(self, prompt: str, *, timeout: float = 60.0) -> Any:
         self._state["sent"].append(prompt)
         await asyncio.sleep(0)
+        if self._send_exc is not None and self._state.get("send_exc_remaining", 0) > 0:
+            self._state["send_exc_remaining"] -= 1
+            raise self._send_exc
         scripts: list[list[tuple[str, dict[str, Any]]]] = self._state["turn_scripts"]
         script = scripts.pop(0) if scripts else []
         final = None
@@ -122,10 +127,15 @@ def _install_fake_copilot(
     *,
     create_exc: Exception | None = None,
     start_exc: Exception | None = None,
+    send_exc: Exception | None = None,
+    send_exc_times: int = 1,
 ) -> dict[str, Any]:
     """Install a fake ``copilot`` module; return a capture dict.
 
     *turn_scripts* is one list of scripted events per ``send_and_wait`` call.
+    *send_exc*, when set, makes ``send_and_wait`` raise it for the first
+    *send_exc_times* calls (then behave normally), so the mid-turn
+    ``send_and_wait`` failure path can be exercised and recovery verified.
     """
     state: dict[str, Any] = {
         "client_kwargs": [],
@@ -136,6 +146,7 @@ def _install_fake_copilot(
         "session_closed": 0,
         "aborted": 0,
         "turn_scripts": list(turn_scripts or []),
+        "send_exc_remaining": send_exc_times if send_exc is not None else 0,
     }
 
     class _FakeClient:
@@ -154,7 +165,7 @@ def _install_fake_copilot(
             state["create_kwargs"].append(kwargs)
             if create_exc is not None:
                 raise create_exc
-            return _FakeSession(state)
+            return _FakeSession(state, send_exc=send_exc)
 
     class _Tool:
         def __init__(
@@ -379,7 +390,8 @@ async def test_run_turn_tool_call_request_and_complete(
     comps = [e for e in events if isinstance(e, ToolCallComplete)]
     assert reqs and reqs[0].name == "sys_session_send" and reqs[0].args == {"to": "x"}
     assert comps and comps[0].name == "sys_session_send"
-    assert comps[0].status != ToolCallStatus.ERROR
+    assert comps[0].status == ToolCallStatus.SUCCESS
+    assert comps[0].result == "done" and comps[0].error is None
     await ex.close()
 
 
@@ -394,7 +406,7 @@ async def test_run_turn_tool_complete_error(monkeypatch: pytest.MonkeyPatch) -> 
                     "TOOL_EXECUTION_COMPLETE",
                     toolCallId="c1",
                     success=False,
-                    error="tool blew up",
+                    error={"message": "tool blew up", "code": "ENOENT"},
                 ),
                 _ev("ASSISTANT_MESSAGE", content="done"),
             ]
@@ -403,7 +415,10 @@ async def test_run_turn_tool_complete_error(monkeypatch: pytest.MonkeyPatch) -> 
     ex = CopilotExecutor(github_token="gho_x")
     events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
     comps = [e for e in events if isinstance(e, ToolCallComplete)]
-    assert comps and comps[0].status == ToolCallStatus.ERROR and "tool blew up" in comps[0].error
+    assert comps and comps[0].status == ToolCallStatus.ERROR
+    # The SDK delivers ``error`` as a {"message", "code"} object; the executor
+    # surfaces the message, not the dict's Python repr.
+    assert comps[0].error == "tool blew up"
     await ex.close()
 
 
@@ -533,3 +548,336 @@ async def test_error_after_partial_text_is_not_masked(monkeypatch: pytest.Monkey
     completes = [e for e in events if isinstance(e, TurnComplete)]
     assert errors and "model call failed mid-stream" in errors[0].message
     assert not completes  # the turn is failed, not reported complete
+
+
+# ---------------------------------------------------------------------------
+# Policy gates (PHASE_LLM_REQUEST / PHASE_LLM_RESPONSE) — parity with the
+# cursor / pi / claude-sdk executors.
+# ---------------------------------------------------------------------------
+
+
+def _verdict(action: str, reason: str = "") -> Any:
+    return types.SimpleNamespace(action=action, reason=reason)
+
+
+@pytest.mark.asyncio
+async def test_policy_request_deny_blocks_before_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(
+        monkeypatch, [[_ev("ASSISTANT_MESSAGE", content="must not send")]]
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+
+    async def deny_request(phase: str, ctx: dict[str, Any]) -> Any:
+        if phase == "PHASE_LLM_REQUEST":
+            return _verdict("POLICY_ACTION_DENY", "blocked req")
+        return _verdict("POLICY_ACTION_ALLOW")
+
+    ex._policy_evaluator = deny_request
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert errors and "call denied by policy: blocked req" in errors[0].message
+    assert not completes
+    assert state["sent"] == []  # denied before send_and_wait ran
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_policy_response_deny_blocks_turn_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="leaked"),
+                _ev("ASSISTANT_MESSAGE", content="leaked"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+
+    async def deny_response(phase: str, ctx: dict[str, Any]) -> Any:
+        if phase == "PHASE_LLM_RESPONSE":
+            return _verdict("POLICY_ACTION_DENY", "bad output")
+        return _verdict("POLICY_ACTION_ALLOW")
+
+    ex._policy_evaluator = deny_response
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert errors and "response denied by policy: bad output" in errors[0].message
+    assert not completes
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_policy_allow_consults_both_phases_and_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="hi"),
+                _ev("ASSISTANT_MESSAGE", content="hi"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    phases: list[str] = []
+
+    async def allow(phase: str, ctx: dict[str, Any]) -> Any:
+        phases.append(phase)
+        return _verdict("POLICY_ACTION_ALLOW")
+
+    ex._policy_evaluator = allow
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert completes and completes[0].response == "hi"
+    assert phases == ["PHASE_LLM_REQUEST", "PHASE_LLM_RESPONSE"]
+    await ex.close()
+
+
+# ---------------------------------------------------------------------------
+# Session restart triggers (tool set + model), beyond the system-prompt case.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_restart_on_tools_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [[_ev("ASSISTANT_MESSAGE", content="one")], [_ev("ASSISTANT_MESSAGE", content="two")]],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    tools_a = [
+        {"name": "alpha", "description": "", "parameters": {"type": "object", "properties": {}}}
+    ]
+    tools_b = [
+        {"name": "beta", "description": "", "parameters": {"type": "object", "properties": {}}}
+    ]
+    _ = [e async for e in ex.run_turn([_user("first")], tools_a, "SYS")]
+    _ = [e async for e in ex.run_turn([_user("second")], tools_b, "SYS")]
+    # Tool set changed → fresh session, old client stopped (so removed tools
+    # can't stay callable and new tools aren't missing).
+    assert len(state["create_kwargs"]) == 2
+    assert state["client_closed"] >= 1
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_session_restart_on_model_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [[_ev("ASSISTANT_MESSAGE", content="one")], [_ev("ASSISTANT_MESSAGE", content="two")]],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    _ = [
+        e
+        async for e in ex.run_turn(
+            [_user("first")], [], "SYS", ExecutorConfig(model="claude-haiku-4.5")
+        )
+    ]
+    _ = [
+        e
+        async for e in ex.run_turn(
+            [_user("second")], [], "SYS", ExecutorConfig(model="gpt-5-mini")
+        )
+    ]
+    assert len(state["create_kwargs"]) == 2
+    assert state["create_kwargs"][0]["model"] == "claude-haiku-4.5"
+    assert state["create_kwargs"][1]["model"] == "gpt-5-mini"
+    await ex.close()
+
+
+# ---------------------------------------------------------------------------
+# Mid-turn send_and_wait failure: retryable + session dropped, then recovers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_and_wait_failure_is_retryable_and_recreates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [[_ev("ASSISTANT_MESSAGE", content="recovered")]],
+        send_exc=RuntimeError("turn wedged"),
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    first = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    errors = [e for e in first if isinstance(e, ExecutorError)]
+    assert errors and "copilot-sdk turn failed: turn wedged" in errors[0].message
+    assert errors[0].retryable is True
+    assert state["client_closed"] >= 1  # the failed turn dropped the session
+    # Next turn re-creates the session (the dropped one is gone) and succeeds.
+    second = [e async for e in ex.run_turn([_user("again")], [], "SYS")]
+    completes = [e for e in second if isinstance(e, TurnComplete)]
+    assert completes and completes[0].response == "recovered"
+    assert len(state["create_kwargs"]) == 2
+    await ex.close()
+
+
+# ---------------------------------------------------------------------------
+# TOOL_EXECUTION_COMPLETE: SDK wire-shape unwrapping + status classification.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_complete_result_unwrapped_from_sdk_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The SDK wraps a tool result as {"content": ..., "detailedContent": ...};
+    # the executor carries the bare content, not the wrapper dict.
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("TOOL_EXECUTION_START", toolName="sys_x", toolCallId="c1"),
+                _ev(
+                    "TOOL_EXECUTION_COMPLETE",
+                    toolCallId="c1",
+                    success=True,
+                    result={"content": "the answer is 42", "detailedContent": "the answer is 42"},
+                ),
+                _ev("ASSISTANT_MESSAGE", content="ok"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    comps = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert comps and comps[0].status == ToolCallStatus.SUCCESS
+    assert comps[0].result == "the answer is 42"
+    await ex.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result,expected",
+    [
+        ({"blocked": True, "reason": "policy"}, ToolCallStatus.BLOCKED),
+        ({"cancelled": True}, ToolCallStatus.CANCELLED),
+    ],
+)
+async def test_tool_complete_blocked_and_cancelled_classification(
+    monkeypatch: pytest.MonkeyPatch, result: dict[str, Any], expected: ToolCallStatus
+) -> None:
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("TOOL_EXECUTION_START", toolName="sys_x", toolCallId="c1"),
+                _ev("TOOL_EXECUTION_COMPLETE", toolCallId="c1", success=True, result=result),
+                _ev("ASSISTANT_MESSAGE", content="ok"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    comps = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert comps and comps[0].status == expected
+    await ex.close()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle + edge branches: interrupt, empty prompt, no-executor, formatting.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_drops_and_recreates(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(
+        monkeypatch,
+        [[_ev("ASSISTANT_MESSAGE", content="one")], [_ev("ASSISTANT_MESSAGE", content="two")]],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    assert await ex.interrupt_session("unknown") is False  # no live session
+    _ = [e async for e in ex.run_turn([_user("first")], [], "SYS")]
+    assert await ex.interrupt_session("conv1") is True
+    assert state["client_closed"] >= 1
+    _ = [e async for e in ex.run_turn([_user("second")], [], "SYS")]
+    assert len(state["create_kwargs"]) == 2  # session re-created after interrupt
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_empty_prompt_completes_without_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_fake_copilot(monkeypatch, [[_ev("ASSISTANT_MESSAGE", content="unused")]])
+    ex = CopilotExecutor(github_token="gho_x")
+    msgs: list[Message] = [{"role": "user", "content": "", "session_id": "conv1"}]
+    events = [e async for e in ex.run_turn(msgs, [], "SYS")]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1 and completes[0].response is None
+    assert state["sent"] == []  # nothing sent for an empty prompt
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_bridged_tool_handler_no_executor_wired(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_copilot(monkeypatch)
+    ex = CopilotExecutor()  # _tool_executor stays None (single-process / pre-turn)
+    handler = ex._make_handler("sys_x")
+    result = await handler(types.SimpleNamespace(arguments={}, tool_call_id="c"))
+    assert result.result_type == "failure"
+    assert "no tool executor wired" in result.error
+
+
+@pytest.mark.asyncio
+async def test_paragraph_break_between_pre_and_post_tool_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pre-tool narration, a tool call, then post-tool narration must not render
+    # run-on: a paragraph break is inserted between the two text segments.
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="before"),
+                _ev("TOOL_EXECUTION_START", toolName="sys_x", toolCallId="c1"),
+                _ev("TOOL_EXECUTION_COMPLETE", toolCallId="c1", success=True, result="done"),
+                _ev("ASSISTANT_MESSAGE_DELTA", deltaContent="after"),
+                _ev("ASSISTANT_MESSAGE", content="before\n\nafter"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("go")], [], "SYS")]
+    text = "".join(e.text for e in events if isinstance(e, TextChunk))
+    assert text == "before\n\nafter"
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert completes and completes[0].response == "before\n\nafter"
+    await ex.close()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_usage_accumulates_cache_read_through_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Two ASSISTANT_USAGE events (one per model call) accumulate end-to-end,
+    # including cacheReadTokens, and total_tokens excludes the cache count.
+    _install_fake_copilot(
+        monkeypatch,
+        [
+            [
+                _ev(
+                    "ASSISTANT_USAGE",
+                    model="claude-haiku-4.5",
+                    inputTokens=10,
+                    outputTokens=2,
+                    cacheReadTokens=5,
+                ),
+                _ev("ASSISTANT_USAGE", inputTokens=3, outputTokens=1, cacheReadTokens=4),
+                _ev("ASSISTANT_MESSAGE", content="ok"),
+            ]
+        ],
+    )
+    ex = CopilotExecutor(github_token="gho_x")
+    events = [e async for e in ex.run_turn([_user("hi")], [], "SYS")]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert completes and completes[0].usage == {
+        "input_tokens": 13,
+        "output_tokens": 3,
+        "cache_read_input_tokens": 9,
+        "total_tokens": 16,
+    }
+    await ex.close()

--- a/tests/inner/test_copilot_harness.py
+++ b/tests/inner/test_copilot_harness.py
@@ -1,0 +1,76 @@
+"""Tests for ``omnigent/inner/copilot_harness.py`` — the ``harness: copilot`` wrap.
+
+The wrap reads ``HARNESS_COPILOT_*`` env vars and constructs a
+:class:`CopilotExecutor` lazily. Constructing the executor does NOT import the
+``github-copilot-sdk`` package (that import is deferred to the first turn), so
+these tests run without the optional SDK installed. Mirrors
+``test_cursor_harness.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omnigent.inner import copilot_harness as ch
+from omnigent.inner.copilot_executor import CopilotExecutor
+
+
+@pytest.fixture(autouse=True)
+def _clear_harness_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "HARNESS_COPILOT_MODEL",
+        "HARNESS_COPILOT_CWD",
+        "HARNESS_COPILOT_GITHUB_TOKEN",
+        "HARNESS_COPILOT_OS_ENV",
+        "HARNESS_COPILOT_SKILLS_FILTER",
+        "HARNESS_COPILOT_BUNDLE_DIR",
+        "HARNESS_COPILOT_AGENT_NAME",
+        "COPILOT_GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_resolve_os_env_default() -> None:
+    os_env = ch._resolve_os_env()
+    assert os_env.type == "caller_process"
+    assert os_env.sandbox is not None and os_env.sandbox.type == "none"
+
+
+def test_resolve_os_env_from_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "HARNESS_COPILOT_OS_ENV",
+        json.dumps({"type": "caller_process", "cwd": "/tmp/x", "sandbox": {"type": "none"}}),
+    )
+    os_env = ch._resolve_os_env()
+    assert os_env.cwd == "/tmp/x"
+
+
+def test_resolve_skills_filter_defaults_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert ch._resolve_skills_filter() == "all"
+    monkeypatch.setenv("HARNESS_COPILOT_SKILLS_FILTER", json.dumps(["a", "b"]))
+    assert ch._resolve_skills_filter() == ["a", "b"]
+    monkeypatch.setenv("HARNESS_COPILOT_SKILLS_FILTER", "not-json")
+    assert ch._resolve_skills_filter() == "all"
+
+
+def test_build_executor_threads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_COPILOT_MODEL", "claude-haiku-4.5")
+    monkeypatch.setenv("HARNESS_COPILOT_GITHUB_TOKEN", "gho_test")
+    monkeypatch.setenv("HARNESS_COPILOT_CWD", "/tmp/work")
+    monkeypatch.setenv("HARNESS_COPILOT_AGENT_NAME", "cop")
+    executor = ch._build_copilot_executor()
+    assert isinstance(executor, CopilotExecutor)
+    assert executor._model_override == "claude-haiku-4.5"
+    assert executor._github_token == "gho_test"
+    assert executor._cwd == "/tmp/work"
+    assert executor._agent_name == "cop"
+
+
+def test_create_app_builds_fastapi() -> None:
+    app = ch.create_app()
+    # The ExecutorAdapter builds a FastAPI app; just assert it has routes.
+    assert hasattr(app, "routes")

--- a/tests/inner/test_copilot_harness.py
+++ b/tests/inner/test_copilot_harness.py
@@ -70,7 +70,31 @@ def test_build_executor_threads_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert executor._agent_name == "cop"
 
 
-def test_create_app_builds_fastapi() -> None:
+def test_build_executor_threads_os_env_bundle_dir_and_ambient_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pathlib import Path
+
+    # No HARNESS_COPILOT_CWD / GITHUB_TOKEN: cwd falls back to os_env.cwd and the
+    # token falls back to an ambient GH_TOKEN.
+    monkeypatch.setenv(
+        "HARNESS_COPILOT_OS_ENV",
+        json.dumps({"type": "caller_process", "cwd": "/tmp/oe", "sandbox": {"type": "none"}}),
+    )
+    monkeypatch.setenv("HARNESS_COPILOT_BUNDLE_DIR", "/tmp/bundle")
+    monkeypatch.setenv("GH_TOKEN", "gho_ambient")
+    executor = ch._build_copilot_executor()
+    assert isinstance(executor, CopilotExecutor)
+    assert executor._os_env_spec is not None and executor._os_env_spec.cwd == "/tmp/oe"
+    assert executor._cwd == "/tmp/oe"  # cwd fell back to os_env.cwd
+    assert executor._bundle_dir == Path("/tmp/bundle")
+    assert executor._github_token == "gho_ambient"  # ambient fallback
+
+
+def test_create_app_exposes_executor_adapter_routes() -> None:
     app = ch.create_app()
-    # The ExecutorAdapter builds a FastAPI app; just assert it has routes.
-    assert hasattr(app, "routes")
+    paths = {getattr(r, "path", "") for r in app.routes}
+    # The ExecutorAdapter wires the harness HTTP contract — assert the real
+    # endpoints exist, not merely that the object has a ``routes`` attribute.
+    assert "/health" in paths
+    assert any("/v1/sessions/" in p and p.endswith("/events") for p in paths)

--- a/tests/onboarding/test_copilot_auth.py
+++ b/tests/onboarding/test_copilot_auth.py
@@ -1,0 +1,112 @@
+"""Tests for ``omnigent/onboarding/copilot_auth.py`` — the Copilot token store.
+
+Copilot's GitHub token lives in a dedicated top-level ``copilot:`` config block
+(not the shared global ``auth:``) and the omnigent secret store, resolved with
+the same ``resolve_secret`` resolver the provider families use. These tests
+isolate the config + secret store to a tmp dir (file backend, no OS keychain)
+and assert the read/resolve/configured helpers behave — including the **soft**
+resolution that returns ``None`` on a dangling reference instead of raising, so
+a run / setup readout falls back rather than crashing. Mirrors
+``test_cursor_auth.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.onboarding import secrets as secret_store
+from omnigent.onboarding.copilot_auth import (
+    COPILOT_SECRET_NAME,
+    copilot_github_token_configured,
+    copilot_github_token_ref,
+    copilot_github_token_settings,
+    looks_like_github_copilot_token,
+    resolve_copilot_github_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Isolate config + secrets to tmp with the file secret backend.
+
+    :returns: The tmp config-home dir, so a test can write a ``config.yaml``.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    return tmp_path
+
+
+def _write_config(tmp_path: Path, block: dict[str, object]) -> None:
+    """Write *block* as the isolated ``config.yaml``."""
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(block))
+
+
+# ---------------------------------------------------------------------------
+# Token-shape check
+# ---------------------------------------------------------------------------
+
+
+def test_looks_like_github_copilot_token_accepts_pat_and_oauth() -> None:
+    assert looks_like_github_copilot_token("github_pat_ABC123")
+    assert looks_like_github_copilot_token("gho_ABC123")
+    assert looks_like_github_copilot_token("ghu_ABC123")
+    assert looks_like_github_copilot_token("ghs_ABC123")
+
+
+def test_looks_like_github_copilot_token_rejects_classic_pat_and_junk() -> None:
+    # Classic ``ghp_`` PATs are not accepted by Copilot.
+    assert not looks_like_github_copilot_token("ghp_ABC123")
+    assert not looks_like_github_copilot_token("")
+    assert not looks_like_github_copilot_token("sk-not-a-github-token")
+
+
+# ---------------------------------------------------------------------------
+# ref / resolve / configured
+# ---------------------------------------------------------------------------
+
+
+def test_ref_and_resolve_none_when_no_block(tmp_path: Path) -> None:
+    assert copilot_github_token_ref() is None
+    assert resolve_copilot_github_token() is None
+    assert copilot_github_token_configured() is False
+
+
+def test_ref_prefers_token_ref_over_inline(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        {"copilot": {"github_token_ref": "env:GH_TOKEN", "github_token": "literal"}},
+    )
+    assert copilot_github_token_ref() == "env:GH_TOKEN"
+
+
+def test_resolve_from_env_reference(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_config(tmp_path, {"copilot": {"github_token_ref": "env:GH_TOKEN"}})
+    monkeypatch.setenv("GH_TOKEN", "gho_resolved")
+    assert resolve_copilot_github_token() == "gho_resolved"
+    assert copilot_github_token_configured() is True
+
+
+def test_resolve_from_keychain_reference(tmp_path: Path) -> None:
+    secret_store.store_secret(COPILOT_SECRET_NAME, "gho_stored")
+    _write_config(tmp_path, {"copilot": {"github_token_ref": f"keychain:{COPILOT_SECRET_NAME}"}})
+    assert resolve_copilot_github_token() == "gho_stored"
+    assert copilot_github_token_configured() is True
+
+
+def test_dangling_reference_is_soft_none(tmp_path: Path) -> None:
+    # An ``env:`` ref to an unset var resolves to None (never raises) and reads
+    # as not-configured, so a run / readout falls back instead of crashing.
+    _write_config(tmp_path, {"copilot": {"github_token_ref": "env:GH_TOKEN_MISSING"}})
+    assert resolve_copilot_github_token() is None
+    assert copilot_github_token_configured() is False
+
+
+def test_settings_shape() -> None:
+    assert copilot_github_token_settings("keychain:copilot") == {
+        "copilot": {"github_token_ref": "keychain:copilot"}
+    }

--- a/tests/onboarding/test_copilot_auth.py
+++ b/tests/onboarding/test_copilot_auth.py
@@ -106,6 +106,27 @@ def test_dangling_reference_is_soft_none(tmp_path: Path) -> None:
     assert copilot_github_token_configured() is False
 
 
+def test_resolve_from_inline_github_token_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A hand-edited config with only the inline ``github_token`` (no
+    # ``github_token_ref``) still resolves via the right-hand ``or`` fallback.
+    _write_config(tmp_path, {"copilot": {"github_token": "env:GH_TOKEN"}})
+    monkeypatch.setenv("GH_TOKEN", "gho_inline")
+    assert copilot_github_token_ref() == "env:GH_TOKEN"
+    assert resolve_copilot_github_token() == "gho_inline"
+    assert copilot_github_token_configured() is True
+
+
+def test_dangling_keychain_reference_is_soft_none(tmp_path: Path) -> None:
+    # A keychain ref to a name that was never stored resolves to None (never
+    # raises) and reads as not-configured — the realistic "deleted keychain
+    # entry" case, distinct from the env-var dangling case above.
+    _write_config(tmp_path, {"copilot": {"github_token_ref": "keychain:copilot-never-stored"}})
+    assert resolve_copilot_github_token() is None
+    assert copilot_github_token_configured() is False
+
+
 def test_settings_shape() -> None:
     assert copilot_github_token_settings("keychain:copilot") == {
         "copilot": {"github_token_ref": "keychain:copilot"}

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -16,15 +16,19 @@ from omnigent.onboarding.harness_readiness import (
 
 @pytest.fixture(autouse=True)
 def _isolate_cursor_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Isolate cursor's API-key sources so its readiness is deterministic.
+    """Isolate cursor + copilot credential sources so their readiness is deterministic.
 
-    Cursor readiness keys off a configured ``CURSOR_API_KEY`` (the ``cursor:``
-    config block or the environment), so point the config home at an empty tmp
-    dir and clear any ambient ``CURSOR_API_KEY`` — otherwise a developer's real
-    key would flip cursor's verdict under these tests.
+    Cursor readiness keys off a configured ``CURSOR_API_KEY`` and copilot off a
+    GitHub token (the ``cursor:`` / ``copilot:`` config blocks or the
+    environment), so point the config home at an empty tmp dir and clear any
+    ambient ``CURSOR_API_KEY`` / ``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` /
+    ``GITHUB_TOKEN`` — otherwise a developer's real key would flip their verdict
+    under these tests.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
 
 
 def _all_clis_installed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -156,6 +160,9 @@ def test_configured_harness_map_covers_all_spellings(
         # Qwen harnesses
         "qwen",
         "qwen-code",
+        # Copilot SDK harness + its user-facing alias.
+        "copilot",
+        "github-copilot",
     }
     assert set(result) == expected_keys
 
@@ -207,14 +214,16 @@ def test_configured_harness_map_gates_only_cli_harnesses(
 def test_configured_harness_map_all_true_with_clis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Every spelling reads True once the CLIs are installed and cursor has a key.
+    """Every spelling reads True once the CLIs are installed and the key/token-
+    gated harnesses are satisfied.
 
     The CLI harnesses pass their binary check, the SDK harnesses are ungated,
-    and cursor (key-gated) is satisfied by a ``CURSOR_API_KEY`` — so nothing is
-    reported unconfigured.
+    cursor (key-gated) is satisfied by a ``CURSOR_API_KEY`` and copilot
+    (token-gated) by a ``GH_TOKEN`` — so nothing is reported unconfigured.
     """
     _all_clis_installed(monkeypatch)
     monkeypatch.setenv("CURSOR_API_KEY", "crsr_ready")
+    monkeypatch.setenv("GH_TOKEN", "gho_ready")
     result = configured_harness_map()
     assert all(result.values())
 

--- a/tests/runtime/test_copilot_spawn_env.py
+++ b/tests/runtime/test_copilot_spawn_env.py
@@ -1,0 +1,109 @@
+"""
+Tests for ``_build_copilot_spawn_env`` in ``omnigent/runtime/workflow.py``.
+
+The spawn-env builder maps ``spec`` fields to the ``HARNESS_COPILOT_*`` env
+vars the copilot harness wrap reads at first-turn time. Like the cursor builder,
+copilot has NO Databricks-gateway path: only an explicit ``api_key`` auth maps
+to ``HARNESS_COPILOT_GITHUB_TOKEN`` (the GitHub token), a stored ``copilot:``
+block or an ambient ``GH_TOKEN`` is the no-auth fallback, and a ``DatabricksAuth``
+profile is deliberately ignored. Mirrors ``test_cursor_spawn_env.py``.
+
+This is a unit test — no subprocess spawn. End-to-end verification of the
+spawn-env → wrap → executor path lives in the harness e2e tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.runtime.workflow import _build_copilot_spawn_env
+from omnigent.spec.types import (
+    AgentSpec,
+    ApiKeyAuth,
+    DatabricksAuth,
+    ExecutorSpec,
+    LLMConfig,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Isolate the global config to an empty tmp dir and clear ambient GitHub
+    tokens so the no-auth / DatabricksAuth cases are deterministic."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
+    for var in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    return tmp_path
+
+
+def _make_spec(
+    *,
+    model: str | None = "claude-haiku-4.5",
+    name: str = "test-copilot",
+    auth: ApiKeyAuth | DatabricksAuth | None = None,
+) -> AgentSpec:
+    """Build a minimal copilot :class:`AgentSpec` for the spawn-env tests."""
+    config: dict[str, object] = {"harness": "copilot"}
+    if model is not None:
+        config["model"] = model
+    return AgentSpec(
+        spec_version=1,
+        name=name,
+        instructions="You are a test agent.",
+        executor=ExecutorSpec(type="omnigent", config=config, model=model, auth=auth),
+        llm=LLMConfig(model=model) if model is not None else None,
+    )
+
+
+def test_model_and_name_threaded() -> None:
+    env = _build_copilot_spawn_env(_make_spec(model="gpt-5-mini", name="cop"))
+    assert env["HARNESS_COPILOT_MODEL"] == "gpt-5-mini"
+    assert env["HARNESS_COPILOT_AGENT_NAME"] == "cop"
+    # skills filter is always set (parity with peer builders).
+    assert "HARNESS_COPILOT_SKILLS_FILTER" in env
+
+
+def test_api_key_auth_maps_to_github_token() -> None:
+    env = _build_copilot_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="gho_fromspec")))
+    assert env["HARNESS_COPILOT_GITHUB_TOKEN"] == "gho_fromspec"
+
+
+def test_databricks_auth_is_ignored() -> None:
+    # A Databricks profile has no copilot equivalent and must not produce a token.
+    env = _build_copilot_spawn_env(_make_spec(auth=DatabricksAuth(profile="oss")))
+    assert "HARNESS_COPILOT_GITHUB_TOKEN" not in env
+
+
+def test_no_auth_falls_back_to_ambient_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "gho_ambient")
+    env = _build_copilot_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_COPILOT_GITHUB_TOKEN"] == "gho_ambient"
+
+
+def test_no_auth_prefers_copilot_specific_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # COPILOT_GITHUB_TOKEN wins over GH_TOKEN (the CLI/SDK precedence order).
+    monkeypatch.setenv("GH_TOKEN", "gho_gh")
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_copilot")
+    env = _build_copilot_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_COPILOT_GITHUB_TOKEN"] == "gho_copilot"
+
+
+def test_no_auth_prefers_stored_block_over_ambient(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"copilot": {"github_token_ref": "env:STORED_COPILOT"}})
+    )
+    monkeypatch.setenv("STORED_COPILOT", "gho_stored")
+    monkeypatch.setenv("GH_TOKEN", "gho_ambient")
+    env = _build_copilot_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_COPILOT_GITHUB_TOKEN"] == "gho_stored"
+
+
+def test_bundle_dir_threaded(tmp_path: Path) -> None:
+    env = _build_copilot_spawn_env(_make_spec(), workdir=tmp_path)
+    assert env["HARNESS_COPILOT_BUNDLE_DIR"] == str(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1341,6 +1341,23 @@ wheels = [
 ]
 
 [[package]]
+name = "github-copilot-sdk"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/d4d576becff84146501e043831bdd2ca5aee57fcfdfface4ee7db7883655/github_copilot_sdk-1.0.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d1ca7fff62b69f8c9aa24eb2d1f615195730d6b7297050e8e240aa38fbae5eba", size = 94824679, upload-time = "2026-06-10T16:54:17.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5f/f3d935b81f11930539cdf47a7e0dbd4d5ccaadba1f4daf0c64892421a81d/github_copilot_sdk-1.0.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dc4b59dfe034bec6a031b291dbe49de8a8558e42d28aee25213c680ab771d54e", size = 88837334, upload-time = "2026-06-10T16:54:23.056Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/94/225ec0258e1630a81e13b193a9258d8c4550b552b6197f903b75002abf75/github_copilot_sdk-1.0.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:bedb442ee4dd40d43870719f91a9fb6e117ca5d76bbbf1807af80cc77ff64257", size = 97255205, upload-time = "2026-06-10T16:54:29.828Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/34/72fb3936e7e8a425f1498bd6693a4e7db678e43fc3912dc5ce9cecccfe23/github_copilot_sdk-1.0.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a498fffba3d8a521eb73f31d08fef9f534e7c57ae6d0a76fa1848beebb3fb6a9", size = 94572477, upload-time = "2026-06-10T16:54:37.253Z" },
+    { url = "https://files.pythonhosted.org/packages/df/95/34aa49c08033acabbe129acf83a2d71a382bd2977ce92f5114a299508a4e/github_copilot_sdk-1.0.1-py3-none-win_amd64.whl", hash = "sha256:29d850cf5cf2b85c0513b68cba112d4a7aba0a9a447893fc7cc69136dd4e6ac1", size = 91387201, upload-time = "2026-06-10T16:54:45.164Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/900b278e519442d4a5fc9dd070b9100f6f1e6b3c6af3b8642b0b3a65d2f5/github_copilot_sdk-1.0.1-py3-none-win_arm64.whl", hash = "sha256:5f69245b1cb2fc1054e78543ee5c10464b53ebbba11e749c7a42002b02ce6b13", size = 90455774, upload-time = "2026-06-10T16:54:53.093Z" },
+]
+
+[[package]]
 name = "gitpython"
 version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
@@ -2773,6 +2790,9 @@ bedrock = [
 boxlite = [
     { name = "boxlite" },
 ]
+copilot = [
+    { name = "github-copilot-sdk" },
+]
 cursor = [
     { name = "cursor-sdk" },
 ]
@@ -2856,6 +2876,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.100,<1" },
     { name = "filelock", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "ftfy", specifier = ">=6.0" },
+    { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = ">=1,<2" },
     { name = "google-antigravity", marker = "extra == 'antigravity'", specifier = ">=0.1,<1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0,<3" },
     { name = "httpx", specifier = ">=0.27,<1" },
@@ -2910,7 +2931,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "openshell", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "openshell", "tracing", "agents-sdk", "antigravity", "copilot", "cursor", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"


### PR DESCRIPTION
Add a first-party `harness: copilot` that drives the GitHub Copilot SDK (`github-copilot-sdk`), mirroring how the cursor and antigravity SDK harnesses are wired. The Python SDK bundles the Copilot CLI binary it drives as a backing server, so the harness needs only the pip dependency (optional `copilot` extra, lazy-imported) — no separate CLI install.

- `omnigent/inner/copilot_executor.py`: `CopilotExecutor` — one persistent `CopilotClient` + `CopilotSession` per conversation, streaming `SessionEvent`s into ExecutorEvents (text/reasoning deltas, tool execution, usage). Omnigent `sys_*` tools bridge in-process via SDK `Tool`s whose async handler routes to `_tool_executor` (awaited in the SDK's own loop — no thread hop). PHASE_LLM_REQUEST/RESPONSE policy parity.
- `omnigent/inner/copilot_harness.py`: the `create_app()` wrap reading `HARNESS_COPILOT_*` env vars.
- `omnigent/onboarding/copilot_auth.py`: a GitHub token store (dedicated `copilot:` config block + secret store), resolved like the cursor key.
- Wiring: harness registry, spec allowlist + `github-copilot` alias, spawn-env builder, runner dispatch + model-env map, model-override set, readiness check, `omnigent setup` management, ap-web label, docs.
- Auth: a GitHub token with Copilot access (fine-grained PAT w/ "Copilot Requests", or a gh/Copilot-CLI OAuth token). No Databricks gateway path.
- `pyproject.toml` / `uv.lock`: `copilot` extra (`github-copilot-sdk>=1,<2`).
- Tests: executor (fake-SDK), harness wrap, spawn-env, auth; readiness test updated for the new spellings.

Verified end-to-end against a local server: a standalone copilot agent, an agentic file create/read tool loop, and polly + debby running their orchestrator brain on `--harness copilot`.

Co-authored-by: Isaac

<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
