### PR TITLE
fix(ci): post Merge Ready for fork PRs via the mirror's workflow_run

### DIFF
--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -21,15 +21,15 @@ name: Merge Ready
 #                a red status explaining the rejection.
 
 on:
-  # `labeled` only; `workflow_run` re-evaluates on same-repo CI completion.
+  # `labeled` only; `workflow_run` re-evaluates on CI completion (same-repo PRs
+  # and the fork-e2e/** mirror push -- see the job `if`).
   pull_request:
     types: [labeled]
   workflow_run:
     workflows: [PR Template, CI, Lint, E2E UI Tests, E2E Tests, Integration Tests]
     types: [completed]
-  # Fork PR e2e runs on a trusted fork-e2e/** mirror branch (see
-  # fork-e2e-mirror.yml); its check_suite completing is the re-eval signal.
-  # ctx maps the suite's head SHA back to the open PR.
+  # check_suite is a fork-PR fallback (workflow_run on the fork-e2e/** push is
+  # primary); ctx maps the head SHA back to the open PR.
   check_suite:
     types: [completed]
   issue_comment:
@@ -64,11 +64,10 @@ jobs:
       checks: read
       actions: read         # evaluate-checks.sh reads GET /actions/runs to classify missing checks
       statuses: write
-    # Fire on automerge/force-merge label adds, same-repo PR workflow_run
-    # completions, fork-e2e/** check_suite completions (mirrored fork PR
-    # e2e -- ctx maps the head SHA back to the PR), `/merge` comments, or a
-    # workflow_dispatch re-eval. Post-merge/nightly runs (push to main, etc.)
-    # have no open PR and are dropped by the ctx step.
+    # Fire on automerge/force-merge label adds, PR CI workflow_run completions
+    # (same-repo and the fork-e2e/** mirror push), `/merge` comments, or a
+    # workflow_dispatch re-eval; check_suite is a fork-PR fallback. Runs with no
+    # open PR (push to main, etc.) are dropped by the ctx step.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -79,7 +78,13 @@ jobs:
       ) ||
       (
         github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request'
+        (
+          github.event.workflow_run.event == 'pull_request' ||
+          (
+            github.event.workflow_run.event == 'push' &&
+            startsWith(github.event.workflow_run.head_branch, 'fork-e2e/')
+          )
+        )
       ) ||
       (
         github.event_name == 'check_suite' &&


### PR DESCRIPTION
## Summary

Makes "Merge Ready" post on fork PRs. It never did: the `evaluate` job's only fork-PR trigger was a `check_suite` whose `head_branch` starts with `fork-e2e/`, but that signal doesn't arrive — the check suites that reach merge-ready carry the **fork** branch name (the PR's own `pull_request` CI suites), which the guard correctly rejects, while the mirror branch's own suites don't cascade an event. The `workflow_run` path didn't cover it either: it required `workflow_run.event == 'pull_request'`, but the mirror's e2e runs are `push` events on `fork-e2e/**`.

The fix broadens the `workflow_run` guard to also fire on a `push` `workflow_run` whose `head_branch` starts with `fork-e2e/`. That signal is reliably delivered when the mirror's E2E / E2E UI / Integration runs complete, and the `ctx` step already resolves the open PR from the run's head SHA (the mirror pushes the exact PR head SHA). The `check_suite` path is kept as a fallback.

Discovered while diagnosing why #24 (a fork PR) never got a Merge Ready status even after its mirror branch and e2e were healthy (post the mirror fix in #398).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Workflow-trigger change. Verified `merge-ready.yml` parses and the `evaluate` `if` expression is balanced and well-formed. Confirmed against #24's run history that the `check_suite`-triggered merge-ready runs were all skipped (their `head_branch` was the fork branch, not `fork-e2e/`), and that the mirror e2e runs are `push` events on `fork-e2e/**` — which the new guard now admits. End-to-end behavior (Merge Ready posts after the mirror e2e completes) is exercised by the next gated fork PR.