### PR TITLE
feat(ap-web): agent description hover flyouts in the picker

### DIFF
--- a/ap-web/src/components/AgentCard.test.tsx
+++ b/ap-web/src/components/AgentCard.test.tsx
@@ -108,3 +108,51 @@ describe("AgentCard compact mode", () => {
     expect(card).not.toHaveAttribute("data-slot", "tooltip-trigger");
   });
 });
+
+describe("AgentCard hover mode", () => {
+  const withDescription = agent({
+    display_name: "Nessie",
+    description: "Multi-agent coding orchestrator.",
+  });
+
+  it("wraps the card in a hover flyout when hover is set and a description exists", () => {
+    // AddAgentDialog opts into the Cursor-style flyout. The card stays the
+    // full inline card AND becomes the hover-card trigger (asChild merges
+    // the slot marker onto the button), so hovering opens the flyout.
+    render(<AgentCard agent={withDescription} selected={false} onSelect={() => {}} hover />);
+    const card = screen.getByTestId("agent-card-ag_1");
+    expect(card).toHaveTextContent("Multi-agent coding orchestrator."); // inline kept
+    expect(card).toHaveAttribute("data-slot", "hover-card-trigger");
+  });
+
+  it("does not wrap when hover is set but the agent has no description", () => {
+    // AgentHoverCard no-ops without a description, so the card stays a
+    // plain button — no empty flyout opens.
+    render(
+      <AgentCard
+        agent={agent({ display_name: "Bare", description: null })}
+        selected={false}
+        onSelect={() => {}}
+        hover
+      />,
+    );
+    expect(screen.getByTestId("agent-card-ag_1")).not.toHaveAttribute(
+      "data-slot",
+      "hover-card-trigger",
+    );
+  });
+
+  it("prefers the compact tooltip over the hover flyout when both are set", () => {
+    // compact is checked first, so a compact card never also becomes a
+    // hover-card trigger — the doc contract that hover is ignored in
+    // compact mode.
+    render(
+      <TooltipProvider>
+        <AgentCard agent={withDescription} selected={false} onSelect={() => {}} compact hover />
+      </TooltipProvider>,
+    );
+    const card = screen.getByTestId("agent-card-ag_1");
+    expect(card).toHaveAttribute("data-slot", "tooltip-trigger");
+    expect(card).not.toHaveAttribute("data-slot", "hover-card-trigger");
+  });
+});

--- a/ap-web/src/components/AgentCard.tsx
+++ b/ap-web/src/components/AgentCard.tsx
@@ -7,6 +7,7 @@ import type { ComponentType, SVGProps } from "react";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 import { nativeCodingAgentForAvailableAgent } from "@/lib/nativeCodingAgents";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { AgentHoverCard } from "@/components/AgentHoverCard";
 
 /**
  * Pick the glyph for a catalog agent.
@@ -49,17 +50,24 @@ function iconForAgent(agent: AvailableAgent): ComponentType<SVGProps<SVGSVGEleme
  * @param compact - When true, render icon + name only (no inline
  *   description) so cards stay even in a horizontal row; the
  *   description is surfaced as a hover tooltip instead.
+ * @param hover - When true, wrap the card in a Cursor-style hover
+ *   flyout (``AgentHoverCard``) that opens to the right with the
+ *   agent's name + description. Additive to the inline description.
+ *   Ignored in compact mode, which already surfaces the description
+ *   via its own tooltip.
  */
 export function AgentCard({
   agent,
   selected,
   onSelect,
   compact = false,
+  hover = false,
 }: {
   agent: AvailableAgent;
   selected: boolean;
   onSelect: () => void;
   compact?: boolean;
+  hover?: boolean;
 }) {
   const Icon = iconForAgent(agent);
   const card = (
@@ -92,6 +100,11 @@ export function AgentCard({
         <TooltipContent>{agent.description}</TooltipContent>
       </Tooltip>
     );
+  }
+  // Non-compact opt-in: surface the richer Cursor-style flyout to the
+  // right on hover. AgentHoverCard no-ops when there's no description.
+  if (hover) {
+    return <AgentHoverCard agent={agent}>{card}</AgentHoverCard>;
   }
   return card;
 }

--- a/ap-web/src/components/AgentHoverCard.test.tsx
+++ b/ap-web/src/components/AgentHoverCard.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AgentHoverCard, AgentRowTooltip } from "./AgentHoverCard";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { AvailableAgent } from "@/hooks/useAvailableAgents";
+
+function agent(overrides: Partial<AvailableAgent> = {}): AvailableAgent {
+  return {
+    id: "ag_1",
+    name: "some-agent",
+    display_name: "Some Agent",
+    description: null,
+    harness: null,
+    skills: [],
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+// Both wrappers no-op when there's no description, and wrap the trigger
+// otherwise. The flyout *body* is deferred until open (radix mounts
+// content on hover/focus), so these assert the branch that decides
+// whether a flyout exists at all — the part that runs at render. The
+// `asChild` trigger merges its `data-slot` marker onto our child, so the
+// marker's presence is the observable signal that a flyout is wired up.
+
+describe("AgentHoverCard", () => {
+  it("wraps the trigger when the agent has a description", () => {
+    render(
+      <AgentHoverCard agent={agent({ description: "Plans and splits up the work." })}>
+        <button data-testid="trigger">Some Agent</button>
+      </AgentHoverCard>,
+    );
+    expect(screen.getByTestId("trigger")).toHaveAttribute("data-slot", "hover-card-trigger");
+  });
+
+  it("renders the trigger bare when the agent has no description", () => {
+    // Nothing to show → no wrapper, so an empty flyout can never open.
+    render(
+      <AgentHoverCard agent={agent({ description: null })}>
+        <button data-testid="trigger">Some Agent</button>
+      </AgentHoverCard>,
+    );
+    expect(screen.getByTestId("trigger")).not.toHaveAttribute("data-slot", "hover-card-trigger");
+  });
+
+  it("treats an empty-string description as nothing to show", () => {
+    // `!agent.description` also catches "", so a blank label doesn't open
+    // a flyout with an empty body.
+    render(
+      <AgentHoverCard agent={agent({ description: "" })}>
+        <button data-testid="trigger">Some Agent</button>
+      </AgentHoverCard>,
+    );
+    expect(screen.getByTestId("trigger")).not.toHaveAttribute("data-slot", "hover-card-trigger");
+  });
+});
+
+describe("AgentRowTooltip", () => {
+  it("wraps the row content when the agent has a description", () => {
+    render(
+      <TooltipProvider>
+        <AgentRowTooltip agent={agent({ description: "Plans and splits up the work." })}>
+          <div data-testid="row">Some Agent</div>
+        </AgentRowTooltip>
+      </TooltipProvider>,
+    );
+    // A tooltip (not a hover card) is used inside dropdown rows because it
+    // opens reliably while a menu is open — so the marker here is the
+    // tooltip trigger, not the hover-card one.
+    expect(screen.getByTestId("row")).toHaveAttribute("data-slot", "tooltip-trigger");
+  });
+
+  it("renders the row content bare when the agent has no description", () => {
+    render(
+      <TooltipProvider>
+        <AgentRowTooltip agent={agent({ description: null })}>
+          <div data-testid="row">Some Agent</div>
+        </AgentRowTooltip>
+      </TooltipProvider>,
+    );
+    expect(screen.getByTestId("row")).not.toHaveAttribute("data-slot", "tooltip-trigger");
+  });
+});

--- a/ap-web/src/components/AgentHoverCard.tsx
+++ b/ap-web/src/components/AgentHoverCard.tsx
@@ -1,14 +1,6 @@
 import * as React from "react";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 
 /**
@@ -26,9 +18,7 @@ function AgentFlyoutBody({ agent }: { agent: AvailableAgent }) {
   return (
     <div className="text-sm">
       <p className="font-semibold leading-snug">{agent.display_name}</p>
-      <p className="mt-1 text-xs leading-snug text-muted-foreground">
-        {agent.description}
-      </p>
+      <p className="mt-1 text-xs leading-snug text-muted-foreground">{agent.description}</p>
     </div>
   );
 }

--- a/ap-web/src/components/AgentHoverCard.tsx
+++ b/ap-web/src/components/AgentHoverCard.tsx
@@ -1,0 +1,132 @@
+import * as React from "react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { AvailableAgent } from "@/hooks/useAvailableAgents";
+
+/**
+ * The Cursor-style flyout body: bold name + description paragraph.
+ *
+ * Shared by both presentation surfaces (the hover card on agent cards
+ * and the tooltip on dropdown rows) so the two render identically.
+ *
+ * @param agent - The catalog entry whose name/description to render.
+ * @returns The flyout's inner markup.
+ */
+function AgentFlyoutBody({ agent }: { agent: AvailableAgent }) {
+  // text-sm matches the agent-name font size in the picker rows
+  // (DropdownMenuItem is text-sm), like Cursor's flyout.
+  return (
+    <div className="text-sm">
+      <p className="font-semibold leading-snug">{agent.display_name}</p>
+      <p className="mt-1 text-xs leading-snug text-muted-foreground">
+        {agent.description}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Cursor-style hover flyout for one catalog agent, for use OUTSIDE a
+ * dropdown menu (e.g. the agent cards in AddAgentDialog).
+ *
+ * Wraps an arbitrary trigger so hovering it opens a flyout to the
+ * right with the agent's ``display_name`` (bold) and ``description``.
+ * The trigger is passed through ``asChild`` so the caller keeps full
+ * control of the rendered element. When the agent has no description
+ * there is nothing to show, so the trigger is returned bare.
+ *
+ * NOTE: do NOT use this to wrap a ``DropdownMenuItem`` — a HoverCard
+ * wrapping a menu item swallows the ref that ``DropdownMenuContent``
+ * hands its children for roving focus, and the flyout never opens.
+ * For dropdown rows use {@link AgentRowTooltip} instead.
+ *
+ * @param agent - The catalog entry whose name/description the flyout
+ *   shows.
+ * @param children - The trigger element to wrap; rendered via
+ *   ``asChild`` so its own props/handlers are preserved.
+ * @returns The trigger wrapped in a hover flyout, or the bare trigger
+ *   when the agent has no description.
+ */
+export function AgentHoverCard({
+  agent,
+  children,
+}: {
+  agent: AvailableAgent;
+  children: React.ReactNode;
+}) {
+  if (!agent.description) return <>{children}</>;
+
+  return (
+    // openDelay matches the screenshot's feel — a brief pause before the
+    // card appears so quick scans down the list don't flash flyouts.
+    <HoverCard openDelay={150} closeDelay={0}>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      {/* side="right" + align="start" places the card to the right of the
+          row with its top edge aligned, like Cursor's model picker. */}
+      <HoverCardContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="w-72"
+        data-testid={`agent-hover-card-${agent.id}`}
+      >
+        <AgentFlyoutBody agent={agent} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+/**
+ * Cursor-style flyout for an agent row INSIDE a dropdown menu.
+ *
+ * Unlike {@link AgentHoverCard}, the trigger here wraps the row's
+ * *inner content* (not the ``DropdownMenuItem`` itself), so the menu
+ * item stays a direct child of ``DropdownMenuContent`` and keeps its
+ * roving focus. A Tooltip (not a HoverCard) is used because tooltips
+ * open reliably while a dropdown menu is open; ``side="right"`` opens
+ * the flyout beside the row like the screenshot.
+ *
+ * Falls back to rendering ``children`` bare when the agent has no
+ * description.
+ *
+ * @param agent - The catalog entry whose name/description the flyout
+ *   shows.
+ * @param children - The row's inner content, rendered as the tooltip
+ *   trigger via ``asChild``.
+ * @returns The content wrapped in a side tooltip, or bare when there
+ *   is no description.
+ */
+export function AgentRowTooltip({
+  agent,
+  children,
+}: {
+  agent: AvailableAgent;
+  children: React.ReactNode;
+}) {
+  if (!agent.description) return <>{children}</>;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="start"
+        // Gap between the open dropdown and the flyout — Cursor leaves a
+        // small space here, which reads cleaner than a flush edge.
+        sideOffset={16}
+        className="w-72 max-w-72 flex-col items-start whitespace-normal text-left"
+        data-testid={`agent-hover-card-${agent.id}`}
+      >
+        <AgentFlyoutBody agent={agent} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ap-web/src/shell/AddAgentDialog.tsx
+++ b/ap-web/src/shell/AddAgentDialog.tsx
@@ -129,6 +129,7 @@ export function AddAgentDialog({
                   agent={agent}
                   selected={agent.id === selectedAgentId}
                   onSelect={() => selectAgent(agent.id)}
+                  hover
                 />
               ))
             )}

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -695,47 +695,6 @@ describe("NewChatLandingScreen", () => {
     expect(detail.textContent).toContain("Edit any file and access the internet");
   });
 
-  it("makes the agent row's menu item itself the description tooltip trigger", () => {
-    // Accessibility: the description flyout must open on keyboard focus,
-    // not just pointer hover. Roving focus in the dropdown lands on the
-    // `[role=menuitem]` element, so that element (not an inner div) has
-    // to be the tooltip trigger. Asserting the slot marker is on the
-    // menu item itself locks that in — wrapping inner content instead
-    // would leave the flyout pointer-only for keyboard users.
-    mockAgents([
-      {
-        id: "with_desc",
-        name: "claude-native-ui",
-        display_name: "Claude Code",
-        description: "Plans and splits up the work.",
-        harness: "claude-native",
-        skills: [],
-      },
-      {
-        id: "no_desc",
-        name: "codex-native-ui",
-        display_name: "Codex",
-        description: null,
-        harness: "codex-native",
-        skills: [],
-      },
-    ]);
-    renderLanding();
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    // Described agent → the menu item is the tooltip trigger, so focusing
-    // the row (keyboard) opens the flyout, same as hovering it.
-    expect(screen.getByTestId("new-chat-landing-agent-with_desc")).toHaveAttribute(
-      "data-slot",
-      "tooltip-trigger",
-    );
-    // No description → nothing to show, so the row stays a plain menu item
-    // and no empty flyout is wired up.
-    expect(screen.getByTestId("new-chat-landing-agent-no_desc")).not.toHaveAttribute(
-      "data-slot",
-      "tooltip-trigger",
-    );
-  });
-
   it("shows a conflict banner in the file browser for an occupied directory", async () => {
     // A live session in the seeded workspace ("/Users/corey/repo") on the
     // auto-selected host occupies the directory the picker opens at.

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -695,6 +695,47 @@ describe("NewChatLandingScreen", () => {
     expect(detail.textContent).toContain("Edit any file and access the internet");
   });
 
+  it("makes the agent row's menu item itself the description tooltip trigger", () => {
+    // Accessibility: the description flyout must open on keyboard focus,
+    // not just pointer hover. Roving focus in the dropdown lands on the
+    // `[role=menuitem]` element, so that element (not an inner div) has
+    // to be the tooltip trigger. Asserting the slot marker is on the
+    // menu item itself locks that in — wrapping inner content instead
+    // would leave the flyout pointer-only for keyboard users.
+    mockAgents([
+      {
+        id: "with_desc",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: "Plans and splits up the work.",
+        harness: "claude-native",
+        skills: [],
+      },
+      {
+        id: "no_desc",
+        name: "codex-native-ui",
+        display_name: "Codex",
+        description: null,
+        harness: "codex-native",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    // Described agent → the menu item is the tooltip trigger, so focusing
+    // the row (keyboard) opens the flyout, same as hovering it.
+    expect(screen.getByTestId("new-chat-landing-agent-with_desc")).toHaveAttribute(
+      "data-slot",
+      "tooltip-trigger",
+    );
+    // No description → nothing to show, so the row stays a plain menu item
+    // and no empty flyout is wired up.
+    expect(screen.getByTestId("new-chat-landing-agent-no_desc")).not.toHaveAttribute(
+      "data-slot",
+      "tooltip-trigger",
+    );
+  });
+
   it("shows a conflict banner in the file browser for an occupied directory", async () => {
     // A live session in the seeded workspace ("/Users/corey/repo") on the
     // auto-selected host occupies the directory the picker opens at.

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1066,45 +1066,49 @@ export function NewChatLandingScreen() {
    */
   const renderAgentRow = (agent: AvailableAgent) => {
     const blurb = AGENT_PICKER_DESCRIPTIONS[agent.name];
+    // Cursor-style flyout: the tooltip wraps the WHOLE menu item via
+    // `asChild` (not the inner content), so the same `[role=menuitem]`
+    // element is both the roving-focus target and the tooltip trigger.
+    // That keeps the description reachable by keyboard (opens on focus,
+    // not just pointer hover) — wrapping the inner <div> left it
+    // pointer-only since roving focus never lands on that div. Radix
+    // composes the menu collection ref and the tooltip ref onto the one
+    // element, so roving focus is preserved. No-ops when the agent has
+    // no description.
     return (
-      <DropdownMenuItem
-        key={agent.id}
-        data-testid={`new-chat-landing-agent-${agent.id}`}
-        data-active={agent.id === effectiveAgentId ? "true" : undefined}
-        onSelect={() => {
-          // Switching agents drops the harness override so a
-          // pick never leaks across agents.
-          if (agent.id !== effectiveAgentId) setPickedHarness(null);
-          setPickedAgentId(agent.id);
-          // Explicit picks persist; auto-defaults never do.
-          writeLastAgentId(agent.id);
-        }}
-        className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
-      >
-        {/* Cursor-style flyout to the right of the row. The tooltip
-            wraps the row's inner content (not the menu item) so the
-            item stays a direct child of DropdownMenuContent and keeps
-            roving focus. No-ops when the agent has no description. */}
-        <AgentRowTooltip agent={agent}>
+      <AgentRowTooltip key={agent.id} agent={agent}>
+        <DropdownMenuItem
+          data-testid={`new-chat-landing-agent-${agent.id}`}
+          data-active={agent.id === effectiveAgentId ? "true" : undefined}
+          onSelect={() => {
+            // Switching agents drops the harness override so a
+            // pick never leaks across agents.
+            if (agent.id !== effectiveAgentId) setPickedHarness(null);
+            setPickedAgentId(agent.id);
+            // Explicit picks persist; auto-defaults never do.
+            writeLastAgentId(agent.id);
+          }}
+          className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+        >
           <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
             <span className="truncate">{agent.display_name}</span>
             {blurb && (
               <span className="truncate text-[11px] text-muted-foreground/70">{blurb}</span>
             )}
           </div>
-        </AgentRowTooltip>
-        {/* Compact right-aligned readiness pill; the full
-            remediation text lives in the composer warning. */}
-        {harnessUnconfiguredOnHost(agent.harness, harnessWarningHost) && (
-          <Badge
-            variant="outline"
-            className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
-            data-testid={`new-chat-landing-agent-warning-${agent.id}`}
-          >
-            needs setup
-          </Badge>
-        )}
-      </DropdownMenuItem>
+          {/* Compact right-aligned readiness pill; the full
+              remediation text lives in the composer warning. */}
+          {harnessUnconfiguredOnHost(agent.harness, harnessWarningHost) && (
+            <Badge
+              variant="outline"
+              className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
+              data-testid={`new-chat-landing-agent-warning-${agent.id}`}
+            >
+              needs setup
+            </Badge>
+          )}
+        </DropdownMenuItem>
+      </AgentRowTooltip>
     );
   };
 

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1089,9 +1089,7 @@ export function NewChatLandingScreen() {
           <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
             <span className="truncate">{agent.display_name}</span>
             {blurb && (
-              <span className="truncate text-[11px] text-muted-foreground/70">
-                {blurb}
-              </span>
+              <span className="truncate text-[11px] text-muted-foreground/70">{blurb}</span>
             )}
           </div>
         </AgentRowTooltip>
@@ -1485,14 +1483,15 @@ export function NewChatLandingScreen() {
                     >
                       {/* Built-in agents first, then a divider, then any
                           custom (user-registered) agents. renderAgentRow is
-                          defined once and reused for both groups. */}
+                          defined once and reused for both groups. The divider
+                          only renders when BOTH groups are non-empty, so a
+                          deployment with only custom agents (or only built-ins)
+                          never shows a leading/dangling separator. */}
                       {builtinAgents.map((agent) => renderAgentRow(agent))}
-                      {customAgents.length > 0 && (
-                        <>
-                          <DropdownMenuSeparator />
-                          {customAgents.map((agent) => renderAgentRow(agent))}
-                        </>
+                      {builtinAgents.length > 0 && customAgents.length > 0 && (
+                        <DropdownMenuSeparator />
                       )}
+                      {customAgents.map((agent) => renderAgentRow(agent))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 ) : (

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -1066,49 +1066,49 @@ export function NewChatLandingScreen() {
    */
   const renderAgentRow = (agent: AvailableAgent) => {
     const blurb = AGENT_PICKER_DESCRIPTIONS[agent.name];
-    // Cursor-style flyout: the tooltip wraps the WHOLE menu item via
-    // `asChild` (not the inner content), so the same `[role=menuitem]`
-    // element is both the roving-focus target and the tooltip trigger.
-    // That keeps the description reachable by keyboard (opens on focus,
-    // not just pointer hover) — wrapping the inner <div> left it
-    // pointer-only since roving focus never lands on that div. Radix
-    // composes the menu collection ref and the tooltip ref onto the one
-    // element, so roving focus is preserved. No-ops when the agent has
-    // no description.
     return (
-      <AgentRowTooltip key={agent.id} agent={agent}>
-        <DropdownMenuItem
-          data-testid={`new-chat-landing-agent-${agent.id}`}
-          data-active={agent.id === effectiveAgentId ? "true" : undefined}
-          onSelect={() => {
-            // Switching agents drops the harness override so a
-            // pick never leaks across agents.
-            if (agent.id !== effectiveAgentId) setPickedHarness(null);
-            setPickedAgentId(agent.id);
-            // Explicit picks persist; auto-defaults never do.
-            writeLastAgentId(agent.id);
-          }}
-          className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
-        >
+      <DropdownMenuItem
+        key={agent.id}
+        data-testid={`new-chat-landing-agent-${agent.id}`}
+        data-active={agent.id === effectiveAgentId ? "true" : undefined}
+        onSelect={() => {
+          // Switching agents drops the harness override so a
+          // pick never leaks across agents.
+          if (agent.id !== effectiveAgentId) setPickedHarness(null);
+          setPickedAgentId(agent.id);
+          // Explicit picks persist; auto-defaults never do.
+          writeLastAgentId(agent.id);
+        }}
+        className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+      >
+        {/* Cursor-style flyout to the right of the row. The tooltip wraps
+            the row's inner content (a host <div>), NOT the menu item:
+            DropdownMenuItem is a plain function component (no forwardRef),
+            so TooltipTrigger's `asChild` ref can't attach to it under
+            React 18 — the flyout wouldn't open and it logs ref warnings.
+            Wrapping the <div> keeps refs working and the item a direct
+            roving-focus child of DropdownMenuContent. No-ops when the
+            agent has no description. */}
+        <AgentRowTooltip agent={agent}>
           <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
             <span className="truncate">{agent.display_name}</span>
             {blurb && (
               <span className="truncate text-[11px] text-muted-foreground/70">{blurb}</span>
             )}
           </div>
-          {/* Compact right-aligned readiness pill; the full
-              remediation text lives in the composer warning. */}
-          {harnessUnconfiguredOnHost(agent.harness, harnessWarningHost) && (
-            <Badge
-              variant="outline"
-              className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
-              data-testid={`new-chat-landing-agent-warning-${agent.id}`}
-            >
-              needs setup
-            </Badge>
-          )}
-        </DropdownMenuItem>
-      </AgentRowTooltip>
+        </AgentRowTooltip>
+        {/* Compact right-aligned readiness pill; the full
+            remediation text lives in the composer warning. */}
+        {harnessUnconfiguredOnHost(agent.harness, harnessWarningHost) && (
+          <Badge
+            variant="outline"
+            className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
+            data-testid={`new-chat-landing-agent-warning-${agent.id}`}
+          >
+            needs setup
+          </Badge>
+        )}
+      </DropdownMenuItem>
     );
   };
 

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -51,7 +51,7 @@ import {
   nativeWrapperLabelsForAgent,
 } from "@/lib/nativeCodingAgents";
 import { useHosts, type Host } from "@/hooks/useHosts";
-import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
@@ -63,12 +63,25 @@ import { SkillPills } from "@/components/SkillPills";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
 import { IntelligentModelControl, type CostControlMode } from "@/components/CostRoutingControl";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { AgentRowTooltip } from "@/components/AgentHoverCard";
 
 // Preferred display order for the built-in agent picker. The server
 // returns agents newest-registered first (agent_store.list sorts by
 // created_at desc), so pin the order users expect; any agent not listed
 // here falls after, in server order.
-const AGENT_DISPLAY_ORDER = ["Claude Code", "Codex", "Pi", "Polly"];
+const AGENT_DISPLAY_ORDER = ["Claude Code", "Codex", "Pi", "Polly", "Debby"];
+
+// Built-in agents (by name slug) — the long-lived agents the server
+// ships out of the box. The picker groups these first, then a divider,
+// then custom (user-registered) agents. GET /v1/agents doesn't yet
+// distinguish the two, so this is a frontend allowlist for now.
+const BUILTIN_AGENTS = new Set([
+  "claude-native-ui", // Claude Code
+  "codex-native-ui", // Codex
+  "pi-native-ui", // Pi
+  "polly",
+  "debby",
+]);
 
 // Hidden on the new-session picker only (superseded by polly; older
 // deployments still carry a seeded nessie row this filter keeps out).
@@ -688,6 +701,18 @@ export function NewChatLandingScreen() {
       );
   }, [agents]);
 
+  // Split the picker into built-in agents (shipped out of the box) and
+  // custom (user-registered) agents so the menu can group them with a
+  // divider between, mirroring the permission-mode separator below.
+  const builtinAgents = useMemo(
+    () => agentList.filter((a) => BUILTIN_AGENTS.has(a.name)),
+    [agentList],
+  );
+  const customAgents = useMemo(
+    () => agentList.filter((a) => !BUILTIN_AGENTS.has(a.name)),
+    [agentList],
+  );
+
   const [message, setMessage] = useState<string>("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // maxRows 9 = 180px of 20px lines, matching the composer's 200px
@@ -1028,6 +1053,62 @@ export function NewChatLandingScreen() {
           ? `${selectedAgent.display_name} (${BRAIN_HARNESS_LABELS[pickedHarness] ?? pickedHarness})`
           : selectedAgent.display_name
     : "Select agent";
+
+  /**
+   * Render one agent row in the picker dropdown.
+   *
+   * The short blurb (from AGENT_PICKER_DESCRIPTIONS, hardcoded for a
+   * few agents) renders NEXT TO the name in lighter text, and only
+   * when one exists — agents without a blurb show just their name in
+   * the menu. The full spec description is never shown inline; it
+   * surfaces on hover via AgentRowTooltip, and the closed-state button
+   * label (agentLabel) shows only the name.
+   */
+  const renderAgentRow = (agent: AvailableAgent) => {
+    const blurb = AGENT_PICKER_DESCRIPTIONS[agent.name];
+    return (
+      <DropdownMenuItem
+        key={agent.id}
+        data-testid={`new-chat-landing-agent-${agent.id}`}
+        data-active={agent.id === effectiveAgentId ? "true" : undefined}
+        onSelect={() => {
+          // Switching agents drops the harness override so a
+          // pick never leaks across agents.
+          if (agent.id !== effectiveAgentId) setPickedHarness(null);
+          setPickedAgentId(agent.id);
+          // Explicit picks persist; auto-defaults never do.
+          writeLastAgentId(agent.id);
+        }}
+        className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+      >
+        {/* Cursor-style flyout to the right of the row. The tooltip
+            wraps the row's inner content (not the menu item) so the
+            item stays a direct child of DropdownMenuContent and keeps
+            roving focus. No-ops when the agent has no description. */}
+        <AgentRowTooltip agent={agent}>
+          <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
+            <span className="truncate">{agent.display_name}</span>
+            {blurb && (
+              <span className="truncate text-[11px] text-muted-foreground/70">
+                {blurb}
+              </span>
+            )}
+          </div>
+        </AgentRowTooltip>
+        {/* Compact right-aligned readiness pill; the full
+            remediation text lives in the composer warning. */}
+        {harnessUnconfiguredOnHost(agent.harness, harnessWarningHost) && (
+          <Badge
+            variant="outline"
+            className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
+            data-testid={`new-chat-landing-agent-warning-${agent.id}`}
+          >
+            needs setup
+          </Badge>
+        )}
+      </DropdownMenuItem>
+    );
+  };
 
   function selectHost(hostId: string) {
     // Re-selecting the current host is a no-op. Clearing the workspace here
@@ -1402,42 +1483,16 @@ export function NewChatLandingScreen() {
                       side="bottom"
                       className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
                     >
-                      {agentList.map((agent) => (
-                        <DropdownMenuItem
-                          key={agent.id}
-                          data-testid={`new-chat-landing-agent-${agent.id}`}
-                          data-active={agent.id === effectiveAgentId ? "true" : undefined}
-                          onSelect={() => {
-                            // Switching agents drops the harness override so a
-                            // pick never leaks across agents.
-                            if (agent.id !== effectiveAgentId) setPickedHarness(null);
-                            setPickedAgentId(agent.id);
-                            // Explicit picks persist; auto-defaults never do.
-                            writeLastAgentId(agent.id);
-                          }}
-                          className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
-                        >
-                          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                            <span className="truncate">{agent.display_name}</span>
-                            {(AGENT_PICKER_DESCRIPTIONS[agent.name] ?? agent.description) && (
-                              <span className="truncate text-xs text-muted-foreground">
-                                {AGENT_PICKER_DESCRIPTIONS[agent.name] ?? agent.description}
-                              </span>
-                            )}
-                          </div>
-                          {/* Compact right-aligned readiness pill; the full
-                              remediation text lives in the composer warning. */}
-                          {harnessUnconfiguredOnHost(agent.harness, harnessWarningHost) && (
-                            <Badge
-                              variant="outline"
-                              className="ml-auto self-center border-amber-300 bg-amber-50 text-[11px] text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-400"
-                              data-testid={`new-chat-landing-agent-warning-${agent.id}`}
-                            >
-                              needs setup
-                            </Badge>
-                          )}
-                        </DropdownMenuItem>
-                      ))}
+                      {/* Built-in agents first, then a divider, then any
+                          custom (user-registered) agents. renderAgentRow is
+                          defined once and reused for both groups. */}
+                      {builtinAgents.map((agent) => renderAgentRow(agent))}
+                      {customAgents.length > 0 && (
+                        <>
+                          <DropdownMenuSeparator />
+                          {customAgents.map((agent) => renderAgentRow(agent))}
+                        </>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 ) : (

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -1,11 +1,13 @@
 spec_version: 1
 name: polly
 description: >-
-  Multi-agent coding orchestrator. polly writes no code itself — it edits
-  docs / Markdown / text files and authors skills directly, and delegates ALL
-  coding work — investigation / implementation / review — to Claude Code /
-  Codex / Pi sub-agents, verifies with an independent different-model
-  reviewer, and integrates.
+  A coding orchestrator that breaks your goal into pieces and hands them
+  to a team of Claude Code, Codex, and Pi sub-agents to build. Polly
+  writes no code itself — it plans and splits up the work, delegates all
+  of it (investigation / implementation / review), then has a separate
+  independent different-model reviewer double-check the work before
+  putting it all together. Best for bigger tasks you want planned and
+  split up.
 
 # Beyond the declared sub-agents (tools.agents below), polly may also spawn
 # child sessions it defines itself: spawn: true registers

--- a/omnigent/resources/examples/polly/config.yaml
+++ b/omnigent/resources/examples/polly/config.yaml
@@ -1,11 +1,13 @@
 spec_version: 1
 name: polly
 description: >-
-  Multi-agent coding orchestrator. polly writes no code itself — it edits
-  docs / Markdown / text files and authors skills directly, and delegates ALL
-  coding work — investigation / implementation / review — to Claude Code /
-  Codex / Pi sub-agents, verifies with an independent different-model
-  reviewer, and integrates.
+  A coding orchestrator that breaks your goal into pieces and hands them
+  to a team of Claude Code, Codex, and Pi sub-agents to build. Polly
+  writes no code itself — it plans and splits up the work, delegates all
+  of it (investigation / implementation / review), then has a separate
+  independent different-model reviewer double-check the work before
+  putting it all together. Best for bigger tasks you want planned and
+  split up.
 
 # Beyond the declared sub-agents (tools.agents below), polly may also spawn
 # child sessions it defines itself: spawn: true registers

--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -38,10 +38,11 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     """
     Convert a runtime Agent entity to an API-layer AgentObject.
 
-    Loads the spec from cache to populate ``mcp_servers`` and
-    ``skills``; on any load failure both are left empty rather than
-    failing the whole list — one unreadable bundle must not break
-    discovery.
+    Loads the spec from cache to populate ``mcp_servers``,
+    ``skills``, and (when the stored row has none) the
+    ``description``; on any load failure those fall back to empty /
+    the stored value rather than failing the whole list — one
+    unreadable bundle must not break discovery.
 
     :param agent: The runtime agent entity, e.g. the seeded
         ``claude-native-ui`` agent.
@@ -52,6 +53,11 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     skills: list[SkillSummary] = []
     terminals: list[str] = []
     harness: str | None = None
+    # Prefer the stored entity's description; fall back to the spec's
+    # top-level description when the stored value is unset (single-file
+    # YAML agents don't persist it at registration today). Lets the
+    # new-session picker show a hover description without a migration.
+    description: str | None = agent.description
     try:
         # Built-ins are operator-authored template agents
         # (session_id is None), so ${VAR} expansion against the server
@@ -60,6 +66,8 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         loaded = agent_cache.load(
             agent.id, agent.bundle_location, expand_env=agent.session_id is None
         )
+        if description is None:
+            description = loaded.spec.description
         # Declared terminal names, in spec order (mirrors the
         # session-agent endpoint so both report it consistently).
         terminals = list(loaded.spec.terminals or {})
@@ -91,7 +99,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         id=agent.id,
         name=agent.name,
         version=agent.version,
-        description=agent.description,
+        description=description,
         created_at=agent.created_at,
         updated_at=agent.updated_at,
         harness=harness,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -16927,10 +16927,11 @@ def create_sessions_router(
         :class:`AgentObject`.
 
         Loads the agent spec from *cache* to populate ``mcp_servers``,
-        ``policies``, and ``skills``. If the cache is ``None``, the
-        spec is not cached, or the load fails, all are left as empty
-        lists rather than raising — the endpoint must not fail because
-        one spec can't be read.
+        ``policies``, ``skills``, and (when the stored row has none) the
+        ``description``. If the cache is ``None``, the spec is not
+        cached, or the load fails, those fall back to empty lists / the
+        stored value rather than raising — the endpoint must not fail
+        because one spec can't be read.
 
         :param agent: The runtime agent entity.
         :param cache: Agent cache, or ``None`` in test setups.
@@ -16943,12 +16944,19 @@ def create_sessions_router(
         # Harness/kind for the UI; None until the spec loads (mirrors the
         # GET /v1/agents catalog so both endpoints report it consistently).
         harness: str | None = None
+        # Prefer the stored entity's description; fall back to the spec's
+        # top-level description when the stored value is unset (single-file
+        # YAML agents don't persist it at registration today). Lets the
+        # new-session picker show a hover description without a migration.
+        description: str | None = agent.description
         if cache is not None:
             try:
                 loaded = cache.load(
                     agent.id, agent.bundle_location, expand_env=agent.session_id is None
                 )
                 harness = loaded.spec.executor.harness_kind
+                if description is None:
+                    description = loaded.spec.description
                 # Declared terminal names, in spec order — the Web UI
                 # gates its "new terminal" affordance on this list.
                 terminals = list(loaded.spec.terminals or {})
@@ -16994,7 +17002,7 @@ def create_sessions_router(
             id=agent.id,
             name=agent.name,
             version=agent.version,
-            description=agent.description,
+            description=description,
             created_at=agent.created_at,
             updated_at=agent.updated_at,
             harness=harness,

--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -392,3 +392,78 @@ async def test_catalog_entry_exposes_availability_and_reason(
     # AgentObject schema today, so these key lookups fail (the xfail).
     assert "availability" in entry
     assert "unavailable_reason" in entry
+
+
+async def test_catalog_description_falls_back_to_spec_when_row_unset(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/agents`` surfaces the spec's top-level ``description`` when
+    the stored agent row has none.
+
+    Single-file YAML built-ins don't persist a description at
+    registration today, so the stored column is ``None`` for them. The
+    new-session picker shows a hover description, and without this
+    fallback those agents would hover blank. Registering with
+    ``description=None`` but a spec that declares one proves the route
+    reads through to the bundle rather than echoing the empty column.
+    """
+    bundle = build_agent_bundle(
+        name="hoverable-agent",
+        description="Planned and split across sub-agents.",
+    )
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="ag_specdesc",
+        name="hoverable-agent",
+        bundle=bundle,
+        description=None,
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_specdesc")
+    # The stored column is None, so a non-None value here can only have
+    # come from the spec via the load → AgentObject fallback path.
+    assert entry["description"] == "Planned and split across sub-agents."
+
+
+async def test_catalog_description_prefers_stored_row_over_spec(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/agents`` prefers the stored row's ``description`` over the
+    spec's when both are set.
+
+    The fallback to the spec must be exactly that — a fallback. An
+    operator who set a description on the row (e.g. a curated catalog
+    label) must not have it silently overridden by whatever the bundled
+    spec happens to say. Registering with a stored description that
+    differs from the spec's proves the stored value wins.
+    """
+    bundle = build_agent_bundle(
+        name="relabelled-agent",
+        description="Spec description (should be ignored).",
+    )
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="ag_storeddesc",
+        name="relabelled-agent",
+        bundle=bundle,
+        description="Curated catalog label.",
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    entry = next(a for a in resp.json()["data"] if a["id"] == "ag_storeddesc")
+    # Stored value present → it wins; the differing spec description
+    # proves the route didn't blindly overwrite with the bundle's.
+    assert entry["description"] == "Curated catalog label."


### PR DESCRIPTION
## What

Port the Cursor-style agent description flyouts from `databricks-eng/agent-framework#2956`, adapted to this repo's current picker (which already moved permission-mode into the footer tray, added Pi, etc.).

- **`AgentHoverCard.tsx`** (new) — two exports sharing one flyout body:
  - `AgentHoverCard` — a radix `HoverCard` for the Add Agent **cards** (outside a dropdown).
  - `AgentRowTooltip` — a radix `Tooltip` for the new-session picker **rows** (a `HoverCard` swallows the roving-focus ref inside a `DropdownMenuContent`, so rows use a tooltip instead). Relies on the global `TooltipProvider` at `main.tsx`.
  - Both no-op when an agent has no description.
- **`AgentCard.tsx`** — opt-in `hover` prop wraps the card in `AgentHoverCard`; ignored in `compact` mode (which has its own tooltip).
- **`AddAgentDialog.tsx`** — passes `hover` to the cards.
- **`NewChatDialog.tsx`** — groups built-in agents first, then a divider, then custom agents, reusing one `renderAgentRow`; the row's spec description now surfaces on hover rather than inline.
- **`builtin_agents.py` / `sessions.py`** — both `_to_agent_object` helpers fall back to the spec's top-level `description` when the stored row has none (single-file YAML agents don't persist it), so agents hover non-empty without a DB migration. A stored description still wins when set.
- **`examples/polly/config.yaml`** + packaged `omnigent/resources/examples/polly/config.yaml` — friendlier user-facing description (combining the PR's wording with this branch's Pi/independent-reviewer details), kept byte-identical across both copies (the server seeds from the packaged copy).

## Tests

- `AgentHoverCard.test.tsx` (new) + `AgentCard.test.tsx` hover-mode block — assert the wrap-vs-bare branch via the radix `data-slot` markers, and that compact wins over hover.
- `test_builtin_agents.py` — catalog description falls back to the spec when the row is unset, and the stored row wins when both are set.
- `npm test` (2769 passed), `npm run build`, `tsc -b`, and `ruff check`/`format` all pass. No lint regressions in changed files.