### PR TITLE
ci: re-run CI/e2e/e2e-ui/integration on label events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore: ['ap-web/**']
   push:
     branches:

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -14,7 +14,7 @@ name: E2E UI Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches:
       - 'fork-e2e/**'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ on:
   schedule:
     - cron: "0 9 * * *"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore: ['ap-web/**']
   push:
     branches:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: "30 9 * * *"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore: ['ap-web/**']
   push:
     branches:


### PR DESCRIPTION
## Summary

Makes `ci`, `e2e`, `e2e-ui`, and `integration` re-run when a label is toggled, so the maintainer `skip-security-scan` waiver (or anything that flips the Security Scan) actually un-blocks them.

Each of these four workflows has a `gate` job that polls and mirrors the single `Security Scan` check. They triggered only on `[opened, synchronize, reopened, ready_for_review]`, so applying `skip-security-scan` re-ran `security-scan.yml` (which already listens for `labeled`/`unlabeled`) and flipped that check — but the four consumers never re-ran, so their `gate` jobs stayed red until the next push or a manual "Re-run failed jobs." Observed on PR #24.

Adding `labeled, unlabeled` to their `pull_request` types lets a label toggle re-run the gated set, and the gate re-polls the now-passing scan. Trade-off: they re-run on any label churn (GitHub can't filter by label name at `on:`); on fork PRs the heavy e2e/integration legs gate-then-skip, so it's mostly the lightweight `gate` job.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Workflow-trigger change only. Verified all four files parse and their `pull_request.types` now include `labeled` and `unlabeled`. End-to-end behavior (toggling `skip-security-scan` re-runs the gated set) is exercised by the next gated PR.