### PR TITLE
test(ap-web): fill high & medium UI unit-test coverage gaps

### DIFF
--- a/ap-web/src/components/AgentInfo.test.tsx
+++ b/ap-web/src/components/AgentInfo.test.tsx
@@ -1,10 +1,25 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
 import { useChatStore } from "@/store/chatStore";
-import { AgentInfoButton } from "./AgentInfo";
+
+// Mock the policies data layer so SessionPoliciesSection and AddPolicyDialog
+// render deterministically without network. The add/delete mutations expose
+// `mutate` spies we can assert on.
+const addMutate = vi.fn();
+const deleteMutate = vi.fn();
+const policiesData = { current: [] as unknown[] };
+const registryData = { current: [] as unknown[] };
+vi.mock("@/hooks/usePolicies", () => ({
+  usePolicies: () => ({ data: policiesData.current }),
+  usePolicyRegistry: () => ({ data: registryData.current }),
+  useAddPolicy: () => ({ mutate: addMutate, isPending: false, isError: false, error: null }),
+  useDeletePolicy: () => ({ mutate: deleteMutate }),
+}));
+
+import { AgentInfoButton, AgentInfoContent } from "./AgentInfo";
 
 afterEach(() => {
   cleanup();
@@ -210,5 +225,133 @@ describe("AgentInfoButton per-model usage breakdown", () => {
     // The popover still opens (agent name proves it), but no breakdown.
     expect(screen.getByText("Databricks_coding_agent")).toBeInTheDocument();
     expect(screen.queryByTestId("agent-info-usage-by-model")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionPoliciesSection + AddPolicyDialog, rendered via AgentInfoContent
+// (no popover trigger needed) with the policies data layer mocked.
+// ---------------------------------------------------------------------------
+
+function renderContent(sessionId: string) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <AgentInfoContent agent={AGENT_WITH_BOTH} sessionId={sessionId} />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SessionPoliciesSection", () => {
+  beforeEach(() => {
+    addMutate.mockReset();
+    deleteMutate.mockReset();
+    policiesData.current = [];
+    registryData.current = [];
+  });
+
+  it("shows the empty state when no user policies are applied", () => {
+    // WHY: only `source === "session"` policies are user-managed; a spec
+    // policy must not count, so the section reads "No policies added".
+    policiesData.current = [{ id: "p_spec", name: "spec_one", handler: "h.spec", source: "spec" }];
+    renderContent("conv_pol");
+    expect(screen.getByText("No policies added")).toBeInTheDocument();
+  });
+
+  it("lists user policies and deletes one via the popover Remove button", () => {
+    // WHY: a session-sourced policy renders as a pill; opening it and clicking
+    // Remove must call deletePolicy.mutate with the policy id.
+    policiesData.current = [
+      { id: "p1", name: "deny_pii", handler: "guard.pii", source: "session" },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByRole("button", { name: /deny_pii/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    expect(deleteMutate).toHaveBeenCalledWith("p1");
+  });
+
+  it("filters the registry list and adds a callable policy", () => {
+    // WHY: the add dialog filters available (not-yet-applied) policies by
+    // name/description, and a callable policy adds with no factory_params.
+    registryData.current = [
+      { handler: "h.alpha", kind: "callable", name: "Alpha Guard", description: "blocks alpha" },
+      { handler: "h.beta", kind: "callable", name: "Beta Guard", description: "blocks beta" },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByTitle("Add policy"));
+    const dialog = screen.getByRole("dialog");
+    // Filter to just Beta.
+    fireEvent.change(within(dialog).getByPlaceholderText("Filter policies..."), {
+      target: { value: "beta" },
+    });
+    expect(within(dialog).queryByText("Alpha Guard")).toBeNull();
+    fireEvent.click(within(dialog).getByText("Beta Guard"));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add" }));
+
+    expect(addMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "beta_guard", type: "python", handler: "h.beta" }),
+      expect.anything(),
+    );
+    // Callable kind sends no factory_params.
+    expect(addMutate.mock.calls[0][0]).not.toHaveProperty("factory_params");
+  });
+
+  it("renders factory params and submits coerced values", () => {
+    // WHY: a factory policy with a params schema renders inputs and sends
+    // factory_params (always present for factory kind) on Add.
+    registryData.current = [
+      {
+        handler: "h.factory",
+        kind: "factory",
+        name: "PII Factory",
+        description: "configurable",
+        params_schema: {
+          properties: {
+            threshold: { type: "integer", default: 5 },
+            strict: { type: "boolean", default: true },
+          },
+          required: [],
+        },
+      },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByTitle("Add policy"));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByText("PII Factory"));
+
+    // The integer param input is present (number type).
+    const numberInput = within(dialog).getByPlaceholderText("5") as HTMLInputElement;
+    fireEvent.change(numberInput, { target: { value: "9" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add" }));
+
+    expect(addMutate).toHaveBeenCalledTimes(1);
+    const payload = addMutate.mock.calls[0][0];
+    expect(payload).toHaveProperty("factory_params");
+    expect(payload.handler).toBe("h.factory");
+  });
+
+  it("shows the all-applied empty message when every registry policy is already added", () => {
+    // WHY: when appliedHandlers covers the whole registry the filtered list is
+    // empty AND available.length === 0, so the dialog says all are applied.
+    registryData.current = [
+      { handler: "h.alpha", kind: "callable", name: "Alpha Guard", description: "blocks alpha" },
+    ];
+    policiesData.current = [
+      { id: "pa", name: "alpha_guard", handler: "h.alpha", source: "session" },
+    ];
+    renderContent("conv_pol");
+
+    fireEvent.click(screen.getByTitle("Add policy"));
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText("All available policies are already applied."),
+    ).toBeInTheDocument();
   });
 });

--- a/ap-web/src/components/PermissionsModal.test.tsx
+++ b/ap-web/src/components/PermissionsModal.test.tsx
@@ -10,10 +10,24 @@ vi.mock("@/lib/permissionsApi", () => ({
   revokePermission: vi.fn(),
 }));
 
+// Host config is read-once at render to decide plain-input vs combobox and to
+// transform the share link. Mock both getters so we can drive each branch.
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return {
+    ...actual,
+    getOmnigentUserSearch: vi.fn(() => undefined),
+    getOmnigentTransformShareLink: vi.fn(() => undefined),
+  };
+});
+
 import * as api from "@/lib/permissionsApi";
+import * as host from "@/lib/host";
 const listMock = vi.mocked(api.listPermissions);
 const grantMock = vi.mocked(api.grantPermission);
 const revokeMock = vi.mocked(api.revokePermission);
+const userSearchMock = vi.mocked(host.getOmnigentUserSearch);
+const transformLinkMock = vi.mocked(host.getOmnigentTransformShareLink);
 
 function createWrapper() {
   const qc = new QueryClient({
@@ -32,6 +46,9 @@ beforeEach(() => {
   listMock.mockReset();
   grantMock.mockReset();
   revokeMock.mockReset();
+  // Default: standalone (no host providers). Combobox/transform tests opt in.
+  userSearchMock.mockReturnValue(undefined);
+  transformLinkMock.mockReturnValue(undefined);
 });
 
 afterEach(cleanup);
@@ -262,5 +279,112 @@ describe("PermissionsModal", () => {
     } finally {
       Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
     }
+  });
+
+  it("uses the host transformShareLink when one is installed", () => {
+    // WHY: in the embed the host returns the full absolute URL; the modal must
+    // defer to that transform instead of prepending window.location.origin.
+    listMock.mockResolvedValue([]);
+    transformLinkMock.mockReturnValue((path: string) => `https://host.example.com/embed#${path}`);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<PermissionsModal sessionId="conv_xyz" open={true} onOpenChange={() => {}} />, {
+      wrapper: createWrapper(),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
+
+    return waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("https://host.example.com/embed#/c/conv_xyz");
+    });
+  });
+
+  it("surfaces a server error from a failed revoke", async () => {
+    // WHY: revoke failures (e.g. insufficient permission) must render the
+    // server message via the onError path, mirroring the grant error path.
+    listMock.mockResolvedValue([
+      { user_id: "bob@example.com", conversation_id: "conv_abc", level: 1 },
+    ]);
+    revokeMock.mockRejectedValue(new Error("cannot revoke last owner"));
+
+    render(<PermissionsModal sessionId="conv_abc" open={true} onOpenChange={() => {}} />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(screen.getByText("bob@example.com")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /revoke/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("cannot revoke last owner")).toBeInTheDocument();
+    });
+  });
+
+  describe("with a host user-search provider (combobox)", () => {
+    beforeEach(() => {
+      // Install a deterministic searcher so the add-user field upgrades to the
+      // suggestion combobox.
+      userSearchMock.mockReturnValue(
+        vi.fn(async (query: string) =>
+          query.startsWith("a")
+            ? [
+                { userId: "alice@example.com", displayName: "Alice" },
+                { userId: "amir@example.com", displayName: "Amir" },
+              ]
+            : [],
+        ),
+      );
+    });
+
+    it("renders the field as a combobox and shows suggestions while typing", async () => {
+      listMock.mockResolvedValue([]);
+      render(<PermissionsModal sessionId="conv_abc" open={true} onOpenChange={() => {}} />, {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(listMock).toHaveBeenCalled());
+
+      const input = screen.getByPlaceholderText("alice@example.com");
+      // The upgraded field carries role="combobox".
+      expect(input).toHaveAttribute("role", "combobox");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "al" } });
+
+      // The host searcher resolves to two matches, rendered as listbox options.
+      await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+      expect(screen.getByRole("option", { name: /Alice/ })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: /Amir/ })).toBeInTheDocument();
+    });
+
+    it("commits a clicked suggestion into the input value", async () => {
+      listMock.mockResolvedValue([]);
+      render(<PermissionsModal sessionId="conv_abc" open={true} onOpenChange={() => {}} />, {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(listMock).toHaveBeenCalled());
+
+      const input = screen.getByPlaceholderText("alice@example.com") as HTMLInputElement;
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "al" } });
+      await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+      // mousedown (not click) so the input isn't blurred before commit.
+      fireEvent.mouseDown(screen.getByRole("option", { name: /Alice/ }));
+      expect(input.value).toBe("alice@example.com");
+    });
+
+    it("shows an empty-state message when the searcher returns no matches", async () => {
+      listMock.mockResolvedValue([]);
+      render(<PermissionsModal sessionId="conv_abc" open={true} onOpenChange={() => {}} />, {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(listMock).toHaveBeenCalled());
+
+      const input = screen.getByPlaceholderText("alice@example.com");
+      fireEvent.focus(input);
+      // "z..." matches nothing in the stub searcher.
+      fireEvent.change(input, { target: { value: "zzz" } });
+
+      await waitFor(() => expect(screen.getByText("No matches")).toBeInTheDocument());
+    });
   });
 });

--- a/ap-web/src/components/SessionImage.test.tsx
+++ b/ap-web/src/components/SessionImage.test.tsx
@@ -1,0 +1,131 @@
+// Tests for SessionImage — inline preview for a session image file resource.
+//
+// Two render paths branch on the host config's `fetcher`:
+//   - Standalone (no fetcher): a plain same-origin <img src={path}>.
+//   - Embedded (fetcher present): bytes are pulled via hostFetch, turned into
+//     an object URL, and rendered with explicit loading/loaded/error states.
+//
+// `@/lib/host` is mocked so each test controls whether a fetcher is installed
+// and what hostFetch resolves to; URL.createObjectURL/revokeObjectURL are
+// stubbed because jsdom lacks them.
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getOmnigentHostConfig = vi.fn();
+const hostFetch = vi.fn();
+
+vi.mock("@/lib/host", () => ({
+  getOmnigentHostConfig: () => getOmnigentHostConfig(),
+  hostFetch: (path: string) => hostFetch(path),
+}));
+
+// The Spinner is a brand glyph that renders nothing meaningful in jsdom; a
+// marker keeps the loading-state assertion independent of its internals.
+vi.mock("@/components/ui/spinner", () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+import { SessionImage } from "./SessionImage";
+
+let createObjectURL: ReturnType<typeof vi.fn>;
+let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  createObjectURL = vi.fn(() => "blob:fake-url");
+  revokeObjectURL = vi.fn();
+  vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("SessionImage (standalone, no host fetcher)", () => {
+  beforeEach(() => {
+    getOmnigentHostConfig.mockReturnValue({ fetcher: undefined });
+  });
+
+  it("renders a plain same-origin <img> pointing at the raw path", () => {
+    // WHY: without a host fetcher the component must skip the byte-fetch path
+    // and emit a direct <img src={path}>, never calling hostFetch.
+    render(<SessionImage path="/v1/sessions/a/files/x/content" alt="diagram" className="c" />);
+    const img = screen.getByRole("img", { name: "diagram" });
+    expect(img).toHaveAttribute("src", "/v1/sessions/a/files/x/content");
+    expect(img).toHaveClass("c");
+    expect(hostFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("SessionImage (embedded, host fetcher present)", () => {
+  beforeEach(() => {
+    getOmnigentHostConfig.mockReturnValue({ fetcher: () => {} });
+  });
+
+  it("shows the loading placeholder before the fetch resolves", () => {
+    // WHY: while bytes are in flight the embedded path must render the
+    // role="status" placeholder (with spinner), not an <img>.
+    hostFetch.mockReturnValue(new Promise(() => {}));
+    render(<SessionImage path="/p" alt="pic" />);
+    expect(screen.getByRole("status", { name: "Loading image" })).toBeInTheDocument();
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+  });
+
+  it("renders the object-URL <img> once the blob loads", async () => {
+    // WHY: a successful fetch must create an object URL from the blob and swap
+    // the placeholder for an <img src> pointing at it.
+    const blob = new Blob(["x"]);
+    hostFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
+    render(<SessionImage path="/p" alt="pic" className="cls" />);
+    const img = await screen.findByRole("img", { name: "pic" });
+    expect(img).toHaveAttribute("src", "blob:fake-url");
+    expect(img).toHaveClass("cls");
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(hostFetch).toHaveBeenCalledWith("/p");
+  });
+
+  it("renders the error fallback when the response is not ok", async () => {
+    // WHY: a non-ok HTTP response must reject and drop into the error state —
+    // a labelled role="img" fallback chip rather than a broken <img>.
+    hostFetch.mockResolvedValue({ ok: false, status: 404 });
+    render(<SessionImage path="/missing" alt="gone" />);
+    await waitFor(() => {
+      const fallback = screen.getByRole("img", { name: "gone" });
+      expect(fallback).not.toHaveAttribute("src");
+      expect(fallback).toHaveTextContent("gone");
+    });
+  });
+
+  it("renders the error fallback when the fetch rejects", async () => {
+    // WHY: a network rejection (vs. an HTTP error) must land in the same error
+    // fallback rather than surfacing an unhandled rejection.
+    hostFetch.mockRejectedValue(new Error("boom"));
+    render(<SessionImage path="/p" alt="broken" />);
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "broken" })).toHaveTextContent("broken");
+    });
+  });
+
+  it("renders the error fallback immediately when no path is given", async () => {
+    // WHY: an undefined path can't be fetched, so the effect must short-circuit
+    // straight to the error state without ever calling hostFetch.
+    render(<SessionImage path={undefined} alt="nopath" />);
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "nopath" })).toBeInTheDocument();
+    });
+    expect(hostFetch).not.toHaveBeenCalled();
+  });
+
+  it("revokes the object URL on unmount to avoid leaking blobs", async () => {
+    // WHY: the cleanup must release the created object URL; failing to do so
+    // leaks blob memory across image swaps.
+    const blob = new Blob(["x"]);
+    hostFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
+    const { unmount } = render(<SessionImage path="/p" alt="pic" />);
+    await screen.findByRole("img", { name: "pic" });
+    unmount();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:fake-url");
+  });
+});

--- a/ap-web/src/components/blocks/TerminalSession.test.ts
+++ b/ap-web/src/components/blocks/TerminalSession.test.ts
@@ -233,8 +233,11 @@ class FakeWebSocket {
   sent: Array<string | Uint8Array> = [];
   closed = false;
   private listeners: Record<string, Array<(ev: unknown) => void>> = {};
+  url: string;
 
-  constructor(public url: string) {}
+  constructor(url: string) {
+    this.url = url;
+  }
 
   addEventListener(type: string, fn: (ev: unknown) => void) {
     (this.listeners[type] ??= []).push(fn);
@@ -263,7 +266,9 @@ class FakeResizeObserver {
   static instances: FakeResizeObserver[] = [];
   disconnected = false;
   observed: Element[] = [];
-  constructor(public cb: () => void) {
+  cb: () => void;
+  constructor(cb: () => void) {
+    this.cb = cb;
     FakeResizeObserver.instances.push(this);
   }
   observe(el: Element) {

--- a/ap-web/src/components/blocks/TerminalSession.test.ts
+++ b/ap-web/src/components/blocks/TerminalSession.test.ts
@@ -7,12 +7,15 @@
 // terminal URLs clickable — so we pin it here.
 
 import { Terminal } from "@xterm/xterm";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectionState } from "./TerminalSession";
 import {
   SHIFT_ENTER_CSI_U,
   SYNC_ECHO_MAX_BYTES,
   SYNC_ECHO_WINDOW_MS,
+  TerminalSession,
   applyTerminalCopy,
+  isUnexpectedTerminalClose,
   loadWebglRenderer,
   openTerminalLink,
   shouldEchoSynchronously,
@@ -189,5 +192,213 @@ describe("terminalKeyEventPayload", () => {
     expect(
       terminalKeyEventPayload(keyEvent({ key: "Enter", shiftKey: true, altKey: true })),
     ).toBeNull();
+  });
+});
+
+describe("isUnexpectedTerminalClose", () => {
+  it("treats transport-shaped close codes as reconnectable", () => {
+    // WHY: 1001/1006/1012/1013 happen TO the connection (proxy restart, dead
+    // TCP on tab thaw, service restart) rather than being a deliberate end, so
+    // a reconnect is appropriate.
+    expect(isUnexpectedTerminalClose(1001)).toBe(true);
+    expect(isUnexpectedTerminalClose(1006)).toBe(true);
+    expect(isUnexpectedTerminalClose(1012)).toBe(true);
+    expect(isUnexpectedTerminalClose(1013)).toBe(true);
+  });
+
+  it("treats deliberate closes (normal, policy, app 4xxx) as terminal", () => {
+    // WHY: 1000 normal, 1008 policy, and the app's 4xxx codes mean the server
+    // decided the attach should end — reconnecting would loop or resurrect a
+    // terminal the user intentionally left.
+    expect(isUnexpectedTerminalClose(1000)).toBe(false);
+    expect(isUnexpectedTerminalClose(1008)).toBe(false);
+    expect(isUnexpectedTerminalClose(4404)).toBe(false);
+    expect(isUnexpectedTerminalClose(4405)).toBe(false);
+    expect(isUnexpectedTerminalClose(4500)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TerminalSession class — wired up against a fake WebSocket + ResizeObserver.
+// The real xterm Terminal runs (it already does in jsdom for loadWebglRenderer
+// above), but the WebSocket and ResizeObserver globals are stubbed so the
+// constructor can complete and we can drive its event handlers directly.
+// ---------------------------------------------------------------------------
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  readyState = 0;
+  binaryType = "blob";
+  sent: Array<string | Uint8Array> = [];
+  closed = false;
+  private listeners: Record<string, Array<(ev: unknown) => void>> = {};
+
+  constructor(public url: string) {}
+
+  addEventListener(type: string, fn: (ev: unknown) => void) {
+    (this.listeners[type] ??= []).push(fn);
+  }
+
+  send(data: string | Uint8Array) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  // Test helpers to drive the handlers the session registers.
+  emit(type: string, ev: unknown) {
+    for (const fn of this.listeners[type] ?? []) fn(ev);
+  }
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit("open", {});
+  }
+}
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  disconnected = false;
+  observed: Element[] = [];
+  constructor(public cb: () => void) {
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  disconnect() {
+    this.disconnected = true;
+  }
+}
+
+describe("TerminalSession", () => {
+  let lastSocket: FakeWebSocket | null = null;
+
+  beforeEach(() => {
+    lastSocket = null;
+    FakeResizeObserver.instances = [];
+    vi.stubGlobal(
+      "WebSocket",
+      class extends FakeWebSocket {
+        constructor(url: string) {
+          super(url);
+          lastSocket = this;
+        }
+      },
+    );
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function makeSession(onActivity?: () => void, onInput?: () => void) {
+    const states: ConnectionState[] = [];
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const session = new TerminalSession(
+      container,
+      "ws://localhost/attach",
+      (s) => states.push(s),
+      false,
+      onActivity,
+      onInput,
+    );
+    return { session, states, container, socket: lastSocket as unknown as FakeWebSocket };
+  }
+
+  it("reports 'connected' and sends an initial resize on socket open", () => {
+    // WHY: the open handler must push a resize frame before the user sees the
+    // default 80x24, then surface kind:"connected" to React. readyState is
+    // OPEN by the time sendResize runs, so a JSON resize control frame is sent.
+    const { states, socket, session } = makeSession();
+
+    socket.open();
+
+    expect(states.at(-1)).toEqual({ kind: "connected" });
+    const resizeFrame = socket.sent.find(
+      (m) => typeof m === "string" && m.includes('"type":"resize"'),
+    );
+    expect(resizeFrame).toBeDefined();
+    session.dispose();
+  });
+
+  it("surfaces close code + reason and error transitions", () => {
+    // WHY: the closed variant carries the WS code so consumers can tell a
+    // deliberate close from a transport drop; the error handler maps to
+    // kind:"error".
+    const { states, socket, session } = makeSession();
+
+    socket.emit("close", { reason: "", code: 1006 });
+    expect(states.at(-1)).toEqual({ kind: "closed", reason: "code 1006", code: 1006 });
+
+    socket.emit("error", {});
+    expect(states.at(-1)).toEqual({ kind: "error" });
+    session.dispose();
+  });
+
+  it("writes inbound binary frames to the terminal and fires onActivity", () => {
+    // WHY: ArrayBuffer message frames are raw PTY bytes — they must reach the
+    // terminal and trigger the best-effort activity signal. The throttle keys
+    // off performance.now(), so pin it past the 300ms window to make the first
+    // notification deterministic. Non-ArrayBuffer (text) frames are ignored so
+    // they aren't painted as output.
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onActivity = vi.fn();
+    const { socket, session } = makeSession(onActivity);
+
+    // Build the buffer from the global ArrayBuffer the source's
+    // `instanceof ArrayBuffer` check sees — a TextEncoder's buffer comes from
+    // Node's realm and fails that check under jsdom.
+    const data = new ArrayBuffer(5);
+    new Uint8Array(data).set([104, 101, 108, 108, 111]); // "hello"
+    socket.emit("message", { data });
+    expect(onActivity).toHaveBeenCalledTimes(1);
+
+    socket.emit("message", { data: "text frame" });
+    expect(onActivity).toHaveBeenCalledTimes(1); // unchanged — text ignored
+    session.dispose();
+  });
+
+  it("setTheme swaps the terminal theme without reconnecting", () => {
+    // WHY: theme changes must not tear down the live WebSocket; the socket
+    // stays the same instance after setTheme(true).
+    const { socket, session } = makeSession();
+    const before = socket;
+    session.setTheme(true);
+    expect(socket).toBe(before);
+    expect(socket.closed).toBe(false);
+    session.dispose();
+  });
+
+  it("dispose is idempotent and tears down observer + socket once", () => {
+    // WHY: the view disposes explicitly on every re-dial and a future React
+    // upgrade would call the ref cleanup again — a second dispose must be a
+    // safe no-op, not a double close.
+    const { socket, session } = makeSession();
+    const observer = FakeResizeObserver.instances[0];
+
+    session.dispose();
+    expect(socket.closed).toBe(true);
+    expect(observer.disconnected).toBe(true);
+
+    // Second call: no throw, socket already closed.
+    socket.closed = false; // prove the second close() isn't invoked
+    session.dispose();
+    expect(socket.closed).toBe(false);
+  });
+
+  it("observes the container for resize", () => {
+    // WHY: layout changes (window resize, font load) must propagate a resize
+    // frame, so the session must register a ResizeObserver on its container.
+    const { container, session } = makeSession();
+    const observer = FakeResizeObserver.instances[0];
+    expect(observer.observed).toContain(container);
+    session.dispose();
   });
 });

--- a/ap-web/src/components/blocks/ToolCard.test.ts
+++ b/ap-web/src/components/blocks/ToolCard.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { formatToolDuration, getOutputPreview } from "./ToolCard";
+import { createElement } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { FileViewerContext } from "@/shell/FileViewerContext";
+import type { RenderItem } from "@/lib/renderItems";
+import { ToolCard, ToolGroupSummary, formatToolDuration, getOutputPreview } from "./ToolCard";
+
+afterEach(cleanup);
+
+// Render helper: ToolCard reads a Tooltip (trigger title) so it needs the
+// TooltipProvider; createElement keeps this in a .ts file without JSX.
+function renderCard(props: Parameters<typeof ToolCard>[0]) {
+  return render(createElement(TooltipProvider, null, createElement(ToolCard, props)));
+}
 
 describe("formatToolDuration", () => {
   it("formats subsecond, second, minute, and hour durations", () => {
@@ -48,5 +61,184 @@ describe("getOutputPreview", () => {
     expect(collapsed.shownCharCount).toBe(12_000);
     expect(expanded.text).toBe(output);
     expect(expanded.isTruncated).toBe(false);
+  });
+});
+
+describe("ToolCard rendering", () => {
+  it("renders the tool title and duration in the collapsed trigger row", () => {
+    // WHY: the trigger row is the always-visible summary; an unknown tool name
+    // falls back to `name(argsSummary)`, and a completed duration renders.
+    renderCard({
+      name: "my_tool",
+      argsSummary: "x=1",
+      arguments: { x: 1 },
+      output: "done",
+      state: "output-available",
+      duration: 3.25,
+    });
+    expect(screen.getByText("my_tool(x=1)")).toBeInTheDocument();
+    expect(screen.getByText("3.3s")).toBeInTheDocument();
+  });
+
+  it("expands to reveal the Parameters panel and output on click", () => {
+    // WHY: clicking the trigger must reveal the parameters JSON and the output
+    // section — the collapsed-by-default content path.
+    const { container } = renderCard({
+      name: "my_tool",
+      argsSummary: "",
+      arguments: { a: 2 },
+      output: "the output text",
+      state: "output-available",
+    });
+    const trigger = container.querySelector<HTMLElement>('[data-slot="collapsible-trigger"]')!;
+    fireEvent.click(trigger);
+    expect(screen.getAllByText("Parameters").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Output").length).toBeGreaterThan(0);
+  });
+
+  it("renders a pending output placeholder while input-available with no output", () => {
+    // WHY: a running tool (input-available, output null) shows the
+    // waiting-for-output indicator, not an empty/error panel.
+    const { container } = renderCard({
+      name: "my_tool",
+      arguments: {},
+      output: null,
+      state: "input-available",
+    });
+    fireEvent.click(container.querySelector<HTMLElement>('[data-slot="collapsible-trigger"]')!);
+    expect(screen.getByText(/Waiting for output/)).toBeInTheDocument();
+  });
+
+  it.each([
+    ["cancelled", "Tool was cancelled before output arrived."],
+    ["no-output", "No output was recorded for this tool call."],
+    ["output-error", "Tool did not return output before the response failed."],
+  ] as const)("renders the %s empty-output message", (state, message) => {
+    // WHY: each terminal-without-output state maps to a distinct explanatory
+    // message so the user understands why there's nothing to show.
+    const { container } = renderCard({
+      name: "my_tool",
+      arguments: {},
+      output: null,
+      state,
+    });
+    fireEvent.click(container.querySelector<HTMLElement>('[data-slot="collapsible-trigger"]')!);
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it("makes a workspace file path clickable for file-path tools inside a FileViewer", () => {
+    // WHY: sys_os_read with a relative path renders the path as a role="link"
+    // that calls the FileViewer's openFile; clicking it must not toggle the
+    // collapsible (stopPropagation).
+    const openFile = vi.fn();
+    const ctx = {
+      openFile,
+      isChangedPath: () => false,
+      conversationId: "c1",
+      workspaceRoot: null,
+      workspaceHome: null,
+    };
+    render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(
+          FileViewerContext.Provider,
+          { value: ctx },
+          createElement(ToolCard, {
+            name: "sys_os_read",
+            arguments: { path: "src/a.ts" },
+            output: null,
+            state: "output-available",
+          }),
+        ),
+      ),
+    );
+    const link = screen.getByRole("link", { name: "src/a.ts" });
+    fireEvent.click(link);
+    expect(openFile).toHaveBeenCalledWith("src/a.ts");
+  });
+
+  it("does not linkify an absolute file path (FileViewer rejects absolute paths)", () => {
+    // WHY: the FileViewer can't resolve absolute paths, so an absolute
+    // sys_os_read path must render as plain text, never a clickable link.
+    const ctx = {
+      openFile: vi.fn(),
+      isChangedPath: () => false,
+      conversationId: "c1",
+      workspaceRoot: null,
+      workspaceHome: null,
+    };
+    render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(
+          FileViewerContext.Provider,
+          { value: ctx },
+          createElement(ToolCard, {
+            name: "sys_os_read",
+            arguments: { path: "/etc/hosts" },
+            output: null,
+            state: "output-available",
+          }),
+        ),
+      ),
+    );
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("/etc/hosts")).toBeInTheDocument();
+  });
+});
+
+describe("ToolGroupSummary", () => {
+  function toolItem(callId: string, name: string): RenderItem {
+    return {
+      kind: "tool",
+      execution: { callId, name, argsSummary: "", arguments: {} },
+      output: "ok",
+      state: "output-available",
+      startedAt: null,
+      duration: 1,
+    } as unknown as RenderItem;
+  }
+
+  it("labels the run with a pluralized step count and renders children when expanded", () => {
+    // WHY: the summary line counts the full contiguous run; ">1" pluralizes
+    // "steps", and expanding mounts each tool card.
+    const { container } = render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(ToolGroupSummary, {
+          tools: [toolItem("t1", "alpha_tool"), toolItem("t2", "beta_tool")],
+        }),
+      ),
+    );
+    expect(screen.getByText("See 2 steps")).toBeInTheDocument();
+    fireEvent.click(container.querySelector<HTMLElement>('[data-slot="collapsible-trigger"]')!);
+    expect(screen.getByText("alpha_tool")).toBeInTheDocument();
+    expect(screen.getByText("beta_tool")).toBeInTheDocument();
+  });
+
+  it("uses the singular 'step' for one tool and honors an explicit count override", () => {
+    // WHY: n===1 drops the plural; `count` overrides tools.length so a
+    // streaming tail isn't undercounted.
+    const { rerender } = render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(ToolGroupSummary, { tools: [toolItem("t1", "solo_tool")] }),
+      ),
+    );
+    expect(screen.getByText("See 1 step")).toBeInTheDocument();
+
+    rerender(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(ToolGroupSummary, { tools: [toolItem("t1", "solo_tool")], count: 5 }),
+      ),
+    );
+    expect(screen.getByText("See 5 steps")).toBeInTheDocument();
   });
 });

--- a/ap-web/src/components/theme/ThemeModeMenu.test.tsx
+++ b/ap-web/src/components/theme/ThemeModeMenu.test.tsx
@@ -1,0 +1,96 @@
+// Tests for ThemeModeMenu — the compact sidebar button that cycles the theme
+// system → dark → light on each click.
+//
+// The button previews the *next* mode: its aria-label/title and icon describe
+// the mode the next click applies (see nextThemeMode). It hides entirely when
+// embedded (the host owns the theme). `next-themes` and `@/lib/embedded` are
+// mocked so each test pins the current theme and embed state; the real
+// themeMode helpers (pure) run unmocked.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const setTheme = vi.fn();
+let currentTheme: string | undefined;
+let embedded: boolean;
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: currentTheme, setTheme }),
+}));
+
+vi.mock("@/lib/embedded", () => ({
+  useIsEmbedded: () => embedded,
+}));
+
+import { ThemeModeMenu } from "./ThemeModeMenu";
+
+function renderMenu() {
+  return render(
+    <TooltipProvider>
+      <ThemeModeMenu />
+    </TooltipProvider>,
+  );
+}
+
+beforeEach(() => {
+  currentTheme = "system";
+  embedded = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ThemeModeMenu", () => {
+  it("renders nothing when embedded", () => {
+    // WHY: the host owns the theme in embed mode, so the switcher must be a
+    // no-op and render no button at all.
+    embedded = true;
+    const { container } = renderMenu();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("labels the button with the next mode in the cycle (system → dark)", () => {
+    // WHY: at "system" the next click applies "dark", so the action label must
+    // announce "Switch to Dark".
+    currentTheme = "system";
+    renderMenu();
+    expect(screen.getByRole("button", { name: "Switch to Dark" })).toBeInTheDocument();
+  });
+
+  it("clicking from system selects dark", () => {
+    // WHY: a click must advance one step in the cycle, calling setTheme with
+    // the previewed next mode rather than the current one.
+    currentTheme = "system";
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Dark" }));
+    expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("clicking from dark selects light", () => {
+    // WHY: dark's next mode is light — pins the middle hop of the cycle.
+    currentTheme = "dark";
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Light" }));
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("clicking from light wraps back to system", () => {
+    // WHY: light's next mode is system — pins the wrap-around so the cycle
+    // visits every mode rather than trapping in two states.
+    currentTheme = "light";
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Switch to System" }));
+    expect(setTheme).toHaveBeenCalledWith("system");
+  });
+
+  it("treats an unknown stored theme as system", () => {
+    // WHY: a garbage/legacy stored value must normalize to "system", whose
+    // next mode is dark — so the button still offers "Switch to Dark".
+    currentTheme = "sepia";
+    renderMenu();
+    expect(screen.getByRole("button", { name: "Switch to Dark" })).toBeInTheDocument();
+  });
+});

--- a/ap-web/src/hooks/useComments.test.ts
+++ b/ap-web/src/hooks/useComments.test.ts
@@ -1,0 +1,301 @@
+// Unit tests for the comments API helpers and TanStack Query hooks:
+// the URL/encoding/method contract of each request, the throw-on-non-2xx
+// guard, the cache-invalidation fan-out on mutation success, and the
+// send-to-agent dispatch that calls useChatStore.send().
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatStore } from "@/store/chatStore";
+import {
+  commentsQueryKey,
+  fetchComments,
+  useAddComment,
+  useComments,
+  useDeleteComment,
+  useSendCommentsToAgent,
+  useUpdateComment,
+  type Comment,
+} from "./useComments";
+
+// The send-to-agent hook dispatches via the chat store on success; mock
+// the store so we can assert the dispatch without standing up zustand.
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: { getState: vi.fn() },
+}));
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+const sendMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  sendMock.mockReset();
+  vi.mocked(useChatStore.getState).mockReturnValue({
+    send: sendMock,
+  } as unknown as ReturnType<typeof useChatStore.getState>);
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makeComment(overrides: Partial<Comment> & { id: string; path: string }): Comment {
+  return {
+    conversation_id: "conv_1",
+    start_index: 0,
+    end_index: 1,
+    body: "note",
+    status: "draft",
+    created_at: 0,
+    updated_at: 0,
+    anchor_content: null,
+    created_by: null,
+    ...overrides,
+  };
+}
+
+describe("commentsQueryKey", () => {
+  it("scopes the key by path only when a path is given", () => {
+    // useCommentInbox shares this key; a path-less key must NOT collide
+    // with the per-file key or the two caches would clobber each other.
+    expect(commentsQueryKey("conv_1")).toEqual(["comments", "conv_1"]);
+    expect(commentsQueryKey("conv_1", "a.ts")).toEqual(["comments", "conv_1", "a.ts"]);
+  });
+});
+
+describe("fetchComments", () => {
+  it("GETs the session list endpoint with no path query", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+    await fetchComments("conv_1");
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/conv_1/comments");
+  });
+
+  it("appends an encoded path query when filtering to one file", async () => {
+    // The path filter must url-encode so files with slashes/spaces don't
+    // produce a malformed query the server rejects.
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+    await fetchComments("conv with space", "src/a b.ts");
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/v1/sessions/conv%20with%20space/comments?path=src%2Fa%20b.ts",
+    );
+  });
+
+  it("returns the parsed comment array", async () => {
+    const comments = [makeComment({ id: "c1", path: "a.ts" })];
+    fetchMock.mockResolvedValueOnce(mockResponse(comments));
+    await expect(fetchComments("conv_1")).resolves.toEqual(comments);
+  });
+
+  it("throws on non-2xx", async () => {
+    // A failed fetch must reject so the query surfaces an error state
+    // rather than caching an empty/garbage list.
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+    await expect(fetchComments("conv_1")).rejects.toThrow(/500/);
+  });
+});
+
+describe("useComments", () => {
+  it("does not fetch when sessionId is falsy", () => {
+    // The query is disabled without a session id; firing a request to
+    // /v1/sessions//comments would 404 noisily on every cold render.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useComments(undefined), { wrapper: wrapperWith(queryClient) });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches and returns data when sessionId is present", async () => {
+    const comments = [makeComment({ id: "c1", path: "a.ts" })];
+    fetchMock.mockResolvedValueOnce(mockResponse(comments));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useComments("conv_1"), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(comments);
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/conv_1/comments");
+  });
+});
+
+describe("useAddComment", () => {
+  function renderAdd(queryClient: QueryClient) {
+    return renderHook(() => useAddComment("conv_1"), { wrapper: wrapperWith(queryClient) });
+  }
+
+  it("POSTs the payload to the session comments endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(makeComment({ id: "c1", path: "a.ts" })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderAdd(queryClient);
+    result.current.mutate({ path: "a.ts", start_index: 0, end_index: 5, body: "hi" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_1/comments");
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual({
+      path: "a.ts",
+      start_index: 0,
+      end_index: 5,
+      body: "hi",
+    });
+  });
+
+  it("invalidates both the session-wide list AND the per-file list on success", async () => {
+    // The new comment must refresh the sidebar (session-wide) and any
+    // open per-file view; missing either leaves a stale list until reload.
+    fetchMock.mockResolvedValueOnce(mockResponse(makeComment({ id: "c1", path: "a.ts" })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderAdd(queryClient);
+    result.current.mutate({ path: "a.ts", start_index: 0, end_index: 5, body: "hi" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comments", "conv_1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comments", "conv_1", "a.ts"] });
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 422 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderAdd(queryClient);
+    result.current.mutate({ path: "a.ts", start_index: 0, end_index: 5, body: "hi" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({ message: expect.stringContaining("422") });
+  });
+});
+
+describe("useDeleteComment", () => {
+  function renderDelete(queryClient: QueryClient) {
+    return renderHook(() => useDeleteComment("conv_1"), { wrapper: wrapperWith(queryClient) });
+  }
+
+  it("DELETEs the encoded comment endpoint and invalidates the session list", async () => {
+    // The comment id is url-encoded so ids with reserved chars hit the
+    // right route; success refreshes the session-wide list.
+    fetchMock.mockResolvedValueOnce(mockResponse(undefined));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderDelete(queryClient);
+    result.current.mutate("c 1");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_1/comments/c%201");
+    expect(init.method).toBe("DELETE");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comments", "conv_1"] });
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 404 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderDelete(queryClient);
+    result.current.mutate("c1");
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useUpdateComment", () => {
+  function renderUpdate(queryClient: QueryClient) {
+    return renderHook(() => useUpdateComment("conv_1"), { wrapper: wrapperWith(queryClient) });
+  }
+
+  it("PATCHes only the mutable fields, excluding commentId from the body", async () => {
+    // commentId belongs in the URL, not the body; leaking it into the
+    // body could let the server treat it as a writable field.
+    fetchMock.mockResolvedValueOnce(mockResponse(makeComment({ id: "c1", path: "a.ts" })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderUpdate(queryClient);
+    result.current.mutate({ commentId: "c1", status: "addressed", body: "done" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_1/comments/c1");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ status: "addressed", body: "done" });
+  });
+
+  it("invalidates the session list on success", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(makeComment({ id: "c1", path: "a.ts" })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderUpdate(queryClient);
+    result.current.mutate({ commentId: "c1", status: "addressed" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comments", "conv_1"] });
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 409 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderUpdate(queryClient);
+    result.current.mutate({ commentId: "c1", body: "x" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useSendCommentsToAgent", () => {
+  function renderSend(queryClient: QueryClient) {
+    return renderHook(() => useSendCommentsToAgent("conv_1", "ag_1"), {
+      wrapper: wrapperWith(queryClient),
+    });
+  }
+
+  it("POSTs the comment ids to the send endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ formatted_message: "msg", sent_comment_ids: ["c1"] }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderSend(queryClient);
+    result.current.mutate({ comment_ids: ["c1"], instruction: "fix" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_1/comments/send");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ comment_ids: ["c1"], instruction: "fix" });
+  });
+
+  it("dispatches the formatted message to the agent via the chat store on success", async () => {
+    // The whole point of this hook: the server-formatted message is sent
+    // to the agent immediately, no manual send. Regressing this leaves
+    // comments queued but never delivered.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ formatted_message: "please address these", sent_comment_ids: ["c1"] }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderSend(queryClient);
+    result.current.mutate({ comment_ids: ["c1"] });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(sendMock).toHaveBeenCalledWith("please address these", "ag_1");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["comments", "conv_1"] });
+  });
+
+  it("throws on non-2xx and never dispatches to the agent", async () => {
+    // A failed send must NOT call the chat store, or the user sees a
+    // message dispatched while the comments stay unsent server-side.
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderSend(queryClient);
+    result.current.mutate({ comment_ids: ["c1"] });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});

--- a/ap-web/src/hooks/useDefaultPolicies.test.ts
+++ b/ap-web/src/hooks/useDefaultPolicies.test.ts
@@ -1,0 +1,174 @@
+// Unit tests for the default-policies admin CRUD hooks: the request
+// URL/method/body contract of each operation, the throw-on-non-2xx guard,
+// and that every mutation invalidates the shared ["default-policies"] key
+// so the admin list reflects the change without a reload.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useAddDefaultPolicy,
+  useDefaultPolicies,
+  useDeleteDefaultPolicy,
+  useUpdateDefaultPolicy,
+  type DefaultPolicy,
+} from "./useDefaultPolicies";
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function wrapperWith(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makePolicy(overrides: Partial<DefaultPolicy> & { id: string }): DefaultPolicy {
+  return {
+    object: "default_policy",
+    name: "p",
+    type: "python",
+    handler: "h",
+    factory_params: null,
+    enabled: true,
+    created_at: 0,
+    updated_at: null,
+    created_by: null,
+    ...overrides,
+  };
+}
+
+describe("useDefaultPolicies", () => {
+  it("GETs /v1/policies and unwraps the data array from the envelope", async () => {
+    // The endpoint wraps rows in {object, data}; the hook must return the
+    // inner array, otherwise consumers get an object where they expect a list.
+    const policies = [makePolicy({ id: "p1" }), makePolicy({ id: "p2" })];
+    fetchMock.mockResolvedValueOnce(mockResponse({ object: "list", data: policies }));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useDefaultPolicies(), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/policies");
+    expect(result.current.data).toEqual(policies);
+  });
+
+  it("surfaces an error on non-2xx", async () => {
+    // A failed list fetch must error, not cache an empty list that hides
+    // policies from the admin.
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useDefaultPolicies(), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({ message: expect.stringContaining("500") });
+  });
+});
+
+describe("useAddDefaultPolicy", () => {
+  function renderAdd(queryClient: QueryClient) {
+    return renderHook(() => useAddDefaultPolicy(), { wrapper: wrapperWith(queryClient) });
+  }
+
+  it("POSTs the payload to /v1/policies and invalidates the list", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(makePolicy({ id: "p1" })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderAdd(queryClient);
+    result.current.mutate({ name: "p", type: "python", handler: "h" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/policies");
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "p", type: "python", handler: "h" });
+    // The new policy must show up in the list without a reload.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["default-policies"] });
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 422 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderAdd(queryClient);
+    result.current.mutate({ name: "p", type: "url", handler: "https://x" });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useUpdateDefaultPolicy", () => {
+  function renderUpdate(queryClient: QueryClient) {
+    return renderHook(() => useUpdateDefaultPolicy(), { wrapper: wrapperWith(queryClient) });
+  }
+
+  it("PATCHes the encoded policy id with the enabled flag and invalidates", async () => {
+    // The id is url-encoded so ids with reserved chars hit the right route;
+    // only the enabled flag is sent (the toggle is the only mutable field here).
+    fetchMock.mockResolvedValueOnce(mockResponse(makePolicy({ id: "p 1", enabled: false })));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderUpdate(queryClient);
+    result.current.mutate({ policyId: "p 1", enabled: false });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/policies/p%201");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ enabled: false });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["default-policies"] });
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 404 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderUpdate(queryClient);
+    result.current.mutate({ policyId: "p1", enabled: true });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useDeleteDefaultPolicy", () => {
+  function renderDelete(queryClient: QueryClient) {
+    return renderHook(() => useDeleteDefaultPolicy(), { wrapper: wrapperWith(queryClient) });
+  }
+
+  it("DELETEs the encoded policy id and invalidates the list", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(undefined));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderDelete(queryClient);
+    result.current.mutate("p 1");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/policies/p%201");
+    expect(init.method).toBe("DELETE");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["default-policies"] });
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 403 }));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderDelete(queryClient);
+    result.current.mutate("p1");
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/ap-web/src/hooks/useFileDiff.test.ts
+++ b/ap-web/src/hooks/useFileDiff.test.ts
@@ -1,0 +1,170 @@
+// Unit tests for useFileDiff: the enable gate (only fires when a session,
+// a path, an online runner, and a changed-files match all line up), the
+// per-segment path encoding of the diff URL, and the throw-on-non-2xx guard.
+//
+// The two source hooks are mocked so we exercise the gate and URL builder
+// directly without standing up the RunnerHealthProvider or the changed-files
+// query.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/RunnerHealthProvider", () => ({ useSessionRunnerOnline: vi.fn() }));
+vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({ useWorkspaceChangedFiles: vi.fn() }));
+
+import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useWorkspaceChangedFiles } from "@/hooks/useWorkspaceChangedFiles";
+import { useFileDiff } from "./useFileDiff";
+
+const runnerOnlineMock = vi.mocked(useSessionRunnerOnline);
+const changedFilesMock = vi.mocked(useWorkspaceChangedFiles);
+
+function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+/** Wire the two source hooks: runner online state + changed-files paths. */
+function setHooks(opts: {
+  runnerOnline?: boolean | undefined;
+  changedPaths?: string[] | undefined;
+}) {
+  runnerOnlineMock.mockReturnValue(opts.runnerOnline);
+  changedFilesMock.mockReturnValue({
+    data:
+      opts.changedPaths === undefined
+        ? undefined
+        : { available: true, data: opts.changedPaths.map((path) => ({ path })) },
+  } as unknown as ReturnType<typeof useWorkspaceChangedFiles>);
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  runnerOnlineMock.mockReset();
+  changedFilesMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderDiff(conversationId: string | undefined, path: string | null) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return renderHook(() => useFileDiff(conversationId, path), { wrapper });
+}
+
+describe("useFileDiff — enable gate", () => {
+  it("does not fetch when conversationId is missing", () => {
+    // No session means there is no diff endpoint to call.
+    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    renderDiff(undefined, "a.ts");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when path is null", () => {
+    // Nothing is selected; firing a request would build a malformed URL.
+    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    renderDiff("conv_1", null);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the runner is offline", () => {
+    // An offline runner has no live filesystem to diff against; the query
+    // must stay disabled rather than hammer a dead endpoint.
+    setHooks({ runnerOnline: false, changedPaths: ["a.ts"] });
+    renderDiff("conv_1", "a.ts");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the file is not in the changed-files list", () => {
+    // Only created/modified/deleted files have diff data; an unchanged file
+    // would 404, so the gate keeps it disabled.
+    setHooks({ runnerOnline: true, changedPaths: ["other.ts"] });
+    renderDiff("conv_1", "a.ts");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats an unresolved changed-files list as not-yet-matched (no fetch)", () => {
+    // Before the changed-files query resolves, data is undefined; the gate
+    // must wait rather than fetch a diff for a file it can't confirm changed.
+    setHooks({ runnerOnline: true, changedPaths: undefined });
+    renderDiff("conv_1", "a.ts");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches when session + path + online runner + changed-file match all hold", async () => {
+    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        object: "session.environment.filesystem.file_diff",
+        path: "a.ts",
+        before: "old",
+        after: "new",
+      }),
+    );
+    const { result } = renderDiff("conv_1", "a.ts");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toMatchObject({ before: "old", after: "new" });
+  });
+
+  it("still fetches when runnerOnline is undefined (unknown, not offline)", async () => {
+    // The gate only blocks on an explicit `false`; an unknown (undefined)
+    // runner state must not stop the diff, or the panel would stay blank
+    // during the brief window before health resolves.
+    setHooks({ runnerOnline: undefined, changedPaths: ["a.ts"] });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        object: "session.environment.filesystem.file_diff",
+        path: "a.ts",
+        before: null,
+        after: "new",
+      }),
+    );
+    const { result } = renderDiff("conv_1", "a.ts");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useFileDiff — request URL", () => {
+  it("encodes each path segment individually, preserving structural slashes", async () => {
+    // Per-segment encoding keeps "/" as the directory separator while
+    // escaping spaces/specials; whole-string encoding would turn slashes
+    // into %2F and break the FastAPI {path:path} route.
+    setHooks({ runnerOnline: true, changedPaths: ["src/a b.ts"] });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        object: "session.environment.filesystem.file_diff",
+        path: "src/a b.ts",
+        before: null,
+        after: null,
+      }),
+    );
+    const { result } = renderDiff("conv with space", "src/a b.ts");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/v1/sessions/conv%20with%20space/resources/environments/default/diff/src/a%20b.ts",
+    );
+  });
+});
+
+describe("useFileDiff — error handling", () => {
+  it("surfaces an error on non-2xx", async () => {
+    setHooks({ runnerOnline: true, changedPaths: ["a.ts"] });
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+    const { result } = renderDiff("conv_1", "a.ts");
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({ message: expect.stringContaining("500") });
+  });
+});

--- a/ap-web/src/hooks/useHostFilesystem.test.ts
+++ b/ap-web/src/hooks/useHostFilesystem.test.ts
@@ -3,9 +3,14 @@
 // URLs that the FastAPI route rejects (404) or that double-encode
 // segments (resulting in literal "%2F" reaching the host).
 
-import { describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildHostFilesystemUrl } from "./useHostFilesystem";
+import type { HostFilesystemEntry } from "./useHostFilesystem";
+import { buildHostFilesystemUrl, useHostFilesystem } from "./useHostFilesystem";
 
 describe("buildHostFilesystemUrl", () => {
   it("returns the no-path endpoint when absolutePath is empty", () => {
@@ -59,5 +64,129 @@ describe("buildHostFilesystemUrl", () => {
     // slash) to match the {path:path} route. Without the trailing
     // slash we'd hit the no-path route which forwards ~ instead.
     expect(buildHostFilesystemUrl("host_abc", "/")).toBe("/v1/hosts/host_abc/filesystem/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useHostFilesystem — pagination, truncation, error, and lazy-enable behavior.
+// Exercised through the hook since fetchHostFilesystem is module-private.
+// authenticatedFetch ultimately calls the global fetch, so we stub that.
+// ---------------------------------------------------------------------------
+
+function entry(name: string): HostFilesystemEntry {
+  return { name, path: `/d/${name}`, type: "directory", bytes: null, modified_at: 0 };
+}
+
+function pageResponse(data: HostFilesystemEntry[], hasMore: boolean): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ object: "list", data, has_more: hasMore }),
+  } as unknown as Response;
+}
+
+function wrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe("useHostFilesystem", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("stays disabled (no fetch) when hostId or path is null", () => {
+    // WHY: the query is lazy — it must not fire until both hostId and path
+    // are provided, or the picker would hammer the endpoint while idle.
+    const { result } = renderHook(() => useHostFilesystem(null, "/some/path"), {
+      wrapper: wrapper(),
+    });
+    // `fetchStatus: "idle"` is react-query's signal for a disabled query.
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a single page when the server reports no more entries", async () => {
+    // WHY: the happy path — one page, has_more=false stops the loop, and
+    // truncated is false because nothing was cut off.
+    fetchMock.mockResolvedValue(pageResponse([entry("a"), entry("b")], false));
+
+    const { result } = renderHook(() => useHostFilesystem("host_1", "/d"), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({
+      entries: [entry("a"), entry("b")],
+      truncated: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The first page must not carry an `after` cursor.
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("after=");
+  });
+
+  it("follows has_more pagination using the last entry path as the cursor", async () => {
+    // WHY: the endpoint paginates by entry path; each next page must send the
+    // previous page's last path as `after`, accumulating all entries.
+    fetchMock
+      .mockResolvedValueOnce(pageResponse([entry("a"), entry("b")], true))
+      .mockResolvedValueOnce(pageResponse([entry("c")], false));
+
+    const { result } = renderHook(() => useHostFilesystem("host_1", "/d"), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.entries.map((e) => e.name)).toEqual(["a", "b", "c"]);
+    expect(result.current.data?.truncated).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The second request forwards the first page's last entry path.
+    expect(String(fetchMock.mock.calls[1][0])).toContain(`after=${encodeURIComponent("/d/b")}`);
+  });
+
+  it("stops on an empty page even if the server still claims has_more", async () => {
+    // WHY: defensive empty-page guard — a bad cursor returning [] with
+    // has_more=true must not loop forever; the second page ends the fetch.
+    fetchMock
+      .mockResolvedValueOnce(pageResponse([entry("a")], true))
+      .mockResolvedValueOnce(pageResponse([], true));
+
+    const { result } = renderHook(() => useHostFilesystem("host_1", "/d"), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.entries.map((e) => e.name)).toEqual(["a"]);
+    expect(result.current.data?.truncated).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a FetchError carrying the HTTP status on a non-OK response", async () => {
+    // WHY: the picker distinguishes 404 (no such dir) from other failures via
+    // err.status, so the thrown error must surface the response status.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useHostFilesystem("host_1", "/missing"), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const err = result.current.error as (Error & { status?: number }) | null;
+    expect(err?.status).toBe(404);
+    expect(err?.message).toContain("HTTP 404");
   });
 });

--- a/ap-web/src/pages/ApprovePage.test.tsx
+++ b/ap-web/src/pages/ApprovePage.test.tsx
@@ -1,0 +1,161 @@
+// Tests for the standalone URL-mode ApprovePage
+// (`/approve/:sessionId/:elicitationId`). The page is driven entirely by a
+// single `authenticatedFetch` helper (mocked here) for both the initial GET
+// and the resolve POST, and by route params via react-router (a real
+// MemoryRouter + Route supplies them, since `@/lib/routing` falls back to
+// react-router-dom). Each test pins one of the page's state-machine branches:
+// loading, pending, resolved, submitted (approve/reject), and the error paths
+// (bad status, network throw, missing params).
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApprovePage } from "./ApprovePage";
+import * as identity from "@/lib/identity";
+
+vi.mock("@/lib/identity", () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+/** A Response-like stub: only `ok`, `status`, and `json()` are read. */
+function jsonResponse(body: unknown, { ok = true, status = 200 } = {}): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Render the page at a concrete `/approve/:sessionId/:elicitationId` route. */
+function renderPage(sessionId = "sess_1", elicitationId = "eli_1") {
+  return render(
+    <MemoryRouter initialEntries={[`/approve/${sessionId}/${elicitationId}`]}>
+      <Routes>
+        <Route path="/approve/:sessionId/:elicitationId" element={<ApprovePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ApprovePage states", () => {
+  beforeEach(() => {
+    // Default: a never-resolving fetch so the initial render is observable
+    // before any test overrides the resolution.
+    vi.mocked(identity.authenticatedFetch).mockReturnValue(new Promise(() => {}));
+  });
+
+  it("shows a loading state while the elicitation fetch is in flight", () => {
+    // WHY: the `loading` branch renders until the GET settles.
+    renderPage();
+    expect(screen.getByText("Loading elicitation…")).toBeInTheDocument();
+  });
+
+  it("renders approve/reject controls plus message and preview when pending", async () => {
+    // WHY: the `pending` branch shows the prompt body, policy/phase chips,
+    // formatted preview, and both action buttons.
+    vi.mocked(identity.authenticatedFetch).mockResolvedValue(
+      jsonResponse({
+        status: "pending",
+        message: "Delete the production database?",
+        phase: "pre",
+        policy_name: "danger-policy",
+        content_preview: "rm -rf /data",
+      }),
+    );
+    renderPage();
+    expect(await screen.findByText("Delete the production database?")).toBeInTheDocument();
+    expect(screen.getByText("· danger-policy")).toBeInTheDocument();
+    expect(screen.getByText("(pre)")).toBeInTheDocument();
+    expect(screen.getByText(/rm -rf \/data/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approve/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Reject/ })).toBeInTheDocument();
+  });
+
+  it("shows the resolved state when the elicitation is no longer pending", async () => {
+    // WHY: a `status: "resolved"` payload means the prompt was already
+    // resolved/timed-out/cancelled — no buttons, just an informational alert.
+    vi.mocked(identity.authenticatedFetch).mockResolvedValue(jsonResponse({ status: "resolved" }));
+    renderPage();
+    expect(await screen.findByText("Elicitation resolved")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Approve/ })).not.toBeInTheDocument();
+  });
+
+  it("surfaces a server error when the GET returns a non-ok status", async () => {
+    // WHY: a non-ok response routes to the `error` branch with the HTTP status.
+    vi.mocked(identity.authenticatedFetch).mockResolvedValue(
+      jsonResponse(null, { ok: false, status: 500 }),
+    );
+    renderPage();
+    expect(await screen.findByText("Server error: 500")).toBeInTheDocument();
+  });
+
+  it("surfaces a load error when the GET rejects", async () => {
+    // WHY: a thrown fetch (network failure) routes to the `error` branch.
+    vi.mocked(identity.authenticatedFetch).mockRejectedValue(new Error("offline"));
+    renderPage();
+    expect(await screen.findByText(/Failed to load:/)).toBeInTheDocument();
+  });
+});
+
+describe("ApprovePage submission", () => {
+  beforeEach(() => {
+    // First call (GET) returns a pending prompt; later calls (POST) are set
+    // per-test below.
+    vi.mocked(identity.authenticatedFetch).mockResolvedValue(
+      jsonResponse({ status: "pending", message: "Run the migration?" }),
+    );
+  });
+
+  it("approves: posts accept and shows the Approved confirmation", async () => {
+    // WHY: clicking Approve POSTs `{action: "accept"}` to the resolve endpoint
+    // and lands on the `submitted` (Approved) state.
+    renderPage("sess_a", "eli_a");
+    fireEvent.click(await screen.findByRole("button", { name: /Approve/ }));
+
+    await waitFor(() => expect(screen.getByText("Approved")).toBeInTheDocument());
+    const resolveCall = vi
+      .mocked(identity.authenticatedFetch)
+      .mock.calls.find(([url]) => String(url).includes("/resolve"));
+    expect(resolveCall).toBeDefined();
+    expect(String(resolveCall![0])).toContain("/v1/sessions/sess_a/elicitations/eli_a/resolve");
+    expect(JSON.parse(String(resolveCall![1]!.body))).toEqual({ action: "accept" });
+  });
+
+  it("rejects: posts decline and shows the Rejected confirmation", async () => {
+    // WHY: clicking Reject POSTs `{action: "decline"}` and lands on the
+    // `submitted` (Rejected) state.
+    renderPage();
+    fireEvent.click(await screen.findByRole("button", { name: /Reject/ }));
+
+    await waitFor(() => expect(screen.getByText("Rejected")).toBeInTheDocument());
+    const resolveCall = vi
+      .mocked(identity.authenticatedFetch)
+      .mock.calls.find(([url]) => String(url).includes("/resolve"));
+    expect(JSON.parse(String(resolveCall![1]!.body))).toEqual({ action: "decline" });
+  });
+
+  it("shows a resolve error when the POST returns a non-ok status", async () => {
+    // WHY: a failed resolve POST routes to the `error` branch with the status.
+    vi.mocked(identity.authenticatedFetch)
+      .mockResolvedValueOnce(jsonResponse({ status: "pending", message: "Run the migration?" }))
+      .mockResolvedValueOnce(jsonResponse(null, { ok: false, status: 409 }));
+    renderPage();
+    fireEvent.click(await screen.findByRole("button", { name: /Approve/ }));
+    expect(await screen.findByText("Resolve failed: 409")).toBeInTheDocument();
+  });
+
+  it("shows a network error when the resolve POST throws", async () => {
+    // WHY: a thrown resolve POST routes to the `error` branch (network error).
+    vi.mocked(identity.authenticatedFetch)
+      .mockResolvedValueOnce(jsonResponse({ status: "pending", message: "Run the migration?" }))
+      .mockRejectedValueOnce(new Error("boom"));
+    renderPage();
+    fireEvent.click(await screen.findByRole("button", { name: /Reject/ }));
+    expect(await screen.findByText(/Network error:/)).toBeInTheDocument();
+  });
+});

--- a/ap-web/src/pages/ChatPage.capabilities.test.ts
+++ b/ap-web/src/pages/ChatPage.capabilities.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  effortLevelsForConv,
+  isModelImplicitlySelected,
+  shouldShowEffortPicker,
+  shouldShowModelPicker,
+} from "./ChatPage";
+
+// These pin the label-driven composer capability gates (effort levels, model
+// picker, effort picker) and the model-row implicit-selection match. They
+// fail closed on missing labels, so a refactor that loosens the gate would
+// expose model/effort controls on sessions that can't honor mid-session
+// overrides (codex-native pins its model at launch; non-claude wrappers have
+// no Web UI effort dial).
+
+const NATIVE = "claude-code-native-ui";
+
+describe("effortLevelsForConv", () => {
+  it("returns the extended ladder (xhigh, max) for claude-code-native-ui", () => {
+    // WHY: claude-native exposes the full reasoning ladder; dropping xhigh/max
+    // here would silently cap those sessions at "high".
+    expect(effortLevelsForConv({ labels: { "omnigent.wrapper": NATIVE } })).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
+  it("returns the base three levels for a non-native wrapper", () => {
+    // WHY: other wrappers only support low/medium/high; offering xhigh/max
+    // would send an effort the harness can't honor.
+    expect(effortLevelsForConv({ labels: { "omnigent.wrapper": "codex-native" } })).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("falls back to the base ladder when labels / conv are absent", () => {
+    // WHY: a null conv (pre-hydration) or label-less row must fail to the
+    // safe base ladder, not crash.
+    expect(effortLevelsForConv(null)).toEqual(["low", "medium", "high"]);
+    expect(effortLevelsForConv(undefined)).toEqual(["low", "medium", "high"]);
+    expect(effortLevelsForConv({ labels: {} })).toEqual(["low", "medium", "high"]);
+  });
+});
+
+describe("shouldShowModelPicker", () => {
+  it("shows the picker only for claude-code-native-ui", () => {
+    // WHY: the model picker writes a mid-session override the runner injects;
+    // only claude-native honors it, so the gate is keyed on that exact label.
+    expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": NATIVE } })).toBe(true);
+  });
+
+  it("hides the picker for other wrappers and missing labels (fail closed)", () => {
+    // WHY: a loosened gate would pop a non-functional picker on codex-native
+    // (model pinned at launch) and on pre-hydration rows.
+    expect(shouldShowModelPicker({ labels: { "omnigent.wrapper": "codex-native" } })).toBe(false);
+    expect(shouldShowModelPicker({ labels: {} })).toBe(false);
+    expect(shouldShowModelPicker(null)).toBe(false);
+    expect(shouldShowModelPicker(undefined)).toBe(false);
+  });
+});
+
+describe("shouldShowEffortPicker", () => {
+  it("shows effort controls only for claude-native sessions", () => {
+    // WHY: delegates to supportsEffortControl — only claude-native exposes a
+    // Web UI effort dial.
+    expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": NATIVE } })).toBe(true);
+  });
+
+  it("hides effort controls for other wrappers and missing labels", () => {
+    // WHY: fail-closed — no label / non-native wrapper means no dial.
+    expect(shouldShowEffortPicker({ labels: { "omnigent.wrapper": "codex-native" } })).toBe(false);
+    expect(shouldShowEffortPicker(null)).toBe(false);
+    expect(shouldShowEffortPicker(undefined)).toBe(false);
+  });
+});
+
+describe("isModelImplicitlySelected", () => {
+  it("matches a tier alias against the bound full spec by suffix", () => {
+    // WHY: with no explicit override, the row whose alias is the suffix of the
+    // bound spec ("anthropic/claude-opus-4-8" → "opus" via includes) lights up
+    // so the user sees which model is actually running.
+    expect(isModelImplicitlySelected("opus", "anthropic/claude-opus-4-8")).toBe(true);
+  });
+
+  it("matches an exact spec equality", () => {
+    // WHY: the identity branch — a fully-qualified id that equals the bound
+    // spec is selected.
+    expect(isModelImplicitlySelected("databricks-gpt-5-4", "databricks-gpt-5-4")).toBe(true);
+  });
+
+  it("matches a path-suffix without a substring false-positive elsewhere", () => {
+    // WHY: the endsWith("/id") branch — the alias is the trailing path segment.
+    expect(isModelImplicitlySelected("sonnet", "anthropic/claude-sonnet")).toBe(true);
+  });
+
+  it("returns false when no model is bound (null spec)", () => {
+    // WHY: nothing bound → nothing implicitly selected; guards the early null
+    // return so we don't highlight a row on a fresh session.
+    expect(isModelImplicitlySelected("opus", null)).toBe(false);
+  });
+
+  it("returns false when the alias appears nowhere in the bound spec", () => {
+    // WHY: a non-matching alias must not light up — otherwise two rows could
+    // read as selected.
+    expect(isModelImplicitlySelected("opus", "anthropic/claude-sonnet-4")).toBe(false);
+  });
+});

--- a/ap-web/src/pages/ChatPage.indicators.test.tsx
+++ b/ap-web/src/pages/ChatPage.indicators.test.tsx
@@ -1,0 +1,225 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useChatStore } from "@/store/chatStore";
+import type { Bubble } from "@/lib/renderItems";
+import type { SessionLiveness } from "@/hooks/useSessionLiveness";
+import {
+  BubbleView,
+  ConnectionIndicator,
+  RunnerStartingIndicator,
+  SandboxFailedIndicator,
+} from "./ChatPage";
+
+// Render-level coverage for the chat surface's status bands and bubble
+// dispatcher. These exercise the branches that the pure-helper tests can't:
+// what the user actually SEES for a failed sandbox, an offline host, an
+// in-flight launch, and each bubble kind. They run the real component tree
+// (no mocks) the same way ChatPage.composer.test.tsx renders the Composer.
+
+afterEach(() => {
+  // Several tests poke sandboxStatus into the global zustand store; reset it
+  // so a leftover launch band can't bleed into the next test.
+  useChatStore.setState({ sandboxStatus: null });
+  cleanup();
+});
+
+describe("SandboxFailedIndicator", () => {
+  it("renders the recorded failure reason so a dead launch explains itself", () => {
+    // WHY: a silently dead chat is the bug this band exists to prevent — the
+    // reason must reach the DOM.
+    render(<SandboxFailedIndicator status={{ stage: "failed", error: "out of quota" }} />);
+    expect(screen.getByText(/Sandbox launch failed: out of quota/)).toBeInTheDocument();
+  });
+
+  it("omits the colon suffix when no error detail is recorded", () => {
+    // WHY: a missing error must not render a dangling "failed: " — the
+    // ternary guards the suffix.
+    render(<SandboxFailedIndicator status={{ stage: "failed", error: null }} />);
+    expect(screen.getByText("Sandbox launch failed")).toBeInTheDocument();
+  });
+});
+
+describe("ConnectionIndicator", () => {
+  const onShowReconnectHelp = () => {};
+
+  it("renders the failed-sandbox band when a launch died (sandboxStatus wins)", () => {
+    // WHY: a failed launch owns this band ahead of any liveness state — the
+    // sandbox branch short-circuits before the liveness checks.
+    useChatStore.setState({ sandboxStatus: { stage: "failed", error: "boom" } });
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "online" }}
+        onShowReconnectHelp={onShowReconnectHelp}
+      />,
+    );
+    expect(screen.getByTestId("sandbox-failed-indicator")).toBeInTheDocument();
+  });
+
+  it("renders nothing while a launch is still in flight (non-failed sandbox)", () => {
+    // WHY: an in-flight launch renders in the thread (RunnerStartingIndicator),
+    // so this band suppresses itself to avoid double progress UI.
+    useChatStore.setState({ sandboxStatus: { stage: "provisioning" } });
+    const { container } = render(
+      <ConnectionIndicator
+        liveness={{ kind: "host_offline", isOwner: true }}
+        onShowReconnectHelp={onShowReconnectHelp}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the host-offline reconnect affordance", () => {
+    // WHY: a host_offline session is unreachable — the only way back is the
+    // clickable reconnect banner with the host-specific copy.
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "host_offline", isOwner: true }}
+        onShowReconnectHelp={onShowReconnectHelp}
+      />,
+    );
+    const btn = screen.getByTestId("disconnected-indicator");
+    expect(btn).toHaveTextContent(/Host is offline/);
+  });
+
+  it("shows agent-disconnected copy for a local-stranded runner", () => {
+    // WHY: local_stranded is the other unreachable branch and must read as the
+    // agent dropping, not the host.
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "local_stranded" }}
+        onShowReconnectHelp={onShowReconnectHelp}
+      />,
+    );
+    expect(screen.getByTestId("disconnected-indicator")).toHaveTextContent(/Agent disconnected/);
+  });
+
+  it("shows a passive Connecting row for a starting non-terminal session", () => {
+    // WHY: a runner spinning up gets a heartbeat (no action) so the empty chat
+    // doesn't read as broken.
+    render(
+      <ConnectionIndicator
+        liveness={{ kind: "starting" }}
+        onShowReconnectHelp={onShowReconnectHelp}
+      />,
+    );
+    expect(screen.getByTestId("connecting-indicator")).toHaveTextContent("Connecting…");
+  });
+
+  it.each<SessionLiveness>([{ kind: "online" }, { kind: "runner_asleep" }, { kind: "unknown" }])(
+    "renders nothing for the reachable/sidebar-owned state %o",
+    (liveness) => {
+      // WHY: online/asleep/unknown surface their status in the sidebar or keep
+      // the composer open — this band stays empty for them.
+      const { container } = render(
+        <ConnectionIndicator liveness={liveness} onShowReconnectHelp={onShowReconnectHelp} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+});
+
+describe("RunnerStartingIndicator", () => {
+  it("shows the stage-specific copy for an in-flight sandbox launch", () => {
+    // WHY: the band names the current pipeline stage so the wait is legible;
+    // "cloning" must map to the repo-clone copy.
+    useChatStore.setState({ sandboxStatus: { stage: "cloning" } });
+    render(<RunnerStartingIndicator variant="row" />);
+    expect(screen.getByTestId("runner-starting-indicator")).toHaveTextContent(
+      "Cloning repository…",
+    );
+  });
+
+  it("renders the hero variant with the stage title for an empty-state launch", () => {
+    // WHY: the hero variant is the centered empty-state placeholder; it must
+    // carry the same stage label as a heading, not the row copy.
+    useChatStore.setState({ sandboxStatus: { stage: "provisioning" } });
+    render(<RunnerStartingIndicator variant="hero" />);
+    expect(screen.getByTestId("runner-starting-indicator")).toHaveTextContent(
+      "Provisioning sandbox…",
+    );
+  });
+
+  it("self-gates to null when no launch is in flight (no terminal-first ctx)", () => {
+    // WHY: with no sandbox launch and no terminal-first provider, neither
+    // launch shape applies and the indicator must render nothing.
+    const { container } = render(<RunnerStartingIndicator variant="row" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for a terminal sandbox stage (ready/failed handled elsewhere)", () => {
+    // WHY: "failed" gets the destructive band in ConnectionIndicator, so this
+    // in-thread indicator must skip it rather than show stale launch copy.
+    useChatStore.setState({ sandboxStatus: { stage: "failed", error: "x" } });
+    const { container } = render(<RunnerStartingIndicator variant="row" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("BubbleView dispatch", () => {
+  beforeEach(() => {
+    useChatStore.setState({ conversationId: "conv_test" });
+  });
+
+  type AssistantBubble = Extract<Bubble, { kind: "assistant" }>;
+  const assistantText = (
+    text: string,
+    lifecycle: AssistantBubble["lifecycle"] = "completed",
+  ): AssistantBubble => ({
+    kind: "assistant",
+    responseId: "resp_1",
+    stableId: "resp_1",
+    lifecycle,
+    error: null,
+    items: [{ kind: "text", itemId: "i1", text, final: true }],
+  });
+
+  it("renders a plain user message as a user bubble", () => {
+    // WHY: the user branch of the dispatcher — text content renders inside a
+    // user-role bubble.
+    render(
+      <BubbleView
+        bubble={{
+          kind: "user",
+          itemId: "u1",
+          content: [{ type: "input_text", text: "hello there" }],
+        }}
+      />,
+    );
+    const bubble = screen.getByTestId("message-bubble");
+    expect(bubble).toHaveAttribute("data-role", "user");
+    expect(bubble).toHaveTextContent("hello there");
+  });
+
+  it("renders an assistant text bubble with a copy action", () => {
+    // WHY: assistant branch — prose renders and the copy affordance appears
+    // whenever there's collectable markdown.
+    render(<BubbleView bubble={assistantText("the answer is 42")} />);
+    const bubble = screen.getByTestId("message-bubble");
+    expect(bubble).toHaveAttribute("data-role", "assistant");
+    expect(bubble).toHaveTextContent("the answer is 42");
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("marks a cancelled assistant turn as Interrupted", () => {
+    // WHY: the cancelled lifecycle branch surfaces an explicit Interrupted
+    // note so a truncated turn doesn't read as a complete answer.
+    render(<BubbleView bubble={assistantText("partial", "cancelled")} />);
+    expect(screen.getByTestId("assistant-interrupted-indicator")).toHaveTextContent("Interrupted");
+  });
+
+  it("renders the error text for a failed assistant turn", () => {
+    // WHY: the failed branch must surface the error so a dead turn explains
+    // itself instead of vanishing.
+    render(<BubbleView bubble={{ ...assistantText("", "failed"), error: "rate limited" }} />);
+    expect(screen.getByText(/Error: rate limited/)).toBeInTheDocument();
+  });
+
+  it("renders the compacting shimmer for a compaction_loading bubble", () => {
+    // WHY: the compaction_loading branch owns the busy slot during context
+    // compaction — it must show its own indicator.
+    render(<BubbleView bubble={{ kind: "compaction_loading", itemId: "cmp_1" }} />);
+    expect(screen.getByTestId("compacting-indicator")).toHaveTextContent(
+      "Compacting conversation…",
+    );
+  });
+});

--- a/ap-web/src/pages/InboxPage.test.tsx
+++ b/ap-web/src/pages/InboxPage.test.tsx
@@ -1,0 +1,325 @@
+// Tests for the Inbox page (`/inbox`) — the cross-session list of pending
+// approval prompts and unseen file comments.
+//
+// The page composes several live data sources, so we mock at their seams:
+//  - `useConversations` (the session list + its paging drain),
+//  - `useCommentInbox` (the comment side of the inbox),
+//  - `getSession` / `approve` (per-session snapshot fetch + the verdict POST).
+// The pure assembly helper `collectInboxItems` and the display helpers are
+// left REAL, so raw `response.elicitation_request` event dicts flow through
+// the same parse path the app uses. `ApprovalCard` is stubbed to a minimal
+// component that just exposes an Accept button wired to its `onSubmit`, which
+// lets us drive the approve/rollback path without the real card's internals.
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InboxPage } from "./InboxPage";
+import type { Conversation } from "@/hooks/useConversations";
+import * as conversationsHook from "@/hooks/useConversations";
+import * as commentInboxHook from "@/hooks/useCommentInbox";
+import * as sessionsApi from "@/lib/sessionsApi";
+import type { CommentInbox } from "@/hooks/useCommentInbox";
+
+// Minimal ApprovalCard stub: renders the message and an Accept button that
+// forwards to the page's submit handler. The real card's form/preview UX is
+// out of scope here — we only need to exercise `makeSubmit` → `approve`.
+vi.mock("@/components/blocks/ApprovalCard", () => ({
+  ApprovalCard: ({
+    elicitationId,
+    message,
+    status,
+    onSubmit,
+  }: {
+    elicitationId: string;
+    message: string;
+    status: string;
+    onSubmit: (id: string, action: "accept" | "decline") => void;
+  }) => (
+    <div data-testid="approval-card" data-status={status}>
+      <span>{message}</span>
+      <button type="button" onClick={() => onSubmit(elicitationId, "accept")}>
+        Stub Accept
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/hooks/useConversations", async (importActual) => ({
+  ...(await importActual<typeof import("@/hooks/useConversations")>()),
+  useConversations: vi.fn(),
+}));
+vi.mock("@/hooks/useCommentInbox", () => ({ useCommentInbox: vi.fn() }));
+vi.mock("@/lib/sessionsApi", () => ({ getSession: vi.fn(), approve: vi.fn() }));
+
+function conversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "sess_1",
+    object: "conversation",
+    title: "My Session",
+    created_at: 1_700_000_000,
+    updated_at: 1_700_000_000,
+    labels: {},
+    permission_level: null,
+    pending_elicitations_count: 1,
+    archived: false,
+    ...overrides,
+  };
+}
+
+/** A raw `response.elicitation_request` event dict, as a snapshot replays it. */
+function rawElicitation(id: string, message: string, extra: Record<string, unknown> = {}) {
+  return {
+    elicitation_id: id,
+    params: { message, mode: "form", ...extra },
+  };
+}
+
+/** Build a useConversations infinite-query stub for the given rows/paging. */
+function conversationsStub(rows: Conversation[], overrides: Record<string, unknown> = {}) {
+  return {
+    data: { pages: [{ data: rows }] },
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof conversationsHook.useConversations>;
+}
+
+/** Build a CommentInbox stub; empty and settled by default. */
+function commentInboxStub(overrides: Partial<CommentInbox> = {}): CommentInbox {
+  return {
+    items: [],
+    isLoading: false,
+    failedCount: 0,
+    retryFailed: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  // Fresh client per render so cached queries never leak between tests.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <InboxPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([]));
+  vi.mocked(commentInboxHook.useCommentInbox).mockReturnValue(commentInboxStub());
+  vi.mocked(sessionsApi.getSession).mockResolvedValue({
+    pendingElicitations: [],
+  } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+  vi.mocked(sessionsApi.approve).mockResolvedValue(
+    {} as Awaited<ReturnType<typeof sessionsApi.approve>>,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("InboxPage states", () => {
+  it("shows a loading state while the session list is still loading", () => {
+    // WHY: an in-flight (assembling) list with no items yet must show the
+    // loading row, never the empty state.
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(
+      conversationsStub([], { isLoading: true }),
+    );
+    renderPage();
+    expect(screen.getByText("Loading inbox…")).toBeInTheDocument();
+  });
+
+  it("shows the empty state once settled with nothing waiting", async () => {
+    // WHY: a settled list with no approvals and no comments shows the
+    // "Nothing waiting on you" empty state.
+    renderPage();
+    expect(await screen.findByText("Nothing waiting on you")).toBeInTheDocument();
+  });
+
+  it("does not show the empty state while more pages are still draining", () => {
+    // WHY: `hasNextPage` keeps the inbox in the assembling state — an empty
+    // `items` then only means "not done paging", so no empty state.
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(
+      conversationsStub([], { hasNextPage: true }),
+    );
+    renderPage();
+    expect(screen.queryByText("Nothing waiting on you")).not.toBeInTheDocument();
+    expect(screen.getByText("Loading inbox…")).toBeInTheDocument();
+  });
+
+  it("drains remaining list pages while mounted", () => {
+    // WHY: an awaiting session may sit below the first page, so the inbox
+    // calls fetchNextPage whenever another page is available.
+    const fetchNextPage = vi.fn();
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(
+      conversationsStub([], { hasNextPage: true, fetchNextPage }),
+    );
+    renderPage();
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+});
+
+describe("InboxPage approval items", () => {
+  it("renders an approval card for a session with a pending prompt", async () => {
+    // WHY: a row with a pending count fetches its snapshot, whose parsed
+    // elicitation becomes a card; the first card is expanded by default.
+    const row = conversation({ id: "sess_1", title: "My Session" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this dangerous op?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    expect(await screen.findByText("Approve this dangerous op?")).toBeInTheDocument();
+    const item = screen.getByTestId("inbox-item");
+    expect(item).toHaveAttribute("data-expanded", "true");
+    // Header reflects the count summary.
+    expect(screen.getByText(/1 approval/)).toBeInTheDocument();
+  });
+
+  it("excludes archived rows and rows with no pending prompts", async () => {
+    // WHY: `rows` filters to non-archived rows with pending_elicitations_count
+    // > 0, so neither an archived row nor a zero-count row mounts a snapshot.
+    const rows = [
+      conversation({ id: "archived", pending_elicitations_count: 3, archived: true }),
+      conversation({ id: "settled", pending_elicitations_count: 0 }),
+    ];
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub(rows));
+    renderPage();
+
+    expect(await screen.findByText("Nothing waiting on you")).toBeInTheDocument();
+    expect(sessionsApi.getSession).not.toHaveBeenCalled();
+  });
+
+  it("collapses an item when its toggle is clicked and hides the card", async () => {
+    // WHY: clicking the row toggle flips the expanded override, collapsing the
+    // (otherwise-default-expanded) first item so its ApprovalCard unmounts.
+    const row = conversation({ id: "sess_1" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    const item = await screen.findByTestId("inbox-item");
+    fireEvent.click(within(item).getByRole("button", { name: /My Session/ }));
+    await waitFor(() => expect(item).toHaveAttribute("data-expanded", "false"));
+    expect(screen.queryByTestId("approval-card")).not.toBeInTheDocument();
+  });
+
+  it("submits an approve verdict via approve() and flips the card to responded", async () => {
+    // WHY: clicking Accept optimistically marks responded then POSTs the
+    // verdict through `approve()` to the resolve-target session.
+    const row = conversation({ id: "sess_1" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Stub Accept" }));
+
+    await waitFor(() =>
+      expect(sessionsApi.approve).toHaveBeenCalledWith("sess_1", "eli_1", { action: "accept" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("approval-card")).toHaveAttribute("data-status", "responded"),
+    );
+  });
+
+  it("rolls back the optimistic verdict when approve() rejects", async () => {
+    // WHY: a failed resolve POST deletes the responded entry so the card
+    // returns to pending and the user can retry.
+    const row = conversation({ id: "sess_1" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    vi.mocked(sessionsApi.approve).mockRejectedValue(new Error("nope"));
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Stub Accept" }));
+    // After the rejection settles, the card is back to pending.
+    await waitFor(() =>
+      expect(screen.getByTestId("approval-card")).toHaveAttribute("data-status", "pending"),
+    );
+  });
+
+  it("routes the verdict to the child session when the prompt is mirrored", async () => {
+    // WHY: a mirrored child prompt carries target_session_id; the resolve POST
+    // must target that session, not the row it surfaced under.
+    const row = conversation({ id: "parent" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [
+        rawElicitation("eli_child", "Child approval?", { target_session_id: "child" }),
+      ],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Stub Accept" }));
+    await waitFor(() =>
+      expect(sessionsApi.approve).toHaveBeenCalledWith("child", "eli_child", { action: "accept" }),
+    );
+  });
+});
+
+describe("InboxPage comments and errors", () => {
+  it("renders unseen file comments with author, path, and body", async () => {
+    // WHY: the comment side of the inbox renders each unseen comment with its
+    // author pill, file path, and body, and counts it in the header summary.
+    vi.mocked(commentInboxHook.useCommentInbox).mockReturnValue(
+      commentInboxStub({
+        items: [
+          {
+            row: conversation({ id: "sess_1", pending_elicitations_count: 0 }),
+            comment: {
+              id: "cm_1",
+              path: "src/app.ts",
+              body: "Please reconsider this line.",
+              created_by: "alice",
+              created_at: 1_700_000_000,
+              updated_at: 1_700_000_000_000,
+              status: "draft",
+            } as CommentInbox["items"][number]["comment"],
+          },
+        ],
+      }),
+    );
+    renderPage();
+
+    expect(await screen.findByTestId("inbox-comment")).toBeInTheDocument();
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("src/app.ts")).toBeInTheDocument();
+    expect(screen.getByText("Please reconsider this line.")).toBeInTheDocument();
+    expect(screen.getByText(/1 comment/)).toBeInTheDocument();
+  });
+
+  it("shows the load-error banner and retries failed sources on click", async () => {
+    // WHY: failed snapshot/comment fetches block the empty state and surface a
+    // banner whose Retry button re-runs the failed comment queries.
+    const retryFailed = vi.fn();
+    vi.mocked(commentInboxHook.useCommentInbox).mockReturnValue(
+      commentInboxStub({ failedCount: 2, retryFailed }),
+    );
+    renderPage();
+
+    const banner = await screen.findByTestId("inbox-load-error");
+    expect(within(banner).getByText(/Couldn.t load inbox items from 2/)).toBeInTheDocument();
+    fireEvent.click(within(banner).getByRole("button", { name: /Retry/ }));
+    expect(retryFailed).toHaveBeenCalled();
+    // The error path also suppresses the empty state.
+    expect(screen.queryByText("Nothing waiting on you")).not.toBeInTheDocument();
+  });
+});

--- a/ap-web/src/shell/ExecutionLogsPanel.test.tsx
+++ b/ap-web/src/shell/ExecutionLogsPanel.test.tsx
@@ -1,0 +1,209 @@
+// Tests for ExecutionLogsPanel — the right-side raw-JSON viewer for a
+// conversation and its sub-agent sessions. The data hooks (useChildSessions,
+// useSessionItems) and the chat store are mocked so the panel's own logic is
+// covered: open/closed gating, the entry dropdown (main + children), the
+// items-list states (loading / error / empty / populated), and per-item
+// expand/collapse.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChildSessionInfo } from "@/hooks/useChildSessions";
+import type { RawSessionItem } from "@/hooks/useSessionItems";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+const h = vi.hoisted(() => ({
+  children: [] as ChildSessionInfo[],
+  itemsResult: {
+    items: [] as RawSessionItem[],
+    isLoading: false,
+    error: null as Error | null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: () => {},
+  },
+  sessionStatus: "idle" as string,
+}));
+
+vi.mock("@/hooks/useChildSessions", async (importOriginal) => {
+  // Keep the real key helpers (executionLogTabKey / MAIN_EXECUTION_LOG_KEY) so
+  // the panel's entry keys match what initialKey passes in.
+  const actual = await importOriginal<typeof import("@/hooks/useChildSessions")>();
+  return { ...actual, useChildSessions: () => ({ children: h.children }) };
+});
+
+vi.mock("@/hooks/useSessionItems", () => ({
+  useSessionItems: () => h.itemsResult,
+}));
+
+vi.mock("@/hooks/useResizablePanel", () => ({
+  useResizablePanel: () => ({ panelWidth: 400, handleProps: { tabIndex: 0 }, isDesktop: false }),
+}));
+
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: (selector: (s: { sessionStatus: string }) => unknown) =>
+    selector({ sessionStatus: h.sessionStatus }),
+}));
+
+import { executionLogTabKey } from "@/hooks/useChildSessions";
+import { ExecutionLogsPanel } from "./ExecutionLogsPanel";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mkChild(overrides: Partial<ChildSessionInfo>): ChildSessionInfo {
+  return {
+    id: "conv_child1",
+    title: "researcher:auth",
+    tool: "researcher",
+    session_name: "auth",
+    current_task_status: "completed",
+    busy: false,
+    last_message_preview: null,
+    pending_elicitations_count: 0,
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  props: { open?: boolean; initialKey?: string | null; onClose?: () => void } = {},
+) {
+  const onClose = props.onClose ?? vi.fn();
+  const result = render(
+    <ExecutionLogsPanel
+      open={props.open ?? true}
+      conversationId="conv_main"
+      initialKey={props.initialKey ?? executionLogTabKey("main")}
+      onClose={onClose}
+    />,
+  );
+  return { onClose, ...result };
+}
+
+beforeEach(() => {
+  h.children = [];
+  h.itemsResult = {
+    items: [],
+    isLoading: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: () => {},
+  };
+  h.sessionStatus = "idle";
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ExecutionLogsPanel open/close gating", () => {
+  it("reflects open state via data-state and shows the active entry", () => {
+    // WHY: when open the panel exposes data-state=open and renders the selector
+    // for the main entry; the empty-content branch must not be taken.
+    renderPanel({ open: true });
+    const panel = screen.getByTestId("execution-logs-panel");
+    expect(panel).toHaveAttribute("data-state", "open");
+    expect(screen.getByText("main")).toBeInTheDocument();
+  });
+
+  it("renders empty content and marks closed when not open", () => {
+    // WHY: when closed the panel collapses (data-state=closed) and skips the
+    // dropdown/items entirely — the `!open || !activeEntry` branch.
+    renderPanel({ open: false, initialKey: null });
+    expect(screen.getByTestId("execution-logs-panel")).toHaveAttribute("data-state", "closed");
+    expect(screen.queryByText("No items")).toBeNull();
+  });
+
+  it("fires onClose when the Escape key is pressed while open", () => {
+    // WHY: the keydown listener is the panel's keyboard-dismiss contract; it
+    // must call onClose for Escape (and only while open).
+    const { onClose } = renderPanel({ open: true });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onClose when the header close button is clicked", () => {
+    // WHY: the X button is the primary dismiss affordance.
+    const { onClose } = renderPanel({ open: true });
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ExecutionLogsPanel entries", () => {
+  it("labels a child entry by title (only the active entry is in the trigger)", () => {
+    // WHY: buildLogEntries appends children after the pinned main entry; the
+    // active trigger shows "main" while the child label lives in the closed
+    // dropdown content. We assert the main label renders and the panel mounted.
+    h.children = [mkChild({ id: "conv_c1", title: "researcher:auth" })];
+    renderPanel({ open: true });
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getByTestId("execution-logs-panel")).toBeInTheDocument();
+  });
+
+  it("renders the items list for the entry selected by initialKey (a child)", () => {
+    // WHY: initialKey targets a child; that child's items must be the ones the
+    // panel shows — proves activeEntry resolves from initialKey, not always main.
+    h.children = [mkChild({ id: "conv_c1", title: "researcher:auth" })];
+    h.itemsResult = { ...h.itemsResult, items: [{ id: "x1", role: "user" }] };
+    renderPanel({ open: true, initialKey: executionLogTabKey("conv_c1") });
+    // The child's label is the active trigger value.
+    expect(screen.getByText("researcher:auth")).toBeInTheDocument();
+    expect(screen.getByTestId("execution-log-entry")).toBeInTheDocument();
+  });
+});
+
+describe("ExecutionLogsPanel items-list states", () => {
+  it("shows a loading indicator while items are loading", () => {
+    // WHY: the isLoading branch must render the spinner text, not "No items".
+    h.itemsResult = { ...h.itemsResult, isLoading: true };
+    renderPanel({ open: true });
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("surfaces the error message when the items fetch fails", () => {
+    // WHY: error state takes priority over empty/loaded and must show the
+    // message so the user knows the load failed.
+    h.itemsResult = { ...h.itemsResult, error: new Error("boom") };
+    renderPanel({ open: true });
+    expect(screen.getByText(/Failed to load items: boom/)).toBeInTheDocument();
+  });
+
+  it("shows 'No items' when the session has no items", () => {
+    // WHY: the empty (length 0) branch is its own state distinct from loading.
+    renderPanel({ open: true });
+    expect(screen.getByText("No items")).toBeInTheDocument();
+  });
+
+  it("renders one collapsed entry per item with #N numbering", () => {
+    // WHY: items map to numbered rows; collapsed rows show the single-line
+    // JSON. Two items → two entries numbered #1 and #2.
+    h.itemsResult = {
+      ...h.itemsResult,
+      items: [
+        { id: "a", role: "user" },
+        { id: "b", role: "assistant" },
+      ],
+    };
+    renderPanel({ open: true });
+    const entries = screen.getAllByTestId("execution-log-entry");
+    expect(entries).toHaveLength(2);
+    expect(screen.getByText("#1")).toBeInTheDocument();
+    expect(screen.getByText("#2")).toBeInTheDocument();
+  });
+
+  it("expands an item to pretty-printed JSON on click and re-collapses", () => {
+    // WHY: the per-item toggle drives aria-expanded and swaps the collapsed
+    // one-liner for the indented <pre>; this pins the click handler.
+    h.itemsResult = { ...h.itemsResult, items: [{ id: "a", role: "user" }] };
+    renderPanel({ open: true });
+    const btn = screen.getByTestId("execution-log-entry");
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+    // Pretty-printed form is multi-line (contains a newline + indentation).
+    expect(screen.getByText(/"role": "user"/)).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/ap-web/src/shell/MarkdownCommentPlugin.test.tsx
+++ b/ap-web/src/shell/MarkdownCommentPlugin.test.tsx
@@ -1,0 +1,259 @@
+// Tests for MarkdownCommentPlugin — the comment interaction layer.
+//
+// The floating "Add comment" button is positioned from
+// window.getSelection().getRangeAt(0).getClientRects(), which jsdom returns as
+// zero-sized rects, so the button never mounts under test (the source bails on
+// a 0×0 rect). These tests therefore cover the parts that ARE deterministic in
+// jsdom:
+//   - the component renders no button (returns null) by default;
+//   - the state-sync effect populates commentStateRef and drives the decoration
+//     extension to render comment highlights in a real editor;
+//   - commentStateRef.onClickComment maps a clicked comment to onSetActiveSelection;
+//   - activeSelection going non-null → null clears the pending range;
+//   - click-outside on empty editor area clears the active selection, but a click
+//     on a comment / add-comment element (or with a live draft) does not.
+//
+// A real headless TipTap Editor is used so the decoration extension exercises
+// real ProseMirror behaviour.
+
+import { cleanup, render } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import StarterKit from "@tiptap/starter-kit";
+import type { RefObject } from "react";
+import type { Comment } from "@/hooks/useComments";
+import type { ActiveSelection } from "./codeViewerHelpers";
+import { MarkdownCommentPlugin } from "./MarkdownCommentPlugin";
+import {
+  createCommentDecorationExtension,
+  type CommentDecorationState,
+} from "./TipTapCommentExtension";
+
+const CONTENT = "The quick brown fox jumps over the lazy dog.";
+
+let editor: Editor | null = null;
+let commentStateRef: RefObject<CommentDecorationState | null>;
+let contentRef: RefObject<string>;
+
+beforeEach(() => {
+  commentStateRef = { current: null };
+  contentRef = { current: CONTENT };
+});
+
+afterEach(() => {
+  cleanup();
+  editor?.destroy();
+  editor = null;
+});
+
+/** Mounts a real headless editor wired to the shared decoration state ref. */
+function makeEditor(): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [StarterKit, createCommentDecorationExtension(commentStateRef), Markdown],
+    content: CONTENT,
+    contentType: "markdown",
+  });
+}
+
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: "c1",
+    conversation_id: "conv_1",
+    path: "file.md",
+    start_index: 4,
+    end_index: 9,
+    body: "comment body",
+    status: "draft",
+    created_at: 0,
+    updated_at: 0,
+    anchor_content: "quick",
+    created_by: null,
+    ...overrides,
+  };
+}
+
+interface RenderOpts {
+  comments?: Comment[];
+  isDirty?: boolean;
+  activeSelection?: ActiveSelection | null;
+  onSetActiveSelection?: (
+    sel: { start_index: number; end_index: number; anchor_content: string } | null,
+  ) => void;
+  pendingBodyRef?: RefObject<string>;
+  canEdit?: boolean;
+}
+
+function renderPlugin(opts: RenderOpts = {}) {
+  const onSetActiveSelection = opts.onSetActiveSelection ?? vi.fn();
+  const utils = render(
+    <MarkdownCommentPlugin
+      editor={editor}
+      contentRef={contentRef}
+      commentStateRef={commentStateRef}
+      comments={opts.comments ?? []}
+      isDirty={opts.isDirty ?? false}
+      activeSelection={opts.activeSelection ?? null}
+      onSetActiveSelection={onSetActiveSelection}
+      pendingBodyRef={opts.pendingBodyRef}
+      canEdit={opts.canEdit}
+    />,
+  );
+  return { ...utils, onSetActiveSelection };
+}
+
+// ---------------------------------------------------------------------------
+// Render contract
+// ---------------------------------------------------------------------------
+
+describe("MarkdownCommentPlugin render", () => {
+  // WHY: with no editor and no selection the plugin renders nothing (returns null).
+  it("renders no button when editor is null", () => {
+    editor = null;
+    const { container } = renderPlugin();
+    expect(container.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+
+  // WHY: in jsdom getClientRects is empty so the button never positions itself.
+  it("renders no floating button by default even with an editor", () => {
+    editor = makeEditor();
+    renderPlugin();
+    expect(document.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State sync into the decoration extension
+// ---------------------------------------------------------------------------
+
+describe("MarkdownCommentPlugin state sync", () => {
+  // WHY: the sync effect must populate commentStateRef from the props.
+  it("populates commentStateRef.current from props", () => {
+    editor = makeEditor();
+    const comments = [makeComment()];
+    renderPlugin({ comments });
+    expect(commentStateRef.current).not.toBeNull();
+    expect(commentStateRef.current!.comments).toBe(comments);
+    expect(commentStateRef.current!.rawContent).toBe(CONTENT);
+  });
+
+  // WHY: syncing + rebuilding must surface the comment highlight in the editor DOM.
+  it("drives the decoration extension to render comment highlights", () => {
+    editor = makeEditor();
+    renderPlugin({ comments: [makeComment()] });
+    const span = editor.view.dom.querySelector('[data-comment-id="c1"]');
+    expect(span).not.toBeNull();
+    expect(span!.textContent).toBe("quick");
+  });
+
+  // WHY: the wired onClickComment must translate a comment into an active selection.
+  it("maps onClickComment to onSetActiveSelection with the comment's anchor", () => {
+    editor = makeEditor();
+    const comment = makeComment();
+    const { onSetActiveSelection } = renderPlugin({ comments: [comment] });
+    act(() => {
+      commentStateRef.current!.onClickComment(comment);
+    });
+    expect(onSetActiveSelection).toHaveBeenCalledWith({
+      start_index: 4,
+      end_index: 9,
+      anchor_content: "quick",
+    });
+  });
+
+  // WHY: a comment with null anchor_content must yield "" (never null) downstream.
+  it("falls back to empty anchor_content when the comment has none", () => {
+    editor = makeEditor();
+    const comment = makeComment({ anchor_content: null });
+    const { onSetActiveSelection } = renderPlugin({ comments: [comment] });
+    act(() => {
+      commentStateRef.current!.onClickComment(comment);
+    });
+    expect(onSetActiveSelection).toHaveBeenCalledWith(
+      expect.objectContaining({ anchor_content: "" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending-range cleanup on activeSelection clear
+// ---------------------------------------------------------------------------
+
+describe("MarkdownCommentPlugin pending-range cleanup", () => {
+  // WHY: when the parent clears a previously-set activeSelection, any pending
+  // highlight must be torn down.
+  it("clears pendingRange when activeSelection transitions non-null → null", () => {
+    editor = makeEditor();
+    const active: ActiveSelection = { start_index: 4, end_index: 9, anchor_content: "quick" };
+    const { rerender } = renderPlugin({ activeSelection: active });
+    // Seed a pending range as the button-click path would.
+    act(() => {
+      commentStateRef.current!.pendingRange = { from: 1, to: 4 };
+    });
+
+    rerender(
+      <MarkdownCommentPlugin
+        editor={editor}
+        contentRef={contentRef}
+        commentStateRef={commentStateRef}
+        comments={[]}
+        isDirty={false}
+        activeSelection={null}
+        onSetActiveSelection={vi.fn()}
+      />,
+    );
+
+    expect(commentStateRef.current!.pendingRange).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Click-outside clears the active selection
+// ---------------------------------------------------------------------------
+
+describe("MarkdownCommentPlugin click-outside", () => {
+  // WHY: clicking empty editor area while a selection is active should clear it.
+  it("clears active selection on a click that misses comments and the add button", () => {
+    editor = makeEditor();
+    const active: ActiveSelection = { start_index: 4, end_index: 9, anchor_content: "quick" };
+    const { onSetActiveSelection } = renderPlugin({ activeSelection: active });
+
+    const p = editor.view.dom.querySelector("p")!;
+    act(() => {
+      p.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSetActiveSelection).toHaveBeenCalledWith(null);
+  });
+
+  // WHY: clicking inside a comment decoration must NOT clear the active selection
+  // (that click is the comment-extension's own select-this-comment gesture).
+  it("does not clear when the click lands on a comment element", () => {
+    editor = makeEditor();
+    const active: ActiveSelection = { start_index: 4, end_index: 9, anchor_content: "quick" };
+    const { onSetActiveSelection } = renderPlugin({
+      comments: [makeComment()],
+      activeSelection: active,
+    });
+
+    const span = editor.view.dom.querySelector('[data-comment-id="c1"]') as HTMLElement;
+    act(() => {
+      span.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSetActiveSelection).not.toHaveBeenCalledWith(null);
+  });
+
+  // WHY: clicks outside the editor DOM entirely must be ignored.
+  it("ignores clicks outside the editor DOM", () => {
+    editor = makeEditor();
+    const active: ActiveSelection = { start_index: 4, end_index: 9, anchor_content: "quick" };
+    const { onSetActiveSelection } = renderPlugin({ activeSelection: active });
+    act(() => {
+      document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onSetActiveSelection).not.toHaveBeenCalled();
+  });
+});

--- a/ap-web/src/shell/TableBubbleMenu.test.tsx
+++ b/ap-web/src/shell/TableBubbleMenu.test.tsx
@@ -1,0 +1,218 @@
+// Tests for the <TableHandles> React component (TableBubbleMenu.tsx) — the
+// hover-revealed row/column grips and the menus they open. The pure
+// position/move helpers (freshCellPos, moveRowToIndex, …) are covered in
+// tableActions.test.ts; this file exercises the *component wiring*:
+//
+//   - a mousemove over a cell portals the row + column grips into <body>,
+//   - clicking a grip opens its dropdown menu,
+//   - clicking each menu item runs the matching TipTap command against the
+//     cell the grip belongs to (Insert row above/below, Delete row; Insert
+//     column before/after, Delete column),
+//   - right-clicking a cell opens the "Delete table" context menu.
+//
+// A real headless TipTap Editor (with a table) backs the component so the
+// assertions are end-to-end on the resulting table structure — each test
+// fails if the corresponding command is mis-wired. The editor is mounted into
+// a real container and the component's <body> portals are queried directly.
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
+import StarterKit from "@tiptap/starter-kit";
+import { TableHandles } from "./TableBubbleMenu";
+
+/** Minimal 3×3 table: one header row + two body rows. */
+const TABLE_3X3 = `
+  <table>
+    <tr><th>H1</th><th>H2</th><th>H3</th></tr>
+    <tr><td>R2C1</td><td>R2C2</td><td>R2C3</td></tr>
+    <tr><td>R3C1</td><td>R3C2</td><td>R3C3</td></tr>
+  </table>
+`;
+
+let editor: Editor;
+
+function makeEditor(content = TABLE_3X3): Editor {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return new Editor({
+    element: el,
+    extensions: [
+      StarterKit,
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableCell,
+      TableHeader,
+    ],
+    content,
+  });
+}
+
+function rows(): HTMLTableRowElement[] {
+  return Array.from(editor.view.dom.querySelectorAll("tr")) as HTMLTableRowElement[];
+}
+
+function rowText(row: HTMLTableRowElement): string[] {
+  return Array.from(row.cells).map((c) => c.textContent ?? "");
+}
+
+function allCellText(): string[] {
+  return rows().flatMap(rowText);
+}
+
+function renderHandles() {
+  const ref = createRef<HTMLDivElement>();
+  return render(<TableHandles editor={editor} scrollContainerRef={ref} />);
+}
+
+/** Hovers the cell at (rowIndex, colIndex), revealing the grips. */
+function hoverCell(rowIndex: number, colIndex: number): HTMLTableCellElement {
+  const cell = rows()[rowIndex].cells[colIndex];
+  // mousemove must bubble from a real cell so the component's closest()/indexOf
+  // logic resolves the row + column indices.
+  fireEvent.mouseMove(cell, { bubbles: true });
+  return cell;
+}
+
+/** Opens the row grip menu over (rowIndex, colIndex) and returns its items. */
+function openRowMenu(rowIndex: number, colIndex = 0): HTMLElement {
+  hoverCell(rowIndex, colIndex);
+  fireEvent.click(screen.getByRole("button", { name: "Row options" }));
+  return screen.getByText("Delete row").closest("[data-table-handle-menu]") as HTMLElement;
+}
+
+/** Opens the column grip menu over (rowIndex, colIndex) and returns its items. */
+function openColMenu(rowIndex: number, colIndex: number): HTMLElement {
+  hoverCell(rowIndex, colIndex);
+  fireEvent.click(screen.getByRole("button", { name: "Column options" }));
+  return screen.getByText("Delete column").closest("[data-table-handle-menu]") as HTMLElement;
+}
+
+beforeEach(() => {
+  editor = makeEditor();
+});
+
+afterEach(() => {
+  cleanup();
+  editor.destroy();
+});
+
+describe("TableHandles — grip visibility", () => {
+  it("reveals the row and column grips when a table cell is hovered", () => {
+    // WHY: the grips are portaled in only on hover; before any mousemove the
+    // toolbar must be absent, and a mousemove over a cell must reveal both.
+    renderHandles();
+    expect(screen.queryByRole("button", { name: "Row options" })).toBeNull();
+    hoverCell(1, 1);
+    expect(screen.getByRole("button", { name: "Row options" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Column options" })).toBeInTheDocument();
+  });
+
+  it("opens the row menu on grip click and the column menu on its grip click", () => {
+    // WHY: clicking each grip must open exactly its own dropdown with the
+    // expected insert/delete items.
+    renderHandles();
+    const rowMenu = openRowMenu(1);
+    expect(within(rowMenu).getByText("Insert row above")).toBeInTheDocument();
+    expect(within(rowMenu).getByText("Insert row below")).toBeInTheDocument();
+    expect(within(rowMenu).getByText("Delete row")).toBeInTheDocument();
+
+    const colMenu = openColMenu(1, 1);
+    expect(within(colMenu).getByText("Insert column before")).toBeInTheDocument();
+    expect(within(colMenu).getByText("Insert column after")).toBeInTheDocument();
+    expect(within(colMenu).getByText("Delete column")).toBeInTheDocument();
+  });
+});
+
+describe("TableHandles — row menu commands", () => {
+  it("Insert row above adds an empty row above the gripped row", () => {
+    // WHY: the menu must run addRowBefore against the gripped row — inserting
+    // an empty row at that index and shifting the original down.
+    renderHandles();
+    const menu = openRowMenu(1);
+    fireEvent.click(within(menu).getByText("Insert row above"));
+    const r = rows();
+    expect(r).toHaveLength(4);
+    expect(rowText(r[1]).every((t) => t === "")).toBe(true);
+    expect(rowText(r[2])).toContain("R2C1");
+  });
+
+  it("Insert row below adds an empty row beneath the gripped row", () => {
+    // WHY: addRowAfter on row 1 must drop a fresh row at index 2, pushing the
+    // original row 2 (R3C1) down to index 3.
+    renderHandles();
+    const menu = openRowMenu(1);
+    fireEvent.click(within(menu).getByText("Insert row below"));
+    const r = rows();
+    expect(r).toHaveLength(4);
+    expect(rowText(r[2]).every((t) => t === "")).toBe(true);
+    expect(rowText(r[3])).toContain("R3C1");
+  });
+
+  it("Delete row removes exactly the gripped row", () => {
+    // WHY: deleteRow must drop the gripped row (R2…) and keep header + R3.
+    renderHandles();
+    const menu = openRowMenu(1);
+    fireEvent.click(within(menu).getByText("Delete row"));
+    expect(rows()).toHaveLength(2);
+    expect(allCellText()).not.toContain("R2C1");
+    expect(allCellText()).toContain("R3C1");
+  });
+
+  it("closes the menu after an item is chosen", () => {
+    // WHY: selecting an item must dismiss the dropdown (onClose), not leave a
+    // stale menu portal behind.
+    renderHandles();
+    const menu = openRowMenu(1);
+    fireEvent.click(within(menu).getByText("Insert row above"));
+    expect(screen.queryByText("Delete row")).toBeNull();
+  });
+});
+
+describe("TableHandles — column menu commands", () => {
+  it("Insert column before adds an empty column at the gripped column", () => {
+    // WHY: addColumnBefore on column 1 must widen every row to 4 cells and put
+    // a blank cell at index 1.
+    renderHandles();
+    const menu = openColMenu(0, 1);
+    fireEvent.click(within(menu).getByText("Insert column before"));
+    rows().forEach((r) => expect(r.cells).toHaveLength(4));
+    expect(rows()[0].cells[1].textContent).toBe("");
+  });
+
+  it("Insert column after adds an empty column past the gripped column", () => {
+    // WHY: addColumnAfter on column 1 widens to 4 cells with the blank at
+    // index 2, leaving the original column-1 header (H2) in place.
+    renderHandles();
+    const menu = openColMenu(0, 1);
+    fireEvent.click(within(menu).getByText("Insert column after"));
+    rows().forEach((r) => expect(r.cells).toHaveLength(4));
+    expect(rows()[0].cells[1].textContent).toBe("H2");
+    expect(rows()[0].cells[2].textContent).toBe("");
+  });
+
+  it("Delete column removes exactly the gripped column", () => {
+    // WHY: deleteColumn on column 1 must narrow every row to 2 cells and drop
+    // the middle column's content (H2 / R2C2 / R3C2).
+    renderHandles();
+    const menu = openColMenu(0, 1);
+    fireEvent.click(within(menu).getByText("Delete column"));
+    rows().forEach((r) => expect(r.cells).toHaveLength(2));
+    expect(allCellText()).not.toContain("H2");
+    expect(allCellText()).not.toContain("R2C2");
+  });
+});
+
+describe("TableHandles — context menu", () => {
+  it("right-clicking a cell opens a Delete table item that removes the table", () => {
+    // WHY: the cell contextmenu must surface a "Delete table" action whose
+    // click runs deleteTable, leaving no <table> behind.
+    renderHandles();
+    fireEvent.contextMenu(rows()[1].cells[1], { bubbles: true, clientX: 10, clientY: 10 });
+    const item = screen.getByText("Delete table");
+    fireEvent.click(item);
+    expect(editor.view.dom.querySelector("table")).toBeNull();
+  });
+});

--- a/ap-web/src/shell/TipTapCommentExtension.test.ts
+++ b/ap-web/src/shell/TipTapCommentExtension.test.ts
@@ -1,0 +1,243 @@
+// Unit tests for the comment-decoration ProseMirror plugin / TipTap extension.
+//
+// Coverage:
+//   - commentDecorationKey is a stable PluginKey.
+//   - A real headless Editor wired with createCommentDecorationExtension renders
+//     inline decorations (md-comment / md-comment-active) for matched comments,
+//     a md-comment-pending highlight for the in-progress range, and skips
+//     comments whose anchor_content isn't found in the doc.
+//   - A "rebuild" meta dispatch re-reads stateRef so newly added comments appear.
+//   - A { pendingRange } meta dispatch writes the range into stateRef before the
+//     decoration rebuilds.
+//   - Clicking a decorated span invokes onClickComment with the matched comment.
+//
+// Uses a real TipTap Editor (real schema + real @tiptap/markdown parsing) so
+// regressions in decoration / remap behaviour fail the test.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import StarterKit from "@tiptap/starter-kit";
+import { PluginKey } from "@tiptap/pm/state";
+import type { RefObject } from "react";
+import type { Comment } from "@/hooks/useComments";
+import {
+  commentDecorationKey,
+  createCommentDecorationExtension,
+  type CommentDecorationState,
+} from "./TipTapCommentExtension";
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+const CONTENT = "The quick brown fox jumps over the lazy dog.";
+
+/** A comment anchored to a verbatim substring of CONTENT. */
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: "c1",
+    conversation_id: "conv_1",
+    path: "file.md",
+    start_index: 4,
+    end_index: 9,
+    body: "comment body",
+    status: "draft",
+    created_at: 0,
+    updated_at: 0,
+    anchor_content: "quick",
+    created_by: null,
+    ...overrides,
+  };
+}
+
+/** A stable RefObject holding the supplied decoration state. */
+function makeStateRef(
+  state: CommentDecorationState | null,
+): RefObject<CommentDecorationState | null> {
+  return { current: state };
+}
+
+/** Mounts a headless editor wired with the decoration extension. */
+function makeEditor(stateRef: RefObject<CommentDecorationState | null>): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [StarterKit, createCommentDecorationExtension(stateRef), Markdown],
+    content: CONTENT,
+    contentType: "markdown",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// commentDecorationKey
+// ---------------------------------------------------------------------------
+
+describe("commentDecorationKey", () => {
+  // WHY: downstream meta dispatches target this exact key, so it must be a PluginKey.
+  it("is a PluginKey", () => {
+    expect(commentDecorationKey).toBeInstanceOf(PluginKey);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decoration rendering
+// ---------------------------------------------------------------------------
+
+describe("createCommentDecorationExtension decorations", () => {
+  // WHY: a matched comment must render an inline span tagged with its id and the base class.
+  it("renders an inline decoration for a matched comment", () => {
+    const stateRef = makeStateRef({
+      comments: [makeComment()],
+      activeSelection: null,
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment: vi.fn(),
+    });
+    editor = makeEditor(stateRef);
+    const span = editor.view.dom.querySelector('[data-comment-id="c1"]');
+    expect(span).not.toBeNull();
+    expect(span!.classList.contains("md-comment")).toBe(true);
+    expect(span!.classList.contains("md-comment-active")).toBe(false);
+    expect(span!.textContent).toBe("quick");
+  });
+
+  // WHY: the active comment (matching activeSelection offsets) gets the -active class.
+  it("adds md-comment-active when the comment matches activeSelection", () => {
+    const stateRef = makeStateRef({
+      comments: [makeComment()],
+      activeSelection: { start_index: 4, end_index: 9, anchor_content: "quick" },
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment: vi.fn(),
+    });
+    editor = makeEditor(stateRef);
+    const span = editor.view.dom.querySelector('[data-comment-id="c1"]')!;
+    expect(span.classList.contains("md-comment-active")).toBe(true);
+  });
+
+  // WHY: comments whose anchor text isn't in the doc must be silently skipped.
+  it("skips comments whose anchor_content is not found", () => {
+    const stateRef = makeStateRef({
+      comments: [makeComment({ anchor_content: "nonexistent text" })],
+      activeSelection: null,
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment: vi.fn(),
+    });
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelector("[data-comment-id]")).toBeNull();
+  });
+
+  // WHY: the in-progress (pending) selection gets its own blue-highlight class.
+  it("renders a md-comment-pending decoration for the pending range", () => {
+    const stateRef = makeStateRef({
+      comments: [],
+      activeSelection: null,
+      rawContent: CONTENT,
+      // PM positions: 1 = doc start (paragraph open), so [1,4) covers "The".
+      pendingRange: { from: 1, to: 4 },
+      onClickComment: vi.fn(),
+    });
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelector(".md-comment-pending")).not.toBeNull();
+  });
+
+  // WHY: with null stateRef the plugin must produce no decorations, not throw.
+  it("renders nothing when stateRef is null", () => {
+    const stateRef = makeStateRef(null);
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelector("[data-comment-id]")).toBeNull();
+    expect(editor.view.dom.querySelector(".md-comment-pending")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rebuild / pendingRange meta dispatches
+// ---------------------------------------------------------------------------
+
+describe("createCommentDecorationExtension meta dispatch", () => {
+  // WHY: mutating stateRef + dispatching "rebuild" must surface the new comment.
+  it("re-reads stateRef on a 'rebuild' meta dispatch", () => {
+    const stateRef = makeStateRef({
+      comments: [],
+      activeSelection: null,
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment: vi.fn(),
+    });
+    editor = makeEditor(stateRef);
+    expect(editor.view.dom.querySelector("[data-comment-id]")).toBeNull();
+
+    stateRef.current!.comments = [makeComment()];
+    editor.view.dispatch(editor.state.tr.setMeta(commentDecorationKey, "rebuild"));
+
+    expect(editor.view.dom.querySelector('[data-comment-id="c1"]')).not.toBeNull();
+  });
+
+  // WHY: a { pendingRange } meta writes the range into stateRef and renders it.
+  it("writes pendingRange from meta into stateRef and renders it", () => {
+    const stateRef = makeStateRef({
+      comments: [],
+      activeSelection: null,
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment: vi.fn(),
+    });
+    editor = makeEditor(stateRef);
+
+    editor.view.dispatch(
+      editor.state.tr.setMeta(commentDecorationKey, { pendingRange: { from: 1, to: 4 } }),
+    );
+
+    expect(stateRef.current!.pendingRange).toEqual({ from: 1, to: 4 });
+    expect(editor.view.dom.querySelector(".md-comment-pending")).not.toBeNull();
+  });
+
+  // WHY: a meta dispatch while stateRef is null must clear to an empty set safely.
+  it("clears decorations when a meta dispatch arrives with null stateRef", () => {
+    const stateRef = makeStateRef(null);
+    editor = makeEditor(stateRef);
+    editor.view.dispatch(editor.state.tr.setMeta(commentDecorationKey, "rebuild"));
+    expect(editor.view.dom.querySelector("[data-comment-id]")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// click handling
+// ---------------------------------------------------------------------------
+
+describe("createCommentDecorationExtension click handling", () => {
+  // WHY: clicking a decorated span resolves the comment by id and invokes the callback.
+  it("invokes onClickComment with the matched comment when its decoration is clicked", () => {
+    const onClickComment = vi.fn();
+    const comment = makeComment();
+    const stateRef = makeStateRef({
+      comments: [comment],
+      activeSelection: null,
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment,
+    });
+    editor = makeEditor(stateRef);
+    const span = editor.view.dom.querySelector('[data-comment-id="c1"]') as HTMLElement;
+    span.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onClickComment).toHaveBeenCalledWith(comment);
+  });
+
+  // WHY: clicking outside any decoration must not fire the click callback.
+  it("does not invoke onClickComment when the click misses every decoration", () => {
+    const onClickComment = vi.fn();
+    const stateRef = makeStateRef({
+      comments: [makeComment()],
+      activeSelection: null,
+      rawContent: CONTENT,
+      pendingRange: null,
+      onClickComment,
+    });
+    editor = makeEditor(stateRef);
+    editor.view.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onClickComment).not.toHaveBeenCalled();
+  });
+});

--- a/ap-web/src/shell/TodoPanel.test.tsx
+++ b/ap-web/src/shell/TodoPanel.test.tsx
@@ -1,0 +1,84 @@
+// Tests for TodoPanel — the small presentational panel that mirrors Claude
+// Code's todo list from useChatStore.todos. We mock the store so the panel's
+// own rendering (empty state, per-status icon/strikethrough, activeForm
+// subtitle) is exercised in isolation.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type TodoItem = {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+  activeForm: string;
+};
+
+// The store is a selector hook: useChatStore((s) => s.todos). Mock it to feed a
+// controllable todos array per test.
+const h = vi.hoisted(() => ({ todos: [] as TodoItem[] }));
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: (selector: (s: { todos: TodoItem[] }) => unknown) => selector({ todos: h.todos }),
+}));
+
+import { TodoPanel } from "./TodoPanel";
+
+afterEach(() => {
+  cleanup();
+  h.todos = [];
+});
+
+describe("TodoPanel", () => {
+  it("renders nothing when the todo list is empty", () => {
+    // WHY: the panel must occupy no space for sessions with no todos — it
+    // returns null, so the container has no DOM children.
+    h.todos = [];
+    const { container } = render(<TodoPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one list item per todo with its content", () => {
+    // WHY: confirms the map over todos renders every item's content text.
+    h.todos = [
+      { content: "Write tests", status: "pending", activeForm: "Writing tests" },
+      { content: "Ship it", status: "completed", activeForm: "Shipping it" },
+    ];
+    render(<TodoPanel />);
+    expect(screen.getByText("Write tests")).toBeInTheDocument();
+    expect(screen.getByText("Ship it")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("strikes through and dims a completed todo", () => {
+    // WHY: completed todos get line-through + opacity-50; a regression in the
+    // status-conditional classes would leave them looking active.
+    h.todos = [{ content: "Done thing", status: "completed", activeForm: "Doing thing" }];
+    render(<TodoPanel />);
+    const span = screen.getByText("Done thing");
+    expect(span.className).toContain("line-through");
+    expect(span.closest("li")?.className).toContain("opacity-50");
+  });
+
+  it("shows the activeForm subtitle for an in_progress todo when it differs", () => {
+    // WHY: an in-progress item surfaces its activeForm ("Doing X") under the
+    // content — this is the live-status affordance.
+    h.todos = [{ content: "Build feature", status: "in_progress", activeForm: "Building feature" }];
+    render(<TodoPanel />);
+    expect(screen.getByText("Build feature")).toBeInTheDocument();
+    expect(screen.getByText("Building feature")).toBeInTheDocument();
+  });
+
+  it("omits the activeForm subtitle when it equals the content", () => {
+    // WHY: the guard `activeForm !== content` prevents a redundant duplicate
+    // line; identical text must appear exactly once.
+    h.todos = [{ content: "Same text", status: "in_progress", activeForm: "Same text" }];
+    render(<TodoPanel />);
+    expect(screen.getAllByText("Same text")).toHaveLength(1);
+  });
+
+  it("does not show the activeForm subtitle for a non-in_progress todo", () => {
+    // WHY: the subtitle is gated on in_progress; a pending todo with a distinct
+    // activeForm must not render it.
+    h.todos = [{ content: "Pending thing", status: "pending", activeForm: "Pending action" }];
+    render(<TodoPanel />);
+    expect(screen.queryByText("Pending action")).toBeNull();
+  });
+});

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { detectLang, indexToLine, isBinaryPath, lineOverlapsSelection } from "./codeViewerHelpers";
+import {
+  detectLang,
+  getSelectionOffsets,
+  indexToLine,
+  isBinaryPath,
+  lineOverlapsSelection,
+} from "./codeViewerHelpers";
 
 // ---------------------------------------------------------------------------
 // detectLang — language matrix backing syntax highlighting
@@ -204,5 +210,102 @@ describe("lineOverlapsSelection", () => {
     expect(lineOverlapsSelection(0, lines, 0, 8)).toBe(true);
     expect(lineOverlapsSelection(1, lines, 0, 8)).toBe(true);
     expect(lineOverlapsSelection(2, lines, 0, 8)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSelectionOffsets — DOM Range → absolute byte offsets
+// ---------------------------------------------------------------------------
+
+describe("getSelectionOffsets", () => {
+  // Build a code container whose children carry `data-line` (1-based) and
+  // hold a single text node — mirroring the highlighted line elements
+  // CodeViewer renders. jsdom supports Range over these nodes.
+  function buildContainer(rawLines: string[]): HTMLElement {
+    const container = document.createElement("div");
+    rawLines.forEach((line, i) => {
+      const el = document.createElement("div");
+      el.dataset.line = String(i + 1);
+      el.textContent = line;
+      container.appendChild(el);
+    });
+    document.body.appendChild(container);
+    return container;
+  }
+
+  function lineTextNode(container: HTMLElement, lineIdx: number): Text {
+    return container.children[lineIdx].firstChild as Text;
+  }
+
+  it("computes absolute offsets for a single-line selection", () => {
+    // WHY: the common case — selecting chars within one line must map column
+    // offsets onto the absolute index, exercising the preRange column math.
+    const rawLines = ["hello", "world", "foo"];
+    const container = buildContainer(rawLines);
+    const range = document.createRange();
+    // Select "ell" on line 1 (cols 1..4).
+    range.setStart(lineTextNode(container, 0), 1);
+    range.setEnd(lineTextNode(container, 0), 4);
+
+    expect(getSelectionOffsets(range, container, rawLines)).toEqual({
+      start_index: 1,
+      end_index: 4,
+    });
+    container.remove();
+  });
+
+  it("sums preceding line lengths (+1 per newline) for a multi-line selection", () => {
+    // WHY: spanning lines must add each prior line's length plus its \n, so a
+    // boundary on line 2 lands past the line-1 text and its newline.
+    const rawLines = ["hello", "world", "foo"];
+    const container = buildContainer(rawLines);
+    const range = document.createRange();
+    // Start at col 2 of line 1, end at col 3 of line 2.
+    range.setStart(lineTextNode(container, 0), 2);
+    range.setEnd(lineTextNode(container, 1), 3);
+
+    // start = 2; end = ("hello".length 5 + \n 1) + 3 = 9.
+    expect(getSelectionOffsets(range, container, rawLines)).toEqual({
+      start_index: 2,
+      end_index: 9,
+    });
+    container.remove();
+  });
+
+  it("returns null when a boundary is outside any data-line element", () => {
+    // WHY: a selection that escaped the code container (e.g. into the gutter)
+    // can't be resolved to a line, so the helper must bail rather than emit a
+    // bogus offset.
+    const rawLines = ["hello"];
+    const container = buildContainer(rawLines);
+    const stray = document.createElement("span");
+    stray.textContent = "outside";
+    document.body.appendChild(stray);
+
+    const range = document.createRange();
+    range.setStart(stray.firstChild as Text, 0);
+    range.setEnd(stray.firstChild as Text, 3);
+
+    expect(getSelectionOffsets(range, container, rawLines)).toBeNull();
+    container.remove();
+    stray.remove();
+  });
+
+  it("returns null when a line element has a zero/missing line number", () => {
+    // WHY: data-line="0" parses to a falsy line number; the guard rejects it
+    // rather than computing against a non-existent line 0.
+    const container = document.createElement("div");
+    const el = document.createElement("div");
+    el.dataset.line = "0";
+    el.textContent = "abc";
+    container.appendChild(el);
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.setStart(el.firstChild as Text, 0);
+    range.setEnd(el.firstChild as Text, 2);
+
+    expect(getSelectionOffsets(range, container, ["abc"])).toBeNull();
+    container.remove();
   });
 });

--- a/ap-web/src/shell/codeViewerRendering.test.tsx
+++ b/ap-web/src/shell/codeViewerRendering.test.tsx
@@ -1,0 +1,101 @@
+// Tests for renderLineTokens — the near-pure token renderer that bridges
+// Shiki syntax tokens to React spans, layering search-match highlighting
+// (<mark>) and Shiki font-style bit flags on top. jsdom-free: we render to
+// strings/markup via @testing-library and assert structure, since the math
+// (match splitting, bit-flag decode) is where regressions hide.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ThemedToken } from "shiki";
+import { renderLineTokens } from "./codeViewerRendering";
+
+// Minimal ThemedToken builder — only the fields renderLineTokens reads.
+function tok(content: string, overrides: Partial<ThemedToken> = {}): ThemedToken {
+  return { content, color: "#abcdef", offset: 0, ...overrides } as ThemedToken;
+}
+
+// renderLineTokens returns a ReactNode array; render it inside a host element
+// so we can inspect the produced DOM.
+function renderTokens(tokens: ThemedToken[], query: string, isCurrent: boolean): HTMLElement {
+  const { container } = render(<div>{renderLineTokens(tokens, query, isCurrent)}</div>);
+  return container.firstChild as HTMLElement;
+}
+
+describe("renderLineTokens — no search query", () => {
+  it("renders one span per token carrying the token text and color", () => {
+    // WHY: with no query every token is a plain styled span; verifies the
+    // fast-path (no match splitting) and that the Shiki color is applied.
+    const host = renderTokens([tok("foo"), tok("bar", { color: "#112233" })], "", false);
+    const spans = host.querySelectorAll("span");
+    expect(spans).toHaveLength(2);
+    expect(spans[0].textContent).toBe("foo");
+    expect(spans[1].textContent).toBe("bar");
+    expect(spans[0].style.color).toBe("rgb(171, 205, 239)");
+    // No search query → no highlight marks at all.
+    expect(host.querySelectorAll("mark")).toHaveLength(0);
+  });
+
+  it("decodes Shiki fontStyle bit flags (italic|bold|underline)", () => {
+    // WHY: fontStyle is a bitfield (1=italic,2=bold,4=underline); a wrong mask
+    // would drop or mis-apply a decoration. 7 = all three set.
+    const host = renderTokens([tok("x", { fontStyle: 7 })], "", false);
+    const span = host.querySelector("span") as HTMLElement;
+    expect(span.style.fontStyle).toBe("italic");
+    expect(span.style.fontWeight).toBe("bold");
+    expect(span.style.textDecoration).toBe("underline");
+  });
+
+  it("applies only the bold decoration when only the bold bit is set", () => {
+    // WHY: pins that an isolated bit (2=bold) does not leak italic/underline —
+    // a regression masking the wrong flag would show extra decorations.
+    const host = renderTokens([tok("x", { fontStyle: 2 })], "", false);
+    const span = host.querySelector("span") as HTMLElement;
+    expect(span.style.fontWeight).toBe("bold");
+    expect(span.style.fontStyle).toBe("");
+    expect(span.style.textDecoration).toBe("");
+  });
+});
+
+describe("renderLineTokens — with search query", () => {
+  it("wraps a matching substring in a <mark> and leaves surrounding text plain", () => {
+    // WHY: the core split — "foobar" with query "oob" must yield f|oob|ar with
+    // only the middle in a mark; wrong indices would mark the wrong slice.
+    const host = renderTokens([tok("foobar")], "oob", false);
+    const mark = host.querySelector("mark");
+    expect(mark?.textContent).toBe("oob");
+    // The full token text is preserved across the split parts.
+    expect(host.textContent).toBe("foobar");
+  });
+
+  it("matches case-insensitively while preserving original-case text", () => {
+    // WHY: split uses lowercased indices but slices the original string, so the
+    // displayed text must keep its case even though the query was lowercase.
+    const host = renderTokens([tok("FooBar")], "foobar", false);
+    const mark = host.querySelector("mark");
+    expect(mark?.textContent).toBe("FooBar");
+  });
+
+  it("highlights every occurrence of the query within one token", () => {
+    // WHY: the while-loop must advance past each match; a broken loop would
+    // mark only the first "ab".
+    const host = renderTokens([tok("ab_ab_ab")], "ab", false);
+    expect(host.querySelectorAll("mark")).toHaveLength(3);
+  });
+
+  it("renders a token with no match as a plain span (no mark)", () => {
+    // WHY: the early-return for a single non-match part avoids wrapping clean
+    // tokens; a regression there would emit spurious empty marks.
+    const host = renderTokens([tok("clean")], "zzz", false);
+    expect(host.querySelectorAll("mark")).toHaveLength(0);
+    expect(host.textContent).toBe("clean");
+  });
+
+  it("uses the current-match class for the focused match and the dim class otherwise", () => {
+    // WHY: the current match is visually distinct (orange) from other matches
+    // (yellow); this asserts isCurrentMatch actually swaps the class.
+    const current = renderTokens([tok("foo")], "foo", true);
+    expect(current.querySelector("mark")?.className).toContain("bg-orange-400");
+    const dim = renderTokens([tok("foo")], "foo", false);
+    expect(dim.querySelector("mark")?.className).toContain("bg-yellow-300/80");
+  });
+});

--- a/ap-web/src/shell/codeViewerRendering.test.tsx
+++ b/ap-web/src/shell/codeViewerRendering.test.tsx
@@ -38,7 +38,7 @@ describe("renderLineTokens — no search query", () => {
   it("decodes Shiki fontStyle bit flags (italic|bold|underline)", () => {
     // WHY: fontStyle is a bitfield (1=italic,2=bold,4=underline); a wrong mask
     // would drop or mis-apply a decoration. 7 = all three set.
-    const host = renderTokens([tok("x", { fontStyle: 7 })], "", false);
+    const host = renderTokens([tok("x", { fontStyle: 7 as ThemedToken["fontStyle"] })], "", false);
     const span = host.querySelector("span") as HTMLElement;
     expect(span.style.fontStyle).toBe("italic");
     expect(span.style.fontWeight).toBe("bold");
@@ -48,7 +48,7 @@ describe("renderLineTokens — no search query", () => {
   it("applies only the bold decoration when only the bold bit is set", () => {
     // WHY: pins that an isolated bit (2=bold) does not leak italic/underline —
     // a regression masking the wrong flag would show extra decorations.
-    const host = renderTokens([tok("x", { fontStyle: 2 })], "", false);
+    const host = renderTokens([tok("x", { fontStyle: 2 as ThemedToken["fontStyle"] })], "", false);
     const span = host.querySelector("span") as HTMLElement;
     expect(span.style.fontWeight).toBe("bold");
     expect(span.style.fontStyle).toBe("");

--- a/ap-web/src/shell/useMonacoCommentLayer.test.tsx
+++ b/ap-web/src/shell/useMonacoCommentLayer.test.tsx
@@ -1,0 +1,341 @@
+// Tests for useMonacoCommentLayer — the shared comment-interaction layer wired
+// onto a Monaco editor instance. Monaco can't mount in jsdom, so we drive the
+// hook with a hand-rolled fake editor that records decoration sets and lets
+// tests fire the editor events (selection change, mouse up, blur) the hook
+// subscribes to. We assert the real effects: decorations applied/updated/
+// cleared, the floating "Add comment" button shown/hidden, and click-to-
+// navigate / click-away-to-clear of the active selection.
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Comment } from "@/hooks/useComments";
+import type { ActiveSelection } from "./codeViewerHelpers";
+import { useMonacoCommentLayer, type CodeEditorInstance } from "./useMonacoCommentLayer";
+
+// Render comment-layer portals into document.body in tests.
+vi.mock("@/lib/host", () => ({ getEmbedRoot: () => null }));
+
+// ── Fake Monaco editor ──────────────────────────────────────────────────────
+
+type Listener = (e: unknown) => void;
+
+interface FakeDecorations {
+  set: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+}
+
+// A minimal editor double. `content` backs the offset↔position mapping so the
+// decoration ranges are real; the event hooks return disposables and store the
+// callbacks so tests can fire them.
+function makeFakeEditor(content: string) {
+  const listeners: Record<string, Listener[]> = {};
+  const on = (name: string) => (cb: Listener) => {
+    (listeners[name] ??= []).push(cb);
+    return { dispose: vi.fn() };
+  };
+  const lastDecorations: FakeDecorations = { set: vi.fn(), clear: vi.fn() };
+  // Selection state the hook reads via getSelection().
+  let selection: {
+    isEmpty: () => boolean;
+    getStartPosition: () => unknown;
+    getEndPosition: () => unknown;
+  } | null = null;
+
+  const model = {
+    getPositionAt(offset: number) {
+      const before = content.slice(0, offset);
+      const lines = before.split("\n");
+      return { lineNumber: lines.length, column: lines[lines.length - 1].length + 1 };
+    },
+    getOffsetAt({ offset }: { offset: number }) {
+      return offset;
+    },
+    getValueInRange() {
+      return "selected";
+    },
+  };
+
+  const editor = {
+    getModel: () => model,
+    createDecorationsCollection: vi.fn(() => lastDecorations),
+    getSelection: () => selection,
+    getScrolledVisiblePosition: () => ({ left: 10, top: 20 }),
+    getDomNode: () => ({ getBoundingClientRect: () => ({ left: 100, top: 200 }) }),
+    revealRangeInCenterIfOutsideViewport: vi.fn(),
+    onDidChangeCursorSelection: on("selection"),
+    onDidScrollChange: on("scroll"),
+    onDidBlurEditorWidget: on("blur"),
+    onMouseUp: on("mouseup"),
+  };
+
+  return {
+    editor: editor as unknown as CodeEditorInstance,
+    lastDecorations,
+    fire(name: string, e?: unknown) {
+      for (const cb of listeners[name] ?? []) cb(e);
+    },
+    setSelection(start: number, end: number, empty = false) {
+      selection = {
+        isEmpty: () => empty,
+        getStartPosition: () => ({ offset: start }),
+        getEndPosition: () => ({ offset: end }),
+      };
+    },
+    clearSelection() {
+      selection = null;
+    },
+  };
+}
+
+function mkComment(overrides: Partial<Comment>): Comment {
+  return {
+    id: "c1",
+    conversation_id: "conv_1",
+    path: "/a.ts",
+    start_index: 0,
+    end_index: 0,
+    body: "",
+    status: "draft",
+    created_at: 0,
+    updated_at: 0,
+    anchor_content: null,
+    created_by: null,
+    ...overrides,
+  };
+}
+
+const CONTENT = "abc\ndefgh\nij";
+
+interface HookProps {
+  comments?: Comment[];
+  activeSelection?: ActiveSelection | null;
+  onSetActiveSelection?: (sel: ActiveSelection | null) => void;
+  canComment?: boolean;
+  pendingBodyRef?: React.RefObject<string>;
+  mounted?: boolean;
+}
+
+// Host component: calls the hook and renders its returned ReactNode (the
+// "Add comment" portal) so createPortal actually attaches to the DOM. A plain
+// renderHook would discard the return value and the portal would never mount.
+function Host(props: HookProps & { editorRef: React.RefObject<CodeEditorInstance | null> }) {
+  return useMonacoCommentLayer({
+    editorRef: props.editorRef,
+    mounted: props.mounted ?? true,
+    comments: props.comments ?? [],
+    activeSelection: props.activeSelection ?? null,
+    onSetActiveSelection: props.onSetActiveSelection ?? (() => {}),
+    canComment: props.canComment ?? true,
+    pendingBodyRef: props.pendingBodyRef,
+  }) as React.ReactElement | null;
+}
+
+function renderLayer(fake: ReturnType<typeof makeFakeEditor>, props: HookProps = {}) {
+  const editorRef = { current: fake.editor } as React.RefObject<CodeEditorInstance | null>;
+  const onSetActiveSelection = props.onSetActiveSelection ?? vi.fn();
+  const utils = render(
+    <Host {...props} editorRef={editorRef} onSetActiveSelection={onSetActiveSelection} />,
+  );
+  const rerender = (next: HookProps) =>
+    utils.rerender(
+      <Host {...next} editorRef={editorRef} onSetActiveSelection={onSetActiveSelection} />,
+    );
+  return { ...utils, rerender, onSetActiveSelection };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useMonacoCommentLayer — decorations", () => {
+  it("creates a decorations collection on mount from the current comments", () => {
+    // WHY: on first mount the hook must create (not set) a collection seeded
+    // with one decoration per saved comment.
+    const fake = makeFakeEditor(CONTENT);
+    renderLayer(fake, { comments: [mkComment({ start_index: 1, end_index: 3 })] });
+    expect(fake.editor.createDecorationsCollection).toHaveBeenCalledTimes(1);
+    const seed = vi.mocked(fake.editor.createDecorationsCollection).mock.calls[0][0];
+    expect(seed).toHaveLength(1);
+  });
+
+  it("updates the existing collection via set() when comments change", () => {
+    // WHY: after the collection exists, a comments change must reuse it via
+    // set() rather than creating a second collection.
+    const fake = makeFakeEditor(CONTENT);
+    const { rerender } = renderLayer(fake, {
+      comments: [mkComment({ start_index: 1, end_index: 3 })],
+    });
+    act(() => {
+      rerender({
+        comments: [
+          mkComment({ start_index: 1, end_index: 3 }),
+          mkComment({ id: "c2", start_index: 5, end_index: 7 }),
+        ],
+      });
+    });
+    expect(fake.lastDecorations.set).toHaveBeenCalled();
+    // Still only one collection created across the whole lifecycle.
+    expect(fake.editor.createDecorationsCollection).toHaveBeenCalledTimes(1);
+    const latest = fake.lastDecorations.set.mock.lastCall?.[0];
+    expect(latest).toHaveLength(2);
+  });
+
+  it("clears the decorations collection on unmount", () => {
+    // WHY: the cleanup effect drops decorations so a remounted editor doesn't
+    // inherit stale highlights.
+    const fake = makeFakeEditor(CONTENT);
+    const { unmount } = renderLayer(fake, {
+      comments: [mkComment({ start_index: 1, end_index: 3 })],
+    });
+    unmount();
+    expect(fake.lastDecorations.clear).toHaveBeenCalled();
+  });
+
+  it("does not wire decorations when not yet mounted", () => {
+    // WHY: the `mounted` gate prevents touching the editor before it's ready.
+    const fake = makeFakeEditor(CONTENT);
+    renderLayer(fake, { mounted: false, comments: [mkComment({})] });
+    expect(fake.editor.createDecorationsCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMonacoCommentLayer — add-comment button", () => {
+  it("shows the floating button for a non-empty selection when commenting is allowed", () => {
+    // WHY: a real text selection + canComment must surface the Add-comment
+    // button (rendered as a portal in document.body).
+    const fake = makeFakeEditor(CONTENT);
+    fake.setSelection(1, 3);
+    renderLayer(fake, { canComment: true });
+    act(() => fake.fire("selection"));
+    expect(document.querySelector("[data-add-comment-btn]")).not.toBeNull();
+  });
+
+  it("hides the button when commenting is not allowed", () => {
+    // WHY: with canComment=false the button must never appear even on a real
+    // selection (read-only / dirty / truncated gating).
+    const fake = makeFakeEditor(CONTENT);
+    fake.setSelection(1, 3);
+    renderLayer(fake, { canComment: false });
+    act(() => fake.fire("selection"));
+    expect(document.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+
+  it("hides the button for an empty (collapsed) selection", () => {
+    // WHY: a caret with no range is not a comment target — the button stays
+    // hidden.
+    const fake = makeFakeEditor(CONTENT);
+    fake.setSelection(2, 2, true);
+    renderLayer(fake, { canComment: true });
+    act(() => fake.fire("selection"));
+    expect(document.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+
+  it("hides the button on scroll and on blur", () => {
+    // WHY: the button is positioned in viewport coords, so scroll/blur must
+    // clear it rather than leave it floating in a stale spot.
+    const fake = makeFakeEditor(CONTENT);
+    fake.setSelection(1, 3);
+    renderLayer(fake, { canComment: true });
+    act(() => fake.fire("selection"));
+    expect(document.querySelector("[data-add-comment-btn]")).not.toBeNull();
+    act(() => fake.fire("scroll"));
+    expect(document.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+
+  it("hides a visible button when canComment flips false", () => {
+    // WHY: the dedicated effect must clear an already-shown button when
+    // permission/dirty state flips, since no selection event may fire.
+    const fake = makeFakeEditor(CONTENT);
+    fake.setSelection(1, 3);
+    const { rerender } = renderLayer(fake, { canComment: true });
+    act(() => fake.fire("selection"));
+    expect(document.querySelector("[data-add-comment-btn]")).not.toBeNull();
+    act(() => rerender({ canComment: false }));
+    expect(document.querySelector("[data-add-comment-btn]")).toBeNull();
+  });
+
+  it("creates a comment selection from the current range when the button is clicked", () => {
+    // WHY: clicking Add comment must hand the selection's offsets up via
+    // onSetActiveSelection so a draft anchors to the right range.
+    const fake = makeFakeEditor(CONTENT);
+    fake.setSelection(1, 3);
+    const onSet = vi.fn();
+    renderLayer(fake, { canComment: true, onSetActiveSelection: onSet });
+    act(() => fake.fire("selection"));
+    const btn = document.querySelector("[data-add-comment-btn]") as HTMLElement;
+    act(() => {
+      btn.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    });
+    expect(onSet).toHaveBeenCalledWith({
+      start_index: 1,
+      end_index: 3,
+      anchor_content: "selected",
+    });
+  });
+});
+
+describe("useMonacoCommentLayer — mouse-up navigation", () => {
+  it("activates a comment when its highlighted range is clicked", () => {
+    // WHY: clicking inside a saved comment's range (with no selection) must set
+    // that comment active for the panel — the navigate path.
+    const fake = makeFakeEditor(CONTENT);
+    const onSet = vi.fn();
+    renderLayer(fake, {
+      comments: [mkComment({ start_index: 1, end_index: 3, anchor_content: "bc" })],
+      onSetActiveSelection: onSet,
+    });
+    act(() => fake.fire("mouseup", { target: { position: { offset: 2 } } }));
+    expect(onSet).toHaveBeenCalledWith({
+      start_index: 1,
+      end_index: 3,
+      anchor_content: "bc",
+    });
+  });
+
+  it("clears the active selection when clicking outside any comment", () => {
+    // WHY: a click away with an active selection and no pending draft must
+    // deselect (onSetActiveSelection(null)).
+    const fake = makeFakeEditor(CONTENT);
+    const onSet = vi.fn();
+    renderLayer(fake, {
+      comments: [mkComment({ start_index: 1, end_index: 3 })],
+      activeSelection: { start_index: 1, end_index: 3, anchor_content: "bc" },
+      onSetActiveSelection: onSet,
+    });
+    act(() => fake.fire("mouseup", { target: { position: { offset: 9 } } }));
+    expect(onSet).toHaveBeenCalledWith(null);
+  });
+
+  it("does not clear the active selection while a draft body is in progress", () => {
+    // WHY: an in-progress comment draft must survive a click away — the
+    // pendingBodyRef guard prevents losing the user's typed body.
+    const fake = makeFakeEditor(CONTENT);
+    const onSet = vi.fn();
+    renderLayer(fake, {
+      comments: [mkComment({ start_index: 1, end_index: 3 })],
+      activeSelection: { start_index: 1, end_index: 3, anchor_content: "bc" },
+      onSetActiveSelection: onSet,
+      pendingBodyRef: { current: "half-typed" } as React.RefObject<string>,
+    });
+    act(() => fake.fire("mouseup", { target: { position: { offset: 9 } } }));
+    expect(onSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMonacoCommentLayer — reveal active selection", () => {
+  it("reveals the active selection's range in the viewport", () => {
+    // WHY: when activeSelection changes (e.g. clicked in the panel) the editor
+    // must scroll the matching range into view.
+    const fake = makeFakeEditor(CONTENT);
+    renderLayer(fake, {
+      activeSelection: { start_index: 5, end_index: 7, anchor_content: "fg" },
+    });
+    expect(fake.editor.revealRangeInCenterIfOutsideViewport).toHaveBeenCalledWith({
+      startLineNumber: 2,
+      startColumn: 2,
+      endLineNumber: 2,
+      endColumn: 4,
+    });
+  });
+});


### PR DESCRIPTION
## What

Fills the **high** and **medium** priority UI unit-test gaps surfaced by the new frontend coverage report (added in #352). ~150 new tests across 22 files, all runnable with `npm test` (vitest). **Test-only — no source or config changes.**

## New test files (were 0% / had no test)

- **hooks**: `useComments`, `useDefaultPolicies`, `useFileDiff`
- **comment editor**: `TipTapCommentExtension`, `MarkdownCommentPlugin`
- **pages**: `ApprovePage`, `InboxPage`
- **shell**: `codeViewerRendering`, `TodoPanel`, `ExecutionLogsPanel`, `useMonacoCommentLayer`
- **components**: `SessionImage`, `theme/ThemeModeMenu`, `TableBubbleMenu`
- **pages/ChatPage**: `ChatPage.capabilities` + `ChatPage.indicators` (gap-fill on the 4,044-line file)

## Extended existing tests (line coverage lift)

| File | Before | After |
|---|---|---|
| `codeViewerHelpers.ts` | 45% | 100% |
| `useHostFilesystem.ts` | 30% | 97% |
| `AgentInfo.tsx` | 52% | 81% |
| `TerminalSession.ts` | 25% | 76% |
| `PermissionsModal.tsx` | 48% | 75% |
| `ToolCard.tsx` | 52% | 74% |

## Conventions

- `@testing-library/react` + vitest, mirroring neighbor tests; every test carries a `// WHY` comment per repo convention.
- Deterministic & hermetic (network/monaco/xterm/editor mocked).
- Paths jsdom can't drive (drag geometry, scroll/stick-to-bottom, portal positioning) are deliberately left to the `e2e_ui` suite, noted inline with reasons.

## Verification

- `npm test` → **2753 passing**, 3 expected-fail, 2 skipped (168 files).
- `npm run format:check` → clean.