### PR TITLE
fix(runner): don't workdir-join omnigent dotted callable tool paths

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -59,6 +59,7 @@ from omnigent.runner.resource_registry import (
     SessionResourceRegistry,
 )
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
+from omnigent.spec.omnigent import OMNIGENT_TOOL_LANGUAGE
 from omnigent.spec.parser import discover_host_skills
 from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
 from omnigent.terminals.ws_bridge import (
@@ -2906,6 +2907,15 @@ def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
     resolved_tools: list[LocalToolInfo] = []
     changed = False
     for info in local_tools:
+        # Omnigent dotted callables (``type: function`` tools) carry an
+        # importable module path (e.g. ``pkg.tools.retain``) in ``path``,
+        # not a file path. Workdir-joining one corrupts it into a bogus
+        # filesystem path, the import fails with ModuleNotFoundError, and
+        # the whole tool schema list is dropped. Pass them through as-is;
+        # only real file tools get resolved against the workdir.
+        if getattr(info, "language", None) == OMNIGENT_TOOL_LANGUAGE:
+            resolved_tools.append(info)
+            continue
         path = getattr(info, "path", None)
         if path and not Path(path).is_absolute():
             resolved_tools.append(dataclasses.replace(info, path=str((workdir / path).resolve())))

--- a/tests/runner/test_spec_workdir_paths.py
+++ b/tests/runner/test_spec_workdir_paths.py
@@ -1,0 +1,87 @@
+"""Regression tests for :func:`omnigent.runner.app._spec_with_workdir_paths`.
+
+The helper rewrites relative local-tool ``path`` values to absolute paths
+under the agent's workdir bundle. It must NOT touch omnigent dotted
+callables (``type: function`` tools, ``language ==
+:data:`OMNIGENT_TOOL_LANGUAGE```): their ``path`` is an importable module
+path (e.g. ``pkg.tools.retain``), not a file path. Workdir-joining one
+corrupts it into a bogus filesystem path, the import fails with
+ModuleNotFoundError, and the whole tool schema list is dropped — leaving
+the agent with zero declared tools (issue #379).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from omnigent.runner.app import _spec_with_workdir_paths
+from omnigent.spec.omnigent import OMNIGENT_TOOL_LANGUAGE
+from omnigent.spec.types import LocalToolInfo
+
+
+@dataclass
+class _FakeAgentSpec:
+    """Minimal spec stub carrying just the ``local_tools`` list.
+
+    :param local_tools: List of tool info objects the spec declares.
+    """
+
+    local_tools: list[LocalToolInfo] = field(default_factory=list)
+
+
+def test_dotted_callable_path_left_unchanged(tmp_path: Path) -> None:
+    """An ``omnigent-python-callable`` tool's dotted ``path`` is passed
+    through verbatim — never workdir-joined."""
+    dotted = "hindsight_omnigent.tools.retain"
+    spec = _FakeAgentSpec(
+        local_tools=[
+            LocalToolInfo(
+                name="retain",
+                path=dotted,
+                language=OMNIGENT_TOOL_LANGUAGE,
+            )
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    assert resolved.local_tools[0].path == dotted
+
+
+def test_python_file_tool_path_is_workdir_joined(tmp_path: Path) -> None:
+    """A regular ``python`` file tool with a relative path is still
+    resolved against the workdir (no regression for real file tools)."""
+    rel = "tools/python/arxiv_search.py"
+    spec = _FakeAgentSpec(
+        local_tools=[
+            LocalToolInfo(
+                name="arxiv_search",
+                path=rel,
+                language="python",
+            )
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    assert resolved.local_tools[0].path == str((tmp_path / rel).resolve())
+
+
+def test_mixed_tools_only_file_tool_is_joined(tmp_path: Path) -> None:
+    """With both kinds present, only the file tool is rewritten; the
+    dotted callable is preserved (the bug that dropped the whole list)."""
+    dotted = "hindsight_omnigent.tools.retain"
+    rel = "tools/python/arxiv_search.py"
+    spec = _FakeAgentSpec(
+        local_tools=[
+            LocalToolInfo(name="retain", path=dotted, language=OMNIGENT_TOOL_LANGUAGE),
+            LocalToolInfo(name="arxiv_search", path=rel, language="python"),
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    by_name = {t.name: t for t in resolved.local_tools}
+    assert by_name["retain"].path == dotted
+    assert by_name["arxiv_search"].path == str((tmp_path / rel).resolve())


### PR DESCRIPTION
Closes #379

## Problem

`_spec_with_workdir_paths` in `omnigent/runner/app.py` workdir-joined **every** local tool's `path`, including omnigent dotted callables (`type: function` tools, `language == 'omnigent-python-callable'`).

That turned an importable module path like `hindsight_omnigent.tools.retain` into `/tmp/<bundle>/hindsight_omnigent.tools.retain`. The import then failed with `ModuleNotFoundError`, `ToolManager.get_tool_schemas()` (a single list-comprehension) aborted, and the runner swallowed it as a WARNING — leaving the agent with **zero declared tools**.

## Fix

Guard the loop body in `_spec_with_workdir_paths`: omnigent dotted callables (`language == OMNIGENT_TOOL_LANGUAGE`) are passed through unchanged, and only real file tools (`language == 'python'`) get resolved against the workdir.

### Before
```
hindsight_omnigent.tools.retain
  -> /tmp/<bundle>/hindsight_omnigent.tools.retain   # ModuleNotFoundError -> 0 tools
tools/python/arxiv_search.py
  -> /tmp/<bundle>/tools/python/arxiv_search.py      # correct
```

### After
```
hindsight_omnigent.tools.retain
  -> hindsight_omnigent.tools.retain                 # unchanged, imports fine
tools/python/arxiv_search.py
  -> /tmp/<bundle>/tools/python/arxiv_search.py      # still correct
```

## Tests

Adds `tests/runner/test_spec_workdir_paths.py` with focused regression coverage:
- an `omnigent-python-callable` tool's dotted `path` is left **unchanged**;
- a regular `python` file-tool with a relative path **is still** workdir-joined (no regression for file tools);
- a mixed spec resolves only the file tool.

## Gates

- `ruff check` / `ruff format --check` — pass
- `mypy` — no new errors (the 125 pre-existing `app.py` errors are unchanged; none at the edited lines)
- `pytest tests/runner/test_spec_workdir_paths.py tests/tools/test_local_callable.py tests/tools/test_manager.py` — 48 passed