### PR TITLE
Fix Claude SDK MCP tool guidance

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -680,6 +680,47 @@ def _build_mcp_tools(
     return mcp_tools
 
 
+def _augment_system_prompt_for_omnigent_mcp_tools(
+    system_prompt: str,
+    tool_schemas: list[ToolSpec],
+) -> str:
+    """
+    Add Claude SDK-specific MCP tool-name guidance to the system prompt.
+
+    Omnigent schemas use bare names such as ``sys_session_send``. The
+    Claude SDK exposes tools from our in-process MCP server to the model
+    as ``mcp__omnigent__<bare_name>``. Bundled agent prompts and skills use
+    bare names because other executors call those directly, so the SDK needs
+    a bridge note to stop the model from trying a non-existent bare tool first.
+    """
+    tool_names = [
+        name for schema in tool_schemas if isinstance((name := schema.get("name")), str) and name
+    ]
+    if not tool_names:
+        return system_prompt
+
+    examples = [name for name in ("sys_session_send", "sys_session_create") if name in tool_names]
+    if examples:
+        example_text = "; ".join(
+            f"use `mcp__omnigent__{name}` when instructions say `{name}`" for name in examples
+        )
+        note = (
+            "Claude SDK tool naming: Omnigent tools are exposed as MCP tools. "
+            f"{example_text}. For any other Omnigent tool, use "
+            "`mcp__omnigent__<tool_name>` rather than the bare name."
+        )
+    else:
+        note = (
+            "Claude SDK tool naming: Omnigent tools are exposed as MCP tools. "
+            "When instructions mention a bare Omnigent tool name, invoke "
+            "`mcp__omnigent__<tool_name>` rather than the bare name."
+        )
+
+    if not system_prompt:
+        return note
+    return f"{system_prompt.rstrip()}\n\n{note}"
+
+
 def _find_system_claude() -> str | None:
     """Find a system-installed ``claude`` CLI binary on PATH.
 
@@ -1825,6 +1866,10 @@ class ClaudeSDKExecutor(Executor):
                 name="omnigent",
                 version="1.0.0",
                 tools=mcp_tools,
+            )
+            system_prompt = _augment_system_prompt_for_omnigent_mcp_tools(
+                system_prompt,
+                tools,
             )
 
         # Build allowed_tools list.  OS-environment operations route

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1591,6 +1591,7 @@ class TestStreamEventStreaming(unittest.TestCase):
             class ClaudeSDKClient:
                 def __init__(self, options):
                     captured_options["allowed_tools"] = getattr(options, "allowed_tools", None)
+                    captured_options["system_prompt"] = getattr(options, "system_prompt", None)
 
                 async def connect(self):
                     return None
@@ -1626,10 +1627,14 @@ class TestStreamEventStreaming(unittest.TestCase):
                                 },
                             }
                         ],
-                        "",
+                        "Delegate through `sys_session_send`.",
                     )
                 ]
             self.assertIn("mcp__omnigent__sys_session_send", captured_options["allowed_tools"])
+            self.assertIn(
+                "use `mcp__omnigent__sys_session_send` when instructions say `sys_session_send`",
+                captured_options["system_prompt"],
+            )
             self.assertIsInstance(events[-1], TurnComplete)
 
         _run(_t())


### PR DESCRIPTION
## Summary

- Add Claude SDK-specific guidance that maps bare Omnigent tool names to their MCP-exposed names.
- Call out `mcp__omnigent__sys_session_send` and `mcp__omnigent__sys_session_create` when those tools are present.
- Cover the `sys_session_send` case with a regression assertion on the SDK system prompt.

## Root cause

Polly's instructions and skills use bare Omnigent tool names such as `sys_session_send`, which is correct for non-SDK executors. The Claude SDK exposes tools from Omnigent's in-process MCP server to the model as `mcp__omnigent__<tool_name>`, so Claude could try the bare name first and only recover after seeing that tools are namespaced.

## Validation

- `rtk python -m compileall omnigent\inner\claude_sdk_executor.py tests\inner\test_claude_sdk_executor.py`
- `rtk python -m ruff check omnigent\inner\claude_sdk_executor.py tests\inner\test_claude_sdk_executor.py`
- `rtk python -m ruff format --check omnigent\inner\claude_sdk_executor.py tests\inner\test_claude_sdk_executor.py`
- `rtk uv run --extra dev python -c "import signal, sys, pytest; signal.SIGUSR1 = signal.SIGTERM; sys.exit(pytest.main(sys.argv[1:]))" tests\inner\test_claude_sdk_executor.py::TestStreamEventStreaming::test_session_send_tool_is_exposed_via_mcp -q`

Fixes #400.
