### PR TITLE
fix(claude-native): pre-accept the headless bypass-permissions dialog

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -724,26 +724,32 @@ def prepare_bridge_dir(
 
 def ensure_claude_workspace_trusted(workspace: Path) -> None:
     """
-    Pre-accept Claude Code's first-run trust + onboarding prompts.
+    Pre-accept Claude Code's first-run trust, onboarding, and
+    bypass-permissions prompts.
 
-    Claude Code blocks on two TUI prompts the first time it launches in
-    a new context: a global onboarding flow (theme / login) gated by the
-    top-level ``hasCompletedOnboarding`` key in ``~/.claude.json``, and a
-    per-directory "Do you trust the files in this folder?" dialog gated
-    by ``projects["<abs cwd>"].hasTrustDialogAccepted``. Neither fires a
+    Claude Code blocks on up to three TUI prompts the first time it
+    launches in a new context: a global onboarding flow (theme / login)
+    gated by the top-level ``hasCompletedOnboarding`` key in
+    ``~/.claude.json``; a per-directory "Do you trust the files in this
+    folder?" dialog gated by ``projects["<abs cwd>"].hasTrustDialogAccepted``;
+    and — when the worker is launched in ``bypassPermissions`` mode
+    (``--dangerously-skip-permissions``) — a one-time "running in Bypass
+    Permissions mode" warning gated by the top-level
+    ``bypassPermissionsModeAccepted`` key. None of these fire a
     ``PermissionRequest`` hook, so on a host-spawned (web-UI-driven)
     session there is nobody at the terminal to answer them: Claude hangs
     and the web UI shows nothing. This is acute with
     per-session git worktrees, which hand Claude a brand-new —
     therefore untrusted — directory on every session.
 
-    Seed both gating keys idempotently so the launch never blocks. Only
-    those two keys are written; all other ``~/.claude.json`` state (the
+    Seed the gating keys idempotently so the launch never blocks. Only
+    these keys are written; all other ``~/.claude.json`` state (the
     user's own onboarding choices, project history, MCP config, OAuth
-    account) is preserved, and the file is left untouched when both keys
-    are already set. This deliberately does NOT skip per-tool permission
-    prompts — those still route to the web UI via the ``PermissionRequest``
-    hook; only the unhookable startup gates are pre-accepted.
+    account) is preserved, and the file is left untouched when they are
+    already set. Pre-accepting these gates does NOT enable bypass mode or
+    skip per-tool permission prompts — those still route to the web UI via
+    the ``PermissionRequest`` hook; only the unhookable startup gates are
+    pre-accepted.
 
     Concurrency: this is a read-modify-write of a file Claude itself also
     rewrites. It runs once, before the terminal is launched (so Claude is
@@ -777,6 +783,12 @@ def ensure_claude_workspace_trusted(workspace: Path) -> None:
     # has never run Claude Code interactively.
     if data.get("hasCompletedOnboarding") is not True:
         data["hasCompletedOnboarding"] = True
+        changed = True
+
+    # Global bypass-permissions gate: a headless bypassPermissions worker
+    # hangs on the one-time, unhookable "Bypass Permissions mode" warning.
+    if data.get("bypassPermissionsModeAccepted") is not True:
+        data["bypassPermissionsModeAccepted"] = True
         changed = True
 
     # Per-directory trust gate. Claude keys its ``projects`` map by the

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1926,10 +1926,10 @@ async def _auto_create_claude_terminal(
         session_id,
         bridge_dir,
     )
-    # Pre-accept Claude's first-run trust + onboarding TUI prompts for this
-    # workspace. They have no PermissionRequest hook, so on a host-spawned
-    # (web-UI-driven) session they would hang Claude in its terminal with
-    # nothing shown in the UI. Acute with per-session worktrees,
+    # Pre-accept Claude's first-run trust, onboarding, and bypass-permissions
+    # TUI prompts for this workspace. They have no PermissionRequest hook, so
+    # on a host-spawned (web-UI-driven) session they would hang Claude in its
+    # terminal with nothing shown in the UI. Acute with per-session worktrees,
     # which launch Claude in a brand-new, untrusted directory.
     ensure_claude_workspace_trusted(Path(workspace))
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4277,12 +4277,12 @@ def test_ensure_trusted_creates_config_when_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    A fresh host (no ``~/.claude.json``) gets both first-run gates set.
+    A fresh host (no ``~/.claude.json``) gets all first-run gates set.
 
     This is the core workspace-trust case: an ``omnigent host`` machine that
-    has never run Claude interactively. Both the global onboarding gate
-    and the per-workspace trust gate must be pre-accepted so Claude does
-    not block on its TUI prompts.
+    has never run Claude interactively. The global onboarding gate, the
+    global bypass-permissions gate, and the per-workspace trust gate must
+    all be pre-accepted so Claude does not block on its TUI prompts.
     """
     config_path = _redirect_home(monkeypatch, tmp_path / "home")
     workspace = tmp_path / "worktrees" / "feature-x"
@@ -4294,6 +4294,9 @@ def test_ensure_trusted_creates_config_when_missing(
     # Global onboarding gate — without this Claude shows the theme/login
     # flow on a never-onboarded machine.
     assert data["hasCompletedOnboarding"] is True
+    # Global bypass-permissions gate — without this a bypassPermissions
+    # worker hangs on the one-time "Bypass Permissions mode" warning.
+    assert data["bypassPermissionsModeAccepted"] is True
     # Per-directory trust gate, keyed by the RESOLVED absolute path —
     # without this Claude shows "Do you trust the files in this folder?".
     assert data["projects"][str(workspace.resolve())]["hasTrustDialogAccepted"] is True
@@ -4304,12 +4307,12 @@ def test_ensure_trusted_preserves_existing_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Seeding adds only the two gates; all other config is preserved.
+    Seeding adds only the gating keys; all other config is preserved.
 
     The file holds the user's OAuth account, MCP config, and per-project
     history. Clobbering any of it would be a regression, so this asserts
-    an unrelated top-level key and a sibling project entry survive
-    untouched while the new workspace's trust gate is added.
+    an unrelated top-level key and a sibling project entry survive untouched
+    while the bypass gate and the new workspace's trust gate are added.
     """
     config_path = _redirect_home(monkeypatch, tmp_path / "home")
     other_workspace = tmp_path / "repo"
@@ -4333,6 +4336,8 @@ def test_ensure_trusted_preserves_existing_state(
     data = json.loads(config_path.read_text())
     # Unrelated top-level state survives — proves we merge, not overwrite.
     assert data["oauthAccount"] == {"emailAddress": "user@example.com"}
+    # The bypass gate is added even on an already-onboarded host.
+    assert data["bypassPermissionsModeAccepted"] is True
     # The pre-existing sibling project is untouched, including its own
     # non-trust keys (a naive ``projects = {key: {...}}`` would drop it).
     assert data["projects"][str(other_workspace.resolve())] == {
@@ -4348,7 +4353,7 @@ def test_ensure_trusted_idempotent_does_not_rewrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    When both gates are already set, the file is left byte-for-byte alone.
+    When the gates are already set, the file is left byte-for-byte alone.
 
     The seed file is written in compact form; the helper's writer uses
     two-space indentation. So if the ``if not changed: return`` short-
@@ -4361,6 +4366,7 @@ def test_ensure_trusted_idempotent_does_not_rewrite(
     workspace.mkdir(parents=True)
     already = {
         "hasCompletedOnboarding": True,
+        "bypassPermissionsModeAccepted": True,
         "projects": {str(workspace.resolve()): {"hasTrustDialogAccepted": True}},
     }
     # Compact, no indentation — distinct from the helper's indent=2 output.
@@ -4371,6 +4377,40 @@ def test_ensure_trusted_idempotent_does_not_rewrite(
 
     # Byte-identical → the helper detected no change and never wrote.
     assert config_path.read_bytes() == before
+
+
+def test_ensure_trusted_adds_bypass_gate_to_already_trusted_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The bypass gate is seeded even when onboarding + trust are already set.
+
+    Regression test for the headless-worker hang: an already-onboarded host
+    that trusts the workspace still blocks a bypassPermissions worker on the
+    one-time warning, because ``bypassPermissionsModeAccepted`` is the only
+    missing gate. The unfixed helper writes nothing, so the assertion below
+    raises ``KeyError`` — i.e. this fails without the fix.
+    """
+    config_path = _redirect_home(monkeypatch, tmp_path / "home")
+    workspace = tmp_path / "worktrees" / "feature-bypass"
+    workspace.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "hasCompletedOnboarding": True,
+                "projects": {str(workspace.resolve()): {"hasTrustDialogAccepted": True}},
+            }
+        )
+    )
+
+    ensure_claude_workspace_trusted(workspace)
+
+    data = json.loads(config_path.read_text())
+    assert data["bypassPermissionsModeAccepted"] is True
+    # The already-set gates are left untouched.
+    assert data["hasCompletedOnboarding"] is True
+    assert data["projects"][str(workspace.resolve())]["hasTrustDialogAccepted"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

A native `claude_code` worker launched headless on a host runner with `--dangerously-skip-permissions` (the translation of `permission_mode: bypassPermissions`) boots but never executes its task. Claude Code shows a one-time "running in Bypass Permissions mode" acceptance dialog the first time that mode is used, and a host-spawned worker has nobody at the terminal to answer it — so it hangs indefinitely with no error. `IS_SANDBOX=1` lets the mode run as root but does not pre-accept the dialog.

`ensure_claude_workspace_trusted()` already pre-accepts the other two unhookable first-run gates — `hasCompletedOnboarding` and per-directory `hasTrustDialogAccepted` — by seeding them into `~/.claude.json` before the terminal launches. This adds the third gate, `bypassPermissionsModeAccepted`, the same idempotent way.

It is inert unless the launch actually uses bypass mode, and it does not itself enable bypass mode or skip per-tool permission prompts (those still route to the web UI via the `PermissionRequest` hook). Fixes #151.

## Test plan

- [x] New unit test `test_ensure_trusted_adds_bypass_gate_to_already_trusted_workspace` — seeds an already-onboarded, already-trusted config and asserts the bypass gate is added; **fails without the production change** (`KeyError: 'bypassPermissionsModeAccepted'`).
- [x] Updated `test_ensure_trusted_creates_config_when_missing` and `test_ensure_trusted_preserves_existing_state` to assert the new gate; updated the idempotency test's seed.
- [x] `ruff check` + `ruff format --check` clean.
