### PR TITLE
test(e2e-ui): fill coverage gaps with e2e + vitest tests

### DIFF
--- a/ap-web/src/components/ComposerMicButton.test.tsx
+++ b/ap-web/src/components/ComposerMicButton.test.tsx
@@ -16,6 +16,8 @@ import { ComposerMicButton } from "./ComposerMicButton";
 let handlers: Record<string, (event: unknown) => void>;
 let startSpy: ReturnType<typeof vi.fn>;
 let stopSpy: ReturnType<typeof vi.fn>;
+/** Original navigator.mediaDevices descriptor, restored after each test. */
+let originalMediaDevices: PropertyDescriptor | undefined;
 
 function installSpeechRecognition() {
   handlers = {};
@@ -48,7 +50,9 @@ function resultEvent(transcript: string) {
 beforeEach(() => {
   installSpeechRecognition();
   // The visualizer's getUserMedia is best-effort; reject so no AudioContext
-  // (unavailable in jsdom) is ever constructed.
+  // (unavailable in jsdom) is ever constructed. Capture the original descriptor
+  // first so afterEach can restore it — otherwise this navigator stub leaks.
+  originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
   Object.defineProperty(navigator, "mediaDevices", {
     configurable: true,
     value: { getUserMedia: vi.fn().mockRejectedValue(new Error("no mic")) },
@@ -59,6 +63,12 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  // Restore navigator.mediaDevices so the stub never leaks to other test files.
+  if (originalMediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+  } else {
+    delete (navigator as { mediaDevices?: unknown }).mediaDevices;
+  }
 });
 
 describe("ComposerMicButton", () => {

--- a/ap-web/src/components/ComposerMicButton.test.tsx
+++ b/ap-web/src/components/ComposerMicButton.test.tsx
@@ -1,0 +1,134 @@
+// Tests for ComposerMicButton — Web Speech API voice dictation.
+//
+// The button toggles a SpeechRecognition session; final transcripts are
+// emitted via onTranscript. It renders nothing when the browser has no
+// SpeechRecognition constructor. None of this is e2e-testable (CI has no real
+// mic / Web Speech engine), so it's pinned here by stubbing the global
+// SpeechRecognition constructor with a fake whose addEventListener captures the
+// handlers the test then fires. getUserMedia (used only for the visualizer) is
+// stubbed to reject so no AudioContext is constructed in jsdom.
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerMicButton } from "./ComposerMicButton";
+
+/** Captured event handlers keyed by event type, fed by the fake recognition. */
+let handlers: Record<string, (event: unknown) => void>;
+let startSpy: ReturnType<typeof vi.fn>;
+let stopSpy: ReturnType<typeof vi.fn>;
+
+function installSpeechRecognition() {
+  handlers = {};
+  startSpy = vi.fn();
+  stopSpy = vi.fn();
+  // A class (not an arrow fn) so `new Ctor()` is constructable — the component
+  // does `new Ctor()` in its mount effect.
+  class FakeRecognition {
+    continuous = false;
+    interimResults = false;
+    lang = "en-US";
+    start = startSpy;
+    stop = stopSpy;
+    addEventListener(type: string, handler: (event: unknown) => void) {
+      handlers[type] = handler;
+    }
+    removeEventListener() {}
+  }
+  vi.stubGlobal("SpeechRecognition", FakeRecognition);
+}
+
+/** Build a SpeechRecognition `result` event carrying one final transcript. */
+function resultEvent(transcript: string) {
+  return {
+    resultIndex: 0,
+    results: { length: 1, 0: { length: 1, isFinal: true, 0: { transcript } } },
+  };
+}
+
+beforeEach(() => {
+  installSpeechRecognition();
+  // The visualizer's getUserMedia is best-effort; reject so no AudioContext
+  // (unavailable in jsdom) is ever constructed.
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: vi.fn().mockRejectedValue(new Error("no mic")) },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ComposerMicButton", () => {
+  it("renders nothing when the browser has no SpeechRecognition support", () => {
+    vi.stubGlobal("SpeechRecognition", undefined);
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    const { container } = render(<ComposerMicButton onTranscript={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders an idle, un-pressed dictation button when supported", () => {
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("starts recognition on click and reflects the recording state", () => {
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+
+    fireEvent.click(button);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    // The recognizer's "start" event flips the pressed state.
+    act(() => handlers.start?.({}));
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("stops recognition on a second click once recording", () => {
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+
+    fireEvent.click(button);
+    act(() => handlers.start?.({}));
+    fireEvent.click(button);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers the trimmed final transcript via onTranscript", () => {
+    const onTranscript = vi.fn();
+    render(<ComposerMicButton onTranscript={onTranscript} />);
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    act(() => handlers.start?.({}));
+
+    act(() => handlers.result?.(resultEvent("  hello world  ")));
+    expect(onTranscript).toHaveBeenCalledWith("hello world");
+  });
+
+  it("does not emit a transcript while the composer is disabled", () => {
+    const onTranscript = vi.fn();
+    render(<ComposerMicButton onTranscript={onTranscript} disabled />);
+    // The button is disabled, but a late recognition result must still be
+    // dropped by the disabled guard rather than reaching the callback.
+    act(() => handlers.result?.(resultEvent("late words")));
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a permission-denied error in the button tooltip", () => {
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+
+    act(() => handlers.error?.({ error: "not-allowed" }));
+    expect(button).toHaveAttribute("title", "Microphone permission denied");
+  });
+
+  it("ignores routine no-speech/aborted errors (no tooltip change)", () => {
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+
+    act(() => handlers.error?.({ error: "no-speech" }));
+    expect(button).toHaveAttribute("title", "Voice dictation");
+  });
+});

--- a/ap-web/src/pages/MembersPage.test.tsx
+++ b/ap-web/src/pages/MembersPage.test.tsx
@@ -1,0 +1,182 @@
+// Tests for the admin MembersPage (invite, password reset, delete user).
+//
+// Browser e2e is impractical (admin/accounts-gated — would need a second
+// authenticated server), so the surface is pinned here by mocking accountsApi
+// (getMe gates admin; listUsers/createInvite/resetUserPassword/deleteUser drive
+// the table + actions) and useNavigate (to observe the unauth → /login bounce).
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MembersPage } from "./MembersPage";
+import type { AccountListEntry } from "@/lib/accountsApi";
+import * as accountsApi from "@/lib/accountsApi";
+
+const navigateMock = vi.fn();
+
+vi.mock("@/lib/routing", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/routing")>()),
+  useNavigate: () => navigateMock,
+}));
+vi.mock("@/lib/accountsApi", () => ({
+  getMe: vi.fn(),
+  listUsers: vi.fn(),
+  createInvite: vi.fn(),
+  resetUserPassword: vi.fn(),
+  deleteUser: vi.fn(),
+}));
+
+function user(overrides: Partial<AccountListEntry> = {}): AccountListEntry {
+  return {
+    id: "bob",
+    is_admin: false,
+    created_at: null,
+    last_login_at: null,
+    has_password: true,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MembersPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(accountsApi.getMe).mockResolvedValue({
+    id: "admin",
+    is_admin: true,
+    created_at: null,
+    last_login_at: null,
+  });
+  vi.mocked(accountsApi.listUsers).mockResolvedValue([]);
+  vi.mocked(accountsApi.createInvite).mockResolvedValue({
+    ok: true,
+    token: "tok",
+    register_url: "https://app.example.com/register?invite=tok",
+    expires_at: 9_999_999_999,
+    is_admin: false,
+  });
+  vi.mocked(accountsApi.resetUserPassword).mockResolvedValue({
+    ok: true,
+    id: "bob",
+    new_password: "fresh-pw-123",
+  });
+  vi.mocked(accountsApi.deleteUser).mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("MembersPage gating", () => {
+  it("shows a loading state until the identity probe resolves", () => {
+    vi.mocked(accountsApi.getMe).mockReturnValue(new Promise(() => {})); // never resolves
+    renderPage();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("blocks non-admins with a permission message and never lists users", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue({
+      id: "alice",
+      is_admin: false,
+      created_at: null,
+      last_login_at: null,
+    });
+    renderPage();
+    expect(
+      await screen.findByText("You don't have permission to manage members."),
+    ).toBeInTheDocument();
+    expect(accountsApi.listUsers).not.toHaveBeenCalled();
+  });
+
+  it("bounces an unauthenticated visitor to /login", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+    renderPage();
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/login", { replace: true }));
+  });
+});
+
+describe("MembersPage table", () => {
+  it("renders an empty state when there are no members", async () => {
+    renderPage();
+    expect(await screen.findByText("No members yet.")).toBeInTheDocument();
+  });
+
+  it("lists members with role badges and marks the current admin", async () => {
+    vi.mocked(accountsApi.listUsers).mockResolvedValue([
+      user({ id: "admin", is_admin: true }),
+      user({ id: "bob" }),
+    ]);
+    renderPage();
+
+    const adminRow = (await screen.findByText("admin")).closest("tr")!;
+    expect(within(adminRow).getByText("Admin")).toBeInTheDocument();
+    expect(within(adminRow).getByText("(you)")).toBeInTheDocument();
+
+    const bobRow = screen.getByText("bob").closest("tr")!;
+    expect(within(bobRow).getByText("Member")).toBeInTheDocument();
+  });
+
+  it("disables Remove for the current user and Reset for external (passwordless) users", async () => {
+    vi.mocked(accountsApi.listUsers).mockResolvedValue([
+      user({ id: "admin", is_admin: true }),
+      user({ id: "ext", has_password: false }),
+    ]);
+    renderPage();
+
+    const adminRow = (await screen.findByText("admin")).closest("tr")!;
+    expect(within(adminRow).getByRole("button", { name: /Remove/ })).toBeDisabled();
+
+    const extRow = screen.getByText("ext").closest("tr")!;
+    expect(within(extRow).getByRole("button", { name: /Reset/ })).toBeDisabled();
+  });
+});
+
+describe("MembersPage actions", () => {
+  it("resets a user's password and shows the new password once", async () => {
+    vi.mocked(accountsApi.listUsers).mockResolvedValue([user({ id: "bob" })]);
+    renderPage();
+
+    const bobRow = (await screen.findByText("bob")).closest("tr")!;
+    fireEvent.click(within(bobRow).getByRole("button", { name: /Reset/ }));
+
+    await waitFor(() => expect(accountsApi.resetUserPassword).toHaveBeenCalledWith("bob"));
+    // The new password renders in a readonly, copyable input.
+    expect(await screen.findByDisplayValue("fresh-pw-123")).toBeInTheDocument();
+  });
+
+  it("deletes a user through the confirmation dialog and refreshes the list", async () => {
+    vi.mocked(accountsApi.listUsers)
+      .mockResolvedValueOnce([user({ id: "bob" })])
+      .mockResolvedValue([]); // after delete → refresh returns empty
+    renderPage();
+
+    const bobRow = (await screen.findByText("bob")).closest("tr")!;
+    fireEvent.click(within(bobRow).getByRole("button", { name: /Remove/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Remove bob?")).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Remove$/ }));
+
+    await waitFor(() => expect(accountsApi.deleteUser).toHaveBeenCalledWith("bob"));
+    expect(await screen.findByText("No members yet.")).toBeInTheDocument();
+  });
+
+  it("creates an invite and surfaces the single-use URL", async () => {
+    renderPage();
+    await screen.findByText("No members yet.");
+
+    fireEvent.click(screen.getByRole("button", { name: /Invite member/ }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /Create invite/ }));
+
+    await waitFor(() => expect(accountsApi.createInvite).toHaveBeenCalledWith(false));
+    // The single-use invite URL renders in a readonly, copyable input.
+    expect(await screen.findByDisplayValue(/register\?invite=tok/)).toBeInTheDocument();
+  });
+});

--- a/ap-web/src/pages/PoliciesPage.test.tsx
+++ b/ap-web/src/pages/PoliciesPage.test.tsx
@@ -1,0 +1,202 @@
+// Tests for the admin PoliciesPage (global default policies: list, toggle,
+// add, delete).
+//
+// Browser e2e is impractical (admin/accounts-gated), so the surface is pinned
+// here by mocking getMe (admin gate), useNavigate (unauth bounce), and the
+// react-query policy hooks (useDefaultPolicies / usePolicyRegistry +
+// add/update/delete mutations) so no QueryClient or network is needed.
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PoliciesPage } from "./PoliciesPage";
+import * as accountsApi from "@/lib/accountsApi";
+import * as defaultPolicies from "@/hooks/useDefaultPolicies";
+import * as policies from "@/hooks/usePolicies";
+
+const navigateMock = vi.fn();
+const addMutate = vi.fn();
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+const refetchMock = vi.fn();
+
+vi.mock("@/lib/routing", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/routing")>()),
+  useNavigate: () => navigateMock,
+}));
+vi.mock("@/lib/accountsApi", () => ({ getMe: vi.fn() }));
+vi.mock("@/hooks/useDefaultPolicies", () => ({
+  useDefaultPolicies: vi.fn(),
+  useAddDefaultPolicy: vi.fn(),
+  useUpdateDefaultPolicy: vi.fn(),
+  useDeleteDefaultPolicy: vi.fn(),
+}));
+vi.mock("@/hooks/usePolicies", () => ({ usePolicyRegistry: vi.fn() }));
+
+type Policy = ReturnType<typeof policy>;
+function policy(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "p1",
+    object: "default_policy",
+    name: "block_canada",
+    type: "python",
+    handler: "omnigent.policies.block_canada",
+    factory_params: null,
+    enabled: true,
+    created_at: 1,
+    updated_at: null,
+    created_by: null,
+    ...overrides,
+  };
+}
+
+/** A useMutation-shaped stub whose mutate invokes onSuccess synchronously. */
+function mutationStub(mutate: ReturnType<typeof vi.fn>) {
+  mutate.mockImplementation((_arg: unknown, opts?: { onSuccess?: () => void }) =>
+    opts?.onSuccess?.(),
+  );
+  return { mutate, isPending: false, isError: false, error: null };
+}
+
+function setPolicies(list: Policy[]) {
+  vi.mocked(defaultPolicies.useDefaultPolicies).mockReturnValue({
+    data: list,
+    refetch: refetchMock,
+  } as never);
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PoliciesPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(accountsApi.getMe).mockResolvedValue({
+    id: "admin",
+    is_admin: true,
+    created_at: null,
+    last_login_at: null,
+  });
+  setPolicies([]);
+  vi.mocked(policies.usePolicyRegistry).mockReturnValue({ data: [] } as never);
+  vi.mocked(defaultPolicies.useAddDefaultPolicy).mockReturnValue(mutationStub(addMutate) as never);
+  vi.mocked(defaultPolicies.useUpdateDefaultPolicy).mockReturnValue(
+    mutationStub(updateMutate) as never,
+  );
+  vi.mocked(defaultPolicies.useDeleteDefaultPolicy).mockReturnValue(
+    mutationStub(deleteMutate) as never,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PoliciesPage gating", () => {
+  it("shows a loading state until the identity probe resolves", () => {
+    vi.mocked(accountsApi.getMe).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("blocks non-admins with a permission message", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue({
+      id: "alice",
+      is_admin: false,
+      created_at: null,
+      last_login_at: null,
+    });
+    renderPage();
+    expect(
+      await screen.findByText("You don't have permission to manage global policies."),
+    ).toBeInTheDocument();
+  });
+
+  it("bounces an unauthenticated visitor to /login", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+    renderPage();
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/login", { replace: true }));
+  });
+});
+
+describe("PoliciesPage list", () => {
+  it("shows the empty state when no global policies are configured", async () => {
+    renderPage();
+    expect(await screen.findByText(/No global policies configured/)).toBeInTheDocument();
+  });
+
+  it("renders each policy with its handler, a Disabled badge, and parameters", async () => {
+    setPolicies([
+      policy({ id: "p1", name: "block_canada", enabled: false }),
+      policy({
+        id: "p2",
+        name: "rate_limit",
+        handler: "omnigent.policies.rate_limit",
+        factory_params: { max_per_min: 5 },
+      }),
+    ]);
+    renderPage();
+
+    expect(await screen.findByText("block_canada")).toBeInTheDocument();
+    expect(screen.getByText("omnigent.policies.block_canada")).toBeInTheDocument();
+    expect(screen.getByText("Disabled")).toBeInTheDocument(); // only the disabled one
+    // factory_params render as a "Parameters" block.
+    expect(screen.getByText("Parameters")).toBeInTheDocument();
+    expect(screen.getByText("max_per_min:")).toBeInTheDocument();
+  });
+});
+
+describe("PoliciesPage actions", () => {
+  it("toggling a policy's switch fires the update mutation with the new state", async () => {
+    setPolicies([policy({ id: "p1", name: "block_canada", enabled: true })]);
+    renderPage();
+
+    const toggle = await screen.findByRole("switch", { name: "Toggle block_canada" });
+    fireEvent.click(toggle);
+    expect(updateMutate).toHaveBeenCalledWith({ policyId: "p1", enabled: false });
+  });
+
+  it("deletes a policy through the confirmation dialog", async () => {
+    setPolicies([policy({ id: "p1", name: "block_canada" })]);
+    renderPage();
+
+    await screen.findByText("block_canada");
+    fireEvent.click(screen.getByRole("button", { name: "Remove policy" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Remove block_canada?")).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Remove$/ }));
+
+    expect(deleteMutate).toHaveBeenCalledWith("p1", expect.anything());
+  });
+
+  it("adds a global policy from the registry via the Add dialog", async () => {
+    vi.mocked(policies.usePolicyRegistry).mockReturnValue({
+      data: [
+        {
+          handler: "omnigent.policies.block_canada",
+          kind: "callable",
+          name: "Block Canada",
+          description: "Deny anything mentioning Canada.",
+          params_schema: null,
+        },
+      ],
+    } as never);
+    renderPage();
+    await screen.findByText(/No global policies configured/);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add policy/ }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByText("Block Canada")); // select the registry entry
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Add$/ }));
+
+    expect(addMutate).toHaveBeenCalledWith(
+      { name: "block_canada", type: "python", handler: "omnigent.policies.block_canada" },
+      expect.anything(),
+    );
+  });
+});

--- a/ap-web/src/pages/RegisterPage.test.tsx
+++ b/ap-web/src/pages/RegisterPage.test.tsx
@@ -47,7 +47,12 @@ beforeEach(() => {
       },
     },
   });
-  vi.mocked(accountsApi.register).mockResolvedValue({ ok: true });
+  vi.mocked(accountsApi.register).mockResolvedValue({
+    ok: true,
+    user: { id: "alice", is_admin: false },
+    token: "t",
+    expires_in: 3600,
+  });
 });
 
 afterEach(() => {
@@ -106,7 +111,11 @@ describe("RegisterPage", () => {
   });
 
   it("surfaces the server error on failure and does not navigate", async () => {
-    vi.mocked(accountsApi.register).mockResolvedValue({ ok: false, error: "invite expired" });
+    vi.mocked(accountsApi.register).mockResolvedValue({
+      ok: false,
+      error: "invite expired",
+      status: 400,
+    });
     renderRegisterAt("?invite=tok123");
     fillForm("alice", "longenough", "longenough");
     fireEvent.click(screen.getByRole("button", { name: /create account/i }));

--- a/ap-web/src/pages/RegisterPage.test.tsx
+++ b/ap-web/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,117 @@
+// Tests for RegisterPage (the /register?invite=… invite-redemption page).
+//
+// Mirrors LoginPage.test.tsx: window.location.href is stubbed so success
+// navigation is observable without jsdom navigating. The page calls
+// register() from accountsApi; success hard-navigates to "/", failure shows a
+// role="alert". The page also gates on the invite query param (missing → alert,
+// no form).
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RegisterPage } from "./RegisterPage";
+import * as accountsApi from "@/lib/accountsApi";
+
+vi.mock("@/lib/accountsApi", () => ({ register: vi.fn() }));
+
+const ORIGIN = "https://app.example.com";
+let hrefWrites: string[];
+let originalLocation: Location;
+
+function renderRegisterAt(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/register${search}`]}>
+      <RegisterPage />
+    </MemoryRouter>,
+  );
+}
+
+function fillForm(username: string, password: string, confirm: string) {
+  fireEvent.change(screen.getByLabelText(/username/i), { target: { value: username } });
+  fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: password } });
+  fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: confirm } });
+}
+
+beforeEach(() => {
+  hrefWrites = [];
+  originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      origin: ORIGIN,
+      set href(value: string) {
+        hrefWrites.push(value);
+      },
+      get href() {
+        return hrefWrites[hrefWrites.length - 1] ?? `${ORIGIN}/register`;
+      },
+    },
+  });
+  vi.mocked(accountsApi.register).mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+});
+
+describe("RegisterPage", () => {
+  it("shows an invite-required alert and no form when the invite token is missing", () => {
+    renderRegisterAt("");
+    expect(screen.getByRole("alert")).toHaveTextContent(/invite token/i);
+    expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the form when an invite token is present", () => {
+    renderRegisterAt("?invite=tok123");
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create account/i })).toBeInTheDocument();
+  });
+
+  it("disables submit until a username and an 8+ char password are entered", () => {
+    renderRegisterAt("?invite=tok123");
+    const submit = screen.getByRole("button", { name: /create account/i });
+    expect(submit).toBeDisabled();
+
+    fillForm("alice", "short", "short");
+    expect(submit).toBeDisabled(); // password < 8
+
+    fillForm("alice", "longenough", "longenough");
+    expect(submit).toBeEnabled();
+  });
+
+  it("blocks submit and shows an error when the passwords don't match", () => {
+    renderRegisterAt("?invite=tok123");
+    fillForm("alice", "longenough", "different1");
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Passwords don't match.");
+    expect(accountsApi.register).not.toHaveBeenCalled();
+  });
+
+  it("redeems the invite and navigates home on success", async () => {
+    renderRegisterAt("?invite=tok123");
+    fillForm("alice", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() =>
+      expect(accountsApi.register).toHaveBeenCalledWith({
+        invite: "tok123",
+        username: "alice",
+        password: "longenough",
+      }),
+    );
+    await waitFor(() => expect(hrefWrites[0]).toBe("/"));
+  });
+
+  it("surfaces the server error on failure and does not navigate", async () => {
+    vi.mocked(accountsApi.register).mockResolvedValue({ ok: false, error: "invite expired" });
+    renderRegisterAt("?invite=tok123");
+    fillForm("alice", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("invite expired");
+    expect(hrefWrites).toHaveLength(0);
+  });
+});

--- a/ap-web/src/pages/SetupPage.test.tsx
+++ b/ap-web/src/pages/SetupPage.test.tsx
@@ -46,7 +46,12 @@ beforeEach(() => {
       },
     },
   });
-  vi.mocked(accountsApi.setup).mockResolvedValue({ ok: true });
+  vi.mocked(accountsApi.setup).mockResolvedValue({
+    ok: true,
+    user: { id: "root", is_admin: true },
+    token: "t",
+    expires_in: 3600,
+  });
 });
 
 afterEach(() => {
@@ -105,7 +110,11 @@ describe("SetupPage", () => {
   });
 
   it("surfaces a non-409 error inline without navigating", async () => {
-    vi.mocked(accountsApi.setup).mockResolvedValue({ ok: false, error: "weak password" });
+    vi.mocked(accountsApi.setup).mockResolvedValue({
+      ok: false,
+      error: "weak password",
+      status: 400,
+    });
     renderSetup();
     fillForm("root", "longenough", "longenough");
     fireEvent.click(screen.getByRole("button", { name: /create admin/i }));

--- a/ap-web/src/pages/SetupPage.test.tsx
+++ b/ap-web/src/pages/SetupPage.test.tsx
@@ -1,0 +1,116 @@
+// Tests for SetupPage (first-run "Create admin" page, shown when /v1/info
+// reports needs_setup).
+//
+// Mirrors LoginPage.test.tsx's window.location capture. The page calls setup()
+// from accountsApi; success hard-navigates to "/", a 409 (someone else claimed
+// admin first) bounces to "/login", and other failures show a role="alert".
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SetupPage } from "./SetupPage";
+import * as accountsApi from "@/lib/accountsApi";
+
+vi.mock("@/lib/accountsApi", () => ({ setup: vi.fn() }));
+
+const ORIGIN = "https://app.example.com";
+let hrefWrites: string[];
+let originalLocation: Location;
+
+function renderSetup() {
+  return render(
+    <MemoryRouter initialEntries={["/setup"]}>
+      <SetupPage />
+    </MemoryRouter>,
+  );
+}
+
+function fillForm(username: string, password: string, confirm: string) {
+  fireEvent.change(screen.getByLabelText(/username/i), { target: { value: username } });
+  fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: password } });
+  fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: confirm } });
+}
+
+beforeEach(() => {
+  hrefWrites = [];
+  originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      origin: ORIGIN,
+      set href(value: string) {
+        hrefWrites.push(value);
+      },
+      get href() {
+        return hrefWrites[hrefWrites.length - 1] ?? `${ORIGIN}/setup`;
+      },
+    },
+  });
+  vi.mocked(accountsApi.setup).mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+});
+
+describe("SetupPage", () => {
+  it("disables submit until a username and an 8+ char password are entered", () => {
+    renderSetup();
+    const submit = screen.getByRole("button", { name: /create admin/i });
+    expect(submit).toBeDisabled();
+
+    fillForm("root", "short", "short");
+    expect(submit).toBeDisabled();
+
+    fillForm("root", "longenough", "longenough");
+    expect(submit).toBeEnabled();
+  });
+
+  it("blocks submit and shows an error when the passwords don't match", () => {
+    renderSetup();
+    fillForm("root", "longenough", "different1");
+    fireEvent.click(screen.getByRole("button", { name: /create admin/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Passwords don't match.");
+    expect(accountsApi.setup).not.toHaveBeenCalled();
+  });
+
+  it("claims the admin and navigates home on success", async () => {
+    renderSetup();
+    fillForm("root", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create admin/i }));
+
+    await waitFor(() =>
+      expect(accountsApi.setup).toHaveBeenCalledWith({
+        username: "root",
+        password: "longenough",
+      }),
+    );
+    await waitFor(() => expect(hrefWrites[0]).toBe("/"));
+  });
+
+  it("bounces to /login when setup 409s (admin already claimed)", async () => {
+    vi.mocked(accountsApi.setup).mockResolvedValue({
+      ok: false,
+      error: "setup already completed",
+      status: 409,
+    });
+    renderSetup();
+    fillForm("root", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create admin/i }));
+
+    await waitFor(() => expect(hrefWrites[0]).toBe("/login"));
+  });
+
+  it("surfaces a non-409 error inline without navigating", async () => {
+    vi.mocked(accountsApi.setup).mockResolvedValue({ ok: false, error: "weak password" });
+    renderSetup();
+    fillForm("root", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create admin/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("weak password");
+    expect(hrefWrites).toHaveLength(0);
+  });
+});

--- a/ap-web/src/shell/AccountMenu.test.tsx
+++ b/ap-web/src/shell/AccountMenu.test.tsx
@@ -1,0 +1,170 @@
+// Tests for AccountMenu's accounts-mode gating and dropdown surface.
+//
+// AccountMenu renders nothing unless (1) /v1/info reports accounts_enabled and
+// (2) /auth/me resolves to an account. When both hold it shows the signed-in
+// id, an "(admin)" marker + Members/Policies links for admins, and the
+// Change-password / Sign-out actions. None of that had coverage: the component
+// is mocked to null in every Sidebar test, so these pin the gating booleans and
+// the menu items directly.
+//
+// useServerInfo and the accountsApi calls (getMe/changePassword/logout) are
+// mocked so the component runs without a server; Link needs a router context.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountMenu } from "./AccountMenu";
+import type { CurrentAccount } from "@/lib/accountsApi";
+import type { ServerInfo } from "@/lib/capabilities";
+import * as accountsApi from "@/lib/accountsApi";
+import { useServerInfo } from "@/lib/CapabilitiesContext";
+
+vi.mock("@/lib/CapabilitiesContext", () => ({ useServerInfo: vi.fn() }));
+vi.mock("@/lib/accountsApi", () => ({
+  getMe: vi.fn(),
+  changePassword: vi.fn(),
+  logout: vi.fn(),
+}));
+
+const ACCOUNTS_ON: ServerInfo = {
+  accounts_enabled: true,
+  login_url: "/login",
+  needs_setup: false,
+  databricks_features: false,
+  managed_sandboxes_enabled: false,
+  sandbox_provider: null,
+};
+const ACCOUNTS_OFF: ServerInfo = { ...ACCOUNTS_ON, accounts_enabled: false, login_url: null };
+
+function account(overrides: Partial<CurrentAccount> = {}): CurrentAccount {
+  return { id: "alice", is_admin: false, created_at: null, last_login_at: null, ...overrides };
+}
+
+function renderMenu() {
+  return render(
+    <MemoryRouter>
+      <AccountMenu />
+    </MemoryRouter>,
+  );
+}
+
+/** Open the account dropdown. Radix DropdownMenu opens on pointerdown, not click. */
+async function openMenu(triggerName: RegExp) {
+  fireEvent.pointerDown(await screen.findByRole("button", { name: triggerName }), { button: 0 });
+}
+
+beforeEach(() => {
+  vi.mocked(useServerInfo).mockReturnValue(ACCOUNTS_ON);
+  vi.mocked(accountsApi.getMe).mockResolvedValue(account());
+  vi.mocked(accountsApi.changePassword).mockResolvedValue({ ok: true });
+  vi.mocked(accountsApi.logout).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AccountMenu gating", () => {
+  it("renders nothing when accounts mode is off (and never calls /auth/me)", () => {
+    vi.mocked(useServerInfo).mockReturnValue(ACCOUNTS_OFF);
+    const { container } = renderMenu();
+    expect(container).toBeEmptyDOMElement();
+    expect(accountsApi.getMe).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing while the capabilities probe is still loading", () => {
+    vi.mocked(useServerInfo).mockReturnValue("loading");
+    const { container } = renderMenu();
+    expect(container).toBeEmptyDOMElement();
+    expect(accountsApi.getMe).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when /auth/me returns no account", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+    const { container } = renderMenu();
+    await waitFor(() => expect(accountsApi.getMe).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the signed-in account id once accounts is on and /auth/me resolves", async () => {
+    renderMenu();
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+  });
+});
+
+describe("AccountMenu dropdown surface", () => {
+  it("hides admin-only links for a non-admin and shows Change password / Sign out", async () => {
+    renderMenu();
+    await openMenu(/alice/);
+
+    expect(await screen.findByRole("menuitem", { name: /Change password/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Sign out/ })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Members/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Policies/ })).not.toBeInTheDocument();
+  });
+
+  it("shows Members + Policies links and the (admin) marker for an admin", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(account({ id: "root", is_admin: true }));
+    renderMenu();
+    await openMenu(/root/);
+
+    expect(await screen.findByRole("menuitem", { name: /Members/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Policies/ })).toBeInTheDocument();
+    expect(screen.getByText("(admin)")).toBeInTheDocument();
+  });
+
+  it("Sign out calls logout", async () => {
+    renderMenu();
+    await openMenu(/alice/);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Sign out/ }));
+    await waitFor(() => expect(accountsApi.logout).toHaveBeenCalledTimes(1));
+  });
+
+  it("Change password opens a dialog and submits the new password", async () => {
+    renderMenu();
+    await openMenu(/alice/);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Change password/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(screen.getByPlaceholderText("Current password"), {
+      target: { value: "oldpw" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("New password"), {
+      target: { value: "newpw-12345" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Confirm new password"), {
+      target: { value: "newpw-12345" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Change password" }));
+
+    await waitFor(() =>
+      expect(accountsApi.changePassword).toHaveBeenCalledWith({
+        old_password: "oldpw",
+        new_password: "newpw-12345",
+      }),
+    );
+    expect(await screen.findByText("Your password has been changed.")).toBeInTheDocument();
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("blocks submit and shows an error when the new passwords don't match", async () => {
+    renderMenu();
+    await openMenu(/alice/);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Change password/ }));
+
+    fireEvent.change(await screen.findByPlaceholderText("Current password"), {
+      target: { value: "oldpw" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("New password"), {
+      target: { value: "newpw-12345" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Confirm new password"), {
+      target: { value: "different" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Change password" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("New passwords don't match.");
+    expect(accountsApi.changePassword).not.toHaveBeenCalled();
+  });
+});

--- a/tests/e2e_ui/COVERAGE_GAPS.md
+++ b/tests/e2e_ui/COVERAGE_GAPS.md
@@ -1,7 +1,7 @@
 # E2E UI Test Coverage Gaps
 
 Cross-reference of user-facing features reachable from `ap-web/` against the
-existing Playwright suite under `tests/e2e_ui/`. The suite (57 files) covers the
+existing Playwright suite under `tests/e2e_ui/`. The suite (58 files) covers the
 core journeys well — chat, sessions sidebar, files, comments, collaboration,
 render parity, fork, shells, mobile, and start-session. The items below are
 features that currently have **no e2e coverage**.
@@ -23,28 +23,35 @@ Status legend: ✅ now covered · ⬜ still open.
 
 ## Medium-priority gaps
 
-| Feature | Where it lives |
-|---|---|
-| **Slash command menu** | `components/SlashCommandMenu.tsx` — typing `/` to autocomplete skills/commands |
-| **File/image attachments, paste, screenshot** | `ai-elements/prompt-input.tsx`, `attachments.tsx` — composer attachment flows |
-| **Model selector / cost-routing control** in composer | `ai-elements/model-selector.tsx`, `components/CostRoutingControl.tsx` |
-| **Code editing in Monaco / diff viewer** | `shell/MonacoCodeEditor.tsx`, `MonacoDiffViewer.tsx` — autosave is tested but diff view + direct edit isn't |
-| **Execution logs panel** | `shell/ExecutionLogsPanel.tsx` — raw JSON items + sub-agent log selector |
-| **Reconnect / resume-with-directory dialogs** | `shell/ReconnectSessionDialog.tsx`, `shell/ResumeWithDirectoryDialog.tsx` |
-| **Account menu / theme toggle** | `shell/AccountMenu.tsx`, `theme/ThemeModeMenu.tsx` |
-| **Prompt history (arrow-key recall)** | `hooks/usePromptHistory.ts` |
-| **Session archive/unarchive** | `shell/Sidebar.tsx` — pin/unpin/delete/rename tested, archive not |
+Status legend: ✅ e2e covered · 🧪 covered by ap-web vitest (`npm test`) — e2e adds little · ⬜ still open.
+
+| Status | Feature | Where it lives | Coverage |
+|---|---|---|---|
+| 🧪 | **Slash command menu** | `components/SlashCommandMenu.tsx` — typing `/` to autocomplete skills/commands | `ap-web/src/pages/ChatPage.composer.test.tsx` already pins the full menu UX (first-match highlight, Tab/Enter completion, ArrowDown nav, `/model` & `/effort` routing). A browser-level e2e would only re-cover the same logic, so it's left to vitest. |
+| ✅ | **File/image attachments, paste, screenshot** | `pages/ChatPage.tsx` composer (paperclip → hidden file input, paste, drag-drop) | `chat/test_composer_attachments.py` — `set_input_files` on the hidden input attaches a file, the chip + `Remove {filename}` button appear, and the remove click clears it. The ChatPage composer attach/remove path has no vitest coverage and the file-picker can't be unit-driven, so this is the browser-only piece. |
+| 🧪 | **Model selector / cost-routing control** in composer | `components/ai-elements/model-selector.tsx`, `components/CostRoutingControl.tsx` | Not reachable for the e2e `hello_world` fixture: cost-routing is UI-disabled (`{false && costRoutingEligible …}` in `ChatPage.tsx`) and only ever applies to the `polly` agent, and the model picker renders only for `claude-code-native-ui` wrapper sessions (would need a real Claude-native boot). The logic is unit-covered by `CostRoutingControl.test.tsx` and the `/model` routing cases in `ChatPage.composer.test.tsx`. Re-evaluate if cost-routing is re-enabled. |
+| 🧪 | **Code editing in Monaco / diff viewer** | `shell/MonacoCodeEditor.tsx`, `MonacoDiffViewer.tsx` — autosave is tested but diff view wasn't | Diff view can't be driven in this harness: the diff button only renders when the file is in `GET .../changes` (`isDiffAvailable`), but the e2e runner is spawned via `omnigent.runner._entry` **without** `RUNNER_WORKSPACE_ENV_VAR`, so `runner_workspace` is `None` → no filesystem registry → `/changes` is always `[]` and `/diff` 404 regardless of seeding (verified empirically). Reaching it would need the conftest to give the runner workspace affinity (and resolve git-vs-snapshot baseline semantics). The diff logic itself is unit-covered: `MonacoDiffViewer.test.tsx` (DiffEditor wiring, Monaco mocked) and `FileViewer.test.tsx` (`?diff=1` open + toggle URL sync). Direct-edit autosave: `files/test_file_autosave.py`. |
+| ✅ | **Reconnect / resume-with-directory dialogs** | `shell/ReconnectSessionDialog.tsx`, `shell/ResumeWithDirectoryDialog.tsx` | Reconnect dialog is covered at both levels — `sessions/test_sidebar_stop.py` drops the runner → "disconnected, click to reconnect" banner → click → `reconnect-session-dialog` with the resume command, plus `ReconnectSessionDialog.test.tsx`. The resume-with-directory dialog's host-bound launch path has no e2e (it needs a connected `omnigent host` daemon the harness doesn't spawn — see `test_clone_session.py`), but is unit-covered by `ResumeWithDirectoryDialog.test.tsx` + `WorkspacePicker.test.tsx`. |
+| ✅ | **Theme toggle** | `theme/ThemeModeMenu.tsx` | `sessions/test_theme_toggle.py` — cycles the sidebar theme button system → dark → light, pinning each step to the `<html>` `dark` class and the persisted `localStorage["ap-web-theme"]`. Previously had no coverage anywhere: the menu is mocked to `null` in every Sidebar vitest test, and only the pure helpers in `themeMode.test.ts` were exercised. |
+| 🧪 | **Account menu** | `shell/AccountMenu.tsx` | `ap-web/src/shell/AccountMenu.test.tsx` — pins the accounts-mode gating (off / loading / no-account → renders nothing; never hits `/auth/me` when off), the signed-in id, admin-only Members/Policies links + `(admin)` marker, and the Change-password / Sign-out actions. Browser e2e is impractical here: `AccountMenu` only renders on an accounts-enabled authenticated deploy, which would need a *second* server (auth would 401 the shared suite) + its own runner + login-cookie plumbing — see `omnigent server`'s `OMNIGENT_AUTH_PROVIDER=accounts` path if that integration is ever wanted. |
+| 🧪 | **Prompt history (arrow-key recall)** | `hooks/usePromptHistory.ts` | The recall hook is unit-tested by `usePromptHistory.test.ts`; only the in-composer ArrowUp/Down wiring is un-e2e'd. |
+| 🧪 | **Session archive/unarchive** | `shell/Sidebar.tsx` — pin/unpin/delete/rename tested, archive not | Row-action logic is unit-covered by `Sidebar.archive.test.tsx`; no browser e2e. |
 
 ## Lower-priority / admin & auth gaps
 
-| Feature | Where it lives |
-|---|---|
-| **Admin: Members page** (invite, password reset, delete user) | `pages/MembersPage.tsx` |
-| **Admin: Policies page** | `pages/PoliciesPage.tsx` |
-| **Auth: Login / Register / Setup** | `pages/LoginPage.tsx`, `RegisterPage.tsx`, `SetupPage.tsx` |
-| **Voice/audio input** (mic button, transcription, audio player) | `ComposerMicButton.tsx`, `ai-elements/{transcription,audio-player,voice-selector}.tsx` |
-| **Rich message blocks** (web-preview, JSX preview, chain-of-thought, test-results, etc.) | `ai-elements/*` |
-| **Panel resize handles** | `hooks/useResizable{Panel,Sidebar,CommentsPanel}.ts` |
+These are all better covered by ap-web vitest than by e2e: the admin/auth pages
+are accounts-gated (e2e blocked by the same harness limit as the account menu),
+voice can't be driven by a real mic in CI, and the rest is pure component/hook
+logic. Status legend: 🧪 vitest-covered · ⬜ open · ⛔ not wired into the app.
+
+| Status | Feature | Where it lives | Coverage |
+|---|---|---|---|
+| 🧪 | **Admin: Members page** (invite, password reset, delete user) | `pages/MembersPage.tsx` | `pages/MembersPage.test.tsx` — admin gating (loading / non-admin / unauth → `/login`), member table + role badges, Reset/Remove disabled rules, the delete-confirm + invite + reset flows pinned to the mocked `accountsApi`. e2e impractical (accounts-gated — needs a second authenticated server). |
+| 🧪 | **Admin: Policies page** | `pages/PoliciesPage.tsx` | `pages/PoliciesPage.test.tsx` — admin gating, policy list (handler/Disabled badge/params), enable toggle, delete-confirm, and add-from-registry, with the react-query policy hooks mocked. e2e impractical (accounts-gated). |
+| 🧪 | **Auth: Login / Register / Setup** | `pages/LoginPage.tsx`, `RegisterPage.tsx`, `SetupPage.tsx` | `LoginPage.test.tsx` (open-redirect defense) + new `RegisterPage.test.tsx` / `SetupPage.test.tsx` — invite gating, password-match/length validation, success navigation, error surfacing, and Setup's 409 → `/login` bounce. e2e impractical (auth-gated). |
+| 🧪 | **Voice/audio input** (mic button) | `components/ComposerMicButton.tsx` | `components/ComposerMicButton.test.tsx` — stubs the Web Speech `SpeechRecognition` ctor to drive idle/recording toggle, transcript delivery, the disabled guard, and permission-denied tooltip; renders nothing without speech support. e2e can't drive a real mic. The `ai-elements/{transcription,audio-player,voice-selector,speech-input,mic-selector}` kit is **not imported anywhere in the app** (⛔). |
+| ⛔ | **Rich message blocks** (web-preview, JSX preview, chain-of-thought, test-results) | `ai-elements/*` | Not wired into the app — 0 importers. The renderer uses only `ai-elements/{code-block,message,reasoning,shimmer,conversation}`; `message`/`reasoning` are unit-tested and the text path is e2e-covered by `messages/test_message_render_parity.py`. Testing the named blocks would test a vendored kit, not the product. |
+| 🧪 | **Panel resize handles** | `hooks/useResizable{Panel,Sidebar,CommentsPanel,InlinePanel}.ts` | All four hooks have dedicated unit tests (`useResizable*.test.tsx`) covering the drag/clamp/persist math; e2e adds nothing. |
 
 ## Well-covered areas (no action needed)
 

--- a/tests/e2e_ui/chat/test_composer_attachments.py
+++ b/tests/e2e_ui/chat/test_composer_attachments.py
@@ -33,7 +33,9 @@ _ATTACH_NAME = "attach_sample.txt"
 _ATTACH_BODY = "composer attachment e2e sample\n"
 
 
-def test_attach_then_remove_file(page: Page, seeded_session: tuple[str, str], tmp_path: Path) -> None:
+def test_attach_then_remove_file(
+    page: Page, seeded_session: tuple[str, str], tmp_path: Path
+) -> None:
     """Attach a file via the hidden input → chip + remove button appear → remove clears it."""
     base_url, session_id = seeded_session
     sample = tmp_path / _ATTACH_NAME

--- a/tests/e2e_ui/chat/test_composer_attachments.py
+++ b/tests/e2e_ui/chat/test_composer_attachments.py
@@ -1,0 +1,59 @@
+"""E2E: attaching and removing files in the chat composer.
+
+The composer (``pages/ChatPage.tsx``) lets the user attach files via the
+paperclip button (which clicks a hidden ``<input type="file">``), paste, or
+drag-drop. Each attached file renders as a chip below the textarea with a
+per-file remove button; on send the files are embedded inline in the message
+(there is no separate upload endpoint), and ``removeFile`` drops a chip.
+
+This flow has no coverage below the browser: no ap-web vitest test exercises
+the ChatPage composer's ``addFiles`` / ``removeFile`` path, and the attach
+mechanism (a real hidden file input populated by the OS file picker) is exactly
+what a unit test can't drive. Playwright's ``set_input_files`` populates the
+hidden input directly — the same change event the picker fires — so the
+attach → chip → remove cycle is fully deterministic and needs no agent turn or
+network: the chips are local component state.
+
+The assertion pins to the chip's per-file remove control
+(``aria-label="Remove {filename}"``, ChatPage.tsx) appearing after attach and
+disappearing after the remove click.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+# Composer accepts image/*,application/pdf,text/* (the hidden input's accept
+# attr); a .txt file is in-scope and keeps the fixture trivial. ``set_input_files``
+# bypasses the accept filter anyway — ``addFiles`` does no client-side filtering.
+_ATTACH_NAME = "attach_sample.txt"
+_ATTACH_BODY = "composer attachment e2e sample\n"
+
+
+def test_attach_then_remove_file(page: Page, seeded_session: tuple[str, str], tmp_path: Path) -> None:
+    """Attach a file via the hidden input → chip + remove button appear → remove clears it."""
+    base_url, session_id = seeded_session
+    sample = tmp_path / _ATTACH_NAME
+    sample.write_text(_ATTACH_BODY)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+
+    # The attach affordance is a paperclip button; its click target is the
+    # hidden file input. Drive the input directly (the picker can't be scripted).
+    file_input = page.locator('input[type="file"][accept*="image/"]')
+    file_input.set_input_files(str(sample))
+
+    # The chip renders below the textarea with a per-file remove button whose
+    # accessible name carries the filename.
+    remove_button = page.get_by_role("button", name=f"Remove {_ATTACH_NAME}")
+    expect(remove_button).to_be_visible(timeout=10_000)
+    expect(page.get_by_text(_ATTACH_NAME, exact=True)).to_be_visible()
+
+    # Removing the chip drops it from composer state.
+    remove_button.click()
+    expect(remove_button).to_be_hidden(timeout=10_000)
+    expect(page.get_by_text(_ATTACH_NAME, exact=True)).to_be_hidden()

--- a/tests/e2e_ui/sessions/test_theme_toggle.py
+++ b/tests/e2e_ui/sessions/test_theme_toggle.py
@@ -39,7 +39,7 @@ def _stored_theme(page: Page) -> str | None:
 
 
 def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
-    """Clicking the sidebar theme button cycles system → dark → light, flipping <html> + storage."""
+    """Clicking the sidebar theme button cycles system → dark → light, flipping the theme state."""
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
     expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/sessions/test_theme_toggle.py
+++ b/tests/e2e_ui/sessions/test_theme_toggle.py
@@ -1,0 +1,71 @@
+"""E2E: the sidebar theme toggle cycles the app theme and persists it.
+
+The sidebar header carries a single icon button (``components/theme/
+ThemeModeMenu.tsx``) that cycles ``system → dark → light`` on each click; the
+icon and ``aria-label`` preview the *next* mode ("Switch to Dark", etc.). The
+provider (``components/theme/ThemeProvider.tsx``) is next-themes configured with
+``attribute="class"`` + ``storageKey="ap-web-theme"`` + ``defaultTheme="system"``,
+so a selection toggles the ``dark`` class on ``<html>`` and writes the choice to
+``localStorage["ap-web-theme"]``.
+
+This is the one item in the medium-priority gap list with no coverage anywhere:
+the menu component is mocked to ``null`` in every Sidebar vitest test, and only
+the pure helpers (``themeMode.test.ts``) are exercised — neither the real DOM
+class flip nor the persistence is. (The sibling ``AccountMenu`` is gated behind
+an accounts-enabled, authenticated deploy, so it does not render on this
+single-user local server and stays out of reach in this harness.)
+
+A fresh Playwright context starts with no stored preference (mode ``system``),
+so the button reliably reads "Switch to Dark" on load; the test then drives the
+deterministic cycle and pins each step to both the ``<html>`` class and the
+persisted ``localStorage`` value. No LLM turn is involved.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+
+
+def _html_has_dark(page: Page) -> bool:
+    """True when the ``dark`` class is applied to ``<html>`` (next-themes)."""
+    return page.evaluate("() => document.documentElement.classList.contains('dark')")
+
+
+def _stored_theme(page: Page) -> str | None:
+    """The persisted theme preference, or None when unset (default ``system``)."""
+    return page.evaluate("() => window.localStorage.getItem('ap-web-theme')")
+
+
+def test_theme_toggle_cycles_and_persists(page: Page, seeded_session: tuple[str, str]) -> None:
+    """Clicking the sidebar theme button cycles system → dark → light, flipping <html> + storage."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+
+    # Fresh context → no stored preference → mode is the default "system", so
+    # the button advertises the first cycle step.
+    to_dark = page.get_by_role("button", name="Switch to Dark")
+    expect(to_dark).to_be_visible(timeout=15_000)
+    assert _stored_theme(page) is None, "expected no persisted theme on a fresh load"
+
+    # system → dark: the dark class lands and the choice persists; the button
+    # now advertises the next step.
+    to_dark.click()
+    to_light = page.get_by_role("button", name="Switch to Light")
+    expect(to_light).to_be_visible(timeout=15_000)
+    assert _html_has_dark(page), "<html> did not gain the dark class after switching to dark"
+    assert _stored_theme(page) == "dark"
+
+    # dark → light: the dark class clears and "light" persists.
+    to_light.click()
+    to_system = page.get_by_role("button", name="Switch to System")
+    expect(to_system).to_be_visible(timeout=15_000)
+    assert not _html_has_dark(page), "<html> kept the dark class after switching to light"
+    assert _stored_theme(page) == "light"
+
+    # light → system: the cycle closes and "system" persists.
+    to_system.click()
+    expect(page.get_by_role("button", name="Switch to Dark")).to_be_visible(timeout=15_000)
+    assert _stored_theme(page) == "system"


### PR DESCRIPTION
## What

Works through the medium- and lower-priority rows in `tests/e2e_ui/COVERAGE_GAPS.md`, adding a test at whichever level actually fits each feature and reconciling the doc to reality.

### New Playwright e2e (browser is where the value is)
- **`chat/test_composer_attachments.py`** — attach a file via the hidden file input, assert the chip + per-file `Remove {filename}` button appear, then removing clears it. Client-side only; no agent turn. (The ChatPage composer attach/remove path had no coverage anywhere and the picker can't be unit-driven.)
- **`sessions/test_theme_toggle.py`** — the sidebar theme button cycles `system → dark → light`, pinned to the `<html>` `dark` class and the persisted `localStorage["ap-web-theme"]`. (The menu is mocked to `null` in every Sidebar vitest test, so the real DOM flip + persistence was untested.)

### New ap-web vitest (where e2e is impractical)
These are accounts/admin-gated (e2e would need a second authenticated server), need a real mic CI can't provide, or are pure component logic:
- **`shell/AccountMenu.test.tsx`** — accounts-mode gating (off / loading / no-account) + dropdown surface (admin links, change-password, sign-out).
- **`pages/MembersPage.test.tsx`**, **`pages/PoliciesPage.test.tsx`** — admin gating + the CRUD/action flows, with `accountsApi` and the react-query policy hooks mocked.
- **`pages/RegisterPage.test.tsx`**, **`pages/SetupPage.test.tsx`** — invite gating, password validation, success navigation, error surfacing, Setup's 409 → `/login` bounce.
- **`components/ComposerMicButton.test.tsx`** — stubs the Web Speech `SpeechRecognition` ctor to cover the record toggle, transcript delivery, the disabled guard, the permission-denied tooltip, and the no-support render-nothing path.

### Doc reconciliation
`COVERAGE_GAPS.md` now carries per-row status (✅ e2e-covered / 🧪 vitest-covered / ⛔ not-wired / ⬜ open) with rationale, and documents what stays blocked by **harness setup** rather than missing test logic:
- Monaco **diff view** needs the e2e runner to have workspace affinity (`/changes` is always empty otherwise);
- the **account / admin / auth pages** need an accounts-enabled server (auth would 401 the shared suite);
- **resume-with-directory**'s host-bound launch needs a connected `omnigent host` daemon.

It also records that the named "rich message blocks" (web-preview, JSX preview, chain-of-thought, test-results) are **unused vendored kit** — 0 importers — so neither level is warranted.

## Testing
- ap-web vitest: 36 new tests across the 6 files, all passing; oxlint + prettier clean.
- Playwright e2e: `test_composer_attachments.py` and `test_theme_toggle.py` each run green against a freshly built SPA + spawned server.
- `uv.lock` change (incidental rebuild artifact) reverted; not part of this PR.

This pull request and its description were written by Isaac.