### PR TITLE
[ui] Fix missing space in CLI command blocks (Geist Mono ligatures)

### DIFF
--- a/ap-web/src/shell/CliCommandBlock.tsx
+++ b/ap-web/src/shell/CliCommandBlock.tsx
@@ -50,7 +50,7 @@ export function CliCommandBlock({
     // line, which doesn't fire if surrounding tokens push it to wrap.
     <div className="flex w-full items-center gap-2 rounded-md border border-border bg-muted px-3 py-2 font-mono text-xs">
       <code
-        className="min-w-0 flex-1 break-all whitespace-pre-wrap"
+        className="min-w-0 flex-1 break-all whitespace-pre-wrap [font-variant-ligatures:none] [font-feature-settings:'liga'_0,'calt'_0]"
         data-testid={`${testIdPrefix}-command`}
       >
         {command}


### PR DESCRIPTION
## Summary

before:


<img width="543" height="207" alt="Screenshot 2026-06-16 at 2 02 44 PM" src="https://github.com/user-attachments/assets/304806b7-a5bd-4e56-af6a-493634780d56" />


after:

<img width="571" height="249" alt="Screenshot 2026-06-16 at 2 02 35 PM" src="https://github.com/user-attachments/assets/b680f31e-6020-43eb-a54e-8074b2ba51d8" />



- Geist Mono Variable's OpenType contextual alternates (`calt`) fire on the ` --` sequence, visually merging the space between a word and a `--flag`, so `omni host --server` rendered as `omni host--server` in the UI
- The space was always present in the DOM (copy-paste gave the correct string); this was purely a font rendering artifact
- Fixed by disabling `liga` and `calt` features on the `<code>` element in `CliCommandBlock`, the shared component used by all CLI command surfaces (new-chat dialog, landing screen, fork dialog, resume-runner dialog)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

The fix is a single CSS property change on a presentational element — no logic, no state, no component API change. Verified manually by loading the new-chat dialog and confirming `omni host --server <url>` renders with the space visible. No E2E coverage added; the existing CLI command block tests exercise copy/paste correctness (which was never broken) and are not affected.