### PR TITLE
fix(security-scan): trust authors in the MAINTAINERS list

### DIFF
--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -4,9 +4,13 @@
 #
 # We scan UNTRUSTED authors and skip trusted ones. "Trusted" is GitHub's
 # native author_association: OWNER / MEMBER / COLLABORATOR -- people with a
-# direct relationship to the repo/org. Everyone else is scanned, INCLUDING
-# returning CONTRIBUTORs (a merged PR in the past does not vouch for the
-# contents of this one) and first-timers (FIRST_TIME_CONTRIBUTOR / NONE).
+# direct relationship to the repo/org -- OR an author in the MAINTAINERS list.
+# The list covers maintainers whose org membership is PRIVATE: GitHub only
+# reports MEMBER in author_association when membership is public, so a private
+# maintainer shows up as CONTRIBUTOR and would otherwise be scanned. Everyone
+# else is scanned, INCLUDING returning CONTRIBUTORs (a merged PR in the past
+# does not vouch for the contents of this one) and first-timers
+# (FIRST_TIME_CONTRIBUTOR / NONE).
 #
 # This is deliberately stricter than fork-e2e/should-mirror.sh, which trusts
 # CONTRIBUTOR: that gate only decides whether to spend a rate-limited test
@@ -90,12 +94,35 @@ case "${EVENT_NAME:-}" in
     ;;
 esac
 
+# Author is a known maintainer? `author_association` only reports MEMBER when
+# the org membership is PUBLIC, so a maintainer with private membership shows up
+# as CONTRIBUTOR in the event payload and would otherwise be scanned. The
+# MAINTAINERS list (from load-maintainers.sh) is authoritative and trusted, so
+# trust the author directly when they appear in it. Only evaluated when
+# MAINTAINERS is passed (the scan does; the per-workflow pollers do not).
+author_is_maintainer() {
+  [[ -n "${MAINTAINERS:-}" && -n "${MAINTAINERS// /}" ]] || return 1
+  [[ -n "${GH_TOKEN:-}" && -n "${REPO:-}" && -n "${PR:-}" ]] || return 1
+
+  local maint_lc author_lc
+  maint_lc=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
+  author_lc=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login' 2>/dev/null \
+    | tr '[:upper:]' '[:lower:]')
+  [[ -n "$author_lc" ]] || return 1
+  for m in $maint_lc; do
+    [[ "$m" == "$author_lc" ]] && return 0
+  done
+  return 1
+}
+
 case "${AUTHOR_ASSOCIATION:-}" in
   OWNER | MEMBER | COLLABORATOR)
     emit false "trusted author (author_association=$AUTHOR_ASSOCIATION)"
     ;;
   *)
-    if skip_label_effective; then
+    if author_is_maintainer; then
+      emit false "trusted author (maintainer; author_association=${AUTHOR_ASSOCIATION:-unknown})"
+    elif skip_label_effective; then
       emit false "maintainer-effective '$SKIP_LABEL' waiver"
     else
       emit true "untrusted author (author_association=${AUTHOR_ASSOCIATION:-unknown})"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,9 +15,10 @@ name: Security Scan
 # / uv sync / test). Detectors run fail-fast -- the first finding fails the job,
 # so a clean PR must pass every one.
 #
-# Trust tiers (should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR) and non-PR
-# events aren't scanned; returning contributors are; first-timers are held by
-# GitHub's native fork-approval gate first.
+# Trust tiers (should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR, or an author
+# in the MAINTAINERS list -- covers maintainers with private org membership) and
+# non-PR events aren't scanned; returning contributors are; first-timers are held
+# by GitHub's native fork-approval gate first.
 
 on:
   pull_request:


### PR DESCRIPTION
## Problem

The Security Scan trust gate (`should-scan.sh`) only skipped scanning for `author_association` of `OWNER`/`MEMBER`/`COLLABORATOR`. GitHub only reports `MEMBER` in the event payload's `author_association` when the org membership is **public** — a maintainer with **private** membership shows up as `CONTRIBUTOR` and gets scanned, then can be failed by the workflow-edit / sensitive-path guards on their own PR.

This is exactly what happened on [run #27609746593 (PR #335)](https://github.com/omnigent-ai/omnigent/actions/runs/27609746593/job/81630806492?pr=335): the author is an org admin and a maintainer, but their membership is private, so the event reported `CONTRIBUTOR`, the scan ran, and it failed on the sensitive-path guard.

## Fix

When `author_association` isn't a trusted tier, also check whether the PR author is in the `MAINTAINERS` list (already loaded by `load-maintainers.sh` and passed into the scan job) before falling through to the skip-label waiver. The author login is read from the trusted API, matched case-insensitively. Fails closed when `MAINTAINERS` or API creds are absent — same semantics as `skip_label_effective`, so the per-workflow pollers (which don't pass `MAINTAINERS`) are unaffected.

## Verification

Smoke-tested locally against PR #335 with `AUTHOR_ASSOCIATION=CONTRIBUTOR`:
- Author in `MAINTAINERS` → `scan=false (trusted author (maintainer; ...))`
- Author removed from list → `scan=true (untrusted author)` (negative path intact)

This pull request and its description were written by Isaac.