### PR TITLE
ci(fork-e2e): gate secret e2e on the e2e-approved label only

### DIFF
--- a/.github/scripts/fork-e2e/should-mirror.sh
+++ b/.github/scripts/fork-e2e/should-mirror.sh
@@ -3,22 +3,26 @@
 # fork-e2e/pr-N branch (which lets e2e run as a `push` with the test-gateway
 # secrets). Called by .github/workflows/fork-e2e-mirror.yml.
 #
-# Gate (any one opens it):
-#   1. The fork-e2e/pr-N branch already exists -> always re-mirror, so new
-#      commits on an already-opened PR re-run e2e.
-#   2. Returning contributor -- author_association is OWNER / MEMBER /
-#      COLLABORATOR / CONTRIBUTOR (GitHub's own "has contributed before"
-#      signal; first-timers are FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / NONE).
-#   3. Maintainer-approved -- the author is in .github/MAINTAINER, or a
-#      maintainer's latest non-COMMENTED review is APPROVED.
+# Gate: the PR currently carries the `e2e-approved` label AND that label was
+# last applied by a maintainer (in .github/MAINTAINER@main). GitHub only lets
+# Triage+ users apply labels, so an external fork author can never apply it; the
+# maintainer check further narrows "anyone with Triage" down to the MAINTAINER
+# list. We read the *labeler* from the issue-events timeline rather than the
+# event sender, so the check still holds on `synchronize` (where the sender is
+# the fork author pushing new commits, not the maintainer who labeled earlier).
 #
-# Case 3 deliberately mirrors maintainer-approval.yml's computation (same
-# MAINTAINER list via load-maintainers.sh, same review semantics). Keep the two
-# in sync; a drift only over-/under-opens the mirror gate (bounded by the
-# rate-limited, revocable test token), it can't bypass the merge gate.
+# The label is intentionally separate from the merge gate (maintainer-approval.yml):
+# labeling runs e2e but does NOT approve the PR for merge, and approving for
+# merge does NOT run e2e. New commits while the label is present re-mirror
+# automatically (this script re-runs on `synchronize`); the security scan plus
+# the maintainer's review are the safety net for post-approval pushes. Removing
+# the label (or closing the PR) deletes the mirror branch -- see the workflow.
 #
-# Env in:  GH_TOKEN, REPO, PR, AUTHOR_ASSOCIATION, MAINTAINERS (space-separated,
-#          from load-maintainers.sh), MIRROR_BRANCH (e.g. fork-e2e/pr-123).
+# Fail closed: any error or unexpected state leaves the gate shut, so secrets
+# never run on an unverified PR.
+#
+# Env in:  GH_TOKEN, REPO, PR, LABEL (gate label name, default e2e-approved),
+#          MAINTAINERS (space-separated, from merge-ready/load-maintainers.sh).
 # Out:     `mirror=true|false` and `reason=<text>` on $GITHUB_OUTPUT.
 
 set -euo pipefail
@@ -29,45 +33,40 @@ emit() {
   echo "mirror=$1 ($2)"
 }
 
-# 1. Already opened: re-mirror every subsequent push.
-if gh api "repos/$REPO/branches/$MIRROR_BRANCH" >/dev/null 2>&1; then
-  emit true "re-mirror: $MIRROR_BRANCH already exists"
+LABEL="${LABEL:-e2e-approved}"
+MAINTAINERS_LC=$(echo "${MAINTAINERS:-}" | tr '[:upper:]' '[:lower:]')
+
+if [[ -z "${MAINTAINERS_LC// /}" ]]; then
+  emit false "no maintainers loaded (.github/MAINTAINER@main empty/missing)"
   exit 0
 fi
 
-# 2. Returning contributor (GitHub's native author_association signal).
-case "$AUTHOR_ASSOCIATION" in
-  OWNER | MEMBER | COLLABORATOR | CONTRIBUTOR)
-    emit true "returning contributor (author_association=$AUTHOR_ASSOCIATION)"
-    exit 0
-    ;;
-esac
-
-# 3. Maintainer-approved (mirrors maintainer-approval.yml; see header note).
-MAINTAINERS_LC=$(echo "${MAINTAINERS:-}" | tr '[:upper:]' '[:lower:]')
-if [[ -n "${MAINTAINERS_LC// /}" ]]; then
-  AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login')
-  AUTHOR_LC=$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')
-
-  for m in $MAINTAINERS_LC; do
-    if [[ "$m" == "$AUTHOR_LC" ]]; then
-      emit true "author @$AUTHOR is a maintainer"
-      exit 0
-    fi
-  done
-
-  # Latest non-COMMENTED review per reviewer; APPROVED by a maintainer opens it.
-  APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-    --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login')
-  for u in $APPROVERS; do
-    u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
-    for m in $MAINTAINERS_LC; do
-      if [[ "$m" == "$u_lc" ]]; then
-        emit true "approved by maintainer @$u"
-        exit 0
-      fi
-    done
-  done
+# 1. Label currently present? Read into a variable first so grep's early exit
+#    can't SIGPIPE the producer, then match against a here-string.
+LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+if ! grep -qxF "$LABEL" <<<"$LABELS"; then
+  emit false "awaiting '$LABEL' label from a maintainer"
+  exit 0
 fi
 
-emit false "awaiting maintainer approval (first-time contributor)"
+# 2. Who applied it last? Latest `labeled` event for this label on the timeline.
+#    (Re-applying after a removal makes the most recent labeler authoritative.)
+LABELER=$(gh api "repos/$REPO/issues/$PR/events" --paginate \
+  --jq "[.[] | select(.event == \"labeled\" and .label.name == \"$LABEL\")] | last | .actor.login // empty")
+
+if [[ -z "$LABELER" ]]; then
+  # Label is present but no labeled event found (e.g. created with the PR via a
+  # template) -- can't attribute it to a maintainer, so stay shut.
+  emit false "'$LABEL' present but no attributable labeler; treating as ungated"
+  exit 0
+fi
+
+LABELER_LC=$(echo "$LABELER" | tr '[:upper:]' '[:lower:]')
+for m in $MAINTAINERS_LC; do
+  if [[ "$m" == "$LABELER_LC" ]]; then
+    emit true "'$LABEL' applied by maintainer @$LABELER"
+    exit 0
+  fi
+done
+
+emit false "'$LABEL' applied by non-maintainer @$LABELER; ignoring"

--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -12,10 +12,10 @@
 # does not vouch for the contents of this one) and first-timers
 # (FIRST_TIME_CONTRIBUTOR / NONE).
 #
-# This is deliberately stricter than fork-e2e/should-mirror.sh, which trusts
-# CONTRIBUTOR: that gate only decides whether to spend a rate-limited test
-# token, whereas this gate decides whether to inspect for attacks, so it errs
-# toward scanning more.
+# This gate is independent of fork-e2e/should-mirror.sh: that one gates secret-
+# bearing e2e on the maintainer-applied `e2e-approved` label, whereas this gate
+# decides whether to inspect for attacks and so errs toward scanning more (it
+# scans returning CONTRIBUTORs that the label gate would not by itself run).
 #
 # author_association is computed by GitHub from the actor's relationship to the
 # repo at event time; it is not attacker-settable from PR contents.

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -1,19 +1,26 @@
 name: Fork e2e mirror
 
-# Mirrors an approved / returning-contributor fork PR's head onto a trusted
-# fork-e2e/pr-N branch so e2e runs there as a `push` (with secrets). It's a pure
-# git-ref update via a GitHub App token (refs pushed by the default GITHUB_TOKEN
-# don't trigger workflows); it never checks out or runs fork code. Gated by
-# should-mirror.sh + the single contributor Security Scan, consulted through the
-# reusable security-gate.yml. pull_request_review is included so a maintainer's
-# approval mirrors immediately, not only on the PR's next push.
+# Mirrors a gated fork PR's head onto a trusted fork-e2e/pr-N branch so e2e runs
+# there as a `push` (with secrets). It's a pure git-ref update via a GitHub App
+# token (refs pushed by the default GITHUB_TOKEN don't trigger workflows); it
+# never checks out or runs fork code. Mirroring requires BOTH the contributor
+# Security Scan to pass (the blocking `gate` job, via security-gate.yml) AND the
+# `e2e-approved` label, present and applied by a maintainer (should-mirror.sh).
+#
+# The `e2e-approved` label is the sole human gate for running secret-bearing e2e
+# on a fork PR. Only Triage+ users can apply labels, and the gate further
+# verifies the labeler is in .github/MAINTAINER, so an external fork author can
+# never open it. It is intentionally separate from the merge gate
+# (maintainer-approval.yml): labeling runs e2e but does NOT approve for merge,
+# and vice-versa. Removing the label (or closing the PR) tears down the mirror
+# branch and stops further secret runs.
 #
 # leak-scan-allow: pull_request_target
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, closed]
-  pull_request_review:
-    types: [submitted]
+    # labeled/unlabeled so applying or removing `e2e-approved` opens or tears
+    # down the mirror immediately, not only on the PR's next push.
+    types: [opened, synchronize, reopened, closed, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -23,11 +30,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Delete the trusted mirror branch when the PR closes. Ungated -- cleanup must
-  # always run so a closed PR never leaves a stale fork-e2e/pr-N branch behind.
+  # Delete the trusted mirror branch when the PR closes or the gate label is
+  # removed. Ungated -- cleanup must always run so a closed PR (or one whose
+  # approval was withdrawn) never leaves a stale fork-e2e/pr-N branch behind.
   cleanup:
     name: cleanup
-    if: ${{ github.event.action == 'closed' && github.event.pull_request.head.repo.fork }}
+    if: >-
+      github.event.pull_request.head.repo.fork
+      && (
+        github.event.action == 'closed'
+        || (github.event.action == 'unlabeled' && github.event.label.name == 'e2e-approved')
+      )
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -54,19 +67,30 @@ jobs:
   # The single contributor Security Scan, consulted as a BLOCKING gate before we
   # mirror fork code onto a trusted branch where e2e runs WITH the gateway secret.
   # The scan itself runs once on the PR (security-scan.yml); this poller mirrors
-  # its result, blocking the mirror on a finding.
+  # its result, blocking the mirror on a finding. Skipped on the teardown actions
+  # (handled by `cleanup`) and on label churn other than `e2e-approved`.
   gate:
     name: security gate
-    if: ${{ github.event.action != 'closed' && github.event.pull_request.head.repo.fork }}
+    if: >-
+      github.event.pull_request.head.repo.fork
+      && github.event.action != 'closed'
+      && github.event.action != 'unlabeled'
+      && (github.event.action != 'labeled' || github.event.label.name == 'e2e-approved')
     uses: ./.github/workflows/security-gate.yml
 
   mirror:
     name: mirror
     needs: gate
-    # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`.
-    if: ${{ github.event.action != 'closed' && github.event.pull_request.head.repo.fork }}
+    # Fork PRs only -- same-repo PRs run e2e directly via `pull_request`. Mirror
+    # only when not tearing down and (for label events) only for the gate label.
+    if: >-
+      github.event.pull_request.head.repo.fork
+      && github.event.action != 'closed'
+      && github.event.action != 'unlabeled'
+      && (github.event.action != 'labeled' || github.event.label.name == 'e2e-approved')
     permissions:
       contents: read
+      issues: read          # read the labeled-by timeline (issues/N/events)
       pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -75,7 +99,6 @@ jobs:
       REPO: ${{ github.repository }}
       PR: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
       MIRROR_BRANCH: fork-e2e/pr-${{ github.event.pull_request.number }}
     steps:
       - name: Check out gate scripts from main
@@ -93,6 +116,8 @@ jobs:
           app-id: ${{ vars.FORK_E2E_APP_ID }}
           private-key: ${{ secrets.FORK_E2E_APP_PRIVATE_KEY }}
 
+      # MAINTAINER@main, never the PR head: the gate verifies the *labeler* is a
+      # maintainer, so a PR can't self-grant by editing its own MAINTAINER copy.
       - name: Load maintainers
         id: maintainers
         run: bash .github/scripts/merge-ready/load-maintainers.sh
@@ -100,6 +125,7 @@ jobs:
       - name: Evaluate mirror gate
         id: gate
         env:
+          LABEL: e2e-approved
           MAINTAINERS: ${{ steps.maintainers.outputs.list }}
         run: bash .github/scripts/fork-e2e/should-mirror.sh
 

--- a/tests/scripts/test_fork_e2e_should_mirror.py
+++ b/tests/scripts/test_fork_e2e_should_mirror.py
@@ -11,33 +11,26 @@ SCRIPT = REPO_ROOT / ".github/scripts/fork-e2e/should-mirror.sh"
 def _run(
     tmp_path: Path,
     *,
-    author_association: str,
-    maintainers: str = "",
-    branch_exists: bool = False,
-    author: str = "octocat",
-    approvers: str = "",
+    labels: str = "",
+    labeler: str = "",
+    maintainers: str = "alice bob",
 ) -> dict[str, str]:
     """
     Run should-mirror.sh against a mocked ``gh`` and return its outputs.
 
-    The mock answers the three calls the script can make:
+    The label-only gate makes exactly two ``gh`` calls, which the mock answers:
 
-    - ``api repos/{repo}/branches/{mirror_branch}`` -> exit 0 if
-      *branch_exists* else exit 1 (the existence probe).
-    - ``pr view {pr} ...`` -> *author* (the PR author login).
-    - ``api repos/{repo}/pulls/{pr}/reviews ...`` -> *approvers*, a
-      space-separated login list printed one per line (post-``--jq``
-      shape the script iterates).
+    - ``pr view {pr} ... --json labels --jq '.labels[].name'`` -> *labels*, a
+      space-separated label list printed one per line (the post-``--jq`` shape
+      the script greps).
+    - ``api repos/{repo}/issues/{pr}/events ...`` -> *labeler*, the login of the
+      account that last applied the gate label (empty if none).
 
     :param tmp_path: Pytest tmp dir for the mock + output file.
-    :param author_association: GitHub ``author_association`` value,
-        e.g. ``"FIRST_TIME_CONTRIBUTOR"`` or ``"CONTRIBUTOR"``.
+    :param labels: Space-separated labels currently on the PR; empty means none.
+    :param labeler: Login the issue-events mock attributes the gate label to.
     :param maintainers: Space-separated maintainer logins (as
         load-maintainers.sh would emit); empty means none.
-    :param branch_exists: Whether fork-e2e/pr-N already exists.
-    :param author: PR author login the ``gh pr view`` mock returns.
-    :param approvers: Space-separated logins whose latest review is
-        APPROVED, as the reviews ``--jq`` would yield.
     :returns: Parsed ``key=value`` GITHUB_OUTPUT lines, e.g.
         ``{"mirror": "true", "reason": "..."}``.
     """
@@ -45,12 +38,12 @@ def _run(
     gh.write_text(
         "#!/usr/bin/env bash\n"
         "set -uo pipefail\n"
-        'if [[ "$1" == "pr" ]]; then echo "$MOCK_AUTHOR"; exit 0; fi\n'
+        # gh pr view <pr> --repo <repo> --json labels --jq '.labels[].name'
+        # shellcheck-style: unquoted expansion intentionally splits labels.
+        'if [[ "$1" == "pr" ]]; then [[ -n "$MOCK_LABELS" ]] && printf "%s\\n" $MOCK_LABELS; exit 0; fi\n'
         'if [[ "$1" == "api" ]]; then\n'
         '  case "$2" in\n'
-        '    *branches/*) [[ "$BRANCH_EXISTS" == "1" ]] && exit 0 || exit 1 ;;\n'
-        # shellcheck-style: unquoted expansion intentionally splits logins.
-        '    *reviews*) [[ -n "$MOCK_APPROVERS" ]] && printf "%s\\n" $MOCK_APPROVERS; exit 0 ;;\n'
+        '    *issues/*events*) [[ -n "$MOCK_LABELER" ]] && printf "%s\\n" "$MOCK_LABELER"; exit 0 ;;\n'
         "  esac\n"
         "fi\n"
         'echo "unexpected gh invocation: $*" >&2\n'
@@ -68,13 +61,12 @@ def _run(
             "GH_TOKEN": "unused",
             "REPO": "test/repo",
             "PR": "7",
+            "LABEL": "e2e-approved",
             "MIRROR_BRANCH": "fork-e2e/pr-7",
-            "AUTHOR_ASSOCIATION": author_association,
             "MAINTAINERS": maintainers,
             "GITHUB_OUTPUT": str(out_file),
-            "BRANCH_EXISTS": "1" if branch_exists else "0",
-            "MOCK_AUTHOR": author,
-            "MOCK_APPROVERS": approvers,
+            "MOCK_LABELS": labels,
+            "MOCK_LABELER": labeler,
         }
     )
     proc = subprocess.run(
@@ -93,96 +85,78 @@ def _run(
     return outputs
 
 
-def test_first_time_contributor_without_approval_does_not_mirror(tmp_path: Path) -> None:
-    """A first-timer with no maintainer approval must NOT open the gate.
+def test_label_applied_by_maintainer_mirrors(tmp_path: Path) -> None:
+    """The gate label, applied by a maintainer, opens the gate.
 
-    This is the whole point of the gate: brand-new contributors don't get a
-    secret-bearing e2e run on first push. Asserts ``mirror=false`` (the e2e
-    suite stays unmirrored until a maintainer reviews).
+    The whole contract: secret-bearing e2e runs only after a maintainer applies
+    ``e2e-approved``. Asserts ``mirror=true`` and that the reason names the
+    maintainer who applied it.
     """
-    out = _run(tmp_path, author_association="FIRST_TIME_CONTRIBUTOR")
+    out = _run(tmp_path, labels="e2e-approved", labeler="bob")
+    assert out["mirror"] == "true"
+    assert "applied by maintainer" in out["reason"]
+
+
+def test_maintainer_match_is_case_insensitive(tmp_path: Path) -> None:
+    """Labeler vs MAINTAINER comparison is case-insensitive.
+
+    GitHub logins are compared lowercased, so a maintainer labelled as ``Bob``
+    still opens the gate against a ``bob`` MAINTAINER entry.
+    """
+    out = _run(tmp_path, labels="e2e-approved", labeler="Bob", maintainers="alice bob")
+    assert out["mirror"] == "true"
+
+
+def test_label_absent_does_not_mirror(tmp_path: Path) -> None:
+    """Without the gate label the gate stays shut.
+
+    No ``e2e-approved`` means no secret-bearing e2e on a fork PR. Asserts
+    ``mirror=false`` and an awaiting-label reason.
+    """
+    out = _run(tmp_path, labels="", labeler="bob")
     assert out["mirror"] == "false"
+    assert "awaiting" in out["reason"]
 
 
-def test_returning_contributor_mirrors(tmp_path: Path) -> None:
-    """A returning contributor (author_association=CONTRIBUTOR) auto-mirrors.
+def test_other_labels_are_ignored(tmp_path: Path) -> None:
+    """Unrelated labels never open the gate.
 
-    Matches GitHub's own "has contributed before" relaxation. Asserts
-    ``mirror=true`` with no maintainer list needed.
+    Only the exact gate label counts; ``bug``/``enhancement`` leave it shut.
     """
-    out = _run(tmp_path, author_association="CONTRIBUTOR")
-    assert out["mirror"] == "true"
-    assert "returning contributor" in out["reason"]
-
-
-def test_member_association_mirrors(tmp_path: Path) -> None:
-    """An org MEMBER's fork PR auto-mirrors (also a returning-type association)."""
-    out = _run(tmp_path, author_association="MEMBER")
-    assert out["mirror"] == "true"
-
-
-def test_maintainer_author_mirrors(tmp_path: Path) -> None:
-    """A first-timer whose login is in MAINTAINER opens the gate.
-
-    Covers the author-is-maintainer branch even when author_association is not
-    a returning value. Asserts ``mirror=true`` and that the reason names the
-    author.
-    """
-    out = _run(
-        tmp_path,
-        author_association="NONE",
-        maintainers="alice bob",
-        author="bob",
-    )
-    assert out["mirror"] == "true"
-    assert "maintainer" in out["reason"]
-
-
-def test_maintainer_approved_review_mirrors(tmp_path: Path) -> None:
-    """A first-timer whose PR a maintainer APPROVED opens the gate.
-
-    Covers the review-approval branch: the author isn't a maintainer, but a
-    maintainer (``bob``) approved. Asserts ``mirror=true``.
-    """
-    out = _run(
-        tmp_path,
-        author_association="FIRST_TIME_CONTRIBUTOR",
-        maintainers="alice bob",
-        author="newcomer",
-        approvers="bob",
-    )
-    assert out["mirror"] == "true"
-    assert "approved by maintainer" in out["reason"]
-
-
-def test_non_maintainer_approval_does_not_mirror(tmp_path: Path) -> None:
-    """An APPROVED review from a NON-maintainer must not open the gate.
-
-    Guards against treating any approval as sufficient: only a maintainer's
-    approval counts. ``eve`` approves but isn't in MAINTAINER, so
-    ``mirror=false``.
-    """
-    out = _run(
-        tmp_path,
-        author_association="FIRST_TIME_CONTRIBUTOR",
-        maintainers="alice bob",
-        author="newcomer",
-        approvers="eve",
-    )
+    out = _run(tmp_path, labels="bug enhancement", labeler="bob")
     assert out["mirror"] == "false"
+    assert "awaiting" in out["reason"]
 
 
-def test_existing_branch_always_remirrors(tmp_path: Path) -> None:
-    """Once fork-e2e/pr-N exists, a first-timer's new push re-mirrors.
+def test_label_applied_by_non_maintainer_does_not_mirror(tmp_path: Path) -> None:
+    """The gate label applied by a NON-maintainer must not open the gate.
 
-    The accepted always-re-mirror behavior: a first-timer with no approval
-    whose branch already exists still mirrors (new commits re-run e2e).
-    Asserts ``mirror=true`` despite the otherwise-closed gate.
+    Triage+ access lets non-maintainers apply labels too, so label presence
+    alone is insufficient: the labeler must be in MAINTAINER. ``eve`` applies it
+    but isn't a maintainer, so ``mirror=false``.
     """
-    out = _run(
-        tmp_path,
-        author_association="FIRST_TIME_CONTRIBUTOR",
-        branch_exists=True,
-    )
-    assert out["mirror"] == "true"
-    assert "re-mirror" in out["reason"]
+    out = _run(tmp_path, labels="e2e-approved", labeler="eve", maintainers="alice bob")
+    assert out["mirror"] == "false"
+    assert "non-maintainer" in out["reason"]
+
+
+def test_label_present_but_unattributable_does_not_mirror(tmp_path: Path) -> None:
+    """A present label with no labeled-event actor stays shut (fail closed).
+
+    If the label can't be attributed to anyone (e.g. seeded outside the events
+    timeline), we can't confirm a maintainer applied it, so ``mirror=false``.
+    """
+    out = _run(tmp_path, labels="e2e-approved", labeler="")
+    assert out["mirror"] == "false"
+    assert "no attributable labeler" in out["reason"]
+
+
+def test_no_maintainers_loaded_does_not_mirror(tmp_path: Path) -> None:
+    """An empty MAINTAINER list fails closed.
+
+    With no maintainers to verify against, even a present label can't be
+    trusted, so the gate stays shut regardless of the labeler.
+    """
+    out = _run(tmp_path, labels="e2e-approved", labeler="bob", maintainers="")
+    assert out["mirror"] == "false"
+    assert "no maintainers" in out["reason"]

--- a/tests/scripts/test_fork_e2e_should_mirror.py
+++ b/tests/scripts/test_fork_e2e_should_mirror.py
@@ -40,10 +40,12 @@ def _run(
         "set -uo pipefail\n"
         # gh pr view <pr> --repo <repo> --json labels --jq '.labels[].name'
         # shellcheck-style: unquoted expansion intentionally splits labels.
-        'if [[ "$1" == "pr" ]]; then [[ -n "$MOCK_LABELS" ]] && printf "%s\\n" $MOCK_LABELS; exit 0; fi\n'
+        'if [[ "$1" == "pr" ]]; then [[ -n "$MOCK_LABELS" ]]'
+        ' && printf "%s\\n" $MOCK_LABELS; exit 0; fi\n'
         'if [[ "$1" == "api" ]]; then\n'
         '  case "$2" in\n'
-        '    *issues/*events*) [[ -n "$MOCK_LABELER" ]] && printf "%s\\n" "$MOCK_LABELER"; exit 0 ;;\n'
+        '    *issues/*events*) [[ -n "$MOCK_LABELER" ]]'
+        ' && printf "%s\\n" "$MOCK_LABELER"; exit 0 ;;\n'
         "  esac\n"
         "fi\n"
         'echo "unexpected gh invocation: $*" >&2\n'


### PR DESCRIPTION
## What

Implements **Option 2** (two-tier fork CI) from `designs/ci-external-contributors-proposal.md`. Secret-bearing e2e on a fork PR now runs **only** after a maintainer applies the **`e2e-approved`** label.

This is the gate decision from PR #286:
- **Tier 1** (lint / ci / security-scan, no secrets) already runs automatically on every fork PR; `e2e*`/`integration` resolve to an empty shard matrix for raw fork PRs, so secrets are never exposed pre-approval. No change needed.
- **Tier 2** (secret-bearing e2e) is gated solely on the `e2e-approved` label — fully decoupled from merge approval. The label does **not** block merging; `maintainer-approval.yml` still gates merge.

## Changes

- **`should-mirror.sh`** — single gate on the `e2e-approved` label. Drops the returning-contributor (`author_association`) auto-open and the maintainer-author / review-`APPROVED` openers. Fails closed if labels can't be read. Re-runs on `synchronize`, so new commits re-mirror automatically while the label is present.
- **`fork-e2e-mirror.yml`** — trigger on `labeled`/`unlabeled` (ignoring unrelated label churn); drop the now-unused `pull_request_review` trigger and the load-maintainers step; delete the mirror branch on `unlabeled` (as well as on close) so secret runs stop when approval is withdrawn.
- **`should-scan.sh`** — refresh a stale cross-reference to should-mirror's gate.

## Flow

External fork PR → Tier 1 runs (no secrets) → maintainer applies `e2e-approved` → head mirrored to `fork-e2e/pr-N` → secret e2e runs → new commits auto-re-run while labeled → maintainer removes label (or PR closes) → mirror branch deleted, no further secret runs.

## Setup done

- Created the repo label `e2e-approved`. Labels can only be applied by users with triage/write, so external authors can't self-grant — that is the permission gate.

## Notes

- `actionlint` isn't installed locally; relying on CI to lint the workflow.
- The design doc (`designs/ci-external-contributors-proposal.md`) lives on `main`; a follow-up can mark Option 2 as implemented and document the maintainer label workflow.