### PR TITLE
Revert "ci: remove oss-regen-on-comment.yml (superseded by pre-commit)"

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -1,0 +1,213 @@
+# A maintainer comments `/regen` on a PR to regenerate the repo's lockfiles
+# (uv.lock + ap-web/package-lock.json) against public PyPI/npm and commit them
+# ONTO that PR's branch. Use when the PR itself moved a dependency; complements
+# oss-regenerate-and-smoke.yml (standalone rolling PR on dispatch).
+#
+# Validation is left to the PR's own CI: the push uses a GitHub App token (NOT
+# GITHUB_TOKEN, which GitHub suppresses to avoid loops), so it re-fires the full
+# check suite on the new commit. Falls back to GITHUB_TOKEN if the App isn't
+# configured (lands, but a maintainer must re-push to run CI).
+#
+# Authorization: only .github/MAINTAINER entries (read from main's tip) may run
+# it — it pushes code. Same-repo PRs only (can't push to a fork branch).
+name: OSS regenerate lockfiles on /regen comment
+
+on:
+  issue_comment:
+    types: [created]
+
+# Read-only at the top level; write scopes live on the jobs below.
+permissions:
+  contents: read
+
+jobs:
+  # Gate: confirm a `/regen` comment on a PR in the OSS repo by a maintainer.
+  # Exposes the PR head ref to the regen job.
+  authorize:
+    permissions:
+      contents: read       # checkout main for load-maintainers.sh
+      pull-requests: write # read the PR head ref, post the fork-rejection comment
+      issues: write        # react to the triggering comment
+    if: >-
+      github.repository == 'omnigent-ai/omnigent'
+      && github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/regen')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ok: ${{ steps.authz.outputs.ok }}
+      head: ${{ steps.pr.outputs.head }}
+      cross: ${{ steps.pr.outputs.cross }}
+    steps:
+      # Checkout main only for load-maintainers.sh; the PR branch is checked
+      # out later (regen job), after authorization passes.
+      - name: Checkout (for the maintainer script)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Load maintainers from .github/MAINTAINER
+        id: maint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/merge-ready/load-maintainers.sh
+
+      - name: Authorize commenter
+        id: authz
+        env:
+          LIST: ${{ steps.maint.outputs.list }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          ok=false
+          for u in $LIST; do
+            if [ "$u" = "$ACTOR" ]; then ok=true; break; fi
+          done
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" != "true" ]; then
+            echo "::notice::@$ACTOR is not in .github/MAINTAINER; ignoring /regen."
+          fi
+
+      - name: Resolve PR head ref
+        id: pr
+        if: steps.authz.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          data=$(gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRefName,isCrossRepository)
+          echo "head=$(echo "$data" | jq -r .headRefName)" >> "$GITHUB_OUTPUT"
+          echo "cross=$(echo "$data" | jq -r .isCrossRepository)" >> "$GITHUB_OUTPUT"
+
+      # ${{ }} values pass via env: and referenced as "$VAR" to avoid injection.
+      - name: Acknowledge (or reject forks)
+        if: steps.authz.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROSS: ${{ steps.pr.outputs.cross }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          if [ "$CROSS" = "true" ]; then
+            gh pr comment "$ISSUE" --repo "$REPO" \
+              --body "⚠️ \`/regen\` supports same-repo PRs only (it can't push to a fork branch). Regenerate locally with \`uv lock\` and push."
+          else
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+              -f content=eyes --silent || true
+          fi
+
+  regen:
+    permissions:
+      contents: write      # push the regenerated lockfiles to the PR branch
+      pull-requests: write # post status comments
+      issues: write        # comment the result on the PR thread
+    needs: authorize
+    if: needs.authorize.outputs.ok == 'true' && needs.authorize.outputs.cross == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # One regen per PR at a time; a second /regen waits rather than racing a push.
+    concurrency:
+      group: oss-regen-comment-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      # No token / no persisted credentials: `uv lock` can execute PR-chosen
+      # build backends, which must not find a push token on disk. The App token
+      # is minted only after `uv lock` and enters only at the push step.
+      - name: Checkout the PR branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.authorize.outputs.head }}
+          persist-credentials: false
+
+      - name: Set up uv (clean public resolution, no proxy cache)
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        with:
+          enable-cache: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      # 7-day cooldown comes from uv.toml (`exclude-newer = "P7D"`), recorded as
+      # a relative span; an env-var cutoff would stamp an absolute date and break
+      # later `uv sync --locked`. npm's cooldown (ap-web/.npmrc min-release-age=7)
+      # is only honored by npm >= 11.10.0; node 20 ships npm 10.x which ignores it.
+      - name: Ensure npm honors the dependency cooldown
+        run: npm install -g "npm@>=11.10.0"
+      # Delete package-lock.json so npm RESOLVES from scratch: min-release-age
+      # only filters during resolution, and --package-lock-only keeps an existing
+      # in-range pin without re-applying the cooldown.
+      - name: Regenerate lockfiles against public PyPI/npm
+        run: |
+          uv lock
+          ( cd ap-web && rm -f package-lock.json && npm install --package-lock-only --no-audit --no-fund )
+
+      # Mint the App token only AFTER `uv lock` so untrusted PR build backends
+      # never see it. Skipped when the App isn't configured (push then falls back
+      # to GITHUB_TOKEN and a maintainer must re-push to run CI).
+      - name: Mint App token
+        id: app-token
+        if: vars.OSS_REGEN_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.OSS_REGEN_APP_ID }}
+          private-key: ${{ secrets.OSS_REGEN_APP_KEY }}
+
+      # ${{ }} values pass via env: as "$VAR" to avoid injection (HEAD_REF is a
+      # user-influenced branch name). The push token authenticates inline (scoped
+      # to this step, never in .git/config) so the push re-triggers the PR's CI.
+      - name: Commit and push to the PR branch
+        id: push
+        env:
+          HEAD_REF: ${{ needs.authorize.outputs.head }}
+          PUSH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # --porcelain (not git diff) so first-time UNTRACKED lockfiles count too.
+          if [ -z "$(git status --porcelain -- uv.lock ap-web/package-lock.json)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Lockfiles already current — nothing to commit."
+            exit 0
+          fi
+          git add uv.lock ap-web/package-lock.json
+          git commit -m "chore(oss): regenerate public lockfiles against public PyPI/npm"
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO}.git" "HEAD:$HEAD_REF"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the result
+        if: always() && steps.push.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          CHANGED: ${{ steps.push.outputs.changed }}
+          # App token used → push re-triggers CI; skipped (GITHUB_TOKEN fallback) → it won't.
+          APP_USED: ${{ steps.app-token.conclusion == 'success' }} # App token → re-triggers CI; fallback → won't
+        run: |
+          if [ "$CHANGED" = "true" ]; then
+            base="✅ Regenerated \`uv.lock\` + \`ap-web/package-lock.json\` against public PyPI/npm and pushed to this PR."
+            if [ "$APP_USED" = "true" ]; then
+              body="$base CI will re-run on the new commit."
+            else
+              body="$base ⚠️ No regen App configured, so this push won't auto-trigger CI — push any commit (or amend) to re-run checks."
+            fi
+            gh pr comment "$ISSUE" --repo "$REPO" --body "$body"
+          else
+            gh pr comment "$ISSUE" --repo "$REPO" \
+              --body "ℹ️ Lockfiles already current against public PyPI/npm — nothing to regenerate."
+          fi
+
+      # Failure path: tell the maintainer on the PR instead of the Actions tab.
+      - name: Comment on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$ISSUE" --repo "$REPO" \
+            --body "❌ \`/regen\` failed — see the [workflow run]($RUN_URL). Lockfiles were not changed."


### PR DESCRIPTION
## Summary

Restores `.github/workflows/oss-regen-on-comment.yml`, the `/regen`-comment workflow that regenerates `uv.lock` + `ap-web/package-lock.json` against public PyPI/npm and pushes them onto the PR branch. This reverts the deletion in #305.

The workflow pushes the regenerated lockfiles via a dedicated GitHub App token (`vars.OSS_REGEN_APP_ID` / `secrets.OSS_REGEN_APP_KEY`) so the new commit **re-fires the PR's CI** (a `GITHUB_TOKEN` push wouldn't). It falls back to `GITHUB_TOKEN` when the App isn't configured — the commit still lands, but a maintainer must re-push to run CI.

Follow-up (separate, manual): re-create the OSS-regen GitHub App and set `OSS_REGEN_APP_ID` (variable) + `OSS_REGEN_APP_KEY` (secret) on the repo so the auto-re-trigger path works. Until then the workflow runs in `GITHUB_TOKEN`-fallback mode.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Restores a previously-shipped workflow verbatim (byte-for-byte from its pre-#305 state); `actionlint`-shaped YAML validated to parse. It's `issue_comment`-triggered, gated to maintainers via `.github/MAINTAINER`, and not a required check, so it adds no gate and can only be invoked by a maintainer comment.