### PR TITLE
fix(download_file): confine untrusted store filename to the workspace (supersedes #46)

### DIFF
--- a/omnigent/tools/builtins/download_file.py
+++ b/omnigent/tools/builtins/download_file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.tools.base import Tool, ToolContext
+from omnigent.tools.builtins.upload_file import safe_resolve
 
 
 class DownloadFileTool(Tool):
@@ -101,10 +102,13 @@ class DownloadFileTool(Tool):
                 }
             )
 
-        dest = _resolve_destination(
-            record.filename,
-            ctx.workspace,
-        )
+        try:
+            dest = _resolve_destination(
+                record.filename,
+                ctx.workspace,
+            )
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
 
@@ -125,9 +129,17 @@ def _resolve_destination(
     """
     Resolve the save path for a downloaded file.
 
+    The stored ``filename`` is untrusted metadata (it originates from
+    whoever uploaded the file and is persisted verbatim). It is reduced
+    to its bare basename and confined to the workspace via
+    :func:`safe_resolve`, so a malicious name such as ``../../escape``
+    or an absolute path cannot cause a write outside the workspace.
+
     :param filename: The file's original filename from the store.
     :param workspace: The agent's workspace directory, or ``None``.
-    :returns: Absolute path to save the file.
+    :returns: Absolute path to save the file, confined to ``workspace``.
+    :raises ValueError: If the resolved path escapes the workspace.
     """
     base = workspace or Path.cwd()
-    return base / filename
+    name = Path(filename).name or "downloaded.bin"
+    return safe_resolve(name, base)

--- a/tests/tools/builtins/test_file_tools.py
+++ b/tests/tools/builtins/test_file_tools.py
@@ -306,6 +306,110 @@ def test_download_file_saves_to_workspace(
     assert saved.name == "hello.txt"
 
 
+@pytest.mark.parametrize(
+    "malicious_filename",
+    [
+        "../escape.txt",
+        "../../escape.txt",
+        "foo/../../bar.txt",
+        "/etc/passwd",
+        "/tmp/abs-escape.txt",
+    ],
+)
+def test_download_file_confines_untrusted_filename_to_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_ctx: ToolContext,
+    malicious_filename: str,
+) -> None:
+    """
+    A malicious stored filename cannot write outside the workspace.
+
+    The stored filename is untrusted metadata (persisted verbatim from
+    whoever uploaded the file). Traversal sequences and absolute paths
+    must be reduced to a basename and confined to the workspace, never
+    escaping it.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tool_ctx: Tool execution context.
+    :param malicious_filename: A traversal/absolute filename to reject.
+    """
+    content = b"payload"
+    monkeypatch.setattr(
+        "omnigent.runtime.get_file_store",
+        lambda: _FakeFileStore(
+            [
+                _FakeFile(
+                    "file_evil",
+                    malicious_filename,
+                    len(content),
+                    "text/plain",
+                    1000,
+                    session_id="conv_alice",
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.get_artifact_store",
+        lambda: _FakeArtifactStore({"file_evil": content}),
+    )
+
+    tool = DownloadFileTool()
+    result = json.loads(tool.invoke('{"file_id": "file_evil"}', tool_ctx))
+
+    # The write must land strictly inside the workspace.
+    saved = Path(result["path"])
+    workspace = tool_ctx.workspace
+    assert workspace is not None
+    assert saved.resolve().is_relative_to(workspace.resolve())
+    # Nothing was written outside the workspace.
+    assert not Path("/etc/passwd").is_symlink()
+    assert saved.exists()
+    assert saved.read_bytes() == content
+
+
+def test_download_file_basenames_store_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_ctx: ToolContext,
+) -> None:
+    """
+    A filename with leading directory components is saved by basename.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tool_ctx: Tool execution context.
+    """
+    content = b"report-bytes"
+    monkeypatch.setattr(
+        "omnigent.runtime.get_file_store",
+        lambda: _FakeFileStore(
+            [
+                _FakeFile(
+                    "file_nested",
+                    "reports/2026/q2.csv",
+                    len(content),
+                    "text/csv",
+                    1000,
+                    session_id="conv_alice",
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.get_artifact_store",
+        lambda: _FakeArtifactStore({"file_nested": content}),
+    )
+
+    tool = DownloadFileTool()
+    result = json.loads(tool.invoke('{"file_id": "file_nested"}', tool_ctx))
+
+    saved = Path(result["path"])
+    workspace = tool_ctx.workspace
+    assert workspace is not None
+    assert saved.name == "q2.csv"
+    assert saved.parent.resolve() == workspace.resolve()
+    assert saved.read_bytes() == content
+
+
 def test_download_file_not_found(
     monkeypatch: pytest.MonkeyPatch,
     tool_ctx: ToolContext,


### PR DESCRIPTION
## What & why

The `download_file` tool saved downloaded bytes to `workspace / record.filename`, where `record.filename` is **untrusted metadata** persisted verbatim from whoever uploaded the file. A filename containing `../` or an absolute path resolves **outside** the workspace, which is an arbitrary-write primitive if `DownloadFileTool.invoke()` is reached directly.

**Severity / reachability:** the production runner dispatches `download_file` through a server-fetch HTTP path (`_execute_file_tool`) that returns `resp.text` and **does not** call `_resolve_destination` today — so this is **defense-in-depth**, not a live exploitable regression. It becomes live the moment the builtin's `invoke()` is dispatched directly (in-process/alternate harness, future refactor) and is exercised by the unit tests now. The weakness pre-existed and is not specific to any single prior PR.

## The fix

```python
def _resolve_destination(filename, workspace):
    base = workspace or Path.cwd()
    name = Path(filename).name or "downloaded.bin"   # strip directory/abs components
    return safe_resolve(name, base)                  # reject anything escaping the workspace
```

- Reuses the existing `safe_resolve` guard from `upload_file.py` (traversal + escaping-symlink rejection).
- Call site now returns a clean `{"error": ...}` if the path is rejected, instead of raising.

## Relationship to #46 and #25

This **supersedes #46** (@agharsallah), which set out to fix exactly this. #46 was opened before #25 ("Remove unreachable download_file destination handling") merged, so it conflicted and re-introduced the `destination` argument that #25 deliberately removed. This PR keeps the #25 API simplification (no `destination` arg) and delivers **only** the #46 confinement, on the one code path that still exists. Credit to @agharsallah via the `Co-authored-by` trailer.

## Tests

- New parametrized traversal test: `../`, `../../`, `foo/../../`, `/etc/passwd`, absolute paths — all confined to the workspace.
- New basename test: `reports/2026/q2.csv` is saved as `q2.csv` inside the workspace.
- `15/15` file-tool tests pass locally.

## Follow-up (not in this PR)

Sanitize `filename` at the **upload trust boundary** (`file_store.create`), since `record.filename` is also used elsewhere (e.g. `Content-Disposition`). Hardening `_resolve_destination` closes the write primitive; sanitizing at ingest closes the class.
