### PR TITLE
Only move Docker :latest on final release tags

### DIFF
--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -85,11 +85,17 @@ jobs:
           TAGS="${IMAGE}:sha-${SHORT_SHA}"
           HOST_TAGS="${HOST_IMAGE}:sha-${SHORT_SHA}"
           bump_latest="false"
-          # A version tag is a release: publish :vX.Y.Z and move :latest.
+          # A version tag is a release: publish the immutable :vX.Y.Z (or
+          # :vX.Y.ZrcN) pin. Only a FINAL release moves :latest — pre-release
+          # tags (vX.Y.ZrcN, vX.Y.Za/b, vX.Y.Z.devN) must not, so :latest tracks
+          # the version `pip install omnigent` resolves to (latest stable on
+          # PyPI), which ignores pre-releases.
           if [[ "${GH_REF}" == refs/tags/v* ]]; then
             TAGS="${TAGS},${IMAGE}:${GH_REF_NAME}"
             HOST_TAGS="${HOST_TAGS},${HOST_IMAGE}:${GH_REF_NAME}"
-            bump_latest="true"
+            if [[ "${GH_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              bump_latest="true"
+            fi
           fi
           # A manual dispatch can opt in to moving :latest (human approval).
           if [ "${BUMP_LATEST}" = "true" ]; then


### PR DESCRIPTION
## Problem

`docker pull ghcr.io/omnigent-ai/omnigent-server:latest` can point at a *different* version than `pip install omnigent`.

`oss-publish-images.yml` moves `:latest` on **any** `refs/tags/v*` push:

```bash
if [[ "${GH_REF}" == refs/tags/v* ]]; then
  TAGS="${TAGS},${IMAGE}:${GH_REF_NAME}"
  ...
  bump_latest="true"
fi
```

That glob matches pre-release tags too — and we push them (tag history: `v0.1.0rc4`, `v0.1.0`, `v0.1.1rc1`, `v0.1.1rc2`, `v0.1.1`). On PyPI an `rcN` is a pre-release, so `pip install omnigent` skips it and resolves to the latest **stable**. So right after pushing `v0.1.1rc1`, `:latest` is the release candidate while `pip install omnigent` still gives the prior stable — a real divergence. The step's own comment already claims ":latest only moves on a real release," but the condition didn't enforce "real."

## Fix

Only move `:latest` for a **final** release tag (`^vX.Y.Z$`). Pre-release tags still publish their immutable `:vX.Y.ZrcN` image — they just no longer touch `:latest`. The `bump_latest` manual-dispatch override is unchanged.

Verified the anchor against real and hypothetical tags:

| tag | moves `:latest`? |
|-----|------------------|
| `v0.1.0`, `v0.1.1`, `v1.2.3` | yes |
| `v0.1.1rc1`, `v1.2.3a1`, `v1.2.3.dev2` | no |
| `main` | no |

This keeps `:latest` tracking the same version PyPI serves by default.