### PR TITLE
fix(sessions): default headless codex-native sub-agents to full bypass

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -9895,27 +9895,33 @@ def _spec_harness(spec: AgentSpec) -> str:
     return canonicalize_harness(harness) or harness
 
 
-def _spec_config_flag_enabled(spec: AgentSpec, key: str) -> bool:
+def _spec_config_flag_explicitly_disabled(spec: AgentSpec, key: str) -> bool:
     """
-    Read a boolean-ish ``executor.config`` flag, tolerating string coercion.
+    Return whether an ``executor.config`` flag is explicitly set false.
 
     The spec parser stringifies every ``executor.config`` value (see
     ``omnigent/spec/parser.py`` — ``{str(k): str(v) ...}``), so a YAML
-    ``yolo: true`` arrives here as the string ``"True"``. A naive
-    ``bool(value)`` is wrong: ``bool("False")`` is ``True``. This compares
-    against the truthy spellings explicitly so only an intentional
-    ``true`` / ``True`` enables the flag.
+    ``yolo: false`` arrives here as the string ``"False"``. A naive
+    ``not bool(value)`` is wrong: ``bool("False")`` is ``True`` (so a
+    naive truthiness test would read ``"False"`` as enabled). This
+    compares against the falsey spellings explicitly so only an
+    intentional ``false`` / ``False`` counts as disabled — an absent key
+    or any other value is NOT disabled.
+
+    Used for opt-OUT semantics: the relevant flag defaults to enabled and
+    an explicit ``false`` is the escape hatch (see the codex-native branch
+    of :func:`_derive_terminal_launch_args_from_spec`).
 
     :param spec: A parsed sub-agent spec.
     :param key: The ``executor.config`` key to read, e.g. ``"yolo"``.
-    :returns: ``True`` only when the value is the boolean ``True`` or the
-        string ``"true"`` (case-insensitive); ``False`` otherwise
+    :returns: ``True`` only when the value is the boolean ``False`` or the
+        string ``"false"`` (case-insensitive); ``False`` otherwise
         (including when the key is absent).
     """
     value = spec.executor.config.get(key)
     if isinstance(value, bool):
-        return value
-    return isinstance(value, str) and value.strip().lower() == "true"
+        return value is False
+    return isinstance(value, str) and value.strip().lower() == "false"
 
 
 def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | None:
@@ -9933,8 +9939,17 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
       ``["--permission-mode", "<value>"]``. The value is passed through
       verbatim so non-YOLO modes (``acceptEdits``, ``plan``, ...) work too;
       YOLO uses ``bypassPermissions``.
-    - codex-native + ``executor.config.yolo`` truthy ->
-      ``["--dangerously-bypass-approvals-and-sandbox"]``.
+    - codex-native -> ``["--dangerously-bypass-approvals-and-sandbox"]``
+      by DEFAULT. A headless codex worker has no human to answer codex's
+      approval prompts, and codex's own command sandbox often cannot even
+      start (e.g. inside a hardened container), so codex's default
+      ``approval_policy=on-request`` + own-sandbox stance stalls the
+      worker on its first Edit/Write/Bash. Full bypass is the only
+      non-stalling stance for the headless seam (the container / worktree
+      is the real boundary, matching claude-native's ``bypassPermissions``
+      and the codex-sdk executor's ``approvalPolicy="never"``). An explicit
+      ``executor.config.yolo: false`` opts back out for a read-only / must
+      -keep-prompting sub-agent. See issue #171.
 
     Only the two native harnesses are translated; for any other harness
     (e.g. ``claude-sdk``, whose bypass is set via the SDK ``permissionMode``
@@ -9956,9 +9971,17 @@ def _derive_terminal_launch_args_from_spec(sub_spec: AgentSpec) -> list[str] | N
             return _validate_terminal_launch_args(["--permission-mode", str(permission_mode)])
         return None
     if harness == _CODEX_NATIVE_HARNESS:
-        if _spec_config_flag_enabled(sub_spec, "yolo"):
-            return _validate_terminal_launch_args(["--dangerously-bypass-approvals-and-sandbox"])
-        return None
+        # Headless default: full bypass. The terminal_launch_args set the
+        # codex --remote TUI's launch flags, which is what creates the
+        # app-server thread and fixes its approval/sandbox stance for the
+        # session; the omnigent executor's later turn/start inherits that
+        # stance (codex_native_executor.run_turn carries no per-turn
+        # approval/sandbox). Without the flag the thread is created at
+        # codex's on-request + own-sandbox default and a headless worker
+        # stalls. An explicit ``yolo: false`` is the opt-out. See #171.
+        if _spec_config_flag_explicitly_disabled(sub_spec, "yolo"):
+            return None
+        return _validate_terminal_launch_args(["--dangerously-bypass-approvals-and-sandbox"])
     return None
 
 
@@ -10246,11 +10269,14 @@ async def _create_session_from_existing_agent(
     #
     # Named sub-agent creates (``body.sub_agent_name`` set) DERIVE these
     # from the trusted, server-loaded sub-spec only — any caller-supplied
-    # ``body.terminal_launch_args`` is ignored. This is the YOLO seam: a
-    # native worker bundle declaring ``permission_mode`` / ``yolo: true``
-    # gets the corresponding full-bypass flag so it can edit in a
-    # headless pane, and a caller cannot inject launch wiring by
-    # smuggling args through the spawn body.
+    # ``body.terminal_launch_args`` is ignored. This is the YOLO seam:
+    # claude-native maps ``permission_mode`` to ``--permission-mode``,
+    # while codex-native defaults to full bypass
+    # (``--dangerously-bypass-approvals-and-sandbox``) so a headless
+    # codex worker can edit/run unattended without stalling on codex's
+    # on-request approval default (opt out with ``yolo: false``). A
+    # caller cannot inject launch wiring by smuggling args through the
+    # spawn body.
     #
     # Sessions that resolve their own agent (top-level sessions and the
     # manual Add Agent child flow where ``sub_agent_name`` is null) keep

--- a/tests/server/routes/test_sessions_yolo_launch_args.py
+++ b/tests/server/routes/test_sessions_yolo_launch_args.py
@@ -1,10 +1,12 @@
 """Unit tests for native-worker YOLO ``terminal_launch_args`` derivation.
 
 Nessie's native sub-agent workers (claude-native / codex-native) launch
-in a headless pane where no human can answer an approval prompt, so they
-declare full-bypass intent in their bundle. The server translates that
-declaration into the per-session ``terminal_launch_args`` the runner
-appends to the claude / codex argv.
+in a headless pane where no human can answer an approval prompt. The
+server translates a worker's bypass stance into the per-session
+``terminal_launch_args`` the runner appends to the claude / codex argv:
+claude-native opts in via ``permission_mode``, while codex-native
+defaults to full bypass (issue #171) because the headless seam has no
+safe non-bypass default, with ``yolo: false`` as the opt-out.
 
 These tests exercise the pure translation helper
 ``_derive_terminal_launch_args_from_spec`` directly with real
@@ -87,30 +89,51 @@ def test_codex_native_yolo_string_true_translates_to_bypass_flag() -> None:
     ]
 
 
-def test_native_spec_without_yolo_field_returns_none() -> None:
+def test_codex_native_without_yolo_field_defaults_to_bypass() -> None:
     """
-    A native sub-agent that declares no bypass field gets no args.
+    A headless codex-native sub-agent defaults to full bypass (issue #171).
 
-    Both native harnesses must return ``None`` when their respective
-    field is absent — otherwise a plain native sub-agent would silently
-    inherit YOLO. ``None`` (not ``[]``) is the contract the create path
+    A codex worker launched by polly runs headless: no human can answer
+    codex's ``approval_policy=on-request`` prompts, and codex's own command
+    sandbox often cannot even start (e.g. in a hardened container), so the
+    default stance stalls the worker on its first Edit/Write/Bash. The
+    derived args MUST carry ``--dangerously-bypass-approvals-and-sandbox``
+    even when the bundle never declared ``yolo`` — the headless seam has no
+    safe non-bypass default — and MUST NOT carry codex's on-request mode.
+    """
+    codex = _spec_with_config({"harness": "codex-native"})
+    args = _derive_terminal_launch_args_from_spec(codex)
+    assert args == ["--dangerously-bypass-approvals-and-sandbox"]
+    # The on-request approval default must not leak back in via these args.
+    assert not any("on-request" in arg for arg in args)
+    assert not any("approval_policy" in arg for arg in args)
+
+
+def test_claude_native_without_permission_mode_returns_none() -> None:
+    """
+    A claude-native sub-agent without ``permission_mode`` still gets no args.
+
+    The codex default-bypass change (issue #171) is scoped to codex-native;
+    claude-native keeps its existing contract (bypass is opt-in via
+    ``permission_mode``, and the harness has a separate one-time bypass
+    acceptance). ``None`` (not ``[]``) is the contract the create path
     treats as "leave terminal_launch_args unset".
     """
     claude = _spec_with_config({"harness": "claude-native"})
-    codex = _spec_with_config({"harness": "codex-native"})
-    # No permission_mode / yolo declared -> nothing to translate.
     assert _derive_terminal_launch_args_from_spec(claude) is None
-    assert _derive_terminal_launch_args_from_spec(codex) is None
 
 
-def test_codex_native_yolo_false_string_returns_none() -> None:
+def test_codex_native_yolo_false_string_opts_out_of_bypass() -> None:
     """
-    ``yolo: false`` (string ``"False"``) must NOT enable bypass.
+    ``yolo: false`` (string ``"False"``) is the explicit bypass opt-out.
 
-    This guards the ``bool("False") is True`` trap: a naive truthiness
-    check on the parser's stringified value would enable YOLO for an
-    explicit opt-out. A failure here means an agent that set
-    ``yolo: false`` would still launch with the dangerous bypass flag.
+    codex-native now defaults to bypass for the headless seam, so the only
+    way to keep codex prompting (e.g. a deliberately read-only sub-agent)
+    is to declare ``yolo: false``. This also guards the
+    ``bool("False") is True`` trap: a naive truthiness check on the
+    parser's stringified value would read ``"False"`` as still-disabled-opt
+    -out incorrectly. A failure here means the opt-out silently fails open
+    (still bypassing) or, conversely, that an absent flag stopped bypassing.
     """
     spec = _spec_with_config({"harness": "codex-native", "yolo": "False"})
     assert _derive_terminal_launch_args_from_spec(spec) is None


### PR DESCRIPTION
## Summary

Fixes #171. A headless codex-native sub-agent (for example a Polly reviewer or implementer) launches in a pane with no human to answer codex's approval prompts, and codex's own command sandbox often cannot even start (for example inside a hardened container). codex's built-in default is `approval_policy=on-request` plus its own sandbox, so the worker stalls forever on its first Edit/Write/Bash and the orchestrator has to retry around it.

## Change

`_derive_terminal_launch_args_from_spec` previously emitted `--dangerously-bypass-approvals-and-sandbox` only when the bundle explicitly declared `yolo: true`. This makes codex-native default to full bypass for the headless sub-agent seam (the container or worktree is the real boundary, mirroring claude-native's `bypassPermissions` and the codex-sdk executor's `approvalPolicy` "never"). An explicit `yolo: false` remains the opt-out for a read-only or must-keep-prompting sub-agent.

## Scope

The change is confined to the named sub-agent create seam (`_derive_terminal_launch_args_from_spec`, only reached when `body.sub_agent_name` is set). The interactive, human-driven terminal launch path (top-level `omnigent codex` and the manual Add Agent flow) keeps its caller-supplied args and is unchanged. claude-native is unchanged.

## Tests

Adds a `_spec_config_flag_explicitly_disabled` helper (opt-out semantics that tolerate the spec parser's string coercion) and tests covering: no yolo -> bypass, `yolo: true` -> bypass, `yolo: false` -> no args (opt-out), and that other harnesses are unaffected.
