### PR TITLE
fix(ap-web): focus composer when a reply quote is added

### DIFF
--- a/ap-web/src/pages/ChatPage.composer.test.tsx
+++ b/ap-web/src/pages/ChatPage.composer.test.tsx
@@ -667,6 +667,47 @@ describe("Composer pending elicitation", () => {
   });
 });
 
+// Clicking the floating "Reply" button adds a quote chip above the composer.
+// The caret must follow into the textarea so the user can type the reply
+// immediately — without this, the quote appears but focus stays on the page
+// and the user has to click the chat box first.
+describe("Composer reply-quote focus", () => {
+  beforeEach(() => {
+    useChatStore.setState({ conversationId: "conv_test", skills: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("focuses the textarea when a reply quote is added", () => {
+    const { rerender } = render(<Composer {...composerProps({ replyQuotes: [] })} />);
+    const ta = textarea();
+    // The mount effect focuses on conversation bind; blur so the assertion
+    // proves the quote-add effect re-focused, not the leftover mount focus.
+    ta.blur();
+    expect(document.activeElement).not.toBe(ta);
+
+    rerender(<Composer {...composerProps({ replyQuotes: ["selected response text"] })} />);
+    expect(document.activeElement).toBe(ta);
+  });
+
+  it("does not steal focus when a quote is removed", () => {
+    // Removing a chip (the X button) shrinks the count — the effect only
+    // fires when the count grows, so focus must stay put.
+    const { rerender } = render(
+      <Composer {...composerProps({ replyQuotes: ["first", "second"] })} />,
+    );
+    const ta = textarea();
+    ta.blur();
+    expect(document.activeElement).not.toBe(ta);
+
+    rerender(<Composer {...composerProps({ replyQuotes: ["first"] })} />);
+    expect(document.activeElement).not.toBe(ta);
+  });
+});
+
 // The "Chatting with sub-agent …" tray peeks above the composer only when a
 // sub-agent label is passed (the active session is a child). It must name the
 // sub-agent so the composer reads as messaging the child, not the orchestrator.

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -2869,6 +2869,17 @@ export function Composer({
     };
   }, [conversationId]);
 
+  // Adding a reply quote (via the floating "Reply" button) should drop the
+  // caret straight into the composer so the user can type immediately. Only
+  // focus when the count grows — removing a quote shouldn't steal focus.
+  const prevQuoteCountRef = useRef(replyQuotes.length);
+  useEffect(() => {
+    if (replyQuotes.length > prevQuoteCountRef.current) {
+      textareaRef.current?.focus();
+    }
+    prevQuoteCountRef.current = replyQuotes.length;
+  }, [replyQuotes.length]);
+
   // Session skills (bundled + host-discovered) come from the snapshot
   // on bind and populate the suggestions menu as ``/skill-name``
   // entries alongside the built-ins.


### PR DESCRIPTION
## Problem

Selecting a response and clicking the floating **Reply ↵** button added a quote chip above the composer, but left focus on the page — so you had to click the chat box before you could start typing.

## Fix

Added a focus effect in the `Composer` component (`ap-web/src/pages/ChatPage.tsx`) that focuses the textarea when the reply-quote count **grows**. Gating on growth (rather than any change) means removing a quote chip via its X button doesn't steal focus. This mirrors the existing focus patterns already in the component (conversation switch, slash-command select).

## Tests

Added a `Composer reply-quote focus` describe block to `ChatPage.composer.test.tsx`:
- focuses the textarea when a reply quote is added
- does not steal focus when a quote is removed (proving the count-grows guard)

All 41 composer tests pass.