### PR TITLE
ci: trigger fork-e2e mirror on the e2e-approved label, not PR review

### DIFF
--- a/.github/scripts/fork-e2e/should-mirror.sh
+++ b/.github/scripts/fork-e2e/should-mirror.sh
@@ -9,19 +9,24 @@
 #   2. Returning contributor -- author_association is OWNER / MEMBER /
 #      COLLABORATOR / CONTRIBUTOR (GitHub's own "has contributed before"
 #      signal; first-timers are FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / NONE).
-#   3. Maintainer-approved -- the author is in .github/MAINTAINER, or a
-#      maintainer's latest non-COMMENTED review is APPROVED.
+#   3. Maintainer signal -- the author is in .github/MAINTAINER, or a maintainer
+#      applied the `e2e-approved` label. The label (not a PR approval) is the
+#      trigger: applying it fires pull_request_target (labeled), which carries
+#      the secrets the mirror needs to mint its App token. A pull_request_review
+#      on a fork PR can't -- it gets only a read-only GITHUB_TOKEN, no secrets.
 #
-# Case 3 deliberately mirrors maintainer-approval.yml's computation (same
-# MAINTAINER list via load-maintainers.sh, same review semantics). Keep the two
-# in sync; a drift only over-/under-opens the mirror gate (bounded by the
-# rate-limited, revocable test token), it can't bypass the merge gate.
+# The MAINTAINER list comes from load-maintainers.sh (same as
+# maintainer-approval.yml). A drift only over-/under-opens the mirror gate
+# (bounded by the rate-limited, revocable test token), it can't bypass the
+# merge gate.
 #
 # Env in:  GH_TOKEN, REPO, PR, AUTHOR_ASSOCIATION, MAINTAINERS (space-separated,
 #          from load-maintainers.sh), MIRROR_BRANCH (e.g. fork-e2e/pr-123).
 # Out:     `mirror=true|false` and `reason=<text>` on $GITHUB_OUTPUT.
 
 set -euo pipefail
+
+APPROVE_LABEL="e2e-approved"
 
 emit() {
   echo "mirror=$1" >> "$GITHUB_OUTPUT"
@@ -43,7 +48,8 @@ case "$AUTHOR_ASSOCIATION" in
     ;;
 esac
 
-# 3. Maintainer-approved (mirrors maintainer-approval.yml; see header note).
+# 3. Maintainer signal: author is a maintainer, or a maintainer applied the
+#    e2e-approved label (see header note).
 MAINTAINERS_LC=$(echo "${MAINTAINERS:-}" | tr '[:upper:]' '[:lower:]')
 if [[ -n "${MAINTAINERS_LC// /}" ]]; then
   AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login')
@@ -56,18 +62,24 @@ if [[ -n "${MAINTAINERS_LC// /}" ]]; then
     fi
   done
 
-  # Latest non-COMMENTED review per reviewer; APPROVED by a maintainer opens it.
-  APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-    --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login')
-  for u in $APPROVERS; do
-    u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
-    for m in $MAINTAINERS_LC; do
-      if [[ "$m" == "$u_lc" ]]; then
-        emit true "approved by maintainer @$u"
-        exit 0
-      fi
+  # e2e-approved label, but only if it is currently present AND was applied by a
+  # maintainer. Label changes need triage/write access, so a fork author can't
+  # self-apply; the timeline-actor check is defence in depth (matches the
+  # maintainer-effective waiver pattern in should-scan.sh).
+  if gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name' \
+       | grep -qx "$APPROVE_LABEL"; then
+    LABELERS=$(gh api "repos/$REPO/issues/$PR/timeline" --paginate \
+      --jq "[.[] | select(.event == \"labeled\" and .label.name == \"$APPROVE_LABEL\")] | .[].actor.login" 2>/dev/null || echo "")
+    for u in $LABELERS; do
+      u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
+      for m in $MAINTAINERS_LC; do
+        if [[ "$m" == "$u_lc" ]]; then
+          emit true "labeled '$APPROVE_LABEL' by maintainer @$u"
+          exit 0
+        fi
+      done
     done
-  done
+  fi
 fi
 
-emit false "awaiting maintainer approval (first-time contributor)"
+emit false "awaiting maintainer '$APPROVE_LABEL' label (first-time contributor)"

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -5,15 +5,16 @@ name: Fork e2e mirror
 # git-ref update via a GitHub App token (refs pushed by the default GITHUB_TOKEN
 # don't trigger workflows); it never checks out or runs fork code. Gated by
 # should-mirror.sh + the single contributor Security Scan, consulted through the
-# reusable security-gate.yml. pull_request_review is included so a maintainer's
-# approval mirrors immediately, not only on the PR's next push.
+# reusable security-gate.yml. To mirror a held first-time-contributor PR a
+# maintainer applies the `e2e-approved` label: that fires pull_request_target
+# (labeled), which -- unlike pull_request_review on a fork PR -- carries the
+# secrets the mirror needs to mint its App token. (pull_request_review can't:
+# on a fork PR it gets only a read-only GITHUB_TOKEN, no secrets/vars.)
 #
 # leak-scan-allow: pull_request_target
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, closed]
-  pull_request_review:
-    types: [submitted]
+    types: [opened, synchronize, reopened, closed, labeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The fork-e2e mirror listened on `pull_request_review` to mirror a held PR the moment a maintainer approves. But a `pull_request_review` on a **fork** PR gets only a read-only `GITHUB_TOKEN` — no secrets or variables — so the mirror's "Mint mirror App token" step fails (`FORK_E2E_APP_ID` resolves empty), the head is never pushed to `fork-e2e/pr-N`, and the downstream e2e never runs. Observed live on #339: its `pull_request_target` run minted the token fine, but the `pull_request_review` run that fired on approval failed with an empty `app-id`.

Switch the maintainer "mirror now" signal to an **`e2e-approved` label**. Applying a label fires `pull_request_target` (labeled), which *does* carry the secrets the mirror needs.

- `fork-e2e-mirror.yml`: drop the `pull_request_review` trigger; add `labeled` to `pull_request_target`.
- `should-mirror.sh`: open the gate when a maintainer applied the `e2e-approved` label — the label must be **present** and have been **applied by a maintainer** (verified via the timeline actor; label changes need triage/write access so a fork author can't self-apply). This replaces the PR-approval-review check. The already-mirrored, returning-contributor, and author-is-maintainer paths are unchanged.

Flow for a held first-time-contributor PR: maintainer reviews, then applies `e2e-approved` → `pull_request_target` (labeled) fires with secrets → the `gate` confirms the `Security Scan` is green → `should-mirror` sees the maintainer label → head is mirrored to `fork-e2e/pr-N` → e2e runs.

Follow-up for whoever merges: create the `e2e-approved` label in the repo and note it in the maintainer/contributor docs.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Workflow/script change: `bash -n` clean on `should-mirror.sh`, `fork-e2e-mirror.yml` parses. The token-access root cause was confirmed live on #339 (the `pull_request_target` run minted `app-id: 4058074`; the `pull_request_review` run got an empty `app-id`), and #339 was unblocked by re-running its `pull_request_target` mirror.