### PR TITLE
fix(ci): mirror fork-PR head by pushing objects, not an API ref-create

### DIFF
--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -132,12 +132,30 @@ jobs:
       - name: Mirror head SHA onto trusted branch
         if: ${{ steps.gate.outputs.mirror == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          if gh api "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/$REPO/git/refs/heads/$MIRROR_BRANCH" -f sha="$HEAD_SHA" -F force=true >/dev/null
-            echo "Updated $MIRROR_BRANCH -> $HEAD_SHA"
-          else
-            gh api -X POST "repos/$REPO/git/refs" -f ref="refs/heads/$MIRROR_BRANCH" -f sha="$HEAD_SHA" >/dev/null
-            echo "Created $MIRROR_BRANCH -> $HEAD_SHA"
+          set -euo pipefail
+          # Move git OBJECTS, don't just point a ref. A fork PR's head commit
+          # reaches the base repo only through the shared fork network (the
+          # `refs/pull/N/head` pull ref); the Git Data refs API refuses to
+          # anchor a NEW branch to a commit the base repo doesn't own, returning
+          # `422 Reference does not exist`. Fetching the pull ref into a scratch
+          # repo and pushing the SHA materializes the object in the base repo so
+          # the ref is valid -- and the App-token push is what triggers the
+          # downstream e2e (a GITHUB_TOKEN push would not). No working tree is
+          # checked out and no fork code runs in this privileged job; only git
+          # objects move. `push -f` covers both first create and re-sync.
+          work="$(mktemp -d)"
+          git -C "$work" init -q
+          origin="https://x-access-token:${TOKEN}@github.com/${REPO}.git"
+          git -C "$work" fetch -q --no-tags "$origin" "refs/pull/${PR}/head"
+          got="$(git -C "$work" rev-parse FETCH_HEAD)"
+          # Mirror EXACTLY the SHA the security scan gated: if the fork raced a
+          # new push after approval, the pull ref would carry an unscanned
+          # commit -- refuse rather than run secret-bearing e2e on it.
+          if [ "$got" != "$HEAD_SHA" ]; then
+            echo "::error::pull/$PR/head is $got but the approved head is $HEAD_SHA; refusing to mirror." >&2
+            exit 1
           fi
+          git -C "$work" push -q -f "$origin" "${HEAD_SHA}:refs/heads/${MIRROR_BRANCH}"
+          echo "Mirrored $MIRROR_BRANCH -> $HEAD_SHA"


### PR DESCRIPTION
## Summary

Fixes the fork-e2e mirror so gated fork PRs actually get their `fork-e2e/pr-N` branch (and therefore run e2e). Observed broken on PR #24: the `mirror` job failed and no branch was created, so e2e never started.

**Root cause.** The "Mirror head SHA onto trusted branch" step created the branch with a pure Git Data refs-API call (`POST /git/refs` pointing at the PR head SHA). For a fork PR, that head commit reaches the base repo only through the shared fork network (the `refs/pull/N/head` pull ref). The refs API operates on the base repo's *own* object store and refuses to anchor a new branch to a commit the base repo doesn't own — it returns `422 Reference does not exist`. So the create silently fails for fork PRs whose head object hasn't been promoted into the base repo, and the mirror branch never appears.

**Fix.** Fetch `refs/pull/N/head` into a scratch repo and `git push` the SHA to the mirror branch with the App token. The push materializes the commit object in the base repo (so the ref is valid) and is what triggers the downstream e2e (a `GITHUB_TOKEN` push would not). `push -f` collapses the old create-vs-update `if/else` into one path.

**Security model preserved.** No working tree is checked out and no fork code runs in the privileged job — only git objects move. The step still runs behind the contributor Security Scan gate and the maintainer-applied `e2e-approved` label, and a new guard refuses to mirror unless the fetched SHA equals the approved head SHA, so a fork that races a push after approval can't slip an unscanned commit into a secret-bearing e2e run.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Reproduced the failure on PR #24 (the `mirror` job's `POST /git/refs` returned `422 Reference does not exist` for the fork head SHA, and `fork-e2e/pr-24` was never created). Validated the fix's mechanism read-only against the live base repo: `git fetch refs/pull/24/head` materializes exactly the approved head `5cfe2ba…` locally, which is the object the API-create couldn't anchor to — so the subsequent push has a valid object to transfer. The workflow YAML parses and the new step passes `bash -n`. End-to-end confirmation will come from re-running the mirror on a gated fork PR once merged.