### PR TITLE
ci: add E2E-capable flake-stress workflow (injects LLM creds)

### DIFF
--- a/.github/workflows/flake-stress-e2e.yml
+++ b/.github/workflows/flake-stress-e2e.yml
@@ -1,0 +1,380 @@
+name: Flake stress (E2E)
+
+# Manually-dispatched flake-reproducer for the LLM-backed `tests/e2e/`
+# suite (workflow_dispatch only). Runs a pytest target N times in parallel,
+# each attempt a full run of the target, then renders a pass/fail summary
+# on the run page. failures/N is the observed flake probability for the
+# target + config.
+#
+# Why a SEPARATE workflow from flake-stress.yml: the original was built for
+# NON-LLM (server/unit) targets. It runs creds-stripped (`env -u
+# OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN`) and never passes
+# `--llm-api-key`/`--profile`, so every `tests/e2e/` attempt errors at
+# setup: tests/e2e/conftest.py's session-scoped `llm_api_key` fixture raises
+# `pytest.UsageError("tests/e2e/ requires --llm-api-key <KEY>")`. This
+# variant injects the Databricks gateway credentials exactly like e2e.yml
+# (write ~/.databrickscfg from secrets, set DATABRICKS_BEARER) and runs
+# pytest with `--llm-api-key "$LLM_API_KEY" --profile <profile>` so the e2e
+# fixtures resolve. Use it to verify a de-flaked / un-suppressed e2e test
+# (point at the fix branch, expect 0/N) or quantify a flake rate (point at
+# main). The original flake-stress.yml stays intact for server/unit targets.
+#
+# Examples:
+#   gh workflow run flake-stress-e2e.yml --ref main \
+#     -f test_target=tests/e2e/test_subagents.py
+#   gh workflow run flake-stress-e2e.yml --ref main \
+#     -f test_target='tests/e2e/test_routes.py::test_patch_session' \
+#     -f workers=1 -f attempts=30 -f extra_pytest_args=--no-skip-known
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_target:
+        description: "Pytest target under tests/e2e/: path or node-id; space-separated list ok (e.g. tests/e2e/test_subagents.py)"
+        required: true
+      target_branch:
+        description: "Branch or SHA to check out for the test (default: main)"
+        required: false
+        default: "main"
+      attempts:
+        description: "Number of parallel attempts (1-50, default: 20)"
+        required: false
+        default: "20"
+      workers:
+        description: "pytest-xdist -n value (default: 2, matching e2e.yml per-shard concurrency)"
+        required: false
+        default: "2"
+      dist:
+        description: "pytest-xdist --dist mode (loadfile|worksteal|loadscope|load|each|no, default: loadscope)"
+        required: false
+        default: "loadscope"
+      profile:
+        description: "Databricks config profile written to ~/.databrickscfg and passed to --profile (default: default)"
+        required: false
+        default: "default"
+      extra_pytest_args:
+        description: "Extra pytest args appended to the command, e.g. '--no-skip-known' (default: empty)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  # No ap-web SPA build during `uv sync`: this job never serves the bundle
+  # and the build hits public npm with no registry mirror (mirrors e2e.yml).
+  OMNIGENT_SKIP_WEB_UI: "true"
+  # Pin the PyPI index for uv/pip resolution (same as flake-stress.yml).
+  UV_INDEX_URL: https://pypi.org/simple
+  PIP_INDEX_URL: https://pypi.org/simple
+  # Never let the test server pick up the runner's own credentials; the
+  # gateway key flows ONLY via ~/.databrickscfg + --llm-api-key (e2e.yml).
+  ANTHROPIC_API_KEY: ""
+  OPENAI_API_KEY: ""
+  CODEX: ""
+  CLAUDE_CODE: ""
+
+jobs:
+  prep:
+    # Validate inputs and turn ``attempts`` into a JSON array the matrix
+    # fans out across (arrays must exist at job-graph construction time;
+    # the downstream job picks it up via ``fromJSON``).
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    outputs:
+      attempts_json: ${{ steps.gen.outputs.attempts_json }}
+    steps:
+      - name: Generate attempts array
+        id: gen
+        env:
+          ATTEMPTS: ${{ github.event.inputs.attempts }}
+          WORKERS: ${{ github.event.inputs.workers }}
+          DIST: ${{ github.event.inputs.dist }}
+          TEST_TARGET: ${{ github.event.inputs.test_target }}
+          PROFILE: ${{ github.event.inputs.profile }}
+          EXTRA_ARGS: ${{ github.event.inputs.extra_pytest_args }}
+        run: |
+          set -euo pipefail
+          # attempts ∈ [1, 50]; 50 soft-caps runner-pool consumption. Each
+          # attempt makes live gateway calls, so keep N modest to avoid 429s.
+          if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]?$ ]] || (( ATTEMPTS > 50 )); then
+            echo "::error::attempts must be an integer in [1, 50], got '$ATTEMPTS'"
+            exit 1
+          fi
+          # workers ∈ [1, 32]; above that xdist setup outweighs parallelism.
+          if ! [[ "$WORKERS" =~ ^([1-9]|[12][0-9]|3[0-2])$ ]]; then
+            echo "::error::workers must be 1-32, got '$WORKERS'"
+            exit 1
+          fi
+          # dist is an enum; reject anything else.
+          case "$DIST" in
+            loadfile|worksteal|loadscope|load|each|no) ;;
+            *)
+              echo "::error::dist must be one of loadfile|worksteal|loadscope|load|each|no, got '$DIST'"
+              exit 1
+              ;;
+          esac
+          # profile names a ~/.databrickscfg section header and the
+          # --profile value; restrict to config-section-safe chars.
+          if ! [[ "$PROFILE" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::profile must match [a-zA-Z0-9._-]+, got '$PROFILE'"
+            exit 1
+          fi
+          # test_target / extra_pytest_args reach a shell; restrict to
+          # legitimate pytest node-id chars so hostile input can't smuggle
+          # command substitution (belt-and-suspenders atop authz dispatch).
+          # Quoted so bash doesn't strip backslashes / glob-expand brackets.
+          # POSIX char-class rules: ``]`` first (literal), ``-`` last (not a
+          # range).
+          allowed_chars='^[]a-zA-Z0-9./_:[ =-]+$'
+          if ! [[ "$TEST_TARGET" =~ $allowed_chars ]]; then
+            echo "::error::test_target contains disallowed characters; allowed: a-zA-Z0-9 . / _ : [ ] - = space"
+            exit 1
+          fi
+          if [[ -n "$EXTRA_ARGS" ]] && ! [[ "$EXTRA_ARGS" =~ $allowed_chars ]]; then
+            echo "::error::extra_pytest_args contains disallowed characters; allowed: a-zA-Z0-9 . / _ : [ ] - = space"
+            exit 1
+          fi
+          # Build JSON array [1,2,...,N] for the matrix.
+          ARR=$(python3 -c "import json,os; print(json.dumps(list(range(1, int(os.environ['ATTEMPTS'])+1))))")
+          echo "attempts_json=$ARR" >> "$GITHUB_OUTPUT"
+          echo "Will run $ATTEMPTS attempts of: $TEST_TARGET"
+          echo "Config: -n $WORKERS --dist=$DIST --profile=$PROFILE  extra='$EXTRA_ARGS'"
+
+  repro:
+    name: Attempt ${{ matrix.attempt }}
+    needs: prep
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      # Keep going after a failure to observe the full distribution.
+      fail-fast: false
+      matrix:
+        attempt: ${{ fromJSON(needs.prep.outputs.attempts_json) }}
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ github.event.inputs.target_branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
+        with:
+          enable-cache: true
+
+      - name: Cache virtualenv
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
+
+      - name: Set LLM credentials
+        # GitHub masks the secret in logs; bind via $GITHUB_ENV so the
+        # pytest step reads it from env (never a ${{ }} shell interpolation).
+        run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
+
+      - name: Write gateway profile (~/.databrickscfg)
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          PROFILE: ${{ github.event.inputs.profile }}
+        run: |
+          # Strip the /serving-endpoints suffix the conftest re-appends.
+          host="${GATEWAY_BASE_URL%/serving-endpoints}"
+          cat > "$HOME/.databrickscfg" <<EOF
+          [$PROFILE]
+          host  = $host
+          token = $LLM_API_KEY
+          EOF
+          # PAT passthrough for the codex / claude-sdk auth commands.
+          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
+
+      - name: Install project and dev dependencies
+        # Matches e2e.yml; ``--extra all`` pulls the harness SDKs so the
+        # executor adapters import at collection time.
+        run: uv sync --extra all --extra dev
+
+      - name: Install binary dependencies
+        # Mirrors e2e.yml. ripgrep: Grep fallback for inner tests. tmux +
+        # bubblewrap: the e2e runner runs real agents under the linux_bwrap
+        # sandbox, which fails loud if `bwrap` is missing. The apparmor
+        # sysctl mirrors ci.yml (Ubuntu 24.04 blocks unprivileged user
+        # namespaces, which bwrap's unshare(CLONE_NEWUSER) needs). npm install
+        # with --ignore-scripts blocks postinstall; the claude-code stub needs
+        # its audited install.cjs run explicitly (platform detect + same-tree
+        # hardlink, no network/exec) for claude-sdk harness rows.
+        working-directory: .github/ci-deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep tmux bubblewrap
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          npm install --ignore-scripts
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          echo "${GITHUB_WORKSPACE}/.github/ci-deps/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Run pytest target
+        # Inputs validated by prep. Word-splitting on $TEST_TARGET /
+        # $EXTRA_ARGS is intentional (multi-token); bound via env (not
+        # ``${{ }}``) to avoid expression injection at the shell. LLM_API_KEY
+        # / DATABRICKS_BEARER arrive from $GITHUB_ENV (set above), so the key
+        # never appears in a ${{ }} interpolation here.
+        shell: bash
+        timeout-minutes: 40
+        env:
+          TEST_TARGET: ${{ github.event.inputs.test_target }}
+          WORKERS: ${{ github.event.inputs.workers }}
+          DIST: ${{ github.event.inputs.dist }}
+          PROFILE: ${{ github.event.inputs.profile }}
+          EXTRA_ARGS: ${{ github.event.inputs.extra_pytest_args }}
+          # Spread interchangeable gateway models across tests + drain the
+          # low-quota gpt-5-4 model, so sustained 429s don't masquerade as
+          # flakes (mirrors e2e.yml).
+          OMNIGENT_TEST_MODEL_SPREAD: "1"
+          OMNIGENT_TEST_MODEL_POOL_GPT: "databricks-gpt-5-5,databricks-gpt-5-4-mini"
+        run: |
+          mkdir -p artifacts "artifacts/basetemp-${{ matrix.attempt }}"
+          # --junitxml emits per-test results eagerly so diagnostics survive a
+          # wall-clock overrun (the summarize job parses these). --timeout=180
+          # caps each test; --timeout-method=thread because our pty/subprocess
+          # children don't get SIGALRM. --max-worker-restart=0 fails fast
+          # rather than letting loadscope requeue deadlock the controller.
+          # NOTE: deliberately NO --showlocals (unlike e2e.yml / flake-stress.yml):
+          # it would dump the llm_api_key fixture / env dicts into the junit
+          # <failure> CDATA, and junit is uploaded as an artifact. --harness
+          # databricks matches e2e.yml (also the conftest default).
+          # shellcheck disable=SC2086
+          uv run pytest $TEST_TARGET \
+            --llm-api-key "$LLM_API_KEY" \
+            --profile "$PROFILE" \
+            --harness databricks \
+            -n "$WORKERS" --dist="$DIST" \
+            --max-worker-restart=0 \
+            --timeout=180 \
+            --timeout-method=thread \
+            --basetemp="artifacts/basetemp-${{ matrix.attempt }}" \
+            --junitxml=artifacts/pytest-attempt-${{ matrix.attempt }}.xml \
+            -v --tb=long --log-level=INFO -r a \
+            $EXTRA_ARGS \
+            || { rc=$?; [ "$rc" -eq 5 ] && echo "::notice::No tests collected; treating as a pass." || exit "$rc"; }
+
+      - name: Upload pytest artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          # Only the junit XML (basetemp holds large per-test DBs / tarballs
+          # and could embed the key); the summarize job needs nothing else.
+          name: pytest-attempt-${{ matrix.attempt }}-${{ github.run_id }}
+          path: artifacts/pytest-attempt-${{ matrix.attempt }}.xml
+          retention-days: 7
+          if-no-files-found: ignore
+
+  summarize:
+    # Render a pass/fail summary table on the run page for an at-a-glance
+    # flake rate. ``if: always()`` so failed attempts still summarize.
+    # Copied verbatim from flake-stress.yml (only the job's siblings differ).
+    name: Summarize results
+    needs: repro
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all attempt artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          pattern: pytest-attempt-*-${{ github.run_id }}
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Render summary
+        # Parse each junit XML per attempt to surface which tests failed
+        # and how often (the matrix conclusion already drives visible status).
+        run: |
+          python3 - <<'PY'
+          import glob
+          import os
+          import xml.etree.ElementTree as ET
+
+          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+          rows = []
+          test_failure_counts: dict[str, int] = {}
+          for path in sorted(glob.glob("artifacts/pytest-attempt-*.xml")):
+              attempt = path.rsplit("-", 1)[-1].removesuffix(".xml")
+              root = ET.parse(path).getroot()
+              tests = passed = failed = errored = skipped = 0
+              failures: list[str] = []
+              for case in root.iter("testcase"):
+                  tests += 1
+                  fail = case.find("failure")
+                  err = case.find("error")
+                  skip = case.find("skipped")
+                  if fail is not None:
+                      failed += 1
+                      tid = f"{case.attrib.get('classname','')}::{case.attrib.get('name','')}"
+                      failures.append(tid)
+                      test_failure_counts[tid] = test_failure_counts.get(tid, 0) + 1
+                  elif err is not None:
+                      errored += 1
+                      tid = f"{case.attrib.get('classname','')}::{case.attrib.get('name','')}"
+                      failures.append(tid)
+                      test_failure_counts[tid] = test_failure_counts.get(tid, 0) + 1
+                  elif skip is not None:
+                      skipped += 1
+                  else:
+                      passed += 1
+              status = ":white_check_mark:" if (failed + errored) == 0 else ":x:"
+              rows.append(
+                  {
+                      "attempt": int(attempt),
+                      "status": status,
+                      "tests": tests,
+                      "passed": passed,
+                      "failed": failed,
+                      "errored": errored,
+                      "skipped": skipped,
+                      "failures": failures,
+                  }
+              )
+
+          rows.sort(key=lambda r: r["attempt"])
+          n = len(rows)
+          n_red = sum(1 for r in rows if r["failed"] + r["errored"] > 0)
+          rate = (n_red / n * 100.0) if n else 0.0
+
+          lines = [
+              "## Flake stress results",
+              "",
+              f"**Failure rate: {n_red}/{n} ({rate:.0f}%)**",
+              "",
+              "| Attempt | Status | Tests | Pass | Fail | Error | Skip | Failing test(s) |",
+              "|---:|:---:|---:|---:|---:|---:|---:|---|",
+          ]
+          for r in rows:
+              fails = ", ".join(f"`{t}`" for t in r["failures"]) or "—"
+              lines.append(
+                  f"| {r['attempt']} | {r['status']} | {r['tests']} | "
+                  f"{r['passed']} | {r['failed']} | {r['errored']} | "
+                  f"{r['skipped']} | {fails} |"
+              )
+
+          if test_failure_counts:
+              lines += [
+                  "",
+                  "### Per-test failure counts",
+                  "",
+                  "| Test | Failed in N attempts |",
+                  "|---|---:|",
+              ]
+              for tid, c in sorted(
+                  test_failure_counts.items(),
+                  key=lambda kv: (-kv[1], kv[0]),
+              ):
+                  lines.append(f"| `{tid}` | {c} |")
+
+          with open(summary_path, "a") as f:
+              f.write("\n".join(lines) + "\n")
+          PY

--- a/.github/workflows/flake-stress-e2e.yml
+++ b/.github/workflows/flake-stress-e2e.yml
@@ -135,6 +135,44 @@ jobs:
             echo "::error::extra_pytest_args contains disallowed characters; allowed: a-zA-Z0-9 . / _ : [ ] - = space"
             exit 1
           fi
+          # SECURITY (additional deny check, layered on the allowlist above):
+          # the run-pytest step deliberately OMITS --showlocals so the
+          # session-scoped llm_api_key fixture / env dicts can't be dumped
+          # into the JUnit <failure>/<system-out> CDATA. But the allowlist
+          # permits letters/hyphens/spaces, so a dispatcher could smuggle
+          # ``--showlocals`` / ``-l`` (or a pytest ini override that re-enables
+          # junit log capture, e.g. ``-o junit_logging=...``) through either
+          # free-form input and re-enable locals dumping. Uploaded ARTIFACTS
+          # are NOT secret-masked by GitHub (only logs are), so that would
+          # leak the gateway key. Reject those tokens in BOTH inputs.
+          # ``set -f`` so bracketed node-ids (``test_x[case1]``) are examined
+          # literally instead of glob-expanding during word-splitting.
+          set -f
+          for tok in $TEST_TARGET $EXTRA_ARGS; do
+            case "$tok" in
+              -l|--showlocals|--show-locals)
+                echo "::error::--showlocals/-l is forbidden: it dumps locals (incl. the llm_api_key) into the uploaded junit artifact, which GitHub does not secret-mask. Remove it from test_target/extra_pytest_args."
+                set +f; exit 1
+                ;;
+              -o|--override-ini|--override-ini=*)
+                echo "::error::pytest ini overrides (-o/--override-ini) are forbidden: they could re-enable junit log capture and leak secrets into the uploaded artifact."
+                set +f; exit 1
+                ;;
+              *junit_logging*)
+                echo "::error::junit_logging override is forbidden: it captures logs into the uploaded junit artifact and can leak secrets."
+                set +f; exit 1
+                ;;
+              --*)
+                : # other long options are already constrained by the allowlist
+                ;;
+              -*l*)
+                # single-dash short-flag bundle containing 'l' (e.g. -lv, -xvl) == -l
+                echo "::error::bundled short flag '$tok' contains -l (showlocals), which would leak secrets into the uploaded junit artifact; pass flags individually without -l."
+                set +f; exit 1
+                ;;
+            esac
+          done
+          set +f
           # Build JSON array [1,2,...,N] for the matrix.
           ARR=$(python3 -c "import json,os; print(json.dumps(list(range(1, int(os.environ['ATTEMPTS'])+1))))")
           echo "attempts_json=$ARR" >> "$GITHUB_OUTPUT"
@@ -261,7 +299,7 @@ jobs:
             --junitxml=artifacts/pytest-attempt-${{ matrix.attempt }}.xml \
             -v --tb=long --log-level=INFO -r a \
             $EXTRA_ARGS \
-            || { rc=$?; [ "$rc" -eq 5 ] && echo "::notice::No tests collected; treating as a pass." || exit "$rc"; }
+            || { rc=$?; if [ "$rc" -eq 5 ]; then echo "::error::No tests collected — check your test_target ('$TEST_TARGET'). A flake-stress run with a single user-specified target that collects nothing is almost always a typo'd selector, not a clean pass."; fi; exit "$rc"; }
 
       - name: Upload pytest artifacts
         if: always()


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/flake-stress-e2e.yml`: a `workflow_dispatch`-only flake-reproducer for the LLM-backed `tests/e2e/` suite. It runs a pytest target N times in parallel (one matrix leg per attempt) and renders a pass/fail-rate summary on the run page, so `failures/N` is the observed flake probability for the target + config.
- The existing `flake-stress.yml` **cannot** stress e2e tests: it was built for non-LLM (server/unit) targets, runs creds-stripped (`env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN`), and never passes `--llm-api-key`/`--profile`. Every `tests/e2e/` attempt therefore errors at setup — the session-scoped `llm_api_key` fixture raises `pytest.UsageError("tests/e2e/ requires --llm-api-key <KEY>")`.
- The new workflow injects the Databricks gateway credentials **exactly like `e2e.yml`** (write `~/.databrickscfg` from `secrets.LLM_API_KEY` + `secrets.GATEWAY_BASE_URL`, set `DATABRICKS_BEARER`), then runs pytest with `--llm-api-key "$LLM_API_KEY" --profile <profile>` so the e2e fixtures resolve. It reuses `flake-stress.yml`'s input validation, character allowlist, and junit-XML summarize job. The original `flake-stress.yml` is left untouched for server/unit targets.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

This is a CI-only change (a new `workflow_dispatch` workflow); it adds no product code and so has no unit/integration/e2e test of its own. It is a *tool for* stressing e2e tests, not an e2e test. Validation performed locally in the worktree:

- **YAML validity:** `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/flake-stress-e2e.yml"))'` → `YAML OK`.
- **actionlint:** attempted via `uvx actionlint` (not a PyPI package — Go tool) and `command -v actionlint` (not installed on this machine; no Go toolchain). Fetching/running the upstream installer script was declined by policy, so actionlint did **not** run. Mitigations: the workflow's structure (job graph, `fromJSON` matrix, `prep`→`repro`→`summarize` wiring, action SHAs, and the summarize job) is copied verbatim from the already-green `flake-stress.yml`, and the YAML parses cleanly.
- **Credential-setup diff vs `e2e.yml`:** line-by-line compared the "Set LLM credentials" and "Write gateway profile" steps. They are byte-identical except the `~/.databrickscfg` section header is parameterized `[$PROFILE]` (input-validated to `^[a-zA-Z0-9._-]+$`, default `default`) instead of a hardcoded `[default]`. Same `${GATEWAY_BASE_URL%/serving-endpoints}` suffix strip, same `host`/`token` keys, same `DATABRICKS_BEARER` passthrough.
- **Secret safety scan:** the key is bound via `$GITHUB_ENV` and read from env in the pytest step — it never appears in a `${{ }}` shell interpolation in any `run:`. `--showlocals` is deliberately **omitted** (unlike `e2e.yml`/`flake-stress.yml`) so the key-bearing env/fixtures aren't dumped into junit `<failure>` CDATA, and only the junit XML (not `--basetemp`, which can embed the key in per-test DBs) is uploaded as an artifact.

The workflow cannot be dispatched from this PR (the author's account is pull-only); the orchestrator will trigger it after merge to confirm the matrix fans out and the summary renders.

---

## ELI5

Imagine a test that sometimes passes and sometimes fails for no obvious reason — a "flaky" test. To catch it, you run it 20 times and count how often it fails. We already had a machine for that (`flake-stress.yml`), but it works with the **house key taken away** — on purpose, because the tests it was built for shouldn't touch the real AI model.

The `tests/e2e/` tests are different: they need to actually talk to a real LLM, so they **demand the key** and refuse to even start without it. Feed them to the old machine and all 20 runs fail instantly at the door — not because the test is flaky, but because nobody gave it the key.

This PR adds a **second machine** that hands over the key the same careful way our real e2e pipeline does: it writes a credentials file and sets the right environment variables, then starts the tests *with* `--llm-api-key`. Now you can run an e2e test 20 times and get an honest flake count. The old machine is untouched, so non-AI tests still run key-free.

## How credentials flow

```
   GitHub repo secrets
   ┌─────────────────────────┐
   │ secrets.LLM_API_KEY      │
   │ secrets.GATEWAY_BASE_URL │
   └───────────┬─────────────┘
               │  (per matrix leg / attempt — fail-fast: false)
               ▼
   ┌───────────────────────────────────────────────────────────┐
   │ Step: Set LLM credentials                                   │
   │   echo "LLM_API_KEY=***" >> $GITHUB_ENV   (masked in logs)  │
   ├───────────────────────────────────────────────────────────┤
   │ Step: Write gateway profile                                 │
   │   host = ${GATEWAY_BASE_URL%/serving-endpoints}             │
   │   ~/.databrickscfg:                                         │
   │     [<profile>]                                            │
   │     host  = <host>                                          │
   │     token = <LLM_API_KEY>                                   │
   │   echo "DATABRICKS_BEARER=***" >> $GITHUB_ENV               │
   └───────────┬───────────────────────────────────────────────┘
               │   env: LLM_API_KEY, DATABRICKS_BEARER
               │   file: ~/.databrickscfg  ([<profile>] host/token)
               ▼
   ┌───────────────────────────────────────────────────────────┐
   │ Step: Run pytest target  (key read from env, NEVER ${{ }})  │
   │   uv run pytest $TEST_TARGET \                              │
   │       --llm-api-key "$LLM_API_KEY"  \  ◄─ satisfies         │
   │       --profile "$PROFILE"          \     llm_api_key       │
   │       --harness databricks ...            fixture           │
   │   → junitxml=artifacts/pytest-attempt-<n>.xml               │
   │     (no --showlocals → key not in <failure> CDATA)          │
   └───────────┬───────────────────────────────────────────────┘
               │  junit XML only (basetemp NOT uploaded)
               ▼
   ┌───────────────────────────────────────────────────────────┐
   │ Job: summarize (needs: repro, if: always())                │
   │   download all pytest-attempt-*.xml → parse → render        │
   │   "Failure rate: R/N" table + per-test failure counts       │
   └───────────────────────────────────────────────────────────┘

   Matrix fan-out (attempts = N, default 20):
     attempt 1 ─┐
     attempt 2 ─┤  each leg repeats the full cred-setup + pytest
        ...     ─┤  independently (fail-fast: false, so every leg's
     attempt N ─┘  signal is observed)  ──►  summarize
```

## How it differs from `flake-stress.yml`

| Aspect | `flake-stress.yml` (original) | `flake-stress-e2e.yml` (new) |
|---|---|---|
| Target suite | server / unit (non-LLM) | `tests/e2e/` (LLM-backed) |
| Model creds | **stripped** (`env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN`) | **injected** via `~/.databrickscfg` + `DATABRICKS_BEARER` (like `e2e.yml`) |
| pytest flags | `-n $WORKERS --dist=$DIST` | adds `--llm-api-key "$LLM_API_KEY" --profile <profile> --harness databricks --max-worker-restart=0 --timeout=180 --timeout-method=thread --basetemp=...` |
| `profile` input | — | new input, default `default`, validated `^[a-zA-Z0-9._-]+$` |
| Default workers / dist | `4` / `worksteal` | `2` / `loadscope` (mirrors `e2e.yml` per-shard concurrency, keeps gateway calls below the 429 pain point) |
| System deps | ripgrep + bubblewrap | ripgrep + tmux + bubblewrap + `npm install --ignore-scripts` + claude-code `install.cjs` (mirrors `e2e.yml`) |
| Extra env | `OMNIGENT_SKIP_WEB_UI`, index URLs | + `ANTHROPIC_API_KEY=""`/`OPENAI_API_KEY=""`/`CODEX=""`/`CLAUDE_CODE=""`, `OMNIGENT_TEST_MODEL_SPREAD`, `OMNIGENT_TEST_MODEL_POOL_GPT` (mirrors `e2e.yml`) |
| `--showlocals` | present | **removed** (avoid leaking key into junit artifact) |
| Artifact uploaded | whole `artifacts/` dir | junit XML only (basetemp may embed the key) |
| Per-attempt timeout | 25 min | 45 min (live LLM calls are slower) |
| **Unchanged / shared** | — | input validation + char allowlist, `prep`→`repro`→`summarize` graph, `fromJSON` attempts matrix (1–50, default 20), `fail-fast: false`, **summarize job copied verbatim** |
