### PR TITLE
test(e2e): harden cancel-history polling helpers (follow-up to #451)

### DIFF
--- a/tests/e2e/test_cancel_history.py
+++ b/tests/e2e/test_cancel_history.py
@@ -24,8 +24,25 @@ from tests.e2e.conftest import (
     send_user_message_to_session,
 )
 
+_POLL_INTERVAL_SECONDS = 0.3
+_SESSION_ITEMS_PAGE_SIZE = 1000
+_SESSION_RUNNING_STATUSES = {"running"}
+_SESSION_PRE_RUNNING_STATUSES = {"idle"}
+_SESSION_NONTERMINAL_STATUSES = {"idle", "running"}
+_SESSION_TERMINAL_ERROR_STATUSES = {"failed"}
 
-def _wait_for_in_progress(
+# The server persists cancellation history as a synthetic user message today.
+# There is no stable structured cancellation item type yet, so keep the
+# wording dependency centralized and documented for future server changes.
+_CANCELLATION_MARKER_TEXT = "interrupted"
+
+# Sequencing heuristic: the interrupt endpoint can acknowledge before async
+# teardown has fully settled. We do not have a response-level in-flight signal
+# here, so keep the stable-idle hold explicit rather than weaker.
+_INTERRUPT_IDLE_HOLD_SECONDS = 1.0
+
+
+def _wait_for_session_running(
     client: httpx.Client,
     session_id: str,
     timeout: float = 60,
@@ -43,11 +60,12 @@ def _wait_for_in_progress(
         resp = client.get(f"/v1/sessions/{session_id}")
         resp.raise_for_status()
         body = resp.json()
-        if body["status"] == "running":
+        status = body["status"]
+        if status in _SESSION_RUNNING_STATUSES:
             return
-        if body["status"] in ("idle", "failed"):
-            raise AssertionError(f"Session reached terminal state {body['status']} before running")
-        time.sleep(0.3)
+        if status not in _SESSION_PRE_RUNNING_STATUSES:
+            raise AssertionError(f"Session reached state {status!r} before running: {body}")
+        time.sleep(_POLL_INTERVAL_SECONDS)
     raise AssertionError(f"Session {session_id} didn't reach running within {timeout}s")
 
 
@@ -78,28 +96,53 @@ def _wait_for_cancellation_marker(
     deadline = time.monotonic() + timeout
     last_items: list[dict[str, Any]] = []
     while time.monotonic() < deadline:
-        items_resp = client.get(
-            f"/v1/sessions/{session_id}/items",
-            params={"order": "desc", "limit": 20},
-        )
-        items_resp.raise_for_status()
-        last_items = items_resp.json()["data"]
-        cancellation_items = [
-            item
-            for item in last_items
-            if item.get("type") == "message"
-            and item.get("role") == "user"
-            and any("interrupted" in c.get("text", "") for c in item.get("content", []))
-        ]
+        last_items = _list_all_session_items(client, session_id)
+        cancellation_items = _filter_cancellation_marker_items(last_items)
         if cancellation_items:
             return cancellation_items
-        time.sleep(0.3)
+        time.sleep(_POLL_INTERVAL_SECONDS)
     raise AssertionError(
         f"Expected a cancellation marker within {timeout}s. Last items: {last_items}"
     )
 
 
-def _wait_for_idle(client: httpx.Client, session_id: str, timeout: float = 30) -> None:
+def _list_all_session_items(client: httpx.Client, session_id: str) -> list[dict[str, Any]]:
+    """Return all currently persisted session items in one paginated snapshot."""
+    items: list[dict[str, Any]] = []
+    after: str | None = None
+    while True:
+        params = {"order": "asc", "limit": _SESSION_ITEMS_PAGE_SIZE}
+        if after is not None:
+            params["after"] = after
+        items_resp = client.get(f"/v1/sessions/{session_id}/items", params=params)
+        items_resp.raise_for_status()
+        page = items_resp.json()
+        page_items = page["data"]
+        items.extend(page_items)
+        if not page.get("has_more"):
+            return items
+        after = page.get("last_id")
+        if after is None:
+            raise AssertionError(f"Items page had has_more without last_id: {page}")
+
+
+def _filter_cancellation_marker_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return persisted synthetic user messages that mark an interrupted turn."""
+    return [
+        item
+        for item in items
+        if item.get("type") == "message"
+        and item.get("role") == "user"
+        and any(_CANCELLATION_MARKER_TEXT in c.get("text", "") for c in item.get("content", []))
+    ]
+
+
+def _wait_for_idle(
+    client: httpx.Client,
+    session_id: str,
+    *,
+    timeout: float = 30,
+) -> None:
     """Poll until the interrupted session finishes teardown."""
     deadline = time.monotonic() + timeout
     last_body: dict[str, Any] = {}
@@ -108,16 +151,21 @@ def _wait_for_idle(client: httpx.Client, session_id: str, timeout: float = 30) -
         resp = client.get(f"/v1/sessions/{session_id}")
         resp.raise_for_status()
         last_body = resp.json()
-        if last_body.get("status") == "idle":
+        status = last_body.get("status")
+        if status in _SESSION_TERMINAL_ERROR_STATUSES:
+            raise AssertionError(f"Session failed during interrupt teardown: {last_body}")
+        if status not in _SESSION_NONTERMINAL_STATUSES:
+            raise AssertionError(
+                f"Session reached unexpected terminal state during interrupt teardown: {last_body}"
+            )
+        if status == "idle":
             if idle_since is None:
                 idle_since = time.monotonic()
-            elif time.monotonic() - idle_since >= 1.0:
+            elif time.monotonic() - idle_since >= _INTERRUPT_IDLE_HOLD_SECONDS:
                 return
         else:
             idle_since = None
-        if last_body.get("status") == "failed":
-            raise AssertionError(f"Session failed during interrupt teardown: {last_body}")
-        time.sleep(0.3)
+        time.sleep(_POLL_INTERVAL_SECONDS)
     raise AssertionError(
         f"Session {session_id} did not become idle within {timeout}s: {last_body}"
     )
@@ -166,7 +214,7 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
     )
 
     # Step 2: wait for it to start, then interrupt via the sessions API.
-    _wait_for_in_progress(http_client, session_id, timeout=60)
+    _wait_for_session_running(http_client, session_id, timeout=60)
     cancel_resp = http_client.post(f"/v1/sessions/{session_id}/events", json={"type": "interrupt"})
     cancel_resp.raise_for_status()
     assert cancel_resp.status_code in (202, 204)
@@ -176,7 +224,9 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
     # persistence task necessarily completes, so poll the session items.
     cancellation_items = _wait_for_cancellation_marker(http_client, session_id)
     assert len(cancellation_items) == 1, (
-        f"Expected exactly 1 cancellation marker, found {len(cancellation_items)}."
+        f"Expected exactly 1 cancellation marker, found {len(cancellation_items)}. "
+        f"Cancellation items: {cancellation_items}. "
+        f"Items: {_list_all_session_items(http_client, session_id)}"
     )
     _wait_for_idle(http_client, session_id)
 
@@ -245,7 +295,7 @@ def test_cancel_mid_tool_call_followup_succeeds(
     )
 
     # Step 2: wait for running (tools should be executing), cancel.
-    _wait_for_in_progress(http_client, session_id, timeout=60)
+    _wait_for_session_running(http_client, session_id, timeout=60)
     # Brief delay so tool calls are persisted.
     time.sleep(2)
     cancel_resp = http_client.post(f"/v1/sessions/{session_id}/events", json={"type": "interrupt"})

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -840,8 +840,6 @@ skips:
     cluster: sandbox-deps-env
     mode: skip
 
-  # Cluster: cancel/history.
-
   # Cluster: databricks_supervisor harness parametrizations broken
   # across multiple unrelated test files (yaml hello world, real
   # hello world, coding supervisor with forks). Likely a single


### PR DESCRIPTION
## Summary

- Hardening follow-up to #451 for `tests/e2e/test_cancel_history.py` helper robustness; this is not an un-suppression.
- Scans the full paginated session item snapshot for cancellation markers instead of only the newest page, centralizes the free-text cancellation sentinel, and restores full item dumps in marker-count diagnostics.
- Keeps the stable-idle teardown fence explicit with named constants, broadens unexpected status failure diagnostics, renames `_wait_for_in_progress` to `_wait_for_session_running`, and removes the stray cancel/history whitespace stub from `tests/known_failures.yaml`.

ELI5: the tests now check the whole chat history for the "interrupted" note and wait for cancellation cleanup in a clearly documented way, so fast extra events are less likely to make the test miss the thing it is trying to verify.

```mermaid
flowchart LR
  A[Send long request] --> B[Wait for session running]
  B --> C[Interrupt session]
  C --> D[Scan all paginated session items]
  D --> E[Find cancellation marker]
  E --> F[Wait for stable idle teardown]
  F --> G[Send follow-up]
  G --> H[Assert follow-up succeeds]
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run:

- `uv run ruff format tests/e2e/test_cancel_history.py`
- `uv run ruff check tests/e2e/test_cancel_history.py`
- `git diff --check`
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest tests/e2e/test_cancel_history.py::test_cancel_appends_history_marker_and_followup_sees_it tests/e2e/test_cancel_history.py::test_cancel_mid_tool_call_followup_succeeds --llm-api-key="$OPENAI_API_KEY" -q -rfs --tb=short`

The changed helpers are exercised by the two existing live cancellation-history E2E tests from #451. No helper extraction to `conftest.py` in this hardening PR to keep the diff module-local and avoid shared fixture churn.
