### PR TITLE
ci(merge-ready): hint to apply `e2e-approved` on unlabeled fork PRs

### DIFF
--- a/.github/scripts/merge-ready/compute-gate.sh
+++ b/.github/scripts/merge-ready/compute-gate.sh
@@ -12,7 +12,7 @@
 #   success  | success  | CI green on its own merits
 #   failure  | failure  | CI red
 #
-# Env in: EVAL, FAILED
+# Env in: EVAL, FAILED, FORK_NEEDS_E2E_LABEL (optional, default false)
 # Out:    state, short_desc, long_desc on $GITHUB_OUTPUT
 
 set -euo pipefail
@@ -25,6 +25,16 @@ else
   STATE=failure
   SHORT="Required checks not all green"
   LONG=$':hourglass: gate not green yet. Required checks not satisfied:\n\n'"$FAILED"$'\nThe merge will fire once these turn green.'
+fi
+
+# Fork PRs never run e2e on their own: the fork `pull_request` run resolves to
+# an empty shard matrix, so the suite only runs once a maintainer applies the
+# `e2e-approved` label (which mirrors the head to a trusted fork-e2e/** branch).
+# Without it the e2e checks are satisfied-via-skip and the PR can go green with
+# e2e never having executed -- so nudge a maintainer to apply the label. Appended
+# to the comment only (long_desc); short_desc is the 140-char commit status.
+if [[ "${FORK_NEEDS_E2E_LABEL:-false}" == "true" ]]; then
+  LONG="$LONG"$'\n\n:information_source: e2e tests do not run automatically on fork PRs. A maintainer can apply the `e2e-approved` label to run the full e2e suite against this PR.'
 fi
 
 # GitHub commit-status descriptions max out at 140 chars.

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -186,11 +186,22 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ steps.ctx.outputs.pr }}
         run: |
-          NAMES=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+          INFO=$(gh pr view "$PR" --repo "$REPO" --json labels,isCrossRepository)
+          NAMES=$(echo "$INFO" | jq -r '.labels[].name')
           if echo "$NAMES" | grep -qx "automerge"; then
             echo "automerge=true" >> "$GITHUB_OUTPUT"
           else
             echo "automerge=false" >> "$GITHUB_OUTPUT"
+          fi
+          # A fork PR without the maintainer-only `e2e-approved` label never
+          # runs e2e (the fork pull_request run is an empty matrix), so the gate
+          # message nudges a maintainer to apply it. Same-repo PRs run e2e with
+          # secrets directly and need no label.
+          if [[ "$(echo "$INFO" | jq -r '.isCrossRepository')" == "true" ]] \
+             && ! echo "$NAMES" | grep -qx "e2e-approved"; then
+            echo "fork_needs_e2e_label=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fork_needs_e2e_label=false" >> "$GITHUB_OUTPUT"
           fi
 
       # post_red gates posting a red status: /merge needs it, automerge opts
@@ -230,6 +241,7 @@ jobs:
         env:
           EVAL: ${{ steps.eval.outcome }}
           FAILED: ${{ steps.eval.outputs.failed }}
+          FORK_NEEDS_E2E_LABEL: ${{ steps.labels.outputs.fork_needs_e2e_label }}
         run: bash .github/scripts/merge-ready/compute-gate.sh
 
       # Skipped when post_red is false AND gate is red: leaves prior

--- a/tests/scripts/test_merge_ready_compute_gate.py
+++ b/tests/scripts/test_merge_ready_compute_gate.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github/scripts/merge-ready/compute-gate.sh"
+
+# A representative FAILED bullet list, the shape evaluate-checks.sh emits.
+FAILED = "- `E2E Tests (shard 0/4)` (still pending or cancelled)\n"
+
+# The hint sentinel -- the maintainer-only label name appears only in the nudge.
+HINT_MARKER = "e2e-approved"
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    eval_outcome: str = "failure",
+    failed: str = FAILED,
+    fork_needs_e2e_label: str | None = None,
+) -> dict[str, str]:
+    """Run compute-gate.sh with the given env and parse its GITHUB_OUTPUT.
+
+    The script makes no ``gh`` calls -- it is a pure function of its env -- so we
+    just set the inputs and read back ``state`` / ``short_desc`` / ``long_desc``.
+
+    :param fork_needs_e2e_label: when ``None`` the var is left unset entirely, to
+        exercise the ``${FORK_NEEDS_E2E_LABEL:-false}`` default (back-compat).
+    """
+    out_file = tmp_path / "gh_output"
+    out_file.touch()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVAL": eval_outcome,
+            "FAILED": failed,
+            "GITHUB_OUTPUT": str(out_file),
+        }
+    )
+    if fork_needs_e2e_label is not None:
+        env["FORK_NEEDS_E2E_LABEL"] = fork_needs_e2e_label
+    else:
+        # Drop any ambient value so the None case deterministically exercises
+        # the script's `:-false` default (os.environ.copy() could inherit it).
+        env.pop("FORK_NEEDS_E2E_LABEL", None)
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"script failed: {proc.stderr}"
+    return _parse_github_output(out_file.read_text())
+
+
+def _parse_github_output(text: str) -> dict[str, str]:
+    """Parse GITHUB_OUTPUT, honoring both ``k=v`` and ``k<<DELIM ... DELIM``."""
+    out: dict[str, str] = {}
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "<<" in line and "=" not in line.split("<<", 1)[0]:
+            key, _, delim = line.partition("<<")
+            body: list[str] = []
+            i += 1
+            while i < len(lines) and lines[i] != delim:
+                body.append(lines[i])
+                i += 1
+            out[key] = "\n".join(body)
+        elif "=" in line:
+            key, _, value = line.partition("=")
+            out[key] = value
+        i += 1
+    return out
+
+
+def test_green_gate_has_no_hint_for_same_repo(tmp_path: Path) -> None:
+    """A green same-repo gate is unchanged: success, no e2e-label nudge."""
+    out = _run(tmp_path, eval_outcome="success", fork_needs_e2e_label="false")
+    assert out["state"] == "success"
+    assert "merging now" in out["long_desc"]
+    assert HINT_MARKER not in out["long_desc"]
+
+
+def test_red_gate_has_no_hint_for_same_repo(tmp_path: Path) -> None:
+    """A red same-repo gate lists failures but adds no e2e-label nudge."""
+    out = _run(tmp_path, eval_outcome="failure", fork_needs_e2e_label="false")
+    assert out["state"] == "failure"
+    assert "gate not green yet" in out["long_desc"]
+    assert HINT_MARKER not in out["long_desc"]
+
+
+def test_red_gate_on_fork_without_label_adds_hint(tmp_path: Path) -> None:
+    """A fork PR missing the label gets the apply-`e2e-approved` nudge appended.
+
+    The failure prose still comes first; the hint is an extra paragraph so the
+    contributor/maintainer sees both what's blocking and how to run e2e.
+    """
+    out = _run(tmp_path, eval_outcome="failure", fork_needs_e2e_label="true")
+    assert out["state"] == "failure"
+    assert "gate not green yet" in out["long_desc"]
+    assert HINT_MARKER in out["long_desc"]
+    assert "do not run automatically on fork PRs" in out["long_desc"]
+
+
+def test_green_gate_on_fork_without_label_adds_hint(tmp_path: Path) -> None:
+    """Even a green fork gate carries the hint: green means e2e was skipped,
+    not that it ran, so the caveat still matters before merge."""
+    out = _run(tmp_path, eval_outcome="success", fork_needs_e2e_label="true")
+    assert out["state"] == "success"
+    assert "merging now" in out["long_desc"]
+    assert HINT_MARKER in out["long_desc"]
+
+
+def test_short_desc_never_carries_hint(tmp_path: Path) -> None:
+    """The hint is comment-only; the 140-char commit status stays clean."""
+    out = _run(tmp_path, eval_outcome="failure", fork_needs_e2e_label="true")
+    assert HINT_MARKER not in out["short_desc"]
+    assert len(out["short_desc"]) <= 140
+
+
+def test_fork_label_var_unset_defaults_to_no_hint(tmp_path: Path) -> None:
+    """With FORK_NEEDS_E2E_LABEL unset, the script defaults to no hint (the
+    ``:-false`` fallback keeps it safe under ``set -u``)."""
+    out = _run(tmp_path, eval_outcome="failure", fork_needs_e2e_label=None)
+    assert out["state"] == "failure"
+    assert HINT_MARKER not in out["long_desc"]


### PR DESCRIPTION
## What

When the Merge Ready gate posts its status comment for a **fork PR that is missing the `e2e-approved` label**, it now appends a one-line nudge telling a maintainer they can apply the label to run the full e2e suite.

> :information_source: e2e tests do not run automatically on fork PRs. A maintainer can apply the `e2e-approved` label to run the full e2e suite against this PR.

## Why

Fork PRs never run e2e on their own: the fork `pull_request` run resolves to an empty shard matrix, so the suite only runs once a maintainer applies the maintainer-only `e2e-approved` label (which mirrors the head to a trusted `fork-e2e/**` branch where secrets flow — see `should-mirror.sh`). Without the label, the e2e checks are *satisfied-via-skip* in `evaluate-checks.sh`, so a fork PR can go green and merge with e2e never having executed — and nothing in the gate message tells a maintainer they can opt in.

This came up on #364: the `/merge` reply listed the e2e shards as not-yet-satisfied, but there was no hint about the `e2e-approved` mechanism.

## How

- **`.github/workflows/merge-ready.yml`** — the existing "Read PR labels" step now also reads `isCrossRepository` and emits `fork_needs_e2e_label=true` when the PR is a fork **and** lacks `e2e-approved`; the flag is passed to the gate computation. Same-repo PRs run e2e with secrets directly, so they never get the hint.
- **`.github/scripts/merge-ready/compute-gate.sh`** — when the flag is set, appends the hint to the gate **comment body** (`long_desc`), which flows into the `/merge` reply via `enable-automerge-comment.sh`. The 140-char commit-status `short_desc` is left untouched.

The hint is appended on both the green and red gate messages for an unlabeled fork PR — green means e2e was *skipped*, not that it ran, so the caveat still matters before merge.

## Tests

- **`tests/scripts/test_merge_ready_compute_gate.py`** (new) — runs `compute-gate.sh` as a pure function of its env and asserts the hint behavior across fork/same-repo × green/red, that `short_desc` never carries the hint (140-char limit), and that an unset `FORK_NEEDS_E2E_LABEL` defaults to no hint (back-compat under `set -u`).

`uv run pytest tests/scripts/test_merge_ready_compute_gate.py tests/scripts/test_fork_e2e_should_mirror.py` → 13 passed. `ruff format`/`ruff check` clean; `merge-ready.yml` validated as YAML.