### PR TITLE
fix(claude-sdk): don't crash runner shutdown when SDK transport lacks _stderr_task_group

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -129,8 +129,8 @@ SdkOptions: TypeAlias = Any  # type: ignore[explicit-any]
 # this executor touches.
 #
 # The private reaches (``_query``, ``_transport``, ``_process``,
-# ``_stderr_task_group``, etc.) are necessary to tear down the CLI
-# subprocess tree when the SDK's own ``disconnect()`` path is unsafe
+# ``_stderr_task`` / ``_stderr_task_group``, etc.) are necessary to tear
+# down the CLI subprocess tree when the SDK's own ``disconnect()`` path is unsafe
 # (different event loop / task) or hangs. The SDK does not expose a
 # supported equivalent, so we treat the private attributes as part of
 # our integration contract and document them here.
@@ -159,6 +159,19 @@ class _CancelScope(Protocol):
 
 class _TaskGroup(Protocol):
     cancel_scope: _CancelScope
+
+
+class _TaskHandle(Protocol):
+    """Private view of the SDK's detached stderr-reader task.
+
+    Current ``claude-agent-sdk`` (>=0.2.x) runs the stderr reader as a
+    single task exposed as ``_stderr_task`` with a ``cancel()`` method;
+    older revs used an anyio task group (``_stderr_task_group``). The
+    executor probes both shapes during force-close, so both are typed
+    optional on ``_ClaudeTransport`` below.
+    """
+
+    def cancel(self) -> None: ...
 
 
 class _ClaudeQuery(Protocol):
@@ -193,6 +206,7 @@ class _ClaudeTransport(Protocol):
     _stdout_stream: _Stream | None
     _stdin_stream: _Stream | None
     _stderr_stream: _Stream | None
+    _stderr_task: _TaskHandle | None
     _stderr_task_group: _TaskGroup | None
     _ready: bool
 
@@ -1489,10 +1503,21 @@ class ClaudeSDKExecutor(Executor):
 
         transport = getattr(client, "_transport", None)
         if transport is not None:
-            stderr_tg = transport._stderr_task_group
-            if stderr_tg is not None:
+            # The SDK's stderr reader changed shape across revs: current
+            # claude-agent-sdk (>=0.2.x) exposes a single ``_stderr_task``
+            # TaskHandle with ``cancel()``; older revs an anyio
+            # ``_stderr_task_group``. Probe both via getattr so a force-close
+            # never raises AttributeError out of lifespan shutdown (which
+            # crashed the runner on session stop).
+            stderr_task = getattr(transport, "_stderr_task", None)
+            if stderr_task is not None:
                 with suppress(Exception):
-                    stderr_tg.cancel_scope.cancel()
+                    stderr_task.cancel()
+            else:
+                stderr_tg = getattr(transport, "_stderr_task_group", None)
+                if stderr_tg is not None:
+                    with suppress(Exception):
+                        stderr_tg.cancel_scope.cancel()
 
             for stream in (
                 transport._stdout_stream,
@@ -1528,7 +1553,10 @@ class ClaudeSDKExecutor(Executor):
             transport._stdout_stream = None
             transport._stdin_stream = None
             transport._stderr_stream = None
-            transport._stderr_task_group = None
+            if getattr(transport, "_stderr_task", None) is not None:
+                transport._stderr_task = None
+            if getattr(transport, "_stderr_task_group", None) is not None:
+                transport._stderr_task_group = None
             transport._ready = False
 
         client._query = None

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -694,6 +694,44 @@ class TestConstructor(unittest.TestCase):
             terminate_tree.assert_called_once()
 
         _run(_t())
+
+    def test_force_close_client_handles_sdk_without_stderr_task_group(self):
+        # Regression: claude-agent-sdk >=0.2.x renamed the stderr reader from an
+        # anyio task group (`_stderr_task_group`) to a single `_stderr_task`
+        # TaskHandle. A transport shaped like the current SDK (no
+        # `_stderr_task_group` attribute at all) must not raise AttributeError
+        # out of `_force_close_client` — that exception escaped the runner's
+        # lifespan shutdown and crashed it on every session stop.
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        stderr_task = SimpleNamespace(cancel=Mock())
+
+        class _Transport:
+            def __init__(self):
+                self._process = SimpleNamespace(returncode=None, pid=12345, wait=AsyncMock())
+                self._stdout_stream = object()
+                self._stdin_stream = object()
+                self._stderr_stream = object()
+                self._stderr_task = stderr_task  # current SDK shape
+                self._ready = True
+
+        transport = _Transport()
+        client = SimpleNamespace(_query=None, _transport=transport)
+
+        async def _t():
+            with patch(
+                "omnigent.inner.claude_sdk_executor._terminate_process_tree"
+            ) as terminate_tree:
+                await ClaudeSDKExecutor._force_close_client(client)
+            terminate_tree.assert_called_once()
+
+        _run(_t())
+
+        # New-shape stderr task was cancelled, the missing legacy attribute was
+        # never created, and the handle was cleared.
+        stderr_task.cancel.assert_called_once()
+        self.assertFalse(hasattr(transport, "_stderr_task_group"))
+        self.assertIsNone(transport._stderr_task)
 
     def test_claude_internal_write_files_omits_missing_config(self):
         from omnigent.inner.claude_sdk_executor import _claude_internal_write_files


### PR DESCRIPTION
## Problem

Stopping a Claude-SDK session crashes the runner. During shutdown,
`ClaudeSDKExecutor._force_close_client` reads `transport._stderr_task_group`
directly:

```
.../runtime/harnesses/_scaffold.py:882 in _lifespan      → await self.on_shutdown()
.../runtime/harnesses/_executor_adapter.py:871 on_shutdown → close_session(...)
.../inner/claude_sdk_executor.py:1492 _force_close_client
    stderr_tg = transport._stderr_task_group
AttributeError: 'SubprocessCLITransport' object has no attribute '_stderr_task_group'
ERROR:    Application shutdown failed. Exiting.
```

`claude-agent-sdk` >= 0.2.x (installed: **0.2.102**) replaced the stderr
reader's anyio task group (`_stderr_task_group`) with a single
`_stderr_task` `TaskHandle`, so the attribute no longer exists. The
`AttributeError` escapes the runner harness's FastAPI lifespan
`on_shutdown`, so the runner dies uncleanly on **every session stop**.

## Fix

- Probe both `_stderr_task` (current SDK) and `_stderr_task_group` (older
  revs) via `getattr`, mirroring how the executor already handles the
  `_query._tg` drift right above this block.
- Cancel `_stderr_task` when present; only clear the legacy attribute when
  it actually exists (don't synthesize it on the new SDK).
- Add a `_TaskHandle` Protocol and the `_stderr_task` field to the
  `_ClaudeTransport` SDK-reach Protocol, and update the module note.

## Tests

- New regression test `test_force_close_client_handles_sdk_without_stderr_task_group`
  uses a transport double shaped like the real SDK 0.2.102 (`_stderr_task`,
  **no** `_stderr_task_group`). It fails on `main` with the exact
  `AttributeError` and passes with this fix.
- Full `tests/inner/test_claude_sdk_executor.py` (98 tests) passes;
  `ruff check` + `ruff format` clean.

The existing `test_force_close_client_uses_process_tree_termination` double
set `_stderr_task_group = None`, which is why CI never caught the SDK drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
