### PR TITLE
ci: add Polly AI review workflow for new PRs

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -24,8 +24,14 @@ env:
   PIP_INDEX_URL: https://pypi.org/simple
 
 jobs:
+  # Security precondition gate (security-gate.yml): untrusted PRs wait for the
+  # scan; trusted authors / non-PR events pass through.
+  gate:
+    uses: ./.github/workflows/security-gate.yml
+
   review:
     name: Polly AI Review
+    needs: gate
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -166,12 +172,27 @@ jobs:
           ${diff}
           \`\`\`
 
+          ## Component domains
+          Classify every changed file into one of these domains and organise
+          your feedback accordingly:
+
+          | Label | Scope | Domain experts |
+          |-------|-------|----------------|
+          | comp:core | server routes, runner, store, forwarders, orchestration | core runtime team |
+          | comp:web-ui | ap-web frontend (React/TS), styles, assets | web/frontend team |
+          | comp:sandbox | sandbox policies, bubblewrap, isolation | core runtime team (sandbox specialists) |
+          | comp:sdk | SDK clients, harness adapters, inner executors | SDK team |
+          | comp:cli | CLI entrypoints, argument parsing | CLI owners |
+          | comp:ci | GitHub Actions workflows, CI scripts | infra team |
+          | comp:docs | docs, README, API.md, changelogs | rotates across all teams |
+
           ## Instructions
-          Review the diff against the PR description. Report:
+          Review the diff against the PR description. For each domain that has
+          changes, report:
           1. **Blocking issues** — bugs, security problems, correctness errors, data loss risks.
           2. **Non-blocking suggestions** — style, naming, performance, test coverage gaps.
-          3. **Summary** — one-paragraph overall assessment.
 
+          End with a short **Summary** — one-paragraph overall assessment.
           Be concise. Do not restate the diff. Focus on what matters.
           PROMPT_EOF
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -194,8 +194,10 @@ jobs:
           mkdir -p "$HOME/.omnigent"
           # Use python to write the config safely — avoids interpolating
           # secrets/URLs into a heredoc where special chars could break YAML.
+          # Uses json (stdlib) instead of yaml to avoid needing PyYAML on
+          # the system python; the output is valid YAML (JSON is a subset).
           python3 -c "
-          import pathlib, os, yaml
+          import pathlib, os, json
           gw = os.environ['GATEWAY_BASE_URL']
           host = gw.removesuffix('/serving-endpoints')
           cfg = {
@@ -218,7 +220,7 @@ jobs:
               }
           }
           pathlib.Path.home().joinpath('.omnigent', 'config.yaml').write_text(
-              yaml.safe_dump(cfg, default_flow_style=False)
+              json.dumps(cfg, indent=2)
           )
           "
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -318,6 +318,8 @@ jobs:
         run: |
           # Each omnigent process writes its own /tmp/polly-tokens-*.json
           # file. Aggregate all of them into totals.
+          echo "Token files found:"
+          ls -la /tmp/polly-tokens*.json 2>/dev/null || echo "  (none)"
           python3 <<'PYEOF'
           import glob, json, os
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -373,7 +373,7 @@ jobs:
           set -euo pipefail
 
           # Build the comment body safely — REVIEW_TEXT is passed via env
-          # (not ${{ }} interpolation) to avoid expression injection.
+          # (not expression interpolation) to avoid expression injection.
           {
             echo "## <img src=\"https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg\" alt=\"\" height=\"20\" valign=\"middle\" /> Polly AI Review"
             echo ""

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -207,9 +207,10 @@ jobs:
 
           # Run Polly headlessly with -p; it starts a local server, sends
           # one turn, prints the assistant response, and exits.
+          # --no-session: ephemeral run, no persistent session state.
           uv run omnigent run examples/polly/ \
             -p "$prompt" \
-            --ephemeral \
+            --no-session \
             2>polly-stderr.log \
             | tee /tmp/polly_output.txt \
             || { echo "::warning::Polly review exited non-zero"; cat polly-stderr.log; }

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -5,17 +5,23 @@ name: Polly AI Review
 # complete, and posts the findings as a PR comment. Uses the same LLM
 # gateway secrets as the e2e suite (LLM_API_KEY + GATEWAY_BASE_URL).
 # Draft PRs are skipped (ready_for_review re-fires).
+#
+# Triggers:
+#   - pull_request opened/synchronize/reopened/ready_for_review (automatic)
+#   - `/review` comment on a PR (manual retrigger by write-access users)
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: polly-review-${{ github.event.pull_request.number }}
+  group: polly-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 env:
@@ -32,28 +38,87 @@ jobs:
   review:
     name: Polly AI Review
     needs: gate
-    if: ${{ !github.event.pull_request.draft }}
+    # Fire on non-draft PRs OR on `/review` comments on PRs by write-access users.
+    if: >-
+      (
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '/review') &&
+        !endsWith(github.actor, '[bot]') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Validate /review command
+        id: trigger
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # Validate `/review` appears as a command (first non-space token on a line).
+          if ! grep -qE '^[[:space:]]*/review([[:space:]]|$)' <<<"$COMMENT_BODY"; then
+            echo "::notice::Comment mentions '/review' but not as a command; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # React with eyes to acknowledge.
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes --silent || true
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PR number and head ref
+        if: steps.trigger.outputs.skip != 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Check out repo
+        if: steps.trigger.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # Fetch enough history for the diff; the PR head is checked out
-          # by default for pull_request events.
+          ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Set up Python
+        if: steps.trigger.outputs.skip != 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version-file: ".python-version"
 
       - name: Set up uv
+        if: steps.trigger.outputs.skip != 'true'
         uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
         with:
           enable-cache: true
 
       - name: Install bubblewrap
+        if: steps.trigger.outputs.skip != 'true'
         # bubblewrap: the linux_bwrap sandbox backend needs bwrap on PATH.
         # apparmor sysctl: Ubuntu 24.04 blocks unprivileged user namespaces
         # that bwrap's unshare(CLONE_NEWUSER) needs; scope is the ephemeral runner.
@@ -63,15 +128,18 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Cache virtualenv
+        if: steps.trigger.outputs.skip != 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
+        if: steps.trigger.outputs.skip != 'true'
         run: uv sync --extra all --extra dev
 
       - name: Install Claude Code CLI
+        if: steps.trigger.outputs.skip != 'true'
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
@@ -81,6 +149,7 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI
+        if: steps.trigger.outputs.skip != 'true'
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
@@ -89,16 +158,17 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Set LLM credentials
+        if: steps.trigger.outputs.skip != 'true'
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: echo "LLM_API_KEY=${LLM_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Write gateway profile (~/.databrickscfg)
+        if: steps.trigger.outputs.skip != 'true'
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
-          host="${GATEWAY_BASE_URL%/serving-endpoints}"
           # Use python to write the config safely — avoids interpolating
           # secrets into a heredoc where special chars could break YAML.
           python3 -c "
@@ -112,6 +182,7 @@ jobs:
           echo "DATABRICKS_BEARER=${LLM_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Write Omnigent provider config
+        if: steps.trigger.outputs.skip != 'true'
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
         run: |
@@ -147,11 +218,12 @@ jobs:
           "
 
       - name: Collect PR context
+        if: steps.trigger.outputs.skip != 'true'
         id: ctx
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
           set -euo pipefail
 
@@ -202,6 +274,7 @@ jobs:
           PYEOF
 
       - name: Run Polly review
+        if: steps.trigger.outputs.skip != 'true'
         id: polly
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
@@ -233,7 +306,7 @@ jobs:
 
       - name: Aggregate token usage
         id: usage
-        if: always()
+        if: always() && steps.trigger.outputs.skip != 'true'
         run: |
           # Each omnigent process writes its own /tmp/polly-tokens-*.json
           # file. Aggregate all of them into totals.
@@ -287,7 +360,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           REVIEW_TEXT: ${{ steps.polly.outputs.review_text }}
           USAGE_SUMMARY: ${{ steps.usage.outputs.usage_summary }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -310,7 +383,22 @@ jobs:
             echo "$footer"
           } > /tmp/comment.md
 
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+          # Upsert: edit the existing Polly comment if one exists, otherwise create.
+          # Look for the marker image in existing comments.
+          existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("Polly AI Review")) | .id' \
+            | tail -1)
+
+          if [ -n "$existing_id" ]; then
+            gh api "repos/${REPO}/issues/comments/${existing_id}" \
+              -X PATCH \
+              --input /tmp/comment.md \
+              -f body="$(cat /tmp/comment.md)" > /dev/null
+            echo "Updated existing comment ${existing_id}"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+            echo "Created new comment"
+          fi
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -1,0 +1,233 @@
+name: Polly AI Review
+
+# Spins up a local Omnigent server + runner inside the CI runner, starts a
+# Polly session with the PR diff, waits for the cross-vendor review to
+# complete, and posts the findings as a PR comment. Uses the same LLM
+# gateway secrets as the e2e suite (LLM_API_KEY + GATEWAY_BASE_URL).
+# Draft PRs are skipped (ready_for_review re-fires).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: polly-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  OMNIGENT_SKIP_WEB_UI: "true"
+  UV_INDEX_URL: https://pypi.org/simple
+  PIP_INDEX_URL: https://pypi.org/simple
+
+jobs:
+  review:
+    name: Polly AI Review
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Fetch enough history for the diff; the PR head is checked out
+          # by default for pull_request events.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
+        with:
+          enable-cache: true
+
+      - name: Install bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap tmux
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Cache virtualenv
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install dependencies
+        run: uv sync --extra all --extra dev
+
+      - name: Install Claude Code CLI
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Install Codex CLI
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.codex-cli" && cd "${GITHUB_WORKSPACE}/.codex-cli"
+          npm install --ignore-scripts --no-audit --no-fund @openai/codex@0.128.0-alpha.1
+          echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Set LLM credentials
+        run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
+
+      - name: Write gateway profile (~/.databrickscfg)
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          host="${GATEWAY_BASE_URL%/serving-endpoints}"
+          cat > "$HOME/.databrickscfg" <<EOF
+          [default]
+          host  = $host
+          token = $LLM_API_KEY
+          EOF
+          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
+
+      - name: Write Omnigent provider config
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+        run: |
+          mkdir -p "$HOME/.omnigent"
+          # The Anthropic Messages surface and the Codex Responses surface live
+          # at different paths off the same workspace host. GATEWAY_BASE_URL is
+          # <host>/serving-endpoints (the OpenAI-compatible surface); strip that
+          # suffix to recover the bare host for the codex /ai-gateway path.
+          host="${GATEWAY_BASE_URL%/serving-endpoints}"
+          cat > "$HOME/.omnigent/config.yaml" <<EOF
+          providers:
+            databricks-gateway:
+              kind: gateway
+              default: [anthropic, openai]
+              anthropic:
+                base_url: "${GATEWAY_BASE_URL}/anthropic"
+                api_key_ref: "env:LLM_API_KEY"
+                models:
+                  default: databricks-claude-sonnet-4-6
+              openai:
+                base_url: "${host}/ai-gateway/codex/v1"
+                api_key_ref: "env:LLM_API_KEY"
+                wire_api: responses
+                models:
+                  default: databricks-gpt-5-4-mini
+          EOF
+
+      - name: Collect PR context
+        id: ctx
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Fetch the diff (capped at 64 KB to stay within prompt limits).
+          diff=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+            -H "Accept: application/vnd.github.v3.diff" \
+            | head -c 65536)
+
+          # Fetch PR metadata.
+          pr_json=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json title,body,baseRefName,headRefName,additions,deletions,changedFiles)
+
+          title=$(echo "$pr_json" | jq -r '.title')
+          body=$(echo "$pr_json"  | jq -r '.body // ""' | head -c 4096)
+          base=$(echo "$pr_json"  | jq -r '.baseRefName')
+          head_ref=$(echo "$pr_json"  | jq -r '.headRefName')
+          adds=$(echo "$pr_json"  | jq -r '.additions')
+          dels=$(echo "$pr_json"  | jq -r '.deletions')
+          files=$(echo "$pr_json" | jq -r '.changedFiles')
+
+          # Build the review prompt and persist to file (avoids shell escaping).
+          cat > /tmp/review_prompt.txt <<PROMPT_EOF
+          Review this pull request and provide structured feedback.
+
+          ## PR Metadata
+          - **Title:** ${title}
+          - **Branch:** ${head_ref} → ${base}
+          - **Stats:** +${adds} / -${dels} across ${files} file(s)
+
+          ## PR Description
+          ${body}
+
+          ## Diff
+          \`\`\`diff
+          ${diff}
+          \`\`\`
+
+          ## Instructions
+          Review the diff against the PR description. Report:
+          1. **Blocking issues** — bugs, security problems, correctness errors, data loss risks.
+          2. **Non-blocking suggestions** — style, naming, performance, test coverage gaps.
+          3. **Summary** — one-paragraph overall assessment.
+
+          Be concise. Do not restate the diff. Focus on what matters.
+          PROMPT_EOF
+
+      - name: Run Polly review
+        id: polly
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          prompt=$(cat /tmp/review_prompt.txt)
+
+          # Run Polly headlessly with -p; it starts a local server, sends
+          # one turn, prints the assistant response, and exits.
+          uv run omnigent run examples/polly/ \
+            -p "$prompt" \
+            --ephemeral \
+            2>polly-stderr.log \
+            | tee /tmp/polly_output.txt \
+            || { echo "::warning::Polly review exited non-zero"; cat polly-stderr.log; }
+
+          echo "review_text<<REVIEW_EOF" >> "$GITHUB_OUTPUT"
+          cat /tmp/polly_output.txt >> "$GITHUB_OUTPUT"
+          echo "REVIEW_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post review comment
+        if: steps.polly.outputs.review_text != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          cat > /tmp/comment.md <<'COMMENT_EOF'
+          ## Polly AI Review
+
+          COMMENT_EOF
+
+          echo "${{ steps.polly.outputs.review_text }}" >> /tmp/comment.md
+
+          cat >> /tmp/comment.md <<'COMMENT_EOF'
+
+          ---
+          <sub>Automated review by Polly · [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>
+          COMMENT_EOF
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: polly-review-logs-${{ github.run_id }}
+          path: |
+            polly-stderr.log
+            /tmp/polly_output.txt
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -205,6 +205,7 @@ jobs:
         id: polly
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          OMNIGENT_TOKEN_USAGE_JSON: /tmp/polly-tokens.json
         run: |
           set -euo pipefail
 
@@ -213,6 +214,8 @@ jobs:
           # Run Polly headlessly with -p; it starts a local server, sends
           # one turn, prints the assistant response, and exits.
           # --no-session: ephemeral run, no persistent session state.
+          # OMNIGENT_TOKEN_USAGE_JSON: each process writes a PID-suffixed
+          # JSON file with token counts; we aggregate them below.
           uv run omnigent run examples/polly/ \
             -p "$prompt" \
             --no-session \
@@ -228,6 +231,57 @@ jobs:
           head -c 61440 /tmp/polly_output.txt >> "$GITHUB_OUTPUT"
           echo "${delim}" >> "$GITHUB_OUTPUT"
 
+      - name: Aggregate token usage
+        id: usage
+        if: always()
+        run: |
+          # Each omnigent process writes its own /tmp/polly-tokens-*.json
+          # file. Aggregate all of them into totals.
+          python3 <<'PYEOF'
+          import glob, json, os
+
+          totals = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "calls": 0}
+          by_model = {}
+
+          for path in glob.glob("/tmp/polly-tokens*.json"):
+              try:
+                  data = json.loads(open(path).read())
+              except (json.JSONDecodeError, OSError):
+                  continue
+              for bucket in data.values():
+                  for k in ("input_tokens", "output_tokens", "total_tokens", "calls"):
+                      totals[k] += bucket.get(k, 0)
+                  for model, mu in bucket.get("by_model", {}).items():
+                      agg = by_model.setdefault(model, {"input_tokens": 0, "output_tokens": 0, "calls": 0})
+                      agg["input_tokens"] += mu.get("input_tokens", 0)
+                      agg["output_tokens"] += mu.get("output_tokens", 0)
+                      agg["calls"] += mu.get("calls", 0)
+
+          # Format a compact summary line.
+          inp = totals["input_tokens"]
+          out = totals["output_tokens"]
+          calls = totals["calls"]
+
+          def fmt(n):
+              if n >= 1_000_000:
+                  return f"{n / 1_000_000:.1f}M"
+              if n >= 1_000:
+                  return f"{n / 1_000:.1f}k"
+              return str(n)
+
+          parts = [f"{fmt(inp)} input", f"{fmt(out)} output", f"{calls} calls"]
+          if by_model:
+              model_parts = []
+              for m, u in sorted(by_model.items(), key=lambda x: -x[1]["input_tokens"]):
+                  model_parts.append(f"{m}: {fmt(u['input_tokens'])}→{fmt(u['output_tokens'])}")
+              parts.append("models: " + ", ".join(model_parts))
+
+          summary = " · ".join(parts)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"usage_summary={summary}\n")
+          print(f"Token usage: {summary}")
+          PYEOF
+
       - name: Post review comment
         if: steps.polly.outputs.review_text != ''
         env:
@@ -235,6 +289,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_TEXT: ${{ steps.polly.outputs.review_text }}
+          USAGE_SUMMARY: ${{ steps.usage.outputs.usage_summary }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -247,7 +302,12 @@ jobs:
             echo "$REVIEW_TEXT"
             echo ""
             echo "---"
-            echo "<sub>Automated review by Polly · [workflow run](${RUN_URL})</sub>"
+            footer="<sub>Automated review by Polly"
+            if [ -n "$USAGE_SUMMARY" ]; then
+              footer="${footer} · tokens: ${USAGE_SUMMARY}"
+            fi
+            footer="${footer} · [workflow run](${RUN_URL})</sub>"
+            echo "$footer"
           } > /tmp/comment.md
 
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -15,13 +15,19 @@ on:
     types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to review.
+        required: true
+        type: string
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: polly-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: polly-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
   cancel-in-progress: true
 
 env:
@@ -38,7 +44,8 @@ jobs:
   review:
     name: Polly AI Review
     needs: gate
-    # Fire on non-draft PRs OR on `/review` comments on PRs by write-access users.
+    # Fire on non-draft PRs, `/review` comments by write-access users,
+    # or workflow_dispatch with a PR number.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -54,7 +61,8 @@ jobs:
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR'
         )
-      )
+      ) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -83,16 +91,13 @@ jobs:
       - name: Resolve PR number
         if: steps.trigger.outputs.skip != 'true'
         id: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ github.event_name }}" in
+            issue_comment)      echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT" ;;
+            workflow_dispatch)   echo "pr_number=${{ inputs.pr }}" >> "$GITHUB_OUTPUT" ;;
+            *)                  echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       # Always check out the default branch (trusted). The PR diff is
       # fetched via the API — we never execute PR-authored code. This

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -7,8 +7,9 @@ name: Polly AI Review
 # Draft PRs are skipped (ready_for_review re-fires).
 #
 # Triggers:
-#   - pull_request opened/synchronize/reopened/ready_for_review (automatic)
+#   - pull_request opened/reopened/ready_for_review (automatic, once per PR)
 #   - `/review` comment on a PR (manual retrigger by write-access users)
+#   - workflow_dispatch with a PR number (manual retrigger from Actions tab)
 
 on:
   pull_request:
@@ -397,10 +398,10 @@ jobs:
             | tail -1)
 
           if [ -n "$existing_id" ]; then
+            # Use -F to read body from file via jq-style @-prefixed path.
             gh api "repos/${REPO}/issues/comments/${existing_id}" \
               -X PATCH \
-              --input /tmp/comment.md \
-              -f body="$(cat /tmp/comment.md)" > /dev/null
+              -F "body=@/tmp/comment.md" > /dev/null
             echo "Updated existing comment ${existing_id}"
           else
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -80,7 +80,7 @@ jobs:
             -f content=eyes --silent || true
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve PR number and head ref
+      - name: Resolve PR number
         if: steps.trigger.outputs.skip != 'true'
         id: pr
         env:
@@ -89,21 +89,21 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            PR_NUMBER="${{ github.event.issue.number }}"
-            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+            echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           else
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           fi
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
+      # Always check out the default branch (trusted). The PR diff is
+      # fetched via the API — we never execute PR-authored code. This
+      # avoids the TOCTOU issue CodeQL flags when issue_comment checks
+      # out untrusted PR code in a privileged workflow.
       - name: Check out repo
         if: steps.trigger.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ steps.pr.outputs.head_sha }}
-          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Set up Python
         if: steps.trigger.outputs.skip != 'true'

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -368,7 +368,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           REVIEW_TEXT: ${{ steps.polly.outputs.review_text }}
           USAGE_SUMMARY: ${{ steps.usage.outputs.usage_summary }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -12,7 +12,7 @@ name: Polly AI Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -54,6 +54,9 @@ jobs:
           enable-cache: true
 
       - name: Install bubblewrap
+        # bubblewrap: the linux_bwrap sandbox backend needs bwrap on PATH.
+        # apparmor sysctl: Ubuntu 24.04 blocks unprivileged user namespaces
+        # that bwrap's unshare(CLONE_NEWUSER) needs; scope is the ephemeral runner.
         run: |
           sudo apt-get update
           sudo apt-get install -y bubblewrap tmux
@@ -86,7 +89,9 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Set LLM credentials
-        run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: echo "LLM_API_KEY=${LLM_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Write gateway profile (~/.databrickscfg)
         env:
@@ -94,40 +99,52 @@ jobs:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           host="${GATEWAY_BASE_URL%/serving-endpoints}"
-          cat > "$HOME/.databrickscfg" <<EOF
-          [default]
-          host  = $host
-          token = $LLM_API_KEY
-          EOF
-          echo "DATABRICKS_BEARER=$LLM_API_KEY" >> "$GITHUB_ENV"
+          # Use python to write the config safely — avoids interpolating
+          # secrets into a heredoc where special chars could break YAML.
+          python3 -c "
+          import pathlib, os
+          cfg = '[default]\nhost  = {host}\ntoken = {token}\n'.format(
+              host=os.environ['GATEWAY_BASE_URL'].removesuffix('/serving-endpoints'),
+              token=os.environ['LLM_API_KEY'],
+          )
+          pathlib.Path.home().joinpath('.databrickscfg').write_text(cfg)
+          "
+          echo "DATABRICKS_BEARER=${LLM_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Write Omnigent provider config
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
         run: |
           mkdir -p "$HOME/.omnigent"
-          # The Anthropic Messages surface and the Codex Responses surface live
-          # at different paths off the same workspace host. GATEWAY_BASE_URL is
-          # <host>/serving-endpoints (the OpenAI-compatible surface); strip that
-          # suffix to recover the bare host for the codex /ai-gateway path.
-          host="${GATEWAY_BASE_URL%/serving-endpoints}"
-          cat > "$HOME/.omnigent/config.yaml" <<EOF
-          providers:
-            databricks-gateway:
-              kind: gateway
-              default: [anthropic, openai]
-              anthropic:
-                base_url: "${GATEWAY_BASE_URL}/anthropic"
-                api_key_ref: "env:LLM_API_KEY"
-                models:
-                  default: databricks-claude-sonnet-4-6
-              openai:
-                base_url: "${host}/ai-gateway/codex/v1"
-                api_key_ref: "env:LLM_API_KEY"
-                wire_api: responses
-                models:
-                  default: databricks-gpt-5-4-mini
-          EOF
+          # Use python to write the config safely — avoids interpolating
+          # secrets/URLs into a heredoc where special chars could break YAML.
+          python3 -c "
+          import pathlib, os, yaml
+          gw = os.environ['GATEWAY_BASE_URL']
+          host = gw.removesuffix('/serving-endpoints')
+          cfg = {
+              'providers': {
+                  'databricks-gateway': {
+                      'kind': 'gateway',
+                      'default': ['anthropic', 'openai'],
+                      'anthropic': {
+                          'base_url': gw + '/anthropic',
+                          'api_key_ref': 'env:LLM_API_KEY',
+                          'models': {'default': 'databricks-claude-sonnet-4-6'},
+                      },
+                      'openai': {
+                          'base_url': host + '/ai-gateway/codex/v1',
+                          'api_key_ref': 'env:LLM_API_KEY',
+                          'wire_api': 'responses',
+                          'models': {'default': 'databricks-gpt-5-4-mini'},
+                      },
+                  }
+              }
+          }
+          pathlib.Path.home().joinpath('.omnigent', 'config.yaml').write_text(
+              yaml.safe_dump(cfg, default_flow_style=False)
+          )
+          "
 
       - name: Collect PR context
         id: ctx
@@ -139,62 +156,50 @@ jobs:
           set -euo pipefail
 
           # Fetch the diff (capped at 64 KB to stay within prompt limits).
-          diff=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
             -H "Accept: application/vnd.github.v3.diff" \
-            | head -c 65536)
+            | head -c 65536 > /tmp/pr_diff.txt
 
-          # Fetch PR metadata.
-          pr_json=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-            --json title,body,baseRefName,headRefName,additions,deletions,changedFiles)
+          # Fetch PR metadata to separate files — avoids embedding
+          # attacker-controlled strings (PR title/body) into heredocs.
+          gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json title,body,baseRefName,headRefName,additions,deletions,changedFiles \
+            > /tmp/pr_meta.json
 
-          title=$(echo "$pr_json" | jq -r '.title')
-          body=$(echo "$pr_json"  | jq -r '.body // ""' | head -c 4096)
-          base=$(echo "$pr_json"  | jq -r '.baseRefName')
-          head_ref=$(echo "$pr_json"  | jq -r '.headRefName')
-          adds=$(echo "$pr_json"  | jq -r '.additions')
-          dels=$(echo "$pr_json"  | jq -r '.deletions')
-          files=$(echo "$pr_json" | jq -r '.changedFiles')
+          # Build the review prompt safely using python — all untrusted
+          # fields (title, body, diff) are read from files, never
+          # interpolated into shell heredocs.
+          python3 <<'PYEOF'
+          import json, pathlib
 
-          # Build the review prompt and persist to file (avoids shell escaping).
-          cat > /tmp/review_prompt.txt <<PROMPT_EOF
-          Review this pull request and provide structured feedback.
+          meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
+          diff = pathlib.Path("/tmp/pr_diff.txt").read_text()
+
+          prompt = f"""Review this pull request and provide structured feedback.
 
           ## PR Metadata
-          - **Title:** ${title}
-          - **Branch:** ${head_ref} → ${base}
-          - **Stats:** +${adds} / -${dels} across ${files} file(s)
+          - **Title:** {meta['title']}
+          - **Branch:** {meta['headRefName']} → {meta['baseRefName']}
+          - **Stats:** +{meta['additions']} / -{meta['deletions']} across {meta['changedFiles']} file(s)
 
           ## PR Description
-          ${body}
+          {(meta.get('body') or '')[:4096]}
 
           ## Diff
-          \`\`\`diff
-          ${diff}
-          \`\`\`
-
-          ## Component domains
-          Classify every changed file into one of these domains and organise
-          your feedback accordingly:
-
-          | Label | Scope | Domain experts |
-          |-------|-------|----------------|
-          | comp:core | server routes, runner, store, forwarders, orchestration | core runtime team |
-          | comp:web-ui | ap-web frontend (React/TS), styles, assets | web/frontend team |
-          | comp:sandbox | sandbox policies, bubblewrap, isolation | core runtime team (sandbox specialists) |
-          | comp:sdk | SDK clients, harness adapters, inner executors | SDK team |
-          | comp:cli | CLI entrypoints, argument parsing | CLI owners |
-          | comp:ci | GitHub Actions workflows, CI scripts | infra team |
-          | comp:docs | docs, README, API.md, changelogs | rotates across all teams |
+          ```diff
+          {diff}
+          ```
 
           ## Instructions
-          Review the diff against the PR description. For each domain that has
-          changes, report:
+          Review the diff against the PR description. Report:
           1. **Blocking issues** — bugs, security problems, correctness errors, data loss risks.
           2. **Non-blocking suggestions** — style, naming, performance, test coverage gaps.
+          3. **Summary** — one-paragraph overall assessment.
 
-          End with a short **Summary** — one-paragraph overall assessment.
           Be concise. Do not restate the diff. Focus on what matters.
-          PROMPT_EOF
+          """
+          pathlib.Path("/tmp/review_prompt.txt").write_text(prompt)
+          PYEOF
 
       - name: Run Polly review
         id: polly
@@ -215,9 +220,13 @@ jobs:
             | tee /tmp/polly_output.txt \
             || { echo "::warning::Polly review exited non-zero"; cat polly-stderr.log; }
 
-          echo "review_text<<REVIEW_EOF" >> "$GITHUB_OUTPUT"
-          cat /tmp/polly_output.txt >> "$GITHUB_OUTPUT"
-          echo "REVIEW_EOF" >> "$GITHUB_OUTPUT"
+          # Use a collision-resistant random delimiter so model output
+          # containing "REVIEW_EOF" cannot truncate the output.
+          delim="REVIEW_$(openssl rand -hex 8)"
+          echo "review_text<<${delim}" >> "$GITHUB_OUTPUT"
+          # Cap at 60 KB — GitHub comment body limit is ~65 KB.
+          head -c 61440 /tmp/polly_output.txt >> "$GITHUB_OUTPUT"
+          echo "${delim}" >> "$GITHUB_OUTPUT"
 
       - name: Post review comment
         if: steps.polly.outputs.review_text != ''
@@ -225,21 +234,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_TEXT: ${{ steps.polly.outputs.review_text }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
-          cat > /tmp/comment.md <<'COMMENT_EOF'
-          ## Polly AI Review
-
-          COMMENT_EOF
-
-          echo "${{ steps.polly.outputs.review_text }}" >> /tmp/comment.md
-
-          cat >> /tmp/comment.md <<'COMMENT_EOF'
-
-          ---
-          <sub>Automated review by Polly · [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>
-          COMMENT_EOF
+          # Build the comment body safely — REVIEW_TEXT is passed via env
+          # (not ${{ }} interpolation) to avoid expression injection.
+          {
+            echo "## <img src=\"https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg\" alt=\"\" height=\"20\" valign=\"middle\" /> Polly AI Review"
+            echo ""
+            echo "$REVIEW_TEXT"
+            echo ""
+            echo "---"
+            echo "<sub>Automated review by Polly · [workflow run](${RUN_URL})</sub>"
+          } > /tmp/comment.md
 
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/comment.md
 


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that triggers a Polly AI review on every non-draft PR
- Spins up a local Omnigent server + runner in CI with `omnigent run examples/polly/ -p ... --ephemeral` — no external server or auth tokens needed
- Installs both Claude Code and Codex CLIs so Polly has two sub-agents for cross-vendor review
- Reuses the existing `LLM_API_KEY` + `GATEWAY_BASE_URL` secrets (same as e2e workflows)
- Posts structured review findings (blocking issues, suggestions, summary) as a PR comment