### PR TITLE
ci: add CODEOWNERS for reviewer routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,11 +12,12 @@
 #
 # Per-area owners are the top maintainers by COMBINED commit count across both
 # repos (databricks-eng/agent-framework full history + omnigent-ai/omnigent),
-# ~3-4 per area. Non-maintainer contributors are excluded, including authors of
-# cross-cutting changes that touch many areas (e.g. the sandbox/egress work),
-# which is why a broad one-off contributor is not listed as an area owner.
-# Note: GitHub requests ALL listed owners on a matching PR. Sanity-check
-# against real ownership and trim where a path has too many requests.
+# ~up to 4 per area. EXCLUDED from the count: mechanical tree-wide sweeps
+# (>100 files) -- the OSS migration import and the package-rename refactors --
+# since they touch every path and credit their author in every area without
+# implying ownership. Non-maintainer contributors are also excluded. Areas
+# whose only touches were sweeps have no entry and fall through to the default.
+# Worth a final human sanity-check.
 #
 # ROUND-ROBIN / even distribution: the `*` default points at a team
 # (@omnigent-ai/maintainers). Create that team and set its "Code review
@@ -36,24 +37,22 @@
 
 # Core agent runtime & harnesses
 /omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
-/omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @dhruv0811
+/omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @fanzeyi
 /omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811 @ckcuslife-source
-/omnigent/server/            @dhruv0811 @dbczumar @ckcuslife-source @TomeHirata
-/omnigent/onboarding/        @SabhyaC26 @dhruv0811 @dbczumar @bbqiu
+/omnigent/server/            @dbczumar @dhruv0811 @ckcuslife-source @TomeHirata
+/omnigent/onboarding/        @SabhyaC26 @dbczumar @dhruv0811 @bbqiu
 /omnigent/policies/          @TomeHirata @SabhyaC26 @dhruv0811 @PattaraS
 /omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
-/omnigent/llms/              @dhruv0811 @PattaraS @ckcuslife-source
+/omnigent/llms/              @PattaraS @ckcuslife-source
 /omnigent/host/              @fanzeyi @dhruv0811 @dbczumar @TomeHirata
-/omnigent/sandbox/           @dhruv0811 @SabhyaC26
-/omnigent/environments/      @dhruv0811
-/omnigent/db/                @dhruv0811 @SabhyaC26 @fanzeyi
-/omnigent/stores/            @serena-ruan @dhruv0811 @SabhyaC26 @TomeHirata
-/omnigent/terminals/         @dhruv0811 @SabhyaC26 @dbczumar @Edwinhe03
-/omnigent/tools/             @dbczumar @SabhyaC26 @dhruv0811 @PattaraS
-/omnigent/client_tools/      @dhruv0811
-/omnigent/entities/          @dhruv0811 @SabhyaC26 @daniellok-db @TomeHirata
+/omnigent/sandbox/           @SabhyaC26
+/omnigent/db/                @SabhyaC26 @fanzeyi
+/omnigent/stores/            @serena-ruan @SabhyaC26 @TomeHirata @fanzeyi
+/omnigent/terminals/         @SabhyaC26 @dbczumar @Edwinhe03
+/omnigent/tools/             @dbczumar @SabhyaC26 @PattaraS
+/omnigent/entities/          @SabhyaC26 @daniellok-db @TomeHirata
 /omnigent/repl/              @dhruv0811 @SabhyaC26 @dbczumar @TomeHirata
-/omnigent/resources/         @SabhyaC26 @dhruv0811 @fanzeyi @serena-ruan
+/omnigent/resources/         @SabhyaC26 @fanzeyi @serena-ruan
 
 # Deploy targets
 /deploy/                     @dhruv0811 @PattaraS @dbczumar @SabhyaC26

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,12 +19,14 @@
 # whose only touches were sweeps have no entry and fall through to the default.
 # Worth a final human sanity-check.
 #
-# DEFAULT / round-robin: there is intentionally no `*` owner here. PRs that
-# match none of the rules below are routed by a repo-level GitHub Action
-# (.github/workflows/auto-assign-reviewer.yml), which load-balances one
-# reviewer from the pool of handles listed in THIS file. That avoids needing
-# an org team (and org-owner setup) for native round-robin, and it naturally
-# excludes maintainers who aren't assigned to any area here.
+# ASSIGNMENT: there is intentionally no `*` owner here. A repo-level GitHub
+# Action (.github/workflows/auto-assign-reviewer.yml) assigns EXACTLY 2
+# load-balanced reviewers per PR, preferring the owners listed below for the
+# area(s) the PR touches (falling back to the full set of handles in this file
+# for unowned paths). It reconciles GitHub's native CODEOWNERS request (which
+# would otherwise ping every owner) down to those 2. So the per-area lists
+# below are the CANDIDATE pool per area, not "everyone gets requested".
+# Maintainers not listed anywhere here are never put into review rotation.
 
 # Repo automation / CI
 /.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,12 +37,12 @@
 # Core agent runtime & harnesses
 /omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
 /omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @dhruv0811
-/omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811
-/omnigent/server/            @dhruv0811 @dbczumar @TomeHirata @SabhyaC26
+/omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811 @ckcuslife-source
+/omnigent/server/            @dhruv0811 @dbczumar @ckcuslife-source @TomeHirata
 /omnigent/onboarding/        @SabhyaC26 @dhruv0811 @dbczumar @bbqiu
 /omnigent/policies/          @TomeHirata @SabhyaC26 @dhruv0811 @PattaraS
-/omnigent/spec/              @SabhyaC26 @dhruv0811
-/omnigent/llms/              @dhruv0811 @PattaraS
+/omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
+/omnigent/llms/              @dhruv0811 @PattaraS @ckcuslife-source
 /omnigent/host/              @fanzeyi @dhruv0811 @dbczumar @TomeHirata
 /omnigent/sandbox/           @dhruv0811 @SabhyaC26
 /omnigent/environments/      @dhruv0811

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,59 +10,60 @@
 # .github/MAINTAINER. Last matching pattern wins, so the `*` default is first
 # and more specific paths override it below.
 #
-# Per-area owners are seeded from the full commit history of the upstream
-# repo (databricks-eng/agent-framework), mapped to public handles by author.
-# A few areas have a top contributor who is not in MAINTAINER (e.g. inner /
-# runner / spec / tools); those list the next most-active maintainers.
-# Still worth a sanity check against real ownership.
+# Per-area owners are the top maintainers by COMBINED commit count across both
+# repos (databricks-eng/agent-framework full history + omnigent-ai/omnigent),
+# ~3-4 per area. Non-maintainer contributors are excluded, including authors of
+# cross-cutting changes that touch many areas (e.g. the sandbox/egress work),
+# which is why a broad one-off contributor is not listed as an area owner.
+# Note: GitHub requests ALL listed owners on a matching PR. Sanity-check
+# against real ownership and trim where a path has too many requests.
 #
 # ROUND-ROBIN / even distribution: the `*` default points at a team
 # (@omnigent-ai/maintainers). Create that team and set its "Code review
 # assignment" to round-robin (load-balance) so unowned PRs are distributed
 # across maintainers instead of pinging everyone. Until the team exists,
 # GitHub ignores the `*` line (no default auto-request) -- the per-area
-# owners below still work. Replace with individuals if you prefer not to use
-# a team.
+# owners below still work.
 
 # Default owner for anything not matched below (round-robin team -- see note).
-*                          @omnigent-ai/maintainers
+*                            @omnigent-ai/maintainers
 
 # Repo automation / CI
-/.github/                  @PattaraS @dhruv0811
+/.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata
 
 # Web UI
-/ap-web/                   @SabhyaC26 @serena-ruan @daniellok-db
+/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @dbczumar
 
 # Core agent runtime & harnesses
-/omnigent/inner/           @SabhyaC26 @TomeHirata
-/omnigent/runner/          @SabhyaC26 @TomeHirata
-/omnigent/runtime/         @TomeHirata @dhruv0811
-/omnigent/server/          @dbczumar @dhruv0811
-/omnigent/onboarding/      @dhruv0811 @dbczumar
-/omnigent/policies/        @TomeHirata @SabhyaC26
-/omnigent/spec/            @dhruv0811 @SabhyaC26
-/omnigent/llms/            @dhruv0811
-/omnigent/host/            @fanzeyi @dhruv0811
-/omnigent/sandbox/         @dhruv0811 @SabhyaC26
-/omnigent/environments/    @dhruv0811
-/omnigent/db/              @dhruv0811 @fanzeyi
-/omnigent/stores/          @serena-ruan @fanzeyi
-/omnigent/terminals/       @SabhyaC26 @dhruv0811
-/omnigent/tools/           @SabhyaC26 @dbczumar
-/omnigent/client_tools/    @dhruv0811
-/omnigent/entities/        @TomeHirata @SabhyaC26
-/omnigent/repl/            @dhruv0811 @SabhyaC26
-/omnigent/resources/       @dhruv0811
+/omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
+/omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @dhruv0811
+/omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811 @ckcuslife-source
+/omnigent/server/            @dhruv0811 @dbczumar @ckcuslife-source @TomeHirata
+/omnigent/onboarding/        @SabhyaC26 @dhruv0811 @dbczumar @bbqiu
+/omnigent/policies/          @TomeHirata @SabhyaC26 @dhruv0811 @PattaraS
+/omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
+/omnigent/llms/              @dhruv0811 @PattaraS @ckcuslife-source
+/omnigent/host/              @fanzeyi @dhruv0811 @dbczumar @TomeHirata
+/omnigent/sandbox/           @dhruv0811 @SabhyaC26
+/omnigent/environments/      @dhruv0811
+/omnigent/db/                @dhruv0811 @SabhyaC26 @fanzeyi
+/omnigent/stores/            @serena-ruan @dhruv0811 @SabhyaC26 @TomeHirata
+/omnigent/terminals/         @dhruv0811 @SabhyaC26 @dbczumar @Edwinhe03
+/omnigent/tools/             @dbczumar @SabhyaC26 @dhruv0811 @PattaraS
+/omnigent/client_tools/      @dhruv0811
+/omnigent/entities/          @dhruv0811 @SabhyaC26 @daniellok-db @TomeHirata
+/omnigent/repl/              @dhruv0811 @SabhyaC26 @dbczumar @TomeHirata
+/omnigent/resources/         @SabhyaC26 @dhruv0811 @fanzeyi @serena-ruan
 
 # Deploy targets
-/deploy/                   @dhruv0811 @PattaraS
+/deploy/                     @dhruv0811 @PattaraS @dbczumar @SabhyaC26
 
 # Python / UI SDKs
-/sdks/                     @fanzeyi @TomeHirata
+/sdks/                       @dbczumar @fanzeyi @SabhyaC26 @TomeHirata
 
 # Tests
-/tests/                    @PattaraS @TomeHirata
+/tests/                      @dbczumar @PattaraS @SabhyaC26 @TomeHirata
 
 # Docs & design
-/docs/                     @dhruv0811 @dbczumar
-/designs/                  @PattaraS @dhruv0811
+/docs/                       @dhruv0811 @dbczumar @TomeHirata @shivam5
+/designs/                    @dbczumar @PattaraS @dhruv0811 @SabhyaC26

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,25 +33,25 @@
 /.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata
 
 # Web UI
-/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @dbczumar @hzub
+/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @hzub
 
 # Core agent runtime & harnesses
 /omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
 /omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @fanzeyi
 /omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811 @ckcuslife-source
 /omnigent/server/            @dbczumar @dhruv0811 @ckcuslife-source @TomeHirata
-/omnigent/onboarding/        @SabhyaC26 @dbczumar @dhruv0811 @bbqiu
-/omnigent/policies/          @TomeHirata @SabhyaC26 @dhruv0811 @PattaraS
+/omnigent/onboarding/        @SabhyaC26 @fanzeyi @dhruv0811 @bbqiu
+/omnigent/policies/          @TomeHirata @dhruv0811 @ckcuslife-source
 /omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
 /omnigent/llms/              @PattaraS @ckcuslife-source
 /omnigent/host/              @fanzeyi @dhruv0811 @dbczumar
 /omnigent/sandbox/           @SabhyaC26
-/omnigent/db/                @fanzeyi
+/omnigent/db/                @fanzeyi @SabhyaC26
 /omnigent/stores/            @serena-ruan @TomeHirata @fanzeyi
-/omnigent/terminals/         @dbczumar @Edwinhe03
-/omnigent/tools/             @dbczumar @PattaraS
+/omnigent/terminals/         @dbczumar @Edwinhe03 @fanzeyi
+/omnigent/tools/             @dbczumar @PattaraS @TomeHirata
 /omnigent/entities/          @daniellok-db @TomeHirata
-/omnigent/repl/              @dhruv0811 @dbczumar @TomeHirata
+/omnigent/repl/              @dhruv0811 @dbczumar
 /omnigent/resources/         @fanzeyi @serena-ruan
 
 # Deploy targets

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,12 +37,12 @@
 # Core agent runtime & harnesses
 /omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
 /omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @dhruv0811
-/omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811 @ckcuslife-source
-/omnigent/server/            @dhruv0811 @dbczumar @ckcuslife-source @TomeHirata
+/omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811
+/omnigent/server/            @dhruv0811 @dbczumar @TomeHirata @SabhyaC26
 /omnigent/onboarding/        @SabhyaC26 @dhruv0811 @dbczumar @bbqiu
 /omnigent/policies/          @TomeHirata @SabhyaC26 @dhruv0811 @PattaraS
-/omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
-/omnigent/llms/              @dhruv0811 @PattaraS @ckcuslife-source
+/omnigent/spec/              @SabhyaC26 @dhruv0811
+/omnigent/llms/              @dhruv0811 @PattaraS
 /omnigent/host/              @fanzeyi @dhruv0811 @dbczumar @TomeHirata
 /omnigent/sandbox/           @dhruv0811 @SabhyaC26
 /omnigent/environments/      @dhruv0811

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,13 +10,13 @@
 # .github/MAINTAINER. Last matching pattern wins, so the `*` default is first
 # and more specific paths override it below.
 #
-# ---------------------------------------------------------------------------
-# DRAFT mapping: seeded from `git log` authorship per area, which is thin for
-# this repo (much of it landed via an internal import). Treat the per-area
-# owners as a starting point and correct them to reflect real ownership.
-# ---------------------------------------------------------------------------
+# Per-area owners are seeded from the full commit history of the upstream
+# repo (databricks-eng/agent-framework), mapped to public handles by author.
+# A few areas have a top contributor who is not in MAINTAINER (e.g. inner /
+# runner / spec / tools); those list the next most-active maintainers.
+# Still worth a sanity check against real ownership.
 #
-# ROUND-ROBIN / even distribution: the `*` default below points at a team
+# ROUND-ROBIN / even distribution: the `*` default points at a team
 # (@omnigent-ai/maintainers). Create that team and set its "Code review
 # assignment" to round-robin (load-balance) so unowned PRs are distributed
 # across maintainers instead of pinging everyone. Until the team exists,
@@ -28,32 +28,41 @@
 *                          @omnigent-ai/maintainers
 
 # Repo automation / CI
-/.github/                  @PattaraS @serena-ruan
+/.github/                  @PattaraS @dhruv0811
 
 # Web UI
-/ap-web/                   @serena-ruan @SabhyaC26
+/ap-web/                   @SabhyaC26 @serena-ruan @daniellok-db
 
 # Core agent runtime & harnesses
 /omnigent/inner/           @SabhyaC26 @TomeHirata
-/omnigent/runner/          @SabhyaC26 @PattaraS
-/omnigent/runtime/         @SabhyaC26
-/omnigent/server/          @ckcuslife-source
-/omnigent/onboarding/      @SabhyaC26
-/omnigent/policies/        @TomeHirata
-/omnigent/spec/            @SabhyaC26
+/omnigent/runner/          @SabhyaC26 @TomeHirata
+/omnigent/runtime/         @TomeHirata @dhruv0811
+/omnigent/server/          @dbczumar @dhruv0811
+/omnigent/onboarding/      @dhruv0811 @dbczumar
+/omnigent/policies/        @TomeHirata @SabhyaC26
+/omnigent/spec/            @dhruv0811 @SabhyaC26
 /omnigent/llms/            @dhruv0811
-/omnigent/host/            @PattaraS @dhruv0811
-/omnigent/sandbox/         @dhruv0811
+/omnigent/host/            @fanzeyi @dhruv0811
+/omnigent/sandbox/         @dhruv0811 @SabhyaC26
 /omnigent/environments/    @dhruv0811
-/omnigent/db/              @dhruv0811
-/omnigent/stores/          @dhruv0811
-/omnigent/repl/            @dhruv0811
+/omnigent/db/              @dhruv0811 @fanzeyi
+/omnigent/stores/          @serena-ruan @fanzeyi
+/omnigent/terminals/       @SabhyaC26 @dhruv0811
+/omnigent/tools/           @SabhyaC26 @dbczumar
+/omnigent/client_tools/    @dhruv0811
+/omnigent/entities/        @TomeHirata @SabhyaC26
+/omnigent/repl/            @dhruv0811 @SabhyaC26
+/omnigent/resources/       @dhruv0811
 
 # Deploy targets
-/deploy/                   @dbczumar
+/deploy/                   @dhruv0811 @PattaraS
+
+# Python / UI SDKs
+/sdks/                     @fanzeyi @TomeHirata
 
 # Tests
-/tests/                    @TomeHirata @PattaraS
+/tests/                    @PattaraS @TomeHirata
 
-# Design docs
-/designs/                  @TomeHirata @serena-ruan
+# Docs & design
+/docs/                     @dhruv0811 @dbczumar
+/designs/                  @PattaraS @dhruv0811

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@
 /.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata
 
 # Web UI
-/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @dbczumar
+/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @dbczumar @hzub
 
 # Core agent runtime & harnesses
 /omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
@@ -44,15 +44,15 @@
 /omnigent/policies/          @TomeHirata @SabhyaC26 @dhruv0811 @PattaraS
 /omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
 /omnigent/llms/              @PattaraS @ckcuslife-source
-/omnigent/host/              @fanzeyi @dhruv0811 @dbczumar @TomeHirata
+/omnigent/host/              @fanzeyi @dhruv0811 @dbczumar
 /omnigent/sandbox/           @SabhyaC26
-/omnigent/db/                @SabhyaC26 @fanzeyi
-/omnigent/stores/            @serena-ruan @SabhyaC26 @TomeHirata @fanzeyi
-/omnigent/terminals/         @SabhyaC26 @dbczumar @Edwinhe03
-/omnigent/tools/             @dbczumar @SabhyaC26 @PattaraS
-/omnigent/entities/          @SabhyaC26 @daniellok-db @TomeHirata
-/omnigent/repl/              @dhruv0811 @SabhyaC26 @dbczumar @TomeHirata
-/omnigent/resources/         @SabhyaC26 @fanzeyi @serena-ruan
+/omnigent/db/                @fanzeyi
+/omnigent/stores/            @serena-ruan @TomeHirata @fanzeyi
+/omnigent/terminals/         @dbczumar @Edwinhe03
+/omnigent/tools/             @dbczumar @PattaraS
+/omnigent/entities/          @daniellok-db @TomeHirata
+/omnigent/repl/              @dhruv0811 @dbczumar @TomeHirata
+/omnigent/resources/         @fanzeyi @serena-ruan
 
 # Deploy targets
 /deploy/                     @dhruv0811 @PattaraS @dbczumar @SabhyaC26

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,15 +19,12 @@
 # whose only touches were sweeps have no entry and fall through to the default.
 # Worth a final human sanity-check.
 #
-# ROUND-ROBIN / even distribution: the `*` default points at a team
-# (@omnigent-ai/maintainers). Create that team and set its "Code review
-# assignment" to round-robin (load-balance) so unowned PRs are distributed
-# across maintainers instead of pinging everyone. Until the team exists,
-# GitHub ignores the `*` line (no default auto-request) -- the per-area
-# owners below still work.
-
-# Default owner for anything not matched below (round-robin team -- see note).
-*                            @omnigent-ai/maintainers
+# DEFAULT / round-robin: there is intentionally no `*` owner here. PRs that
+# match none of the rules below are routed by a repo-level GitHub Action
+# (.github/workflows/auto-assign-reviewer.yml), which load-balances one
+# reviewer from the pool of handles listed in THIS file. That avoids needing
+# an org team (and org-owner setup) for native round-robin, and it naturally
+# excludes maintainers who aren't assigned to any area here.
 
 # Repo automation / CI
 /.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,59 @@
+# Code owners -- reviewer routing for pull requests.
+#
+# GitHub auto-requests a review from the owner(s) of any path a PR touches.
+# This is ROUTING ONLY: it does not gate merge. The merge gate stays
+# `Maintainer Approval` + `Merge Ready` (branch protection). Do NOT enable
+# "Require review from Code Owners" in branch protection unless you intend
+# these to become blocking.
+#
+# Owners must be maintainers with write access -- entries are drawn from
+# .github/MAINTAINER. Last matching pattern wins, so the `*` default is first
+# and more specific paths override it below.
+#
+# ---------------------------------------------------------------------------
+# DRAFT mapping: seeded from `git log` authorship per area, which is thin for
+# this repo (much of it landed via an internal import). Treat the per-area
+# owners as a starting point and correct them to reflect real ownership.
+# ---------------------------------------------------------------------------
+#
+# ROUND-ROBIN / even distribution: the `*` default below points at a team
+# (@omnigent-ai/maintainers). Create that team and set its "Code review
+# assignment" to round-robin (load-balance) so unowned PRs are distributed
+# across maintainers instead of pinging everyone. Until the team exists,
+# GitHub ignores the `*` line (no default auto-request) -- the per-area
+# owners below still work. Replace with individuals if you prefer not to use
+# a team.
+
+# Default owner for anything not matched below (round-robin team -- see note).
+*                          @omnigent-ai/maintainers
+
+# Repo automation / CI
+/.github/                  @PattaraS @serena-ruan
+
+# Web UI
+/ap-web/                   @serena-ruan @SabhyaC26
+
+# Core agent runtime & harnesses
+/omnigent/inner/           @SabhyaC26 @TomeHirata
+/omnigent/runner/          @SabhyaC26 @PattaraS
+/omnigent/runtime/         @SabhyaC26
+/omnigent/server/          @ckcuslife-source
+/omnigent/onboarding/      @SabhyaC26
+/omnigent/policies/        @TomeHirata
+/omnigent/spec/            @SabhyaC26
+/omnigent/llms/            @dhruv0811
+/omnigent/host/            @PattaraS @dhruv0811
+/omnigent/sandbox/         @dhruv0811
+/omnigent/environments/    @dhruv0811
+/omnigent/db/              @dhruv0811
+/omnigent/stores/          @dhruv0811
+/omnigent/repl/            @dhruv0811
+
+# Deploy targets
+/deploy/                   @dbczumar
+
+# Tests
+/tests/                    @TomeHirata @PattaraS
+
+# Design docs
+/designs/                  @TomeHirata @serena-ruan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,10 +60,3 @@
 
 # Python / UI SDKs
 /sdks/                       @dbczumar @fanzeyi @SabhyaC26 @TomeHirata
-
-# Tests
-/tests/                      @dbczumar @PattaraS @SabhyaC26 @TomeHirata
-
-# Docs & design
-/docs/                       @dhruv0811 @dbczumar @TomeHirata @shivam5
-/designs/                    @dbczumar @PattaraS @dhruv0811 @SabhyaC26

--- a/.github/workflows/auto-assign-reviewer-test.yml
+++ b/.github/workflows/auto-assign-reviewer-test.yml
@@ -1,0 +1,33 @@
+name: Auto-assign Reviewer Test
+
+# Offline unit test for the reviewer-assignment logic: runs
+# auto-assign-reviewer.test.js (mocked GitHub client, real .github/CODEOWNERS).
+# Triggers only when the assigner, its test, or CODEOWNERS change. Runs on
+# `pull_request` (PR head checkout) so it tests the PR's own version. No
+# secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/auto-assign-reviewer.js
+      - .github/workflows/auto-assign-reviewer.test.js
+      - .github/CODEOWNERS
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-assign-reviewer-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run reviewer-assignment unit test
+        run: node .github/workflows/auto-assign-reviewer.test.js

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -1,94 +1,132 @@
-// Repo-level round-robin reviewer assignment (no org team needed).
+// Repo-level reviewer assignment: assign EXACTLY 2 load-balanced reviewers per
+// PR, preferring the owners of the area(s) the PR touches.
 //
-// Acts as the "default" owner for PRs that CODEOWNERS did NOT already route:
-// if a PR has no requested reviewer, assign one maintainer from a load-balanced
-// pool. The pool is derived FROM .github/CODEOWNERS at runtime -- the union of
-// per-area owner handles -- so maintainers who aren't assigned anywhere in
-// CODEOWNERS are intentionally excluded from review rotation.
+// Ownership comes from .github/CODEOWNERS (read at runtime), but GitHub's native
+// CODEOWNERS auto-request would request ALL area owners -- we want only 2,
+// balanced -- so this action reconciles the request list down to its 2 picks.
+// The candidate pool is the union of CODEOWNERS owners for the PR's changed
+// files; if the PR touches no owned path, it falls back to the full CODEOWNERS
+// pool. Maintainers not listed anywhere in CODEOWNERS are never in rotation.
 //
-// Fairness is stateless: we pick the candidate with the fewest CURRENTLY open
-// review requests (random tie-break), so load self-balances without a tracking
-// file/issue.
+// "Balance in general": picks are the candidates with the fewest CURRENTLY open
+// review requests across the repo (random tie-break) -- stateless fairness.
 //
-// Invoked from auto-assign-reviewer.yml via actions/github-script.
+// Only handles drawn from CODEOWNERS are ever removed, so a manually-added
+// reviewer outside that set is left untouched.
 module.exports = async ({ github, context, core }) => {
   const fs = require("fs");
+  const TARGET = 2;
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
-  if (!pr) {
-    core.info("No pull_request in payload; nothing to do.");
+  if (!pr || pr.draft) {
+    core.info("No PR or draft; nothing to do.");
     return;
   }
-  if (pr.draft) {
-    core.info("Draft PR; skipping.");
-    return;
-  }
+  const author = (pr.user && pr.user.login ? pr.user.login : "").toLowerCase();
 
-  // Don't pile on: if CODEOWNERS (or anyone) already requested a reviewer/team,
-  // this default rotation stays out of the way.
-  const already =
-    (pr.requested_reviewers || []).length + (pr.requested_teams || []).length;
-  if (already > 0) {
-    core.info(`PR already has ${already} requested reviewer(s)/team(s); skipping default rotation.`);
-    return;
-  }
-
-  // Build the pool from CODEOWNERS: handles on path rules only, excluding
-  // org/team handles (which contain a "/") and the PR author.
+  // --- Parse CODEOWNERS into ordered (prefix -> owners) rules + the full pool.
   const text = fs.readFileSync(".github/CODEOWNERS", "utf8");
-  const pool = []; // original-case logins, de-duped
-  const seen = new Set();
+  const rules = []; // { prefix, owners: [logins] }  (path rules only)
+  const poolSet = new Map(); // lc -> original-case
   for (const raw of text.split("\n")) {
     const line = raw.trim();
-    if (!line.startsWith("/")) continue; // skip comments, blanks, and the `*` line
-    for (const tok of line.split(/\s+/).slice(1)) {
-      if (tok.startsWith("@") && !tok.includes("/")) {
-        const login = tok.slice(1);
-        const key = login.toLowerCase();
-        if (!seen.has(key)) {
-          seen.add(key);
-          pool.push(login);
-        }
-      }
-    }
+    if (!line.startsWith("/")) continue;
+    const [pat, ...toks] = line.split(/\s+/);
+    const owners = toks
+      .filter((t) => t.startsWith("@") && !t.includes("/"))
+      .map((t) => t.slice(1));
+    owners.forEach((o) => poolSet.set(o.toLowerCase(), o));
+    // `/dir/` -> match files under `dir/`
+    rules.push({ prefix: pat.replace(/^\//, ""), owners });
+  }
+  const managed = new Set([...poolSet.keys()]); // everyone CODEOWNERS can manage
+
+  // --- Owners of the area(s) this PR touches (last matching rule wins per file).
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+  const areaOwners = new Map(); // lc -> original
+  for (const f of files) {
+    let match = null;
+    for (const r of rules) if (f.filename.startsWith(r.prefix)) match = r; // last wins
+    if (match) match.owners.forEach((o) => areaOwners.set(o.toLowerCase(), o));
   }
 
-  const author = (pr.user && pr.user.login ? pr.user.login : "").toLowerCase();
-  const candidates = pool.filter((u) => u.toLowerCase() !== author);
+  // Candidates: area owners, else the full pool. Never the author.
+  let candidates = [...(areaOwners.size ? areaOwners : poolSet).values()].filter(
+    (u) => u.toLowerCase() !== author
+  );
   if (candidates.length === 0) {
-    core.info("No eligible candidates in the CODEOWNERS pool; skipping.");
+    core.info("No eligible candidates; nothing to do.");
     return;
   }
 
-  // Current open-review load per candidate (stateless fairness signal).
+  // --- Global open-review load (stateless fairness signal).
   const openPRs = await github.paginate(github.rest.pulls.list, {
     owner,
     repo,
     state: "open",
     per_page: 100,
   });
-  const load = Object.fromEntries(candidates.map((u) => [u.toLowerCase(), 0]));
-  for (const p of openPRs) {
+  const load = new Map();
+  for (const p of openPRs)
     for (const r of p.requested_reviewers || []) {
       const l = (r.login || "").toLowerCase();
-      if (l in load) load[l] += 1;
+      load.set(l, (load.get(l) || 0) + 1);
     }
+  const loadOf = (u) => load.get(u.toLowerCase()) || 0;
+
+  // Helper: take the N lowest-load from a list, random tie-break within a tier.
+  const takeLowest = (list, n) => {
+    const byTier = {};
+    for (const u of list) (byTier[loadOf(u)] ||= []).push(u);
+    const out = [];
+    for (const k of Object.keys(byTier).map(Number).sort((a, b) => a - b)) {
+      const shuffled = byTier[k]
+        .map((v) => [Math.random(), v])
+        .sort((a, b) => a[0] - b[0])
+        .map(([, v]) => v);
+      for (const u of shuffled) if (out.length < n) out.push(u);
+      if (out.length >= n) break;
+    }
+    return out;
+  };
+
+  // Desired = 2 lowest-load from candidates; top up from the full pool if an
+  // area has fewer than 2 owners.
+  let desired = takeLowest(candidates, TARGET);
+  if (desired.length < TARGET) {
+    const have = new Set(desired.map((u) => u.toLowerCase()).concat(author));
+    const filler = [...poolSet.values()].filter((u) => !have.has(u.toLowerCase()));
+    desired = desired.concat(takeLowest(filler, TARGET - desired.length));
   }
+  const desiredLc = new Set(desired.map((u) => u.toLowerCase()));
 
-  // Lowest load first; random tie-break within the lowest tier.
-  const min = Math.min(...candidates.map((u) => load[u.toLowerCase()]));
-  const lowest = candidates.filter((u) => load[u.toLowerCase()] === min);
-  const pick = lowest[Math.floor(Math.random() * lowest.length)];
+  // --- Reconcile current requested reviewers to exactly `desired`.
+  const current = (pr.requested_reviewers || []).map((r) => r.login);
+  const currentLc = new Set(current.map((c) => c.toLowerCase()));
+  const toAdd = desired.filter((u) => !currentLc.has(u.toLowerCase()));
+  // Only remove CODEOWNERS-managed reviewers we didn't pick -- never humans
+  // added from outside the pool.
+  const toRemove = current.filter(
+    (u) => managed.has(u.toLowerCase()) && !desiredLc.has(u.toLowerCase())
+  );
 
-  try {
+  if (toAdd.length) {
     await github.rest.pulls.requestReviewers({
-      owner,
-      repo,
-      pull_number: pr.number,
-      reviewers: [pick],
+      owner, repo, pull_number: pr.number, reviewers: toAdd,
     });
-    core.info(`Assigned @${pick} (open-review load ${min}; pool of ${candidates.length}).`);
-  } catch (e) {
-    core.warning(`Could not request @${pick}: ${e.message}`);
   }
+  if (toRemove.length) {
+    await github.rest.pulls.removeRequestedReviewers({
+      owner, repo, pull_number: pr.number, reviewers: toRemove,
+    });
+  }
+  core.info(
+    `Reviewers -> [${desired.join(", ")}]` +
+      ` (area pool ${areaOwners.size || "∅→full"}, +${toAdd.length}/-${toRemove.length}).`
+  );
 };

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -13,7 +13,9 @@
 //
 // Only handles drawn from CODEOWNERS are ever removed, so a manually-added
 // reviewer outside that set is left untouched.
-module.exports = async ({ github, context, core }) => {
+// `dryRun` (set when the workflow runs on a `pull_request` that edits this
+// script) logs the picks instead of mutating reviewers -- a live smoke test.
+module.exports = async ({ github, context, core, dryRun = false }) => {
   const fs = require("fs");
   const TARGET = 2;
   const { owner, repo } = context.repo;
@@ -115,18 +117,18 @@ module.exports = async ({ github, context, core }) => {
     (u) => managed.has(u.toLowerCase()) && !desiredLc.has(u.toLowerCase())
   );
 
-  if (toAdd.length) {
+  if (toAdd.length && !dryRun) {
     await github.rest.pulls.requestReviewers({
       owner, repo, pull_number: pr.number, reviewers: toAdd,
     });
   }
-  if (toRemove.length) {
+  if (toRemove.length && !dryRun) {
     await github.rest.pulls.removeRequestedReviewers({
       owner, repo, pull_number: pr.number, reviewers: toRemove,
     });
   }
   core.info(
-    `Reviewers -> [${desired.join(", ")}]` +
+    `${dryRun ? "[DRY RUN] " : ""}Reviewers -> [${desired.join(", ")}]` +
       ` (area pool ${areaOwners.size || "∅→full"}, +${toAdd.length}/-${toRemove.length}).`
   );
 };

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -1,0 +1,94 @@
+// Repo-level round-robin reviewer assignment (no org team needed).
+//
+// Acts as the "default" owner for PRs that CODEOWNERS did NOT already route:
+// if a PR has no requested reviewer, assign one maintainer from a load-balanced
+// pool. The pool is derived FROM .github/CODEOWNERS at runtime -- the union of
+// per-area owner handles -- so maintainers who aren't assigned anywhere in
+// CODEOWNERS are intentionally excluded from review rotation.
+//
+// Fairness is stateless: we pick the candidate with the fewest CURRENTLY open
+// review requests (random tie-break), so load self-balances without a tracking
+// file/issue.
+//
+// Invoked from auto-assign-reviewer.yml via actions/github-script.
+module.exports = async ({ github, context, core }) => {
+  const fs = require("fs");
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    core.info("No pull_request in payload; nothing to do.");
+    return;
+  }
+  if (pr.draft) {
+    core.info("Draft PR; skipping.");
+    return;
+  }
+
+  // Don't pile on: if CODEOWNERS (or anyone) already requested a reviewer/team,
+  // this default rotation stays out of the way.
+  const already =
+    (pr.requested_reviewers || []).length + (pr.requested_teams || []).length;
+  if (already > 0) {
+    core.info(`PR already has ${already} requested reviewer(s)/team(s); skipping default rotation.`);
+    return;
+  }
+
+  // Build the pool from CODEOWNERS: handles on path rules only, excluding
+  // org/team handles (which contain a "/") and the PR author.
+  const text = fs.readFileSync(".github/CODEOWNERS", "utf8");
+  const pool = []; // original-case logins, de-duped
+  const seen = new Set();
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line.startsWith("/")) continue; // skip comments, blanks, and the `*` line
+    for (const tok of line.split(/\s+/).slice(1)) {
+      if (tok.startsWith("@") && !tok.includes("/")) {
+        const login = tok.slice(1);
+        const key = login.toLowerCase();
+        if (!seen.has(key)) {
+          seen.add(key);
+          pool.push(login);
+        }
+      }
+    }
+  }
+
+  const author = (pr.user && pr.user.login ? pr.user.login : "").toLowerCase();
+  const candidates = pool.filter((u) => u.toLowerCase() !== author);
+  if (candidates.length === 0) {
+    core.info("No eligible candidates in the CODEOWNERS pool; skipping.");
+    return;
+  }
+
+  // Current open-review load per candidate (stateless fairness signal).
+  const openPRs = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+  const load = Object.fromEntries(candidates.map((u) => [u.toLowerCase(), 0]));
+  for (const p of openPRs) {
+    for (const r of p.requested_reviewers || []) {
+      const l = (r.login || "").toLowerCase();
+      if (l in load) load[l] += 1;
+    }
+  }
+
+  // Lowest load first; random tie-break within the lowest tier.
+  const min = Math.min(...candidates.map((u) => load[u.toLowerCase()]));
+  const lowest = candidates.filter((u) => load[u.toLowerCase()] === min);
+  const pick = lowest[Math.floor(Math.random() * lowest.length)];
+
+  try {
+    await github.rest.pulls.requestReviewers({
+      owner,
+      repo,
+      pull_number: pr.number,
+      reviewers: [pick],
+    });
+    core.info(`Assigned @${pick} (open-review load ${min}; pool of ${candidates.length}).`);
+  } catch (e) {
+    core.warning(`Could not request @${pick}: ${e.message}`);
+  }
+};

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -1,0 +1,95 @@
+// Local unit test for auto-assign-reviewer.js -- mocks the GitHub client and
+// runs the real decision logic against the real .github/CODEOWNERS (cwd must be
+// the repo root). No network. Loads are made distinct so picks are deterministic.
+const path = require("path");
+const script = require(path.resolve(".github/workflows/auto-assign-reviewer.js"));
+
+function mkOpenPRs(loadMap) {
+  // one open PR per (reviewer, count) so the script's tally reproduces loadMap
+  const prs = [];
+  for (const [login, n] of Object.entries(loadMap))
+    for (let i = 0; i < n; i++) prs.push({ requested_reviewers: [{ login }] });
+  return prs;
+}
+
+async function run({ files, load = {}, current = [], author = "someauthor" }) {
+  const listFiles = () => {}; listFiles._tag = "files";
+  const list = () => {}; list._tag = "open";
+  const added = [], removed = [];
+  const github = {
+    paginate: async (fn) => (fn._tag === "files"
+      ? files.map((f) => ({ filename: f }))
+      : mkOpenPRs(load)),
+    rest: { pulls: {
+      listFiles, list,
+      requestReviewers: async ({ reviewers }) => added.push(...reviewers),
+      removeRequestedReviewers: async ({ reviewers }) => removed.push(...reviewers),
+    } },
+  };
+  const context = {
+    repo: { owner: "omnigent-ai", repo: "omnigent" },
+    payload: { pull_request: {
+      number: 1, draft: false,
+      user: { login: author },
+      requested_reviewers: current.map((l) => ({ login: l })),
+    } },
+  };
+  const core = { info: () => {}, warning: (m) => console.log("WARN", m) };
+  await script({ github, context, core });
+  return { added: added.sort(), removed: removed.sort() };
+}
+
+function assert(name, cond, detail) {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+}
+
+(async () => {
+  // 1. inner PR: owners SabhyaC26,TomeHirata,dhruv0811,dbczumar. Loads make the
+  //    two lowest deterministic: dhruv0811(0), dbczumar(1) win.
+  let r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+  });
+  assert("inner picks 2 lowest-load owners", JSON.stringify(r.added) === JSON.stringify(["dbczumar", "dhruv0811"]), JSON.stringify(r));
+
+  // 2. unowned path -> full pool; lowest two by load chosen.
+  r = await run({
+    files: ["README.md"],
+    load: { PattaraS: 9, "serena-ruan": 9, dhruv0811: 9, TomeHirata: 9, SabhyaC26: 9,
+            "daniellok-db": 9, hzub: 0, dbczumar: 1, fanzeyi: 9, "ckcuslife-source": 9,
+            bbqiu: 9, Edwinhe03: 9 },
+  });
+  assert("unowned -> 2 lowest from full pool", JSON.stringify(r.added) === JSON.stringify(["dbczumar", "hzub"]), JSON.stringify(r));
+
+  // 3. db has only 2 owners (fanzeyi, SabhyaC26) -> both selected.
+  r = await run({ files: ["omnigent/db/x.py"], load: {} });
+  assert("db (2 owners) -> both", JSON.stringify(r.added) === JSON.stringify(["SabhyaC26", "fanzeyi"]), JSON.stringify(r));
+
+  // 4. reconcile: native CODEOWNERS already requested all 4 inner owners; keep 2
+  //    lowest-load, remove the other 2.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    current: ["SabhyaC26", "TomeHirata", "dhruv0811", "dbczumar"],
+  });
+  assert("reconcile removes the 2 highest-load already-requested",
+    JSON.stringify(r.removed) === JSON.stringify(["SabhyaC26", "TomeHirata"]) && r.added.length === 0,
+    JSON.stringify(r));
+
+  // 5. author excluded from selection.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 0, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    author: "SabhyaC26",
+  });
+  assert("author not assigned to own PR", !r.added.includes("SabhyaC26"), JSON.stringify(r));
+
+  // 6. external human reviewer (outside pool) is never removed.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { dhruv0811: 0, dbczumar: 1, SabhyaC26: 5, TomeHirata: 4 },
+    current: ["dhruv0811", "dbczumar", "some-external-human"],
+  });
+  assert("external reviewer preserved", !r.removed.includes("some-external-human"), JSON.stringify(r));
+})();

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -16,6 +16,15 @@ name: Auto-assign Reviewer
 on:
   pull_request_target:
     types: [opened, ready_for_review]
+  # Smoke test: when a PR edits this assigner, run it against the PR's OWN
+  # version in DRY-RUN (logs picks, mutates nothing) -- same idea as mlflow's
+  # skipAssignment. The companion unit test (auto-assign-reviewer.test.js)
+  # covers the logic offline.
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - .github/workflows/auto-assign-reviewer.yml
+      - .github/workflows/auto-assign-reviewer.js
 
 permissions:
   contents: read
@@ -35,16 +44,21 @@ jobs:
     permissions:
       pull-requests: write   # request reviewers
     steps:
-      - name: Check out .github from the default branch (trusted)
+      # Real runs (pull_request_target): check out the TRUSTED default branch.
+      # Dry-run smoke test (pull_request): check out the PR head so we exercise
+      # the PR's own version of the script. (pull_request gets a read-only token
+      # and no secrets, and dry-run mutates nothing -- so running the PR's
+      # script here is safe.)
+      - name: Check out .github
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.repository.default_branch }}
           sparse-checkout: .github
           persist-credentials: false
-      - name: Assign a reviewer from the CODEOWNERS pool
+      - name: Assign 2 balanced reviewers from the CODEOWNERS pool
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           retries: 3
           script: |
             const script = require('./.github/workflows/auto-assign-reviewer.js');
-            await script({ github, context, core });
+            await script({ github, context, core, dryRun: context.eventName === 'pull_request' });

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,15 +1,17 @@
 name: Auto-assign Reviewer
 
-# Repo-level round-robin reviewer assignment -- the "default" for PRs that
-# CODEOWNERS did not already route. No org team required (so no org-owner
-# setup, unlike GitHub's native team review assignment). The candidate pool is
-# derived from .github/CODEOWNERS at runtime, so maintainers not listed there
-# are excluded from rotation. See auto-assign-reviewer.js.
+# Repo-level reviewer assignment: assign EXACTLY 2 load-balanced reviewers per
+# PR, preferring the owners of the area(s) it touches. No org team required (so
+# no org-owner setup, unlike GitHub's native team review assignment). Ownership
+# is read from .github/CODEOWNERS at runtime; native CODEOWNERS would request
+# ALL area owners, so this action reconciles the request list down to its 2
+# balanced picks. Maintainers not listed in CODEOWNERS are never in rotation.
+# See auto-assign-reviewer.js.
 #
-# pull_request_target so it can request reviewers on fork PRs too (a fork's
+# pull_request_target so it can manage reviewers on fork PRs too (a fork's
 # pull_request token is read-only). Safe: it checks out only the trusted
-# default branch (.github), never PR head, and runs no PR code -- it just reads
-# CODEOWNERS and calls the reviewers API.
+# default branch (.github), never PR head, and runs no PR code -- it reads
+# CODEOWNERS + the changed-file list and calls the reviewers API.
 
 on:
   pull_request_target:

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -15,7 +15,7 @@ name: Auto-assign Reviewer
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
   # Smoke test: when a PR edits this assigner, run it against the PR's OWN
   # version in DRY-RUN (logs picks, mutates nothing) -- same idea as mlflow's
   # skipAssignment. The companion unit test (auto-assign-reviewer.test.js)

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,0 +1,48 @@
+name: Auto-assign Reviewer
+
+# Repo-level round-robin reviewer assignment -- the "default" for PRs that
+# CODEOWNERS did not already route. No org team required (so no org-owner
+# setup, unlike GitHub's native team review assignment). The candidate pool is
+# derived from .github/CODEOWNERS at runtime, so maintainers not listed there
+# are excluded from rotation. See auto-assign-reviewer.js.
+#
+# pull_request_target so it can request reviewers on fork PRs too (a fork's
+# pull_request token is read-only). Safe: it checks out only the trusted
+# default branch (.github), never PR head, and runs no PR code -- it just reads
+# CODEOWNERS and calls the reviewers API.
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-assign-reviewer-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    if: >-
+      github.repository == 'omnigent-ai/omnigent'
+      && !github.event.pull_request.draft
+      && !endsWith(github.actor, '[bot]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write   # request reviewers
+    steps:
+      - name: Check out .github from the default branch (trusted)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Assign a reviewer from the CODEOWNERS pool
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/workflows/auto-assign-reviewer.js');
+            await script({ github, context, core });


### PR DESCRIPTION
Implements the **reviewer-routing** half of the contributor-review proposal (designs/contributor-review-merge-proposal.md). No CODEOWNERS existed before.

## What it does
GitHub auto-requests a review from the owner(s) of any path a PR touches. **Routing only — it does not gate merge.** The merge gate stays `Maintainer Approval` + `Merge Ready`. (Do **not** turn on "Require review from Code Owners" in branch protection unless you want these to become blocking.)

Owners are maintainers from `.github/MAINTAINER` — verified every individual handle is present there (so no "unknown owner" lines), and every path exists in the tree.

## ⚠️ The per-area mapping is a DRAFT
It was seeded from `git log` authorship, which is **thin** for this repo (much of it landed via an internal import), so the per-area owners are a *starting point*, not ground truth. Please correct them to reflect real ownership. The signals that surfaced:

| Area | Draft owners |
|---|---|
| `/.github/` | PattaraS, serena-ruan |
| `/ap-web/` | serena-ruan, SabhyaC26 |
| `/omnigent/inner/` | SabhyaC26, TomeHirata |
| `/omnigent/runner/` | SabhyaC26, PattaraS |
| `/omnigent/server/` | ckcuslife-source |
| `/omnigent/policies/` | TomeHirata |
| `/omnigent/{llms,host,sandbox,db,stores,repl,environments}/` | dhruv0811 (low confidence — 1 commit each) |
| `/deploy/` | dbczumar |
| `/tests/` | TomeHirata, PattaraS |
| `/designs/` | TomeHirata, serena-ruan |

## Round-robin (the other half)
Round-robin is a GitHub **team setting**, not a file, so it can't ship in this PR. The `*` default points at `@omnigent-ai/maintainers`; to enable even distribution:
1. Create the `maintainers` team, and
2. set its **Code review assignment** to round-robin / load-balance.

Until that team exists, GitHub **ignores the `*` line** (no default auto-request) — which is a safe no-op; the per-area owners still work. Prefer individuals over a team? Say so and I'll swap it.

## Note
A `CODEOWNERS` referencing a not-yet-created team will show an "Unknown owner: @omnigent-ai/maintainers" warning in the GitHub UI until the team is made — expected, and intentional to signal the desired end state.