### PR TITLE
ci: normalize package-lock.json registry to public npm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Check uv.lock uses the public PyPI index
         run: python scripts/normalize_uv_lock_registry.py --check uv.lock
 
+      # Backstop to the normalize-npm-lock-registry pre-commit hook: fail if
+      # a committed `resolved` URL points at the Databricks npm proxy. The
+      # freshness gate below can't catch this — npm keeps an existing
+      # `resolved` host on re-resolve. Pure stdlib check, no node needed.
+      - name: Check package-lock.json uses the public npm registry
+        run: python scripts/normalize_npm_lock_registry.py --check ap-web/package-lock.json
+
       - name: Set up uv
         uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,17 @@ repos:
         files: ^uv\.lock$
         pass_filenames: true
 
+      # Same as above for the npm lockfile: a local `npm install` against
+      # the Databricks npm proxy bakes that host into `resolved` URLs. This
+      # OSS repo must always commit the public npm host. Fixer: re-stage if
+      # it changes.
+      - id: normalize-npm-lock-registry
+        name: normalize package-lock.json registry to registry.npmjs.org
+        language: system
+        entry: .venv/bin/python scripts/normalize_npm_lock_registry.py
+        files: ^ap-web/package-lock\.json$
+        pass_filenames: true
+
   # ── File hygiene ────────────────────────────────────────────────
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/scripts/normalize_npm_lock_registry.py
+++ b/scripts/normalize_npm_lock_registry.py
@@ -1,0 +1,134 @@
+"""Normalize the package registry in ``ap-web/package-lock.json`` to public npm.
+
+Local ``npm install`` runs resolve against whatever registry is configured
+on the developer's machine (e.g. the Databricks npm proxy via
+``NPM_CONFIG_REGISTRY`` or ``~/.npmrc``). When npm resolves a package
+freshly — a new dependency, or a from-scratch ``rm package-lock.json &&
+npm install`` — it bakes that registry's host into the ``resolved`` URL of
+every affected entry. For this OSS repo the committed lockfile must always
+point at public npm (``https://registry.npmjs.org``) so the lock is
+reproducible for contributors who don't have the proxy — CI already pins
+``NPM_CONFIG_REGISTRY: https://registry.npmjs.org/`` for the same reason.
+
+Only the *host* of a proxy ``resolved`` URL is rewritten; the package path
+is preserved (``…/-/foo-1.2.3.tgz`` is identical on the proxy and on public
+npm). Non-proxy hosts are left untouched, so a future git / GitHub-tarball
+dependency is never clobbered — only hosts matching :data:`_PROXY_HOST_MARKER`
+are normalized.
+
+This is a pre-commit *fixer*: it rewrites the URLs in place and exits
+non-zero when it changed anything, so the commit aborts and the developer
+re-stages the normalized lockfile (mirroring ``end-of-file-fixer`` and
+friends, and the sibling ``normalize_uv_lock_registry.py``).
+
+Pass ``--check`` to validate without writing: it exits non-zero (and names
+the offending hosts) when a file still carries proxy URLs, but leaves it
+untouched. CI runs this mode against the committed lockfile as a backstop
+to the pre-commit hook — the ``package-lock.json`` freshness gate cannot
+catch a proxy URL, because npm preserves an existing ``resolved`` host on
+re-resolve rather than rewriting it to the configured registry.
+
+Usage::
+
+    python scripts/normalize_npm_lock_registry.py ap-web/package-lock.json          # fix
+    python scripts/normalize_npm_lock_registry.py --check ap-web/package-lock.json   # verify
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+# The canonical public registry host the committed lockfile must always use.
+_CANONICAL_HOST = "registry.npmjs.org"
+
+# A host is treated as a (Databricks) proxy to rewrite when it contains this
+# marker. Kept deliberately narrow so only proxy mirrors are normalized and
+# legitimate non-npm sources (git, GitHub tarballs) are never touched.
+_PROXY_HOST_MARKER = "databricks"
+
+# Captures the URL inside a package-lock ``"resolved": "<url>"`` entry.
+_RESOLVED_RE = re.compile(r'("resolved":\s*")(https?://[^"]+)(")')
+
+
+def _proxy_resolved_urls(text: str) -> list[str]:
+    """Return the ``resolved`` URLs in *text* that point at a proxy host.
+
+    :param text: Full contents of a ``package-lock.json`` file.
+    :returns: Each proxy ``resolved`` URL, in order, duplicates preserved.
+    """
+    out: list[str] = []
+    for m in _RESOLVED_RE.finditer(text):
+        host = urlsplit(m.group(2)).hostname or ""
+        if _PROXY_HOST_MARKER in host:
+            out.append(m.group(2))
+    return out
+
+
+def normalize_text(text: str) -> str:
+    """Return *text* with every proxy ``resolved`` host rewritten to public npm.
+
+    :param text: Full contents of a ``package-lock.json`` file.
+    :returns: The same text with each proxy ``resolved`` URL's host replaced
+        by :data:`_CANONICAL_HOST`; the scheme is forced to ``https`` and the
+        path/query/fragment are preserved. Non-proxy URLs are unchanged.
+    """
+
+    def _sub(m: re.Match[str]) -> str:
+        parts = urlsplit(m.group(2))
+        if _PROXY_HOST_MARKER not in (parts.hostname or ""):
+            return m.group(0)
+        fixed = urlunsplit(
+            ("https", _CANONICAL_HOST, parts.path, parts.query, parts.fragment)
+        )
+        return f"{m.group(1)}{fixed}{m.group(3)}"
+
+    return _RESOLVED_RE.sub(_sub, text)
+
+
+def main(argv: list[str]) -> int:
+    """Normalize (or, with ``--check``, validate) each given lockfile.
+
+    :param argv: Filenames to process, optionally preceded/followed by the
+        ``--check`` flag (passed by pre-commit or CI).
+    :returns: In fix mode, ``1`` when a file was modified (so the commit
+        aborts and the change is re-staged) else ``0``. In ``--check`` mode,
+        ``1`` when any file still carries proxy URLs (printing the offending
+        hosts) else ``0``; no file is written.
+    """
+    check = "--check" in argv
+    files = [a for a in argv if a != "--check"]
+
+    if check:
+        ok = True
+        for name in files:
+            offenders = _proxy_resolved_urls(Path(name).read_text())
+            if offenders:
+                ok = False
+                hosts = sorted({urlsplit(u).hostname or "" for u in offenders})
+                print(
+                    f"{name}: {len(offenders)} proxy registry URL(s) "
+                    f"(expected host {_CANONICAL_HOST}): {', '.join(hosts)}"
+                )
+                print(
+                    "Fix with: python scripts/normalize_npm_lock_registry.py "
+                    f"{name} && git add {name}"
+                )
+        return 0 if ok else 1
+
+    changed = False
+    for name in files:
+        path = Path(name)
+        original = path.read_text()
+        normalized = normalize_text(original)
+        if normalized != original:
+            path.write_text(normalized)
+            print(f"{name}: normalized registry host to {_CANONICAL_HOST}")
+            changed = True
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/normalize_npm_lock_registry.py
+++ b/scripts/normalize_npm_lock_registry.py
@@ -80,9 +80,7 @@ def normalize_text(text: str) -> str:
         parts = urlsplit(m.group(2))
         if _PROXY_HOST_MARKER not in (parts.hostname or ""):
             return m.group(0)
-        fixed = urlunsplit(
-            ("https", _CANONICAL_HOST, parts.path, parts.query, parts.fragment)
-        )
+        fixed = urlunsplit(("https", _CANONICAL_HOST, parts.path, parts.query, parts.fragment))
         return f"{m.group(1)}{fixed}{m.group(3)}"
 
     return _RESOLVED_RE.sub(_sub, text)

--- a/tests/test_normalize_npm_lock_registry.py
+++ b/tests/test_normalize_npm_lock_registry.py
@@ -1,0 +1,190 @@
+"""Unit tests for ``scripts/normalize_npm_lock_registry.py``.
+
+The pre-commit fixer rewrites every proxy ``"resolved": "<url>"`` host in
+``ap-web/package-lock.json`` to public npm so a developer's local
+registry/proxy never leaks into the committed lockfile. These tests pin
+that contract: proxy ``resolved`` hosts are normalized (path preserved,
+scheme forced to https), npmjs and other non-proxy hosts are left alone,
+the fixer is idempotent, and ``main`` signals modifications via its exit
+code (1 = changed → commit aborts and re-stages; 0 = clean).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "normalize_npm_lock_registry.py"
+
+# The canonical host the fixer must always produce — kept in the test as
+# an independent literal so a change to the script's constant is caught.
+_CANONICAL_HOST = "registry.npmjs.org"
+
+# A representative Databricks proxy host the lockfile must never retain.
+_PROXY_HOST = "npm-proxy.cloud.databricks.com"
+
+# A package path shared by the proxy/canonical URL pair — identical on the
+# proxy mirror and on public npm, so only the host should ever change.
+_PKG_PATH = "/@adobe/css-tools/-/css-tools-4.5.0.tgz"
+
+
+def _resolved(host: str, *, scheme: str = "https", path: str = _PKG_PATH) -> str:
+    """Render one ``"resolved": "<url>"`` lockfile line for *host*."""
+    return f'      "resolved": "{scheme}://{host}{path}",\n'
+
+
+def _load_module() -> Any:
+    """Import ``scripts/normalize_npm_lock_registry.py`` from its file path.
+
+    ``scripts/`` is not a package on ``sys.path`` (mirrors
+    ``tests/test_normalize_uv_lock_registry.py``'s loader), so load it
+    directly.
+
+    :returns: The imported module, exposing ``normalize_text``,
+        ``_proxy_resolved_urls``, and ``main``.
+    """
+    spec = importlib.util.spec_from_file_location("scripts_normalize_npm_lock", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not locate the script at {_SCRIPT_PATH}."
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MOD = _load_module()
+
+
+def test_normalize_text_rewrites_proxy_host() -> None:
+    """A Databricks-proxy ``resolved`` host is rewritten to public npm."""
+    assert _MOD.normalize_text(_resolved(_PROXY_HOST)) == _resolved(_CANONICAL_HOST)
+
+
+def test_normalize_text_preserves_package_path() -> None:
+    """Only the host changes — the package path is carried over verbatim."""
+    path = "/some-scope/pkg/-/pkg-9.9.9-beta.1.tgz"
+    result = _MOD.normalize_text(_resolved(_PROXY_HOST, path=path))
+    assert result == _resolved(_CANONICAL_HOST, path=path)
+
+
+def test_normalize_text_forces_https_on_proxy() -> None:
+    """An http proxy URL is upgraded to https when normalized."""
+    result = _MOD.normalize_text(_resolved(_PROXY_HOST, scheme="http"))
+    assert result == _resolved(_CANONICAL_HOST, scheme="https")
+
+
+def test_normalize_text_rewrites_every_occurrence() -> None:
+    """Multiple proxy ``resolved`` entries are all normalized in one pass."""
+    text = _resolved(_PROXY_HOST) * 3
+    result = _MOD.normalize_text(text)
+    assert _PROXY_HOST not in result
+    assert result.count(_CANONICAL_HOST) == 3
+
+
+def test_normalize_text_leaves_npmjs_untouched() -> None:
+    """A ``resolved`` URL already on public npm is returned unchanged."""
+    text = _resolved(_CANONICAL_HOST)
+    assert _MOD.normalize_text(text) == text
+
+
+def test_normalize_text_leaves_non_proxy_hosts_untouched() -> None:
+    """git / GitHub-tarball ``resolved`` sources and other content survive."""
+    text = (
+        _resolved("github.com", path="/org/repo/archive/abcdef.tar.gz")
+        + _resolved("codeload.github.com", path="/org/repo/tar.gz/abcdef")
+        + '      "version": "1.2.3",\n'
+        + '      "integrity": "sha512-deadbeef==",\n'
+    )
+    assert _MOD.normalize_text(text) == text
+
+
+def test_normalize_text_ignores_proxy_url_outside_resolved_field() -> None:
+    """A proxy host in a non-``resolved`` field is not touched."""
+    text = f'      "funding": "https://{_PROXY_HOST}/sponsors",\n'
+    assert _MOD.normalize_text(text) == text
+
+
+def test_normalize_text_already_canonical_is_noop() -> None:
+    """Text already pointing at public npm is returned unchanged."""
+    text = _resolved(_CANONICAL_HOST)
+    assert _MOD.normalize_text(text) == text
+
+
+def test_proxy_resolved_urls_lists_offenders() -> None:
+    """The check helper reports each proxy ``resolved`` URL, in order."""
+    proxy_url = f"https://{_PROXY_HOST}{_PKG_PATH}"
+    text = _resolved(_PROXY_HOST) + _resolved(_CANONICAL_HOST) + _resolved(_PROXY_HOST)
+    assert _MOD._proxy_resolved_urls(text) == [proxy_url, proxy_url]
+
+
+def test_proxy_resolved_urls_empty_when_canonical() -> None:
+    """A fully-canonical lockfile reports no offenders."""
+    assert _MOD._proxy_resolved_urls(_resolved(_CANONICAL_HOST)) == []
+
+
+def test_main_rewrites_file_and_returns_one_when_changed(tmp_path: Path) -> None:
+    """``main`` rewrites a proxy lockfile in place and returns 1 (changed)."""
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_resolved(_PROXY_HOST))
+    rc = _MOD.main([str(lock)])
+    assert rc == 1
+    assert lock.read_text() == _resolved(_CANONICAL_HOST)
+
+
+def test_main_returns_zero_when_already_canonical(tmp_path: Path) -> None:
+    """``main`` leaves a canonical lockfile untouched and returns 0 (clean)."""
+    lock = tmp_path / "package-lock.json"
+    original = _resolved(_CANONICAL_HOST)
+    lock.write_text(original)
+    rc = _MOD.main([str(lock)])
+    assert rc == 0
+    assert lock.read_text() == original
+
+
+def test_main_is_idempotent(tmp_path: Path) -> None:
+    """A second run after normalization is a no-op returning 0."""
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_resolved(_PROXY_HOST))
+    assert _MOD.main([str(lock)]) == 1
+    assert _MOD.main([str(lock)]) == 0
+
+
+def test_main_handles_multiple_files(tmp_path: Path) -> None:
+    """Given several files, any change yields exit 1 and each is normalized."""
+    proxy = _resolved(_PROXY_HOST)
+    canonical = _resolved(_CANONICAL_HOST)
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(proxy)
+    b.write_text(canonical)
+    rc = _MOD.main([str(a), str(b)])
+    assert rc == 1
+    assert a.read_text() == canonical
+    assert b.read_text() == canonical
+
+
+def test_main_check_fails_without_writing(tmp_path: Path) -> None:
+    """``--check`` returns 1 for a proxy lockfile and does NOT modify it."""
+    lock = tmp_path / "package-lock.json"
+    original = _resolved(_PROXY_HOST)
+    lock.write_text(original)
+    rc = _MOD.main(["--check", str(lock)])
+    assert rc == 1
+    # Check mode must be read-only — the file is left exactly as-is.
+    assert lock.read_text() == original
+
+
+def test_main_check_passes_when_canonical(tmp_path: Path) -> None:
+    """``--check`` returns 0 for an already-canonical lockfile."""
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_resolved(_CANONICAL_HOST))
+    assert _MOD.main(["--check", str(lock)]) == 0
+
+
+def test_main_check_flag_position_independent(tmp_path: Path) -> None:
+    """``--check`` is recognized whether it precedes or follows the file."""
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_resolved(_CANONICAL_HOST))
+    assert _MOD.main([str(lock), "--check"]) == 0


### PR DESCRIPTION
## What

Add `scripts/normalize_npm_lock_registry.py` and wire it as a pre-commit fixer plus a CI `--check` backstop in `lint.yml`, mirroring the existing `normalize_uv_lock_registry.py` for `uv.lock`.

## Why

A local `npm install` resolving through the Databricks npm proxy bakes that host into the `resolved` URLs of `ap-web/package-lock.json`. This OSS repo must always commit the public `registry.npmjs.org` host so the lockfile is reproducible for contributors who don't have the proxy.

The freshness gate (#355) **cannot** catch this: npm preserves an existing `resolved` host on re-resolve rather than rewriting it to the configured registry, so a proxy URL slips through `npm install --package-lock-only` unchanged. A dedicated normalizer is genuinely needed — exactly as it is for `uv.lock`.

## How it works

- **Fixer** (pre-commit): rewrites only proxy `resolved` hosts back to `registry.npmjs.org`, preserving the package path; exits non-zero when it changes anything so the commit aborts and the developer re-stages. Non-proxy hosts (git / GitHub tarball deps) are never touched.
- **`--check`** (CI): validates the committed lockfile without writing, naming any offending hosts. Runs in `lint.yml` next to the `uv.lock --check`, as a backstop to the pre-commit hook.

## Changes

- **`scripts/normalize_npm_lock_registry.py`** (new) — fixer + `--check`, stdlib only.
- **`.pre-commit-config.yaml`** — register `normalize-npm-lock-registry` (mirrors the uv hook).
- **`lint.yml`** — add the `--check` step.

Verified: `--check` passes on the current committed lockfile; an injected proxy URL is detected and fixed with byte-identical output (no collateral edits).

This pull request and its description were written by Isaac.
