### PR TITLE
fix(runner): dispatch native python tools against the bundle workdir

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2878,6 +2878,11 @@ def _resolved_spec_workdir(entry: Any) -> Path | None:
     return entry.workdir if isinstance(entry, ResolvedSpec) else None
 
 
+def _resolved_workdir_for_spec(spec: Any, fallback: Path | None) -> Path | None:
+    """Return the bundle workdir for a possibly wrapped spec entry."""
+    return _resolved_spec_workdir(spec) or fallback
+
+
 @dataclasses.dataclass(frozen=True)
 class _SessionSnapshot:
     """One ``GET /v1/sessions/{id}`` projected for all runner readers.
@@ -8735,6 +8740,7 @@ def create_runner_app(
         _turn_agent_id = dispatch.agent_id if dispatch else body.get("agent_id")
         _has_mcp_hint = dispatch.has_mcp_servers if dispatch else body.get("has_mcp_servers")
         _turn_spec: Any = None
+        _turn_spec_entry: Any = None
         _turn_spec_resolved = False
         _mcp_schemas: list[dict[str, Any]] = []
         _mcp_tool_names: set[str] = set()
@@ -8746,6 +8752,7 @@ def create_runner_app(
             _turn_spec = _unwrap_resolved_spec(_turn_spec_entry)
             if _turn_spec is None:
                 _session_entry = _session_spec_cache.get(conv_id)
+                _turn_spec_entry = _session_entry
                 _turn_spec = _unwrap_resolved_spec(_session_entry)
             if _turn_spec is None and spec_resolver is not None:
                 try:
@@ -8769,6 +8776,7 @@ def create_runner_app(
                 else:
                     if _turn_spec is not None:
                         _spec_cache[_turn_agent_id] = _resolved_turn_spec
+                        _turn_spec_entry = _resolved_turn_spec
             _turn_spec_resolved = True
             _turn_mcp: Any = ProxyMcpManager(conv_id, server_client)
             if _eager_spec_error is None and _turn_spec is not None:
@@ -8789,9 +8797,9 @@ def create_runner_app(
             (typically ``_response_failed_event`` from inside the SSE
             generator).
             """
-            nonlocal _turn_spec, _turn_spec_resolved
+            nonlocal _turn_spec, _turn_spec_entry, _turn_spec_resolved
             if _turn_spec_resolved:
-                return _turn_spec, None
+                return _turn_spec_entry or _turn_spec, None
             _turn_spec_resolved = True
             # Session-level cache has the sub-agent's resolved spec
             # (set by _run_turn_bg) for child sessions. Check it
@@ -8799,14 +8807,16 @@ def create_runner_app(
             # sub-spec, not the root spec.
             session_cached = _session_spec_cache.get(conv_id)
             if session_cached is not None:
+                _turn_spec_entry = session_cached
                 _turn_spec = _unwrap_resolved_spec(session_cached)
-                return _turn_spec, None
+                return session_cached, None
             if not _turn_agent_id or spec_resolver is None:
                 return None, None
             cached = _spec_cache.get(_turn_agent_id)
             if cached is not None:
+                _turn_spec_entry = cached
                 _turn_spec = _unwrap_resolved_spec(cached)
-                return _turn_spec, None
+                return cached, None
             try:
                 resolved = await spec_resolver(_turn_agent_id, conv_id)
             except (httpx.HTTPError, RuntimeError) as exc:
@@ -8822,8 +8832,10 @@ def create_runner_app(
                 )
             if resolved is not None:
                 _spec_cache[_turn_agent_id] = resolved
+                _turn_spec_entry = resolved
                 _turn_spec = _unwrap_resolved_spec(resolved)
-            return _turn_spec, None
+                return resolved, None
+            return None, None
 
         async def proxy_stream():
             # If eager spec resolution failed (MCP path), emit the
@@ -9076,6 +9088,42 @@ def create_runner_app(
                                             _spec_for_dispatch_hint, "local_tools", []
                                         )
                                     )
+                                    if (
+                                        not _is_spec_local
+                                        and not is_mcp
+                                        and not should_dispatch_locally(tool_name)
+                                    ):
+                                        # The cheap _session_spec_cache lookup above
+                                        # can miss for bundle-deployed agents with NO
+                                        # MCP servers (the eager MCP path never resolved
+                                        # their spec), leaving a native python tool
+                                        # mis-classified as client-side. Resolve once to
+                                        # recompute _is_spec_local so it dispatches
+                                        # locally against the bundle workdir.
+                                        #
+                                        # A hint-only resolution failure is NON-fatal:
+                                        # we keep the prior _is_spec_local=False and let
+                                        # the tool relay to the client exactly as base
+                                        # did, rather than aborting the turn with
+                                        # response.failed. Only the real dispatch path
+                                        # below surfaces resolver errors fatally, since
+                                        # it genuinely needs the spec to dispatch.
+                                        (
+                                            _spec_for_dispatch_hint_entry,
+                                            _lazy_hint_err,
+                                        ) = await _resolve_turn_spec_lazy()
+                                        if _lazy_hint_err is None:
+                                            _spec_for_dispatch_hint = _unwrap_resolved_spec(
+                                                _spec_for_dispatch_hint_entry
+                                            )
+                                            _is_spec_local = any(
+                                                getattr(info, "name", None) == tool_name
+                                                and getattr(info, "language", None)
+                                                in ("python", "omnigent-python-callable")
+                                                for info in getattr(
+                                                    _spec_for_dispatch_hint, "local_tools", []
+                                                )
+                                            )
                                     _should_dispatch = _should_dispatch_tool_locally(
                                         tool_name,
                                         dispatch=dispatch,
@@ -9090,7 +9138,7 @@ def create_runner_app(
                                         # failures surface as response.failed
                                         # SSE (see the response.failed contract).
                                         (
-                                            _spec_for_dispatch,
+                                            _spec_for_dispatch_entry,
                                             _lazy_err,
                                         ) = await _resolve_turn_spec_lazy()
                                         if _lazy_err is not None:
@@ -9099,6 +9147,20 @@ def create_runner_app(
                                                 {"message": _err_msg, "type": _err_type}
                                             )
                                             return
+                                        # Bundle-deployed agents carry their own
+                                        # workdir (where tools/python/*.py live).
+                                        # Dispatch native tools against it, falling
+                                        # back to runner_workspace for non-bundle
+                                        # agents. This mirrors schema generation,
+                                        # which already builds ToolManager with the
+                                        # resolved spec workdir.
+                                        _dispatch_workdir = _resolved_workdir_for_spec(
+                                            _spec_for_dispatch_entry,
+                                            runner_workspace,
+                                        )
+                                        _spec_for_dispatch = _unwrap_resolved_spec(
+                                            _spec_for_dispatch_entry
+                                        )
                                         # All tool calls go through AP:/mcp
                                         # (ProxyMcpManager in Omnigent mode), which
                                         # enforces TOOL_CALL + TOOL_RESULT
@@ -9128,7 +9190,7 @@ def create_runner_app(
                                                     task_id=_omnigent_task_id or _response_id,
                                                     agent_id=_agent_id_for_dispatch,
                                                     agent_name=body.get("model"),
-                                                    runner_workspace=runner_workspace,
+                                                    runner_workspace=_dispatch_workdir,
                                                     mcp_manager=_dispatch_mcp,
                                                     session_inbox=_session_inboxes.get(conv_id),
                                                     session_async_tasks=_session_async_tasks.get(
@@ -11890,12 +11952,14 @@ def create_runner_app(
                 # any name without ``__`` is definitively a runner-local tool.
                 # Policy enforcement is handled by the AP server.
                 spec_entry = _session_spec_cache.get(session_id)
+                spec_workdir = _resolved_spec_workdir(spec_entry)
                 spec = _unwrap_resolved_spec(spec_entry)
                 if spec is None and spec_resolver is not None:
                     _agent_id = _session_agent_ids.get(session_id)
                     if _agent_id:
                         try:
                             resolved = await spec_resolver(_agent_id, session_id)
+                            spec_workdir = _resolved_spec_workdir(resolved)
                             spec = _unwrap_resolved_spec(resolved)
                         except Exception:  # noqa: BLE001
                             pass
@@ -11912,7 +11976,7 @@ def create_runner_app(
                         task_id=session_id,
                         agent_id=_agent_id_local,
                         agent_name=getattr(spec, "name", None),
-                        runner_workspace=runner_workspace,
+                        runner_workspace=spec_workdir or runner_workspace,
                         mcp_manager=None,
                         session_inbox=_session_inboxes.get(session_id),
                         session_async_tasks=_session_async_tasks.get(session_id),

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2883,6 +2883,16 @@ def _resolved_workdir_for_spec(spec: Any, fallback: Path | None) -> Path | None:
     return _resolved_spec_workdir(spec) or fallback
 
 
+def _is_spec_local_native_python_tool(spec: Any, tool_name: str) -> bool:
+    """Return whether *tool_name* is a spec-declared native python tool."""
+    unwrapped = _unwrap_resolved_spec(spec)
+    return any(
+        getattr(info, "name", None) == tool_name
+        and getattr(info, "language", None) in ("python", "omnigent-python-callable")
+        for info in getattr(unwrapped, "local_tools", [])
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class _SessionSnapshot:
     """One ``GET /v1/sessions/{id}`` projected for all runner readers.
@@ -9080,13 +9090,9 @@ def create_runner_app(
                                     _spec_for_dispatch_hint = _unwrap_resolved_spec(
                                         _session_spec_cache.get(conv_id)
                                     )
-                                    _is_spec_local = any(
-                                        getattr(info, "name", None) == tool_name
-                                        and getattr(info, "language", None)
-                                        in ("python", "omnigent-python-callable")
-                                        for info in getattr(
-                                            _spec_for_dispatch_hint, "local_tools", []
-                                        )
+                                    _is_spec_local = _is_spec_local_native_python_tool(
+                                        _spec_for_dispatch_hint,
+                                        tool_name,
                                     )
                                     if (
                                         not _is_spec_local
@@ -9116,13 +9122,9 @@ def create_runner_app(
                                             _spec_for_dispatch_hint = _unwrap_resolved_spec(
                                                 _spec_for_dispatch_hint_entry
                                             )
-                                            _is_spec_local = any(
-                                                getattr(info, "name", None) == tool_name
-                                                and getattr(info, "language", None)
-                                                in ("python", "omnigent-python-callable")
-                                                for info in getattr(
-                                                    _spec_for_dispatch_hint, "local_tools", []
-                                                )
+                                            _is_spec_local = _is_spec_local_native_python_tool(
+                                                _spec_for_dispatch_hint,
+                                                tool_name,
                                             )
                                     _should_dispatch = _should_dispatch_tool_locally(
                                         tool_name,
@@ -9148,15 +9150,17 @@ def create_runner_app(
                                             )
                                             return
                                         # Bundle-deployed agents carry their own
-                                        # workdir (where tools/python/*.py live).
-                                        # Dispatch native tools against it, falling
-                                        # back to runner_workspace for non-bundle
-                                        # agents. This mirrors schema generation,
-                                        # which already builds ToolManager with the
-                                        # resolved spec workdir.
-                                        _dispatch_workdir = _resolved_workdir_for_spec(
-                                            _spec_for_dispatch_entry,
-                                            runner_workspace,
+                                        # workdir for spec-local native python
+                                        # tools (where tools/python/*.py live).
+                                        # Builtins / OS-env / relayed tools must
+                                        # keep the caller's runner workspace.
+                                        _dispatch_workdir = (
+                                            _resolved_workdir_for_spec(
+                                                _spec_for_dispatch_entry,
+                                                runner_workspace,
+                                            )
+                                            if _is_spec_local
+                                            else runner_workspace
                                         )
                                         _spec_for_dispatch = _unwrap_resolved_spec(
                                             _spec_for_dispatch_entry
@@ -11964,6 +11968,12 @@ def create_runner_app(
                         except Exception:  # noqa: BLE001
                             pass
                 _agent_id_local = _session_agent_ids.get(session_id)
+                dispatch_workspace = (
+                    spec_workdir
+                    if spec_workdir is not None
+                    and _is_spec_local_native_python_tool(spec, tool_name)
+                    else runner_workspace
+                )
                 try:
                     output = await execute_tool(
                         tool_name=tool_name,
@@ -11976,7 +11986,7 @@ def create_runner_app(
                         task_id=session_id,
                         agent_id=_agent_id_local,
                         agent_name=getattr(spec, "name", None),
-                        runner_workspace=spec_workdir or runner_workspace,
+                        runner_workspace=dispatch_workspace,
                         mcp_manager=None,
                         session_inbox=_session_inboxes.get(session_id),
                         session_async_tasks=_session_async_tasks.get(session_id),

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -50,6 +50,7 @@ from omnigent.runner.app import (
     _PiNativeLaunchConfig,
     _publish_native_terminal_start_error,
     _publish_terminal_pending,
+    _resolved_workdir_for_spec,
     _session_labels_for_runner_spawn,
     _terminal_lookup_miss_log_state,
     _wake_post_is_retryable,
@@ -656,6 +657,143 @@ async def test_runner_session_tool_schemas_use_resolved_bundle_workdir(tmp_path:
     schemas = harness_client.posted_bodies[0].get("tools") or []
     assert any(s.get("function", {}).get("name") == "bundle_tool" for s in schemas), (
         f"expected bundled local tool schema, got {schemas}"
+    )
+
+
+def test_resolved_workdir_for_spec_prefers_bundle_workdir(tmp_path: Path) -> None:
+    """``_resolved_workdir_for_spec`` uses ``ResolvedSpec.workdir`` over fallback.
+
+    Bundle-deployed agents carry their own workdir (where
+    ``tools/python/*.py`` live). The dispatch path must thread that
+    workdir into ``dispatch_tool_locally`` so native python tools are
+    found at call time — not the generic ``runner_workspace``.
+    """
+    bundle_dir = tmp_path / "bundle"
+    runner_workspace = tmp_path / "workspace"
+    spec = AgentSpec(spec_version=1, name="bundle-agent")
+    entry = ResolvedSpec(spec=spec, workdir=bundle_dir)
+
+    assert _resolved_workdir_for_spec(entry, runner_workspace) == bundle_dir
+
+
+def test_resolved_workdir_for_spec_falls_back_without_bundle(tmp_path: Path) -> None:
+    """Non-bundle specs fall back to ``runner_workspace`` (prior behavior).
+
+    A bare ``AgentSpec`` (no ResolvedSpec wrapper) or a ``ResolvedSpec``
+    with ``workdir=None`` carries no bundle dir, so dispatch must keep
+    using the CLI launch workspace exactly as base did.
+    """
+    runner_workspace = tmp_path / "workspace"
+    bare_spec = AgentSpec(spec_version=1, name="plain-agent")
+
+    # Unwrapped spec → no workdir → fallback.
+    assert _resolved_workdir_for_spec(bare_spec, runner_workspace) == runner_workspace
+    # ResolvedSpec with no workdir → fallback.
+    wrapped_no_workdir = ResolvedSpec(spec=bare_spec, workdir=None)
+    assert _resolved_workdir_for_spec(wrapped_no_workdir, runner_workspace) == runner_workspace
+    # Missing fallback stays None (don't fabricate a path).
+    assert _resolved_workdir_for_spec(bare_spec, None) is None
+
+
+@pytest.mark.asyncio
+async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bundle agent's native python tool dispatches against the bundle workdir.
+
+    End-to-end through ``POST /v1/sessions/{conv}/events`` (no live LLM):
+    the scripted harness emits an ``action_required`` for a spec-declared
+    python tool, and the runner must dispatch it locally with
+    ``runner_workspace`` set to the resolved ``ResolvedSpec.workdir`` (the
+    bundle dir), not the generic CLI ``runner_workspace``. This is the
+    dispatch-time counterpart to
+    :func:`test_runner_session_tool_schemas_use_resolved_bundle_workdir`,
+    which only proved schema generation used the bundle workdir.
+    """
+    import omnigent.runner.tool_dispatch as _tool_dispatch
+
+    bundle_dir = tmp_path / "bundle"
+    tool_dir = bundle_dir / "tools" / "python"
+    tool_dir.mkdir(parents=True)
+    (tool_dir / "bundle_tool.py").write_text(
+        "from omnigent_client.tools import tool\n\n"
+        "@tool\n"
+        "def bundle_tool(text: str) -> str:\n"
+        "    return text\n"
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    spec = AgentSpec(
+        spec_version=1,
+        name="bundle-agent",
+        local_tools=[
+            LocalToolInfo(
+                name="bundle_tool",
+                path="tools/python/bundle_tool.py",
+                language="python",
+            )
+        ],
+    )
+
+    captured_workspaces: list[Path | None] = []
+
+    async def _fake_dispatch(*, runner_workspace: Path | None = None, **kwargs: Any) -> str:
+        captured_workspaces.append(runner_workspace)
+        return "ok"
+
+    monkeypatch.setattr(_tool_dispatch, "dispatch_tool_locally", _fake_dispatch)
+
+    sse_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "status": "action_required",
+                    "name": "bundle_tool",
+                    "call_id": "call_bundle",
+                    "arguments": json.dumps({"text": "from-bundle"}),
+                },
+            }
+        ),
+        _sse({"type": "response.completed", "response": {"id": "resp_1"}}),
+    ]
+    harness_client = _ScriptedHarnessClient(sse_frames)
+    pm = _FakeProcessManager(harness_client)
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> ResolvedSpec:
+        del agent_id, session_id
+        return ResolvedSpec(spec=spec, workdir=bundle_dir)
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        runner_workspace=workspace,
+    )
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions/conv_bundle/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_bundle",
+                "model": "bundle-agent",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        for _ in range(100):
+            if captured_workspaces:
+                break
+            await asyncio.sleep(0.05)
+
+    assert captured_workspaces, "native tool must be dispatched locally"
+    assert captured_workspaces[0] == bundle_dir, (
+        "dispatch must use the resolved bundle workdir, not runner_workspace "
+        f"({workspace!r}); got {captured_workspaces[0]!r}"
     )
 
 

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -37,6 +37,7 @@ from omnigent.claude_native_bridge import (
 from omnigent.entities.session_resources import SessionResourceView, terminal_resource_id
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner import create_runner_app
+from omnigent.runner import tool_dispatch as _tool_dispatch
 from omnigent.runner.app import (
     _RUNNER_DISPATCHED_FIELD,
     _WAKE_POST_MAX_ATTEMPTS,
@@ -710,8 +711,6 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
     :func:`test_runner_session_tool_schemas_use_resolved_bundle_workdir`,
     which only proved schema generation used the bundle workdir.
     """
-    import omnigent.runner.tool_dispatch as _tool_dispatch
-
     bundle_dir = tmp_path / "bundle"
     tool_dir = bundle_dir / "tools" / "python"
     tool_dir.mkdir(parents=True)
@@ -808,8 +807,6 @@ async def test_sessions_native_dispatches_builtin_tool_with_runner_workspace(
     original runner workspace even when the agent spec was resolved from an
     extracted bundle directory.
     """
-    import omnigent.runner.tool_dispatch as _tool_dispatch
-
     bundle_dir = tmp_path / "bundle"
     bundle_dir.mkdir()
     workspace = tmp_path / "workspace"
@@ -885,8 +882,6 @@ async def test_mcp_execute_dispatches_builtin_tool_with_runner_workspace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """``/mcp/execute`` also keeps builtin OS-env tools in runner_workspace."""
-    import omnigent.runner.tool_dispatch as _tool_dispatch
-
     bundle_dir = tmp_path / "bundle"
     bundle_dir.mkdir()
     workspace = tmp_path / "workspace"

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -798,6 +798,159 @@ async def test_sessions_native_dispatches_native_tool_with_bundle_workdir(
 
 
 @pytest.mark.asyncio
+async def test_sessions_native_dispatches_builtin_tool_with_runner_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bundle agent's builtin OS-env tool dispatches in runner_workspace.
+
+    Bundle workdirs are only for spec-local native python tools. Builtins
+    such as ``sys_os_write`` run in the caller process and must keep the
+    original runner workspace even when the agent spec was resolved from an
+    extracted bundle directory.
+    """
+    import omnigent.runner.tool_dispatch as _tool_dispatch
+
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    spec = AgentSpec(spec_version=1, name="bundle-agent")
+
+    captured_workspaces: list[Path | None] = []
+
+    async def _fake_dispatch(*, runner_workspace: Path | None = None, **kwargs: Any) -> str:
+        captured_workspaces.append(runner_workspace)
+        return "ok"
+
+    monkeypatch.setattr(_tool_dispatch, "dispatch_tool_locally", _fake_dispatch)
+
+    sse_frames = [
+        _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "status": "action_required",
+                    "name": "sys_os_write",
+                    "call_id": "call_write",
+                    "arguments": json.dumps(
+                        {"path": "created-by-tool.txt", "content": "from workspace"}
+                    ),
+                },
+            }
+        ),
+        _sse({"type": "response.completed", "response": {"id": "resp_1"}}),
+    ]
+    harness_client = _ScriptedHarnessClient(sse_frames)
+    pm = _FakeProcessManager(harness_client)
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> ResolvedSpec:
+        del agent_id, session_id
+        return ResolvedSpec(spec=spec, workdir=bundle_dir)
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        runner_workspace=workspace,
+    )
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions/conv_builtin/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_bundle",
+                "model": "bundle-agent",
+                "content": [{"type": "input_text", "text": "write a file"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert resp.status_code == 202
+        for _ in range(100):
+            if captured_workspaces:
+                break
+            await asyncio.sleep(0.05)
+
+    assert captured_workspaces, "builtin tool must be dispatched locally"
+    assert captured_workspaces[0] == workspace, (
+        "builtin OS-env dispatch must use runner_workspace, not the bundle workdir "
+        f"({bundle_dir!r}); got {captured_workspaces[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_execute_dispatches_builtin_tool_with_runner_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/mcp/execute`` also keeps builtin OS-env tools in runner_workspace."""
+    import omnigent.runner.tool_dispatch as _tool_dispatch
+
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    spec = AgentSpec(spec_version=1, name="bundle-agent")
+
+    captured_workspaces: list[Path | None] = []
+
+    async def _fake_execute_tool(*, runner_workspace: Path | None = None, **kwargs: Any) -> str:
+        captured_workspaces.append(runner_workspace)
+        return "ok"
+
+    monkeypatch.setattr(_tool_dispatch, "execute_tool", _fake_execute_tool)
+
+    harness_client = _ScriptedHarnessClient(
+        [_sse({"type": "response.completed", "response": {"id": "resp_1"}})]
+    )
+    pm = _FakeProcessManager(harness_client)
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> ResolvedSpec:
+        del agent_id, session_id
+        return ResolvedSpec(spec=spec, workdir=bundle_dir)
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        runner_workspace=workspace,
+    )
+    async with _runner_client(app) as client:
+        seed_resp = await client.post(
+            "/v1/sessions/conv_execute_builtin/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "ag_bundle",
+                "model": "bundle-agent",
+                "content": [{"type": "input_text", "text": "seed"}],
+                "harness": "openai-agents",
+            },
+        )
+        assert seed_resp.status_code == 202
+        for _ in range(100):
+            if harness_client.posted_bodies:
+                break
+            await asyncio.sleep(0.05)
+
+        execute_resp = await client.post(
+            "/v1/sessions/conv_execute_builtin/mcp/execute",
+            json={
+                "method": "tools/call",
+                "params": {
+                    "name": "sys_os_write",
+                    "arguments": {"path": "created-by-tool.txt", "content": "from workspace"},
+                },
+            },
+        )
+
+    assert execute_resp.status_code == 200
+    assert execute_resp.json() == {"result": {"output": "ok"}}
+    assert captured_workspaces == [workspace]
+
+
+@pytest.mark.asyncio
 async def test_sessions_native_path_injects_mcp_schemas() -> None:
     """``POST /v1/sessions/{conv}/events`` with a message body injects MCP schemas.
 


### PR DESCRIPTION
## Summary

- Thread the resolved **bundle workdir** (`ResolvedSpec.workdir`) into runner-local tool **dispatch** instead of always using the generic `runner_workspace`. Bundle-deployed agents keep their native python tools under `tools/python/*.py` inside the bundle dir; dispatch now resolves tools against that dir, falling back to `runner_workspace` for non-bundle agents.
- Schema generation already used `ToolManager(spec, workdir=cached_spec_workdir or runner_workspace)`, but **dispatch** passed bare `runner_workspace` — so a bundle agent's tool advertised correctly at schema time then failed to be found at call time. This closes that gap.
- The new spec-resolution **hint-block** (which recomputes `_is_spec_local`) is made **non-fatal** so it never widens the turn-failure surface for agents with no MCP servers.
- This is the salvaged **product half** of split PR #411 (`polly/archer-live-llm`). The archer tests / example config / `known_failures.yaml` from that PR are being removed separately — none of them are touched here.

## ELI5

Imagine each agent ships in its own backpack (the "bundle") that holds its custom tools. When we *list* the agent's tools, we correctly look inside the backpack. But when the agent actually *uses* a tool, we were looking in the generic shared closet instead of the backpack — so the tool was "missing." This change makes us reach into the same backpack both when listing tools and when running them.

## Diagram

```
                         BEFORE (bug)
                         ───────────
 schema generation ─────► ToolManager(spec, workdir = bundle_workdir)   ✅ finds tools/python/*.py
                                                          └─ ResolvedSpec.workdir

 tool dispatch     ─────► dispatch_tool_locally(runner_workspace = runner_workspace)  ❌ generic CLI dir
                                                                       └─ tools/python/*.py NOT here


                         AFTER (fix)
                         ───────────
 _resolve_turn_spec_lazy() ──► returns ResolvedSpec ENTRY (not unwrapped)
                                       │
            ┌──────────────────────────┴───────────────────────────┐
            ▼                                                        ▼
 _resolved_workdir_for_spec(entry, runner_workspace)        _unwrap_resolved_spec(entry)
   = entry.workdir or runner_workspace                        = spec
            │                                                        │
            ▼                                                        ▼
 dispatch_tool_locally(runner_workspace = _dispatch_workdir, agent_spec = spec)
                                          └─ bundle_workdir ✅ (or runner_workspace fallback)
```

```mermaid
flowchart TD
    A[action_required: native python tool] --> B{is_spec_local / mcp / builtin?}
    B -- "miss (bundle agent, no MCP)" --> H[hint-block: _resolve_turn_spec_lazy]
    H -- "ok" --> R[recompute _is_spec_local from resolved spec]
    H -- "resolver error (NON-fatal)" --> K[keep base behavior, relay to client]
    R --> D[_should_dispatch_tool_locally]
    B -- "hit" --> D
    D -- "dispatch locally" --> W["_dispatch_workdir = _resolved_workdir_for_spec(entry, runner_workspace)"]
    W --> X["dispatch_tool_locally(runner_workspace = _dispatch_workdir)"]
    X --> Y[ToolManager finds tools/python/*.py in bundle dir]
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

New tests in `tests/runner/test_app_sessions_native.py` (no live LLM):

1. **`test_resolved_workdir_for_spec_prefers_bundle_workdir`** (unit) — asserts `_resolved_workdir_for_spec` returns `ResolvedSpec.workdir` when present, over the `runner_workspace` fallback.
2. **`test_resolved_workdir_for_spec_falls_back_without_bundle`** (unit) — asserts a bare `AgentSpec`, a `ResolvedSpec(workdir=None)`, and a missing fallback all degrade to prior behavior (fallback / `None`), so non-bundle agents are unaffected.
3. **`test_sessions_native_dispatches_native_tool_with_bundle_workdir`** (integration) — drives `POST /v1/sessions/{conv}/events` with a scripted harness that emits an `action_required` for a spec-declared python tool, monkeypatches `dispatch_tool_locally`, and asserts the captured `runner_workspace` equals the resolved **bundle dir** (not the CLI `runner_workspace`). This is the dispatch-time counterpart to the existing `test_runner_session_tool_schemas_use_resolved_bundle_workdir` (which only proved schema generation used the bundle workdir).

Deliberately avoids any archer dependency (archer is being deleted in the sibling split). The integration test was mutation-checked: reverting the `runner_workspace=_dispatch_workdir` line makes it fail (got the generic `workspace` dir), confirming it guards the fix.

### How the review concern was resolved

The new hint-block forced turn-spec resolution on every non-local/non-mcp/non-builtin tool call for MCP-less agents, and a resolver error there would abort the turn via `_response_failed_event` — widening the turn-failure surface vs. base. Chosen fix: **option (b)** — a *hint-only* resolution failure is **non-fatal**. On `_lazy_hint_err`, we keep `_is_spec_local=False` and relay the tool to the client exactly as base did, rather than aborting. Only the real dispatch path below still surfaces resolver errors fatally, since it genuinely needs the spec to dispatch. A comment in `app.py` documents this. (The hint block remains gated so it only runs when local dispatch is actually plausible, i.e. the cheap cache lookup classified the tool as non-local.)

### Commands run

```
uv run ruff check omnigent/runner/app.py tests/runner/test_app_sessions_native.py
# → All checks passed!

uv run pytest tests/runner/test_app_sessions_native.py -k "workdir or bundle_workdir"
# → 4 passed (3 new + existing schema test)

uv run pytest tests/runner/test_app_sessions_native.py tests/runner/test_runner_dispatch.py
# → 3 failed, 278 passed
#   The 3 failures are codex-native turn-interrupt/compact tests and are
#   PRE-EXISTING on the base branch (verified by `git stash` + re-run) —
#   unrelated to this dispatch-workdir change.
```

`uv run mypy omnigent/runner/app.py` adds only 2 `explicit-any` findings (`_turn_spec_entry: Any`, `_resolved_workdir_for_spec(spec: Any, ...)`), matching the file's existing 126 `explicit-any` errors and the sibling `_resolved_spec_workdir(entry: Any)` / `_turn_spec: Any` style; this module is not mypy-gated.
