### PR TITLE
fix: prevent Enter from sending message during IME composition

### DIFF
--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -2804,6 +2804,7 @@ export function Composer({
   // Nonce bumped when bare "/model" is submitted; opens the AgentPicker
   // dropdown instead of sending (see submit()).
   const [pickerOpenNonce, setPickerOpenNonce] = useState(0);
+  const [isComposing, setIsComposing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Highlight overlay mirroring the textarea; scroll-synced so the tinted
@@ -3270,7 +3271,7 @@ export function Composer({
 
     // Enter sends; Shift+Enter inserts a newline. On mobile, Enter inserts a
     // newline (no Shift available on-screen) and Send must be tapped instead.
-    if (e.key === "Enter" && !e.shiftKey && !isMobile && !e.nativeEvent.isComposing) {
+    if (e.key === "Enter" && !e.shiftKey && !isMobile && !isComposing && !e.nativeEvent.isComposing) {
       e.preventDefault();
       submit();
       return;
@@ -3447,6 +3448,8 @@ export function Composer({
               else resetCursor();
             }}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
             onPaste={handlePaste}
             onScroll={(e) => {
               // Keep the overlay's scroll position locked to the textarea's.


### PR DESCRIPTION
## Summary

Fixes #433

Adds `compositionstart`/`compositionend` state tracking to the chat textarea in `ChatPage.tsx` to prevent Enter from sending a message while Japanese IME composition is active.

## Problem

When entering Japanese text in the chat input, pressing Enter to confirm an IME composition sends the chat message immediately. The first Enter should only confirm the IME composition, not submit the message.

## Root Cause

The previous implementation only checked `e.nativeEvent.isComposing` which is unreliable on some browsers/IME engines. The `prompt-input.tsx` component already has a more robust dual approach.

## Fix

- Added `isComposing` state variable
- Added `onCompositionStart` and `onCompositionEnd` handlers to the textarea
- Updated the Enter key check to use both `isComposing` state AND `e.nativeEvent.isComposing`

This matches the pattern already used in `prompt-input.tsx` (lines 914, 973-974, 992-993).

## Testing

- Verified the fix doesn't affect normal Enter-to-send behavior
- Verified Shift+Enter still inserts newlines
- Verified mobile behavior is unchanged