### PR TITLE
ci: fork-only reviewer auto-assignment (2 reviewers, non-maintainer)

### DIFF
--- a/.github/reviewers
+++ b/.github/reviewers
@@ -1,0 +1,51 @@
+# Reviewer routing map -- area -> candidate reviewers.
+#
+# This is NOT a GitHub CODEOWNERS file. It deliberately lives at .github/reviewers
+# (a non-magic path) so GitHub's native CODEOWNERS feature does NOT auto-request
+# reviewers. All assignment is driven by .github/workflows/auto-assign-reviewer.yml,
+# which:
+#   - runs ONLY on fork PRs authored by a non-maintainer, and
+#   - assigns EXACTLY 2 load-balanced reviewers from the area(s) the PR touches
+#     (falling back to the full set of handles in this file for unowned paths).
+# So the per-area lists below are the CANDIDATE pool per area, not "everyone gets
+# requested". This is routing only -- it does not gate merge (that stays
+# Maintainer Approval + Merge Ready).
+#
+# Syntax is CODEOWNERS-like for familiarity: "<path-prefix>  @handle @handle".
+# Last matching line wins per file. Owners must be maintainers in
+# .github/MAINTAINER. Per-area owners are the top maintainers by COMBINED commit
+# count across both repos (databricks-eng/agent-framework full history +
+# omnigent-ai/omnigent), up to ~4 per area, excluding tree-wide mechanical
+# sweeps (>100 files) and non-maintainer contributors. Worth a periodic
+# sanity-check.
+
+# Repo automation / CI
+/.github/                    @PattaraS @serena-ruan @dhruv0811 @TomeHirata
+
+# Web UI
+/ap-web/                     @SabhyaC26 @serena-ruan @daniellok-db @hzub
+
+# Core agent runtime & harnesses
+/omnigent/inner/             @SabhyaC26 @TomeHirata @dhruv0811 @dbczumar
+/omnigent/runner/            @SabhyaC26 @TomeHirata @serena-ruan @fanzeyi
+/omnigent/runtime/           @TomeHirata @SabhyaC26 @dhruv0811 @ckcuslife-source
+/omnigent/server/            @dbczumar @dhruv0811 @ckcuslife-source @TomeHirata
+/omnigent/onboarding/        @SabhyaC26 @fanzeyi @dhruv0811 @bbqiu
+/omnigent/policies/          @TomeHirata @dhruv0811 @ckcuslife-source
+/omnigent/spec/              @SabhyaC26 @dhruv0811 @ckcuslife-source
+/omnigent/llms/              @PattaraS @ckcuslife-source
+/omnigent/host/              @fanzeyi @dhruv0811 @dbczumar
+/omnigent/sandbox/           @SabhyaC26
+/omnigent/db/                @fanzeyi @SabhyaC26
+/omnigent/stores/            @serena-ruan @TomeHirata @fanzeyi
+/omnigent/terminals/         @dbczumar @Edwinhe03 @fanzeyi
+/omnigent/tools/             @dbczumar @PattaraS @TomeHirata
+/omnigent/entities/          @daniellok-db @TomeHirata
+/omnigent/repl/              @dhruv0811 @dbczumar
+/omnigent/resources/         @fanzeyi @serena-ruan
+
+# Deploy targets
+/deploy/                     @dhruv0811 @PattaraS @dbczumar @SabhyaC26
+
+# Python / UI SDKs
+/sdks/                       @dbczumar @fanzeyi @SabhyaC26 @TomeHirata

--- a/.github/workflows/auto-assign-reviewer-test.yml
+++ b/.github/workflows/auto-assign-reviewer-test.yml
@@ -1,0 +1,34 @@
+name: Auto-assign Reviewer Test
+
+# Offline unit test for the reviewer-assignment logic: runs
+# auto-assign-reviewer.test.js (mocked GitHub client, real .github/reviewers +
+# .github/MAINTAINER). Triggers only when the assigner, its test, the reviewers
+# map, or the maintainer list change. Runs on `pull_request` (PR head checkout)
+# so it tests the PR's own version. No secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/auto-assign-reviewer.js
+      - .github/workflows/auto-assign-reviewer.test.js
+      - .github/reviewers
+      - .github/MAINTAINER
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-assign-reviewer-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run reviewer-assignment unit test
+        run: node .github/workflows/auto-assign-reviewer.test.js

--- a/.github/workflows/auto-assign-reviewer-test.yml
+++ b/.github/workflows/auto-assign-reviewer-test.yml
@@ -2,8 +2,8 @@ name: Auto-assign Reviewer Test
 
 # Offline unit test for the reviewer-assignment logic: runs
 # auto-assign-reviewer.test.js (mocked GitHub client, real .github/reviewers +
-# .github/MAINTAINER). Triggers only when the assigner, its test, the reviewers
-# map, or the maintainer list change. Runs on `pull_request` (PR head checkout)
+# .github/MAINTAINER). Triggers only when the assigner, its test, or the
+# reviewers map change. Runs on `pull_request` (PR head checkout)
 # so it tests the PR's own version. No secrets, no network.
 
 on:
@@ -12,7 +12,6 @@ on:
       - .github/workflows/auto-assign-reviewer.js
       - .github/workflows/auto-assign-reviewer.test.js
       - .github/reviewers
-      - .github/MAINTAINER
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -1,0 +1,167 @@
+// Repo-level reviewer assignment: assign EXACTLY 2 load-balanced reviewers to
+// FORK PRs authored by a NON-maintainer, preferring the owners of the area(s)
+// the PR touches.
+//
+// Ownership comes from .github/reviewers (a custom, non-magic path -- NOT
+// .github/CODEOWNERS -- so GitHub's native CODEOWNERS auto-request never fires;
+// this action is the sole assigner). The candidate pool is the union of owners
+// for the PR's changed files; if the PR touches no listed path, it falls back to
+// the full set of handles in the file. Maintainers not listed there are never in
+// rotation.
+//
+// Scope guard (skipped only for dryRun, which just logs): assignment runs only
+// when the PR is from a fork AND the author is not in .github/MAINTAINER --
+// non-fork / collaborator / maintainer PRs are left alone (authors pick their
+// own reviewers).
+//
+// "Balance in general": picks are the candidates with the fewest CURRENTLY open
+// review requests across the repo (random tie-break) -- stateless fairness.
+//
+// Only handles drawn from .github/reviewers are ever removed when reconciling,
+// so a manually-added reviewer outside that set is left untouched.
+//
+// `dryRun` (set when the workflow runs on a `pull_request` that edits this
+// script) logs the picks instead of mutating reviewers -- a live smoke test.
+module.exports = async ({ github, context, core, dryRun = false }) => {
+  const fs = require("fs");
+  const TARGET = 2;
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+  if (!pr || pr.draft) {
+    core.info("No PR or draft; nothing to do.");
+    return;
+  }
+  const author = (pr.user && pr.user.login ? pr.user.login : "").toLowerCase();
+
+  // --- Scope guard: fork PRs from non-maintainers only. Skipped for dryRun
+  // (the smoke test exercises the selection logic on a same-repo PR).
+  if (!dryRun) {
+    const isFork = !!(pr.head && pr.head.repo && pr.head.repo.fork);
+    if (!isFork) {
+      core.info("Not a fork PR; skipping (reviewer auto-assignment is fork-only).");
+      return;
+    }
+    let authorIsMaintainer = false;
+    try {
+      const m = fs.readFileSync(".github/MAINTAINER", "utf8");
+      const maint = new Set(
+        m.split("\n").map((l) => l.replace(/#.*/, "").trim().toLowerCase()).filter(Boolean)
+      );
+      authorIsMaintainer = maint.has(author);
+    } catch (e) {
+      core.warning("Could not read .github/MAINTAINER; proceeding without the maintainer check.");
+    }
+    if (authorIsMaintainer) {
+      core.info(`Author @${author} is a maintainer; skipping (fork PRs from non-maintainers only).`);
+      return;
+    }
+  }
+
+  // --- Parse .github/reviewers into ordered (prefix -> owners) rules + the pool.
+  const text = fs.readFileSync(".github/reviewers", "utf8");
+  const rules = []; // { prefix, owners: [logins] }  (path rules only)
+  const poolSet = new Map(); // lc -> original-case
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line.startsWith("/")) continue;
+    const [pat, ...toks] = line.split(/\s+/);
+    const owners = toks
+      .filter((t) => t.startsWith("@") && !t.includes("/"))
+      .map((t) => t.slice(1));
+    owners.forEach((o) => poolSet.set(o.toLowerCase(), o));
+    // `/dir/` -> match files under `dir/`
+    rules.push({ prefix: pat.replace(/^\//, ""), owners });
+  }
+  const managed = new Set([...poolSet.keys()]); // everyone this action can manage
+
+  // --- Owners of the area(s) this PR touches (last matching rule wins per file).
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+  const areaOwners = new Map(); // lc -> original
+  for (const f of files) {
+    let match = null;
+    for (const r of rules) if (f.filename.startsWith(r.prefix)) match = r; // last wins
+    if (match) match.owners.forEach((o) => areaOwners.set(o.toLowerCase(), o));
+  }
+
+  // Candidates: area owners, else the full pool. Never the author.
+  let candidates = [...(areaOwners.size ? areaOwners : poolSet).values()].filter(
+    (u) => u.toLowerCase() !== author
+  );
+  if (candidates.length === 0) {
+    core.info("No eligible candidates; nothing to do.");
+    return;
+  }
+
+  // --- Global open-review load (stateless fairness signal).
+  const openPRs = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+  const load = new Map();
+  for (const p of openPRs)
+    for (const r of p.requested_reviewers || []) {
+      const l = (r.login || "").toLowerCase();
+      load.set(l, (load.get(l) || 0) + 1);
+    }
+  const loadOf = (u) => load.get(u.toLowerCase()) || 0;
+
+  // Helper: take the N lowest-load from a list, random tie-break within a tier.
+  const takeLowest = (list, n) => {
+    const byTier = {};
+    for (const u of list) (byTier[loadOf(u)] ||= []).push(u);
+    const out = [];
+    for (const k of Object.keys(byTier).map(Number).sort((a, b) => a - b)) {
+      const shuffled = byTier[k]
+        .map((v) => [Math.random(), v])
+        .sort((a, b) => a[0] - b[0])
+        .map(([, v]) => v);
+      for (const u of shuffled) if (out.length < n) out.push(u);
+      if (out.length >= n) break;
+    }
+    return out;
+  };
+
+  // Desired = 2 lowest-load from candidates; top up from the full pool if an
+  // area has fewer than 2 owners.
+  let desired = takeLowest(candidates, TARGET);
+  if (desired.length < TARGET) {
+    const have = new Set(desired.map((u) => u.toLowerCase()).concat(author));
+    const filler = [...poolSet.values()].filter((u) => !have.has(u.toLowerCase()));
+    desired = desired.concat(takeLowest(filler, TARGET - desired.length));
+  }
+  const desiredLc = new Set(desired.map((u) => u.toLowerCase()));
+
+  // --- Reconcile current requested reviewers to exactly `desired`. With native
+  // CODEOWNERS gone there is normally nothing pre-requested, but on a reopened
+  // PR (or after a manual add) this keeps the set at the 2 balanced picks.
+  const current = (pr.requested_reviewers || []).map((r) => r.login);
+  const currentLc = new Set(current.map((c) => c.toLowerCase()));
+  const toAdd = desired.filter((u) => !currentLc.has(u.toLowerCase()));
+  // Only remove handles this action manages -- never a human added from outside
+  // the reviewers file.
+  const toRemove = current.filter(
+    (u) => managed.has(u.toLowerCase()) && !desiredLc.has(u.toLowerCase())
+  );
+
+  if (toAdd.length && !dryRun) {
+    await github.rest.pulls.requestReviewers({
+      owner, repo, pull_number: pr.number, reviewers: toAdd,
+    });
+  }
+  if (toRemove.length && !dryRun) {
+    await github.rest.pulls.removeRequestedReviewers({
+      owner, repo, pull_number: pr.number, reviewers: toRemove,
+    });
+  }
+  core.info(
+    `${dryRun ? "[DRY RUN] " : ""}Reviewers -> [${desired.join(", ")}]` +
+      ` (area pool ${areaOwners.size || "∅→full"}, +${toAdd.length}/-${toRemove.length}).`
+  );
+};

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -9,20 +9,17 @@
 // the full set of handles in the file. Maintainers not listed there are never in
 // rotation.
 //
-// Scope guard (skipped only for dryRun, which just logs): assignment runs only
-// when the PR is from a fork AND the author is not in .github/MAINTAINER --
-// non-fork / collaborator / maintainer PRs are left alone (authors pick their
-// own reviewers).
+// Scope guard: assignment runs only when the PR is from a fork AND the author is
+// not in .github/MAINTAINER. Non-fork / collaborator / maintainer PRs are left
+// alone (authors pick their own reviewers). Fails closed -- if maintainer status
+// can't be determined, it skips rather than risk assigning a maintainer's PR.
 //
 // "Balance in general": picks are the candidates with the fewest CURRENTLY open
 // review requests across the repo (random tie-break) -- stateless fairness.
 //
 // Only handles drawn from .github/reviewers are ever removed when reconciling,
 // so a manually-added reviewer outside that set is left untouched.
-//
-// `dryRun` (set when the workflow runs on a `pull_request` that edits this
-// script) logs the picks instead of mutating reviewers -- a live smoke test.
-module.exports = async ({ github, context, core, dryRun = false }) => {
+module.exports = async ({ github, context, core }) => {
   const fs = require("fs");
   const TARGET = 2;
   const { owner, repo } = context.repo;
@@ -33,28 +30,32 @@ module.exports = async ({ github, context, core, dryRun = false }) => {
   }
   const author = (pr.user && pr.user.login ? pr.user.login : "").toLowerCase();
 
-  // --- Scope guard: fork PRs from non-maintainers only. Skipped for dryRun
-  // (the smoke test exercises the selection logic on a same-repo PR).
-  if (!dryRun) {
-    const isFork = !!(pr.head && pr.head.repo && pr.head.repo.fork);
-    if (!isFork) {
-      core.info("Not a fork PR; skipping (reviewer auto-assignment is fork-only).");
-      return;
-    }
-    let authorIsMaintainer = false;
-    try {
-      const m = fs.readFileSync(".github/MAINTAINER", "utf8");
-      const maint = new Set(
-        m.split("\n").map((l) => l.replace(/#.*/, "").trim().toLowerCase()).filter(Boolean)
-      );
-      authorIsMaintainer = maint.has(author);
-    } catch (e) {
-      core.warning("Could not read .github/MAINTAINER; proceeding without the maintainer check.");
-    }
-    if (authorIsMaintainer) {
-      core.info(`Author @${author} is a maintainer; skipping (fork PRs from non-maintainers only).`);
-      return;
-    }
+  // --- Scope guard: fork PRs from non-maintainers only.
+  // Precise fork test: the head repo differs from the base repo (head.repo.fork
+  // alone means "head repo is a fork of anything", which can false-positive).
+  const isFork = !!(
+    pr.head && pr.head.repo && pr.base && pr.base.repo &&
+    pr.head.repo.full_name !== pr.base.repo.full_name
+  );
+  if (!isFork) {
+    core.info("Not a fork PR; skipping (reviewer auto-assignment is fork-only).");
+    return;
+  }
+  let maint;
+  try {
+    const m = fs.readFileSync(".github/MAINTAINER", "utf8");
+    maint = new Set(
+      m.split("\n").map((l) => l.replace(/#.*/, "").trim().toLowerCase()).filter(Boolean)
+    );
+  } catch (e) {
+    // Fail closed: can't verify maintainer status -> don't risk assigning a
+    // maintainer-authored PR.
+    core.warning("Could not read .github/MAINTAINER; skipping to stay fail-closed.");
+    return;
+  }
+  if (maint.has(author)) {
+    core.info(`Author @${author} is a maintainer; skipping (fork PRs from non-maintainers only).`);
+    return;
   }
 
   // --- Parse .github/reviewers into ordered (prefix -> owners) rules + the pool.
@@ -74,7 +75,8 @@ module.exports = async ({ github, context, core, dryRun = false }) => {
   }
   const managed = new Set([...poolSet.keys()]); // everyone this action can manage
 
-  // --- Owners of the area(s) this PR touches (last matching rule wins per file).
+  // --- Owners of the area(s) this PR touches (last matching rule wins per file,
+  // unioned across all changed files).
   const files = await github.paginate(github.rest.pulls.listFiles, {
     owner,
     repo,
@@ -138,9 +140,9 @@ module.exports = async ({ github, context, core, dryRun = false }) => {
   }
   const desiredLc = new Set(desired.map((u) => u.toLowerCase()));
 
-  // --- Reconcile current requested reviewers to exactly `desired`. With native
-  // CODEOWNERS gone there is normally nothing pre-requested, but on a reopened
-  // PR (or after a manual add) this keeps the set at the 2 balanced picks.
+  // --- Reconcile current requested reviewers to exactly `desired`. Normally
+  // nothing is pre-requested, but on a reopened PR (or after a manual add) this
+  // keeps the set at the 2 balanced picks.
   const current = (pr.requested_reviewers || []).map((r) => r.login);
   const currentLc = new Set(current.map((c) => c.toLowerCase()));
   const toAdd = desired.filter((u) => !currentLc.has(u.toLowerCase()));
@@ -150,18 +152,18 @@ module.exports = async ({ github, context, core, dryRun = false }) => {
     (u) => managed.has(u.toLowerCase()) && !desiredLc.has(u.toLowerCase())
   );
 
-  if (toAdd.length && !dryRun) {
+  if (toAdd.length) {
     await github.rest.pulls.requestReviewers({
       owner, repo, pull_number: pr.number, reviewers: toAdd,
     });
   }
-  if (toRemove.length && !dryRun) {
+  if (toRemove.length) {
     await github.rest.pulls.removeRequestedReviewers({
       owner, repo, pull_number: pr.number, reviewers: toRemove,
     });
   }
   core.info(
-    `${dryRun ? "[DRY RUN] " : ""}Reviewers -> [${desired.join(", ")}]` +
+    `Reviewers -> [${desired.join(", ")}]` +
       ` (area pool ${areaOwners.size || "∅→full"}, +${toAdd.length}/-${toRemove.length}).`
   );
 };

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -34,7 +34,9 @@ async function run({ files, load = {}, current = [], author = "someexternaldev",
     payload: { pull_request: {
       number: 1, draft: false,
       user: { login: author },
-      head: { repo: { fork } },
+      // precise fork detection compares head vs base full_name
+      head: { repo: { full_name: fork ? "external-contributor/omnigent" : "omnigent-ai/omnigent" } },
+      base: { repo: { full_name: "omnigent-ai/omnigent" } },
       requested_reviewers: current.map((l) => ({ login: l })),
     } },
   };
@@ -81,19 +83,43 @@ function assert(name, cond, detail) {
     JSON.stringify(r.removed) === JSON.stringify(["SabhyaC26", "TomeHirata"]) && r.added.length === 0,
     JSON.stringify(r));
 
-  // 5. external human reviewer (outside pool) is never removed.
+  // 5. mixed current: a managed reviewer not in `desired` is removed, while an
+  //    external (unmanaged) reviewer in the same call is preserved.
   r = await run({
     files: ["omnigent/inner/foo.py"],
     load: { dhruv0811: 0, dbczumar: 1, SabhyaC26: 5, TomeHirata: 4 },
-    current: ["dhruv0811", "dbczumar", "some-external-human"],
+    current: ["SabhyaC26", "some-external-human"],
   });
-  assert("external reviewer preserved", !r.removed.includes("some-external-human"), JSON.stringify(r));
+  assert("mixed: managed removed, external preserved",
+    r.removed.includes("SabhyaC26") &&
+    !r.removed.includes("some-external-human") &&
+    JSON.stringify(r.added) === JSON.stringify(["dbczumar", "dhruv0811"]),
+    JSON.stringify(r));
 
-  // 6. scope guard: non-fork PR -> nothing assigned.
+  // 6. single-owner area (sandbox -> @SabhyaC26): tops up to 2 from the pool.
+  r = await run({
+    files: ["omnigent/sandbox/x.py"],
+    load: { SabhyaC26: 0, hzub: 0, dhruv0811: 9, dbczumar: 9, TomeHirata: 9, PattaraS: 9,
+            "serena-ruan": 9, "daniellok-db": 9, fanzeyi: 9, "ckcuslife-source": 9, bbqiu: 9, Edwinhe03: 9 },
+  });
+  assert("single-owner area tops up to 2",
+    r.added.length === 2 && r.added.includes("SabhyaC26"), JSON.stringify(r));
+
+  // 7. multi-area PR (inner + tools): candidate pool is the UNION; a tools-only
+  //    owner (PattaraS) and an inner owner (dhruv0811) can both be picked.
+  r = await run({
+    files: ["omnigent/inner/a.py", "omnigent/tools/b.py"],
+    load: { SabhyaC26: 9, TomeHirata: 9, dbczumar: 9, PattaraS: 0, dhruv0811: 1 },
+  });
+  assert("multi-area unions both areas' owners",
+    r.added.includes("PattaraS") && r.added.includes("dhruv0811") && r.added.length === 2,
+    JSON.stringify(r));
+
+  // 8. scope guard: non-fork PR -> nothing assigned.
   r = await run({ files: ["omnigent/inner/foo.py"], fork: false });
   assert("non-fork PR is skipped", r.added.length === 0 && r.removed.length === 0, JSON.stringify(r));
 
-  // 7. scope guard: fork PR authored by a maintainer -> nothing assigned.
+  // 9. scope guard: fork PR authored by a maintainer -> nothing assigned.
   r = await run({ files: ["omnigent/inner/foo.py"], author: "dhruv0811" });
   assert("maintainer-authored fork PR is skipped", r.added.length === 0 && r.removed.length === 0, JSON.stringify(r));
 })();

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -1,0 +1,99 @@
+// Local unit test for auto-assign-reviewer.js -- mocks the GitHub client and
+// runs the real decision logic against the real .github/reviewers and
+// .github/MAINTAINER (cwd must be the repo root). No network. Loads are made
+// distinct so picks are deterministic.
+const path = require("path");
+const script = require(path.resolve(".github/workflows/auto-assign-reviewer.js"));
+
+function mkOpenPRs(loadMap) {
+  // one open PR per (reviewer, count) so the script's tally reproduces loadMap
+  const prs = [];
+  for (const [login, n] of Object.entries(loadMap))
+    for (let i = 0; i < n; i++) prs.push({ requested_reviewers: [{ login }] });
+  return prs;
+}
+
+// author defaults to a non-maintainer; fork defaults to true -- so the scope
+// guard passes and the selection logic runs (the cases that assert on picks).
+async function run({ files, load = {}, current = [], author = "someexternaldev", fork = true }) {
+  const listFiles = () => {}; listFiles._tag = "files";
+  const list = () => {}; list._tag = "open";
+  const added = [], removed = [];
+  const github = {
+    paginate: async (fn) => (fn._tag === "files"
+      ? files.map((f) => ({ filename: f }))
+      : mkOpenPRs(load)),
+    rest: { pulls: {
+      listFiles, list,
+      requestReviewers: async ({ reviewers }) => added.push(...reviewers),
+      removeRequestedReviewers: async ({ reviewers }) => removed.push(...reviewers),
+    } },
+  };
+  const context = {
+    repo: { owner: "omnigent-ai", repo: "omnigent" },
+    payload: { pull_request: {
+      number: 1, draft: false,
+      user: { login: author },
+      head: { repo: { fork } },
+      requested_reviewers: current.map((l) => ({ login: l })),
+    } },
+  };
+  const core = { info: () => {}, warning: (m) => console.log("WARN", m) };
+  await script({ github, context, core });
+  return { added: added.sort(), removed: removed.sort() };
+}
+
+function assert(name, cond, detail) {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+}
+
+(async () => {
+  // 1. inner PR: owners SabhyaC26,TomeHirata,dhruv0811,dbczumar. Loads make the
+  //    two lowest deterministic: dhruv0811(0), dbczumar(1) win.
+  let r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+  });
+  assert("inner picks 2 lowest-load owners", JSON.stringify(r.added) === JSON.stringify(["dbczumar", "dhruv0811"]), JSON.stringify(r));
+
+  // 2. unowned path -> full pool; lowest two by load chosen.
+  r = await run({
+    files: ["README.md"],
+    load: { PattaraS: 9, "serena-ruan": 9, dhruv0811: 9, TomeHirata: 9, SabhyaC26: 9,
+            "daniellok-db": 9, hzub: 0, dbczumar: 1, fanzeyi: 9, "ckcuslife-source": 9,
+            bbqiu: 9, Edwinhe03: 9 },
+  });
+  assert("unowned -> 2 lowest from full pool", JSON.stringify(r.added) === JSON.stringify(["dbczumar", "hzub"]), JSON.stringify(r));
+
+  // 3. db has only 2 owners (fanzeyi, SabhyaC26) -> both selected.
+  r = await run({ files: ["omnigent/db/x.py"], load: {} });
+  assert("db (2 owners) -> both", JSON.stringify(r.added) === JSON.stringify(["SabhyaC26", "fanzeyi"]), JSON.stringify(r));
+
+  // 4. reconcile: all 4 inner owners already requested; keep 2 lowest-load,
+  //    remove the other 2.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
+    current: ["SabhyaC26", "TomeHirata", "dhruv0811", "dbczumar"],
+  });
+  assert("reconcile removes the 2 highest-load already-requested",
+    JSON.stringify(r.removed) === JSON.stringify(["SabhyaC26", "TomeHirata"]) && r.added.length === 0,
+    JSON.stringify(r));
+
+  // 5. external human reviewer (outside pool) is never removed.
+  r = await run({
+    files: ["omnigent/inner/foo.py"],
+    load: { dhruv0811: 0, dbczumar: 1, SabhyaC26: 5, TomeHirata: 4 },
+    current: ["dhruv0811", "dbczumar", "some-external-human"],
+  });
+  assert("external reviewer preserved", !r.removed.includes("some-external-human"), JSON.stringify(r));
+
+  // 6. scope guard: non-fork PR -> nothing assigned.
+  r = await run({ files: ["omnigent/inner/foo.py"], fork: false });
+  assert("non-fork PR is skipped", r.added.length === 0 && r.removed.length === 0, JSON.stringify(r));
+
+  // 7. scope guard: fork PR authored by a maintainer -> nothing assigned.
+  r = await run({ files: ["omnigent/inner/foo.py"], author: "dhruv0811" });
+  assert("maintainer-authored fork PR is skipped", r.added.length === 0 && r.removed.length === 0, JSON.stringify(r));
+})();

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -12,54 +12,40 @@ name: Auto-assign Reviewer
 # pull_request token is read-only). Safe: it checks out only the trusted default
 # branch (.github), never PR head, and runs no PR code -- it reads .github/
 # reviewers + .github/MAINTAINER + the changed-file list and calls the reviewers
-# API.
+# API. The offline unit test (auto-assign-reviewer.test.js) covers the logic.
 
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
-  # Smoke test: when a PR edits this assigner, run it against the PR's OWN
-  # version in DRY-RUN (logs picks, mutates nothing). The companion unit test
-  # (auto-assign-reviewer.test.js) covers the logic offline.
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - .github/workflows/auto-assign-reviewer.yml
-      - .github/workflows/auto-assign-reviewer.js
 
 permissions:
   contents: read
 
 concurrency:
   group: auto-assign-reviewer-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   assign:
-    # Real runs only spin up for fork PRs; the dry-run (pull_request event on an
-    # assigner edit) always runs. The author-is-maintainer check needs the
-    # MAINTAINER file, so it lives in the script.
+    # Fork PRs only (precise: head repo differs from this repo). The
+    # author-is-maintainer half of the guard needs the MAINTAINER file, so it
+    # lives in the script.
     if: >-
       github.repository == 'omnigent-ai/omnigent'
       && !github.event.pull_request.draft
       && !endsWith(github.actor, '[bot]')
-      && (
-        github.event.pull_request.head.repo.fork
-        || github.event_name == 'pull_request'
-      )
+      && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       pull-requests: write   # request reviewers
     steps:
-      # Real runs (pull_request_target): check out the TRUSTED default branch.
-      # Dry-run smoke test (pull_request): check out the PR head so we exercise
-      # the PR's own version of the script. (pull_request gets a read-only token
-      # and no secrets, and dry-run mutates nothing -- so running the PR's
-      # script here is safe.)
+      # Trusted default branch only (.github sparse). Never the PR head, so no
+      # PR-authored code runs.
       - name: Check out .github
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.repository.default_branch }}
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github
           persist-credentials: false
       - name: Assign 2 balanced reviewers from the .github/reviewers pool
@@ -68,4 +54,4 @@ jobs:
           retries: 3
           script: |
             const script = require('./.github/workflows/auto-assign-reviewer.js');
-            await script({ github, context, core, dryRun: context.eventName === 'pull_request' });
+            await script({ github, context, core });

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,0 +1,71 @@
+name: Auto-assign Reviewer
+
+# Repo-level reviewer assignment: assign EXACTLY 2 load-balanced reviewers to
+# FORK PRs authored by a non-maintainer, preferring the owners of the area(s) the
+# PR touches. No org team required. Ownership is read from .github/reviewers at
+# runtime -- a custom, non-magic path (NOT .github/CODEOWNERS), so GitHub's
+# native CODEOWNERS auto-request never fires and this action is the sole
+# assigner. Non-fork / collaborator / maintainer PRs are left alone.
+# See auto-assign-reviewer.js.
+#
+# pull_request_target so it can manage reviewers on fork PRs (a fork's
+# pull_request token is read-only). Safe: it checks out only the trusted default
+# branch (.github), never PR head, and runs no PR code -- it reads .github/
+# reviewers + .github/MAINTAINER + the changed-file list and calls the reviewers
+# API.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+  # Smoke test: when a PR edits this assigner, run it against the PR's OWN
+  # version in DRY-RUN (logs picks, mutates nothing). The companion unit test
+  # (auto-assign-reviewer.test.js) covers the logic offline.
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - .github/workflows/auto-assign-reviewer.yml
+      - .github/workflows/auto-assign-reviewer.js
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-assign-reviewer-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    # Real runs only spin up for fork PRs; the dry-run (pull_request event on an
+    # assigner edit) always runs. The author-is-maintainer check needs the
+    # MAINTAINER file, so it lives in the script.
+    if: >-
+      github.repository == 'omnigent-ai/omnigent'
+      && !github.event.pull_request.draft
+      && !endsWith(github.actor, '[bot]')
+      && (
+        github.event.pull_request.head.repo.fork
+        || github.event_name == 'pull_request'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write   # request reviewers
+    steps:
+      # Real runs (pull_request_target): check out the TRUSTED default branch.
+      # Dry-run smoke test (pull_request): check out the PR head so we exercise
+      # the PR's own version of the script. (pull_request gets a read-only token
+      # and no secrets, and dry-run mutates nothing -- so running the PR's
+      # script here is safe.)
+      - name: Check out .github
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.repository.default_branch }}
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Assign 2 balanced reviewers from the .github/reviewers pool
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/workflows/auto-assign-reviewer.js');
+            await script({ github, context, core, dryRun: context.eventName === 'pull_request' });

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -38,6 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      # Job-level permissions REPLACE the workflow-level block (they don't
+      # merge), so contents:read must be restated here for actions/checkout.
+      contents: read
       pull-requests: write   # request reviewers
     steps:
       # Trusted default branch only (.github sparse). Never the PR head, so no


### PR DESCRIPTION
Reintroduces reviewer routing after the #473 revert (#487), redesigned to fix the issue that surfaced: reviewers were being auto-assigned on **non-fork PRs** too.

## What was wrong before
`.github/CODEOWNERS` is a *magic* path — GitHub's native CODEOWNERS feature auto-requests **all** owners of a touched area on **every** PR (fork or not), the moment it opens. Our action could only react *after* that (trim 4 → 2). So non-fork/collaborator PRs still got auto-assigned, and there was a request-then-trim flicker.

## The fix
- **Ownership moves to `.github/reviewers`** — a non-magic path. Native CODEOWNERS never fires, so this action is the *sole* assigner. (Same area→owner map as before; routing only, never a merge gate.)
- **Scope guard** in `auto-assign-reviewer.js`: assign only when the PR **is from a fork** AND the **author is not in `.github/MAINTAINER`**. Non-fork / collaborator / maintainer PRs are left alone (authors pick their own reviewers).
- Still assigns **exactly 2** load-balanced reviewers from the touched area(s) (full-pool fallback for unowned paths).
- Real runs (`pull_request_target`) only spin up for fork PRs; the dry-run smoke test (`pull_request` on an assigner edit) bypasses the guard to exercise selection logic.

## Tests
`auto-assign-reviewer.test.js` (offline, mocked client, real `.github/reviewers` + `.github/MAINTAINER`) — 7/7 pass, including the two new guard cases:
- non-fork PR → skipped
- maintainer-authored fork PR → skipped

## Safety
`pull_request_target` with **no PR-code checkout** (sparse-checkout of `.github` from the trusted default branch), no secrets — only reads the reviewers map + changed-file list and calls the reviewers API. Same shape as the repo's other `pull_request_target` data-only workflows.