### PR TITLE
fix(supervisor): wire databricks_supervisor spawn-env + list-shaped tools (un-suppress 5)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3705,14 +3705,17 @@ class _DeployConfig(BaseModel):  # type: ignore[explicit-any]  # Pydantic extra=
         if absent.
     :param executor: The executor configuration block, or
         ``None`` if absent.
-    :param tools: The tools configuration block, or ``None``
-        if absent.
+    :param tools: The tools configuration block/list, or ``None``
+        if absent. Mapping-shaped tools are modeled after the standard
+        ``tools.builtins`` config; list-shaped tools are the Databricks
+        supervisor pass-through form and are intentionally accepted so
+        deploy-time env expansion does not reject otherwise valid bundles.
     """
 
     model_config = ConfigDict(extra="allow")
     llm: _LLMDeploy | None = None
     executor: _ExecutorDeploy | None = None
-    tools: _ToolsDeploy | None = None
+    tools: _ToolsDeploy | list[dict[str, Any]] | None = None  # type: ignore[explicit-any]
 
 
 def _expand_config_env_vars(  # type: ignore[explicit-any]  # raw is parsed YAML (heterogeneous values)
@@ -3767,7 +3770,7 @@ def _expand_config_env_vars(  # type: ignore[explicit-any]  # raw is parsed YAML
             raw["executor"]["auth"].update(expand_fn(auth_secrets))
             changed = True
 
-    if cfg.tools is not None and cfg.tools.builtins is not None:
+    if isinstance(cfg.tools, _ToolsDeploy) and cfg.tools.builtins is not None:
         changed = (
             _expand_builtin_env_vars(
                 raw["tools"]["builtins"],

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -12537,6 +12537,7 @@ def _build_spawn_env_from_spec(
             _build_claude_sdk_spawn_env,
             _build_codex_spawn_env,
             _build_cursor_spawn_env,
+            _build_databricks_supervisor_spawn_env,
             _build_openai_agents_sdk_spawn_env,
             _build_pi_spawn_env,
         )
@@ -12553,6 +12554,8 @@ def _build_spawn_env_from_spec(
             env = _build_cursor_spawn_env(spec, workdir=workdir)
         elif harness == "antigravity":
             env = _build_antigravity_spawn_env(spec)
+        elif harness == "databricks_supervisor":
+            env = _build_databricks_supervisor_spawn_env(spec)
         else:
             # Native terminal harnesses and unknown harnesses build env elsewhere.
             return None

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1416,6 +1416,42 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
     return env
 
 
+def _build_databricks_supervisor_spawn_env(spec: AgentSpec) -> dict[str, str]:
+    """Build the ``HARNESS_SUPERVISOR_*`` env-var dict.
+
+    The Databricks supervisor harness is an in-process harness like
+    openai-agents, but it uses its own env prefix and accepts a
+    pass-through list of Databricks-resident tools.
+
+    :param spec: The agent spec.
+    :returns: Spawn env consumed by ``databricks_supervisor_harness``.
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model:
+        env["HARNESS_SUPERVISOR_MODEL"] = model
+    if spec.executor.supervisor_tools is not None:
+        env["HARNESS_SUPERVISOR_TOOLS_JSON"] = json.dumps(spec.executor.supervisor_tools)
+
+    if spec.executor.connection is not None:
+        env["HARNESS_SUPERVISOR_CONNECTION_JSON"] = json.dumps(spec.executor.connection)
+
+    spec_auth = spec.executor.auth
+    if isinstance(spec_auth, ApiKeyAuth):
+        connection = {"api_key": spec_auth.api_key}
+        if spec_auth.base_url:
+            connection["base_url"] = spec_auth.base_url
+        env["HARNESS_SUPERVISOR_CONNECTION_JSON"] = json.dumps(connection)
+    elif isinstance(spec_auth, DatabricksAuth):
+        env["HARNESS_SUPERVISOR_DATABRICKS_PROFILE"] = spec_auth.profile
+    elif spec.executor.profile:
+        env["HARNESS_SUPERVISOR_DATABRICKS_PROFILE"] = spec.executor.profile
+    elif spec.executor.config.get("profile"):
+        env["HARNESS_SUPERVISOR_DATABRICKS_PROFILE"] = str(spec.executor.config["profile"])
+
+    return env
+
+
 def _build_cursor_spawn_env(
     spec: AgentSpec,
     *,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1226,6 +1226,37 @@ def test_expand_config_expands_builtin_tool_config(
     assert entry["name"] == "web_search_pplx"
 
 
+def test_expand_config_accepts_supervisor_tool_list() -> None:
+    """
+    ``_expand_config_env_vars`` accepts the Databricks supervisor
+    ``tools:`` list shape without trying to treat it as ``tools.builtins``.
+    """
+    from omnigent.spec import expand_env_vars
+
+    raw: dict[str, Any] = {
+        "spec_version": 1,
+        "executor": {
+            "type": "omnigent",
+            "model": "databricks-claude-sonnet-4-6",
+            "config": {"harness": "databricks_supervisor"},
+        },
+        "tools": [
+            {
+                "type": "uc_connection",
+                "uc_connection": {
+                    "name": "system_ai_agent_google_drive",
+                    "description": "Search team Google Drive",
+                },
+            }
+        ],
+    }
+
+    changed = _expand_config_env_vars(raw, expand_env_vars)
+
+    assert changed is False
+    assert raw["tools"][0]["uc_connection"]["name"] == "system_ai_agent_google_drive"
+
+
 def test_expand_config_expands_executor_connection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/e2e/omnigent/test_run_omnigent_supervisor.py
+++ b/tests/e2e/omnigent/test_run_omnigent_supervisor.py
@@ -67,7 +67,7 @@ What breaks if a regression goes in:
 
 Skip behaviour:
 
-- Profile from ``examples/databricks_supervisor/config.yaml`` missing
+- Profile from ``tests/resources/examples/databricks_supervisor/config.yaml`` missing
   from ``~/.databrickscfg`` → skip with config hint.
 - OAuth required on first use → skip with login instructions.
 
@@ -99,7 +99,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 # The example bundle is the single source of truth for the profile
 # and model. The e2e tests read them from here so there's no
 # separate env var to keep in sync.
-_EXAMPLE_BUNDLE = _REPO_ROOT / "examples" / "databricks_supervisor"
+_EXAMPLE_BUNDLE = _REPO_ROOT / "tests" / "resources" / "examples" / "databricks_supervisor"
 
 _DATABRICKSCFG_PATH = Path.home() / ".databrickscfg"
 
@@ -231,7 +231,7 @@ def _write_supervisor_bundle(
     :returns: Path to the bundle directory.
     """
     example_config = yaml.safe_load((_EXAMPLE_BUNDLE / "config.yaml").read_text())
-    model = example_config["llm"]["model"]
+    model = (example_config.get("llm") or {}).get("model") or example_config["executor"]["model"]
     bundle = tmp_path / "supervisor_bundle"
     bundle.mkdir()
     config: dict[str, object] = {
@@ -291,6 +291,7 @@ def _run_supervisor(
         "omnigent",
         "run",
         str(bundle),
+        "--no-session",
         "-p",
         user_prompt,
     ]

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -353,36 +353,6 @@ skips:
     cluster: repl-pexpect-cli
     mode: skip
 
-  - id: tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_oneshot
-    reason: "Shard 3 bulk: coding supervisor one-shot. Triage under #532."
-    issue: 532
-    cluster: subagent-supervisor-routing
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_exposes_subagent_tools
-    reason: "Shard 3 bulk: coding supervisor subagent tools."
-    issue: 532
-    cluster: subagent-supervisor-routing
-    mode: skip
-
-  # Verified live on oss 2026-06-11: spawn / ambient_hint / parallel
-  # pass under the module's 600s signal-method timeout marker, but
-  # continuation failed 1 of 2 runs with a clean AssertionError (the
-  # sub-agent result never reached the parent via auto-wake within
-  # 240s; passed standalone in 47s). Flaky auto-wake delivery, needs
-  # product investigation before re-greening.
-  - id: tests/e2e/test_named_sub_agent_persistence.py::test_send_to_named_sub_agent_continuation_e2e
-    reason: "Flaky live: turn-2 sys_session_send result intermittently never auto-wakes the parent within 240s (#532)."
-    issue: 532
-    cluster: subagent-supervisor-routing
-    mode: skip
-
-  - id: tests/e2e/test_named_sub_agent_persistence.py::test_cross_parent_named_isolation_e2e
-    reason: "Wedges the e2e shard in CI: this test dispatches a sub-agent in TWO separate runner-bound sessions on the same runner, and the second session's async sub-agent dispatch / auto-wake contends with the first, hanging well past the shard's per-test timeout (the other 4 test_named_sub_agent_persistence tests pass after the #2534 session-flow migration; this two-concurrent-sessions-on-one-runner interaction needs separate investigation). Passes locally on oss in ~30s."
-    issue: 532
-    cluster: subagent-supervisor-routing
-    mode: skip
-
   - id: tests/e2e/test_policies_e2e.py::test_policy_gate_deny_persists_to_history
     reason: "Sessions API migration reaches inline INPUT DENY, but the synchronous DENY verdict is not persisted as an assistant sentinel in conversation_items; needs product-side persistence fix before unsuppressing."
     issue: 476
@@ -433,12 +403,6 @@ skips:
     reason: "Shard 3 bulk: sys-terminal basic round-trip. Same sys-terminal family."
     issue: 532
     cluster: terminal-d6
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_run_omnigent_example_agents.py::test_run_omnigent_example_yaml[agent_with_subagent_session]
-    reason: "Shard 3 bulk: run_omnigent example-yaml agent_with_subagent_session."
-    issue: 532
-    cluster: subagent-supervisor-routing
     mode: skip
 
   - id: tests/e2e/test_sys_terminal_e2e.py::test_sys_terminal_ten_parallel_dispatches_complete_e2e

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -1359,6 +1359,24 @@ def test_build_spawn_env_applies_model_override(
     assert overridden["HARNESS_CLAUDE_SDK_MODEL"] == "claude-sonnet-4-6"
 
 
+def test_build_spawn_env_supports_databricks_supervisor() -> None:
+    """The runner builds the supervisor harness env instead of returning ``None``."""
+    spec = AgentSpec(
+        spec_version=1,
+        name="supervisor-test",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "databricks_supervisor"},
+            model="databricks-claude-sonnet-4-6",
+        ),
+    )
+
+    env = _build_spawn_env_from_spec(spec, "databricks_supervisor")
+
+    assert env is not None
+    assert env["HARNESS_SUPERVISOR_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
 @pytest.mark.asyncio
 async def test_resolve_harness_config_applies_harness_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/runtime/test_databricks_supervisor_spawn_env.py
+++ b/tests/runtime/test_databricks_supervisor_spawn_env.py
@@ -1,0 +1,45 @@
+"""Tests for the Databricks supervisor harness spawn env."""
+
+from __future__ import annotations
+
+import json
+
+from omnigent.runtime.workflow import _build_databricks_supervisor_spawn_env
+from omnigent.spec.types import AgentSpec, DatabricksAuth, ExecutorSpec, LLMConfig
+
+
+def _make_spec() -> AgentSpec:
+    """Build a minimal Databricks supervisor spec."""
+    model = "databricks-claude-sonnet-4-6"
+    tools = [
+        {
+            "type": "uc_connection",
+            "uc_connection": {
+                "name": "system_ai_agent_google_drive",
+                "description": "Search team Google Drive",
+            },
+        }
+    ]
+    return AgentSpec(
+        spec_version=1,
+        name="supervisor-test",
+        instructions="Use the connector.",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "databricks_supervisor"},
+            model=model,
+            supervisor_tools=tools,
+            auth=DatabricksAuth(profile="oss"),
+        ),
+        llm=LLMConfig(model=model),
+    )
+
+
+def test_supervisor_spawn_env_threads_model_profile_and_tools() -> None:
+    """The supervisor harness gets every required ``HARNESS_SUPERVISOR_*`` key."""
+    env = _build_databricks_supervisor_spawn_env(_make_spec())
+
+    assert env["HARNESS_SUPERVISOR_MODEL"] == "databricks-claude-sonnet-4-6"
+    assert env["HARNESS_SUPERVISOR_DATABRICKS_PROFILE"] == "oss"
+    tools = json.loads(env["HARNESS_SUPERVISOR_TOOLS_JSON"])
+    assert tools[0]["uc_connection"]["name"] == "system_ai_agent_google_drive"


### PR DESCRIPTION
## Summary

- Unsuppresses 5 verified `subagent-supervisor-routing` e2e rows that now pass live: coding-supervisor smoke/tool listing, named sub-agent continuation/isolation, and the sub-agent-session example YAML.
- Fixes two Databricks supervisor harness routing drifts found during triage: deploy-time env expansion now accepts supervisor `tools:` lists, and the runner now supplies `HARNESS_SUPERVISOR_*` spawn env for the `databricks_supervisor` harness.
- Repairs the Databricks supervisor e2e helper to use the current fixture path/model shape and isolated `--no-session` runs, but leaves those tests suppressed because they still require valid Databricks profile credentials/connectors.

### ELI5

Some tests were skipped because the “boss agent sends work to helper agents” path used to break. I checked each skipped test. Five now work, so I removed their skip labels. While checking the Databricks-supervisor ones, I found the helper-agent launch was forgetting to pack the supervisor’s model/tools into the backpack it gives the worker process; this PR fixes that packing step, but the live Databricks tests still need real valid workspace credentials, so they stay skipped.

### Diagram

```mermaid
flowchart LR
  YAML[Agent YAML / bundle] --> Parser[Spec parser]
  Parser --> Bundle[CLI bundle env expansion]
  Bundle --> Runner[Runner resolves harness]
  Runner --> Env[HARNESS_SUPERVISOR_* env]
  Env --> Harness[databricks_supervisor harness]
  Harness --> Gateway[Databricks Supervisor Gateway]
```

### Per-test decisions

| Test | Decision | Evidence |
| --- | --- | --- |
| `tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_oneshot` | FIX: remove suppression | Passed standalone and in combined 5-node live run. |
| `tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_exposes_subagent_tools` | FIX: remove suppression | Passed standalone and in combined 5-node live run. |
| `tests/e2e/test_named_sub_agent_persistence.py::test_send_to_named_sub_agent_continuation_e2e` | FIX: remove suppression | Passed standalone and in combined 5-node live run. |
| `tests/e2e/test_named_sub_agent_persistence.py::test_cross_parent_named_isolation_e2e` | FIX: remove suppression | Passed standalone and in combined 5-node live run. |
| `tests/e2e/omnigent/test_run_omnigent_example_agents.py::test_run_omnigent_example_yaml[agent_with_subagent_session]` | FIX: remove suppression | Passed standalone and in combined 5-node live run. |
| `tests/e2e/omnigent/test_run_omnigent_example_agents.py::test_run_omnigent_example_yaml[coding_supervisor_with_forks]` | DEFER: leave suppressed | Still fails live: `Error: turn failed`; likely real supervisor/forked-worker routing or product behavior. |
| `tests/e2e/omnigent/test_run_omnigent_supervisor.py::test_supervisor_google_drive_returns_files` | DEFER: leave suppressed | Harness/model/tool-list drift fixed; local live run now reaches auth/profile failure: profile `oss` missing required `token`. |
| `tests/e2e/omnigent/test_run_omnigent_supervisor.py::test_supervisor_atlassian_returns_jira_issue` | DEFER: leave suppressed | Same helper/product path as Google Drive; not unsuppressed without a clean live pass. |
| `tests/e2e/omnigent/test_example_coding_supervisor_with_forks.py::test_coding_supervisor_with_forks_one_shot[databricks_supervisor]` | DEFER: leave suppressed | Initially exposed missing `HARNESS_SUPERVISOR_MODEL`; fixed by unit-covered spawn-env change, but live Databricks supervisor auth remains unavailable locally. |
| `tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[databricks_supervisor]` | DEFER: leave suppressed | After spawn-env fix, reaches gateway and fails with HTTP 401 unsupported/missing credential. |
| `tests/e2e/omnigent/test_yaml_hello_world_real.py::test_yaml_hello_world_real[databricks_supervisor]` | DEFER: leave suppressed | Same Databricks supervisor auth family as `test_yaml_agent_with_tools[databricks_supervisor]`. |
| `tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_codex_shell_not_disabled` | DEFER: leave suppressed | Still fails: Codex worker does not read fixture sentinel; stdout only says it launched the worker. |

### Product bugs / follow-ups found

- `codex_worker` delegation still does not reliably read files through the coding supervisor path. Evidence: `test_run_omnigent_coding_supervisor_codex_shell_not_disabled` fails because sentinel `CODEX_SHELL_REGRESSION_MARKER_XYZQ` is absent and stdout only reports launch acknowledgement.
- Forked coding supervisor example still fails with `Error: turn failed` in `test_run_omnigent_example_yaml[coding_supervisor_with_forks]`; this remains a likely product/harness routing issue.
- Databricks supervisor e2es now get past local harness model/tool-list drift, but local validation is blocked by Databricks credential/profile state (`oss` has no PAT token; one run reached gateway HTTP 401). These stay suppressed until validated with a working workspace/profile.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run:

- `uv run pytest --collect-only -q <all 12 cluster nodeids>` — confirmed every suppressed id still resolves to a real test.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest --no-skip-known -q -rfs --tb=short tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_oneshot --llm-api-key="$OPENAI_API_KEY" --profile oss` — passed.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest --no-skip-known -q -rfs --tb=short tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_exposes_subagent_tools --llm-api-key="$OPENAI_API_KEY" --profile oss` — passed.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest --no-skip-known -q -rfs --tb=short tests/e2e/test_named_sub_agent_persistence.py::test_send_to_named_sub_agent_continuation_e2e --llm-api-key="$OPENAI_API_KEY"` — passed.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest --no-skip-known -q -rfs --tb=short tests/e2e/test_named_sub_agent_persistence.py::test_cross_parent_named_isolation_e2e --llm-api-key="$OPENAI_API_KEY"` — passed.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest --no-skip-known -q -rfs --tb=short tests/e2e/omnigent/test_run_omnigent_example_agents.py::test_run_omnigent_example_yaml[agent_with_subagent_session] --llm-api-key="$OPENAI_API_KEY" --profile oss` — passed.
- `env -u DATABRICKS_TOKEN -u OPENAI_API_KEY uv run pytest -q -rfs --tb=short <five unsuppressed nodeids> --llm-api-key="$OPENAI_API_KEY" --profile oss` — `5 passed` in 96.12s.
- `uv run pytest -q tests/runtime/test_databricks_supervisor_spawn_env.py tests/runner/test_runner_dispatch.py::test_build_spawn_env_supports_databricks_supervisor tests/cli/test_cli.py::test_expand_config_accepts_supervisor_tool_list` — `3 passed`.
- `uv run ruff format omnigent/cli.py omnigent/runtime/workflow.py omnigent/runner/app.py tests/cli/test_cli.py tests/runtime/test_databricks_supervisor_spawn_env.py tests/runner/test_runner_dispatch.py tests/e2e/omnigent/test_run_omnigent_supervisor.py` — clean after formatting.
- `uv run ruff check omnigent/cli.py omnigent/runtime/workflow.py omnigent/runner/app.py tests/cli/test_cli.py tests/runtime/test_databricks_supervisor_spawn_env.py tests/runner/test_runner_dispatch.py tests/e2e/omnigent/test_run_omnigent_supervisor.py` — `All checks passed!`.
- `python - <<'PY' ... yaml.safe_load(Path('tests/known_failures.yaml').read_text()) ... PY` — `known_failures.yaml parses`.

Deferred live failures were intentionally not unsuppressed because they did not produce a clean local pass.
