### PR TITLE
fix(sandbox): stop bwrap aborting on a dotfile-mask target that raced away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,12 +144,23 @@ jobs:
           PYTHONFAULTHANDLER: "1"
           PYTEST_PROGRESS_LOG_DIR: artifacts/progress
           OMNIGENT_TOKEN_USAGE_JSON: artifacts/tokens-${{ matrix.group }}.json
-          COVERAGE_FILE: artifacts/.coverage.${{ matrix.group }}
+          # Write coverage data OUTSIDE the repo working dir. coverage.py's
+          # parallel writer (xdist -n) drops transient
+          # ``.coverage.<group>.<host>.pid<N>.<rand>`` files next to
+          # COVERAGE_FILE and renames them away as it combines. When those
+          # landed under the repo (the bwrap sandbox ro-binds cwd), the
+          # dotfile masker could race them: it scanned a transient file,
+          # then bwrap tried to create the now-vanished mountpoint inside a
+          # read-only mount and aborted the helper ("Can't create file ...:
+          # Read-only file system"). Keeping the churn in $RUNNER_TEMP means
+          # the sandbox never sees it. The final combined file is copied back
+          # into artifacts/ below for the coverage-report job to consume.
+          COVERAGE_FILE: ${{ runner.temp }}/omnigent-coverage/.coverage.${{ matrix.group }}
           # sysmon: the default C-trace coverage backend pushed the heaviest
           # shard past its timeout; only line coverage is collected.
           COVERAGE_CORE: sysmon
         run: |
-          mkdir -p artifacts artifacts/progress
+          mkdir -p artifacts artifacts/progress "$(dirname "$COVERAGE_FILE")"
           EXTRA_ARGS=()
           if [[ "$FORCE_ALL_TESTS" == "true" ]]; then
             EXTRA_ARGS=(--no-skip-known)
@@ -167,6 +178,20 @@ jobs:
               -v --tb=long --showlocals --log-level=INFO -r a \
               "${EXTRA_ARGS[@]}" \
               || { rc=$?; [ "$rc" -eq 5 ] && echo "::notice::No tests collected in this shard; treating as a pass." || exit "$rc"; }
+
+      - name: Stage coverage data for upload
+        if: always()
+        shell: bash
+        # COVERAGE_FILE lives under $RUNNER_TEMP (outside the sandboxed repo);
+        # copy the combined per-shard data file back into artifacts/ so the
+        # coverage-report job's ``covdata/**/.coverage.*`` glob still finds it.
+        run: |
+          cov_file="${{ runner.temp }}/omnigent-coverage/.coverage.${{ matrix.group }}"
+          if [[ -f "$cov_file" ]]; then
+            cp "$cov_file" "artifacts/.coverage.${{ matrix.group }}"
+          else
+            echo "::notice::No coverage data file at $cov_file; nothing to stage."
+          fi
 
       - name: Upload pytest artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,17 +144,9 @@ jobs:
           PYTHONFAULTHANDLER: "1"
           PYTEST_PROGRESS_LOG_DIR: artifacts/progress
           OMNIGENT_TOKEN_USAGE_JSON: artifacts/tokens-${{ matrix.group }}.json
-          # Write coverage data OUTSIDE the repo working dir. coverage.py's
-          # parallel writer (xdist -n) drops transient
-          # ``.coverage.<group>.<host>.pid<N>.<rand>`` files next to
-          # COVERAGE_FILE and renames them away as it combines. When those
-          # landed under the repo (the bwrap sandbox ro-binds cwd), the
-          # dotfile masker could race them: it scanned a transient file,
-          # then bwrap tried to create the now-vanished mountpoint inside a
-          # read-only mount and aborted the helper ("Can't create file ...:
-          # Read-only file system"). Keeping the churn in $RUNNER_TEMP means
-          # the sandbox never sees it. The final combined file is copied back
-          # into artifacts/ below for the coverage-report job to consume.
+          # Outside the repo: coverage.py's transient `.coverage.*` files
+          # under the ro-bound cwd raced the sandbox's dotfile masker. Staged
+          # back into artifacts/ below for the coverage-report job.
           COVERAGE_FILE: ${{ runner.temp }}/omnigent-coverage/.coverage.${{ matrix.group }}
           # sysmon: the default C-trace coverage backend pushed the heaviest
           # shard past its timeout; only line coverage is collected.
@@ -182,9 +174,6 @@ jobs:
       - name: Stage coverage data for upload
         if: always()
         shell: bash
-        # COVERAGE_FILE lives under $RUNNER_TEMP (outside the sandboxed repo);
-        # copy the combined per-shard data file back into artifacts/ so the
-        # coverage-report job's ``covdata/**/.coverage.*`` glob still finds it.
         run: |
           cov_file="${{ runner.temp }}/omnigent-coverage/.coverage.${{ matrix.group }}"
           if [[ -f "$cov_file" ]]; then

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -1002,12 +1002,52 @@ def _dotfile_and_symlink_mask_args(
             entries.append(entry)
     args: list[str] = []
     for entry in entries:
+        # Re-stat at the last moment before emitting. A mask mount
+        # overlays /dev/null (file) or a tmpfs (dir) ONTO an existing
+        # path; bwrap never has to create the mountpoint when the
+        # target is still there. But a transient dotfile (e.g. the
+        # ``.coverage.<group>.<host>.pid<N>.<rand>`` files coverage.py
+        # writes-then-renames under cwd while ``--cov`` runs in
+        # parallel) can vanish between the scan above and the ``bwrap``
+        # exec. When that target lives under a read-only bind (cwd is
+        # ro-bound by default), bwrap must CREATE the missing mountpoint
+        # inside a RO mount and aborts the whole sandbox with
+        # "Can't create file ...: Read-only file system" — note that
+        # ``--bind-try`` only tolerates a missing SOURCE (/dev/null
+        # always exists), NOT an uncreatable TARGET. Skipping a target
+        # that no longer exists is safe: there is nothing left to leak,
+        # and every PERSISTENT host dotfile still exists at this point
+        # so it is still masked — the host-dotfile-leak defense is
+        # unchanged.
+        if not _path_exists_lstat(entry.path):
+            continue
         if entry.kind == "dir":
             args.extend(["--tmpfs", str(entry.path)])
         else:
-            # --bind-try: silently skips if the file vanished since scan (TOCTOU).
+            # --bind-try: silently skips if the file vanished between
+            # this re-stat and the exec (narrower residual TOCTOU).
             args.extend(["--bind-try", "/dev/null", str(entry.path)])
     return args
+
+
+def _path_exists_lstat(path: Path) -> bool:
+    """
+    Return whether *path* exists without following a final symlink.
+
+    Used to drop dotfile-mask candidates that raced out from under the
+    scan before the ``bwrap`` exec. ``lstat`` (not ``stat``) so a
+    dangling or escaping symlink still counts as present and gets
+    masked — we want to overlay the link path itself, not its target.
+
+    :param path: Candidate mask target.
+    :returns: ``True`` when the path still exists (including broken
+        symlinks), ``False`` when it has been removed.
+    """
+    try:
+        os.lstat(path)
+    except OSError:
+        return False
+    return True
 
 
 def _scratch_tmpdir(write_roots: list[Path]) -> Path | None:

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -1002,30 +1002,17 @@ def _dotfile_and_symlink_mask_args(
             entries.append(entry)
     args: list[str] = []
     for entry in entries:
-        # Re-stat at the last moment before emitting. A mask mount
-        # overlays /dev/null (file) or a tmpfs (dir) ONTO an existing
-        # path; bwrap never has to create the mountpoint when the
-        # target is still there. But a transient dotfile (e.g. the
-        # ``.coverage.<group>.<host>.pid<N>.<rand>`` files coverage.py
-        # writes-then-renames under cwd while ``--cov`` runs in
-        # parallel) can vanish between the scan above and the ``bwrap``
-        # exec. When that target lives under a read-only bind (cwd is
-        # ro-bound by default), bwrap must CREATE the missing mountpoint
-        # inside a RO mount and aborts the whole sandbox with
-        # "Can't create file ...: Read-only file system" — note that
-        # ``--bind-try`` only tolerates a missing SOURCE (/dev/null
-        # always exists), NOT an uncreatable TARGET. Skipping a target
-        # that no longer exists is safe: there is nothing left to leak,
-        # and every PERSISTENT host dotfile still exists at this point
-        # so it is still masked — the host-dotfile-leak defense is
-        # unchanged.
+        # Re-stat just before emitting: a mask overlays onto an EXISTING
+        # path, so a transient dotfile (e.g. coverage.py's `.coverage.*`)
+        # that vanished since the scan would force bwrap to create the
+        # mountpoint inside the ro-bound cwd and abort. Skipping a gone
+        # target is safe — persistent host dotfiles still exist and are
+        # still masked.
         if not _path_exists_lstat(entry.path):
             continue
         if entry.kind == "dir":
             args.extend(["--tmpfs", str(entry.path)])
         else:
-            # --bind-try: silently skips if the file vanished between
-            # this re-stat and the exec (narrower residual TOCTOU).
             args.extend(["--bind-try", "/dev/null", str(entry.path)])
     return args
 
@@ -1034,10 +1021,8 @@ def _path_exists_lstat(path: Path) -> bool:
     """
     Return whether *path* exists without following a final symlink.
 
-    Used to drop dotfile-mask candidates that raced out from under the
-    scan before the ``bwrap`` exec. ``lstat`` (not ``stat``) so a
-    dangling or escaping symlink still counts as present and gets
-    masked — we want to overlay the link path itself, not its target.
+    ``lstat`` (not ``stat``) so a dangling / escaping symlink still
+    counts as present and gets masked.
 
     :param path: Candidate mask target.
     :returns: ``True`` when the path still exists (including broken

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -769,6 +769,64 @@ def test_dotfile_masking_hides_disallowed_dotfiles(tmp_path: Path) -> None:
     assert not _argv_mentions(argv, regular_path, after_token="--bind-try")
 
 
+def test_dotfile_masking_skips_target_that_vanished_after_scan(
+    tmp_path: Path,
+) -> None:
+    """
+    A dotfile that the scan saw but that no longer exists when the
+    argv is assembled produces NO mask triple — the TOCTOU race that
+    used to abort the helper.
+
+    Repro of the flaky CI failure: ``--cov`` under ``pytest -n``
+    drops transient ``.coverage.<group>.<host>.pid<N>.<rand>`` files
+    under cwd, which is ro-bound into the sandbox, then renames them
+    away. The masker scanned a transient file and emitted
+    ``--bind-try /dev/null <path>``; by exec time the file was gone,
+    so bwrap had to CREATE the mountpoint inside a read-only mount
+    and died with "Can't create file ...: Read-only file system".
+    ``--bind-try`` only tolerates a missing SOURCE (/dev/null), not
+    an uncreatable TARGET, so the last-moment re-stat must drop the
+    candidate entirely.
+
+    A persistent dotfile present alongside the vanished one is still
+    masked — the host-dotfile-leak defense is unchanged.
+    """
+    from omnigent.inner import bwrap_sandbox
+    from omnigent.inner._cwd_scan import MaskedEntry
+
+    cwd = tmp_path.resolve(strict=False)
+    # A persistent secret that must stay masked.
+    (tmp_path / ".env").write_text("SECRET=42")
+    present_path = cwd / ".env"
+    # A transient coverage data file the scan "saw" but that has been
+    # renamed/removed before the argv is built — never created on disk.
+    vanished_path = cwd / ".coverage.inner-rest.host.pid2942.XbRGYxCx"
+
+    real_scan = bwrap_sandbox.scan_cwd_mask_entries
+
+    def _scan_with_phantom(*args: object, **kwargs: object) -> list[MaskedEntry]:
+        entries = list(real_scan(*args, **kwargs))  # type: ignore[arg-type]
+        entries.append(MaskedEntry(path=vanished_path, kind="file"))
+        return entries
+
+    backend = _make_backend()
+    policy = _make_policy(tmp_path, allow_hidden=[".venv"])
+    with patch.object(bwrap_sandbox, "scan_cwd_mask_entries", _scan_with_phantom):
+        argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    # The persistent dotfile is still masked.
+    assert _has_pair(argv, "--bind-try", "/dev/null", str(present_path)), (
+        ".env (present) should still be masked with --bind-try /dev/null."
+    )
+    # The vanished target produces no mask of any kind — nothing for
+    # bwrap to create a mountpoint for inside the ro-bound cwd.
+    assert _index_of_triple(argv, "--bind-try", "/dev/null", str(vanished_path)) is None, (
+        "A vanished dotfile must NOT be masked — bwrap would have to "
+        "create the mountpoint inside the read-only cwd bind and abort. "
+        f"argv slice: {[t for t in argv if 'coverage' in t]}"
+    )
+
+
 # NOTE: walker-decision tests (escape symlink defense, recursion,
 # allow_hidden basename matching, the three overflow modes) moved to
 # ``tests/inner/test_cwd_scan.py``. That suite asserts the

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -773,33 +773,19 @@ def test_dotfile_masking_skips_target_that_vanished_after_scan(
     tmp_path: Path,
 ) -> None:
     """
-    A dotfile that the scan saw but that no longer exists when the
-    argv is assembled produces NO mask triple — the TOCTOU race that
-    used to abort the helper.
-
-    Repro of the flaky CI failure: ``--cov`` under ``pytest -n``
-    drops transient ``.coverage.<group>.<host>.pid<N>.<rand>`` files
-    under cwd, which is ro-bound into the sandbox, then renames them
-    away. The masker scanned a transient file and emitted
-    ``--bind-try /dev/null <path>``; by exec time the file was gone,
-    so bwrap had to CREATE the mountpoint inside a read-only mount
-    and died with "Can't create file ...: Read-only file system".
-    ``--bind-try`` only tolerates a missing SOURCE (/dev/null), not
-    an uncreatable TARGET, so the last-moment re-stat must drop the
-    candidate entirely.
-
-    A persistent dotfile present alongside the vanished one is still
-    masked — the host-dotfile-leak defense is unchanged.
+    A dotfile the scan saw but that vanished before the argv is built
+    produces NO mask triple — otherwise bwrap would try to create the
+    mountpoint inside the ro-bound cwd and abort (the flaky CI failure,
+    where coverage.py's transient ``.coverage.*`` files raced the scan).
+    A persistent dotfile alongside it is still masked.
     """
     from omnigent.inner import bwrap_sandbox
     from omnigent.inner._cwd_scan import MaskedEntry
 
     cwd = tmp_path.resolve(strict=False)
-    # A persistent secret that must stay masked.
     (tmp_path / ".env").write_text("SECRET=42")
     present_path = cwd / ".env"
-    # A transient coverage data file the scan "saw" but that has been
-    # renamed/removed before the argv is built — never created on disk.
+    # Never created on disk: simulates a file renamed away after the scan.
     vanished_path = cwd / ".coverage.inner-rest.host.pid2942.XbRGYxCx"
 
     real_scan = bwrap_sandbox.scan_cwd_mask_entries
@@ -814,12 +800,9 @@ def test_dotfile_masking_skips_target_that_vanished_after_scan(
     with patch.object(bwrap_sandbox, "scan_cwd_mask_entries", _scan_with_phantom):
         argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
 
-    # The persistent dotfile is still masked.
     assert _has_pair(argv, "--bind-try", "/dev/null", str(present_path)), (
         ".env (present) should still be masked with --bind-try /dev/null."
     )
-    # The vanished target produces no mask of any kind — nothing for
-    # bwrap to create a mountpoint for inside the ro-bound cwd.
     assert _index_of_triple(argv, "--bind-try", "/dev/null", str(vanished_path)) is None, (
         "A vanished dotfile must NOT be masked — bwrap would have to "
         "create the mountpoint inside the read-only cwd bind and abort. "


### PR DESCRIPTION
## Problem

`tests/inner/sandbox/test_egress_e2e.py::test_s2_egress_blocks_private_destination_by_default[linux_bwrap]` flakes in CI:

```
AssertionError: {'error': "os_env helper failed: OS environment helper exited with code None: bwrap: Can't create file at .../artifacts/.coverage.inner-rest.runnervm1li68.pid2942.XbRGYxCx: Read-only file system"}
```

## Root cause (TOCTOU in the bwrap dotfile masker)

1. CI runs pytest with `COVERAGE_FILE: artifacts/.coverage.<group>` and `--cov` in parallel (`-n 8`). coverage.py's parallel writer drops transient per-process `.coverage.<group>.<host>.pid<N>.<rand>` files next to `COVERAGE_FILE`, then renames/combines them away.
2. The bwrap sandbox binds `cwd` **read-only**, and `artifacts/` lives under cwd.
3. To prevent host-dotfile leaks, the sandbox walks cwd and masks every dotfile by emitting `--bind-try /dev/null <path>`. The `.coverage.*` files match.
4. A `--bind-try` mask works by overlaying `/dev/null` **onto an existing target** — bwrap never has to create the mountpoint when the target is present. But a transient `.coverage.*` file seen at scan time can **vanish before the `bwrap` exec**. bwrap then has to *create* the missing mountpoint inside the read-only cwd bind → `Can't create file ...: Read-only file system` → helper aborts → test fails. `--bind-try` only tolerates a missing **source** (`/dev/null`), not an uncreatable **target**.

## Fix (two layers)

**1. Sandbox robustness (`bwrap_sandbox.py`)** — re-`lstat` each mask candidate at the last moment before emitting and skip it if it no longer exists. Persistent host dotfiles always exist at that point, so the leak defense is unchanged; only vanished transient targets are dropped. Applies to both file and dir masks. `lstat` (not `stat`) so dangling/escaping symlinks still get masked.

**2. CI removes the cause (`ci.yml`)** — point `COVERAGE_FILE` at `$RUNNER_TEMP` so the coverage write/rename churn never lands under the sandboxed repo. A new "Stage coverage data for upload" step copies the combined per-shard file back into `artifacts/` so the `coverage-report` job's `covdata/**/.coverage.*` glob still finds it.

## Test

Adds `test_dotfile_masking_skips_target_that_vanished_after_scan`: injects a phantom (vanished) `.coverage.*` entry into the scan results and asserts **no** mask triple is emitted for it, while a present `.env` is still masked. Verified it fails without the sandbox guard and passes with it.

## Notes

The 4 pre-existing `test_resolve_*` failures on macOS are unrelated (bwrap is Linux-only); confirmed they fail identically on clean `main`.
