### PR TITLE
ci: label PRs by size (size/XS..XL)

### DIFF
--- a/.github/scripts/pr-size/compute_label.py
+++ b/.github/scripts/pr-size/compute_label.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Compute a ``size/{XS,S,M,L,XL}`` label for a PR from its changed files.
+
+Reads the GitHub ``pulls/{n}/files`` JSON array on stdin (objects with
+``filename``, ``additions``, ``deletions``) and prints the size label. Lock
+and generated files are excluded so a dependency bump does not inflate the
+size. Pure stdlib so it runs without an install and is unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# Files whose churn should not count toward review size.
+GENERATED = (
+    re.compile(r"^uv\.lock$"),
+    re.compile(r"(^|/)package-lock\.json$"),
+    re.compile(r"(^|/)yarn\.lock$"),
+)
+
+# Upper bound (inclusive) of changed lines for each label, smallest first.
+THRESHOLDS = (
+    ("XS", 9),
+    ("S", 49),
+    ("M", 199),
+    ("L", 499),
+    ("XL", float("inf")),
+)
+
+
+def is_generated(filename: str) -> bool:
+    return any(p.search(filename) for p in GENERATED)
+
+
+def size_label(total: int) -> str:
+    for name, upper in THRESHOLDS:
+        if total <= upper:
+            return f"size/{name}"
+    raise AssertionError("THRESHOLDS must end with an unbounded bucket")
+
+
+def total_changes(files: list[dict]) -> int:
+    return sum(
+        f.get("additions", 0) + f.get("deletions", 0)
+        for f in files
+        if not is_generated(f.get("filename", ""))
+    )
+
+
+def main() -> int:
+    files = json.load(sys.stdin)
+    print(size_label(total_changes(files)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/pr-size.js
+++ b/.github/workflows/pr-size.js
@@ -1,0 +1,85 @@
+// Computes a `size/*` label for a PR from its added + deleted lines,
+// excluding generated / lock files, and reconciles the label on the PR.
+
+const GENERATED = [/^uv\.lock$/, /package-lock\.json$/, /yarn\.lock$/];
+
+const THRESHOLDS = {
+  XS: 9,
+  S: 49,
+  M: 199,
+  L: 499,
+  XL: Infinity,
+};
+
+function isGenerated(filename) {
+  return GENERATED.some((p) => p.test(filename));
+}
+
+function getSize(total) {
+  return Object.entries(THRESHOLDS).find(([, max]) => total <= max)[0];
+}
+
+module.exports = async ({ github, context }) => {
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+
+  const maxThreshold = Math.max(...Object.values(THRESHOLDS).filter(isFinite));
+  let total = 0;
+  for (const f of files) {
+    if (!isGenerated(f.filename)) {
+      total += f.additions + f.deletions;
+    }
+    if (total > maxThreshold) break;
+  }
+
+  const sizeLabel = `size/${getSize(total)}`;
+  console.log(`Size: ${total} lines -> ${sizeLabel}`);
+
+  const currentLabels = (
+    await github.paginate(github.rest.issues.listLabelsOnIssue, {
+      owner,
+      repo,
+      issue_number: pr.number,
+    })
+  ).map((l) => l.name);
+
+  // Remove stale size labels.
+  for (const label of currentLabels) {
+    if (label.startsWith("size/") && label !== sizeLabel) {
+      console.log(`Removing stale label: ${label}`);
+      await github.rest.issues
+        .removeLabel({ owner, repo, issue_number: pr.number, name: label })
+        .catch((e) => console.warn(`Failed to remove label ${label}: ${e.message}`));
+    }
+  }
+
+  // Add the correct label, creating it on first use.
+  if (!currentLabels.includes(sizeLabel)) {
+    try {
+      await github.rest.issues.getLabel({ owner, repo, name: sizeLabel });
+    } catch (e) {
+      if (e.status !== 404) throw e;
+      console.log(`Creating label: ${sizeLabel}`);
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name: sizeLabel,
+        color: "ededed",
+        description: `Pull request size: ${sizeLabel.replace("size/", "")}`,
+      });
+    }
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: pr.number,
+      labels: [sizeLabel],
+    });
+  }
+};

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,9 +1,10 @@
 name: PR Size Labeling
 
 # Applies a `size/{XS,S,M,L,XL}` label to each PR based on its added +
-# deleted lines (excluding lock / generated files). Runs as
-# pull_request_target so it can label fork PRs, but never checks out or
-# executes PR code — it reads file stats and updates labels via the API.
+# deleted lines (excluding lock / generated files), so reviewers can gauge
+# review effort at a glance. Runs as pull_request_target so it can label fork
+# PRs, but never checks out or executes PR code -- it reads file stats and
+# updates labels via the API, using only the default-branch script.
 
 on:
   pull_request_target:
@@ -31,12 +32,39 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: .github/workflows/pr-size.js
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/scripts/pr-size
           persist-credentials: false
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          retries: 3
-          script: |
-            const script = require('./.github/workflows/pr-size.js');
-            await script({ github, context });
+          python-version: "3.11"
+
+      - name: Compute and apply size label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          size_label=$(
+            gh api --paginate "/repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100" \
+              | .github/scripts/pr-size/compute_label.py
+          )
+          echo "Computed: ${size_label}"
+
+          # Ensure the label exists (idempotent), then attach it.
+          gh label create "${size_label}" --repo "${REPO}" --color ededed \
+            --description "Pull request size: ${size_label#size/}" --force >/dev/null
+
+          gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-label "${size_label}"
+
+          # Drop any stale size/* labels from a previous run.
+          gh api --paginate "/repos/${REPO}/issues/${PR_NUMBER}/labels" --jq '.[].name' \
+            | while read -r label; do
+                if [[ "${label}" == size/* && "${label}" != "${size_label}" ]]; then
+                  echo "Removing stale label: ${label}"
+                  gh pr edit "${PR_NUMBER}" --repo "${REPO}" --remove-label "${label}"
+                fi
+              done

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,42 @@
+name: PR Size Labeling
+
+# Applies a `size/{XS,S,M,L,XL}` label to each PR based on its added +
+# deleted lines (excluding lock / generated files). Runs as
+# pull_request_target so it can label fork PRs, but never checks out or
+# executes PR code — it reads file stats and updates labels via the API.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label-pr-size:
+    name: PR Size Labeling
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout default-branch script
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/workflows/pr-size.js
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/workflows/pr-size.js');
+            await script({ github, context });

--- a/tests/github/test_pr_size_label.py
+++ b/tests/github/test_pr_size_label.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "pr-size" / "compute_label.py"
+)
+spec = importlib.util.spec_from_file_location("compute_pr_size", SCRIPT)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+@pytest.mark.parametrize(
+    "total, expected",
+    [
+        (0, "size/XS"),
+        (9, "size/XS"),
+        (10, "size/S"),
+        (49, "size/S"),
+        (50, "size/M"),
+        (199, "size/M"),
+        (200, "size/L"),
+        (499, "size/L"),
+        (500, "size/XL"),
+        (10_000, "size/XL"),
+    ],
+)
+def test_size_label_boundaries(total: int, expected: str) -> None:
+    assert module.size_label(total) == expected
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["uv.lock", "package-lock.json", "ap-web/package-lock.json", "ap-web/electron/yarn.lock"],
+)
+def test_lock_files_are_generated(filename: str) -> None:
+    assert module.is_generated(filename)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["omnigent/runtime/workflow.py", "docs/uv.lock.md", "src/package-lock.json.bak"],
+)
+def test_source_files_are_not_generated(filename: str) -> None:
+    assert not module.is_generated(filename)
+
+
+def test_total_changes_excludes_generated() -> None:
+    files = [
+        {"filename": "omnigent/a.py", "additions": 30, "deletions": 10},
+        {"filename": "uv.lock", "additions": 5000, "deletions": 4000},
+        {"filename": "ap-web/package-lock.json", "additions": 800, "deletions": 0},
+    ]
+    # Only the source file counts: 30 + 10 = 40 -> size/S.
+    assert module.total_changes(files) == 40
+    assert module.size_label(module.total_changes(files)) == "size/S"
+
+
+def test_total_changes_missing_fields_default_to_zero() -> None:
+    assert module.total_changes([{"filename": "x.py"}]) == 0


### PR DESCRIPTION
## Summary

Adds a **PR Size Labeling** workflow that applies a `size/{XS,S,M,L,XL}` label to every PR based on its added + deleted line count, so reviewers can gauge review effort at a glance.

- Computes the total from the PR's changed files, excluding lock / generated files (`uv.lock`, `package-lock.json`, `yarn.lock`) so a dependency bump doesn't inflate the size.
- Reconciles labels on each update: ensures the target label exists, adds it, then removes any stale `size/*` label from a previous run.
- Runs as `pull_request_target` so it can label fork PRs. It never checks out or executes PR code — the GitHub API I/O is done in bash via `gh`, and only the default-branch script is checked out (sparse).

Implementation follows the repo's dominant convention: a stdlib-only Python script under `.github/scripts/pr-size/` invoked via `gh` + `setup-python` (the same shape as `pr-template` and `security-scan`). `compute_label.py` holds the pure logic — generated-file exclusion and threshold mapping — and is unit-tested.

Thresholds (lines changed): XS ≤ 9, S ≤ 49, M ≤ 199, L ≤ 499, XL otherwise.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `tests/github/test_pr_size_label.py` covering the threshold boundaries (0/9/10/49/50/199/200/499/500/10000 → XS/S/M/L/XL), the generated-file exclusions (lock files excluded, source files counted), and the missing-field default. Ran `uv run python -m pytest tests/github/test_pr_size_label.py` (19 passed). Also validated the workflow YAML parses and smoke-tested `compute_label.py` against a sample `pulls/{n}/files` payload. End-to-end label application will be exercised once the workflow lands on the default branch (pull_request_target runs from the base ref).
