### PR TITLE
test(e2e): harden AskUserQuestion test against unrelated pending cards

### DIFF
--- a/tests/e2e_ui/approvals/test_ask_user_question.py
+++ b/tests/e2e_ui/approvals/test_ask_user_question.py
@@ -98,7 +98,21 @@ def test_ask_user_question_form_renders_and_submits(
     # the PermissionRequest hook to the server and surfaces as a form here.
     _send(page, _ASK_PROMPT)
 
-    card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+    # Scope the wait to the pending approval card that *contains* the
+    # AskUserQuestion form, rather than grabbing ``.first`` pending card and
+    # then asserting the form inside it. The prompt forbids other tool calls,
+    # but if Claude ever calls an approval-requiring tool first (the same
+    # degree of freedom that flaked test_exit_plan_mode.py the other way),
+    # ``.first`` would latch onto that unrelated card and fail even though the
+    # question card appears moments later. Filtering by ``has=`` waits for the
+    # right card specifically. This does not weaken the assertion: if Claude
+    # never calls AskUserQuestion, no such card ever appears and the test still
+    # times out and fails.
+    card = (
+        page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
+        .filter(has=page.locator(_FORM))
+        .first
+    )
     expect(card).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
     form = card.locator(_FORM)
     expect(form).to_be_visible(timeout=30_000)


### PR DESCRIPTION
## Summary

Follow-up to #446 (exit-plan-mode de-flake). While fixing that test we noticed its sibling, `test_ask_user_question.py`, carries the **same latent locator anti-pattern** that caused #446 — so this hardens it preemptively.

## The latent bug

The test grabbed `.first` pending approval card, then asserted the AskUserQuestion form *inside* it:

```python
card = page.locator('[data-testid="approval-card"][data-state="pending"]').first
form = card.locator('[data-testid="ask-user-question-form"]')
expect(form).to_be_visible(timeout=30_000)   # fails if .first was the wrong card
```

The prompt forbids other tool calls, so the risk is **lower** than #446 (which described a goal and let the model choose the tool). But if Claude ever calls an approval-requiring tool first, `.first` latches onto that unrelated card and the form-visibility check fails — even though the question card appears moments later. That's exactly the failure mode from #446, just in the other direction.

## Fix

Scope the wait to the pending card that *contains* the form, via `.filter(has=...)` (matching the convention already used in the sidebar suites — `test_sidebar_delete.py`, etc.):

```python
card = (
    page.locator('[data-testid="approval-card"][data-state="pending"]')
    .filter(has=page.locator('[data-testid="ask-user-question-form"]'))
    .first
)
```

## Why this doesn't weaken the test

This is **not** a "race on either card / accept any outcome" loosening. If Claude never calls `AskUserQuestion`, no matching card ever appears and the test still times out and fails — the regression-catching behavior is fully preserved. The filter only stops the test from latching onto a *transient unrelated* card on its way to the right one.

## Testing

- Passes `py_compile`.
- Pure locator-scoping change; no fixture or prompt changes.
- The e2e itself needs a real Claude Code boot + live server (900s ceiling), so it's left to **CI to exercise**.
