### PR TITLE
ci: align OSS lockfile regen with the lint freshness gate

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -133,15 +133,22 @@ jobs:
       # a relative span; an env-var cutoff would stamp an absolute date and break
       # later `uv sync --locked`. npm's cooldown (ap-web/.npmrc min-release-age=7)
       # is only honored by npm >= 11.10.0; node 20 ships npm 10.x which ignores it.
+      # Pin the EXACT version (not a range) and keep it in lockstep with
+      # .github/actions/setup-node (npm 11.12.1): this workflow generates the
+      # lockfile and that action verifies it, so a version gap would fail the
+      # freshness gate in lint.yml.
       - name: Ensure npm honors the dependency cooldown
-        run: npm install -g "npm@>=11.10.0"
+        run: npm install -g npm@11.12.1
       # Delete package-lock.json so npm RESOLVES from scratch: min-release-age
       # only filters during resolution, and --package-lock-only keeps an existing
       # in-range pin without re-applying the cooldown.
+      # --legacy-peer-deps is REQUIRED and MUST match the flag lint.yml verifies
+      # with (React 18 runtime vs React 19 peers would otherwise ERESOLVE-fail,
+      # and a flag mismatch rewrites dev/extraneous flags, failing the gate).
       - name: Regenerate lockfiles against public PyPI/npm
         run: |
           uv lock
-          ( cd ap-web && rm -f package-lock.json && npm install --package-lock-only --no-audit --no-fund )
+          ( cd ap-web && rm -f package-lock.json && npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund )
 
       # Mint the App token only AFTER `uv lock` so untrusted PR build backends
       # never see it. Skipped when the App isn't configured (push then falls back

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -62,11 +62,18 @@ jobs:
       # Delete the lockfile so npm RESOLVES from scratch: min-release-age only
       # filters during resolution, and --package-lock-only keeps an existing
       # in-range pin without re-applying the cooldown.
+      #
+      # --legacy-peer-deps is REQUIRED: the tree pins React 18 at runtime while
+      # much of the UI stack (and @types/react) peer-requires React 19, so npm's
+      # strict resolver would ERESOLVE-fail without it. It MUST match the flag the
+      # freshness gate in lint.yml verifies with; generating without it resolves
+      # the peer graph differently and rewrites the dev/devOptional/extraneous
+      # flags, failing that byte-exact gate.
       - name: Regenerate package-lock.json
         working-directory: ap-web
         run: |
           rm -f package-lock.json
-          npm install --package-lock-only --no-audit --no-fund
+          npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund
 
       # Validate BEFORE committing: the Docker build proves the regenerated
       # locks + public registries produce a working image.


### PR DESCRIPTION
## Summary

The two OSS lockfile-regen workflows generate `ap-web/package-lock.json` with `npm install --package-lock-only` **without** `--legacy-peer-deps`, while the lint freshness gate (`lint.yml`) verifies it **with** `--legacy-peer-deps`. The two commands resolve the peer-dependency graph differently, so a lockfile produced correctly by the regen automation fails the gate's byte-exact `git diff --exit-code` — exactly what happened in #359.

`--legacy-peer-deps` is **load-bearing**, not cosmetic: the tree pins `react`/`react-dom` to `^18` at runtime while ~100 packages in the UI stack (and `@types/react@19`) peer-require React 19 *exclusively* (`@lobehub/*`, `shiki-stream`, …). npm 7+ would `ERESOLVE`-fail without the flag. Because `npm ci`, the Docker build, and local dev all use `--legacy-peer-deps`, the lockfile must be **generated** the same way it's installed and verified. Generating without it reclassifies transitive deps (`dev` / `devOptional` / `extraneous`), which is precisely the drift the #359 gate rejected.

## Changes

- Add `--legacy-peer-deps` to the regen command in **both** `oss-regenerate-and-smoke.yml` and `oss-regen-on-comment.yml`, so generation matches the `lint.yml` verifier.
- Pin `oss-regen-on-comment.yml` to the exact `npm@11.12.1` (was a floating `npm@>=11.10.0`), keeping it in lockstep with `.github/actions/setup-node` and `oss-regenerate-and-smoke.yml` so npm version skew can't churn the lockfile metadata.

## Test coverage

- [x] Not applicable — CI workflow change; YAML validated to parse.

## Notes

No outbound npm access in the authoring environment, so the regenerated lockfile was not byte-verified locally. The change makes all three invocations (both regens + the lint gate) use the identical `npm install --package-lock-only --legacy-peer-deps` command under the same pinned npm. A follow-up worth tracking separately: resolving the React 18-vs-19 split so `--legacy-peer-deps` can eventually be dropped for honest peer resolution.