### PR TITLE
test(e2e): migrate 3 policy-guardrails pass-through tests to sessions API

### DIFF
--- a/tests/e2e/test_policies_e2e.py
+++ b/tests/e2e/test_policies_e2e.py
@@ -40,7 +40,6 @@ from httpx_sse import connect_sse
 from tests.e2e.conftest import (
     create_runner_bound_session,
     poll_session_until_terminal,
-    poll_until_terminal,
     send_user_message_to_session,
     upload_agent,
 )
@@ -318,22 +317,23 @@ def _post_user_message(client: httpx.Client, session_id: str, text: str) -> http
 def test_policy_gate_allows_clean_message(
     http_client: httpx.Client,
     policy_gate_agent: str,
+    live_runner_id: str,
 ) -> None:
     """A normal message (no sentinel) passes through the
     policy → reaches the LLM → gets a real response. If
     this regresses, the policy is over-firing and blocking
     legitimate traffic."""
-    resp = http_client.post(
-        "/v1/responses",
-        json={
-            "model": policy_gate_agent,
-            "input": "Say hi in exactly three words.",
-            "background": True,
-        },
+    session_id = create_runner_bound_session(
+        http_client, agent_name=policy_gate_agent, runner_id=live_runner_id
     )
-    resp.raise_for_status()
-    rid = resp.json()["id"]
-    body = poll_until_terminal(http_client, rid, timeout=120)
+    rid = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Say hi in exactly three words.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid, timeout=120
+    )
     # Terminal status must be completed — policy ALLOW should
     # not turn the turn into a failure.
     assert body["status"] == "completed", f"Unexpected status: {body.get('error')}"
@@ -388,39 +388,35 @@ def test_policy_gate_denies_sentinel_message(
 def test_policy_gate_deny_persists_to_history(
     http_client: httpx.Client,
     policy_gate_agent: str,
+    live_runner_id: str,
 ) -> None:
     """After a DENY, a follow-up turn on the same
     conversation sees the sentinel in history. Proves the
     sentinel was written to conversation_items (not just
     surfaced on the stream)."""
-    # Turn 1: DENY.
-    resp1 = http_client.post(
-        "/v1/responses",
-        json={
-            "model": policy_gate_agent,
-            "input": "Trigger BLOCK_THIS_TOKEN please.",
-            "background": True,
-        },
+    session_id = create_runner_bound_session(
+        http_client, agent_name=policy_gate_agent, runner_id=live_runner_id
     )
-    resp1.raise_for_status()
-    rid1 = resp1.json()["id"]
-    body1 = poll_until_terminal(http_client, rid1, timeout=60)
-    assert body1["status"] == "completed"
-    assert "[Denied by policy" in _extract_all_assistant_text(body1)
+
+    # Turn 1: DENY. The events endpoint resolves INPUT-policy
+    # DENY synchronously, so no runner turn is queued.
+    resp1 = _post_user_message(http_client, session_id, "Trigger BLOCK_THIS_TOKEN please.")
+    assert resp1.status_code == 202, f"unexpected status: {resp1.status_code} {resp1.text[:300]}"
+    verdict = resp1.json()
+    assert verdict.get("denied") is True, f"expected synchronous DENY verdict; got {verdict}"
+    assert "BLOCK_THIS_TOKEN" in verdict.get("reason", ""), (
+        f"expected reason mentioning BLOCK_THIS_TOKEN; got {verdict}"
+    )
 
     # Turn 2: clean follow-up on the same conversation.
-    resp2 = http_client.post(
-        "/v1/responses",
-        json={
-            "model": policy_gate_agent,
-            "input": "Reply with a single word: OK",
-            "previous_response_id": rid1,
-            "background": True,
-        },
+    rid2 = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Reply with a single word: OK",
     )
-    resp2.raise_for_status()
-    rid2 = resp2.json()["id"]
-    body2 = poll_until_terminal(http_client, rid2, timeout=120)
+    body2 = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid2, timeout=120
+    )
     # Turn 2 completed without crashing — the engine rebuilt
     # cleanly on a conversation that already had a DENYed
     # turn-1 sentinel in history.
@@ -435,9 +431,8 @@ def test_policy_gate_deny_persists_to_history(
     assert len(text2.strip()) > 0
     # Fetch conversation items — the turn-1 sentinel MUST
     # be persisted so replay sees it.
-    conv_id = body2["conversation"]["id"]
     items_resp = http_client.get(
-        f"/v1/sessions/{conv_id}/items",
+        f"/v1/sessions/{session_id}/items",
         params={"limit": 100},
     )
     items_resp.raise_for_status()
@@ -513,22 +508,23 @@ def test_label_gate_taint_persists_across_turns(
 def test_label_gate_untainted_conversation_passes(
     http_client: httpx.Client,
     label_gate_agent: str,
+    live_runner_id: str,
 ) -> None:
     """A conversation that never triggers taint_on_banana
     should pass every turn — the condition
     ``tainted: "1"`` never matches against the default
     ``tainted: "0"`` seed."""
-    resp = http_client.post(
-        "/v1/responses",
-        json={
-            "model": label_gate_agent,
-            "input": "Hello. Reply briefly.",
-            "background": True,
-        },
+    session_id = create_runner_bound_session(
+        http_client, agent_name=label_gate_agent, runner_id=live_runner_id
     )
-    resp.raise_for_status()
-    rid = resp.json()["id"]
-    body = poll_until_terminal(http_client, rid, timeout=120)
+    rid = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Hello. Reply briefly.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid, timeout=120
+    )
     assert body["status"] == "completed", f"Clean conversation failed: {body.get('error')}"
     text = _extract_all_assistant_text(body)
     assert "[Denied by policy" not in text
@@ -593,7 +589,9 @@ def test_no_guardrails_agent_unaffected(
         session_id=session_id,
         content="What is 2 + 2? Answer with one number only.",
     )
-    body = poll_until_terminal(http_client, rid, timeout=120)
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid, timeout=120
+    )
     assert body["status"] == "completed", f"Archer (no guardrails) failed: {body.get('error')}"
     text = _extract_all_assistant_text(body)
     # Real LLM output — not a policy sentinel.

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -286,12 +286,6 @@ skips:
     cluster: run-ap-examples-harness
     mode: skip
 
-  - id: tests/e2e/test_policies_e2e.py::test_label_gate_untainted_conversation_passes
-    reason: "Shard 1 bulk: label-gate untainted-pass; policy cluster."
-    issue: 476
-    cluster: policy-guardrails
-    mode: skip
-
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_approve_always_caches_for_later_turns
     reason: "Shard 1 bulk: REPL approval pexpect-timeout family."
     issue: 532
@@ -395,20 +389,14 @@ skips:
     cluster: subagent-supervisor-routing
     mode: skip
 
-  - id: tests/e2e/test_policies_e2e.py::test_policy_gate_allows_clean_message
-    reason: "Shard 3 bulk: policy-gate clean-pass. Policy cluster."
+  - id: tests/e2e/test_policies_e2e.py::test_streaming_api_explicit_approval_allows_llm
+    reason: "Shard 3 bulk: streaming-API explicit approval. Policy / approval cluster."
     issue: 476
     cluster: policy-guardrails
     mode: skip
 
   - id: tests/e2e/test_policies_e2e.py::test_policy_gate_deny_persists_to_history
-    reason: "Shard 3 bulk: policy-gate deny persists to history. Policy cluster."
-    issue: 476
-    cluster: policy-guardrails
-    mode: skip
-
-  - id: tests/e2e/test_policies_e2e.py::test_streaming_api_explicit_approval_allows_llm
-    reason: "Shard 3 bulk: streaming-API explicit approval. Policy / approval cluster."
+    reason: "Sessions API migration reaches inline INPUT DENY, but the synchronous DENY verdict is not persisted as an assistant sentinel in conversation_items; needs product-side persistence fix before unsuppressing."
     issue: 476
     cluster: policy-guardrails
     mode: skip
@@ -805,12 +793,6 @@ skips:
     issue: 483
     cluster: policy-guardrails
     mode: skip
-  - id: tests/e2e/test_policies_e2e.py::test_no_guardrails_agent_unaffected
-    reason: "Force-merge backlog (policy cluster). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: policy-guardrails
-    mode: skip
-
   # Cluster: claude_coder sandbox enforcement. All 5 tests in
   # test_claude_coder_sandbox.py flipped together — suggests the
   # sandbox enforcement path or its fixture regressed.

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -389,14 +389,14 @@ skips:
     cluster: subagent-supervisor-routing
     mode: skip
 
-  - id: tests/e2e/test_policies_e2e.py::test_streaming_api_explicit_approval_allows_llm
-    reason: "Shard 3 bulk: streaming-API explicit approval. Policy / approval cluster."
+  - id: tests/e2e/test_policies_e2e.py::test_policy_gate_deny_persists_to_history
+    reason: "Sessions API migration reaches inline INPUT DENY, but the synchronous DENY verdict is not persisted as an assistant sentinel in conversation_items; needs product-side persistence fix before unsuppressing."
     issue: 476
     cluster: policy-guardrails
     mode: skip
 
-  - id: tests/e2e/test_policies_e2e.py::test_policy_gate_deny_persists_to_history
-    reason: "Sessions API migration reaches inline INPUT DENY, but the synchronous DENY verdict is not persisted as an assistant sentinel in conversation_items; needs product-side persistence fix before unsuppressing."
+  - id: tests/e2e/test_policies_e2e.py::test_streaming_api_explicit_approval_allows_llm
+    reason: "Shard 3 bulk: streaming-API explicit approval. Policy / approval cluster."
     issue: 476
     cluster: policy-guardrails
     mode: skip


### PR DESCRIPTION
## Summary

- Migrates the TEST-FIXABLE policy-guardrails E2E allow/pass-through tests from legacy `POST /v1/responses` polling to the runner-bound sessions API pattern already used by the passing deny siblings.
- Unsuppresses the three migrated tests that now pass live through the Databricks gateway: policy clean allow, label-gate untainted allow, and no-guardrails agent unaffected.
- Leaves the streaming SSE tests suppressed, and keeps deny-persistence suppressed after migration confirmed a separate product gap: synchronous INPUT DENY publishes a stream sentinel but does not persist an assistant sentinel in `conversation_items`.

ELI5: these tests were knocking on an old door that no longer exists. This changes the fixable tests to knock on the new sessions door, while leaving tests alone when the new door reveals a real product behavior gap instead of a test harness bug.

```mermaid
flowchart LR
    Test[Test sends user message] --> Session[runner-bound session]
    Session --> Events[POST /v1/sessions/:id/events]
    Events --> Policy{Input policy}
    Policy -->|ALLOW| Runner[runner + LLM]
    Runner --> Poll[GET /v1/sessions/:id until idle]
    Poll --> Assert[assert non-empty non-deny output]
    Policy -->|DENY| Inline[inline denied verdict]
    Inline --> ProductGap[stream sentinel published, assistant item not persisted]
```

### Per-test decisions

| Test | Decision | Result / reason |
| --- | --- | --- |
| `test_policy_gate_allows_clean_message` | Migrated + unsuppressed | Passes via sessions API; verifies completed status, non-empty LLM output, and no deny sentinel. |
| `test_label_gate_untainted_conversation_passes` | Migrated + unsuppressed | Passes via sessions API; verifies untainted conversation reaches LLM and is not denied. |
| `test_no_guardrails_agent_unaffected` | Migrated + unsuppressed | Passes via sessions API; verifies no-guardrails archer agent still produces non-deny LLM output. |
| `test_policy_gate_deny_persists_to_history` | Migrated but still suppressed | Sessions path reaches synchronous INPUT DENY, but no assistant deny sentinel is persisted to `conversation_items`; product-side persistence gap, not simple legacy polling drift. |
| `test_streaming_api_explicit_approval_allows_llm` | Deferred / left suppressed | Streaming SSE legacy route has separate `#532` 409 conflict / SSE content-type mismatch root cause. |
| `test_streaming_api_explicit_decline_denies` | Deferred / left suppressed | Same streaming SSE wire issue, not simple sessions polling drift. |
| `test_streaming_api_malformed_verdict_rejected_by_route` | Deferred / left suppressed | Same streaming SSE wire issue, not simple sessions polling drift. |

### Deferred list

- `test_policy_gate_deny_persists_to_history`: confirmed product gap for synchronous INPUT DENY persistence on sessions API.
- `test_streaming_api_explicit_approval_allows_llm`: streaming SSE `#532` wire issue.
- `test_streaming_api_explicit_decline_denies`: streaming SSE `#532` wire issue.
- `test_streaming_api_malformed_verdict_rejected_by_route`: streaming SSE `#532` wire issue.

### Product bugs confirmed

- Synchronous INPUT policy DENY on `POST /v1/sessions/{id}/events` publishes a policy deny event and returns `{"queued": false, "denied": true, ...}`, but does not persist an assistant deny sentinel in `conversation_items`. The migrated `test_policy_gate_deny_persists_to_history` fails with persisted assistant texts containing only the follow-up LLM reply (`['OK']`).
- The streaming SSE tests remain a separate known product/wire issue per existing suppression reason (`#532` 409 conflict / SSE content-type mismatch); not changed in this PR.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run from `/Users/pat.sukprasert/git/omnigent-worktrees/jun-17-known-failure-fix/.worktrees/policy-guardrails-e2e-migrate`:

- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest tests/e2e/test_policies_e2e.py::test_policy_gate_allows_clean_message --llm-api-key="$TOKEN" --profile=DEFAULT --tb=short -q -rfs` → `1 passed, 1 warning in 7.28s`
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest tests/e2e/test_policies_e2e.py::test_policy_gate_deny_persists_to_history --llm-api-key="$TOKEN" --profile=DEFAULT --tb=short -q -rfs` → `1 failed`; confirmed separate product persistence gap, so suppression retained with a precise reason.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest tests/e2e/test_policies_e2e.py::test_label_gate_untainted_conversation_passes --llm-api-key="$TOKEN" --profile=DEFAULT --tb=short -q -rfs` → `1 passed, 1 warning in 9.80s`
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest tests/e2e/test_policies_e2e.py::test_no_guardrails_agent_unaffected --llm-api-key="$TOKEN" --profile=DEFAULT --tb=short -q -rfs` → `1 passed, 1 warning in 8.19s`
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest tests/e2e/test_policies_e2e.py::test_policy_gate_allows_clean_message tests/e2e/test_policies_e2e.py::test_label_gate_untainted_conversation_passes tests/e2e/test_policies_e2e.py::test_no_guardrails_agent_unaffected --llm-api-key="$TOKEN" --profile=DEFAULT --tb=short -q -rfs` → `3 passed, 1 warning in 15.67s`
- `uv run ruff format tests/e2e/test_policies_e2e.py` → `1 file left unchanged`
- `uv run ruff check tests/e2e/test_policies_e2e.py` → `All checks passed!`
- `uv run python - <<'PY' ... yaml.safe_load(Path('tests/known_failures.yaml').read_text()) ... PY` → `tests/known_failures.yaml parsed successfully`

Note: `uv run ruff format tests/e2e/test_policies_e2e.py tests/known_failures.yaml` failed because ruff cannot parse YAML; the Python file was formatted/linted with ruff and the YAML file was validated separately with PyYAML. A bare OpenAI-key attempt for `test_policy_gate_allows_clean_message` reached the migrated sessions path but failed at the local gateway with `gpt-4o does not exist`; the Databricks-profile route was used for representative live validation because it rewrites fixture models to Databricks serving endpoints.
