### PR TITLE
fix(policies): default ASK approval timeout to 1 day, not 30s

### DIFF
--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -26,10 +26,17 @@ if TYPE_CHECKING:
 DEFAULT_POLICY_CLASSIFIER_TIMEOUT = 30
 
 # Default timeout (seconds) for user approval on an ASK policy.
-# 30 s matches omnigent parity. Overrideable per-policy via
-# ``PolicySpec.ask_timeout`` or spec-wide via
-# ``GuardrailsSpec.ask_timeout``. See POLICIES.md §7, §13.
-DEFAULT_ASK_TIMEOUT = 30
+# One day — an ASK is a human-in-the-loop gate and should outlive a
+# user stepping away, matching every other wait-for-a-human budget in
+# the native path (the PermissionRequest / evaluate-policy hook
+# long-polls and their server-side mirrors are all 86400). A shorter
+# default fails closed (DENY) without any user input, flipping the web
+# card to a neutral "Resolved elsewhere" — surprising for an
+# interactive session. Headless/unattended agents that want a fast
+# fail-closed should override this per-policy via ``PolicySpec.ask_timeout``
+# or spec-wide via ``GuardrailsSpec.ask_timeout`` (see polly's config).
+# See POLICIES.md §7, §13.
+DEFAULT_ASK_TIMEOUT = 86400
 
 
 @dataclass(frozen=True)
@@ -1332,7 +1339,7 @@ class GuardrailsSpec:
     :param ask_timeout: Spec-wide default approval timeout in
         seconds. Individual policies may override via
         ``PolicySpec.ask_timeout``. Defaults to
-        :data:`DEFAULT_ASK_TIMEOUT` (30 s).
+        :data:`DEFAULT_ASK_TIMEOUT` (1 day).
     """
 
     labels: dict[str, LabelDef] | None = None

--- a/tests/runtime/policies/test_builder_error_paths.py
+++ b/tests/runtime/policies/test_builder_error_paths.py
@@ -74,7 +74,7 @@ def test_resolve_non_callable_rejected() -> None:
     """Dotted path resolves to a non-callable (e.g. a module
     constant) → ValueError naming the resolved type."""
     # Point at a non-callable module-level constant
-    # (`omnigent.spec.types.DEFAULT_ASK_TIMEOUT` = 30, an int).
+    # (`omnigent.spec.types.DEFAULT_ASK_TIMEOUT` is an int).
     with pytest.raises(ValueError, match=r"not callable"):
         resolve_function_policy(
             _fn_spec("omnigent.spec.types.DEFAULT_ASK_TIMEOUT"),


### PR DESCRIPTION
## Problem

An ASK policy is a human-in-the-loop gate, but `DEFAULT_ASK_TIMEOUT` was **30s**. When the user didn't answer within 30s the server failed closed (DENY) with no input, and the web card flipped to the neutral **"Resolved elsewhere"** pill — looking like a silent auto-resolve.

This bit the `session_cost_budget` warning-threshold ASK in particular: it re-fires on every `request`/`tool_call` until approved (the approved-checkpoint `state_update` lands only on accept), so each one timed out in turn — hence multiple "Resolved elsewhere" cards at the same $0.30 threshold.

## Fix

Every other wait-for-a-human budget in the native path is already `86400` (1 day): the `PermissionRequest` / `evaluate-policy` hook long-polls and their server-side mirrors. The design intent (see `sessions.py` and polly's config) is that everything waits a day and the policy `ask_timeout` is the real cap — so a 30s default was the lone outlier that capped first. This aligns the default with the rest of the system.

Headless/unattended agents that want a fast fail-closed still override per-policy via `PolicySpec.ask_timeout` or spec-wide via `GuardrailsSpec.ask_timeout` (polly already does).

## Notes

- Only affects deployments that don't explicitly set `guardrails.ask_timeout` (configs that already set it, like polly's 86400, are unchanged).
- A running server must be restarted to pick up the new default.

## Tests

Policy parser / builder / engine / sessions-policy suites pass (63).