### PR TITLE
Use crane tag for floating-tag retags to preserve image digest

### DIFF
--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -194,8 +194,8 @@ jobs:
 
   promote-nightly:
     # Daily cron (or a manual force_nightly dispatch): move :latest-nightly to
-    # the current main build by retagging the existing :latest-dev manifest
-    # (multi-arch safe, no rebuild).
+    # the current main build by retagging :latest-dev with `crane tag`
+    # (digest-preserving, no rebuild).
     if: github.repository == 'omnigent-ai/omnigent' && (github.event_name == 'schedule' || inputs.force_nightly)
     permissions:
       contents: read
@@ -203,8 +203,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+      - name: Set up crane
+        uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0  # v0.6
+        with:
+          version: v0.21.6
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
@@ -216,10 +218,12 @@ jobs:
       - name: Promote latest-dev -> latest-nightly
         run: |
           set -euo pipefail
+          # crane tag points a new tag at an EXISTING manifest digest without
+          # re-serializing it, so :latest-nightly keeps :latest-dev's exact digest.
           for img in ghcr.io/omnigent-ai/omnigent-server ghcr.io/omnigent-ai/omnigent-host; do
-            if docker buildx imagetools inspect "${img}:latest-dev" >/dev/null 2>&1; then
-              docker buildx imagetools create -t "${img}:latest-nightly" "${img}:latest-dev"
-              echo "promoted ${img}:latest-dev -> ${img}:latest-nightly"
+            if crane digest "${img}:latest-dev" >/dev/null 2>&1; then
+              crane tag "${img}:latest-dev" latest-nightly
+              echo "promoted ${img}:latest-dev -> :latest-nightly ($(crane digest "${img}:latest-nightly"))"
             else
               echo "::warning::${img}:latest-dev not found yet; skipping nightly promotion"
             fi
@@ -228,8 +232,8 @@ jobs:
   reconcile-floating:
     # Manual reconcile (workflow_dispatch with reconcile_floating=true): repoint
     # :latest and :latest-rc onto the correct EXISTING version images, computed
-    # from the tag list with PEP 440 ordering. Retags via imagetools (no
-    # rebuild). Idempotent — also a "fix the floating tags if they ever drift"
+    # from the tag list with PEP 440 ordering. Retags with `crane tag`
+    # (digest-preserving). Idempotent — also a "fix the floating tags if they drift"
     # button, and the way to backfill them for releases cut before this scheme.
     if: github.repository == 'omnigent-ai/omnigent' && inputs.reconcile_floating
     permissions:
@@ -241,8 +245,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+      - name: Set up crane
+        uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0  # v0.6
+        with:
+          version: v0.21.6
 
       - name: Set up uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
@@ -267,16 +273,19 @@ jobs:
             uv run --with packaging --no-project python .github/scripts/oss-publish-images/reconcile_targets.py)
           echo "targets: latest-rc<-${RC_TAG}  latest<-${LATEST_TAG}"
 
-          # dst=floating tag, src=version tag (skip when src is "-" or its image is absent).
+          # crane tag repoints a tag onto an EXISTING manifest digest without
+          # re-serializing it (unlike `imagetools create`, which wraps a
+          # single-platform image in a fresh manifest list and changes the
+          # digest). dst=floating tag, src=version tag.
           retag() {
             local img="$1" dst="$2" src="$3"
             if [ "${src}" = "-" ]; then
               echo "::warning::no source for ${img}:${dst}; skipping"
               return
             fi
-            if docker buildx imagetools inspect "${img}:${src}" >/dev/null 2>&1; then
-              docker buildx imagetools create -t "${img}:${dst}" "${img}:${src}"
-              echo "set ${img}:${dst} -> ${src}"
+            if crane digest "${img}:${src}" >/dev/null 2>&1; then
+              crane tag "${img}:${src}" "${dst}"
+              echo "set ${img}:${dst} -> ${src} ($(crane digest "${img}:${dst}"))"
             else
               echo "::warning::${img}:${src} image not found; skipping ${img}:${dst}"
             fi


### PR DESCRIPTION
## Problem

After running `reconcile_floating`, `:latest` and `:latest-rc` point at a **different digest** than `v0.1.1`, even though they were retagged from it:

```
v0.1.1     -> sha256:005a929c…   (plain image manifest, manifest.v2+json)
latest     -> sha256:877fc62…    (manifest LIST wrapping 005a929c…)
latest-rc  -> sha256:877fc62…    (same)
```

`docker buildx imagetools create -t DST SRC` **always builds a fresh manifest list (index)**. The images are built single-platform (`linux/amd64`), so `v0.1.1` is a plain image manifest; `imagetools create` wrapped it in a one-entry list whose child *is* `005a929c…`. Content pulled is identical, but the top-level digest changed — so digest pinning to `005a929c…` no longer matches `:latest`.

This affects every retag path: `reconcile-floating` and `promote-nightly`.

## Fix

Switch both jobs from `docker buildx imagetools create` to **`crane tag`**, which points a tag at an **existing** manifest digest without re-serializing it. The floating tags then keep the exact digest of their source (`:latest` / `:latest-rc` = `v0.1.1`'s digest; `:latest-nightly` = `:latest-dev`'s digest).

- crane installed via SHA-pinned `imjasonh/setup-crane@59c71e96…` (v0.6), pinned to crane `v0.21.6`.
- Auth via the existing `docker/login-action` (crane reads `~/.docker/config.json`).
- Existence checks switch from `imagetools inspect` to `crane digest`.
- Dropped the now-unused `setup-buildx` from these two jobs. **`build-and-push` is unchanged** — it tags at build time via `build-push-action`, already sharing one digest across all its tags.

## After merge

Re-run **Actions → Publish images (public) → Run workflow → `reconcile_floating`** to repoint `:latest` / `:latest-rc` onto `v0.1.1`'s digest (`sha256:005a929c…`). The run log prints the resulting digest per tag so it can be confirmed.

## Note

This is a workflow-only change; the digest-preserving behavior can't be fully exercised until it runs in CI (a retag needs `packages: write`, which only the Actions token has). `crane tag`'s digest-preserving behavior is well-established, and the steps log the resulting digest for verification.