### PR TITLE
Fix harness idle watchdog heartbeat handling

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -94,11 +94,11 @@ _SHUTDOWN_GRACE_S = 4.5
 # classifiers make their own LLM call on the Omnigent server side.
 _POLICY_EVAL_TIMEOUT_S = 35.0
 
-# Per-turn IDLE watchdog: max gap WITHOUT progress before a wedged
+# Per-turn IDLE watchdog: max gap WITHOUT stream activity before a wedged
 # ``run_turn`` becomes ``response.failed`` (vs heartbeating forever).
-# Every non-heartbeat ``ctx.emit`` resets the deadline (see
-# ``_guarded_run_turn``), so a long-but-active turn is never killed.
-# Env var name kept for the ops knob; ``<= 0`` disables.
+# Every ``ctx.emit`` resets the deadline (see ``_guarded_run_turn``), so
+# a long quiet await is not killed while the stream heartbeat is still
+# alive. Env var name kept for the ops knob; ``<= 0`` disables.
 _TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "240"))
 
 # Absolute per-turn ceiling: a hard cap on TOTAL turn duration, backstop
@@ -431,12 +431,12 @@ class TurnContext:
             ``OutputTextDeltaEvent(type="response.output_text.delta",
             delta="hi")``.
         """
-        # Treat any non-heartbeat event as progress and push the idle
-        # watchdog deadline forward. Heartbeats are keep-alive, NOT
-        # progress — letting them reset the deadline would defeat the
-        # watchdog (a wedged turn's 15s heartbeats would keep it alive
-        # forever).
-        if self._reset_idle_watchdog is not None and not isinstance(event, HeartbeatEvent):
+        # Any stream event is activity. ``response.heartbeat`` is not
+        # substantive progress, but it proves the turn stream is still
+        # alive while ``run_turn`` is parked on a legitimate quiet await
+        # such as LLM/tool/sub-agent work. The absolute watchdog remains
+        # the backstop for a turn that heartbeats but never finishes.
+        if self._reset_idle_watchdog is not None:
             self._reset_idle_watchdog()
         self._event_queue.put_nowait(event)
 
@@ -1381,17 +1381,15 @@ class HarnessApp:
 
         Enforces two per-turn watchdogs, whichever trips first:
 
-        - IDLE (:data:`_TURN_IDLE_TIMEOUT_S`): each non-heartbeat
-          ``ctx.emit`` reschedules its deadline via the
-          ``_reset_idle_watchdog`` hook, so a turn that keeps making
-          progress (an orchestrator running tests + build + many tool
-          calls) is never killed — only one that emits nothing for the
-          whole window. This replaces the prior fixed *cumulative* cap,
-          which guillotined long-but-healthy turns mid-stream.
+        - IDLE (:data:`_TURN_IDLE_TIMEOUT_S`): each ``ctx.emit``
+          reschedules its deadline via the ``_reset_idle_watchdog``
+          hook. Heartbeats count as stream activity here, so a turn
+          parked on a legitimate quiet await is not killed solely for
+          withholding substantive deltas.
         - ABSOLUTE (:data:`_TURN_ABSOLUTE_TIMEOUT_S`): a hard ceiling on
           total duration, never rescheduled. Backstops the idle watchdog
-          against a runaway-but-active loop the idle one never sees as
-          stuck.
+          against a runaway-but-active or heartbeat-only loop the idle
+          one never sees as stuck.
 
         Either expiry surfaces a wedged/runaway ``run_turn`` as
         ``response.failed``.
@@ -1410,8 +1408,9 @@ class HarnessApp:
             def _reset() -> None:
                 # Push ONLY the idle deadline ``idle_timeout`` s past now
                 # (the absolute ceiling is never rescheduled). Called from
-                # ``ctx.emit`` during ``run_turn`` (inside the active
-                # context), so the reschedule is always valid.
+                # ``ctx.emit`` while the guarded turn context is active
+                # (run_turn itself or the heartbeat task), so the
+                # reschedule is always valid.
                 idle_wd.reschedule(loop.time() + idle_timeout)
 
             ctx._reset_idle_watchdog = _reset
@@ -1423,14 +1422,15 @@ class HarnessApp:
         except TimeoutError as exc:
             if idle_wd.expired():
                 _logger.warning(
-                    "run_turn for %s made no progress for %.0fs (idle turn watchdog); "
+                    "run_turn for %s emitted no stream activity for %.0fs "
+                    "(idle turn watchdog); "
                     "marking the turn failed",
                     ctx.response_id,
                     idle_timeout,
                 )
                 raise RuntimeError(
                     f"turn exceeded the {idle_timeout:.0f}s harness idle watchdog "
-                    f"(run_turn emitted no events for {idle_timeout:.0f}s; "
+                    f"(run_turn emitted no stream activity for {idle_timeout:.0f}s; "
                     f"likely a wedged LLM or tool call)"
                 ) from exc
             if absolute_wd.expired():

--- a/tests/runtime/harnesses/_test_scaffold_harnesses.py
+++ b/tests/runtime/harnesses/_test_scaffold_harnesses.py
@@ -401,12 +401,10 @@ class _WedgedFastHeartbeatHarness(HarnessApp):
     """
     Hangs forever in ``run_turn`` while emitting fast heartbeats.
 
-    Exercises the load-bearing detail of the idle-reset watchdog:
-    ``response.heartbeat`` is keep-alive, NOT progress, so it must NOT
-    reset the idle deadline. With a 0.2s heartbeat against a 2s watchdog,
-    ~10 heartbeats fire inside the window — if heartbeats reset the
-    watchdog, the turn would never fail; the watchdog must still fire and
-    terminate the wedged turn with ``response.failed``.
+    Exercises the absolute watchdog backstop: ``response.heartbeat`` is
+    keep-alive stream activity and refreshes the idle deadline, but a
+    run_turn that only heartbeats and never finishes must still be
+    terminated by the absolute ceiling.
 
     Overrides ``_heartbeat_loop`` (not the module constant) because the
     constant is read once at subprocess import and a test-process
@@ -425,11 +423,36 @@ class _WedgedFastHeartbeatHarness(HarnessApp):
         await asyncio.Event().wait()  # never set; hang until the watchdog fires
 
 
+class _QuietWaitHeartbeatHarness(HarnessApp):
+    """
+    Stays quiet longer than the idle watchdog while the heartbeat loop
+    proves the turn stream is still alive, then completes.
+
+    This models a legitimate long await inside ``run_turn``: the harness
+    is not producing substantive deltas while an LLM/tool/sub-agent is
+    working, but the SSE stream is still able to emit low-cost
+    ``response.heartbeat`` frames.
+    """
+
+    async def _heartbeat_loop(self, ctx: TurnContext) -> None:
+        from omnigent.server.schemas import HeartbeatEvent
+
+        while True:
+            await asyncio.sleep(0.2)
+            ctx.emit(HeartbeatEvent(type="response.heartbeat"))
+
+    async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
+        del request
+        await asyncio.sleep(2.5)
+        ctx.emit(OutputTextDeltaEvent(type="response.output_text.delta", delta="done"))
+
+
 _FIXTURES: dict[str, type[HarnessApp]] = {
     "echo": _EchoHarness,
     "wedged": _WedgedHarness,
     "busy_progress": _BusyProgressHarness,
     "wedged_fast_heartbeat": _WedgedFastHeartbeatHarness,
+    "quiet_wait_heartbeat": _QuietWaitHeartbeatHarness,
     "usage": _UsageHarness,
     "tool_dispatch": _ToolDispatchHarness,
     "elicitation": _ElicitationHarness,

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -249,9 +249,18 @@ def use_busy_progress(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def use_wedged_fast_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Spawn the wedged-with-fast-heartbeats harness; 2s idle watchdog."""
+    """Spawn a heartbeat-only wedged harness with a short absolute cap."""
     monkeypatch.setenv("HARNESS_TEST_FIXTURE", "wedged_fast_heartbeat")
-    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "2")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "1")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "3")
+
+
+@pytest.fixture
+def use_quiet_wait_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spawn a quiet wait that outlasts the 1s idle watchdog."""
+    monkeypatch.setenv("HARNESS_TEST_FIXTURE", "quiet_wait_heartbeat")
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "1")
+    monkeypatch.setenv("HARNESS_TURN_ABSOLUTE_TIMEOUT_S", "10")
 
 
 @pytest.fixture
@@ -532,8 +541,8 @@ async def test_per_turn_watchdog_allows_active_turn_past_window(
     A turn that keeps emitting progress must complete even when its
     total duration exceeds the watchdog window.
 
-    The watchdog is an *idle* timeout: each non-heartbeat event resets
-    the deadline, so an orchestrator turn that legitimately runs for
+    The watchdog is an *idle* timeout: each stream event resets the
+    deadline, so an orchestrator turn that legitimately runs for
     minutes (tests + build + many tool calls) isn't killed mid-turn. The
     ``busy_progress`` harness emits a delta every 0.1s for ~3s against a
     2s watchdog. This test FAILS on the old fixed-cumulative watchdog
@@ -569,48 +578,74 @@ async def test_per_turn_watchdog_allows_active_turn_past_window(
     )
 
 
-async def test_per_turn_watchdog_ignores_heartbeats(
-    use_wedged_fast_heartbeat: None,
+async def test_per_turn_watchdog_allows_quiet_heartbeat_wait_past_idle_window(
+    use_quiet_wait_heartbeat: None,
     manager: HarnessProcessManager,
 ) -> None:
     """
-    Heartbeats must NOT reset the idle watchdog.
+    A quiet-but-live turn must not fail only because it emits no deltas.
 
-    ``response.heartbeat`` is keep-alive, not progress. If it reset the
-    deadline, a wedged turn emitting heartbeats every 15s would never
-    fail. The ``wedged_fast_heartbeat`` harness hangs forever while
-    firing a 0.2s heartbeat against a 2s watchdog (~10 heartbeats inside
-    the window); the watchdog must still fire and terminate the turn.
+    Polly/orchestrator turns can park inside ``run_turn`` while an LLM,
+    tool, or sub-agent is doing useful work. During that window the only
+    low-cost activity may be ``response.heartbeat``; those heartbeats
+    must keep the idle watchdog from reporting a false wedge.
     """
-    conv_id = "conv_wedged_fast_heartbeat"
+    conv_id = "conv_quiet_wait_heartbeat"
     client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
     body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
     events: list[_ParsedSSEEvent] = []
-    # Above the 2s watchdog, below the suite timeout. If heartbeats wrongly
-    # reset the deadline the stream never terminates and this timeout trips
-    # — a clean failure rather than a silent pass.
     async with asyncio.timeout(20):
         async with client.stream("POST", f"/v1/sessions/{conv_id}/events", json=body) as response:
             async for event in _stream_iter(response):
                 events.append(event)
 
     event_types = [e.event for e in events]
-    # Heartbeats fired throughout, but the wedged turn made no real
-    # progress — the idle watchdog must ignore the heartbeats and fail.
-    assert event_types[-1] == "response.failed", (
-        f"Wedged turn must fail despite ongoing heartbeats; got "
-        f"{event_types[-1]!r}. If response.completed/no-terminal, "
-        f"heartbeats wrongly reset the idle watchdog."
+    assert event_types[-1] == "response.completed", (
+        f"A quiet wait with heartbeats must complete, not be killed by the "
+        f"idle watchdog; got {event_types!r}."
     )
-    # At least one heartbeat must have actually fired inside the window —
-    # otherwise this test would pass even if heartbeat-reset were broken.
+    assert "response.heartbeat" in event_types, (
+        f"Expected heartbeats during the quiet wait; got {event_types!r}."
+    )
+    assert "response.output_text.delta" in event_types, (
+        f"Expected the post-wait completion delta; got {event_types!r}."
+    )
+
+
+async def test_per_turn_absolute_watchdog_caps_heartbeat_only_wedged_turn(
+    use_wedged_fast_heartbeat: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """
+    Heartbeat-only wedged turns must still hit the absolute watchdog.
+
+    ``response.heartbeat`` is keep-alive, not substantive progress, but
+    it must refresh the idle watchdog so quiet legitimate awaits are not
+    falsely killed. The separate absolute watchdog remains the hard cap:
+    a run_turn that only heartbeats and never finishes still terminates.
+    """
+    conv_id = "conv_wedged_fast_heartbeat"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    body = {"type": "message", "role": "user", "model": "test-agent", "content": []}
+    events: list[_ParsedSSEEvent] = []
+    # Above the 3s absolute cap, below the suite timeout.
+    async with asyncio.timeout(20):
+        async with client.stream("POST", f"/v1/sessions/{conv_id}/events", json=body) as response:
+            async for event in _stream_iter(response):
+                events.append(event)
+
+    event_types = [e.event for e in events]
+    assert event_types[-1] == "response.failed", (
+        f"Heartbeat-only wedged turn must fail at the absolute cap; got "
+        f"{event_types[-1]!r} (full: {event_types!r})."
+    )
     assert "response.heartbeat" in event_types, (
         f"Expected heartbeats during the wedged window; got {event_types!r}. "
-        f"Without them this test wouldn't exercise heartbeat-vs-watchdog."
+        f"Without them this test would not exercise heartbeat activity."
     )
     error = events[-1].data["response"]["error"]
-    assert error is not None and "watchdog" in error["message"], (
-        f"Watchdog failure must carry an explanatory error message; got {error!r}."
+    assert error is not None and "absolute" in error["message"], (
+        f"Failure must come from the absolute ceiling, not idle; got {error!r}."
     )
 
 


### PR DESCRIPTION
## Summary
- Treat harness heartbeat frames as stream activity for the per-turn idle watchdog so quiet-but-live waits are not falsely failed
- Keep the absolute watchdog as the hard cap for heartbeat-only or runaway turns
- Add scaffold regression coverage for quiet heartbeat waits and heartbeat-only wedged turns

## Tests
- uv run --extra dev ruff check omnigent/runtime/harnesses/_scaffold.py tests/runtime/harnesses/test_scaffold.py tests/runtime/harnesses/_test_scaffold_harnesses.py
- git diff --check
- uv run --extra dev python -m pytest tests/runtime/harnesses/test_scaffold.py -q
- uv run --extra dev python -m pytest tests/runtime/harnesses -q