### PR TITLE
fix(runner): don't prepend workdir to dotted callable tool paths

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2909,6 +2909,22 @@ class _SessionSnapshot:
     sub_agent_name: str | None = None
 
 
+_TOOL_SOURCE_SUFFIXES = (".py", ".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs")
+
+
+def _is_relative_tool_file(path: str) -> bool:
+    """Whether ``path`` is a workdir-relative tool *source file* rather than a dotted callable.
+
+    ``LocalToolInfo.path`` is overloaded: it is either a relative file path (e.g.
+    ``tools/python/arxiv_search.py``) or a dotted callable import path (e.g.
+    ``pkg.module.func``). Only the former is workdir-relative; a relative source file has a
+    path separator or a known source suffix, whereas a dotted callable has neither.
+    """
+    if Path(path).is_absolute():
+        return False
+    return "/" in path or os.sep in path or path.endswith(_TOOL_SOURCE_SUFFIXES)
+
+
 def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
     if workdir is None or spec is None:
         return spec
@@ -2919,7 +2935,9 @@ def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
     changed = False
     for info in local_tools:
         path = getattr(info, "path", None)
-        if path and not Path(path).is_absolute():
+        # Only rewrite relative *file* paths. Prepending the workdir to a dotted callable
+        # import path corrupts it, so the tool fails to import and is silently dropped (#378).
+        if path and _is_relative_tool_file(path):
             resolved_tools.append(dataclasses.replace(info, path=str((workdir / path).resolve())))
             changed = True
         else:

--- a/tests/runner/test_spec_workdir_paths.py
+++ b/tests/runner/test_spec_workdir_paths.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from omnigent.runner.app import _is_relative_tool_file, _spec_with_workdir_paths
+from omnigent.spec.types import AgentSpec, ExecutorSpec, LocalToolInfo
+
+
+def test_is_relative_tool_file_distinguishes_dotted_callable_from_file() -> None:
+    # Dotted callable import paths (``type: function`` tools) are not workdir-relative files.
+    assert _is_relative_tool_file("hindsight_omnigent.tools.retain") is False
+    assert _is_relative_tool_file("examples._shared.tool_functions.search_web") is False
+    # Relative source files are (whether nested or at the bundle root).
+    assert _is_relative_tool_file("tools/python/arxiv_search.py") is True
+    assert _is_relative_tool_file("arxiv_search.py") is True
+    assert _is_relative_tool_file("mytool.ts") is True
+    # Absolute paths are left untouched.
+    assert _is_relative_tool_file("/abs/tools/x.py") is False
+
+
+def test_spec_with_workdir_paths_preserves_dotted_callable_paths(tmp_path) -> None:
+    # Regression for #378: a single-file YAML agent's ``type: function`` tool carries a dotted
+    # callable import path. Workdir resolution must not prepend the bundle dir to it (which
+    # corrupts the import and silently drops the whole tool set); only real relative file
+    # paths get resolved against the workdir.
+    callable_tool = LocalToolInfo(
+        name="retain", path="hindsight_omnigent.tools.retain", language="python"
+    )
+    file_tool = LocalToolInfo(name="arxiv", path="tools/arxiv.py", language="python")
+    spec = AgentSpec(
+        spec_version=1,
+        executor=ExecutorSpec(type="claude_sdk"),
+        local_tools=[callable_tool, file_tool],
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    by_name = {t.name: t for t in resolved.local_tools}
+    # The dotted callable path is left untouched ...
+    assert by_name["retain"].path == "hindsight_omnigent.tools.retain"
+    # ... while a genuine relative file path is resolved against the workdir.
+    assert by_name["arxiv"].path == str((tmp_path / "tools/arxiv.py").resolve())


### PR DESCRIPTION
## What

Single-file YAML agents that declare `type: function` tools (dotted `callable` paths) have those tools **silently dropped** (#378). `_spec_with_workdir_paths` prepends the agent-bundle workdir to every `LocalToolInfo.path`, but that field is overloaded — it is either a relative file path (`tools/x.py`) **or** a dotted callable import path (`pkg.module.func`). Prepending the workdir to a dotted path corrupts the import, the tool fails to load, and (with no per-tool error isolation) the entire tool set is dropped and swallowed as a WARNING — so the model silently runs with none of its declared tools.

## Fix

Only rewrite paths that look like a relative source *file* (a path separator or a source suffix); leave dotted callable import paths untouched. This matches the issue's diagnosis and its validated one-line fix.

## Test

`tests/runner/test_spec_workdir_paths.py` (both pass locally):
- `_is_relative_tool_file` distinguishes dotted callables from file paths.
- `_spec_with_workdir_paths` leaves a `type: function` tool's dotted path untouched while still resolving a relative file path against the workdir.

## Note

The issue also flags a secondary 'defense in depth' problem: `get_tool_schemas()` has no per-tool error isolation, so one bad tool removes the whole toolset (swallowed as a WARNING). That's a larger, separate change — happy to follow up, but kept this PR scoped to the path corruption that is the root cause.

Fixes #378