### PR TITLE
fix: use correct Codex approval mode values and CLI flag

### DIFF
--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -478,7 +478,7 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toBeUndefined();
   });
 
-  it("posts --approval-mode <mode> when a non-default mode is picked for codex-native", async () => {
+  it("posts --ask-for-approval <mode> when a non-default mode is picked for codex-native", async () => {
     setAgents([agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
       ok: true,
@@ -487,12 +487,12 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the footer tray's Advanced menu and pick full-auto.
+    // Open the footer tray's Advanced menu and pick "never".
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-auto"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-approval-never"));
     // A non-default pick is suffixed onto the pill.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
-      "Codex (Full auto)",
+      "Codex (Never)",
     );
     typeMessage("go");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
@@ -500,7 +500,7 @@ describe("NewChatLandingScreen create flow", () => {
     await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
     const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.terminal_launch_args).toEqual(["--approval-mode", "full-auto"]);
+    expect(body.terminal_launch_args).toEqual(["--ask-for-approval", "never"]);
   });
 
   it("omits terminal_launch_args when approval mode is left at default for codex-native", async () => {

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -685,13 +685,13 @@ describe("NewChatLandingScreen", () => {
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
-    const fullAutoOption = screen.getByTestId("new-chat-landing-approval-full-auto");
-    expect(fullAutoOption.textContent).toContain("Full auto");
+    const neverOption = screen.getByTestId("new-chat-landing-approval-never");
+    expect(neverOption.textContent).toContain("Never");
     // The footer line explains the SELECTED mode until a row is hovered.
     const detail = screen.getByTestId("new-chat-landing-approval-detail");
-    expect(detail.textContent).toContain("Prompts before edits and commands");
-    fireEvent.pointerEnter(fullAutoOption);
-    expect(detail.textContent).toContain("Runs everything; no prompts or safety checks");
+    expect(detail.textContent).toContain("Model decides when to ask for approval");
+    fireEvent.pointerEnter(neverOption);
+    expect(detail.textContent).toContain("Never asks for approval");
   });
 
   it("shows a conflict banner in the file browser for an occupied directory", async () => {

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -112,22 +112,27 @@ const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; descriptio
   },
 ];
 
-// Codex's `--approval-mode` choices. Codex-native sessions only.
-// "suggest" is Codex's default (prompts before everything); any other value
-// is passed through as `--approval-mode <value>` via the session's
-// terminal_launch_args. Keep in sync with `codex --help`.
-const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "suggest";
+// Codex's `--ask-for-approval` choices (codex CLI). Codex-native sessions
+// only. "on-request" is Codex's default; any other value is passed through
+// as `--ask-for-approval <value>` via the session's terminal_launch_args.
+// Keep in sync with `codex --help` and
+// https://developers.openai.com/codex/agent-approvals-security
+const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "on-request";
 const CODEX_NATIVE_APPROVAL_MODES: { value: string; label: string; description: string }[] = [
-  { value: "suggest", label: "Suggest", description: "Prompts before edits and commands" },
   {
-    value: "auto-edit",
-    label: "Auto edit",
-    description: "Auto-applies file edits; commands still prompt",
+    value: "untrusted",
+    label: "Untrusted",
+    description: "Runs only known-safe read operations automatically",
   },
   {
-    value: "full-auto",
-    label: "Full auto",
-    description: "Runs everything; no prompts or safety checks",
+    value: "on-request",
+    label: "On request",
+    description: "Model decides when to ask for approval",
+  },
+  {
+    value: "never",
+    label: "Never",
+    description: "Never asks for approval; failures go straight to the model",
   },
 ];
 
@@ -1087,7 +1092,7 @@ export function NewChatLandingScreen() {
             agentSupportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
               ? ["--permission-mode", permissionMode]
               : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
-                ? ["--approval-mode", approvalMode]
+                ? ["--ask-for-approval", approvalMode]
                 : undefined,
           // Cost-control switch from the "Cost Optimized" pill; polly-only
           // (cost control is a polly feature) and omitted when unset so the

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -358,10 +358,10 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
 def test_start_session_select_approval_mode(seeded_session: tuple[str, str]) -> None:
     """Picking a non-default approval mode rides along to the create call.
 
-    Selecting "Full auto" in the agent picker's Advanced settings menu
+    Selecting "Never" in the agent picker's Advanced settings menu
     must (a) surface in the agent chip label as immediate feedback and
     (b) reach ``POST /v1/sessions`` as
-    ``terminal_launch_args: ["--approval-mode", "full-auto"]``.
+    ``terminal_launch_args: ["--ask-for-approval", "never"]``.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_approval_mode(base_url, session_id))
@@ -406,15 +406,15 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             # gated on the Codex-native agent — is present.
             await page.get_by_test_id("new-chat-landing-advanced-chip").click()
             # All three Codex approval modes render as radio rows.
-            for mode in ("suggest", "auto-edit", "full-auto"):
+            for mode in ("untrusted", "on-request", "never"):
                 await expect(
                     page.get_by_test_id(f"new-chat-landing-approval-{mode}")
                 ).to_be_visible()
-            await page.get_by_test_id("new-chat-landing-approval-full-auto").click()
+            await page.get_by_test_id("new-chat-landing-approval-never").click()
 
             # The chip label reflects the non-default pick immediately.
             await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
-                "Full auto"
+                "Never"
             )
 
             await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
@@ -425,7 +425,7 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             assert body["agent_id"] == "ag_codex_e2e", body
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
-            assert body.get("terminal_launch_args") == ["--approval-mode", "full-auto"], body
+            assert body.get("terminal_launch_args") == ["--ask-for-approval", "never"], body
         finally:
             await browser.close()
 


### PR DESCRIPTION
## Summary
- Fixes the Codex approval mode selector in the New Chat dialog to use the correct CLI flag and values
- `--approval-mode` → `--ask-for-approval` (the actual Codex CLI flag)
- `suggest`/`auto-edit`/`full-auto` → `untrusted`/`on-request`/`never` (the actual values from `codex --help`)
- Default changed from `suggest` to `on-request`
- Updates all unit, flow, and e2e tests

Ref: https://developers.openai.com/codex/agent-approvals-security

## Test plan
- [x] Unit tests pass (133 tests)
- [x] Flow tests updated with correct flag and values
- [x] E2e test updated with correct mode values

This pull request and its description were written by Isaac.