### PR TITLE
db: add turns + idempotency_keys tables (Phase 1 schema)

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -780,3 +780,189 @@ class SqlUserDailyCost(Base):
     cost_usd: Mapped[float] = mapped_column(Float, nullable=False)
     ask_approved_usd: Mapped[float] = mapped_column(Float, nullable=False, server_default="0")
     updated_at: Mapped[int] = mapped_column(Integer)
+
+
+class SqlTurn(Base):
+    """
+    SQLAlchemy model for the ``turns`` table.
+
+    A turn is the server-authoritative, durable record of a single
+    agent response/dispatch. It promotes the latent ``response_id``
+    (``resp_...``) concept — already stamped on
+    ``conversation_items`` — into a first-class row owned by the
+    runner under a lease, so the turn's lifecycle is decoupled from
+    the client connection. A client disconnect updates only
+    ``attached`` / ``last_client_seen`` and must never transition a
+    ``RUNNING`` turn.
+
+    See ``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md`` (issue #466).
+
+    :param id: The turn id, which **is** the response/task id minted
+        by :func:`omnigent.db.utils.generate_task_id`, e.g.
+        ``"resp_d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3"``. Not a parallel
+        id space.
+    :param conversation_id: Owning conversation/session id.
+    :param status: Lifecycle state — one of ``CREATED``, ``QUEUED``,
+        ``RUNNING``, ``PAUSING``, ``PAUSED``, ``COMPLETED``,
+        ``FAILED``, ``CANCELLED``. ``PAUSING``/``PAUSED`` are
+        forward-compat for Phase 4 and unused in Phase 1.
+    :param error_code: Failure taxonomy value set at a terminal
+        transition — one of ``TRANSPORT_DISCONNECT``, ``RUNNER_LOST``,
+        ``WORKER_BOOT_FAILURE``, ``WORKER_TASK_FAILURE``,
+        ``CANCELLED``. Only ``WORKER_*`` values may feed vendor
+        health/routing. ``None`` on non-terminal or successful turns.
+    :param error_message: Optional human-readable failure detail.
+    :param vendor: Worker vendor the turn dispatched to, e.g.
+        ``"claude_code"``, ``"codex"``, ``"pi"``.
+    :param intent: Send intent that created the turn — one of
+        ``enqueue``, ``steer``, ``attach``.
+    :param input_json: The send payload, persisted durably *before*
+        any work starts so a retried/idempotent send returns the same
+        turn rather than re-sending empty state.
+    :param lease_owner: Runner id that currently owns execution of
+        this turn (the runner pinned via ``conversations.runner_id``).
+        ``None`` until a runner claims the lease. Runner-held, never
+        client-held.
+    :param lease_epoch: Monotonic fencing token. Incremented on each
+        lease acquisition; every heartbeat and terminal write carries
+        it so a stale owner's compare-and-set affects zero rows.
+    :param last_heartbeat_at: Unix epoch seconds of the last runner
+        heartbeat, or ``None`` before the turn runs.
+    :param lease_expires_at: ``last_heartbeat_at + TTL`` (epoch
+        seconds); the orphan sweeper marks live turns past this as
+        ``RUNNER_LOST``.
+    :param attached: Whether a client is currently observing the
+        turn's stream. Observation only — never gates execution.
+    :param last_client_seen: Unix epoch seconds a client was last
+        attached, or ``None``.
+    :param created_at: Unix epoch seconds when the turn row was
+        created.
+    :param start_ts: Unix epoch seconds when the turn entered
+        ``RUNNING``, or ``None``.
+    :param end_ts: Unix epoch seconds when the turn reached a terminal
+        state, or ``None``.
+    :param checkpoint_id: Phase 4 forward-compat for tool-boundary
+        checkpoints. Always ``None`` in Phase 1.
+    """
+
+    __tablename__ = "turns"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # --- state machine ---
+    status: Mapped[str] = mapped_column(String(16), nullable=False, server_default="CREATED")
+    error_code: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # --- dispatch payload (durable before work starts) ---
+    vendor: Mapped[str] = mapped_column(String(32), nullable=False)
+    intent: Mapped[str] = mapped_column(String(16), nullable=False)
+    input_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # --- lease / ownership (runner-held, never client-held) ---
+    lease_owner: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    lease_epoch: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    last_heartbeat_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    lease_expires_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # --- observation (client liveness; never gates execution) ---
+    attached: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=false())
+    last_client_seen: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # --- timing ---
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+    start_ts: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    end_ts: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # --- Phase 4 forward-compat; always NULL in Phase 1 ---
+    checkpoint_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('CREATED','QUEUED','RUNNING','PAUSING','PAUSED',"
+            "'COMPLETED','FAILED','CANCELLED')",
+            name="ck_turns_status",
+        ),
+        CheckConstraint(
+            "error_code IS NULL OR error_code IN "
+            "('TRANSPORT_DISCONNECT','RUNNER_LOST','WORKER_BOOT_FAILURE',"
+            "'WORKER_TASK_FAILURE','CANCELLED')",
+            name="ck_turns_error_code",
+        ),
+        # Orphan-sweep hot path: scan live, leased turns by expiry.
+        Index(
+            "ix_turns_live_lease",
+            "lease_expires_at",
+            sqlite_where=text("status IN ('RUNNING','PAUSING')"),
+            postgresql_where=text("status IN ('RUNNING','PAUSING')"),
+        ),
+        # Per-session listing and "current turn" lookup.
+        Index(
+            "ix_turns_conversation_created",
+            "conversation_id",
+            text("created_at DESC"),
+        ),
+        # At most ONE non-terminal turn per conversation (queue depth 1,
+        # single-runner affinity). Makes "agent is already processing" a
+        # DB invariant: a racing dispatch hits IntegrityError, which the
+        # API converts to a structured 409 Attach-Required. Same pattern
+        # as ix_conversations_parent_title_unique above.
+        Index(
+            "ux_turns_one_active_per_conversation",
+            "conversation_id",
+            unique=True,
+            sqlite_where=text("status IN ('CREATED','QUEUED','RUNNING','PAUSING','PAUSED')"),
+            postgresql_where=text("status IN ('CREATED','QUEUED','RUNNING','PAUSING','PAUSED')"),
+        ),
+    )
+
+
+class SqlIdempotencyKey(Base):
+    """
+    SQLAlchemy model for the ``idempotency_keys`` table.
+
+    Records a client-generated idempotency key so a retried mutating
+    send (e.g. one resent after a reconnect) is a no-op that returns
+    the original turn rather than creating a duplicate or an
+    empty-state turn.
+
+    See ``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md`` (issue #466).
+
+    :param key: The client-generated idempotency key (UUIDv7),
+        stored raw as the primary key.
+    :param conversation_id: Owning conversation/session id.
+    :param turn_id: The turn this key created or returned. A replayed
+        key resolves back to this same turn.
+    :param request_fingerprint: SHA-256 hex of the canonicalized
+        request payload. A second use of the same key with a
+        different fingerprint is rejected (HTTP 422) rather than
+        silently returning the wrong turn.
+    :param created_at: Unix epoch seconds when the key was first seen.
+        Used by a TTL sweep to GC keys past the client retry horizon.
+    """
+
+    __tablename__ = "idempotency_keys"
+
+    key: Mapped[str] = mapped_column(String(36), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    turn_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("turns.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    request_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        Index("ix_idempotency_keys_conversation", "conversation_id"),
+        Index("ix_idempotency_keys_created_at", "created_at"),
+    )

--- a/omnigent/db/migrations/versions/n1a2b3c4d5e6_phase1_server_authoritative_turns.py
+++ b/omnigent/db/migrations/versions/n1a2b3c4d5e6_phase1_server_authoritative_turns.py
@@ -1,0 +1,161 @@
+"""phase 1 server-authoritative turns
+
+Revision ID: n1a2b3c4d5e6
+Revises: m1a2b3c4d5e6
+Create Date: 2026-06-17 00:00:00.000000
+
+Phase 1 of the disconnect-tolerance work (issue #466, design
+``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md``). Introduces the
+server-authoritative turn record so a turn's lifecycle is decoupled
+from the client connection.
+
+Adds:
+
+- ``turns``: the durable, runner-owned turn record. ``id`` is the
+  existing response/task id (``resp_...``). Carries the lifecycle
+  ``status``, the failure ``error_code`` taxonomy, the dispatch
+  payload, the runner lease (``lease_owner`` / ``lease_epoch`` /
+  ``last_heartbeat_at`` / ``lease_expires_at``) and client-observation
+  fields (``attached`` / ``last_client_seen``) that never gate
+  execution. ``checkpoint_id`` is forward-compat for Phase 4 and
+  always NULL here.
+
+  Three indexes: ``ix_turns_live_lease`` (partial, the orphan-sweep
+  hot path), ``ix_turns_conversation_created`` (per-session listing),
+  and ``ux_turns_one_active_per_conversation`` (partial UNIQUE) which
+  enforces queue-depth-1 per conversation so a racing dispatch hits an
+  IntegrityError that the API converts to a structured 409
+  Attach-Required. Partial predicates use the dialect-specific
+  ``sqlite_where`` / ``postgresql_where`` kwargs, mirroring
+  ``ix_conversations_parent_title_unique``.
+
+- ``idempotency_keys``: client-generated UUIDv7 dedup so a retried
+  send returns the original turn instead of creating a duplicate.
+
+- ``conversations.default_send_intent``: optional per-session override
+  for the send-intent default (NULL resolves from the system policy
+  default).
+
+All additions are nullable or carry a server_default, so the change is
+online-safe (no table rewrite). The ``conversations`` column add uses
+``batch_alter_table`` to stay SQLite-safe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "n1a2b3c4d5e6"
+down_revision: str | None = "m1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "turns",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("conversation_id", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=16), server_default="CREATED", nullable=False),
+        sa.Column("error_code", sa.String(length=32), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("vendor", sa.String(length=32), nullable=False),
+        sa.Column("intent", sa.String(length=16), nullable=False),
+        sa.Column("input_json", sa.Text(), nullable=False),
+        sa.Column("lease_owner", sa.String(length=64), nullable=True),
+        sa.Column("lease_epoch", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("last_heartbeat_at", sa.Integer(), nullable=True),
+        sa.Column("lease_expires_at", sa.Integer(), nullable=True),
+        sa.Column("attached", sa.Boolean(), server_default=sa.false(), nullable=False),
+        sa.Column("last_client_seen", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.Column("start_ts", sa.Integer(), nullable=True),
+        sa.Column("end_ts", sa.Integer(), nullable=True),
+        sa.Column("checkpoint_id", sa.String(length=64), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('CREATED','QUEUED','RUNNING','PAUSING','PAUSED',"
+            "'COMPLETED','FAILED','CANCELLED')",
+            name="ck_turns_status",
+        ),
+        sa.CheckConstraint(
+            "error_code IS NULL OR error_code IN "
+            "('TRANSPORT_DISCONNECT','RUNNER_LOST','WORKER_BOOT_FAILURE',"
+            "'WORKER_TASK_FAILURE','CANCELLED')",
+            name="ck_turns_error_code",
+        ),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # Orphan-sweep hot path: live, leased turns by expiry.
+    op.create_index(
+        "ix_turns_live_lease",
+        "turns",
+        ["lease_expires_at"],
+        unique=False,
+        sqlite_where=sa.text("status IN ('RUNNING','PAUSING')"),
+        postgresql_where=sa.text("status IN ('RUNNING','PAUSING')"),
+    )
+    # Per-session listing / current-turn lookup (newest first).
+    op.create_index(
+        "ix_turns_conversation_created",
+        "turns",
+        ["conversation_id", sa.text("created_at DESC")],
+        unique=False,
+    )
+    # Queue-depth-1 invariant: at most one non-terminal turn per
+    # conversation. A racing dispatch hits IntegrityError -> 409.
+    op.create_index(
+        "ux_turns_one_active_per_conversation",
+        "turns",
+        ["conversation_id"],
+        unique=True,
+        sqlite_where=sa.text("status IN ('CREATED','QUEUED','RUNNING','PAUSING','PAUSED')"),
+        postgresql_where=sa.text("status IN ('CREATED','QUEUED','RUNNING','PAUSING','PAUSED')"),
+    )
+
+    op.create_table(
+        "idempotency_keys",
+        sa.Column("key", sa.String(length=36), nullable=False),
+        sa.Column("conversation_id", sa.String(length=64), nullable=False),
+        sa.Column("turn_id", sa.String(length=64), nullable=False),
+        sa.Column("request_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["turn_id"], ["turns.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("key"),
+    )
+    op.create_index(
+        "ix_idempotency_keys_conversation",
+        "idempotency_keys",
+        ["conversation_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_idempotency_keys_created_at",
+        "idempotency_keys",
+        ["created_at"],
+        unique=False,
+    )
+
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.add_column(
+            sa.Column("default_send_intent", sa.String(length=16), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_column("default_send_intent")
+
+    op.drop_index("ix_idempotency_keys_created_at", table_name="idempotency_keys")
+    op.drop_index("ix_idempotency_keys_conversation", table_name="idempotency_keys")
+    op.drop_table("idempotency_keys")
+
+    op.drop_index("ux_turns_one_active_per_conversation", table_name="turns")
+    op.drop_index("ix_turns_conversation_created", table_name="turns")
+    op.drop_index("ix_turns_live_lease", table_name="turns")
+    op.drop_table("turns")

--- a/tests/db/test_migration_phase1_turns.py
+++ b/tests/db/test_migration_phase1_turns.py
@@ -1,0 +1,212 @@
+"""Tests for the Phase 1 server-authoritative ``turns`` schema.
+
+Covers the migration ``n1a2b3c4d5e6_phase1_server_authoritative_turns``
+(issue #466, ``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md``):
+
+1. The ``turns`` and ``idempotency_keys`` tables exist with the
+   expected columns after the full chain applies.
+2. ``conversations.default_send_intent`` is added as a nullable column.
+3. The ``ux_turns_one_active_per_conversation`` partial-unique index
+   enforces queue-depth-1: at most one *non-terminal* turn per
+   conversation, while terminal turns are excluded from the constraint.
+   This invariant is what makes "agent is already processing" a database
+   fact (the racing dispatch hits IntegrityError -> 409 Attach-Required),
+   so it is the single most important behavior to lock down.
+4. The status / error_code CHECK constraints reject out-of-taxonomy
+   values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.db.utils import clear_engine_cache, get_or_create_engine, now_epoch
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite DB with the full alembic chain applied; cleaned up after.
+
+    :param tmp_path: Pytest-managed temp directory for the SQLite file.
+    :returns: Engine pointed at the migrated database.
+    """
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def _seed_conversation(conn: sa.Connection, conversation_id: str = "conv_test") -> None:
+    """Insert a minimal ``conversations`` row to satisfy the turns FK.
+
+    ``get_or_create_engine`` enables SQLite foreign-key enforcement, so a
+    ``turns`` row needs a real parent conversation. Only the NOT NULL
+    columns without a default need values.
+    """
+    now = now_epoch()
+    conn.execute(
+        sa.text(
+            "INSERT INTO conversations (id, created_at, updated_at, "
+            "root_conversation_id) VALUES (:id, :now, :now, :id)"
+        ),
+        {"id": conversation_id, "now": now},
+    )
+
+
+def _insert_turn(
+    conn: sa.Connection,
+    *,
+    turn_id: str,
+    conversation_id: str = "conv_test",
+    status: str = "RUNNING",
+    error_code: str | None = None,
+) -> None:
+    """Insert a minimal ``turns`` row.
+
+    Assumes the parent conversation already exists (see
+    :func:`_seed_conversation`).
+    """
+    conn.execute(
+        sa.text(
+            "INSERT INTO turns "
+            "(id, conversation_id, status, error_code, vendor, intent, "
+            " input_json, lease_epoch, attached, created_at) "
+            "VALUES (:id, :cid, :status, :ec, 'claude_code', 'enqueue', "
+            " '{}', 0, 0, :now)"
+        ),
+        {
+            "id": turn_id,
+            "cid": conversation_id,
+            "status": status,
+            "ec": error_code,
+            "now": now_epoch(),
+        },
+    )
+
+
+def test_turns_and_idempotency_tables_present(db_engine: Engine) -> None:
+    """Both new tables exist with their expected columns after migration.
+
+    A failure here means the migration didn't apply — every ORM path
+    that touches ``SqlTurn`` / ``SqlIdempotencyKey`` would crash.
+    """
+    insp = sa.inspect(db_engine)
+    tables = set(insp.get_table_names())
+    assert "turns" in tables, "migration must create the 'turns' table"
+    assert "idempotency_keys" in tables, "migration must create the 'idempotency_keys' table"
+
+    turn_cols = {c["name"] for c in insp.get_columns("turns")}
+    expected = {
+        "id",
+        "conversation_id",
+        "status",
+        "error_code",
+        "error_message",
+        "vendor",
+        "intent",
+        "input_json",
+        "lease_owner",
+        "lease_epoch",
+        "last_heartbeat_at",
+        "lease_expires_at",
+        "attached",
+        "last_client_seen",
+        "created_at",
+        "start_ts",
+        "end_ts",
+        "checkpoint_id",
+    }
+    missing = expected - turn_cols
+    assert not missing, f"turns table missing columns: {sorted(missing)}"
+
+    idem_cols = {c["name"] for c in insp.get_columns("idempotency_keys")}
+    assert idem_cols >= {
+        "key",
+        "conversation_id",
+        "turn_id",
+        "request_fingerprint",
+        "created_at",
+    }, f"idempotency_keys missing columns: {idem_cols}"
+
+
+def test_default_send_intent_column_added_nullable(db_engine: Engine) -> None:
+    """``conversations.default_send_intent`` exists and is nullable.
+
+    Nullable so pre-feature rows stay valid and resolve from the system
+    policy default rather than being rejected on read.
+    """
+    cols = sa.inspect(db_engine).get_columns("conversations")
+    match = [c for c in cols if c["name"] == "default_send_intent"]
+    assert len(match) == 1, (
+        "expected exactly one conversations.default_send_intent column; "
+        "if 0, the migration didn't add it"
+    )
+    assert match[0]["nullable"], (
+        "default_send_intent must be NULLABLE (NULL => resolve from policy)"
+    )
+
+
+def test_one_active_turn_per_conversation_enforced(db_engine: Engine) -> None:
+    """The partial-unique index allows only one non-terminal turn per session.
+
+    This is the load-bearing invariant: a second active dispatch must be
+    rejected at the DB layer so the API can convert the IntegrityError to
+    a structured 409 Attach-Required instead of racing two live turns.
+    """
+    with db_engine.begin() as conn:
+        _seed_conversation(conn)
+        _insert_turn(conn, turn_id="resp_a", status="RUNNING")
+
+    with db_engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            _insert_turn(conn, turn_id="resp_b", status="QUEUED")
+
+
+def test_terminal_turns_excluded_from_active_uniqueness(db_engine: Engine) -> None:
+    """A completed turn frees the slot, and terminal turns may coexist.
+
+    The partial predicate excludes terminal statuses, so finishing one
+    turn lets the next one start, and multiple terminal turns on the same
+    conversation never collide.
+    """
+    with db_engine.begin() as conn:
+        _seed_conversation(conn)
+        _insert_turn(conn, turn_id="resp_a", status="RUNNING")
+        conn.execute(sa.text("UPDATE turns SET status='COMPLETED' WHERE id='resp_a'"))
+        # New active turn is now allowed.
+        _insert_turn(conn, turn_id="resp_b", status="RUNNING")
+        # A second terminal turn coexists with the active one.
+        _insert_turn(conn, turn_id="resp_c", status="FAILED", error_code="RUNNER_LOST")
+
+    with db_engine.connect() as conn:
+        count = conn.execute(sa.text("SELECT COUNT(*) FROM turns")).scalar_one()
+    assert count == 3, "expected all three turns to persist"
+
+
+def test_status_check_constraint_rejects_unknown_value(db_engine: Engine) -> None:
+    """An out-of-enum ``status`` is rejected by the CHECK constraint."""
+    with db_engine.begin() as conn:
+        _seed_conversation(conn)
+        with pytest.raises(IntegrityError):
+            _insert_turn(conn, turn_id="resp_x", status="BOGUS")
+
+
+def test_error_code_check_constraint_rejects_unknown_value(db_engine: Engine) -> None:
+    """An out-of-taxonomy ``error_code`` is rejected by the CHECK constraint.
+
+    Keeping the failure taxonomy closed at the DB layer prevents a typo'd
+    code from silently bypassing the WORKER_*-only routing filter.
+    """
+    with db_engine.begin() as conn:
+        _seed_conversation(conn)
+        with pytest.raises(IntegrityError):
+            _insert_turn(conn, turn_id="resp_y", status="FAILED", error_code="NOT_A_CODE")


### PR DESCRIPTION
## What

First **code** PR for the disconnect-tolerance work (issue #466). Adds the server-authoritative turn schema — no behavior change yet; the tables are inert until later PRs wire the dispatch path.

📚 **Stacked on #470** (the Phase 1 implementation plan). Base that first. Design: #461.

## Changes

- **`SqlTurn`** model + `turns` table — durable, runner-owned turn record. `id` **is** the existing `resp_…` response/task id (not a new id space). Carries lifecycle `status`, failure `error_code`, dispatch payload, the runner lease (`lease_owner`/`lease_epoch`/`last_heartbeat_at`/`lease_expires_at`), and client-observation fields (`attached`/`last_client_seen`) that never gate execution. `PAUSING`/`PAUSED` and `checkpoint_id` are forward-compat for later phases and unused here.
- **`SqlIdempotencyKey`** model + `idempotency_keys` table — client UUIDv7 dedup so a retried send returns the original turn.
- **`conversations.default_send_intent`** — nullable per-session intent override.
- **Migration `n1a2b3c4d5e6`** (`down_revision = m1a2b3c4d5e6`) — dual-dialect (SQLite + Postgres), `batch_alter_table` for the column add, partial indexes via `sqlite_where`/`postgresql_where`.

## The load-bearing piece

`ux_turns_one_active_per_conversation` is a **partial UNIQUE index** over the non-terminal statuses. It makes "agent is already processing" a **database invariant**: a racing second dispatch hits `IntegrityError`, which a later PR converts to a structured `409 Attach-Required`. Same pattern as the existing `ix_conversations_parent_title_unique`.

## Verification

- ✅ `alembic upgrade head` / `downgrade -1` round-trip cleanly on SQLite.
- ✅ 7 new tests (`tests/db/test_migration_phase1_turns.py`): tables/columns present, `default_send_intent` nullable, **the queue-depth-1 invariant** (2nd active turn rejected; freed once terminal; terminals coexist), and both CHECK constraints reject out-of-taxonomy values.
- ✅ Existing `test_migrations_sqlite_safe.py` guard still passes (downgrade uses batch mode).
- ✅ `ruff check` + `ruff format` clean.

## Notes for reviewers

- Pure additive schema; nothing reads these tables yet.
- Queue-depth-1 is intentional for Phase 1 (one runner per conversation). Bumping depth later means making this index non-unique + adding a `queue_seq` — flagged in the plan.
