### PR TITLE
fix(pi-native): show "Pi" not the raw slug in the model picker for forked/switched sessions

### DIFF
--- a/ap-web/src/components/AgentInfo.test.tsx
+++ b/ap-web/src/components/AgentInfo.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/hooks/usePolicies", () => ({
   useDeletePolicy: () => ({ mutate: deleteMutate }),
 }));
 
-import { AgentInfoButton, AgentInfoContent } from "./AgentInfo";
+import { AgentInfoButton, AgentInfoContent, agentDisplayLabel } from "./AgentInfo";
 
 afterEach(() => {
   cleanup();
@@ -353,5 +353,28 @@ describe("SessionPoliciesSection", () => {
     expect(
       within(dialog).getByText("All available policies are already applied."),
     ).toBeInTheDocument();
+  });
+});
+
+describe("agentDisplayLabel", () => {
+  it("maps native wrapper slugs to their display name", () => {
+    expect(agentDisplayLabel("pi-native-ui")).toBe("Pi");
+    expect(agentDisplayLabel("claude-native-ui")).toBe("Claude");
+    expect(agentDisplayLabel("codex-native-ui")).toBe("Codex");
+  });
+
+  it("strips the fork/switch clone suffix before resolving the native label", () => {
+    // Fork/switch routes clone a bound agent as "<name> (fork|switch <id>)".
+    // The label must still resolve to "Pi" rather than the capitalized raw
+    // slug "Pi-native-ui …" shown in the in-session model picker.
+    expect(agentDisplayLabel("pi-native-ui (fork conv_ab12)")).toBe("Pi");
+    expect(agentDisplayLabel("pi-native-ui (switch conv_ab12)")).toBe("Pi");
+    expect(agentDisplayLabel("claude-native-ui (fork conv_ab12)")).toBe("Claude");
+    expect(agentDisplayLabel("codex-native-ui (switch conv_ab12)")).toBe("Codex");
+  });
+
+  it("capitalizes non-native names and strips their clone suffix", () => {
+    expect(agentDisplayLabel("polly")).toBe("Polly");
+    expect(agentDisplayLabel("polly (fork conv_ab12)")).toBe("Polly");
   });
 });

--- a/ap-web/src/components/AgentInfo.tsx
+++ b/ap-web/src/components/AgentInfo.tsx
@@ -24,6 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { capitalizeAgentName } from "@/lib/agentLabels";
 import { coercePolicyParams } from "@/lib/policyParams";
+import { agentBaseName } from "@/lib/forkHarness";
 import { nativeCodingAgentForAgentName } from "@/lib/nativeCodingAgents";
 import { useChatStore } from "@/store/chatStore";
 
@@ -32,11 +33,19 @@ import { useChatStore } from "@/store/chatStore";
  * the name capital-first (server agent names are lowercase slugs, e.g.
  * ``"polly"`` → ``"Polly"``). Keeps the chat surfaces consistent with
  * the new-chat picker's capitalization.
+ *
+ * Strips the `" (fork <id>)"` / `" (switch <id>)"` suffix the fork/switch
+ * routes append to a cloned agent's name before resolving, so a clone of
+ * a native wrapper (e.g. `"pi-native-ui (fork conv_ab12)"`) still maps to
+ * its display name ("Pi") instead of falling through to the capitalized
+ * raw slug ("Pi-native-ui …"). Mirrors how `useAvailableAgents` and the
+ * fork/switch pickers already match clones back to their base agent.
  */
 export function agentDisplayLabel(name: string): string {
-  const nativeAgent = nativeCodingAgentForAgentName(name);
+  const baseName = agentBaseName(name);
+  const nativeAgent = nativeCodingAgentForAgentName(baseName);
   if (nativeAgent?.key === "claude") return "Claude";
-  return nativeAgent?.displayName ?? capitalizeAgentName(name);
+  return nativeAgent?.displayName ?? capitalizeAgentName(baseName);
 }
 
 /** Compact pill row listing MCP servers attached to an agent. */

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -183,3 +183,73 @@ def test_fork_switch_agent_carries_history(
         assert _WRAPPER_LABEL_KEY not in labels, (
             f"SDK-target fork must stay in chat mode (no wrapper), got {labels!r}"
         )
+
+
+def test_fork_into_pi_labels_model_picker_pi(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Forking SDK → Pi labels the in-session model picker "Pi", not the slug.
+
+    The fork/switch routes clone the bound agent with a ``" (fork <id>)"``
+    suffix, so the fork binds an agent named ``pi-native-ui (fork <id>)``.
+    The composer's model-picker pill resolves that name through
+    ``agentDisplayLabel``, which must strip the clone suffix AND map the
+    native wrapper slug to its display name ("Pi") — not fall through to the
+    capitalized raw slug ("Pi-native-ui (fork …)"). This guards that mapping
+    on the user-visible surface; the unit cases live in ``AgentInfo.test.tsx``.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a runner-bound
+        ``hello_world`` (openai-agents SDK) source session.
+    """
+    base_url, session_id = seeded_session
+    pi_agent_id = _agent_id_by_name(base_url, "pi-native-ui")
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # One turn so the fork has an assistant bubble to anchor "Fork from here".
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(composer).to_be_visible()
+    composer.fill(f"Reply with one short word. Marker: {_MARKER}")
+    page.get_by_role("button", name="Send", exact=True).click()
+    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    expect(assistant).to_be_visible(timeout=60_000)
+
+    # Fork from the response, switching the agent to Pi.
+    assistant.hover()
+    page.get_by_test_id("fork-from-response").first.click()
+    dialog = page.get_by_test_id("fork-session-dialog")
+    expect(dialog).to_be_visible()
+    page.get_by_test_id("fork-session-agent-select").click()
+    option = page.get_by_test_id(f"fork-session-agent-option-{pi_agent_id}")
+    expect(option).to_be_visible()
+    option.click()
+    page.get_by_test_id("fork-session-submit").click()
+
+    # Land on the new Pi-bound fork (a distinct session id).
+    expect(page).to_have_url(
+        re.compile(rf"/c/(?!{re.escape(session_id)})conv_[0-9a-f]+"),
+        timeout=30_000,
+    )
+    fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
+    assert fork_id != session_id
+
+    # Sanity-check the precondition this test exists for: the clone really
+    # binds a SUFFIXED name, so the picker assertion exercises the strip
+    # rather than passing trivially on a bare ``pi-native-ui``.
+    agent_resp = httpx.get(f"{base_url}/v1/sessions/{fork_id}/agent", timeout=30.0)
+    agent_resp.raise_for_status()
+    bound_name = agent_resp.json()["name"]
+    assert bound_name.startswith("pi-native-ui") and bound_name != "pi-native-ui", (
+        f"expected a clone-suffixed pi agent name to exercise the strip, got {bound_name!r}"
+    )
+
+    # The model-picker pill shows the friendly "Pi" — the clone suffix and
+    # the raw wrapper slug ("native-ui") must both be gone. Pre-fix this read
+    # "Pi-native-ui (fork conv_…)".
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_be_visible(timeout=30_000)
+    expect(trigger).to_contain_text("Pi")
+    expect(trigger).not_to_contain_text("native-ui")
+    expect(trigger).not_to_contain_text("fork")


### PR DESCRIPTION
## What

The in-session **model picker** displayed a forked/switched Pi session as **`Pi-native-ui`** instead of **`Pi`**.

## Why

The picker labels agents via `agentDisplayLabel(name)` in `ap-web/src/components/AgentInfo.tsx`, which resolves a native wrapper slug to its display name (`pi-native-ui` → `Pi`) using an **exact-name** lookup. But it didn't strip the `" (fork <id>)"` / `" (switch <id>)"` suffix the fork/switch routes append when cloning a bound agent.

So a Pi session created via fork or switch (the capability added in #230) is bound to an agent named e.g. `pi-native-ui (fork conv_ab12)`. That exact string misses the native lookup and falls through to `capitalizeAgentName(...)` → **`Pi-native-ui …`**.

Every other surface (`useAvailableAgents`, the fork/switch dialogs) already strips the suffix via `agentBaseName`, so `agentDisplayLabel` was the lone gap.

## Fix

Strip the clone suffix with `agentBaseName` before the native lookup, mirroring the rest of the codebase. This corrects all three `agentDisplayLabel` call sites: the picker trigger pill, the picker dropdown row, and the agent-info popover. Claude/Codex/Polly clones benefit identically.

## Testing

- New unit tests in `AgentInfo.test.tsx` assert clones resolve to `Pi` / `Claude` / `Codex` (and non-native clones like `polly (fork …)` → `Polly`).
- `vitest` (full `AgentInfo.test.tsx`), `tsc -b`, and `oxlint` all pass.
- Related picker suites (`ChatPage.composer`, `sidebarNav`, `AgentCard`, `SwitchAgentDialog`, `ForkSessionDialog`) green.