### PR TITLE
feat: warn on non-loopback bind without auth; fix mobile/LAN docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ omnigent host  https://your-host    # new sessions can now run on this machine
 >
 > "Real auth" for a network-exposed server means one of: built-in
 > **accounts** (`OMNIGENT_AUTH_ENABLED=1`), **OIDC**
-> (`OMNIGENT_OIDC_ISSUER=...`), or a trusted reverse proxy that injects the
+> (`OMNIGENT_AUTH_ENABLED=1` with `OMNIGENT_OIDC_ISSUER=...`), or a trusted
+> reverse proxy that injects the
 > `X-Forwarded-Email` header. Plain header mode with none of these is the
 > proxy-only posture and 401s direct clients.
 

--- a/README.md
+++ b/README.md
@@ -228,26 +228,53 @@ omnigent host  https://your-host    # new sessions can now run on this machine
 ```
 
 > [!TIP]
-> On your own network you don't need a deploy. Open your machine's LAN
-> address on your phone (e.g. `http://192.168.x.x:6767`).
+> **Reach it from your phone on the same network — no deploy needed.** The
+> default local server binds loopback (`127.0.0.1`), and `omnigent server
+> start` (the background daemon) is loopback-only by design, so a LAN
+> address won't connect to either. Instead run the **foreground** server
+> bound to your machine's LAN IP, with auth turned on (otherwise a
+> non-loopback bind rejects every request with 401):
+>
+> ```bash
+> OMNIGENT_AUTH_ENABLED=1 omnigent server --host 192.168.x.x --port 6767
+> ```
+>
+> The accounts cookie secret auto-generates on first boot. You then claim the
+> admin account by choosing a username + password: at the terminal prompt when
+> you launch the server on a TTY, or from a **Create admin** form on the first
+> web visit when it runs headless. No password is ever printed or
+> auto-generated. Once the admin exists, open `http://192.168.x.x:6767` on your
+> phone and sign in.
+>
+> "Real auth" for a network-exposed server means one of: built-in
+> **accounts** (`OMNIGENT_AUTH_ENABLED=1`), **OIDC**
+> (`OMNIGENT_OIDC_ISSUER=...`), or a trusted reverse proxy that injects the
+> `X-Forwarded-Email` header. Plain header mode with none of these is the
+> proxy-only posture and 401s direct clients.
 
 ### 5. Collaborate with your team
 
 Omnigent supports **multi-user accounts**, controlled by one environment
-variable:
+variable. For a server other devices can reach (your LAN, a teammate on the
+network), turn accounts on and bind the **foreground** server to your LAN IP:
 
 ```bash
-OMNIGENT_AUTH_ENABLED=1 omnigent server start
+OMNIGENT_AUTH_ENABLED=1 omnigent server --host 192.168.x.x --port 6767
 ```
 
-The **Docker deploy in [step 4](#4-deploy-a-server-and-use-it-from-your-phone)
-turns it on for you** (`OMNIGENT_AUTH_ENABLED` defaults to `1` there).
+`omnigent server start` (the background daemon) also honors
+`OMNIGENT_AUTH_ENABLED=1`, but it binds loopback only — fine for accounts on
+this machine, not reachable from the network. The **Docker deploy in
+[step 4](#4-deploy-a-server-and-use-it-from-your-phone) turns accounts on for
+you** (`OMNIGENT_AUTH_ENABLED` defaults to `1` there).
 
 #### Invite your teammates
 
-Open the web UI (`http://localhost:6767` locally, or your host's URL) and
-sign in as `admin`; first run prints the password and saves it locally. Then
-open **Admin → Members → Invite** to create a single-use invite link, no
+Open the web UI (`http://localhost:6767` locally, or your host's URL). On a
+fresh instance the first visit shows a **Create admin** form to choose the
+admin username + password (no password is ever printed or auto-generated).
+Signed in as that admin, open **Admin → Members → Invite** to create a
+single-use invite link, no
 email server needed. Send it over; your teammate opens it, sets a password,
 and they're in. Signup is invite-only.
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2823,6 +2823,7 @@ def server(
     # deploy behind an identity-injecting proxy. setdefault so an
     # operator's explicit OMNIGENT_LOCAL_SINGLE_USER=0 wins. Must run
     # before create_auth_provider() below, which reads the var.
+    from omnigent.server.auth import local_single_user_enabled as _local_single_user_enabled
     from omnigent.server.auth import resolve_auth_source as _resolve_auth_source
 
     _is_loopback_bind = host in ("127.0.0.1", "localhost", "::1")
@@ -2833,6 +2834,38 @@ def server(
     _auth_provider_explicit = bool(_raw_auth_provider and _raw_auth_provider.strip())
     if _is_loopback_bind and not _auth_provider_explicit and _resolve_auth_source() == "header":
         os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
+
+    # A non-loopback bind that resolves to plain header mode with no
+    # single-user fallback rejects EVERY request with 401: header mode
+    # reads identity from the X-Forwarded-Email header, the loopback
+    # single-user fallback above did not fire (this bind is not
+    # loopback), and no operator set OMNIGENT_LOCAL_SINGLE_USER. That is
+    # the correct, expected posture behind an identity-injecting reverse
+    # proxy, but a silent foot-gun for someone exposing the server on a
+    # LAN without one. Warn (do NOT refuse — legitimate reverse-proxy
+    # deploys are also header mode): a proxy operator reads it as a
+    # reminder to set the header, a naive LAN binder learns to turn on
+    # accounts/OIDC. This is guidance only; the fail-closed behavior is
+    # unchanged and single-user is never auto-enabled on a non-loopback
+    # bind.
+    if (
+        not _is_loopback_bind
+        and not _local_single_user_enabled()
+        and _resolve_auth_source() == "header"
+    ):
+        click.secho(
+            f"WARNING: binding {host}:{port} (non-loopback) in header auth "
+            "mode with no single-user fallback. Every request without an "
+            "'X-Forwarded-Email' header will be rejected with 401.\n"
+            "  - Behind a trusted reverse proxy: ensure it injects "
+            "'X-Forwarded-Email' on every forwarded request, or clients "
+            "will get 401.\n"
+            "  - Serving a LAN directly (e.g. from a phone): enable real "
+            "auth first -- set OMNIGENT_AUTH_ENABLED=1 for the built-in "
+            "accounts login, or configure OIDC (OMNIGENT_OIDC_ISSUER=...).",
+            fg="yellow",
+            err=True,
+        )
 
     if _is_canonical_local_server:
         from omnigent.host.local_server import (

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2862,7 +2862,8 @@ def server(
             "will get 401.\n"
             "  - Serving a LAN directly (e.g. from a phone): enable real "
             "auth first -- set OMNIGENT_AUTH_ENABLED=1 for the built-in "
-            "accounts login, or configure OIDC (OMNIGENT_OIDC_ISSUER=...).",
+            "accounts login, or for OIDC set OMNIGENT_AUTH_ENABLED=1 together "
+            "with OMNIGENT_OIDC_ISSUER=... (or set OMNIGENT_AUTH_PROVIDER=oidc).",
             fg="yellow",
             err=True,
         )

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -442,6 +442,9 @@ def test_foreground_non_loopback_header_no_auth_warns(monkeypatch: pytest.Monkey
     # Both audiences are addressed: proxy operators and naive LAN binders.
     assert "X-Forwarded-Email" in result.output
     assert "OMNIGENT_AUTH_ENABLED=1" in result.output
+    # OIDC guidance requires the enable switch (issuer alone resolves to header
+    # mode and still 401s), so it must name AUTH_ENABLED alongside the issuer.
+    assert "OMNIGENT_AUTH_ENABLED=1 together with OMNIGENT_OIDC_ISSUER" in result.output
 
 
 def test_foreground_loopback_does_not_warn(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_server_lifecycle.py
+++ b/tests/cli/test_server_lifecycle.py
@@ -11,7 +11,7 @@ from click import ClickException
 from click.testing import CliRunner
 
 from omnigent.cli import _HostDaemonRecord, _SessionPagesResult, cli
-from omnigent.host.local_server import LocalServerInfo, LocalServerStartup
+from omnigent.host.local_server import _DEFAULT_LOCAL_PORT, LocalServerInfo, LocalServerStartup
 
 
 def _record(
@@ -379,3 +379,122 @@ def test_server_stop_finds_untracked_orphan_when_pidfile_lost(
 
     assert result.exit_code == 0, result.output
     assert "Stopped the background server." in result.output
+
+
+# ── foreground `server`: non-loopback + no-auth warning ─────────────
+
+
+class _StopBeforeServe(Exception):
+    """Sentinel raised by a patched ``_load_config`` to stop the foreground
+    server boot right after the bind/auth warning decision, before any real
+    server setup (no stores, no uvicorn bind)."""
+
+
+def _stop_after_auth_decision(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Short-circuit the foreground ``omnigent server`` boot.
+
+    ``_load_config`` is the first heavy step after the bind/auth warning
+    block, so raising there lets the warning (if any) be emitted while
+    stopping before stores are built or a socket is bound.
+    """
+
+    def _raise(_path: str | None) -> dict[str, object]:
+        raise _StopBeforeServe
+
+    monkeypatch.setattr("omnigent.cli._load_config", _raise)
+
+
+def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset every auth-related env var to a known-unset baseline.
+
+    ``monkeypatch.delenv`` records the prior value so teardown also undoes
+    the ``OMNIGENT_LOCAL_SINGLE_USER`` that the loopback path sets via
+    ``os.environ.setdefault`` — keeping the warning tests isolated.
+    """
+    for name in (
+        "OMNIGENT_AUTH_PROVIDER",
+        "OMNIGENT_AUTH_ENABLED",
+        "OMNIGENT_ACCOUNTS_ENABLED",
+        "OMNIGENT_OIDC_ISSUER",
+        "OMNIGENT_LOCAL_SINGLE_USER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+_WARNING_MARKER = "Every request without an 'X-Forwarded-Email' header will be rejected with 401"
+
+
+def test_foreground_non_loopback_header_no_auth_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-loopback bind in header mode with no single-user fallback warns.
+
+    Header mode + no ``OMNIGENT_LOCAL_SINGLE_USER`` + a non-loopback bind
+    means every request 401s; the foreground server must say so at startup.
+    """
+    _clear_auth_env(monkeypatch)
+    _stop_after_auth_decision(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["server", "--host", "0.0.0.0"])
+
+    # The boot stopped at the patched seam — i.e. we ran past the warning.
+    assert isinstance(result.exception, _StopBeforeServe), result.output
+    assert f"WARNING: binding 0.0.0.0:{_DEFAULT_LOCAL_PORT} (non-loopback)" in result.output
+    assert _WARNING_MARKER in result.output
+    # Both audiences are addressed: proxy operators and naive LAN binders.
+    assert "X-Forwarded-Email" in result.output
+    assert "OMNIGENT_AUTH_ENABLED=1" in result.output
+
+
+def test_foreground_loopback_does_not_warn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A loopback bind never triggers the non-loopback auth warning.
+
+    Loopback is the single-user local posture (the fallback is auto-enabled),
+    so there is no 401 foot-gun and no warning. Stubbing a healthy server
+    makes the canonical-local path reuse it and exit cleanly.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setattr(
+        "omnigent.host.local_server.local_server_url_if_healthy",
+        lambda: f"http://127.0.0.1:{_DEFAULT_LOCAL_PORT}",
+    )
+
+    result = CliRunner().invoke(cli, ["server", "--host", "127.0.0.1"])
+
+    assert result.exit_code == 0, result.output
+    assert "reusing it" in result.output  # took the canonical-local reuse path
+    assert "WARNING" not in result.output
+    assert "401" not in result.output
+
+
+def test_foreground_non_loopback_accounts_does_not_warn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-loopback with accounts auth (OMNIGENT_AUTH_ENABLED=1) does not warn.
+
+    Accounts mode authenticates every request, so there is no silent-401
+    foot-gun — the warning is header-mode-only.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+    _stop_after_auth_decision(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["server", "--host", "0.0.0.0"])
+
+    assert isinstance(result.exception, _StopBeforeServe), result.output
+    assert "WARNING" not in result.output
+    assert "401" not in result.output
+
+
+def test_foreground_non_loopback_oidc_does_not_warn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-loopback with OIDC configured does not warn.
+
+    An operator-supplied OIDC issuer resolves to ``oidc`` mode (not header),
+    so the warning is suppressed without ever constructing OIDC config.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+    monkeypatch.setenv("OMNIGENT_OIDC_ISSUER", "https://issuer.example")
+    _stop_after_auth_decision(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["server", "--host", "0.0.0.0"])
+
+    assert isinstance(result.exception, _StopBeforeServe), result.output
+    assert "WARNING" not in result.output
+    assert "401" not in result.output


### PR DESCRIPTION
## Summary

Binding the foreground `omnigent server` to a non-loopback host (e.g. `--host 0.0.0.0` or a LAN IP) in the default `header` auth mode does **not** auto-enable the loopback single-user fallback, so every request without an `X-Forwarded-Email` header is rejected with 401. That is the correct posture behind a trusted identity-injecting reverse proxy, but a silent foot-gun for anyone exposing the server on a LAN (e.g. to reach it from a phone) without one — the server boots "successfully" yet 401s every request.

This PR keeps that fail-closed behavior unchanged and instead makes it discoverable.

### Changes

- **Startup warning** (`omnigent/cli.py`): when the bind is non-loopback, resolves to `header` mode, and the single-user fallback is not enabled, print a non-fatal warning that addresses both audiences — reverse-proxy operators are reminded to inject `X-Forwarded-Email`, and direct LAN binders are told to enable accounts (`OMNIGENT_AUTH_ENABLED=1`) or OIDC. Single-user is still never auto-enabled on a non-loopback bind, and the fail-closed behavior is unchanged.
- **README fixes**: the mobile and "collaborate with your team" sections previously implied a bare LAN address or `omnigent server start` would serve the network. Corrected to document the foreground `--host` bind with auth, that the background daemon (`server start`) is loopback-only by design, and the create-admin bootstrap flow (no password is printed/auto-generated).

## Test plan

- `pytest tests/cli/test_server_lifecycle.py` — **20 passed**, including 4 new tests:
  - warns on non-loopback + header + no single-user fallback
  - silent on a loopback bind
  - silent with accounts mode (`OMNIGENT_AUTH_ENABLED=1`)
  - silent with OIDC configured
- `ruff check` — passed
- `ruff format --check` — clean

New tests short-circuit the boot / mock `subprocess.Popen` and never bind a real socket, so they don't touch port 6767 or conflict with a running server.
