### PR TITLE
test(e2e): resolve cancel-history suppressions (fix 2, defer 2)

### DIFF
--- a/tests/e2e/test_cancel_history.py
+++ b/tests/e2e/test_cancel_history.py
@@ -20,36 +20,37 @@ import httpx
 
 from tests.e2e.conftest import (
     create_runner_bound_session,
-    poll_until_terminal,
+    poll_session_until_terminal,
     send_user_message_to_session,
 )
 
 
 def _wait_for_in_progress(
     client: httpx.Client,
-    response_id: str,
+    session_id: str,
     timeout: float = 60,
 ) -> None:
     """
-    Poll until the response transitions to ``in_progress``.
+    Poll until the runner-native session transitions to ``running``.
 
     :param client: HTTP client.
-    :param response_id: The response ID to poll.
+    :param session_id: The session ID to poll.
     :param timeout: Max seconds to wait.
     :raises AssertionError: If not in_progress within timeout.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        resp = client.get(f"/v1/responses/{response_id}")
+        resp = client.get(f"/v1/sessions/{session_id}")
+        resp.raise_for_status()
         body = resp.json()
-        if body["status"] == "in_progress":
+        if body["status"] == "running":
             return
-        if body["status"] in ("completed", "failed", "cancelled"):
+        if body["status"] in ("idle", "failed"):
             raise AssertionError(
-                f"Response reached terminal state {body['status']} before in_progress"
+                f"Session reached terminal state {body['status']} before running"
             )
         time.sleep(0.3)
-    raise AssertionError(f"Response {response_id} didn't reach in_progress within {timeout}s")
+    raise AssertionError(f"Session {session_id} didn't reach running within {timeout}s")
 
 
 def _extract_all_text(body: dict[str, Any]) -> str:
@@ -68,6 +69,58 @@ def _extract_all_text(body: dict[str, Any]) -> str:
                 if text:
                     parts.append(text)
     return "\n".join(parts)
+
+
+def _wait_for_cancellation_marker(
+    client: httpx.Client,
+    session_id: str,
+    timeout: float = 30,
+) -> list[dict[str, Any]]:
+    """Poll persisted session items until the interrupt marker appears."""
+    deadline = time.monotonic() + timeout
+    last_items: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        items_resp = client.get(
+            f"/v1/sessions/{session_id}/items",
+            params={"order": "desc", "limit": 20},
+        )
+        items_resp.raise_for_status()
+        last_items = items_resp.json()["data"]
+        cancellation_items = [
+            item
+            for item in last_items
+            if item.get("type") == "message"
+            and item.get("role") == "user"
+            and any("interrupted" in c.get("text", "") for c in item.get("content", []))
+        ]
+        if cancellation_items:
+            return cancellation_items
+        time.sleep(0.3)
+    raise AssertionError(
+        f"Expected a cancellation marker within {timeout}s. Last items: {last_items}"
+    )
+
+
+def _wait_for_idle(client: httpx.Client, session_id: str, timeout: float = 30) -> None:
+    """Poll until the interrupted session finishes teardown."""
+    deadline = time.monotonic() + timeout
+    last_body: dict[str, Any] = {}
+    idle_since: float | None = None
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/sessions/{session_id}")
+        resp.raise_for_status()
+        last_body = resp.json()
+        if last_body.get("status") == "idle":
+            if idle_since is None:
+                idle_since = time.monotonic()
+            elif time.monotonic() - idle_since >= 1.0:
+                return
+        else:
+            idle_since = None
+        if last_body.get("status") == "failed":
+            raise AssertionError(f"Session failed during interrupt teardown: {last_body}")
+        time.sleep(0.3)
+    raise AssertionError(f"Session {session_id} did not become idle within {timeout}s: {last_body}")
 
 
 def test_cancel_appends_history_marker_and_followup_sees_it(
@@ -112,31 +165,20 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
         ),
     )
 
-    # Step 2: wait for it to start, then cancel.
-    _wait_for_in_progress(http_client, response_id, timeout=60)
-    cancel_resp = http_client.post(f"/v1/responses/{response_id}/cancel")
+    # Step 2: wait for it to start, then interrupt via the sessions API.
+    _wait_for_in_progress(http_client, session_id, timeout=60)
+    cancel_resp = http_client.post(f"/v1/sessions/{session_id}/events", json={"type": "interrupt"})
     cancel_resp.raise_for_status()
-    assert cancel_resp.json()["status"] == "cancelled"
+    assert cancel_resp.status_code in (202, 204)
 
-    # Step 3: verify the conversation has the cancellation marker.
-    items_resp = http_client.get(
-        f"/v1/sessions/{session_id}/items",
-        params={"order": "desc", "limit": 5},
-    )
-    items_resp.raise_for_status()
-    items = items_resp.json()["data"]
-    # Find the cancellation marker — a user message with
-    # "interrupted" in its text.
-    cancellation_items = [
-        item
-        for item in items
-        if item.get("type") == "message"
-        and item.get("role") == "user"
-        and any("interrupted" in c.get("text", "") for c in item.get("content", []))
-    ]
+    # Step 3: verify the conversation has the cancellation marker. The
+    # interrupt endpoint acknowledges before the runner's async marker
+    # persistence task necessarily completes, so poll the session items.
+    cancellation_items = _wait_for_cancellation_marker(http_client, session_id)
     assert len(cancellation_items) == 1, (
-        f"Expected exactly 1 cancellation marker, found {len(cancellation_items)}. Items: {items}"
+        f"Expected exactly 1 cancellation marker, found {len(cancellation_items)}."
     )
+    _wait_for_idle(http_client, session_id)
 
     # Step 4: send a follow-up in the same session.
     followup_id = send_user_message_to_session(
@@ -150,7 +192,12 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
     )
 
     # Step 5: wait for the follow-up to complete.
-    followup_body = poll_until_terminal(http_client, followup_id, timeout=120)
+    followup_body = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=followup_id,
+        timeout=120,
+    )
     assert followup_body["status"] == "completed", (
         f"Follow-up failed: {followup_body.get('error')}"
     )
@@ -197,12 +244,14 @@ def test_cancel_mid_tool_call_followup_succeeds(
         ),
     )
 
-    # Step 2: wait for in_progress (tools should be executing), cancel.
-    _wait_for_in_progress(http_client, response_id, timeout=60)
+    # Step 2: wait for running (tools should be executing), cancel.
+    _wait_for_in_progress(http_client, session_id, timeout=60)
     # Brief delay so tool calls are persisted.
     time.sleep(2)
-    cancel_resp = http_client.post(f"/v1/responses/{response_id}/cancel")
+    cancel_resp = http_client.post(f"/v1/sessions/{session_id}/events", json={"type": "interrupt"})
     cancel_resp.raise_for_status()
+    assert cancel_resp.status_code in (202, 204)
+    _wait_for_idle(http_client, session_id)
 
     # Step 3: follow-up in the same session — would fail with 400 before the fix.
     followup_id = send_user_message_to_session(
@@ -211,7 +260,12 @@ def test_cancel_mid_tool_call_followup_succeeds(
         content="Never mind the search. Just say hello.",
     )
 
-    followup_body = poll_until_terminal(http_client, followup_id, timeout=120)
+    followup_body = poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=followup_id,
+        timeout=120,
+    )
     # The follow-up must complete, not fail with an LLM error.
     assert followup_body["status"] == "completed", (
         f"Follow-up after tool-call cancel failed: "

--- a/tests/e2e/test_cancel_history.py
+++ b/tests/e2e/test_cancel_history.py
@@ -46,9 +46,7 @@ def _wait_for_in_progress(
         if body["status"] == "running":
             return
         if body["status"] in ("idle", "failed"):
-            raise AssertionError(
-                f"Session reached terminal state {body['status']} before running"
-            )
+            raise AssertionError(f"Session reached terminal state {body['status']} before running")
         time.sleep(0.3)
     raise AssertionError(f"Session {session_id} didn't reach running within {timeout}s")
 
@@ -120,7 +118,9 @@ def _wait_for_idle(client: httpx.Client, session_id: str, timeout: float = 30) -
         if last_body.get("status") == "failed":
             raise AssertionError(f"Session failed during interrupt teardown: {last_body}")
         time.sleep(0.3)
-    raise AssertionError(f"Session {session_id} did not become idle within {timeout}s: {last_body}")
+    raise AssertionError(
+        f"Session {session_id} did not become idle within {timeout}s: {last_body}"
+    )
 
 
 def test_cancel_appends_history_marker_and_followup_sees_it(
@@ -155,7 +155,7 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
     session_id = create_runner_bound_session(
         http_client, agent_name=archer_agent, runner_id=live_runner_id
     )
-    response_id = send_user_message_to_session(
+    send_user_message_to_session(
         http_client,
         session_id=session_id,
         content=(
@@ -234,7 +234,7 @@ def test_cancel_mid_tool_call_followup_succeeds(
     session_id = create_runner_bound_session(
         http_client, agent_name=archer_agent, runner_id=live_runner_id
     )
-    response_id = send_user_message_to_session(
+    send_user_message_to_session(
         http_client,
         session_id=session_id,
         content=(

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -877,16 +877,6 @@ skips:
     mode: skip
 
   # Cluster: cancel/history.
-  - id: tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it
-    reason: "Force-merge backlog (cancel-history cluster). First observed failing at 2fe283bf (2026-05-23T00:08:54Z, E2E)."
-    issue: 0
-    cluster: steering-cancel-compaction-state
-    mode: skip
-  - id: tests/e2e/test_cancel_history.py::test_cancel_mid_tool_call_followup_succeeds
-    reason: "Force-merge backlog (cancel-history cluster). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: steering-cancel-compaction-state
-    mode: skip
 
   # Cluster: databricks_supervisor harness parametrizations broken
   # across multiple unrelated test files (yaml hello world, real


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

- Fixes the two `cancel-history` E2E tests in cluster `steering-cancel-compaction-state` by moving them from stale `/v1/responses/{id}` polling/cancel semantics to the current runner-native sessions API.
- Adds bounded waits for async cancellation-marker persistence and stable `idle` teardown before sending follow-up messages, avoiding teardown-window injection races.
- Removes 2 resolved `tests/known_failures.yaml` entries; leaves steering async-drain and compaction entries suppressed because local validation still showed unresolved/stale-marker failures.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run:

- `uv run --no-sync pytest --collect-only -q --no-skip-known tests/e2e/test_steering_during_async_drain_e2e.py::test_steering_breaks_blocked_async_drain tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it tests/e2e/test_cancel_history.py::test_cancel_mid_tool_call_followup_succeeds tests/e2e/omnigent/test_compaction_sessions_native_e2e.py::test_compaction_fires_and_agent_retains_context` → 4 collected.
- `uv run --no-sync pytest --no-skip-known -q -rfs --tb=short --llm-api-key="$OPENAI_API_KEY" tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it tests/e2e/test_cancel_history.py::test_cancel_mid_tool_call_followup_succeeds` → 2 passed in 15.62s.
- `uv run --no-sync pytest --collect-only -q --no-skip-known tests/e2e/test_steering_during_async_drain_e2e.py::test_steering_breaks_blocked_async_drain tests/e2e/omnigent/test_compaction_sessions_native_e2e.py::test_compaction_fires_and_agent_retains_context` → 2 collected; entries left suppressed.
- `uv run --no-sync pytest --no-skip-known -q -rfs --tb=short --llm-api-key="$OPENAI_API_KEY" tests/e2e/test_steering_during_async_drain_e2e.py::test_steering_breaks_blocked_async_drain` → failed locally before final diff was limited, showing `/v1/responses` 404 / sessions rewrite did not produce async-client-tool handle; left suppressed.
- `uv run --no-sync pytest --no-skip-known -q -rfs --tb=short --llm-api-key="$OPENAI_API_KEY" --profile oss tests/e2e/omnigent/test_compaction_sessions_native_e2e.py::test_compaction_fires_and_agent_retains_context` → failed locally before final diff was limited on stale REPL `state: running`/`sleeping` marker behavior; left suppressed.

ELI5: the cancel tests were looking at the old “response” mailbox after asking the current “session” runner to do work. This updates the tests to watch and interrupt the session itself, then waits until the runner has finished putting the “that was interrupted” note into history before asking the next question.

Diagram:

```text
Before
user turn -> /v1/sessions/{id}/events
cancel test -> GET/POST /v1/responses/{response_id}  (stale path)
follow-up -> races teardown / polls wrong terminal state

After
user turn -> /v1/sessions/{id}/events
cancel test -> wait session running -> POST interrupt event
            -> wait marker persisted -> wait stable session idle
follow-up -> /v1/sessions/{id}/events -> poll session terminal output
```

Per-test decisions:

| Nodeid | Decision | Known failure entry | Validation |
| --- | --- | --- | --- |
| `tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it` | FIX: responses→sessions API drift plus async marker/idle wait. | Removed. | Ran with `--llm-api-key`; passed in paired run. |
| `tests/e2e/test_cancel_history.py::test_cancel_mid_tool_call_followup_succeeds` | FIX: responses→sessions API drift plus stable idle wait before follow-up. | Removed. | Ran with `--llm-api-key`; passed in paired run. |
| `tests/e2e/test_steering_during_async_drain_e2e.py::test_steering_breaks_blocked_async_drain` | Left suppressed: nodeid resolves, but local run hit stale `/v1/responses` 404; a sessions rewrite attempt did not produce the async client-tool handle. Needs focused product/test redesign. | Kept. | Collected; attempted run failed locally, no pass claimed. |
| `tests/e2e/omnigent/test_compaction_sessions_native_e2e.py::test_compaction_fires_and_agent_retains_context` | Left suppressed: nodeid resolves, but local run showed stale REPL state marker behavior (`state: running`/`sleeping`) after dependency sync and `--profile oss`. Needs focused pexpect/UI sync work. | Kept. | Collected; attempted run failed locally, no pass claimed. |

Known-failures removed: 2.

Deferred / left-suppressed product bugs: none proven. The remaining steering and compaction entries are left suppressed as unresolved test-side/API/UI-marker drift, not claimed product bugs.
