### PR TITLE
test: verify auto-assign reviewer routing (please ignore, will close)

### DIFF
--- a/deploy/AUTOASSIGN_TEST.md
+++ b/deploy/AUTOASSIGN_TEST.md
@@ -1,0 +1,4 @@
+# Auto-assign reviewer test
+
+Throwaway file to exercise `.github/workflows/auto-assign-reviewer.yml`.
+This PR is a test of reviewer routing and will be closed.


### PR DESCRIPTION
Dummy PR to test the merged `Auto-assign Reviewer` workflow (#473). Touches `/deploy/` so it should end with exactly 2 of its CODEOWNERS requested (native CODEOWNERS requests all 4, the action trims to the 2 lowest-load). Will be closed after verification.