### PR TITLE
feat(ci): enforce coverage gate (red ✗ on drop, still non-blocking)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -38,9 +38,11 @@ env:
   # so a tiny jitter doesn't fail a PR. A real regression clears this easily.
   COVERAGE_TOLERANCE: "0.5"
   # "false" = observe only: a regression posts a success status annotated
-  # "would fail once enforced" instead of a red ✗. Set "true" to post real
-  # failure statuses once the gate has run cleanly for a while.
-  COVERAGE_ENFORCE: "false"
+  # "would fail once enforced" instead of a red ✗. "true" = a regression posts a
+  # real failure (red ✗). This stays non-blocking until the status is also marked
+  # a required check in branch protection — so red ✗ surfaces the drop without
+  # blocking the merge.
+  COVERAGE_ENFORCE: "true"
   # How many recent main commits to scan for the last recorded baseline status.
   # Must exceed the longest expected run of consecutive merges that don't touch
   # a given suite. Capped at 100 (the GraphQL history page size); raising it


### PR DESCRIPTION
Flips `COVERAGE_ENFORCE` from `"false"` to `"true"`.

## Behavior change
A PR that drops coverage below the main baseline (beyond `COVERAGE_TOLERANCE` = 0.5pt) now posts a **real `failure` status (red ✗)** instead of the observe-only green `(would fail once enforced)` note.

| Situation | Before (observe) | After (this PR) |
|---|---|---|
| Coverage ≥ baseline | ✅ green | ✅ green |
| Coverage < baseline | ✅ green, "would fail once enforced" | ❌ **red** `Coverage dropped: NN% < baseline MM%` |
| No baseline yet | ✅ green | ✅ green |

## Still non-blocking
The `Coverage` / `Coverage (ui)` statuses are **not** in `main`'s required status checks, so a red ✗ is informational — it surfaces the regression on the PR without blocking the merge. Turning it into a hard gate is a separate branch-protection-only change (add the two contexts to required checks); no repo file changes it.