### PR TITLE
fix(ci): short-circuit Security Gate poll when scan is held for first-timers

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -56,6 +56,18 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "Untrusted PR -- waiting for the single 'Security Scan' check on $HEAD_SHA"
+          # First-timer short-circuit. When a first-time contributor's runs are
+          # held behind GitHub's approval gate, Security Scan shows up as a
+          # workflow RUN with conclusion=action_required and NO check-run, so the
+          # poll below never sees it and spins the full ~6 min before failing
+          # open. Detect the held state and proceed now (same fail-open outcome);
+          # the gate re-runs on the next push or e2e-approved label event.
+          held=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&event=pull_request" \
+            --jq '[.workflow_runs[] | select(.name=="Security Scan")] | sort_by(.created_at) | last | .conclusion' 2>/dev/null || echo "")
+          if [ "$held" = "action_required" ]; then
+            echo "::warning::Security Scan is awaiting maintainer approval (action_required); proceeding (fail-open). It will re-gate on the next push or the e2e-approved label event."
+            exit 0
+          fi
           q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
           conclusion=""
           details_url=""


### PR DESCRIPTION
## Problem

On a first-time-contributor fork PR, the two `pull_request_target` gate callers (**Copilot Review Request** and **Fork e2e mirror**) each spin their `Security Gate` job for the full ~6 minutes and then fail open — wasted time on every such PR.

Root cause: a first-timer's `pull_request` workflows (Security Scan among them) are held behind GitHub's native *"approve workflows to run"* gate. The held scan surfaces as a workflow **run** with `conclusion=action_required` and produces **no check-run**. The gate poller in `security-gate.yml` watches `check-runs` by name, so it never sees the held scan and polls until timeout before failing open.

## Fix

Before the poll loop, query the workflow-runs API for the `Security Scan` run on the head SHA. If it's `action_required`, the scan is provably held — proceed immediately (same fail-open outcome, minus the dead wait) with a clear warning. The gate re-runs and consults the real scan on the PR's next push or `e2e-approved` label event, once a maintainer releases the held runs.

No behavior change for trusted authors or PRs where the scan actually runs — the new branch only triggers on `action_required`.

## Verification

- Confirmed against the live held PR #489: the added query returns `action_required`, and that PR has no `Security Scan` check-run (only the workflow run carries the signal).
- YAML parses cleanly.