### PR TITLE
ci(merge-ready): reliable fork-PR triggers (check_suite + workflow_dispatch)

### DIFF
--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -3,10 +3,13 @@ name: Merge Ready
 # Posts the "Merge Ready" commit status on the PR head SHA -- the single
 # required branch-protection check, backed by the REQUIRED list inside
 # this workflow. Triggers: `/merge` comment (write-access commenter only),
-# `pull_request` labeled (acts only with `automerge`/`force-merge`), and
-# `workflow_run` on CI completion. Posted via the REST API (not the job's
-# implicit check run) so the status lands on the PR head SHA, since these
-# jobs run on the default branch.
+# `pull_request` labeled (acts only with `automerge`/`force-merge`),
+# `workflow_run` on same-repo CI completion, `check_suite` completion on a
+# `fork-e2e/**` branch (the mirrored fork PR e2e -- a delivery that actually
+# fires, unlike the brittle fork-PR `workflow_run` hop it replaces), and
+# `workflow_dispatch` (programmatic/manual re-evaluation of one PR). Posted
+# via the REST API (not the job's implicit check run) so the status lands on
+# the PR head SHA, since these jobs run on the default branch.
 #
 # Labels:
 #   automerge    enable GitHub auto-merge (one-shot on label add) + opt
@@ -18,21 +21,38 @@ name: Merge Ready
 #                a red status explaining the rejection.
 
 on:
-  # `labeled` only; `workflow_run` re-evaluates on CI completion.
+  # `labeled` only; `workflow_run` re-evaluates on same-repo CI completion.
   pull_request:
     types: [labeled]
   workflow_run:
     workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
     types: [completed]
+  # Fork PR e2e runs on a trusted fork-e2e/** mirror branch (see
+  # fork-e2e-mirror.yml); its check_suite completing is the re-eval signal.
+  # ctx maps the suite's head SHA back to the open PR.
+  check_suite:
+    types: [completed]
   issue_comment:
     types: [created]
+  # Programmatic / manual re-evaluation of a single PR -- a reliable entry
+  # point that does not depend on the fork-e2e mirror at all.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to (re)evaluate.
+        required: true
+        type: string
+      sha:
+        description: Head SHA to post on (defaults to the PR's current head).
+        required: false
+        type: string
 
 # Read-only at top level; write scopes live on the job below.
 permissions:
   contents: read
 
 concurrency:
-  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.head_sha }}
+  group: merge-ready-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.event.check_suite.head_sha || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -44,12 +64,11 @@ jobs:
       checks: read
       actions: read         # evaluate-checks.sh reads GET /actions/runs to classify missing checks
       statuses: write
-    # Fire on automerge/force-merge label adds, PR-originated
-    # workflow_run completions, or `/merge` comments. workflow_run is
-    # filtered to PR runs plus the fork-e2e `push` on `fork-e2e/**`
-    # (mirrored fork PR e2e -- see fork-e2e-mirror.yml; ctx step maps
-    # its head SHA back to the PR). Post-merge/nightly/dispatch runs
-    # have no PR to post on and are excluded.
+    # Fire on automerge/force-merge label adds, same-repo PR workflow_run
+    # completions, fork-e2e/** check_suite completions (mirrored fork PR
+    # e2e -- ctx maps the head SHA back to the PR), `/merge` comments, or a
+    # workflow_dispatch re-eval. Post-merge/nightly runs (push to main, etc.)
+    # have no open PR and are dropped by the ctx step.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -60,14 +79,13 @@ jobs:
       ) ||
       (
         github.event_name == 'workflow_run' &&
-        (
-          github.event.workflow_run.event == 'pull_request' ||
-          (
-            github.event.workflow_run.event == 'push' &&
-            startsWith(github.event.workflow_run.head_branch, 'fork-e2e/')
-          )
-        )
+        github.event.workflow_run.event == 'pull_request'
       ) ||
+      (
+        github.event_name == 'check_suite' &&
+        startsWith(github.event.check_suite.head_branch, 'fork-e2e/')
+      ) ||
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
@@ -96,11 +114,32 @@ jobs:
           # Via env, not interpolated: author-controlled, so direct
           # interpolation would be a shell-injection vector.
           WF_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          CS_PRS: ${{ toJSON(github.event.check_suite.pull_requests) }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_INPUT: ${{ inputs.pr }}
+          SHA_INPUT: ${{ inputs.sha }}
         run: |
+          # Resolve the open PR from a head SHA -- fork-PR events leave the
+          # payload's pull_requests array empty (cross-repo).
+          resolve_pr_from_sha() {
+            gh api "repos/$REPO/commits/$1/pulls" \
+              --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true
+          }
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             PR="${{ github.event.pull_request.number }}"
             SHA="${{ github.event.pull_request.head.sha }}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # PR_INPUT is dispatcher-controlled; validate before shell use.
+            if ! [[ "$PR_INPUT" =~ ^[0-9]+$ ]]; then
+              echo "::error::workflow_dispatch input 'pr' must be a PR number"
+              exit 1
+            fi
+            PR="$PR_INPUT"
+            if [[ "$SHA_INPUT" =~ ^[0-9a-f]{7,40}$ ]]; then
+              SHA="$SHA_INPUT"
+            else
+              SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+            fi
           elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
             # The job `if` contains() pre-filter also fires on incidental
             # mentions; re-validate `/merge` as a command (first non-space
@@ -112,15 +151,21 @@ jobs:
             fi
             PR="${{ github.event.issue.number }}"
             SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+          elif [[ "${{ github.event_name }}" == "check_suite" ]]; then
+            # Mirrored fork e2e completed on fork-e2e/pr-N; its head SHA is
+            # the PR head (the mirror pushes the exact fork head SHA).
+            SHA="${{ github.event.check_suite.head_sha }}"
+            PR=$(echo "$CS_PRS" | jq -r '.[0].number // empty')
+            [[ -z "$PR" ]] && PR=$(resolve_pr_from_sha "$SHA")
+            if [[ -z "$PR" ]]; then
+              echo "::notice::Skipped: check_suite has no associated open PR"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             PR=$(echo "$WF_PRS" | jq -r '.[0].number // empty')
             SHA="${{ github.event.workflow_run.head_sha }}"
-            if [[ -z "$PR" ]]; then
-              # Fork-PR runs leave workflow_run.pull_requests empty, so
-              # resolve the open PR from the head SHA.
-              PR=$(gh api "repos/$REPO/commits/$SHA/pulls" \
-                --jq 'map(select(.state == "open")) | .[0].number // empty' 2>/dev/null || true)
-            fi
+            [[ -z "$PR" ]] && PR=$(resolve_pr_from_sha "$SHA")
             if [[ -z "$PR" ]]; then
               echo "::notice::Skipped: workflow_run has no associated PR (push to main, etc)"
               echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -275,12 +320,16 @@ jobs:
           PR: ${{ steps.ctx.outputs.pr }}
         run: bash .github/scripts/merge-ready/enable-automerge-label.sh
 
-      # workflow_run only. On pull_request labeled, auto-merge was
-      # enabled in an earlier step; failing here makes the label look
-      # broken even though it worked.
+      # Not on pull_request-labeled: auto-merge was enabled in an earlier
+      # step there, so failing here would make the label look broken even
+      # though it worked. Safe on workflow_run/check_suite/workflow_dispatch.
       - name: Fail job when gate is red
         if: >-
-          github.event_name == 'workflow_run' &&
+          (
+            github.event_name == 'workflow_run' ||
+            github.event_name == 'check_suite' ||
+            github.event_name == 'workflow_dispatch'
+          ) &&
           steps.ctx.outputs.skip != 'true' &&
           steps.eligible.outputs.run == 'true' &&
           steps.eligible.outputs.post_red == 'true' &&


### PR DESCRIPTION
## ELI5

Think of **Merge Ready** as a doorman who must give a green stamp before a PR can merge. The doorman doesn't watch the tests himself — he just needs someone to ring a **doorbell** so he wakes up, checks the test results stuck to the PR, and stamps it green.

- For **normal PRs** (same repo), the doorbell works fine.
- For **fork PRs** (outside contributors), the tests that need secrets can't run directly — for safety they're copied onto a trusted `fork-e2e/**` branch and run there. The doorbell was wired to that branch... but the wire was cut: the bell **never rang**, so the doorman never woke up, never stamped, and the PR sat blocked forever (that's what happened to #339 — someone had to stamp it by hand with `/merge`).

This PR rewires the doorbell so it actually rings for fork PRs (`check_suite`), and adds a **manual buzzer** anyone can press (`workflow_dispatch`) if the automatic one ever fails again. The doorman and his green-stamp logic don't change at all.

## Diagram (fork PR flow)

```mermaid
flowchart TD
    A[Fork PR opened/updated] --> B[fork-e2e-mirror pushes head SHA<br/>onto trusted branch fork-e2e/pr-N]
    B --> C[E2E / UI / Integration run on<br/>fork-e2e/pr-N · all green]
    C --> D{Doorbell: who tells<br/>Merge Ready to re-check?}

    D -->|"❌ OLD: workflow_run on<br/>fork-e2e/** push (never delivered)"| X[Merge Ready never runs<br/>→ status missing<br/>→ PR BLOCKED]
    D -->|"✅ NEW: check_suite completed<br/>on fork-e2e/** branch"| E[Merge Ready evaluates the<br/>PR head SHA's checks]
    M["✅ NEW: workflow_dispatch<br/>(manual / automation buzzer)"] --> E

    E --> F[Post green Merge Ready<br/>status on PR head SHA<br/>→ PR mergeable]

    style X fill:#ffd6d6,stroke:#c0392b
    style F fill:#d6f5d6,stroke:#27ae60
    style M fill:#d6e4ff,stroke:#2c6fbf
```

Note: Merge Ready always reads/evaluates **the PR head SHA** (where the required checks, including the mirrored e2e, report). The `fork-e2e/**` branch was only ever the doorbell, never a data source — which is why swapping the doorbell mechanism is a safe, localized fix.

---

## Problem

Fork PRs never get the required **Merge Ready** status posted, so their merge box stays `BLOCKED` even when every CI check is green. PR #339 hit this — all checks green, but `Merge Ready` was missing on the head commit and it had to be forced through with `/merge`.

### Root cause

`Merge Ready` is evaluated and posted **on the PR head SHA** (`evaluate-checks.sh` reads the head SHA; the status is posted there). The required checks — including the mirrored fork e2e — all report onto that SHA. So the `fork-e2e/**` branch was never a *data* dependency; it was only used as a re-eval **doorbell** via `workflow_run` on the mirrored e2e `push`.

That doorbell doesn't ring for fork PRs. Tracing #339: the mirror pushed `fork-e2e/pr-339`, e2e ran green there as `push` (head SHA = PR head), but their completion produced **zero** `Merge Ready` runs for that SHA — across two separate pushes — while same-repo commits got dozens of `workflow_run`-triggered re-evals in the same window. The `workflow_run` + `fork-e2e/**` hop is effectively dead for forks.

## Fix

- **Drop** the dead `workflow_run` + `fork-e2e/**` push sub-clause from the job `if`.
- **Re-evaluate fork PRs on `check_suite: completed`** filtered to `fork-e2e/**` branches — a commit-level delivery that fires when the mirrored e2e suite finishes, mapped back to the open PR via the existing head-SHA → PR lookup. Same signal the old hop wanted, via a delivery path that isn't subject to `workflow_run`'s workflow-name matching.
- **Add `workflow_dispatch`** (`pr`, optional `sha`) as a reliable manual/programmatic re-eval entry point that doesn't depend on the mirror at all.
- Broaden the red-gate failure step to the new automatic/dispatch events.

No change to the security-sensitive `pull_request_target` mirror workflow (`fork-e2e-mirror.yml`).

## Validation

- `yaml.safe_load` parses; all five triggers present.
- `bash -n` on the rewritten `ctx` script: clean.
- The automatic fork path (`check_suite`) should be confirmed on a live fork PR end-to-end. `workflow_dispatch` guarantees a manual recovery regardless: `gh workflow run merge-ready.yml -f pr=<N>`.

## Coordination

Several in-flight PRs are reworking the fork-e2e gating (e.g. *"trigger fork-e2e mirror on the e2e-approved label"*, *"gate secret e2e on the e2e-approved label only"*). This change only touches `merge-ready.yml` triggers, but should be sequenced with those.