### PR TITLE
test(e2e): fix examples-coverage drift guard + add 4 missing example tests (un-suppress)

### DIFF
--- a/tests/e2e/omnigent/test_example_agent_with_os_env_bwrap.py
+++ b/tests/e2e/omnigent/test_example_agent_with_os_env_bwrap.py
@@ -1,0 +1,65 @@
+"""Structural test for the bubblewrap-sandboxed os_env example
+(``tests/resources/examples/agent_with_os_env_bwrap.yaml``).
+
+The opt-in hardened (Linux) variant of ``agent_with_os_env``: same ``sys_os_*``
+tools, but the helper subprocess runs inside the ``linux_bwrap`` launcher
+(fresh namespaces, read-only cwd, dotfile masking, egress allowlist). Pure
+spec-load — the actual sandbox only engages on Linux at run time, so the
+credential-gated one-shot can't assert it on a macOS CI host; this guard locks
+the distinctive ``sandbox: type: linux_bwrap`` + egress wiring instead.
+
+What breaks if this fails:
+- the spec parser regresses on ``os_env.sandbox`` of type ``linux_bwrap``,
+- the egress allowlist drops off the sandbox spec (the agent would gain
+  unrestricted network, or lose its intended httpbin reachability),
+- the variant silently degrades to ``sandbox: type: none`` (no isolation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_agent_with_os_env_bwrap.py -> repo root 3 up.
+_BWRAP_YAML = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "resources"
+    / "examples"
+    / "agent_with_os_env_bwrap.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def bwrap_spec() -> AgentSpec:
+    """Load and validate the bwrap-sandboxed example once for the module."""
+    return load(_BWRAP_YAML)
+
+
+def test_uses_linux_bwrap_sandbox(bwrap_spec: AgentSpec) -> None:
+    """
+    The example wires an ``os_env`` block whose sandbox is ``linux_bwrap``.
+    Degrading to ``type: none`` (or dropping the sandbox) would silently remove
+    the isolation the example exists to demonstrate.
+    """
+    assert bwrap_spec.os_env is not None
+    assert bwrap_spec.os_env.type == "caller_process"
+    assert bwrap_spec.os_env.sandbox is not None
+    assert bwrap_spec.os_env.sandbox.type == "linux_bwrap"
+
+
+def test_egress_allowlist_present(bwrap_spec: AgentSpec) -> None:
+    """
+    The sandbox pins an egress allowlist (httpbin GET routes). Losing it would
+    either open unrestricted network or strip the reachability the example
+    relies on — both regressions worth failing on.
+    """
+    sandbox = bwrap_spec.os_env.sandbox
+    assert sandbox.egress_rules == [
+        "GET httpbin.org/get",
+        "GET httpbin.org/status/*",
+    ]

--- a/tests/e2e/omnigent/test_example_agent_with_os_env_seatbelt.py
+++ b/tests/e2e/omnigent/test_example_agent_with_os_env_seatbelt.py
@@ -1,0 +1,64 @@
+"""Structural test for the macOS-seatbelt-sandboxed os_env example
+(``tests/resources/examples/agent_with_os_env_seatbelt.yaml``).
+
+The macOS sibling of ``agent_with_os_env_bwrap``: same ``sys_os_*`` tools, but
+the helper subprocess runs under the ``darwin_seatbelt`` sandbox
+(``sandbox-exec`` profile, read-only cwd, dotfile masking, egress allowlist).
+Pure spec-load — the live sandbox only engages on macOS at run time, so this
+guard locks the distinctive ``sandbox: type: darwin_seatbelt`` + egress wiring
+rather than depending on the credential-gated one-shot.
+
+What breaks if this fails:
+- the spec parser regresses on ``os_env.sandbox`` of type ``darwin_seatbelt``,
+- the egress allowlist drops off the sandbox spec,
+- the variant silently degrades to ``sandbox: type: none`` (no isolation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_agent_with_os_env_seatbelt.py -> repo root 3 up.
+_SEATBELT_YAML = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "resources"
+    / "examples"
+    / "agent_with_os_env_seatbelt.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def seatbelt_spec() -> AgentSpec:
+    """Load and validate the seatbelt-sandboxed example once for the module."""
+    return load(_SEATBELT_YAML)
+
+
+def test_uses_darwin_seatbelt_sandbox(seatbelt_spec: AgentSpec) -> None:
+    """
+    The example wires an ``os_env`` block whose sandbox is ``darwin_seatbelt``.
+    Degrading to ``type: none`` (or dropping the sandbox) would silently remove
+    the isolation the example exists to demonstrate.
+    """
+    assert seatbelt_spec.os_env is not None
+    assert seatbelt_spec.os_env.type == "caller_process"
+    assert seatbelt_spec.os_env.sandbox is not None
+    assert seatbelt_spec.os_env.sandbox.type == "darwin_seatbelt"
+
+
+def test_egress_allowlist_present(seatbelt_spec: AgentSpec) -> None:
+    """
+    The sandbox pins an egress allowlist (httpbin GET routes). Losing it would
+    either open unrestricted network or strip the reachability the example
+    relies on — both regressions worth failing on.
+    """
+    sandbox = seatbelt_spec.os_env.sandbox
+    assert sandbox.egress_rules == [
+        "GET httpbin.org/get",
+        "GET httpbin.org/status/*",
+    ]

--- a/tests/e2e/omnigent/test_example_debby.py
+++ b/tests/e2e/omnigent/test_example_debby.py
@@ -1,0 +1,84 @@
+"""Structural test for the Debby two-headed brainstorming bundle (examples/debby).
+
+Debby never answers from a single model: every question is fanned out to BOTH a
+Claude sub-agent and a GPT sub-agent — two plain (non-coding) responders on the
+claude-sdk and openai-agents harnesses — and the ``debate`` skill has them
+critique each other before converging. Pure spec-load — no LLM, no credentials —
+modeled on ``test_example_polly.py``.
+
+What breaks if this fails:
+- the two heads collapse onto one vendor (no cross-model contrast — Debby's whole
+  point), or a head is dropped entirely,
+- a head silently switches harness (e.g. the GPT head ends up on claude-sdk),
+- the ``debate`` skill is dropped or renamed (the critique loop regresses),
+- the ``os_env`` block disappears (the heads lose the file/shell tools the
+  brainstorming surface relies on).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_debby.py -> repo root is 3 parents up.
+_DEBBY_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "debby"
+
+
+@pytest.fixture(scope="module")
+def debby_spec() -> AgentSpec:
+    """Load and validate the debby bundle once for the module."""
+    return load(_DEBBY_BUNDLE)
+
+
+def test_debby_is_two_headed_cross_vendor(debby_spec: AgentSpec) -> None:
+    """
+    Debby has exactly two heads — ``claude`` on claude-sdk and ``gpt`` on
+    openai-agents — so every answer contrasts two distinct vendors.
+
+    A missing/renamed head, or both heads landing on the same harness, removes
+    the cross-model contrast that is Debby's entire reason to exist.
+    """
+    assert debby_spec.name == "debby"
+    fam = {a.name: a.executor.config.get("harness") for a in debby_spec.sub_agents}
+    assert sorted(debby_spec.tools.agents) == ["claude", "gpt"]
+    assert fam["claude"] == "claude-sdk"
+    assert fam["gpt"] == "openai-agents"
+    # Two distinct vendors → the heads always disagree across providers.
+    assert len(set(fam.values())) == 2
+
+
+def test_debby_heads_are_unpinned(debby_spec: AgentSpec) -> None:
+    """
+    Neither head pins a model: each inherits whatever Claude / OpenAI provider
+    the user configured (Anthropic key, subscription, gateway, or Databricks).
+
+    Un-pinning is load-bearing for OSS — a Databricks-specific model id would
+    404 on a plain Anthropic / OpenAI key. Re-introducing a pin re-couples a
+    head to one provider, so fail here if a model reappears.
+    """
+    by_name = {a.name: a for a in debby_spec.sub_agents}
+    for name in ("claude", "gpt"):
+        assert by_name[name].executor.model is None, name
+        assert by_name[name].executor.profile is None, name
+
+
+def test_debby_debate_skill_present(debby_spec: AgentSpec) -> None:
+    """The ``debate`` skill is discovered from skills/debate/SKILL.md."""
+    assert sorted(s.name for s in debby_spec.skills) == ["debate"]
+
+
+def test_debby_has_os_env(debby_spec: AgentSpec) -> None:
+    """
+    Debby carries an ``os_env`` block so the bridged ``sys_os_*`` tools register
+    for the brainstorming surface. The shipped sandbox is ``type: none`` so the
+    bundle loads on macOS too. Dropping ``os_env`` would leave the heads with no
+    file/shell tools at all.
+    """
+    assert debby_spec.os_env is not None
+    assert debby_spec.os_env.type == "caller_process"
+    assert debby_spec.os_env.sandbox is not None
+    assert debby_spec.os_env.sandbox.type == "none"

--- a/tests/e2e/omnigent/test_example_swe_org.py
+++ b/tests/e2e/omnigent/test_example_swe_org.py
@@ -1,0 +1,100 @@
+"""Structural test for the SWE-org engineering-director example
+(``tests/resources/examples/swe_org.yaml``).
+
+A single-file multi-agent demo in the spirit of ``coding_supervisor.yaml``: a
+director root delegates to a team of role sub-agents that run on *different*
+models for different jobs (Claude for backend / QA / staff-review, GPT for
+frontend / design), all able to inspect the repo through inherited ``os_env``
+tools, with two function-policy guardrails. Pure spec-load — no LLM, no
+credentials — modeled on ``test_example_polly.py``.
+
+What breaks if this fails:
+- a team role is dropped/renamed (the org loses a function),
+- the deliberate cross-model split collapses onto one vendor (the demo's
+  "different models for different jobs" point),
+- the ``os_env`` block disappears (agents can no longer inspect/edit the repo),
+- a guardrail (per-turn tool rate-limit or search budget) is removed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_swe_org.py -> repo root is 3 parents up.
+_SWE_ORG_YAML = (
+    Path(__file__).resolve().parents[3] / "tests" / "resources" / "examples" / "swe_org.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def swe_org_spec() -> AgentSpec:
+    """Load and validate the swe_org example once for the module."""
+    return load(_SWE_ORG_YAML)
+
+
+def test_director_root(swe_org_spec: AgentSpec) -> None:
+    """
+    The root is the engineering director on the openai-agents harness. Its name
+    is intentionally ``swe_org_director`` (the file stem ``swe_org`` is the
+    agent *identity* for coverage; the spec ``name`` is the in-product role).
+    """
+    assert swe_org_spec.name == "swe_org_director"
+    assert swe_org_spec.executor.config.get("harness") == "openai-agents"
+
+
+def test_team_roles_and_cross_model_split(swe_org_spec: AgentSpec) -> None:
+    """
+    Exactly five team roles, with a deliberate cross-model split: backend / QA /
+    staff-reviewer on claude-sdk (Sonnet), frontend / product-designer on
+    openai-agents (GPT). Collapsing every role onto one harness/model defeats
+    the "different models for different jobs" point of the demo.
+    """
+    by_name = {a.name: a for a in swe_org_spec.sub_agents}
+    assert sorted(swe_org_spec.tools.agents) == [
+        "backend_engineer",
+        "frontend_engineer",
+        "product_designer",
+        "qa_engineer",
+        "staff_reviewer",
+    ]
+    claude_roles = {"backend_engineer", "qa_engineer", "staff_reviewer"}
+    gpt_roles = {"frontend_engineer", "product_designer"}
+    for name in claude_roles:
+        assert by_name[name].executor.config.get("harness") == "claude-sdk", name
+    for name in gpt_roles:
+        assert by_name[name].executor.config.get("harness") == "openai-agents", name
+    # Both vendors are represented — not a single-model org.
+    harnesses = {a.executor.config.get("harness") for a in swe_org_spec.sub_agents}
+    assert harnesses == {"claude-sdk", "openai-agents"}
+
+
+def test_director_has_os_env(swe_org_spec: AgentSpec) -> None:
+    """
+    The director carries an ``os_env`` block so the inherited ``sys_os_*`` tools
+    register and the org can inspect/edit the repo. Dropping it would leave the
+    director claiming repo access it cannot exercise.
+    """
+    assert swe_org_spec.os_env is not None
+    assert swe_org_spec.os_env.type == "caller_process"
+
+
+def test_director_guardrails(swe_org_spec: AgentSpec) -> None:
+    """
+    The director carries both function-policy guardrails: a per-turn tool-call
+    rate limit and a search budget. Each must keep non-empty ``function``
+    wiring or the resolver would fail closed on the first gated call.
+    """
+    assert swe_org_spec.guardrails is not None
+    by_name = {p.name: p for p in swe_org_spec.guardrails.policies}
+    assert sorted(by_name) == ["rate_limit", "search_budget"]
+    # The rate limit pins a concrete per-turn cap via factory kwargs.
+    rate_args = by_name["rate_limit"].function.arguments
+    assert rate_args["factory_kwargs"]["limit"] == 25
+    # Each policy names a resolvable handler target.
+    for name in ("rate_limit", "search_budget"):
+        assert by_name[name].function.arguments.get("target")

--- a/tests/e2e/omnigent/test_examples_coverage_sync.py
+++ b/tests/e2e/omnigent/test_examples_coverage_sync.py
@@ -1,8 +1,19 @@
-"""Drift guard: every agent — top-level ``examples/*.yaml``,
-dir-shaped ``examples/<name>/`` (containing ``config.yaml``), or
-test-only ``tests/resources/agents/<name>/`` — must have a
-dedicated ``test_example_<name>.py`` file under
-``tests/e2e/omnigent/``.
+"""Drift guard: every agent — dir-shaped ``examples/<name>/`` or
+``tests/resources/examples/<name>/`` (containing ``config.yaml``),
+single-YAML ``examples/<name>.yaml`` or
+``tests/resources/examples/<name>.yaml``, or test-only
+``tests/resources/agents/<name>/`` — must have a dedicated
+``test_example_<name>.py`` file under ``tests/e2e/omnigent/``.
+
+The set of agent roots scanned here is kept in lock-step with the
+resolution order in
+``tests/e2e/omnigent/_example_helpers.py::example_yaml_path`` — the
+helper the per-example tests use to find their YAML. If the guard
+scans fewer roots than the helper resolves, a ``test_example_*.py``
+that points at a real agent in the un-scanned root looks "orphaned"
+to the guard even though it runs fine. (That exact skew —
+``tests/resources/examples/`` being resolvable by the helper but
+invisible to the guard — is what this file historically tripped on.)
 
 When a new agent lands in any of those roots, the author should
 add a test file in the same commit. This test fails loud if an
@@ -16,6 +27,57 @@ coverage-per-agent rule can't silently drift.
 from __future__ import annotations
 
 from pathlib import Path
+
+import yaml
+
+
+def _is_agent_yaml(path: Path) -> bool:
+    """
+    Whether a top-level ``.yaml`` is an agent spec (has a ``name:``)
+    rather than a non-agent config that merely lives alongside the
+    examples — e.g. ``server_config_with_policies.yaml``, which is a
+    ``omnigent server --config`` file (only ``policies:``), not an
+    agent. Mirrors the ``missing required key 'name'`` check the spec
+    loader itself uses to reject non-agent YAMLs.
+
+    :param path: Candidate ``.yaml`` / ``.yml`` file.
+    :returns: ``True`` when the parsed mapping has a ``name`` key.
+    """
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return False
+    return isinstance(data, dict) and "name" in data
+
+
+def _scan_agent_root(root: Path, *, require_config_yaml: bool) -> set[str]:
+    """
+    Collect agent identities under one root: dir-shaped agents
+    (directory name) and single-YAML demos (filename stem).
+
+    :param root: Directory to scan (skipped if it does not exist).
+    :param require_config_yaml: When ``True``, a directory counts
+        only if it contains ``config.yaml`` (AGENTSPEC bundles —
+        excludes non-agent dirs like ``examples/databricks_apps/``).
+        When ``False``, any directory counts (test-only fixtures
+        under ``tests/resources/agents/`` may be single-file
+        bundles).
+    :returns: Set of agent names found under *root*.
+    """
+    found: set[str] = set()
+    if not root.is_dir():
+        return found
+    for p in root.iterdir():
+        if p.name.startswith(("_", ".")):
+            continue
+        if p.is_dir():
+            if not require_config_yaml or (p / "config.yaml").is_file():
+                found.add(p.name)
+        elif p.is_file() and p.suffix in {".yaml", ".yml"} and _is_agent_yaml(p):
+            # Single-YAML demo: filename stem is the agent identity.
+            found.add(p.stem)
+    return found
+
 
 # Agents that have e2e tests in files other than the
 # ``test_example_<name>.py`` naming convention (historical, pre-
@@ -95,16 +157,40 @@ _ALT_COVERED: frozenset[str] = frozenset(
         "timer-test",
         # ralph_loop is a loop-mode demo; no dedicated e2e yet.
         "ralph_loop",
+        # ── tests/resources/examples/ agents covered by name elsewhere ──
+        # agent_with_client_tools: client-tool knobs are asserted in
+        # tests/spec/test_tool_runtime.py (loads the YAML directly).
+        "agent_with_client_tools",
+        # risk_score_agent: the built-in session-risk-score policy is
+        # exercised in tests/runtime/policies/test_example_omnigent_yamls.py.
+        "risk_score_agent",
+        # databricks_supervisor: covered by
+        # tests/e2e/omnigent/test_run_omnigent_supervisor.py plus a wide
+        # spread of spec/runner/executor unit tests.
+        "databricks_supervisor",
+        # ── tests/resources/agents/ fixtures covered by name elsewhere ──
+        # web-search-test: loaded by
+        # tests/e2e/test_web_search_async_dispatch_e2e.py.
+        "web-search-test",
+        # workspace-file-writer: loaded by the changed-files e2e tests
+        # (test_filesystem_changed_files_e2e.py /
+        # test_non_git_changed_files_e2e.py).
+        "workspace-file-writer",
+        # sdk-chat-builtin: single-YAML fixture loaded by name as the
+        # fork-switch target in the native→SDK e2e tests
+        # (test_host_claude_native_fork_e2e.py, test_switch_agent_e2e.py,
+        # test_switch_agent_native_e2e.py, test_sessions_fork_e2e.py).
+        "sdk-chat-builtin",
     }
 )
 
 
 def test_every_agent_has_a_dedicated_test_file() -> None:
     """
-    Walk both agent roots and assert each directory has either
-    a matching ``test_example_<name>.py`` file or an entry in
+    Walk every agent root and assert each agent has either a
+    matching ``test_example_<name>.py`` file or an entry in
     :data:`_ALT_COVERED`. Also flag orphaned test files whose
-    ``<name>`` no longer matches any agent directory.
+    ``<name>`` no longer matches any agent.
 
     :raises AssertionError: When an agent is missing coverage
         or a test file points at a removed agent.
@@ -112,31 +198,26 @@ def test_every_agent_has_a_dedicated_test_file() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     e2e_dir = repo_root / "tests" / "e2e" / "omnigent"
 
-    # Top-level ``examples/<name>/`` AGENTSPEC dirs (must contain a
-    # ``config.yaml`` to count — excludes non-agent dirs like
-    # ``examples/databricks_apps/``).
+    # Agent roots. These MUST stay in lock-step with the resolution
+    # order in ``_example_helpers.example_yaml_path`` (see the module
+    # docstring): the helper resolves ``examples/``,
+    # ``tests/resources/examples/`` (single-YAML + dir-shaped), and
+    # ``tests/resources/agents/`` — so the guard must scan all three,
+    # or a real per-example test in an un-scanned root reads as an
+    # orphan. Both ``examples/`` and ``tests/resources/examples/``
+    # carry shipped/demo agents, so each contributes dir-shaped
+    # AGENTSPEC bundles (``config.yaml`` required, to exclude non-agent
+    # dirs) and single-YAML demos (content-filtered to real specs).
     on_disk: set[str] = set()
-    examples_root = repo_root / "examples"
-    if examples_root.is_dir():
-        for p in examples_root.iterdir():
-            if p.is_dir() and not p.name.startswith(("_", ".")) and (p / "config.yaml").is_file():
-                on_disk.add(p.name)
+    on_disk |= _scan_agent_root(repo_root / "examples", require_config_yaml=True)
+    on_disk |= _scan_agent_root(
+        repo_root / "tests" / "resources" / "examples", require_config_yaml=True
+    )
     # Test-only fixture agents under ``tests/resources/agents/`` —
     # any directory counts (single-file bundles are valid here).
-    test_resources_root = repo_root / "tests" / "resources" / "agents"
-    if test_resources_root.is_dir():
-        for p in test_resources_root.iterdir():
-            if p.is_dir() and not p.name.startswith(("_", ".")):
-                on_disk.add(p.name)
-    # Top-level single-YAML demos (``examples/<name>.yaml``). Each
-    # YAML filename stem counts as an agent identity for coverage
-    # purposes — the post-2026-04-24 layout puts simple demos at
-    # the top level rather than wrapping them in a directory.
-    top_level_root = repo_root / "examples"
-    if top_level_root.is_dir():
-        for p in top_level_root.iterdir():
-            if p.is_file() and p.suffix in {".yaml", ".yml"} and not p.name.startswith(("_", ".")):
-                on_disk.add(p.stem)
+    on_disk |= _scan_agent_root(
+        repo_root / "tests" / "resources" / "agents", require_config_yaml=False
+    )
 
     # Pick up existing tests by file-name convention.
     named_covered: set[str] = set()

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -60,17 +60,6 @@ skips:
     cluster: runner-wedge-subprocess-fanout
     mode: skip
 
-  # Shard 2 iteration: drift-guard meta-test trips on real coverage
-  # gaps: several shipped agents (databricks_supervisor,
-  # databricks_supervisor_mcp_agent, devportal_mcp_agent, swe_org,
-  # agent_with_client_tools, ...) have no test_example_<name>.py.
-  # Closing those gaps is real coverage work, not the iteration scope.
-  - id: tests/e2e/omnigent/test_examples_coverage_sync.py::test_every_agent_has_a_dedicated_test_file
-    reason: "Coverage gap: several shipped examples have no test_example_*.py."
-    issue: 532
-    cluster: example-coverage-gap
-    mode: skip
-
   # Shard 2 iteration: openai-agents harness on databricks-gpt-5-mini
   # via ai-oss frequently exceeds the test's internal 60s
   # turn-completion timeout (state stays "running" past the


### PR DESCRIPTION
## Summary

- Resolves the suppressed drift-guard meta-test `tests/e2e/omnigent/test_examples_coverage_sync.py::test_every_agent_has_a_dedicated_test_file` (cluster `example-coverage-gap`, issue 68/532).
- **Root cause was a guard bug, not a real coverage hole**: the guard scanned only **3** agent roots, while the helper its per-example tests use — `_example_helpers.example_yaml_path` — resolves agents from **4**, including `tests/resources/examples/`. That skew made the guard flag five *real* `test_example_*.py` files as "orphans", because their agents live in the root the guard never scanned.
- Fix aligns the guard's roots with the helper, content-filters top-level YAMLs to real agent specs, adds **4 real dedicated tests** for agents that genuinely lacked one, allowlists agents whose coverage lives in differently-named tests, and removes the `known_failures.yaml` entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

The touched test is a **structural drift-guard** (no LLM, no credentials). All new tests are pure `omnigent.spec.load` checks, modeled on the existing credential-free `test_example_polly.py`, so they run on any host.

Commands run (in the shared-venv worktree):

```
# The previously-suppressed guard — now passes
.venv/bin/python -m pytest tests/e2e/omnigent/test_examples_coverage_sync.py -v
# -> 1 passed

# The 4 new dedicated structural tests
.venv/bin/python -m pytest \
  tests/e2e/omnigent/test_example_debby.py \
  tests/e2e/omnigent/test_example_swe_org.py \
  tests/e2e/omnigent/test_example_agent_with_os_env_bwrap.py \
  tests/e2e/omnigent/test_example_agent_with_os_env_seatbelt.py -v
# -> 12 passed

# Lint / format
.venv/bin/python -m ruff check <touched files>           # All checks passed!
.venv/bin/python -m ruff format <touched files>          # formatted
.venv/bin/python dev/lint/lint_no_skipped_tests.py <...> # clean
```

Note on mypy: running mypy directly on these spec-load tests surfaces `union-attr`
errors (e.g. `GuardrailsSpec | None has no attribute policies`) — but the
**pre-existing** `test_example_polly.py` produces the identical errors, mypy is
**not** in this repo's pre-commit hooks, and the new files match that established
convention. No new divergence introduced.

---

## ELI5

Think of a classroom rule: **every student must hand in a homework folder.**

A monitor (`test_every_agent_has_a_dedicated_test_file`) checks two things:
1. **Every student has a folder** — every *agent* has a `test_example_<name>.py`.
2. **No folder belongs to a student who left** — no test file points at an agent that no longer exists.

The monitor was looking in **3 classrooms** for students, but the actual roll-call list (`example_yaml_path`, the function the homework folders themselves use to find their student) covered **4 classrooms**. So five folders for students sitting in the 4th classroom (`tests/resources/examples/`) looked like they belonged to *nobody* — the monitor raised a false alarm ("orphaned folders!") and the test was suppressed.

The fix: **make the monitor check the same 4 classrooms the roll-call already uses.** Once it does, the five "orphans" match real students. That also reveals a few students who truly had no folder yet (debby, swe_org, and the two sandbox variants) — so we wrote real folders for them — plus some students whose homework is in a *differently-named* folder, which we recorded on the allow-list with a note saying where.

## How the guard works (after this PR)

```
                    SCANNED AGENT ROOTS                          DISCOVERED TEST FILES
        (must match example_yaml_path's resolution order)     tests/e2e/omnigent/

  examples/<name>/            (dir + config.yaml)  ┐
  examples/<name>.yaml        (agent-spec YAML*)   │
  tests/resources/examples/<name>/  (dir+config)   ├──►  on_disk ─┐      test_example_<name>.py
  tests/resources/examples/<name>.yaml (agent*)    │              │            │
  tests/resources/agents/<name>/    (any dir)      │              │            ▼
  tests/resources/agents/<name>.yaml (agent*)      ┘              │      named_covered
       (* = content-filtered: must have a `name:` key,            │
          so server_config_with_policies.yaml is excluded)        │            │
                                                                  ▼            ▼
                                          ┌──────────────────────────────────────────────┐
                                          │  missing = on_disk - named_covered - ALT       │ must be ∅
                                          │  stale   = named_covered - on_disk - ORPHAN     │ must be ∅
                                          └──────────────────────────────────────────────┘
                                                            ▲
                                                            │
                                       _ALT_COVERED (allow-list): agents whose
                                       coverage lives in a differently-named test
                                       (e.g. databricks_supervisor, web-search-test,
                                        sdk-chat-builtin, ...), each with a pointer.

  THE BUG (before):  the guard scanned only the left column MINUS
  `tests/resources/examples/`, but the test files in the right column resolve
  their agents THROUGH that root. So 5 real test files had no matching agent in
  `on_disk` → counted as `stale` → assertion failed → test suppressed.
```

```mermaid
flowchart TD
    subgraph Roots["Agent roots (now in lock-step with example_yaml_path)"]
        E1["examples/ &mdash; dirs + agent YAMLs"]
        E2["tests/resources/examples/ &mdash; dirs + agent YAMLs<br/><b>(was NOT scanned &rarr; the bug)</b>"]
        E3["tests/resources/agents/ &mdash; dirs + agent YAMLs"]
    end
    Roots --> OD["on_disk: set of agent names"]
    TF["test_example_&lt;name&gt;.py files"] --> NC["named_covered"]
    ALT["_ALT_COVERED allow-list<br/>(coverage in differently-named tests)"] --> CHK
    OD --> CHK{"missing = on_disk - named_covered - ALT == ∅<br/>stale = named_covered - on_disk - ORPHAN == ∅"}
    NC --> CHK
    CHK -->|both empty| PASS["✅ guard passes"]
    CHK -->|non-empty| FAIL["❌ assertion error"]
```

## Per-test decisions (cluster `example-coverage-gap`)

| Test (nodeid) | Decision | Rationale |
|---|---|---|
| `tests/e2e/omnigent/test_examples_coverage_sync.py::test_every_agent_has_a_dedicated_test_file` | **FIXED** | The failure was a guard bug, not a product bug or a real coverage hole. (1) **STALE** half: guard scanned 3 roots while `example_yaml_path` resolves 4 — adding `tests/resources/examples/` makes the 5 "orphaned" test files (`agent_with_os_env`, `agent_with_uc_tools`, `claude_code_agent`, `rate_limited_search_agent`, `secure_research_agent`) match their real agents. (2) **MISSING** half: surfaced agents with no dedicated test — wrote real structural tests for `debby`, `swe_org`, `agent_with_os_env_bwrap`, `agent_with_os_env_seatbelt`; allowlisted `agent_with_client_tools`, `risk_score_agent`, `databricks_supervisor`, `web-search-test`, `workspace-file-writer`, `sdk-chat-builtin` (coverage exists under other names, each with a pointer). Content-filter on top-level YAMLs excludes `server_config_with_policies.yaml` (a server config, not an agent). Removed the entry from `known_failures.yaml`. |

**Tests left suppressed as product bugs:** none. This was a test-infrastructure bug; no product behavior was at fault.

### New test files added
- `tests/e2e/omnigent/test_example_debby.py` — two-headed cross-vendor bundle (claude-sdk + openai-agents heads, unpinned models, `debate` skill, `os_env`).
- `tests/e2e/omnigent/test_example_swe_org.py` — engineering-director org: 5 team roles, deliberate cross-model split, `os_env`, rate-limit + search-budget guardrails.
- `tests/e2e/omnigent/test_example_agent_with_os_env_bwrap.py` — `sandbox: linux_bwrap` + egress allowlist.
- `tests/e2e/omnigent/test_example_agent_with_os_env_seatbelt.py` — `sandbox: darwin_seatbelt` + egress allowlist.
