### PR TITLE
test(e2e): resolve sandbox-deps-env suppressions (fix 6, defer 2)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -92,6 +92,9 @@ _DATABRICKS_MODEL_MAP: dict[str, str] = {
 # spawning, terminal hierarchies, etc.) and have no docs pointing
 # at them from elsewhere in the repo.
 _CLAUDE_CODER_DIR = _REPO_ROOT / "tests" / "resources" / "agents" / "claude-coder"
+_CLAUDE_CODER_SANDBOX_DIR = (
+    _REPO_ROOT / "tests" / "resources" / "agents" / "claude-coder-sandbox"
+)
 _OPENAI_CODER_DIR = _REPO_ROOT / "tests" / "resources" / "examples" / "openai-coder"
 _SYS_TERMINAL_TEST_DIR = _REPO_ROOT / "tests" / "resources" / "agents" / "sys-terminal-test"
 # A plain claude-sdk chat agent seeded as a BUILT-IN (via the server's
@@ -790,6 +793,28 @@ def claude_coder_agent(http_client: httpx.Client, databricks_workspace_host: str
     return upload_agent(
         http_client,
         _CLAUDE_CODER_DIR,
+        rewrite_model_for_databricks=databricks_workspace_host is not None,
+    )
+
+
+@pytest.fixture(scope="session")
+def claude_coder_sandbox_agent(
+    http_client: httpx.Client, databricks_workspace_host: str | None
+) -> str:
+    """
+    Upload the Claude SDK coder agent that declares an active ``os_env`` sandbox.
+
+    The generic ``claude_coder_agent`` intentionally has no ``os_env`` so most
+    Claude SDK e2es exercise the default native CLI behavior. Workspace
+    enforcement tests need the opposite: a fixture whose spec requests the
+    platform sandbox and grants writes only inside the conversation workspace.
+
+    :param http_client: HTTP client pointed at the server.
+    :returns: The agent name, ``"claude-coder-sandbox"``.
+    """
+    return upload_agent(
+        http_client,
+        _CLAUDE_CODER_SANDBOX_DIR,
         rewrite_model_for_databricks=databricks_workspace_host is not None,
     )
 

--- a/tests/e2e/test_claude_coder_sandbox.py
+++ b/tests/e2e/test_claude_coder_sandbox.py
@@ -88,7 +88,7 @@ def _dispatch_and_wait(
 
 def test_read_blocked_outside_workspace(
     http_client: httpx.Client,
-    claude_coder_agent: str,
+    claude_coder_sandbox_agent: str,
     live_runner_id: str,
 ) -> None:
     """
@@ -118,7 +118,7 @@ def test_read_blocked_outside_workspace(
     try:
         body = _dispatch_and_wait(
             http_client,
-            agent_name=claude_coder_agent,
+            agent_name=claude_coder_sandbox_agent,
             runner_id=live_runner_id,
             prompt=f"Use the Read tool to read {secret_path}. Do NOT use Bash or cat.",
         )
@@ -141,7 +141,7 @@ def test_read_blocked_outside_workspace(
 
 def test_write_blocked_outside_workspace(
     http_client: httpx.Client,
-    claude_coder_agent: str,
+    claude_coder_sandbox_agent: str,
     live_runner_id: str,
 ) -> None:
     """
@@ -159,7 +159,7 @@ def test_write_blocked_outside_workspace(
     try:
         body = _dispatch_and_wait(
             http_client,
-            agent_name=claude_coder_agent,
+            agent_name=claude_coder_sandbox_agent,
             runner_id=live_runner_id,
             prompt=f"Run this exact Bash command: echo ESCAPED > {target}",
         )
@@ -177,7 +177,7 @@ def test_write_blocked_outside_workspace(
 
 def test_write_succeeds_inside_workspace(
     http_client: httpx.Client,
-    claude_coder_agent: str,
+    claude_coder_sandbox_agent: str,
     live_runner_id: str,
 ) -> None:
     """
@@ -191,7 +191,7 @@ def test_write_succeeds_inside_workspace(
     """
     body = _dispatch_and_wait(
         http_client,
-        agent_name=claude_coder_agent,
+        agent_name=claude_coder_sandbox_agent,
         runner_id=live_runner_id,
         prompt=(
             "Create a file called test_sandbox.txt in the "
@@ -209,7 +209,7 @@ def test_write_succeeds_inside_workspace(
 
 def test_glob_blocked_outside_workspace(
     http_client: httpx.Client,
-    claude_coder_agent: str,
+    claude_coder_sandbox_agent: str,
     live_runner_id: str,
 ) -> None:
     """
@@ -233,7 +233,7 @@ def test_glob_blocked_outside_workspace(
     try:
         body = _dispatch_and_wait(
             http_client,
-            agent_name=claude_coder_agent,
+            agent_name=claude_coder_sandbox_agent,
             runner_id=live_runner_id,
             prompt="Use the Glob tool to search for *.txt files in /tmp. Do NOT use Bash or ls.",
         )
@@ -253,7 +253,7 @@ def test_glob_blocked_outside_workspace(
 
 def test_edit_blocked_outside_workspace(
     http_client: httpx.Client,
-    claude_coder_agent: str,
+    claude_coder_sandbox_agent: str,
     live_runner_id: str,
 ) -> None:
     """
@@ -277,7 +277,7 @@ def test_edit_blocked_outside_workspace(
     try:
         body = _dispatch_and_wait(
             http_client,
-            agent_name=claude_coder_agent,
+            agent_name=claude_coder_sandbox_agent,
             runner_id=live_runner_id,
             prompt=(
                 f"Use the Edit tool to replace 'ORIGINAL_CONTENT_DO_NOT_MODIFY' "

--- a/tests/e2e/test_sandbox_dependencies.py
+++ b/tests/e2e/test_sandbox_dependencies.py
@@ -64,8 +64,8 @@ def test_pip_install_and_use_package(
     live_runner_id: str,
 ) -> None:
     """
-    The agent installs a PyPI package via ``pip install`` in the
-    sandbox and uses it in a subsequent Python command.
+    The agent installs a PyPI package via ``pip`` in the sandbox and
+    uses it in a subsequent Python command.
 
     Uses ``cowsay`` — a tiny package with no C dependencies that
     installs in <2 seconds.
@@ -81,10 +81,13 @@ def test_pip_install_and_use_package(
         http_client,
         session_id=session_id,
         content=(
-            "Use the sys_os_shell tool to: "
-            "1) pip install cowsay "
-            "2) Run: python -c \"import cowsay; cowsay.cow('hello from omnigent')\" "
-            "Show me the output."
+            "Use the sys_os_shell tool to run these commands in order. "
+            "Do not skip steps or use other install methods.\n"
+            "1) `python -m ensurepip --upgrade`\n"
+            "2) `python -m pip install cowsay --target ./_sandbox_pip_cowsay`\n"
+            "3) `PYTHONPATH=./_sandbox_pip_cowsay python -c "
+            "\"import cowsay; cowsay.cow('hello from omnigent')\"`\n"
+            "Show me the cow ASCII art output."
         ),
     )
 
@@ -102,10 +105,9 @@ def test_pip_install_and_use_package(
         "The agent may not have used the sandbox tool."
     )
 
-    # The cowsay ASCII art must appear in the output — proves the
-    # package was installed AND executed successfully. If pip fails
-    # (SSL, network, etc.), the test fails — that's a broken
-    # environment, not something to handle gracefully.
+    # The cowsay ASCII art must appear in the output — proves pip was
+    # bootstrapped when absent, the package installed into the workspace,
+    # and the package executed successfully.
     text = _extract_all_text(body)
     all_output = " ".join(
         str(it.get("output", ""))

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -208,12 +208,6 @@ skips:
     issue: 532
     cluster: repl-pexpect-cli
     mode: skip
-  - id: tests/e2e/test_sandbox_dependencies.py::test_pip_install_and_use_package
-    reason: "The repo's uv-managed .venv doesn't expose `python -m pip`, so the agent's `pip install cowsay` errors with 'no module named pip' and the cowsay assertion fails. Dispatch path is correct (agent reaches sys_os_shell and surfaces the env failure as a real tool result); the env assumption is broken. Fix needs `python3 -m ensurepip` in the sandbox setup or a switch to `uv pip install`. The npm sibling test passes — node has no equivalent issue."
-    issue: 532
-    cluster: sandbox-deps-env
-    mode: skip
-
   - id: tests/e2e/test_sys_async_inbox_e2e.py::test_sys_cancel_async_aborts_in_flight_dispatch_e2e
     reason: "Shard 0 bulk: sys async-inbox cancel mid-dispatch. Triage under #532."
     issue: 532
@@ -684,12 +678,6 @@ skips:
   # 2 are the existing files-upload 409 'conversation not bound
   # to a runner' family. Triage under #532.
 
-  - id: tests/e2e/test_sandbox_dependencies.py::test_uv_pip_install_and_use_package
-    reason: "Failing deterministically on `main` and across multiple feature branches: 4 of 5 most recent E2E runs reported `runtime_error: harness failed` from the agent loop, with the agent never completing the `uv pip install cowsay` + python run round-trip. Sibling test_pip_install_and_use_package was already quarantined (#532). The harness-failed signal is generic; needs deeper investigation (sandbox dependency install path, harness lifecycle) before un-quarantining."
-    issue: 532
-    cluster: sandbox-deps-env
-    mode: skip
-
   - id: tests/e2e/test_filesystem_changed_files_e2e.py::test_diff_endpoint_shows_git_diff_for_modified_file
     reason: "Failing deterministically on `main` and across multiple feature branches: 3 of 5 most recent E2E runs reported `Agent turn failed with status 'failed'. The workspace-file-writer agent did not complete successfully.` Likely a regression in the workspace-file-writer agent spec or its dispatch; needs owner investigation before un-quarantining."
     issue: 532
@@ -847,36 +835,6 @@ skips:
     cluster: policy-guardrails
     mode: skip
 
-  # Cluster: claude_coder sandbox enforcement. All 5 tests in
-  # test_claude_coder_sandbox.py flipped together — suggests the
-  # sandbox enforcement path or its fixture regressed.
-  - id: tests/e2e/test_claude_coder_sandbox.py::test_edit_blocked_outside_workspace
-    reason: "Force-merge backlog (claude-coder sandbox cluster: all 5 sandbox tests flipped together). First observed failing at 0449cd1a (2026-05-22T08:44:22Z, E2E)."
-    issue: 0
-    cluster: sandbox-deps-env
-    mode: skip
-  - id: tests/e2e/test_claude_coder_sandbox.py::test_glob_blocked_outside_workspace
-    reason: "Force-merge backlog (claude-coder sandbox cluster). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: sandbox-deps-env
-    mode: skip
-  - id: tests/e2e/test_claude_coder_sandbox.py::test_read_blocked_outside_workspace
-    reason: "Force-merge backlog (claude-coder sandbox cluster). First observed failing at 1a515983 (2026-05-23T06:28:30Z, E2E)."
-    issue: 0
-    cluster: sandbox-deps-env
-    mode: skip
-  - id: tests/e2e/test_claude_coder_sandbox.py::test_write_blocked_outside_workspace
-    reason: "Force-merge backlog (claude-coder sandbox cluster). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: sandbox-deps-env
-    mode: skip
-  - id: tests/e2e/test_claude_coder_sandbox.py::test_write_succeeds_inside_workspace
-    reason: "Force-merge backlog (claude-coder sandbox cluster). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: sandbox-deps-env
-    mode: skip
-
-  # Cluster: cancel/history.
   - id: tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it
     reason: "Force-merge backlog (cancel-history cluster). First observed failing at 2fe283bf (2026-05-23T00:08:54Z, E2E)."
     issue: 0
@@ -929,20 +887,6 @@ skips:
     issue: 0
     cluster: files-uploads-attachments
     mode: skip
-  - id: tests/e2e/test_sandbox_dependencies.py::test_npm_install_and_use_package
-    reason: "Force-merge backlog (standalone). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: sandbox-deps-env
-    mode: skip
-  # ──────────────────────────────────────────────────────────────
-  # Residual CI stabilization after #1375 (2026-05-25).
-  #
-  # #1375 quarantined the first force-merge backlog batch, but fresh
-  # post-merge CI still exposed additional red tests/hangs. These are
-  # intentionally quarantined separately so main/merge-queue can go
-  # green before focused fix+unjail PRs land.
-  # ──────────────────────────────────────────────────────────────
-
   - id: tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_codex_shell_not_disabled
     reason: "Flaky e2e: codex worker doesn't read fixture file — shell_tool regression or supervisor delegation failure."
     issue: 0

--- a/tests/resources/agents/claude-coder-sandbox/claude-coder-sandbox.yaml
+++ b/tests/resources/agents/claude-coder-sandbox/claude-coder-sandbox.yaml
@@ -1,0 +1,30 @@
+name: claude-coder-sandbox
+description: Claude SDK coding assistant with workspace-scoped native tools for sandbox e2e tests.
+
+executor:
+  harness: claude-sdk
+  model: claude-sonnet-4-20250514
+
+prompt: |
+  You are a coding assistant running in a workspace sandbox. Use the requested
+  file or shell tool exactly, then summarize the observed result concisely.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    # Let the parser choose the active backend for the CI host:
+    # linux_bwrap on Linux with bwrap, darwin_seatbelt on macOS.
+    # The workspace must be writable so the positive inside-workspace
+    # test exercises real native file operations.
+    write_paths: ["."]
+
+tools:
+  reviewer:
+    type: agent
+    description: Reviews code for bugs, security issues, and quality problems.
+    executor:
+      harness: claude-sdk
+      model: claude-sonnet-4-20250514
+    prompt: |
+      You are a code reviewer. Be specific and concise.

--- a/tests/spec/test_load.py
+++ b/tests/spec/test_load.py
@@ -385,3 +385,26 @@ def test_load_omnigent_yaml_threads_executor_extra_max_tokens_to_llm_extra(
 
     assert spec.llm is not None
     assert spec.llm.extra["max_tokens"] == 65536
+
+
+def test_claude_coder_sandbox_fixture_requests_workspace_only_sandbox() -> None:
+    """
+    The Claude sandbox e2e fixture must explicitly request an active
+    platform sandbox and grant writes only to the conversation workspace.
+
+    What breaks if this fails: the outside-workspace e2es can pass or fail
+    based on Claude Code's unsandboxed native-tool behavior instead of the
+    Omnigent ``os_env`` contract they are supposed to cover.
+    """
+    spec = load_omnigent_yaml(
+        Path("tests/resources/agents/claude-coder-sandbox/claude-coder-sandbox.yaml")
+    )
+
+    assert spec.name == "claude-coder-sandbox"
+    assert spec.os_env is not None
+    assert spec.os_env.cwd == "."
+    assert spec.os_env.sandbox is not None
+    assert spec.os_env.sandbox.type in {"linux_bwrap", "darwin_seatbelt", "none"}
+    assert spec.os_env.sandbox.type != "none"
+    assert spec.os_env.sandbox.write_paths == ["."]
+    assert spec.os_env.sandbox.read_paths is None


### PR DESCRIPTION
## Summary

- Unquarantines 8 `sandbox-deps-env` e2es after fixing their test-side assumptions.
- Adds a dedicated `claude-coder-sandbox` fixture agent so Claude workspace-enforcement tests exercise Omnigent `os_env` sandboxing instead of the generic unsandboxed Claude fixture.
- Makes the pip dependency-install e2e bootstrap `pip` with `ensurepip` and install into the conversation workspace, matching uv-managed environments where `.venv/bin/python -m pip` is absent.

ELI5: these tests were asking the wrong robot or assuming a tool already existed. The sandbox tests now use a robot that is actually inside the sandbox, and the pip test now first installs the pip tool before using it.

```mermaid
flowchart TD
  A[known_failures sandbox-deps-env] --> B{per test}
  B --> C[dependency install e2es]
  B --> D[Claude workspace sandbox e2es]
  B --> E[os_env example one-shots]
  C --> F[bootstrap/install in workspace]
  D --> G[dedicated sandboxed Claude fixture]
  F --> H[remove suppressions]
  G --> H
  E --> I[defer: still bulk one-shot issues]
```

### Per-test decisions

| Test | Decision | Suppression | Notes |
| --- | --- | --- | --- |
| `tests/e2e/test_sandbox_dependencies.py::test_pip_install_and_use_package` | FIX | Removed | `python -m pip` is absent in the uv-managed `.venv`; prompt now runs `python -m ensurepip --upgrade`, then installs `cowsay` into `./_sandbox_pip_cowsay` and runs with `PYTHONPATH`. |
| `tests/e2e/test_sandbox_dependencies.py::test_uv_pip_install_and_use_package` | KEEP/UNSUPPRESS | Removed | Existing test already uses workspace-local `--target` and `--cache-dir`; nodeid verified real. |
| `tests/e2e/test_sandbox_dependencies.py::test_npm_install_and_use_package` | KEEP/UNSUPPRESS | Removed | No product/test change needed; prior reason was force-merge backlog only; nodeid verified real. |
| `tests/e2e/test_claude_coder_sandbox.py::test_read_blocked_outside_workspace` | FIX | Removed | Now uses `claude_coder_sandbox_agent`, whose YAML declares active platform sandbox and workspace-only writes. |
| `tests/e2e/test_claude_coder_sandbox.py::test_write_blocked_outside_workspace` | FIX | Removed | Same fixture fix; outside `/tmp` writes are covered by the actual os-env sandbox. |
| `tests/e2e/test_claude_coder_sandbox.py::test_write_succeeds_inside_workspace` | FIX | Removed | Same fixture fix; sandbox config grants `write_paths: ["."]` so positive workspace write remains meaningful. |
| `tests/e2e/test_claude_coder_sandbox.py::test_glob_blocked_outside_workspace` | FIX | Removed | Same fixture fix; sentinel non-leak assertion now targets sandboxed native-tool session. |
| `tests/e2e/test_claude_coder_sandbox.py::test_edit_blocked_outside_workspace` | FIX | Removed | Same fixture fix; outside edit target must remain unchanged. |
| `tests/e2e/omnigent/test_example_secure_research_agent_os_env.py::test_secure_research_agent_os_env_one_shot` | DEFER | Left suppressed | Bulk one-shot/example issue; not fixed in this subset. Nodeid verified real. |
| `tests/e2e/omnigent/test_example_agent_with_os_env_fork.py::test_agent_with_os_env_fork_one_shot` | DEFER | Left suppressed | Still documented as exits 0 with no stdout; not fixed in this subset. Nodeid verified real. |

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run:

- `uv sync --extra dev --extra claude-sdk --extra openai-agents` — completed; created/synced the required uv environment. Reverted unrelated `uv.lock` / `ap-web/package-lock.json` churn produced by local registry/npm behavior.
- `uv run --no-sync pytest --collect-only --no-skip-known -q <10 sandbox-deps-env nodeids>` — passed, 10 tests collected; verifies every target id still resolves.
- `uv run --no-sync python - <<'PY' ... load_agent_def(...) ... PY` — passed; verified new sandbox fixture plus the two deferred example fixtures parse.
- `uv run --no-sync pytest -q tests/spec/test_load.py::test_claude_coder_sandbox_fixture_requests_workspace_only_sandbox tests/inner/test_sandbox.py tests/inner/test_seatbelt_sandbox.py --tb=short -rfs` — passed: 74 passed, 1 skipped. Validates the new sandbox fixture contract and relevant macOS sandbox plumbing.
- `uv run --no-sync ruff check tests/e2e/conftest.py tests/e2e/test_claude_coder_sandbox.py tests/e2e/test_sandbox_dependencies.py tests/spec/test_load.py` — passed.
- `uv run --no-sync pytest --no-skip-known -q <8 unquarantined nodeids> --llm-api-key "$OPENAI_API_KEY" --tb=short -rfs` — attempted locally; all 8 failed in `poll_until_terminal` with `JSONDecodeError` from a non-JSON response. This is recorded as an environment/routing limitation of the local OpenAI-path run, not a claimed pass.

Local limitations:

- Databricks e2e path could not be run: `databricks auth token --profile ai-oss -o json` reports the cached refresh token is invalid and asks for `databricks auth login --profile ai-oss`.
- This host is macOS (`Darwin`) and has no `bwrap`; Linux `linux_bwrap` live behavior remains for CI.
- A broad `tests/inner/test_bwrap_sandbox.py` run on macOS produced 4 expected platform errors for Linux-only resolve tests, so it was not used as validation for this PR.

Deferred / left suppressed:

- `tests/e2e/omnigent/test_example_secure_research_agent_os_env.py::test_secure_research_agent_os_env_one_shot`
- `tests/e2e/omnigent/test_example_agent_with_os_env_fork.py::test_agent_with_os_env_fork_one_shot`

Left-suppressed product bugs:

- None newly identified in this subset. The two remaining `sandbox-deps-env` entries are deferred bulk/example one-shot failures, not reclassified here as product bugs.
