### PR TITLE
ci: report frontend unit-test coverage (parity with backend)

### DIFF
--- a/.github/workflows/ap-web-tests.yml
+++ b/.github/workflows/ap-web-tests.yml
@@ -78,8 +78,9 @@ jobs:
           node -e "process.stdout.write(String(require('./coverage/coverage-summary.json').total.lines.pct))" \
             > ui-coverage-summary/total.txt
           echo "Total UI coverage: $(cat ui-coverage-summary/total.txt)%"
-          # Render a markdown table into the job summary (parity with the
-          # backend coverage-report job's GITHUB_STEP_SUMMARY table).
+          # Render a markdown table; tee it to both the job log (visible inline)
+          # and the run's Summary tab (parity with the backend coverage-report
+          # job's GITHUB_STEP_SUMMARY table).
           node -e '
             const t = require("./coverage/coverage-summary.json").total;
             const row = (k) => `| ${k[0].toUpperCase()}${k.slice(1)} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`;
@@ -87,7 +88,7 @@ jobs:
               "## UI Coverage\n\n" +
               "| Metric | % | Covered/Total |\n|---|---|---|\n" +
               ["lines","statements","functions","branches"].map(row).join("\n") + "\n");
-          ' >> "$GITHUB_STEP_SUMMARY"
+          ' | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload UI coverage summary
         if: always()

--- a/.github/workflows/ap-web-tests.yml
+++ b/.github/workflows/ap-web-tests.yml
@@ -59,6 +59,30 @@ jobs:
         working-directory: ap-web
         run: npm run format:check
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: ap-web
-        run: npm test
+        run: npm run test:coverage
+
+      # Distill the v8 json-summary into a single total.txt, mirroring the
+      # backend's coverage-report job. ui-code-coverage.yml (privileged
+      # workflow_run) consumes this artifact and posts the report-only status.
+      - name: Summarize coverage
+        if: always()
+        working-directory: ap-web
+        run: |
+          mkdir -p ui-coverage-summary
+          if [[ ! -f coverage/coverage-summary.json ]]; then
+            echo "::warning::No coverage-summary.json; skipping UI coverage report."
+            exit 0
+          fi
+          node -e "process.stdout.write(String(require('./coverage/coverage-summary.json').total.lines.pct))" \
+            > ui-coverage-summary/total.txt
+          echo "Total UI coverage: $(cat ui-coverage-summary/total.txt)%"
+
+      - name: Upload UI coverage summary
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: ui-coverage-summary-${{ github.run_id }}
+          path: ap-web/ui-coverage-summary/
+          retention-days: 14

--- a/.github/workflows/ap-web-tests.yml
+++ b/.github/workflows/ap-web-tests.yml
@@ -78,6 +78,16 @@ jobs:
           node -e "process.stdout.write(String(require('./coverage/coverage-summary.json').total.lines.pct))" \
             > ui-coverage-summary/total.txt
           echo "Total UI coverage: $(cat ui-coverage-summary/total.txt)%"
+          # Render a markdown table into the job summary (parity with the
+          # backend coverage-report job's GITHUB_STEP_SUMMARY table).
+          node -e '
+            const t = require("./coverage/coverage-summary.json").total;
+            const row = (k) => `| ${k[0].toUpperCase()}${k.slice(1)} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`;
+            process.stdout.write(
+              "## UI Coverage\n\n" +
+              "| Metric | % | Covered/Total |\n|---|---|---|\n" +
+              ["lines","statements","functions","branches"].map(row).join("\n") + "\n");
+          ' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload UI coverage summary
         if: always()

--- a/.github/workflows/ui-code-coverage.yml
+++ b/.github/workflows/ui-code-coverage.yml
@@ -1,0 +1,61 @@
+name: UI Code Coverage
+
+# Posts a report-only `Coverage (ui)` commit status from the `ui-coverage-summary`
+# artifact produced by the `ap-web Tests` workflow (vitest --coverage). Runs on
+# workflow_run (privileged, statuses:write) but does NOT check out PR code — it
+# only consumes the artifact, so it isn't a "dangerous workflow". The status is
+# always success (the % rides in the description) and is never required, so it
+# can't block a merge. Frontend counterpart to code-coverage.yml.
+
+on:
+  workflow_run:
+    workflows: [ap-web Tests]
+    types: [completed]
+
+# Read-only at the top level; write scopes live on the job below.
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-code-coverage-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  post:
+    name: Post UI coverage status
+    permissions:
+      actions: read     # download the ui-coverage-summary artifact from the run
+      statuses: write   # post the Coverage (ui) status on the PR head SHA
+    # PR-originated runs only; other completions have no PR head SHA.
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Data only — never the PR's code. Tolerate a missing artifact (fork PRs,
+      # or a run that produced no coverage) via the no-data guard below.
+      - name: Download UI coverage summary
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          name: ui-coverage-summary-${{ github.event.workflow_run.id }}
+          path: ui-coverage-summary
+
+      - name: Post Coverage (ui) status on PR head SHA
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [[ ! -f ui-coverage-summary/total.txt ]]; then
+            echo "::notice::No ui-coverage-summary artifact; nothing to post."
+            exit 0
+          fi
+          TOTAL=$(cat ui-coverage-summary/total.txt)
+          gh api "repos/$REPO/statuses/$SHA" \
+            -f state=success \
+            -f context="Coverage (ui)" \
+            -f description="Total UI line coverage: ${TOTAL}%" >/dev/null
+          echo "Posted Coverage (ui)=${TOTAL}% on $SHA"

--- a/ap-web/.gitignore
+++ b/ap-web/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-embed
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -78,6 +78,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.8",
         "ai-elements": "^1.9.0",
         "jsdom": "^29.1.1",
         "oxlint": "^1.62.0",
@@ -812,6 +813,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -6761,6 +6772,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6770,6 +6782,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6879,6 +6892,37 @@
           "optional": true
         },
         "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
           "optional": true
         }
       }
@@ -7419,6 +7463,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astring": {
       "version": "1.9.0",
@@ -9938,6 +10001,16 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -10334,6 +10407,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -10820,6 +10900,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -11521,6 +11640,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-extensions": {
@@ -16104,6 +16251,19 @@
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -16168,6 +16328,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -16458,7 +16619,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17265,22 +17426,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/ap-web/package.json
+++ b/ap-web/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@databricks/sdk-experimental": "^0.17.0",
@@ -126,6 +127,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.8",
     "ai-elements": "^1.9.0",
     "jsdom": "^29.1.1",
     "oxlint": "^1.62.0",

--- a/ap-web/vite.config.ts
+++ b/ap-web/vite.config.ts
@@ -134,6 +134,25 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],
+    coverage: {
+      provider: "v8",
+      // `all` counts untested source files as 0%, so the total reflects the
+      // whole frontend (parity with the backend's --cov=omnigent), not just
+      // files a test happened to import.
+      all: true,
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.d.ts",
+        "src/test-setup.ts",
+        // Vendored UI kit, not product code (see tests/e2e_ui/COVERAGE_GAPS.md).
+        "src/components/ai-elements/**",
+      ],
+      reportsDirectory: "./coverage",
+      // text-summary: human-readable console line; json-summary: machine-
+      // readable coverage/coverage-summary.json that CI distills to total.txt.
+      reporter: ["text-summary", "json-summary"],
+    },
   },
   server: {
     proxy: proxyConfig,

--- a/ap-web/vite.config.ts
+++ b/ap-web/vite.config.ts
@@ -136,10 +136,9 @@ export default defineConfig({
     setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",
-      // `all` counts untested source files as 0%, so the total reflects the
-      // whole frontend (parity with the backend's --cov=omnigent), not just
-      // files a test happened to import.
-      all: true,
+      // With `include` set, vitest counts every matching source file (untested
+      // ones as 0%), so the total reflects the whole frontend — parity with the
+      // backend's --cov=omnigent, not just files a test happened to import.
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
         "src/**/*.test.{ts,tsx}",


### PR DESCRIPTION
## What

Brings **UI unit-test coverage** to parity with the backend's report-only `Coverage` status. Today `ap-web` runs vitest in CI but measures **no coverage at all**, so there's zero visibility into frontend unit coverage.

This is **report-only** — the new status is never required and can't block a merge, exactly like the existing backend `Coverage` status (`code-coverage.yml`).

## Changes

**`ap-web` — turn on vitest coverage**
- Add `@vitest/coverage-v8` + a `test:coverage` script (`vitest run --coverage`).
- Configure `coverage` in `vite.config.ts`: `provider: v8`, `all: true` (untested `src` files count as 0, so the total reflects the whole frontend like the backend's `--cov=omnigent`), excludes test files / `*.d.ts` / the vendored `ai-elements/**` kit, `json-summary` + `text-summary` reporters.
- gitignore `coverage/`.

**`ap-web-tests.yml` — emit the artifact** (unprivileged PR context, mirroring CI's `coverage-report` job)
- Test step now runs `npm run test:coverage`.
- Distills `coverage/coverage-summary.json` -> `ui-coverage-summary/total.txt` (the `.total.lines.pct`) and uploads it as `ui-coverage-summary-<run_id>`.

**`ui-code-coverage.yml` (new)** — privileged `workflow_run` consumer mirroring `code-coverage.yml`
- On `ap-web Tests` completion, downloads the artifact and posts a `Coverage (ui)` commit status (`state=success`, % in the description). Never checks out PR code; no-data guard for fork PRs.

## Verification

- `npm run test:coverage` locally -> 152 files pass, **73.45% line coverage**, `coverage-summary.json` emitted.
- `total.txt` distill command -> `73.45`.
- `coverage/` git-ignored; `format:check` passes.
- Lockfile `resolved` URLs pinned to `registry.npmjs.org` (matches CI's `NPM_CONFIG_REGISTRY`).

## Not in this PR (deferred follow-ups)

- Making the `e2e-ui-required` LLM judge accept vitest unit tests as valid coverage.
- Patch/diff-coverage *gating* (this PR only reports, doesn't enforce a threshold).