### PR TITLE
fix: use Codex /permissions TUI presets for approval mode

### DIFF
--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -478,7 +478,7 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toBeUndefined();
   });
 
-  it("posts --ask-for-approval <mode> when a non-default mode is picked for codex-native", async () => {
+  it("posts sandbox + approval args when a non-default preset is picked for codex-native", async () => {
     setAgents([agent({ id: "ag_codex", name: "codex-native-ui", display_name: "Codex" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
       ok: true,
@@ -487,12 +487,12 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the footer tray's Advanced menu and pick "never".
+    // Open the footer tray's Advanced menu and pick "Full access".
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-approval-never"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-access"));
     // A non-default pick is suffixed onto the pill.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
-      "Codex (Never)",
+      "Codex (Full access)",
     );
     typeMessage("go");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
@@ -500,7 +500,12 @@ describe("NewChatLandingScreen create flow", () => {
     await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
     const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.terminal_launch_args).toEqual(["--ask-for-approval", "never"]);
+    expect(body.terminal_launch_args).toEqual([
+      "--sandbox",
+      "danger-full-access",
+      "--ask-for-approval",
+      "never",
+    ]);
   });
 
   it("omits terminal_launch_args when approval mode is left at default for codex-native", async () => {

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -685,13 +685,14 @@ describe("NewChatLandingScreen", () => {
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
-    const neverOption = screen.getByTestId("new-chat-landing-approval-never");
-    expect(neverOption.textContent).toContain("Never");
+    const fullAccessOption = screen.getByTestId("new-chat-landing-approval-full-access");
+    expect(fullAccessOption.textContent).toContain("Full access");
     // The footer line explains the SELECTED mode until a row is hovered.
     const detail = screen.getByTestId("new-chat-landing-approval-detail");
-    expect(detail.textContent).toContain("Model decides when to ask for approval");
-    fireEvent.pointerEnter(neverOption);
-    expect(detail.textContent).toContain("Never asks for approval");
+    // Default is selected initially.
+    expect(detail.textContent).toContain("Read/edit/run in workspace");
+    fireEvent.pointerEnter(fullAccessOption);
+    expect(detail.textContent).toContain("Edit any file and access the internet");
   });
 
   it("shows a conflict banner in the file browser for an occupied directory", async () => {

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -112,27 +112,37 @@ const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; descriptio
   },
 ];
 
-// Codex's `--ask-for-approval` choices (codex CLI). Codex-native sessions
-// only. "on-request" is Codex's default; any other value is passed through
-// as `--ask-for-approval <value>` via the session's terminal_launch_args.
+// Codex approval presets matching the `/permissions` TUI popup.
+// Each preset bundles a sandbox profile + approval policy, mirroring
+// codex-rs/utils/approval-presets/src/lib.rs. "default" is the auto
+// preset (workspace-write + on-request) and sends no flags so the
+// runner uses Codex's built-in default.
 // Keep in sync with `codex --help` and
 // https://developers.openai.com/codex/agent-approvals-security
-const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "on-request";
-const CODEX_NATIVE_APPROVAL_MODES: { value: string; label: string; description: string }[] = [
+const CODEX_NATIVE_DEFAULT_APPROVAL_MODE = "default";
+const CODEX_NATIVE_APPROVAL_MODES: {
+  value: string;
+  label: string;
+  description: string;
+  args: string[];
+}[] = [
   {
-    value: "untrusted",
-    label: "Untrusted",
-    description: "Runs only known-safe read operations automatically",
+    value: "default",
+    label: "Default",
+    description: "Read/edit/run in workspace; approval for external edits or network",
+    args: [],
   },
   {
-    value: "on-request",
-    label: "On request",
-    description: "Model decides when to ask for approval",
+    value: "full-access",
+    label: "Full access",
+    description: "Edit any file and access the internet without approval",
+    args: ["--sandbox", "danger-full-access", "--ask-for-approval", "never"],
   },
   {
-    value: "never",
-    label: "Never",
-    description: "Never asks for approval; failures go straight to the model",
+    value: "read-only",
+    label: "Read only",
+    description: "Read files only; approval required for edits, commands, or network",
+    args: ["--sandbox", "read-only", "--ask-for-approval", "on-request"],
   },
 ];
 
@@ -1092,7 +1102,7 @@ export function NewChatLandingScreen() {
             agentSupportsPermissionMode && permissionMode !== CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE
               ? ["--permission-mode", permissionMode]
               : agentSupportsApprovalMode && approvalMode !== CODEX_NATIVE_DEFAULT_APPROVAL_MODE
-                ? ["--ask-for-approval", approvalMode]
+                ? (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.args ?? [])
                 : undefined,
           // Cost-control switch from the "Cost Optimized" pill; polly-only
           // (cost control is a polly feature) and omitted when unset so the

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -356,12 +356,13 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
 
 
 def test_start_session_select_approval_mode(seeded_session: tuple[str, str]) -> None:
-    """Picking a non-default approval mode rides along to the create call.
+    """Picking a non-default approval preset rides along to the create call.
 
-    Selecting "Never" in the agent picker's Advanced settings menu
+    Selecting "Full access" in the agent picker's Advanced settings menu
     must (a) surface in the agent chip label as immediate feedback and
     (b) reach ``POST /v1/sessions`` as
-    ``terminal_launch_args: ["--ask-for-approval", "never"]``.
+    ``terminal_launch_args: ["--sandbox", "danger-full-access",
+    "--ask-for-approval", "never"]``.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_approval_mode(base_url, session_id))
@@ -405,16 +406,16 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             # Codex auto-selects (only built-in), so the Advanced chip —
             # gated on the Codex-native agent — is present.
             await page.get_by_test_id("new-chat-landing-advanced-chip").click()
-            # All three Codex approval modes render as radio rows.
-            for mode in ("untrusted", "on-request", "never"):
+            # All three Codex approval presets render as radio rows.
+            for mode in ("default", "full-access", "read-only"):
                 await expect(
                     page.get_by_test_id(f"new-chat-landing-approval-{mode}")
                 ).to_be_visible()
-            await page.get_by_test_id("new-chat-landing-approval-never").click()
+            await page.get_by_test_id("new-chat-landing-approval-full-access").click()
 
             # The chip label reflects the non-default pick immediately.
             await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
-                "Never"
+                "Full access"
             )
 
             await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
@@ -425,7 +426,12 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             assert body["agent_id"] == "ag_codex_e2e", body
             assert body["host_id"] == _HOST_ID, body
             assert body["workspace"] == "/work/repo", body
-            assert body.get("terminal_launch_args") == ["--ask-for-approval", "never"], body
+            assert body.get("terminal_launch_args") == [
+                "--sandbox",
+                "danger-full-access",
+                "--ask-for-approval",
+                "never",
+            ], body
         finally:
             await browser.close()
 


### PR DESCRIPTION
## Summary
- Replaces the incorrect raw `--ask-for-approval` values (`untrusted`/`on-request`/`never`) with the three presets from Codex's `/permissions` TUI popup
- **Default** — workspace-write sandbox + on-request approval (no flags, Codex's built-in default)
- **Full access** — `--sandbox danger-full-access --ask-for-approval never`
- **Read only** — `--sandbox read-only --ask-for-approval on-request`
- Each preset bundles sandbox + approval policy, matching `codex-rs/utils/approval-presets/src/lib.rs`

## Test plan
- [x] Unit tests pass (129 tests)
- [x] Flow test verifies Full access emits `["--sandbox", "danger-full-access", "--ask-for-approval", "never"]`
- [x] E2e test updated with correct preset values
- [x] TypeScript type check passes

This pull request and its description were written by Isaac.