### PR TITLE
ci: auto-run Polly on a maintainer-approved fork PR

### DIFF
--- a/.github/workflows/polly-review-approval-dispatch.yml
+++ b/.github/workflows/polly-review-approval-dispatch.yml
@@ -39,7 +39,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      actions: write   # dispatch polly-review.yml
+      pull-requests: read   # pulls.get + pulls.listReviews (validation)
+      actions: write        # dispatch polly-review.yml
     steps:
       - name: Download recorded PR number
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -59,8 +60,17 @@ jobs:
               owner, repo, artifact_id: art.id, archive_format: 'zip',
             });
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(dl.data));
-      - name: Unzip
-        run: unzip -o pr_number.zip || true
+      - name: Unzip recorded PR number
+        run: |
+          if [ -f pr_number.zip ]; then
+            # Fail loudly on a corrupt archive -- don't mask it.
+            unzip -o pr_number.zip
+          else
+            # No artifact is the EXPECTED case when stage 1's record job was
+            # skipped (e.g. a same-repo PR approval, which still completes the
+            # stage-1 workflow). The next step no-ops cleanly on the missing file.
+            echo "No pr_number.zip from the triggering run; nothing to do."
+          fi
       - name: Validate (fork + maintainer approval) and dispatch Polly
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -80,6 +90,13 @@ jobs:
 
             // Re-fetch the PR from the API -- never trust the artifact for identity.
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+
+            // Ignore belated review events (network delay / GitHub retry) on a PR
+            // that is no longer open -- don't spend a gateway run on a merged/closed PR.
+            if (pr.state !== 'open') {
+              core.info(`PR #${pull_number} is ${pr.state}, not open; skipping.`);
+              return;
+            }
 
             // Fork only: same-repo PRs already get Polly on open.
             if (!pr.head.repo || pr.head.repo.full_name === `${owner}/${repo}`) {
@@ -109,6 +126,9 @@ jobs:
             }
 
             // Is a maintainer's latest DECISIVE (non-COMMENTED) review an APPROVAL?
+            // Keep each reviewer's latest decisive review by submitted_at, so a
+            // later DISMISSED / CHANGES_REQUESTED supersedes an earlier APPROVAL --
+            // a dismissed maintainer approval correctly does NOT count below.
             const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number });
             const latestByUser = new Map();
             for (const r of reviews) {

--- a/.github/workflows/polly-review-approval-dispatch.yml
+++ b/.github/workflows/polly-review-approval-dispatch.yml
@@ -1,0 +1,137 @@
+name: Polly Review Approval Dispatch
+
+# Stage 2 (privileged) of the "run Polly when a maintainer approves a fork PR"
+# relay. Triggered by the completion of "Polly Review On Approval", it runs from
+# the base repo on `workflow_run`, so it gets a writable token (actions: write)
+# even for fork PRs and isn't held behind the fork-approval gate.
+#
+# It reads the recorded PR number, then re-derives the trust decision from
+# TRUSTED sources only -- the PR object and reviews from the API, and the
+# maintainer list from MAINTAINER@main (never the PR head, never the artifact's
+# word on identity). If the PR is from a fork AND a maintainer's latest decisive
+# review is APPROVED, it dispatches polly-review.yml (its existing
+# workflow_dispatch entry point) for that PR.
+#
+# Maintainer approval is the trust gate that authorizes spending the LLM gateway
+# secret on fork code -- the same model as the fork-e2e `e2e-approved` gate.
+# Polly itself never runs PR code: it reviews the diff fetched via the API from
+# a default-branch checkout.
+#
+# This workflow checks out NO code and runs NO PR code -- it only reads API data
+# and dispatches a workflow, so it is not a "dangerous" workflow_run consumer.
+
+on:
+  workflow_run:
+    workflows: [Polly Review On Approval]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: polly-review-approval-dispatch-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write   # dispatch polly-review.yml
+    steps:
+      - name: Download recorded PR number
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const arts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: context.payload.workflow_run.id,
+            });
+            const art = arts.data.artifacts.find(a => a.name === 'polly-approval-pr-number');
+            if (!art) {
+              core.info('No PR-number artifact on the triggering run; nothing to do.');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner, repo, artifact_id: art.id, archive_format: 'zip',
+            });
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(dl.data));
+      - name: Unzip
+        run: unzip -o pr_number.zip || true
+      - name: Validate (fork + maintainer approval) and dispatch Polly
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+
+            if (!fs.existsSync('pr_number')) {
+              core.info('No pr_number file; nothing to do.');
+              return;
+            }
+            const pull_number = Number(fs.readFileSync('pr_number', 'utf8').trim());
+            if (!Number.isInteger(pull_number) || pull_number <= 0) {
+              core.warning('Recorded PR number is not a positive integer; aborting.');
+              return;
+            }
+
+            // Re-fetch the PR from the API -- never trust the artifact for identity.
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+
+            // Fork only: same-repo PRs already get Polly on open.
+            if (!pr.head.repo || pr.head.repo.full_name === `${owner}/${repo}`) {
+              core.info(`PR #${pull_number} is not from a fork; skipping (same-repo PRs get Polly on open).`);
+              return;
+            }
+
+            // Load maintainers from MAINTAINER@main (trusted; never the PR head,
+            // so a PR can't grant itself approval power by editing the file).
+            const maintainers = new Set();
+            try {
+              const { data: f } = await github.rest.repos.getContent({
+                owner, repo, path: '.github/MAINTAINER', ref: 'main',
+              });
+              const text = Buffer.from(f.content, 'base64').toString('utf8');
+              for (const line of text.split('\n')) {
+                const u = line.replace(/#.*$/, '').trim().toLowerCase();
+                if (u) maintainers.add(u);
+              }
+            } catch (e) {
+              core.warning('Could not read .github/MAINTAINER@main; aborting.');
+              return;
+            }
+            if (maintainers.size === 0) {
+              core.warning('No maintainers configured on main; aborting.');
+              return;
+            }
+
+            // Is a maintainer's latest DECISIVE (non-COMMENTED) review an APPROVAL?
+            const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number });
+            const latestByUser = new Map();
+            for (const r of reviews) {
+              if (r.state === 'COMMENTED') continue;        // non-decisive
+              const login = ((r.user && r.user.login) || '').toLowerCase();
+              if (!login) continue;
+              const prev = latestByUser.get(login);
+              if (!prev || new Date(r.submitted_at) >= new Date(prev.submitted_at)) {
+                latestByUser.set(login, r);
+              }
+            }
+            const approvedByMaintainer = [...latestByUser.entries()].some(
+              ([login, r]) => r.state === 'APPROVED' && maintainers.has(login)
+            );
+            if (!approvedByMaintainer) {
+              core.info(`No maintainer approval on PR #${pull_number}; not dispatching Polly.`);
+              return;
+            }
+
+            core.info(`Maintainer-approved fork PR #${pull_number}; dispatching Polly review.`);
+            await github.rest.actions.createWorkflowDispatch({
+              owner, repo,
+              workflow_id: 'polly-review.yml',
+              ref: 'main',
+              inputs: { pr: String(pull_number) },
+            });

--- a/.github/workflows/polly-review-on-approval.yml
+++ b/.github/workflows/polly-review-on-approval.yml
@@ -1,0 +1,52 @@
+name: Polly Review On Approval
+
+# Stage 1 of the "run Polly when a maintainer approves a fork PR" relay.
+#
+# Why a relay: a fork PR's `pull_request_review` token is read-only and held
+# behind the fork-approval gate, so this job can't dispatch Polly (which needs
+# the LLM gateway secret) itself. It only records the PR number as an artifact;
+# the privileged dispatch happens in polly-review-approval-dispatch.yml on
+# `workflow_run`. Same shape as the maintainer-approval-rerun relay.
+#
+# Scope: ONLY fork PRs. Same-repo (collaborator) PRs already get an automatic
+# Polly review on open (polly-review.yml), so they don't need this path.
+#
+# This stage records on ANY approving review of a fork PR; the authoritative
+# "was it a maintainer?" check is done in stage 2 from trusted API data +
+# MAINTAINER@main (this read-only stage is not trusted to make that decision).
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: polly-review-on-approval-${{ github.event.pull_request.number }}
+  # Don't cancel in-progress: a cancelled run could drop the recorded artifact.
+  cancel-in-progress: false
+
+jobs:
+  record:
+    # Approvals only, and only on fork PRs (same-repo PRs are handled on open).
+    if: >-
+      github.event.review.state == 'approved'
+      && github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Record PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p pr
+          echo "$PR_NUMBER" > pr/pr_number
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: polly-approval-pr-number
+          path: pr/
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
PR 2 of 3 implementing automated AI review on external-contributor PRs (designs/contributor-review-merge-proposal.md). Follows #454 (Copilot on fork PRs).

## Problem
Fork PRs skip Polly's auto-review on open because fork `pull_request` runs get no secrets (no `LLM_API_KEY`). Today the only way to get Polly on a fork PR is a maintainer manually commenting `/review`.

## What this does
Auto-runs Polly when a **maintainer approves** a fork PR. Maintainer approval is the trust gate that authorizes spending the LLM gateway secret on fork code — the same model as the fork-e2e `e2e-approved` gate.

## Why two workflows (a relay)
A fork PR's `pull_request_review` token is read-only and held behind the fork-approval gate, so it can't dispatch a secret-bearing job itself. This mirrors the existing `maintainer-approval-rerun` → `-rerun-run` relay:

1. **`polly-review-on-approval.yml`** (read-only): on any approving review of a *fork* PR, record the PR number as an artifact. No secrets, no code execution.
2. **`polly-review-approval-dispatch.yml`** (privileged `workflow_run`): re-derive the trust decision from **trusted sources only** — the PR object + reviews from the API, and the maintainer list from `MAINTAINER@main` (never the PR head, never the artifact's word on identity). If the PR is a fork **and** a maintainer's latest decisive review is `APPROVED`, dispatch `polly-review.yml` via its existing `workflow_dispatch` entry point.

## Security
- Neither workflow **checks out or runs PR code**. `polly-review.yml` is **unchanged** — we reuse its `workflow_dispatch` path.
- The recorded artifact is only a PR *number*, validated as a positive integer; stage 2 re-validates fork-status and maintainer-approval from the API before dispatching, so a tampered/wrong number can't make Polly run on a non-approved PR.
- Maintainer list read from `MAINTAINER@main`, consistent with `load-maintainers.sh` / `maintainer-approval.yml` — a PR can't grant itself approval power.
- Same-repo PRs keep their existing on-open auto-review (this path is fork-only).

## Next
PR 3: Merge Ready waits for Polly to complete on fork PRs (advisory verdict, required-to-complete; bounded by the existing maintainer force-merge escape hatch).