### PR TITLE
feat(sandbox): add podman as an alternative container runtime

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -178,6 +178,20 @@ tools:
 
 For client-provided tools, use `runtime: client` and do not set `callable`.
 
+### Tool sandbox containers
+
+Local Python tools can run inside a container image by declaring a sandbox image.
+Use `container_image` for new specs; `docker_image` remains accepted as a
+deprecated alias for backwards compatibility. Set `container_runtime: podman` to
+run the image with Podman instead of Docker.
+
+```yaml
+tools:
+  sandbox:
+    container_image: python:3.12-slim
+    container_runtime: podman  # optional; defaults to docker
+```
+
 ### Sub-agent tool
 
 ```yaml

--- a/omnigent/runtime/caps.py
+++ b/omnigent/runtime/caps.py
@@ -24,8 +24,8 @@ class RuntimeCaps:
     :param sandbox_enabled: Whether to use ``srt`` sandboxing for
         local tool execution when available on PATH. ``True`` by
         default. This is a runtime security policy — agents cannot
-        opt out. The agent spec only controls ``docker_image``
-        (what container to use).
+        opt out. The agent spec only controls ``container_image``
+        (what container to use) and ``container_runtime``.
     :param default_policies: Server-wide policies appended after
         per-agent policies on every session. Loaded from the
         ``policies:`` key in the server ``--config`` YAML

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -222,10 +222,10 @@ def _reject_unsupported_concepts(spec: AgentSpec) -> None:
     # a spec field" because the field is consumed upstream and
     # has no meaning to the harness.
 
-    # Sandbox declarations (omnigent ``tools.sandbox.docker_image``
+    # Sandbox declarations (omnigent ``tools.sandbox.container_image``
     # and the omnigent OSEnvSandboxSpec) are unsupported. Fail loud
     # if either is populated.
-    if spec.tools.sandbox.docker_image is not None:
+    if spec.tools.sandbox.container_image is not None:
         raise OmnigentError(
             "tools.sandbox translation to omnigent OSEnvSpec is unsupported; "
             "the adapter rejects specs with sandbox rather than silently dropping it",

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -417,13 +417,13 @@ def _parse_sandbox_config(
     """
     Parse the ``tools.sandbox`` block from config.yaml.
 
-    Only agent-level settings (``docker_image``,
-    ``container_runtime``) are parsed here. Whether sandboxing
-    is enabled is a runtime decision, not an agent config
-    decision::
+    Accepted settings: ``container_image`` (preferred),
+    ``docker_image`` (deprecated alias), and
+    ``container_runtime``. Whether sandboxing is enabled is a
+    runtime decision, not an agent config decision::
 
         sandbox:
-          docker_image: python:3.12-slim
+          container_image: python:3.12-slim
           container_runtime: podman  # optional, defaults to docker
 
     :param raw: The raw ``sandbox`` value from the ``tools``
@@ -437,8 +437,9 @@ def _parse_sandbox_config(
         raise ValueError(
             f"Unsupported container_runtime {runtime!r}; expected 'docker' or 'podman'."
         )
+    image = raw.get("container_image") or raw.get("docker_image")
     return SandboxConfig(
-        docker_image=raw.get("docker_image"),
+        container_image=image,
         container_runtime=runtime,
     )
 

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -417,12 +417,14 @@ def _parse_sandbox_config(
     """
     Parse the ``tools.sandbox`` block from config.yaml.
 
-    Only agent-level settings (``docker_image``) are parsed here.
-    Whether sandboxing is enabled is a runtime decision, not an
-    agent config decision::
+    Only agent-level settings (``docker_image``,
+    ``container_runtime``) are parsed here. Whether sandboxing
+    is enabled is a runtime decision, not an agent config
+    decision::
 
         sandbox:
           docker_image: python:3.12-slim
+          container_runtime: podman  # optional, defaults to docker
 
     :param raw: The raw ``sandbox`` value from the ``tools``
         block. ``None`` means not specified (use defaults).
@@ -430,8 +432,14 @@ def _parse_sandbox_config(
     """
     if raw is None or not isinstance(raw, dict):
         return SandboxConfig()
+    runtime = raw.get("container_runtime", "docker")
+    if runtime not in ("docker", "podman"):
+        raise ValueError(
+            f"Unsupported container_runtime {runtime!r}; expected 'docker' or 'podman'."
+        )
     return SandboxConfig(
         docker_image=raw.get("docker_image"),
+        container_runtime=runtime,
     )
 
 

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -772,12 +772,15 @@ class SandboxConfig:
     is enabled/enforced is a runtime decision — see
     ``RuntimeCaps.sandbox_enabled``.
 
-    :param docker_image: When set, tools run inside this Docker
-        container instead of a local subprocess. Docker provides
-        its own isolation, e.g. ``"python:3.12-slim"``.
+    :param docker_image: When set, tools run inside this container
+        instead of a local subprocess. The container runtime
+        provides its own isolation, e.g. ``"python:3.12-slim"``.
+    :param container_runtime: The container CLI to use, either
+        ``"docker"`` (default) or ``"podman"``.
     """
 
     docker_image: str | None = None
+    container_runtime: str = "docker"
 
 
 @dataclass

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -772,15 +772,23 @@ class SandboxConfig:
     is enabled/enforced is a runtime decision — see
     ``RuntimeCaps.sandbox_enabled``.
 
-    :param docker_image: When set, tools run inside this container
-        instead of a local subprocess. The container runtime
-        provides its own isolation, e.g. ``"python:3.12-slim"``.
+    :param container_image: When set, tools run inside this
+        container instead of a local subprocess, e.g.
+        ``"python:3.12-slim"``.
+    :param docker_image: Deprecated alias for ``container_image``.
+        If both are set, ``container_image`` takes precedence.
     :param container_runtime: The container CLI to use, either
         ``"docker"`` (default) or ``"podman"``.
     """
 
+    container_image: str | None = None
     docker_image: str | None = None
     container_runtime: str = "docker"
+
+    def __post_init__(self) -> None:
+        if self.container_image is None and self.docker_image is not None:
+            self.container_image = self.docker_image
+        self.docker_image = self.container_image
 
 
 @dataclass

--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -16,7 +16,7 @@ file may host several.
 Execution tiers (in priority order):
 
 1. **Container** — ``docker run`` or ``podman run`` with network
-   disabled. Used when ``sandbox.docker_image`` is configured.
+   disabled. Used when ``sandbox.container_image`` is configured.
    The runtime is selected via ``sandbox.container_runtime``.
 2. **srt + uv** — ``srt uv run --with ... -- python _runner.py``.
    Used when srt is on PATH, sandbox enabled, and tool has PEP 723
@@ -118,7 +118,7 @@ class LocalPythonTool(Tool):
         :param module_path: Absolute path to the tool file, e.g.
             ``Path("/tmp/cache/ag_abc/tools/python/my_tools.py")``.
         :param sandbox_config: Agent-level sandbox settings
-            (docker_image).
+            (container_image, container_runtime).
         :param srt_available: Whether ``srt`` is on PATH.
         :param uv_available: Whether ``uv`` is on PATH.
         :param sandbox_enabled: Runtime policy for srt sandboxing.
@@ -244,7 +244,7 @@ class LocalPythonTool(Tool):
         # chain, so the fd 3 pipe doesn't survive to the inner
         # Python process. Use the stdout protocol instead.
         srt_active = self._srt_available and self._sandbox_enabled
-        use_stdout = self._sandbox_config.docker_image is not None or srt_active
+        use_stdout = self._sandbox_config.container_image is not None or srt_active
         cmd = self._build_command(state_root=state_root)
         if use_stdout:
             return self._invoke_stdout(cmd, request, workspace=ctx.workspace)
@@ -351,7 +351,7 @@ class LocalPythonTool(Tool):
             concurrent ``invoke()`` calls.
         :returns: The command list for ``subprocess.Popen``.
         """
-        if self._sandbox_config.docker_image is not None:
+        if self._sandbox_config.container_image is not None:
             return self._build_docker_command()
 
         base = [sys.executable, _RUNNER_PATH]
@@ -442,7 +442,7 @@ class LocalPythonTool(Tool):
         the response to stdout instead of fd 3.
 
         Only called from :meth:`_build_command` under the
-        ``docker_image is not None`` branch, so the assert
+        ``container_image is not None`` branch, so the assert
         documents a caller-enforced invariant — a fail-loud
         check if that invariant ever drifts, rather than the
         previous ``image or ""`` fallback which would have
@@ -451,11 +451,11 @@ class LocalPythonTool(Tool):
 
         :returns: The container run command list.
         """
-        image = self._sandbox_config.docker_image
+        image = self._sandbox_config.container_image
         assert image is not None, (
-            "_build_docker_command called without a docker_image — "
+            "_build_docker_command called without a container_image — "
             "caller (_build_command) must gate on "
-            "``self._sandbox_config.docker_image is not None``"
+            "``self._sandbox_config.container_image is not None``"
         )
         runtime = self._sandbox_config.container_runtime
         return [

--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -15,8 +15,9 @@ file may host several.
 
 Execution tiers (in priority order):
 
-1. **Docker** — ``docker run`` with network disabled. Used when
-   ``sandbox.docker_image`` is configured.
+1. **Container** — ``docker run`` or ``podman run`` with network
+   disabled. Used when ``sandbox.docker_image`` is configured.
+   The runtime is selected via ``sandbox.container_runtime``.
 2. **srt + uv** — ``srt uv run --with ... -- python _runner.py``.
    Used when srt is on PATH, sandbox enabled, and tool has PEP 723
    inline deps.
@@ -434,7 +435,7 @@ class LocalPythonTool(Tool):
 
     def _build_docker_command(self) -> list[str]:
         """
-        Build a ``docker run`` command for container execution.
+        Build a container ``run`` command (Docker or Podman).
 
         The container runs with network disabled, stdin piped,
         and ``_AP_RESPONSE_MODE=stdout`` so the runner writes
@@ -446,9 +447,9 @@ class LocalPythonTool(Tool):
         check if that invariant ever drifts, rather than the
         previous ``image or ""`` fallback which would have
         silently passed an empty string as the image name to
-        ``docker run``.
+        the container runtime.
 
-        :returns: The docker run command list.
+        :returns: The container run command list.
         """
         image = self._sandbox_config.docker_image
         assert image is not None, (
@@ -456,8 +457,9 @@ class LocalPythonTool(Tool):
             "caller (_build_command) must gate on "
             "``self._sandbox_config.docker_image is not None``"
         )
+        runtime = self._sandbox_config.container_runtime
         return [
-            "docker",
+            runtime,
             "run",
             "--rm",
             "-i",
@@ -468,9 +470,6 @@ class LocalPythonTool(Tool):
             image,
             "python",
             "-c",
-            # Inline the runner as a one-liner that reads stdin
-            # and writes to stdout. The full _runner.py is not
-            # available inside the container.
             (
                 "import sys,json,importlib.util,asyncio,os;"
                 "os.environ['_AP_RESPONSE_MODE']='stdout';"

--- a/tests/e2e/omnigent/test_run_omnigent_adapter_rejections.py
+++ b/tests/e2e/omnigent/test_run_omnigent_adapter_rejections.py
@@ -63,7 +63,7 @@ _TIMEOUT_SEC = 30
 #   commit a081406 ("stdio MCP: finish the round-trip");
 #   :class:`MCPServerConfig` round-trips through the reverse
 #   translator as :class:`MCPTool`. No longer rejected.
-# - **`tools.sandbox.docker_image`**: still rejected, but no
+# - **`tools.sandbox.container_image`**: still rejected, but no
 #   example YAML in the repo declares it, so there's nothing to
 #   parametrize over today. The drift-guard intent (a yaml
 #   author silently loses sandbox isolation) survives in the

--- a/tests/spec/test_omnigent_translator.py
+++ b/tests/spec/test_omnigent_translator.py
@@ -231,14 +231,14 @@ def test_sandbox_block_rejected_with_clear_message(
     basic_spec: AgentSpec,
 ) -> None:
     """
-    A spec that requests a sandbox (``tools.sandbox.docker_image``)
+    A spec that requests a sandbox (``tools.sandbox.container_image``)
     is rejected with a message naming ``sandbox``.
 
     **What breaks if this fails**: the harness runs tools outside
     the sandbox the spec asked for — a security violation.
     """
     basic_spec.tools = ToolsConfig(
-        sandbox=SandboxConfig(docker_image="python:3.12-slim"),
+        sandbox=SandboxConfig(container_image="python:3.12-slim"),
     )
     with pytest.raises(OmnigentError, match=r"sandbox"):
         agent_spec_to_agent_def(basic_spec)

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -1072,6 +1072,45 @@ def test_parse_inline_mcp_skips_standard_tools_keys(tmp_path: Path) -> None:
     assert spec.mcp_servers[0].name == "real_mcp"
 
 
+def test_parse_tools_sandbox_docker_image_alias(tmp_path: Path) -> None:
+    """Legacy ``tools.sandbox.docker_image`` remains a valid image alias."""
+    config = {
+        "spec_version": 1,
+        "name": "legacy-docker-image",
+        "tools": {
+            "sandbox": {
+                "docker_image": "python:3.12-slim",
+                "container_runtime": "podman",
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert spec.tools.sandbox.container_image == "python:3.12-slim"
+    assert spec.tools.sandbox.docker_image == "python:3.12-slim"
+    assert spec.tools.sandbox.container_runtime == "podman"
+
+
+def test_parse_tools_sandbox_container_image_precedence(tmp_path: Path) -> None:
+    """Preferred ``container_image`` wins when both image keys exist."""
+    config = {
+        "spec_version": 1,
+        "name": "container-image-precedence",
+        "tools": {
+            "sandbox": {
+                "container_image": "python:3.12-slim",
+                "docker_image": "python:3.11-slim",
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert spec.tools.sandbox.container_image == "python:3.12-slim"
+    assert spec.tools.sandbox.docker_image == "python:3.12-slim"
+
+
 def test_parse_inline_mcp_skips_non_mcp_type_entries(tmp_path: Path) -> None:
     """
     Tools-block entries whose ``type`` is not ``"mcp"`` are silently

--- a/tests/tools/test_local.py
+++ b/tests/tools/test_local.py
@@ -415,6 +415,7 @@ def _make_tool(
     *,
     has_inline_deps: bool = False,
     inline_deps: list[str] | None = None,
+    container_image: str | None = None,
     docker_image: str | None = None,
     container_runtime: str = "docker",
     srt_available: bool = False,
@@ -432,6 +433,7 @@ def _make_tool(
         inline_deps=inline_deps,
     )
     sandbox_config = SandboxConfig(
+        container_image=container_image,
         docker_image=docker_image,
         container_runtime=container_runtime,
     )
@@ -485,18 +487,26 @@ def test_build_command_srt_disabled(tmp_path: Path) -> None:
     assert cmd[0] == sys.executable
 
 
-def test_build_command_docker(tmp_path: Path) -> None:
-    """docker_image set → docker run command."""
-    tool = _make_tool(tmp_path, docker_image="python:3.11")
+def test_build_command_container(tmp_path: Path) -> None:
+    """container_image set → docker run command (default runtime)."""
+    tool = _make_tool(tmp_path, container_image="python:3.11")
     cmd = tool._build_command(state_root=None)
     assert cmd[0] == "docker"
     assert "run" in cmd
     assert "python:3.11" in cmd
 
 
+def test_build_command_docker_image_alias(tmp_path: Path) -> None:
+    """docker_image (deprecated alias) still works."""
+    tool = _make_tool(tmp_path, docker_image="python:3.11")
+    cmd = tool._build_command(state_root=None)
+    assert cmd[0] == "docker"
+    assert "python:3.11" in cmd
+
+
 def test_build_command_podman(tmp_path: Path) -> None:
     """container_runtime='podman' → podman run command."""
-    tool = _make_tool(tmp_path, docker_image="python:3.11", container_runtime="podman")
+    tool = _make_tool(tmp_path, container_image="python:3.11", container_runtime="podman")
     cmd = tool._build_command(state_root=None)
     assert cmd[0] == "podman"
     assert "run" in cmd

--- a/tests/tools/test_local.py
+++ b/tests/tools/test_local.py
@@ -416,6 +416,7 @@ def _make_tool(
     has_inline_deps: bool = False,
     inline_deps: list[str] | None = None,
     docker_image: str | None = None,
+    container_runtime: str = "docker",
     srt_available: bool = False,
     uv_available: bool = False,
     sandbox_enabled: bool = True,
@@ -430,7 +431,10 @@ def _make_tool(
         has_inline_deps=has_inline_deps,
         inline_deps=inline_deps,
     )
-    sandbox_config = SandboxConfig(docker_image=docker_image)
+    sandbox_config = SandboxConfig(
+        docker_image=docker_image,
+        container_runtime=container_runtime,
+    )
     tools = load_local_python_tools(
         [info],
         tmp_path,
@@ -486,6 +490,15 @@ def test_build_command_docker(tmp_path: Path) -> None:
     tool = _make_tool(tmp_path, docker_image="python:3.11")
     cmd = tool._build_command(state_root=None)
     assert cmd[0] == "docker"
+    assert "run" in cmd
+    assert "python:3.11" in cmd
+
+
+def test_build_command_podman(tmp_path: Path) -> None:
+    """container_runtime='podman' → podman run command."""
+    tool = _make_tool(tmp_path, docker_image="python:3.11", container_runtime="podman")
+    cmd = tool._build_command(state_root=None)
+    assert cmd[0] == "podman"
     assert "run" in cmd
     assert "python:3.11" in cmd
 


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

  - Adds a `container_runtime` field to `SandboxConfig` ("docker" or "podman", defaults to "docker")
  - Parses and validates the new field from `tools.sandbox.container_runtime` in config.yaml
  - Uses the configured runtime in `_build_docker_command()` instead of a hardcoded "docker" binary
  - Adds a test for podman command construction
 
Usage:

  ```yaml
  tools:
    sandbox:
      docker_image: python:3.12-slim
      container_runtime: podman
```



## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->

Existing default behavior is unchanged. New test is added to test podman container runtime.