### PR TITLE
fix(ci): walk back main history to find the coverage baseline

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -41,6 +41,10 @@ env:
   # "would fail once enforced" instead of a red ✗. Set "true" to post real
   # failure statuses once the gate has run cleanly for a while.
   COVERAGE_ENFORCE: "false"
+  # How many recent main commits to scan back through for the last recorded
+  # baseline status. Needs to exceed the longest expected run of consecutive
+  # merges that don't touch a given suite; 100 is a generous margin.
+  BASELINE_LOOKBACK: "100"
 
 jobs:
   post:
@@ -103,13 +107,35 @@ jobs:
             exit 0
           fi
 
-          # On a PR: baseline = the matching status on main's HEAD.
-          BASE_DESC=$(gh api "repos/$REPO/commits/main/status" \
-            -q ".statuses[] | select(.context==\"$CONTEXT\") | .description" 2>/dev/null | head -n1 || true)
-          BASELINE=$(printf '%s' "$BASE_DESC" | grep -oE '[0-9]+(\.[0-9]+)?' | head -n1 || true)
+          # On a PR: baseline = the most recent $CONTEXT status recorded on main.
+          # We can't just read main's HEAD: the two producers are path-filtered
+          # against each other (backend CI ignores ap-web/**, ap-web Tests only
+          # runs on ap-web/**), so a one-sided merge leaves HEAD carrying only one
+          # suite's status. Reading HEAD alone would then report "no baseline yet"
+          # and silently disable the other gate. Instead walk back through recent
+          # main commits and take the first one that actually carries $CONTEXT.
+          BASELINE=""
+          BASELINE_SHA=""
+          for sha in $(gh api "repos/$REPO/commits?sha=main&per_page=$BASELINE_LOOKBACK" \
+            -q '.[].sha' 2>/dev/null); do
+            d=$(gh api "repos/$REPO/commits/$sha/status" \
+              -q ".statuses[] | select(.context==\"$CONTEXT\") | .description" 2>/dev/null | head -n1 || true)
+            n=$(printf '%s' "$d" | grep -oE '[0-9]+(\.[0-9]+)?' | head -n1 || true)
+            if [[ -n "$n" ]]; then
+              BASELINE="$n"
+              BASELINE_SHA="$sha"
+              break
+            fi
+          done
+
+          if [[ -n "$BASELINE" ]]; then
+            echo "Baseline ${CONTEXT}=${BASELINE}% from main ${BASELINE_SHA}"
+          fi
 
           if [[ -z "$BASELINE" ]]; then
-            # No baseline recorded on main yet (first rollout) — report, don't gate.
+            # No $CONTEXT status in the last $BASELINE_LOOKBACK main commits
+            # (first rollout, or this suite hasn't run on main yet) — report,
+            # don't gate.
             gh api "repos/$REPO/statuses/$SHA" \
               -f state=success \
               -f context="$CONTEXT" \

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -41,9 +41,10 @@ env:
   # "would fail once enforced" instead of a red ✗. Set "true" to post real
   # failure statuses once the gate has run cleanly for a while.
   COVERAGE_ENFORCE: "false"
-  # How many recent main commits to scan back through for the last recorded
-  # baseline status. Needs to exceed the longest expected run of consecutive
-  # merges that don't touch a given suite; 100 is a generous margin.
+  # How many recent main commits to scan for the last recorded baseline status.
+  # Must exceed the longest expected run of consecutive merges that don't touch
+  # a given suite. Capped at 100 (the GraphQL history page size); raising it
+  # past 100 would require cursor pagination.
   BASELINE_LOOKBACK: "100"
 
 jobs:
@@ -51,7 +52,7 @@ jobs:
     name: Post coverage status
     permissions:
       actions: read     # download the coverage artifact from the producing run
-      contents: read    # read main's baseline status via the commits API
+      contents: read    # read main's baseline statuses via the GraphQL API
       statuses: write   # post the coverage status on the head SHA
     # PR runs (gate) and pushes to main (record baseline). Other completions have
     # no PR head SHA / aren't the baseline branch.
@@ -112,21 +113,21 @@ jobs:
           # against each other (backend CI ignores ap-web/**, ap-web Tests only
           # runs on ap-web/**), so a one-sided merge leaves HEAD carrying only one
           # suite's status. Reading HEAD alone would then report "no baseline yet"
-          # and silently disable the other gate. Instead walk back through recent
-          # main commits and take the first one that actually carries $CONTEXT.
-          BASELINE=""
-          BASELINE_SHA=""
-          for sha in $(gh api "repos/$REPO/commits?sha=main&per_page=$BASELINE_LOOKBACK" \
-            -q '.[].sha' 2>/dev/null); do
-            d=$(gh api "repos/$REPO/commits/$sha/status" \
-              -q ".statuses[] | select(.context==\"$CONTEXT\") | .description" 2>/dev/null | head -n1 || true)
-            n=$(printf '%s' "$d" | grep -oE '[0-9]+(\.[0-9]+)?' | head -n1 || true)
-            if [[ -n "$n" ]]; then
-              BASELINE="$n"
-              BASELINE_SHA="$sha"
-              break
-            fi
-          done
+          # and silently disable the other gate. Instead scan recent main commits
+          # and take the most recent that actually carries $CONTEXT. A single
+          # GraphQL query fetches the whole window's statuses at once (the legacy
+          # commit statuses we post appear under Commit.status.contexts), so this
+          # is one API call regardless of how far back the baseline sits.
+          BASELINE_JSON=$(gh api graphql \
+            -f query='query($owner:String!,$name:String!,$n:Int!){repository(owner:$owner,name:$name){ref(qualifiedName:"refs/heads/main"){target{... on Commit{history(first:$n){nodes{oid status{contexts{context description}}}}}}}}}' \
+            -F owner="${REPO%/*}" -F name="${REPO#*/}" -F n="$BASELINE_LOOKBACK" 2>/dev/null || true)
+          # Newest-first; keep only commits carrying $CONTEXT, take the first.
+          BASELINE_LINE=$(printf '%s' "$BASELINE_JSON" | jq -r --arg ctx "$CONTEXT" '
+            [ .data.repository.ref.target.history.nodes[]
+              | { oid: .oid, desc: (.status.contexts[]? | select(.context == $ctx) | .description) } ]
+            | .[0] // empty | "\(.oid)\t\(.desc)"' 2>/dev/null || true)
+          BASELINE_SHA=$(printf '%s' "$BASELINE_LINE" | cut -f1)
+          BASELINE=$(printf '%s' "$BASELINE_LINE" | cut -f2- | grep -oE '[0-9]+(\.[0-9]+)?' | head -n1 || true)
 
           if [[ -n "$BASELINE" ]]; then
             echo "Baseline ${CONTEXT}=${BASELINE}% from main ${BASELINE_SHA}"


### PR DESCRIPTION
## Problem

The coverage ratchet (#414) read the baseline from **main's HEAD** commit status. But the two producers are path-filtered against each other:

- backend `CI`: `paths-ignore: ['ap-web/**']`
- `ap-web Tests`: `paths: ['ap-web/**']`

So a merge that touches only one side records only that suite's status on the new main HEAD. Reading HEAD alone then finds **no status for the other suite** and reports `(no baseline yet)`, which silently disables that gate.

### Reproduced
Smoke test on #432: after an ap-web-only PR (#430) became main HEAD, the backend gate reported `Total coverage: 81% (no baseline yet)` even though `81%` was recorded one commit earlier on `c4aa2e72`. The UI gate, meanwhile, compared correctly (`UI coverage 79.59% (baseline 79.59%)`). In steady state this means **most merges would leave one gate dormant.**

## Fix

On a PR, instead of reading only HEAD, **walk back through recent main commits** (`BASELINE_LOOKBACK=100`) and take the first that actually carries the suite's status. The `(no baseline yet)` path now only triggers genuinely — first rollout, or a suite that has never run on main.

No new storage or credentials; the privileged no-checkout `workflow_run` model is unchanged. (The "standard" alternative — a SHA-keyed store like Codecov, or a repo Actions Variable cache — was considered; walk-back was chosen as the lowest-friction fix that preserves the current security model.)

## Cost
1–N extra read-only API calls per PR (typically 1–2; 100 worst case if a suite has been quiet for a long stretch).