### PR TITLE
fix(ap-web): wrap long session names in delete dialog

### DIFF
--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1101,7 +1101,7 @@ function ConversationRow({
           <DialogHeader>
             <DialogTitle>Delete conversation?</DialogTitle>
             <DialogDescription>
-              <span className="font-medium">{label}</span> and all of its history will be removed.
+              <span className="font-medium break-all">{label}</span> and all of its history will be removed.
               This cannot be undone.
             </DialogDescription>
           </DialogHeader>

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1101,8 +1101,8 @@ function ConversationRow({
           <DialogHeader>
             <DialogTitle>Delete conversation?</DialogTitle>
             <DialogDescription>
-              <span className="font-medium break-all">{label}</span> and all of its history will be removed.
-              This cannot be undone.
+              <span className="font-medium break-all">{label}</span> and all of its history will be
+              removed. This cannot be undone.
             </DialogDescription>
           </DialogHeader>
           {gitBranch !== null && (


### PR DESCRIPTION
## Summary
The delete-conversation dialog rendered the session label with no word-break behavior, so a long unbreakable name (e.g. a pytest node id like `tests/e2e_ui/chat/test_multi_turn_chat.py::test_multi_turn_chat`) overflowed past the dialog's right edge and got clipped.

This adds `break-all` to the label span so the name wraps onto multiple lines inside the dialog, matching the branch-name `<code>` element below it.

## Testing
- Verified manually in the Vite dev server (`npm run dev`) that a long-named session now wraps in the delete dialog.