### PR TITLE
feat: add approval mode selector for Codex sessions in web UI

### DIFF
--- a/ap-web/src/lib/nativeCodingAgents.ts
+++ b/ap-web/src/lib/nativeCodingAgents.ts
@@ -5,7 +5,7 @@ export const UI_MODE_LABEL_KEY = "omnigent.ui";
 export const UI_MODE_TERMINAL_VALUE = "terminal";
 
 export type NativeCodingAgentIconKind = "claude" | "codex" | "pi";
-export type NativeCodingAgentCapability = "permissionMode";
+export type NativeCodingAgentCapability = "permissionMode" | "approvalMode";
 
 export interface NativeCodingAgentSpec {
   key: NativeCodingAgentIconKind;
@@ -37,6 +37,7 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "Codex",
     iconKind: "codex",
     sortRank: 20,
+    capabilities: ["approvalMode"],
   },
   {
     key: "pi",

--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -478,6 +478,51 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toBeUndefined();
   });
 
+  it("posts --approval-mode <mode> when a non-default mode is picked for codex-native", async () => {
+    setAgents([agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_codex" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    // Open the footer tray's Advanced menu and pick full-auto.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-auto"));
+    // A non-default pick is suffixed onto the pill.
+    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
+      "Codex (Full auto)",
+    );
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.terminal_launch_args).toEqual(["--approval-mode", "full-auto"]);
+  });
+
+  it("omits terminal_launch_args when approval mode is left at default for codex-native", async () => {
+    setAgents([agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_codex" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).not.toContain("(");
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.labels?.["omnigent.wrapper"]).toBe("codex-native-ui");
+    expect(body.terminal_launch_args).toBeUndefined();
+  });
+
   it("posts harness_override when a brain harness is picked from the Advanced menu", async () => {
     // polly's spec declares claude-sdk; the Advanced menu offers the
     // override set.

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -670,12 +670,28 @@ describe("NewChatLandingScreen", () => {
     expect(detail.textContent).toContain("Prompts before edits and commands");
     fireEvent.pointerEnter(planOption);
     expect(detail.textContent).toContain("Plans only; makes no edits");
-    // Switch to Codex (a2: not native, no overridable harness) — the whole
-    // Advanced chip is gone since --permission-mode only applies to the
-    // claude CLI and codex-native offers no harness override.
+    // Switch to Codex (a2: codex-native) — the Advanced chip stays visible
+    // but now shows approval-mode radios instead of permission-mode radios.
+    // Close the Advanced menu first (Escape), then switch agents.
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
-    expect(screen.queryByTestId("new-chat-landing-advanced-chip")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-advanced-chip")).not.toBeNull();
+  });
+
+  it("shows approval-mode options in the Advanced menu for the codex-native agent", () => {
+    renderLanding();
+    // Switch to Codex first.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    const fullAutoOption = screen.getByTestId("new-chat-landing-approval-full-auto");
+    expect(fullAutoOption.textContent).toContain("Full auto");
+    // The footer line explains the SELECTED mode until a row is hovered.
+    const detail = screen.getByTestId("new-chat-landing-approval-detail");
+    expect(detail.textContent).toContain("Prompts before edits and commands");
+    fireEvent.pointerEnter(fullAutoOption);
+    expect(detail.textContent).toContain("Runs everything; no prompts or safety checks");
   });
 
   it("shows a conflict banner in the file browser for an occupied directory", async () => {

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -112,6 +112,25 @@ const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; descriptio
   },
 ];
 
+// Codex's `--approval-mode` choices. Codex-native sessions only.
+// "suggest" is Codex's default (prompts before everything); any other value
+// is passed through as `--approval-mode <value>` via the session's
+// terminal_launch_args. Keep in sync with `codex --help`.
+const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "suggest";
+const CODEX_NATIVE_APPROVAL_MODES: { value: string; label: string; description: string }[] = [
+  { value: "suggest", label: "Suggest", description: "Prompts before edits and commands" },
+  {
+    value: "auto-edit",
+    label: "Auto edit",
+    description: "Auto-applies file edits; commands still prompt",
+  },
+  {
+    value: "full-auto",
+    label: "Full auto",
+    description: "Runs everything; no prompts or safety checks",
+  },
+];
+
 function HostOption({ host }: { host: Host }) {
   const isOnline = host.status === "online";
   return (
@@ -534,6 +553,52 @@ function PermissionModeOptions({
 }
 
 /**
+ * Codex approval-mode radio rows, rendered inside the Advanced settings
+ * menu in the composer footer. Mirror of {@link PermissionModeOptions}
+ * for the Codex-native agent.
+ *
+ * @param value Currently selected mode, e.g. ``"suggest"``.
+ * @param onValueChange Selection callback (receives the mode value).
+ */
+function ApprovalModeOptions({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (mode: string) => void;
+}) {
+  const [previewed, setPreviewed] = useState<string | null>(null);
+  const detail = CODEX_NATIVE_APPROVAL_MODES.find(
+    (m) => m.value === (previewed ?? value),
+  )?.description;
+  return (
+    <>
+      <DropdownMenuRadioGroup value={value} onValueChange={onValueChange}>
+        {CODEX_NATIVE_APPROVAL_MODES.map((mode) => (
+          <DropdownMenuRadioItem
+            key={mode.value}
+            value={mode.value}
+            data-testid={`new-chat-landing-approval-${mode.value}`}
+            onFocus={() => setPreviewed(mode.value)}
+            onPointerEnter={() => setPreviewed(mode.value)}
+            className="rounded-sm pl-2 py-1 text-xs"
+          >
+            {mode.label}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+      <DropdownMenuSeparator />
+      <p
+        data-testid="new-chat-landing-approval-detail"
+        className="min-h-5 px-2 pt-0.5 pb-1 text-xs leading-relaxed text-muted-foreground"
+      >
+        {detail}
+      </p>
+    </>
+  );
+}
+
+/**
  * Brain-harness radio rows for an overridable bundle agent, rendered
  * inside the Advanced settings menu in the composer footer.
  *
@@ -697,6 +762,12 @@ export function NewChatLandingScreen() {
   const [permissionMode, setPermissionMode] = useState<string>(
     CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE,
   );
+  // Approval mode for Codex (codex --approval-mode). Only meaningful for
+  // the codex-native wrapper; ignored otherwise. Lives in the footer
+  // tray's Advanced settings menu.
+  const [approvalMode, setApprovalMode] = useState<string>(
+    CODEX_NATIVE_DEFAULT_APPROVAL_MODE,
+  );
   // Per-session brain-harness override for bundle agents (polly / debby).
   // null = the agent spec's declared harness (no override sent); cleared on
   // every agent switch so a pick never leaks across agents.
@@ -772,6 +843,7 @@ export function NewChatLandingScreen() {
     (agentList.some((a) => a.id === pickedAgentId) ? pickedAgentId : agentList[0]?.id) ?? null;
   const selectedAgent = agentList.find((a) => a.id === effectiveAgentId);
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
+  const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   // Native-terminal agents interpret slash commands inside their own CLI
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
@@ -921,6 +993,8 @@ export function NewChatLandingScreen() {
   // radios live in the footer tray's Advanced settings menu.
   const permissionModeLabel =
     CLAUDE_NATIVE_PERMISSION_MODES.find((m) => m.value === permissionMode)?.label ?? permissionMode;
+  const approvalModeLabel =
+    CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.label ?? approvalMode;
   // Effective brain harness for the selected agent: the user's pick, else
   // the spec's declared harness. null for non-overridable agents (native
   // wrappers, agents whose spec failed to load).
@@ -928,16 +1002,18 @@ export function NewChatLandingScreen() {
     selectedAgent?.harness != null && selectedAgent.harness in BRAIN_HARNESS_LABELS
       ? selectedAgent.harness
       : null;
-  // The label suffixes the permission mode / harness only when the user
-  // explicitly changed it in the Advanced menu — defaults read as just the
-  // agent name. pickedHarness is non-null only for an explicit non-default
-  // pick (re-picking the spec default clears it).
+  // The label suffixes the permission/approval mode / harness only when the
+  // user explicitly changed it in the Advanced menu — defaults read as just
+  // the agent name. pickedHarness is non-null only for an explicit
+  // non-default pick (re-picking the spec default clears it).
   const agentLabel = selectedAgent
     ? supportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
       ? `${selectedAgent.display_name} (${permissionModeLabel})`
-      : pickedHarness != null
-        ? `${selectedAgent.display_name} (${BRAIN_HARNESS_LABELS[pickedHarness] ?? pickedHarness})`
-        : selectedAgent.display_name
+      : supportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
+        ? `${selectedAgent.display_name} (${approvalModeLabel})`
+        : pickedHarness != null
+          ? `${selectedAgent.display_name} (${BRAIN_HARNESS_LABELS[pickedHarness] ?? pickedHarness})`
+          : selectedAgent.display_name
     : "Select agent";
 
   function selectHost(hostId: string) {
@@ -978,6 +1054,7 @@ export function NewChatLandingScreen() {
       const agent = agentList.find((a) => a.id === effectiveAgentId);
       const nativeLabels = nativeWrapperLabelsForAgent(agent);
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
+      const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
       const res = await authenticatedFetch("/v1/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1006,12 +1083,14 @@ export function NewChatLandingScreen() {
           // The values are the registered wrapper ids the runner keys off —
           // they must match the wrapper registry, not the agent display name.
           labels: nativeLabels,
-          // Permission mode → `claude --permission-mode <mode>`, persisted as
+          // Permission / approval mode → CLI flag pair, persisted as
           // terminal_launch_args. Omitted for the default and non-native agents.
           terminal_launch_args:
             agentSupportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
               ? ["--permission-mode", permissionMode]
-              : undefined,
+              : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
+                ? ["--approval-mode", approvalMode]
+                : undefined,
           // Cost-control switch from the "Cost Optimized" pill; polly-only
           // (cost control is a polly feature) and omitted when unset so the
           // session defers to the spec default.
@@ -1663,10 +1742,12 @@ export function NewChatLandingScreen() {
               )}
 
               {/* Advanced settings chip — per-agent knobs that don't warrant
-                their own chip: the brain-harness override (bundle agents)
-                and Claude Code's permission mode. Hidden when the selected
-                agent has neither. */}
-              {(selectedAgentDefaultHarness != null || supportsPermissionMode) && (
+                their own chip: the brain-harness override (bundle agents),
+                Claude Code's permission mode, and Codex's approval mode.
+                Hidden when the selected agent has none. */}
+              {(selectedAgentDefaultHarness != null ||
+                supportsPermissionMode ||
+                supportsApprovalMode) && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
@@ -1706,6 +1787,23 @@ export function NewChatLandingScreen() {
                         <PermissionModeOptions
                           value={permissionMode}
                           onValueChange={setPermissionMode}
+                        />
+                      </>
+                    )}
+                    {/* Approval mode (Codex only) — codex-native has no
+                      overridable harness, so the two sections never co-render
+                      today; the separator covers a future agent with both. */}
+                    {supportsApprovalMode && (
+                      <>
+                        {(selectedAgentDefaultHarness != null || supportsPermissionMode) && (
+                          <DropdownMenuSeparator />
+                        )}
+                        <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
+                          Approval mode
+                        </div>
+                        <ApprovalModeOptions
+                          value={approvalMode}
+                          onValueChange={setApprovalMode}
                         />
                       </>
                     )}

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -765,9 +765,7 @@ export function NewChatLandingScreen() {
   // Approval mode for Codex (codex --approval-mode). Only meaningful for
   // the codex-native wrapper; ignored otherwise. Lives in the footer
   // tray's Advanced settings menu.
-  const [approvalMode, setApprovalMode] = useState<string>(
-    CODEX_NATIVE_DEFAULT_APPROVAL_MODE,
-  );
+  const [approvalMode, setApprovalMode] = useState<string>(CODEX_NATIVE_DEFAULT_APPROVAL_MODE);
   // Per-session brain-harness override for bundle agents (polly / debby).
   // null = the agent spec's declared harness (no override sent); cleared on
   // every agent switch so a pick never leaks across agents.
@@ -1801,10 +1799,7 @@ export function NewChatLandingScreen() {
                         <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
                           Approval mode
                         </div>
-                        <ApprovalModeOptions
-                          value={approvalMode}
-                          onValueChange={setApprovalMode}
-                        />
+                        <ApprovalModeOptions value={approvalMode} onValueChange={setApprovalMode} />
                       </>
                     )}
                   </DropdownMenuContent>

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -134,6 +134,30 @@ def _agents_body() -> str:
     )
 
 
+def _codex_native_agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: the native Codex agent.
+
+    ``codex-native-ui`` + ``harness: "codex-native"`` is what the frontend
+    maps (via ``nativeCodingAgents``) to the ``approvalMode`` capability,
+    gating the Codex approval-mode UI in the Advanced menu. Sole agent, so
+    it auto-selects and no explicit pick is needed.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_codex_e2e",
+                    "name": "codex-native-ui",
+                    "display_name": "Codex",
+                    "description": "OpenAI's coding agent",
+                    "harness": "codex-native",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
 def _bundle_agents_body() -> str:
     """Stub body for ``GET /v1/agents``: the two harness-overridable bundle agents.
 
@@ -327,6 +351,81 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
             assert body.get("terminal_launch_args") == ["--permission-mode", "acceptEdits"], body
+        finally:
+            await browser.close()
+
+
+def test_start_session_select_approval_mode(seeded_session: tuple[str, str]) -> None:
+    """Picking a non-default approval mode rides along to the create call.
+
+    Selecting "Full auto" in the agent picker's Advanced settings menu
+    must (a) surface in the agent chip label as immediate feedback and
+    (b) reach ``POST /v1/sessions`` as
+    ``terminal_launch_args: ["--approval-mode", "full-auto"]``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_approval_mode(base_url, session_id))
+
+
+async def _drive_approval_mode(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page,
+                created_session_id=session_id,
+                create_bodies=create_bodies,
+                agents_body=_codex_native_agents_body(),
+            )
+
+            # Neutralize agent discovery so only the stubbed Codex agent
+            # feeds the picker.
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # Codex auto-selects (only built-in), so the Advanced chip —
+            # gated on the Codex-native agent — is present.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
+            # All three Codex approval modes render as radio rows.
+            for mode in ("suggest", "auto-edit", "full-auto"):
+                await expect(
+                    page.get_by_test_id(f"new-chat-landing-approval-{mode}")
+                ).to_be_visible()
+            await page.get_by_test_id("new-chat-landing-approval-full-auto").click()
+
+            # The chip label reflects the non-default pick immediately.
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "Full auto"
+            )
+
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_codex_e2e", body
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/work/repo", body
+            assert body.get("terminal_launch_args") == ["--approval-mode", "full-auto"], body
         finally:
             await browser.close()
 


### PR DESCRIPTION
## Summary
- Adds an **Approval mode** selector (Suggest / Auto edit / Full auto) in the Advanced dropdown for Codex sessions, mirroring Claude Code's existing Permission mode selector
- Sends `--approval-mode <mode>` as `terminal_launch_args` when a non-default mode is picked
- Adds `approvalMode` capability to the Codex native agent spec

Closes #272

## Test plan
- [x] Existing `NewChatDialog` unit and flow tests pass (129 tests)
- [x] `nativeCodingAgents` tests pass (4 tests)
- [x] TypeScript type check passes
- [x] New unit test: approval-mode radios render in the Advanced menu for Codex, with hover descriptions
- [x] New flow test: non-default approval mode posts `["--approval-mode", "full-auto"]` in `terminal_launch_args`
- [x] New flow test: default approval mode omits `terminal_launch_args`
- [x] Manual: create a Codex session with "Full auto" selected, verify the TUI launches with `--approval-mode full-auto`