### PR TITLE
feat(ap-web): allow JSON files in the chat attachment picker

### DIFF
--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -3324,7 +3324,7 @@ export function Composer({
         ref={fileInputRef}
         type="file"
         multiple
-        accept="image/*,application/pdf,text/*"
+        accept="image/*,application/pdf,text/*,application/json"
         className="hidden"
         onChange={(e) => {
           if (e.target.files) {

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1298,7 +1298,7 @@ export function NewChatLandingScreen() {
               ref={fileInputRef}
               type="file"
               multiple
-              accept="image/*,application/pdf,text/*"
+              accept="image/*,application/pdf,text/*,application/json"
               className="hidden"
               data-testid="new-chat-landing-file-input"
               onChange={(e) => {

--- a/tests/e2e_ui/chat/test_composer_attachments.py
+++ b/tests/e2e_ui/chat/test_composer_attachments.py
@@ -26,11 +26,18 @@ from pathlib import Path
 from playwright.sync_api import Page, expect
 
 _COMPOSER = "Ask the agent anything…"
-# Composer accepts image/*,application/pdf,text/* (the hidden input's accept
-# attr); a .txt file is in-scope and keeps the fixture trivial. ``set_input_files``
-# bypasses the accept filter anyway — ``addFiles`` does no client-side filtering.
+# Composer accepts image/*,application/pdf,text/*,application/json (the hidden
+# input's accept attr); a .txt file is in-scope and keeps the fixture trivial.
+# ``set_input_files`` bypasses the accept filter anyway — ``addFiles`` does no
+# client-side filtering.
 _ATTACH_NAME = "attach_sample.txt"
 _ATTACH_BODY = "composer attachment e2e sample\n"
+
+# JSON is its own MIME (``application/json``), which is NOT covered by the
+# ``text/*`` wildcard, so it has to be listed in the ``accept`` attr explicitly
+# for the OS picker (and the drag-drop ``matchesAccept`` validator) to admit it.
+_JSON_NAME = "attach_sample.json"
+_JSON_BODY = '{"composer": "attachment", "e2e": true}\n'
 
 
 def test_attach_then_remove_file(
@@ -59,3 +66,40 @@ def test_attach_then_remove_file(
     remove_button.click()
     expect(remove_button).to_be_hidden(timeout=10_000)
     expect(page.get_by_text(_ATTACH_NAME, exact=True)).to_be_hidden()
+
+
+def test_attach_json_file(
+    page: Page, seeded_session: tuple[str, str], tmp_path: Path
+) -> None:
+    """A ``.json`` file is admitted by the picker and attaches as a chip.
+
+    Guards the change that added ``application/json`` to the composer's
+    ``accept`` list. Two things are asserted:
+
+    1. The hidden input advertises ``application/json`` in its ``accept`` attr.
+       This is the part the OS file picker and the drag-drop ``matchesAccept``
+       validator (``prompt-input.tsx``) actually read — and the part that would
+       regress if the MIME were dropped from the list. ``set_input_files`` can't
+       cover it because it bypasses the accept filter entirely.
+    2. Driving a real ``.json`` file through the input still yields the chip +
+       remove control, i.e. ``addFiles`` accepts the JSON end-to-end.
+    """
+    base_url, session_id = seeded_session
+    sample = tmp_path / _JSON_NAME
+    sample.write_text(_JSON_BODY)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+
+    file_input = page.locator('input[type="file"][accept*="image/"]')
+    # The accept attr is what gates the picker/drag-drop; assert JSON is listed.
+    accept = file_input.get_attribute("accept")
+    assert accept is not None and "application/json" in accept, (
+        f"composer file input should accept application/json; got {accept!r}"
+    )
+
+    file_input.set_input_files(str(sample))
+
+    remove_button = page.get_by_role("button", name=f"Remove {_JSON_NAME}")
+    expect(remove_button).to_be_visible(timeout=10_000)
+    expect(page.get_by_text(_JSON_NAME, exact=True)).to_be_visible()

--- a/tests/e2e_ui/chat/test_composer_attachments.py
+++ b/tests/e2e_ui/chat/test_composer_attachments.py
@@ -92,9 +92,9 @@ def test_attach_json_file(page: Page, seeded_session: tuple[str, str], tmp_path:
     file_input = page.locator('input[type="file"][accept*="image/"]')
     # The accept attr is what gates the picker/drag-drop; assert JSON is listed.
     accept = file_input.get_attribute("accept")
-    assert (
-        accept is not None and "application/json" in accept
-    ), f"composer file input should accept application/json; got {accept!r}"
+    assert accept is not None and "application/json" in accept, (
+        f"composer file input should accept application/json; got {accept!r}"
+    )
 
     file_input.set_input_files(str(sample))
 

--- a/tests/e2e_ui/chat/test_composer_attachments.py
+++ b/tests/e2e_ui/chat/test_composer_attachments.py
@@ -68,9 +68,7 @@ def test_attach_then_remove_file(
     expect(page.get_by_text(_ATTACH_NAME, exact=True)).to_be_hidden()
 
 
-def test_attach_json_file(
-    page: Page, seeded_session: tuple[str, str], tmp_path: Path
-) -> None:
+def test_attach_json_file(page: Page, seeded_session: tuple[str, str], tmp_path: Path) -> None:
     """A ``.json`` file is admitted by the picker and attaches as a chip.
 
     Guards the change that added ``application/json`` to the composer's
@@ -94,9 +92,9 @@ def test_attach_json_file(
     file_input = page.locator('input[type="file"][accept*="image/"]')
     # The accept attr is what gates the picker/drag-drop; assert JSON is listed.
     accept = file_input.get_attribute("accept")
-    assert accept is not None and "application/json" in accept, (
-        f"composer file input should accept application/json; got {accept!r}"
-    )
+    assert (
+        accept is not None and "application/json" in accept
+    ), f"composer file input should accept application/json; got {accept!r}"
 
     file_input.set_input_files(str(sample))
 


### PR DESCRIPTION
## What


https://github.com/user-attachments/assets/5f35d297-2520-4de3-ba9d-bfbb754769d3



Adds `application/json` to the `accept` lists for both chat composer file pickers, so users can attach `.json` files to chat messages.

- `ap-web/src/shell/NewChatDialog.tsx` — landing-page composer
- `ap-web/src/pages/ChatPage.tsx` — in-session composer

Both now use `accept="image/*,application/pdf,text/*,application/json"`.

## Why

`.json` files report the MIME type `application/json`, which is **not** covered by `text/*`. Since `PromptInput`'s `matchesAccept` does exact matching for non-wildcard patterns, JSON files were rejected by both the native picker and the drag-drop validation.

The backend already supports JSON: `content_resolver.py`'s `_FILE_DATA_PASSTHROUGH_MIMES` includes `application/json`, so no server-side change is needed.

## Testing

Manual: select/drag a `.json` file into both composers and confirm it attaches.

This pull request and its description were written by Isaac.