### PR TITLE
fix(e2e): refuse dev-server base URLs and enforce headless/fresh-context

### DIFF
--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -15,10 +15,11 @@ Local usage::
     # run against a freshly built SPA + spawned server
     uv run pytest tests/e2e_ui -v
 
-    # iterate against an already-running dev server
+    # iterate against an already-running server (dev hosts/ports need opt-in)
     cd ap-web && npm run dev &
     omnigent server --agent examples/hello_world.yaml &
-    uv run pytest tests/e2e_ui --ui-base-url http://127.0.0.1:5173
+    OMNIGENT_E2E_ALLOW_DEV_BASE_URL=1 \
+      uv run pytest tests/e2e_ui --ui-base-url http://127.0.0.1:5173
 
 ``omnigent server`` is documented at ``omnigent/cli.py:server``:
 it spins up uvicorn with the Omnigent app and spawns an out-of-process
@@ -41,13 +42,17 @@ import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import filelock
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e_ui.url_safety import DEV_PORTS, unsafe_ui_base_url_reason
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_ALLOW_DEV_BASE_URL_ENV = "OMNIGENT_E2E_ALLOW_DEV_BASE_URL"
 
 
 def open_right_rail(page: Page) -> None:
@@ -192,8 +197,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help=(
             "Skip both the SPA build and the server spawn; point Playwright "
-            "at this URL instead. Useful when iterating with `npm run dev` + "
-            "a long-lived `omnigent server` process."
+            "at this URL instead. Refuses known dev hosts/ports unless "
+            f"{_ALLOW_DEV_BASE_URL_ENV}=1 is set."
         ),
     )
     parser.addoption(
@@ -220,6 +225,64 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=int,
         default=None,
         help="1-indexed shard this run executes (requires --splits).",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Fail fast on unsafe e2e-ui harness options.
+
+    :param config: Pytest config with repo and pytest-playwright options.
+    """
+    base_url = config.getoption("--ui-base-url")
+    if base_url:
+        _validate_ui_base_url(base_url)
+
+    if os.environ.get("CI") and config.getoption("--headed", default=False):
+        raise pytest.UsageError(
+            "tests/e2e_ui must run headless in CI. Remove --headed; headed "
+            "browser windows are only allowed for local debugging."
+        )
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(
+    browser_type_launch_args: dict[str, Any],
+    pytestconfig: pytest.Config,
+) -> dict[str, Any]:
+    """Default UI e2e browser launches to headless, with CI enforcement."""
+    launch_args = {**browser_type_launch_args}
+    if os.environ.get("CI"):
+        launch_args["headless"] = True
+    elif not pytestconfig.getoption("--headed", default=False):
+        launch_args.setdefault("headless", True)
+    return launch_args
+
+
+@pytest.fixture
+def browser_context_args(
+    browser_context_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a new context options dict for each test.
+
+    pytest-playwright already creates a fresh context for its function-scoped
+    ``context`` and ``page`` fixtures. Keeping this wrapper function-scoped
+    makes that contract explicit and prevents accidental mutable option reuse.
+    """
+    return {**browser_context_args}
+
+
+def _validate_ui_base_url(base_url: str) -> None:
+    reason = unsafe_ui_base_url_reason(base_url)
+    if reason is None or os.environ.get(_ALLOW_DEV_BASE_URL_ENV) == "1":
+        return
+    dev_ports = ", ".join(str(port) for port in sorted(DEV_PORTS))
+    raise pytest.UsageError(
+        f"Refusing --ui-base-url={base_url!r}: {reason}. Reusing a dev or "
+        "production-like server is unsafe because e2e UI tests share that "
+        "server's database, artifacts, and runner state. Omit --ui-base-url "
+        "to let the fixture spawn an isolated server on a random port. If "
+        "you intentionally want to reuse this server for local debugging, "
+        f"set {_ALLOW_DEV_BASE_URL_ENV}=1. Refused dev ports: {dev_ports}."
     )
 
 
@@ -318,9 +381,12 @@ def _find_free_port() -> int:
 
     :returns: An available port number.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+    while True:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+        if port not in DEV_PORTS:
+            return port
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -381,12 +381,17 @@ def _find_free_port() -> int:
 
     :returns: An available port number.
     """
-    while True:
+    max_attempts = 100
+    for _ in range(max_attempts):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
             port = s.getsockname()[1]
         if port not in DEV_PORTS:
             return port
+    raise RuntimeError(
+        f"Could not find a free e2e UI port outside dev ports "
+        f"{sorted(DEV_PORTS)} after {max_attempts} attempts"
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e_ui/url_safety.py
+++ b/tests/e2e_ui/url_safety.py
@@ -7,6 +7,7 @@ import socket
 from urllib.parse import urlparse
 
 DEV_PORTS = frozenset({6767, 8000, 5173})
+# Literal hostnames are a fast path; resolved IPs are classified by _dev_address_reason.
 DEV_HOSTNAMES = frozenset({"localhost", "0.0.0.0"})
 
 
@@ -26,7 +27,8 @@ def unsafe_ui_base_url_reason(base_url: str) -> str | None:
         port = parsed.port
     except ValueError:
         return "it has an invalid port"
-    if port in DEV_PORTS:
+    # No explicit port is not itself unsafe; host checks below still apply.
+    if port is not None and port in DEV_PORTS:
         return f"port {port} is a known Omnigent/Vite dev port"
     if host in DEV_HOSTNAMES:
         return f"host {host!r} is a local dev host"
@@ -67,8 +69,8 @@ def _dev_address_reason(address: ipaddress.IPv4Address | ipaddress.IPv6Address) 
         return "a loopback address"
     if address.is_unspecified:
         return "an unspecified local address"
-    if address.is_private:
-        return "a private-network address"
     if address.is_link_local:
         return "a link-local address"
+    if address.is_private:
+        return "a private-network address"
     return None

--- a/tests/e2e_ui/url_safety.py
+++ b/tests/e2e_ui/url_safety.py
@@ -1,0 +1,74 @@
+"""Safety checks for opt-in e2e-ui external server reuse."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+DEV_PORTS = frozenset({6767, 8000, 5173})
+DEV_HOSTNAMES = frozenset({"localhost", "0.0.0.0"})
+
+
+def unsafe_ui_base_url_reason(base_url: str) -> str | None:
+    """Return why ``base_url`` looks unsafe for shared e2e-ui reuse.
+
+    ``--ui-base-url`` points tests at a server this pytest session did not
+    spawn. Known dev ports and local/private hosts are refused by default so a
+    run cannot silently share a developer server, database, or artifact store.
+    """
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return "it must be an absolute http(s) URL with a host"
+
+    host = parsed.hostname.rstrip(".").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        return "it has an invalid port"
+    if port in DEV_PORTS:
+        return f"port {port} is a known Omnigent/Vite dev port"
+    if host in DEV_HOSTNAMES:
+        return f"host {host!r} is a local dev host"
+
+    host_reason = _dev_host_reason(host)
+    if host_reason is not None:
+        return host_reason
+    return None
+
+
+def _dev_host_reason(host: str) -> str | None:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return _resolved_dev_host_reason(host)
+    return _dev_address_reason(address)
+
+
+def _resolved_dev_host_reason(host: str) -> str | None:
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return None
+    for info in infos:
+        address_text = info[4][0]
+        try:
+            address = ipaddress.ip_address(address_text)
+        except ValueError:
+            continue
+        reason = _dev_address_reason(address)
+        if reason is not None:
+            return f"host {host!r} resolves to {address_text}, {reason}"
+    return None
+
+
+def _dev_address_reason(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    if address.is_loopback:
+        return "a loopback address"
+    if address.is_unspecified:
+        return "an unspecified local address"
+    if address.is_private:
+        return "a private-network address"
+    if address.is_link_local:
+        return "a link-local address"
+    return None

--- a/tests/test_e2e_ui_url_safety.py
+++ b/tests/test_e2e_ui_url_safety.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from tests.e2e_ui.url_safety import DEV_PORTS, unsafe_ui_base_url_reason
+
+
+@pytest.mark.parametrize("port", sorted(DEV_PORTS))
+def test_unsafe_ui_base_url_reason_refuses_known_dev_ports(port: int) -> None:
+    reason = unsafe_ui_base_url_reason(f"http://example.com:{port}")
+
+    assert reason == f"port {port} is a known Omnigent/Vite dev port"
+
+
+@pytest.mark.parametrize(
+    ("ui_base_url", "expected"),
+    [
+        ("http://127.0.0.1:54321", "loopback address"),
+        ("http://localhost:54321", "local dev host"),
+        ("http://10.0.0.5:54321", "private-network address"),
+        ("http://[::1]:54321", "loopback address"),
+        ("not-a-url", "absolute http(s) URL"),
+    ],
+)
+def test_unsafe_ui_base_url_reason_refuses_dev_hosts(
+    ui_base_url: str,
+    expected: str,
+) -> None:
+    reason = unsafe_ui_base_url_reason(ui_base_url)
+
+    assert reason is not None
+    assert expected in reason
+
+
+def test_unsafe_ui_base_url_reason_allows_public_non_dev_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *args, **kwargs: [])
+
+    assert unsafe_ui_base_url_reason("https://example.com:443") is None

--- a/tests/test_e2e_ui_url_safety.py
+++ b/tests/test_e2e_ui_url_safety.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 import socket
+from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
+from tests.e2e_ui.conftest import pytest_configure
 from tests.e2e_ui.url_safety import DEV_PORTS, unsafe_ui_base_url_reason
+
+
+@dataclass
+class _ConfigStub:
+    options: dict[str, Any]
+
+    def getoption(self, name: str, default: Any = None) -> Any:
+        return self.options.get(name, default)
 
 
 @pytest.mark.parametrize("port", sorted(DEV_PORTS))
@@ -40,3 +51,28 @@ def test_unsafe_ui_base_url_reason_allows_public_non_dev_port(
     monkeypatch.setattr(socket, "getaddrinfo", lambda *args, **kwargs: [])
 
     assert unsafe_ui_base_url_reason("https://example.com:443") is None
+
+
+def test_unsafe_ui_base_url_reason_handles_missing_port_explicitly() -> None:
+    reason = unsafe_ui_base_url_reason("http://127.0.0.1")
+
+    assert reason == "a loopback address"
+
+
+def test_pytest_configure_rejects_headed_in_ci(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CI", "1")
+
+    with pytest.raises(pytest.UsageError, match="must run headless in CI"):
+        pytest_configure(_ConfigStub({"--ui-base-url": None, "--headed": True}))
+
+
+def test_pytest_configure_rejects_dev_ui_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OMNIGENT_E2E_ALLOW_DEV_BASE_URL", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    with pytest.raises(pytest.UsageError, match="Refusing --ui-base-url"):
+        pytest_configure(
+            _ConfigStub({"--ui-base-url": "http://127.0.0.1:5173", "--headed": False})
+        )


### PR DESCRIPTION
## Summary

Behavior-changing hardening for `tests/e2e_ui`:

- Refuses `--ui-base-url` values that target known dev ports (`5173`, `6767`, `8000`) or local/private dev hosts by default.
- Keeps `--ui-base-url` available with an explicit local-debug escape hatch: `OMNIGENT_E2E_ALLOW_DEV_BASE_URL=1`.
- Fails fast when `--headed` is requested in CI and makes headless/fresh-context intent explicit for pytest-playwright.
- Leaves the default pytest lane unchanged; `tests/e2e_ui` remains opt-in via the existing `--ignore` addopts.

## Behavior Change

This intentionally stops e2e UI runs from silently attaching to a developer's long-lived Vite/Omnigent server and sharing its database, artifacts, runner state, or browser window. Developers who intentionally want that unsafe local-debug mode can opt in with:

```bash
OMNIGENT_E2E_ALLOW_DEV_BASE_URL=1 uv run pytest tests/e2e_ui --ui-base-url http://127.0.0.1:5173
```

## Verification

```text
$ uv run ruff format --check tests/e2e_ui/conftest.py tests/e2e_ui/url_safety.py tests/test_e2e_ui_url_safety.py
3 files already formatted

$ uv run ruff check tests/e2e_ui/conftest.py tests/e2e_ui/url_safety.py tests/test_e2e_ui_url_safety.py
All checks passed!

$ uv run python -c 'import ast,sys; ast.parse(open("tests/e2e_ui/conftest.py").read())'
# passed with no output

$ uv run pytest tests/test_e2e_ui_url_safety.py -q
Running 9 items in this shard
.........                                                                [100%]
9 passed, 1 warning in 0.05s

$ uv run pytest tests/e2e_ui --collect-only -q
Running 96 items in this shard
96 tests collected in 0.13s

$ uvx pyrefly check tests/e2e_ui/conftest.py tests/e2e_ui/url_safety.py tests/test_e2e_ui_url_safety.py
INFO 0 errors
```

Additional fail-fast smokes:

```text
$ uv run pytest tests/e2e_ui --collect-only -q --ui-base-url http://127.0.0.1:5173
ERROR: Refusing --ui-base-url='http://127.0.0.1:5173': port 5173 is a known Omnigent/Vite dev port. Reusing a dev or production-like server is unsafe because e2e UI tests share that server's database, artifacts, and runner state. Omit --ui-base-url to let the fixture spawn an isolated server on a random port. If you intentionally want to reuse this server for local debugging, set OMNIGENT_E2E_ALLOW_DEV_BASE_URL=1. Refused dev ports: 5173, 6767, 8000.

$ CI=1 uv run pytest tests/e2e_ui --collect-only -q --headed
ERROR: tests/e2e_ui must run headless in CI. Remove --headed; headed browser windows are only allowed for local debugging.
```
