### PR TITLE
test(e2e-ui): mark multi-turn recall test llm_flaky

### DIFF
--- a/tests/e2e_ui/chat/test_multi_turn_chat.py
+++ b/tests/e2e_ui/chat/test_multi_turn_chat.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from playwright.sync_api import Page, expect
 
 _COMPOSER = "Ask the agent anything…"
@@ -27,6 +28,11 @@ def _send(page: Page, text: str) -> None:
     page.get_by_role("button", name="Send", exact=True).click()
 
 
+# Real-LLM nondeterminism: the model must reply "stored" then echo the token
+# verbatim. llm_flaky reruns rotate the model per attempt (databricks-gpt-5-4 ->
+# -5-5), which is exactly the right retry for a recall flake. Safe here because
+# e2e-ui.yml runs serially (no xdist) with no --timeout=180 cap.
+@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)
 def test_multi_turn_recall_through_ui(
     page: Page,
     seeded_session: tuple[str, str],


### PR DESCRIPTION
## What

Marks `tests/e2e_ui/chat/test_multi_turn_chat.py::test_multi_turn_recall_through_ui` with `@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)`.

## Why

The test depends on the model replying `"stored"` and then echoing a random token **verbatim** across two turns — inherent real-LLM nondeterminism, not a code bug. `llm_flaky` reruns rotate the model per attempt (`databricks-gpt-5-4` → `-5-5` via `tests/_model_pools.py`), the appropriate retry for a recall flake.

## Why `llm_flaky` and not plain `flaky`

`flaky` is for timing/scheduling races; `llm_flaky` is for real-LLM nondeterminism and additionally rotates models per attempt. This failure mode is the latter.

## Safety

The `llm_flaky` caveat warns against heavy e2e tests that can hit the `--timeout=180` cap under xdist. That does not apply here: `e2e-ui.yml` runs serially via `--splits`/`--group` (no xdist) and passes no `--timeout`, relying on per-test Playwright waits (capped at 60s/phase).