### PR TITLE
Fix Archer live LLM known failures

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2878,6 +2878,11 @@ def _resolved_spec_workdir(entry: Any) -> Path | None:
     return entry.workdir if isinstance(entry, ResolvedSpec) else None
 
 
+def _resolved_workdir_for_spec(spec: Any, fallback: Path | None) -> Path | None:
+    """Return the bundle workdir for a possibly wrapped spec entry."""
+    return _resolved_spec_workdir(spec) or fallback
+
+
 @dataclasses.dataclass(frozen=True)
 class _SessionSnapshot:
     """One ``GET /v1/sessions/{id}`` projected for all runner readers.
@@ -8735,6 +8740,7 @@ def create_runner_app(
         _turn_agent_id = dispatch.agent_id if dispatch else body.get("agent_id")
         _has_mcp_hint = dispatch.has_mcp_servers if dispatch else body.get("has_mcp_servers")
         _turn_spec: Any = None
+        _turn_spec_entry: Any = None
         _turn_spec_resolved = False
         _mcp_schemas: list[dict[str, Any]] = []
         _mcp_tool_names: set[str] = set()
@@ -8746,6 +8752,7 @@ def create_runner_app(
             _turn_spec = _unwrap_resolved_spec(_turn_spec_entry)
             if _turn_spec is None:
                 _session_entry = _session_spec_cache.get(conv_id)
+                _turn_spec_entry = _session_entry
                 _turn_spec = _unwrap_resolved_spec(_session_entry)
             if _turn_spec is None and spec_resolver is not None:
                 try:
@@ -8769,6 +8776,7 @@ def create_runner_app(
                 else:
                     if _turn_spec is not None:
                         _spec_cache[_turn_agent_id] = _resolved_turn_spec
+                        _turn_spec_entry = _resolved_turn_spec
             _turn_spec_resolved = True
             _turn_mcp: Any = ProxyMcpManager(conv_id, server_client)
             if _eager_spec_error is None and _turn_spec is not None:
@@ -8789,9 +8797,9 @@ def create_runner_app(
             (typically ``_response_failed_event`` from inside the SSE
             generator).
             """
-            nonlocal _turn_spec, _turn_spec_resolved
+            nonlocal _turn_spec, _turn_spec_entry, _turn_spec_resolved
             if _turn_spec_resolved:
-                return _turn_spec, None
+                return _turn_spec_entry or _turn_spec, None
             _turn_spec_resolved = True
             # Session-level cache has the sub-agent's resolved spec
             # (set by _run_turn_bg) for child sessions. Check it
@@ -8799,14 +8807,16 @@ def create_runner_app(
             # sub-spec, not the root spec.
             session_cached = _session_spec_cache.get(conv_id)
             if session_cached is not None:
+                _turn_spec_entry = session_cached
                 _turn_spec = _unwrap_resolved_spec(session_cached)
-                return _turn_spec, None
+                return session_cached, None
             if not _turn_agent_id or spec_resolver is None:
                 return None, None
             cached = _spec_cache.get(_turn_agent_id)
             if cached is not None:
+                _turn_spec_entry = cached
                 _turn_spec = _unwrap_resolved_spec(cached)
-                return _turn_spec, None
+                return cached, None
             try:
                 resolved = await spec_resolver(_turn_agent_id, conv_id)
             except (httpx.HTTPError, RuntimeError) as exc:
@@ -8822,8 +8832,10 @@ def create_runner_app(
                 )
             if resolved is not None:
                 _spec_cache[_turn_agent_id] = resolved
+                _turn_spec_entry = resolved
                 _turn_spec = _unwrap_resolved_spec(resolved)
-            return _turn_spec, None
+                return resolved, None
+            return None, None
 
         async def proxy_stream():
             # If eager spec resolution failed (MCP path), emit the
@@ -9076,6 +9088,32 @@ def create_runner_app(
                                             _spec_for_dispatch_hint, "local_tools", []
                                         )
                                     )
+                                    if (
+                                        not _is_spec_local
+                                        and not is_mcp
+                                        and not should_dispatch_locally(tool_name)
+                                    ):
+                                        (
+                                            _spec_for_dispatch_hint_entry,
+                                            _lazy_hint_err,
+                                        ) = await _resolve_turn_spec_lazy()
+                                        if _lazy_hint_err is not None:
+                                            _err_type, _err_msg = _lazy_hint_err
+                                            yield _response_failed_event(
+                                                {"message": _err_msg, "type": _err_type}
+                                            )
+                                            return
+                                        _spec_for_dispatch_hint = _unwrap_resolved_spec(
+                                            _spec_for_dispatch_hint_entry
+                                        )
+                                        _is_spec_local = any(
+                                            getattr(info, "name", None) == tool_name
+                                            and getattr(info, "language", None)
+                                            in ("python", "omnigent-python-callable")
+                                            for info in getattr(
+                                                _spec_for_dispatch_hint, "local_tools", []
+                                            )
+                                        )
                                     _should_dispatch = _should_dispatch_tool_locally(
                                         tool_name,
                                         dispatch=dispatch,
@@ -9090,7 +9128,7 @@ def create_runner_app(
                                         # failures surface as response.failed
                                         # SSE (see the response.failed contract).
                                         (
-                                            _spec_for_dispatch,
+                                            _spec_for_dispatch_entry,
                                             _lazy_err,
                                         ) = await _resolve_turn_spec_lazy()
                                         if _lazy_err is not None:
@@ -9099,6 +9137,13 @@ def create_runner_app(
                                                 {"message": _err_msg, "type": _err_type}
                                             )
                                             return
+                                        _dispatch_workdir = _resolved_workdir_for_spec(
+                                            _spec_for_dispatch_entry,
+                                            runner_workspace,
+                                        )
+                                        _spec_for_dispatch = _unwrap_resolved_spec(
+                                            _spec_for_dispatch_entry
+                                        )
                                         # All tool calls go through AP:/mcp
                                         # (ProxyMcpManager in Omnigent mode), which
                                         # enforces TOOL_CALL + TOOL_RESULT
@@ -9128,7 +9173,7 @@ def create_runner_app(
                                                     task_id=_omnigent_task_id or _response_id,
                                                     agent_id=_agent_id_for_dispatch,
                                                     agent_name=body.get("model"),
-                                                    runner_workspace=runner_workspace,
+                                                    runner_workspace=_dispatch_workdir,
                                                     mcp_manager=_dispatch_mcp,
                                                     session_inbox=_session_inboxes.get(conv_id),
                                                     session_async_tasks=_session_async_tasks.get(
@@ -11811,12 +11856,14 @@ def create_runner_app(
                         },
                     )
                 spec_entry = _session_spec_cache.get(session_id)
+                spec_workdir = _resolved_spec_workdir(spec_entry)
                 spec = _unwrap_resolved_spec(spec_entry)
                 if spec is None and spec_resolver is not None:
                     _agent_id = _session_agent_ids.get(session_id)
                     if _agent_id:
                         try:
                             resolved = await spec_resolver(_agent_id, session_id)
+                            spec_workdir = _resolved_spec_workdir(resolved)
                             spec = _unwrap_resolved_spec(resolved)
                         except Exception:  # noqa: BLE001
                             pass
@@ -11890,12 +11937,14 @@ def create_runner_app(
                 # any name without ``__`` is definitively a runner-local tool.
                 # Policy enforcement is handled by the AP server.
                 spec_entry = _session_spec_cache.get(session_id)
+                spec_workdir = _resolved_spec_workdir(spec_entry)
                 spec = _unwrap_resolved_spec(spec_entry)
                 if spec is None and spec_resolver is not None:
                     _agent_id = _session_agent_ids.get(session_id)
                     if _agent_id:
                         try:
                             resolved = await spec_resolver(_agent_id, session_id)
+                            spec_workdir = _resolved_spec_workdir(resolved)
                             spec = _unwrap_resolved_spec(resolved)
                         except Exception:  # noqa: BLE001
                             pass
@@ -11912,7 +11961,7 @@ def create_runner_app(
                         task_id=session_id,
                         agent_id=_agent_id_local,
                         agent_name=getattr(spec, "name", None),
-                        runner_workspace=runner_workspace,
+                        runner_workspace=spec_workdir or runner_workspace,
                         mcp_manager=None,
                         session_inbox=_session_inboxes.get(session_id),
                         session_async_tasks=_session_async_tasks.get(session_id),

--- a/tests/e2e/test_archer_local_tool.py
+++ b/tests/e2e/test_archer_local_tool.py
@@ -108,6 +108,13 @@ def test_archer_calls_word_count_tool(
         f"the ftfy dependency): {tool_output!r}"
     )
     tool_data = json.loads(tool_output)
+    if "content" in tool_data:
+        tool_text = "\n".join(
+            block.get("text", "")
+            for block in tool_data["content"]
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+        tool_data = json.loads(tool_text)
     assert tool_data["word_count"] == 7, (
         f"Expected word_count=7, got {tool_data}. Tool may have failed or returned wrong result."
     )

--- a/tests/e2e/test_archer_steering.py
+++ b/tests/e2e/test_archer_steering.py
@@ -19,13 +19,14 @@ import httpx
 
 from tests.e2e.conftest import (
     create_runner_bound_session,
-    poll_until_terminal,
+    poll_session_until_terminal,
     send_user_message_to_session,
 )
 
 
 def _wait_for_spawn(
     client: httpx.Client,
+    session_id: str,
     response_id: str,
     timeout: float = 120,
 ) -> None:
@@ -41,16 +42,21 @@ def _wait_for_spawn(
     :param timeout: Max seconds to wait.
     :raises AssertionError: If no spawn call within timeout.
     """
+    del response_id
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        resp = client.get(f"/v1/responses/{response_id}")
+        resp = client.get(f"/v1/sessions/{session_id}")
+        resp.raise_for_status()
         body = resp.json()
-        for item in body.get("output", []):
+        for item in body.get("items", []):
+            data = item.get("data") if isinstance(item.get("data"), dict) else {}
             if item.get("type") == "function_call" and item.get("name") == "sys_session_send":
                 return
-        if body["status"] in ("completed", "failed"):
+            if item.get("type") == "function_call" and data.get("name") == "sys_session_send":
+                return
+        if body["status"] in ("idle", "failed"):
             raise AssertionError(
-                f"Response completed without spawning a sub-agent. Output: {body.get('output')}"
+                f"Response completed without spawning a sub-agent. Items: {body.get('items')}"
             )
         time.sleep(0.5)
     raise AssertionError(f"sys_session_send not found in output within {timeout}s")
@@ -104,7 +110,7 @@ def test_steering_during_auto_collect(
     )
 
     # Step 2: wait for spawn to happen.
-    _wait_for_spawn(http_client, response_id, timeout=120)
+    _wait_for_spawn(http_client, session_id, response_id, timeout=120)
 
     # Step 3: steer through the same session.
     final_id = send_user_message_to_session(
@@ -119,7 +125,12 @@ def test_steering_during_auto_collect(
     steered_into_running = final_id == response_id
 
     # Step 4: wait for the task to complete (whichever ID).
-    final = poll_until_terminal(http_client, final_id, timeout=300)
+    final = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=final_id,
+        timeout=300,
+    )
 
     # Step 5: assert.
     assert final["status"] == "completed", (

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -308,12 +308,6 @@ skips:
     cluster: async-dispatch-inbox-sse
     mode: skip
 
-  - id: tests/e2e/test_archer_local_tool.py::test_archer_calls_word_count_tool
-    reason: "Local Python tool 'word_count' not registered on the archer agent in CI; tool-loading regression, not LLM flakiness. Failed all 3 retry attempts in PR #2053."
-    issue: 532
-    cluster: archer-live-llm
-    mode: skip
-
   - id: tests/e2e/test_archer_output_files.py::test_archer_generates_chart_and_uploads
     reason: "No file_citation annotation produced; upload_file/annotation pipeline regression, not LLM flakiness. Failed all 3 retry attempts in PR #2053."
     issue: 532
@@ -940,13 +934,6 @@ skips:
     cluster: sandbox-deps-env
     mode: skip
 
-  # Cluster: steering — test_steering.py + test_archer_steering.py
-  # flipped together.
-  - id: tests/e2e/test_archer_steering.py::test_steering_during_auto_collect
-    reason: "Force-merge backlog (steering cluster). First observed failing at 4d60bca0 (2026-05-23T00:37:02Z, E2E)."
-    issue: 0
-    cluster: archer-live-llm
-    mode: skip
   # Cluster: cancel/history.
   - id: tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it
     reason: "Force-merge backlog (cancel-history cluster). First observed failing at 2fe283bf (2026-05-23T00:08:54Z, E2E)."

--- a/tests/resources/examples/archer/agents/fact_checker/config.yaml
+++ b/tests/resources/examples/archer/agents/fact_checker/config.yaml
@@ -1,0 +1,15 @@
+spec_version: 1
+name: fact_checker
+description: Verifies claims by searching for corroborating or contradicting evidence.
+
+executor:
+  type: omnigent
+  model: databricks-gpt-5-4
+  config:
+    harness: openai-agents
+
+prompt: |
+  You are a fact-checker. When given a claim or statement, search the web
+  to find evidence that supports or contradicts it. Return a brief verdict
+  (supported, contradicted, or mixed) with the key sources you found.
+  Be precise and cite URLs.

--- a/tests/resources/examples/archer/agents/summarizer/config.yaml
+++ b/tests/resources/examples/archer/agents/summarizer/config.yaml
@@ -1,0 +1,15 @@
+spec_version: 1
+name: summarizer
+description: Condenses long content into concise, structured summaries.
+
+executor:
+  type: omnigent
+  model: databricks-gpt-5-4
+  config:
+    harness: openai-agents
+
+prompt: |
+  You are a summarizer. When given a topic or long text, produce a concise
+  summary that captures the key points. Use bullet points for clarity.
+  If given a topic instead of text, search the web first to gather
+  information, then summarize your findings.

--- a/tests/resources/examples/archer/config.yaml
+++ b/tests/resources/examples/archer/config.yaml
@@ -45,35 +45,11 @@ os_env:
   cwd: .
 
 tools:
+  agents:
+    - fact_checker
+    - summarizer
+
   builtins:
     - upload_file
     - list_files
     - download_file
-
-  fact_checker:
-    type: agent
-    description: Verifies claims by searching for corroborating or contradicting evidence.
-    executor:
-      type: omnigent
-      model: databricks-gpt-5-4
-      config:
-        harness: openai-agents
-    prompt: |
-      You are a fact-checker. When given a claim or statement, search the web
-      to find evidence that supports or contradicts it. Return a brief verdict
-      (supported, contradicted, or mixed) with the key sources you found.
-      Be precise and cite URLs.
-
-  summarizer:
-    type: agent
-    description: Condenses long content into concise, structured summaries.
-    executor:
-      type: omnigent
-      model: databricks-gpt-5-4
-      config:
-        harness: openai-agents
-    prompt: |
-      You are a summarizer. When given a topic or long text, produce a concise
-      summary that captures the key points. Use bullet points for clarity.
-      If given a topic instead of text, search the web first to gather
-      information, then summarize your findings.


### PR DESCRIPTION
## Summary

- Fixes Archer live-LLM local Python tool dispatch so runner-local bundle tools keep their extracted bundle workdir through policy/MCP proxy execution.
- Updates the Archer fixture to declare current-spec sub-agents under `tools.agents` with `agents/fact_checker` and `agents/summarizer` bundles.
- Rewrites stale runner-native e2e assertions and removes both `cluster: archer-live-llm` suppressions from `tests/known_failures.yaml`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Decisions by suppressed test:
- `tests/e2e/test_archer_local_tool.py::test_archer_calls_word_count_tool`: fixed product dispatch and rewrote a stale assertion. The product bug was that runner-native local tool execution could lose the `ResolvedSpec.workdir`, so `word_count` was advertised but not executable after the AP MCP/policy proxy round trip. The assertion now still validates the actual `word_count=7` result while tolerating the MCP text-content wrapper used on that path.
- `tests/e2e/test_archer_steering.py::test_steering_during_auto_collect`: fixed stale test plumbing and fixture setup. Runner-native sessions do not expose these turns through `GET /v1/responses/{id}`, so the test now polls the session snapshot. The Archer fixture also now uses current sub-agent declarations so `sys_session_send` is actually available.

Exact commands run:
- `uv run pytest tests/e2e/test_archer_local_tool.py::test_archer_calls_word_count_tool tests/e2e/test_archer_steering.py::test_steering_during_auto_collect --llm-api-key="$OPENAI_API_KEY" --no-skip-known -q -rfs --tb=short` → `2 passed in 44.57s`
- `uv run pytest tests/e2e/test_archer_local_tool.py::test_archer_calls_word_count_tool --llm-api-key="$OPENAI_API_KEY" --no-skip-known -q -rfs --tb=short` → `1 passed in 16.96s`
- `uv run pytest tests/e2e/test_archer_local_tool.py::test_archer_calls_word_count_tool tests/e2e/test_archer_steering.py::test_steering_during_auto_collect --llm-api-key="$OPENAI_API_KEY" -q -rfs --tb=short` → `2 passed, 1 warning in 171.48s (0:02:51)`
- `git diff --check` → passed

ELI5:
Archer had a toolbox packed inside its backpack. The system showed the model a label for the `word_count` tool, but when the model tried to use it, the runner forgot where the backpack was unpacked and looked in the wrong place. This change keeps the backpack location attached all the way to tool execution, and updates Archer's helper-agent list to the format the current loader understands.

Diagram:
```mermaid
flowchart LR
  A[Archer turn] --> B[Runner resolves bundled spec]
  B --> C[ResolvedSpec includes workdir]
  C --> D[LLM sees word_count and sys_session_send]
  D --> E[AP MCP proxy applies policies]
  E --> F[Runner executes tool with bundle workdir]
  F --> G[E2E validates word_count and steering]
```
