### PR TITLE
ci(lint): gate ap-web/package-lock.json freshness

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,6 +86,22 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: npm ci --legacy-peer-deps
 
+      # The npm equivalent of the `uv sync --locked` gate above. `npm ci`
+      # only checks the lockfile is CONSISTENT with package.json; it
+      # tolerates cosmetic drift (dev/extraneous flags, metadata) that a
+      # fresh resolution would rewrite. Regenerate the lockfile and fail
+      # if it differs from the committed one.
+      - name: Check ap-web/package-lock.json is up to date
+        working-directory: ap-web
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund
+          git diff --exit-code package-lock.json || {
+            echo "::error::ap-web/package-lock.json is out of date. Run 'npm install --package-lock-only --legacy-peer-deps' in ap-web/ and commit the result."
+            exit 1
+          }
+
       - name: Run formatting, lint, and typing checks
         run: uv run pre-commit run --all-files --show-diff-on-failure
 

--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -6761,6 +6761,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6770,6 +6771,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16168,6 +16170,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -16458,7 +16461,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17265,22 +17268,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
## What

Add the npm analog of the existing `uv sync --locked` gate: a dedicated step in `lint.yml` that fails CI when `ap-web/package-lock.json` is out of sync with a fresh resolution.

```yaml
- name: Check ap-web/package-lock.json is up to date
  working-directory: ap-web
  env:
    NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
  run: |
    npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund
    git diff --exit-code package-lock.json || { ... }
```

## Why

`npm ci` (already in the workflow) only checks the lockfile is *consistent* with `package.json` — it tolerates cosmetic drift (`dev`/`extraneous` flags, metadata) that a fresh resolution would rewrite. This new gate regenerates the lockfile and fails on any difference, surfacing staleness with a clear fix-it message instead of letting it accumulate.

This builds on #351, which pinned npm to the exact version (11.12.1) in both the regen workflow and the `setup-node` composite action — so the npm that *generates* the lockfile matches the one that *verifies* it here, and the gate won't flake on version skew.

## Changes

- **`lint.yml`** — add the freshness-gate step after `npm ci`.
- **`ap-web/package-lock.json`** — regenerate the currently-stale lockfile so the gate is green from the first run. It carried a dropped `extraneous` `yaml` entry and missing `dev` flags on `@types/react`, `@types/react-dom`, `tailwindcss`, and `typescript` (all `devDependencies`).

Verified: the gate passes against current `main` — a fresh `npm install --package-lock-only` produces no diff.

This pull request and its description were written by Isaac.
