### PR TITLE
fix(ap-web): show the asleep hint when the runner is asleep on reconnect

### DIFF
--- a/ap-web/src/shell/FilesPanel.test.tsx
+++ b/ap-web/src/shell/FilesPanel.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  RunnerOfflineError,
   type WorkspaceChangedFile,
   type WorkspaceFile,
   useWorkspaceAllFiles,
@@ -12,6 +13,7 @@ import {
   useWorkspaceEnvironment,
   useWorkspaceFileSearch,
 } from "@/hooks/useWorkspaceChangedFiles";
+import { type SessionLiveness, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { FilesPanel } from "./FilesPanel";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import { FolderTree } from "./FolderTree";
@@ -24,7 +26,19 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
   useWorkspaceFileSearch: vi.fn(),
   // Real export consumed by FlatFileList's `instanceof` check; the full
   // module mock would otherwise drop it (undefined → instanceof throws).
-  RunnerOfflineError: class RunnerOfflineError extends Error {},
+  RunnerOfflineError: class extends Error {},
+}));
+
+// FilesPanel derives the runner-asleep hint from session liveness; mock the
+// hook (and its row helper) so tests drive `kind` directly. Defaults to a
+// live session — overridden per-test. `useSession` is mocked too so the panel
+// doesn't need a QueryClient in these unit renders.
+vi.mock("@/hooks/useSession", () => ({
+  useSession: vi.fn(() => ({ session: null, isLoading: false, error: null })),
+}));
+vi.mock("@/hooks/useSessionLiveness", () => ({
+  useSessionLiveness: vi.fn(() => ({ kind: "online" })),
+  livenessRowFromSession: vi.fn(() => null),
 }));
 
 const useAllFilesMock = vi.mocked(useWorkspaceAllFiles);
@@ -32,6 +46,7 @@ const useChangedFilesMock = vi.mocked(useWorkspaceChangedFiles);
 const useDirectoryMock = vi.mocked(useWorkspaceDirectory);
 const useEnvironmentMock = vi.mocked(useWorkspaceEnvironment);
 const useSearchMock = vi.mocked(useWorkspaceFileSearch);
+const useLivenessMock = vi.mocked(useSessionLiveness);
 
 function file(path: string, bytes = 10): WorkspaceFile {
   return {
@@ -158,6 +173,9 @@ beforeEach(() => {
   useDirectoryMock.mockReset();
   useEnvironmentMock.mockReset();
   useSearchMock.mockReset();
+  // Reset liveness to a live runner so a leaked override can't bleed across
+  // tests (mockReturnValue persists through clearAllMocks).
+  useLivenessMock.mockReturnValue({ kind: "online" });
 });
 
 afterEach(() => {
@@ -1140,5 +1158,67 @@ describe("FilesPanel tree (Explore) search", () => {
 
     expect(screen.getByRole("textbox", { name: "files to include" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "files to exclude" })).toHaveValue("");
+  });
+});
+
+function changedFilesError() {
+  // The Changed-files fetch 503s when the runner is unreachable; FlatFileList
+  // detects it via `error instanceof RunnerOfflineError`.
+  return {
+    data: undefined,
+    error: new RunnerOfflineError(),
+    isError: true,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useWorkspaceChangedFiles>;
+}
+
+function renderOfflinePanel(liveness: SessionLiveness) {
+  useLivenessMock.mockReturnValue(liveness);
+  useAllFilesMock.mockReturnValue(allFilesResult([]));
+  useChangedFilesMock.mockReturnValue(changedFilesError());
+  useDirectoryMock.mockReturnValue(directoryResult());
+  useEnvironmentMock.mockReturnValue(environmentResult());
+  useSearchMock.mockReturnValue(searchResult());
+  return render(
+    <MemoryRouter initialEntries={["/c/conv_offline"]}>
+      <Routes>
+        <Route
+          path="/c/:conversationId"
+          element={
+            <FilesPanel
+              sort="recent"
+              onSortChange={vi.fn()}
+              flatView={true}
+              onFileSelect={vi.fn()}
+              onFlatViewChange={vi.fn()}
+              showHidden={false}
+              onShowHiddenChange={vi.fn()}
+            />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("FilesPanel runner-asleep reconnect hint", () => {
+  it("shows the reconnect hint when the runner is asleep (host up) and the files fetch 503s", () => {
+    // Host reconnected before the first new message: runner down, host up →
+    // liveness `runner_asleep` (sessionStatus is NOT "failed"). The panel must
+    // guide the user to send a message, not claim "No files in workspace".
+    renderOfflinePanel({ kind: "runner_asleep" });
+
+    expect(screen.getByText(/agent is asleep/i)).toBeInTheDocument();
+    expect(screen.getByText(/send a message in the chat to reconnect/i)).toBeInTheDocument();
+  });
+
+  it("keeps the empty state (not the hint) for a still-starting session", () => {
+    // A brand-new session mid-cold-boot reads as `starting`, not
+    // `runner_asleep`, so it keeps the normal empty state and does not alarm
+    // the user — the deliberate behavior this change must preserve.
+    renderOfflinePanel({ kind: "starting" });
+
+    expect(screen.queryByText(/agent is asleep/i)).toBeNull();
+    expect(screen.getByText(/no workspace changes yet/i)).toBeInTheDocument();
   });
 });

--- a/ap-web/src/shell/FilesPanel.tsx
+++ b/ap-web/src/shell/FilesPanel.tsx
@@ -19,6 +19,8 @@ import {
   useWorkspaceEnvironment,
   useWorkspaceFileSearch,
 } from "@/hooks/useWorkspaceChangedFiles";
+import { useSession } from "@/hooks/useSession";
+import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -275,18 +277,24 @@ export function FilesPanel({
   frameless,
 }: FilesPanelProps) {
   const { conversationId } = useParams<{ conversationId: string }>();
-  // The runner went offline (e.g. its host restarted): `sessionStatus`
-  // is "failed", set by `_on_runner_disconnect` server-side when the
-  // runner's tunnel drops (and also client-side in chatStore when the
-  // SSE stream itself dies). Either way the session can't be reached and
-  // a message reconnects it. A brand-new session whose runner just hasn't
-  // started is never "failed", so this distinguishes "asleep, send a
-  // message to reconnect" from a fresh session that should show the
-  // normal empty state — a real liveness signal, not an inference from
-  // chat history.
-  const runnerWentOffline = useChatStore(
+  // Show the "agent is asleep — send a message to reconnect" hint (rather
+  // than a misleading "No files" empty state) whenever a message would bring
+  // the workspace back: either the runner tunnel "failed", or the session is
+  // `runner_asleep` (runner down, host up — e.g. a host reconnect before the
+  // first new message, which never goes "failed"). A still-cold-booting
+  // session reads as `starting`, not `runner_asleep`, so it keeps the normal
+  // empty state.
+  const sessionFailed = useChatStore(
     (s) => s.conversationId === conversationId && s.sessionStatus === "failed",
   );
+  const turnActive = useChatStore(
+    (s) => s.conversationId === conversationId && s.status === "streaming",
+  );
+  const { session } = useSession(conversationId);
+  const liveness = useSessionLiveness(conversationId, livenessRowFromSession(session), {
+    turnActive,
+  });
+  const runnerWentOffline = sessionFailed || liveness.kind === "runner_asleep";
   const [collapsed, setCollapsed] = useState(false);
   const [changedSearch, setChangedSearch] = useState("");
   const [treeSearch, setTreeSearch] = useState("");


### PR DESCRIPTION
## Summary

After a host reconnects to the server but before you send the next message, the runner isn't recreated yet — so the file browser's changed/all-files queries 503 (`RunnerOfflineError`) and the panel renders the misleading **"No files in workspace"** empty state instead of the existing "agent is asleep — send a message to reconnect" hint.

The hint was gated only on `sessionStatus === "failed"`, which a clean host reconnect never sets (the session goes idle, not failed), so this case fell through.

This drives the hint off the session's derived liveness (`useSessionLiveness`) instead: it shows when the session is **`runner_asleep`** (runner down, host up — the next message relaunches it), in addition to the existing `"failed"` trigger. A still-cold-booting session reads as `starting`, not `runner_asleep`, so it keeps the normal empty state — the deliberate fresh-session behavior, unchanged. Fixes #386.

## Test plan

- [x] New `FilesPanel.test.tsx` cases: `runner_asleep` + a 503 → shows the reconnect hint (**fails without the production change**); `starting` → keeps the empty state (preserves the deliberate fresh-session behavior).
- [x] `vitest run` — 39 passed (new + existing `FilesPanel` / `FlatFileList` / `FolderTree`).
- [x] `oxlint`, `prettier --check`, and `tsc -b` all clean.

This is a small empty-state→hint render swap, fully covered by the colocated Vitest above. Happy to add a `tests/e2e_ui/` test if the gate wants one.
