### PR TITLE
fix(ci): re-run security scan on review + explain the maintainer waiver

### DIFF
--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -86,9 +86,11 @@ skip_label_effective() {
 # trigger -- push to main / fork-e2e/** (the mirror branch only exists after a
 # returning-contributor / maintainer-approval gate), schedule, dispatch -- is a
 # trusted context, so proceed without scanning. pull_request_review is included
-# because the fork-e2e mirror fires on a maintainer's approval, and that path
-# must still consult the head SHA's Security Scan (the review payload carries
-# the same pull_request + author_association fields).
+# for two reasons: (1) the security-scan workflow itself re-runs on review so a
+# maintainer's approval can complete a skip-security-scan waiver that was labeled
+# first; (2) the fork-e2e mirror fires on a maintainer's approval and must still
+# consult the head SHA's Security Scan. Both carry the same pull_request +
+# author_association fields, so the gate is evaluated identically.
 case "${EVENT_NAME:-}" in
   pull_request | pull_request_target | pull_request_review) ;;
   *)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,6 +25,15 @@ on:
     # labeled/unlabeled so applying or removing the maintainer skip label
     # (skip-security-scan) re-runs the scan and flips this check.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  # A maintainer's approval is the OTHER half of the skip-security-scan waiver
+  # (the label alone is not maintainer-effective -- see should-scan.sh). Without
+  # this trigger a PR that is labeled FIRST and approved LATER never re-runs, so
+  # the stale failing check sticks. `submitted` flips the check once a maintainer
+  # approves; `dismissed` re-gates if that approval is later removed. should-scan.sh
+  # already accepts the pull_request_review payload (same pull_request +
+  # author_association fields), so no script change is needed.
+  pull_request_review:
+    types: [submitted, dismissed]
 
 permissions:
   contents: read
@@ -150,3 +159,20 @@ jobs:
           # Gating pass: ERROR-severity rules fail the scan.
           uvx semgrep scan --config "$RULES" --severity=ERROR --error \
             --metrics=off --quiet $(cat targets.txt)
+
+      # Surfaced on ANY detector failure above (sensitive-path / secret / exfil
+      # / workflow-misuse / semgrep): the detectors say WHAT they found; this
+      # says HOW a maintainer can waive it. The waiver needs BOTH a maintainer
+      # approval AND the label -- the label alone is not maintainer-effective
+      # (see should-scan.sh). Either action re-runs this scan via the labeled /
+      # pull_request_review triggers above.
+      - name: Explain the maintainer waiver (on failure)
+        if: ${{ failure() }}
+        run: |
+          MSG="A maintainer can skip the Security Scan by approving this PR AND applying the 'skip-security-scan' label (the label alone is not enough -- the author must be a maintainer or a maintainer must have approved). Either action re-runs this scan automatically."
+          echo "::error::$MSG"
+          {
+            echo "### Security Scan failed"
+            echo
+            echo "$MSG"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The `skip-security-scan` waiver is only *maintainer-effective* when the label is present **AND** (the author is a maintainer OR a maintainer's latest decisive review is APPROVED). Two rough edges fell out of that:

1. **Label-then-approve never re-ran.** `security-scan.yml` triggered on `labeled`/`unlabeled` but not on reviews. So if a maintainer applied the label *first* and approved *later*, the approval didn't re-run the scan and the stale failing **Security Scan** check stuck. (Approve-then-label already worked, because the label event re-ran it.)
2. **The failure gave no way out.** The detectors (sensitive-path, secret, exfil, workflow-misuse, semgrep) explained *what* they found but never mentioned the maintainer escape hatch, so contributors had no idea how to get unblocked.

## Changes

- **`pull_request_review` trigger** (`types: [submitted, dismissed]`) on `security-scan.yml`. `submitted` lets a maintainer approval complete a label-first waiver; `dismissed` re-gates if the approval is later removed. `should-scan.sh` already accepts the review payload (same `pull_request` + `author_association` fields) — no logic change, just an updated comment documenting the second reason it handles the event.
- **`if: failure()` guidance step** that surfaces the waiver on *any* detector failure: a maintainer can approve **and** apply `skip-security-scan`, and either action re-runs the scan. Emitted as both an `::error::` annotation and a job-summary block. One central step rather than editing each detector.

Removing the label already re-triggers via the existing `unlabeled` type, so the loop now works in every direction: label, unlabel, approve, dismiss.

## Notes

- Takes effect only after this merges to `main` — `pull_request_review` evaluates triggers from the base branch, and the scanner always checks out scripts from `main`.
- `submitted` fires on every review (even non-maintainer comments), so the scan re-runs on review activity. It's a cheap static-only scan and `cancel-in-progress` collapses bursts, so the extra runs are bounded.

🤖 This pull request and its description were written by Isaac, an AI coding agent (Claude Code).