### PR TITLE
fix(ci): e2e-ui gate no longer crashes on large UI PRs

### DIFF
--- a/.github/scripts/e2e-ui-required/check.sh
+++ b/.github/scripts/e2e-ui-required/check.sh
@@ -64,9 +64,10 @@ fi
 # --- 2. LLM judge: behavior change without adequate e2e_ui coverage? ------
 # Build a bounded diff blob: only ap-web/** and tests/e2e_ui/** patches. Each
 # file's patch is truncated to MAX_PATCH_LINES so one huge file can't crowd out
-# the others, keeping the prompt representative across many-file PRs. A final
-# head -c is an overall backstop for PRs with very many files.
+# the others, keeping the prompt representative across many-file PRs. An
+# overall byte cap (applied below) is a backstop for PRs with very many files.
 MAX_PATCH_LINES=400
+MAX_BLOB_BYTES=60000
 # `gh api --paginate` (no --jq) merges all pages into one JSON array; pipe that
 # to jq so --argjson reaches jq (gh api itself has no --argjson flag).
 DIFF_BLOB=$(gh api "repos/$REPO/pulls/$PR/files" --paginate \
@@ -77,8 +78,13 @@ DIFF_BLOB=$(gh api "repos/$REPO/pulls/$PR/files" --paginate \
     | (if ($lines | length) > $max
          then (($lines[:$max] | join("\n")) + "\n... (patch truncated at \($max) lines)")
          else $p end) as $trunc
-    | "=== \(.status) \(.filename) ===\n\($trunc)"' \
-  | head -c 60000)
+    | "=== \(.status) \(.filename) ===\n\($trunc)"')
+# Apply the overall byte cap in-shell, NOT via `... | head -c`. Under
+# `set -o pipefail`, head closing the pipe early sends jq SIGPIPE, and that
+# broken-pipe exit aborts the whole gate on any large UI PR (diff > cap) --
+# fail-closed before the judge or the skip-label logic ever runs. Bash slicing
+# truncates the captured string with no pipe to break.
+DIFF_BLOB=${DIFF_BLOB:0:$MAX_BLOB_BYTES}
 
 PR_TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq '.title')
 


### PR DESCRIPTION
## Problem

The `E2E UI Required` gate (`/.github/scripts/e2e-ui-required/check.sh`) **fails closed on any large UI PR**, regardless of content. Seen on #372 (a tests-only PR):

```
jq: error: writing output failed: Broken pipe
##[error]Process completed with exit code 2.
```

The gate builds the diff blob it sends to the LLM judge with:

```sh
DIFF_BLOB=$(gh api .../files --paginate | jq -r '...' | head -c 60000)
```

When the `ap-web/**` + `tests/e2e_ui/**` diff exceeds 60 KB (#372's is **178 KB**), `head -c 60000` reads its 60 KB and closes the pipe while `jq` still has output to write. `jq` gets SIGPIPE → "Broken pipe" → non-zero exit. The script runs under `set -euo pipefail`, so that broken-pipe exit **aborts the whole gate (exit 2)** — *before* the LLM judge call (case 2) or the `skip-e2e-ui-test` label logic (case 3) ever run.

Consequences:
- Every large UI PR is blocked regardless of whether it actually needs a test — including a 100%-tests PR.
- The `skip-e2e-ui-test` waiver can't rescue it, because the crash happens before the label is even checked.

## Fix

Capture `jq`'s full output into a variable, then truncate the string **in-shell** with bash parameter expansion (`${DIFF_BLOB:0:N}`). No pipe, so nothing to break under `pipefail`. Same 60 KB cap; per-file `MAX_PATCH_LINES` truncation unchanged.

## Verification

- `bash -n check.sh` → clean.
- Reproduced the SIGPIPE-under-`pipefail` crash, and confirmed the new bash-slice path truncates a 178 KB string to exactly 60 KB and exits 0.

## Rollout

The gate runs via `pull_request_target` and checks out `.github/scripts` from `main`, so this must land on `main` to take effect. Once merged, re-running `E2E UI Required` on #372 (and any other large UI PR) picks up the fixed copy.