### PR TITLE
phase1(turns): turn state machine + leased TurnStore (fenced CAS)

### DIFF
--- a/omnigent/runtime/turn_state.py
+++ b/omnigent/runtime/turn_state.py
@@ -1,0 +1,257 @@
+"""
+Pure turn state-machine and failure-taxonomy logic.
+
+This module is the transport-agnostic, DB-agnostic core of Phase 1
+server-authoritative turns (issue #466,
+``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md``). It contains only
+pure functions and constants: the legal status set, the transition
+matrix, the failure taxonomy, the ``WORKER_*``-only routing gate, and
+lease-expiry classification.
+
+It deliberately has **no** database, asyncio, or tunnel dependencies so
+it can be unit-tested exhaustively with a table of cases and reused
+unchanged by both the server dispatch path and the runner-side
+supervisor. The persistence layer that applies these rules under a
+fenced compare-and-set lives in :mod:`omnigent.stores.turn_store`.
+
+Two design rules this module encodes:
+
+1. A client disconnect may only touch ``attached`` / ``last_client_seen``;
+   it can **never** drive a status transition. That is why no transition
+   in :data:`_LEGAL_TRANSITIONS` is keyed to a client event.
+2. Only ``WORKER_*`` failure codes may feed vendor health/routing.
+   :func:`is_worker_attributable` is the single gate, so transport and
+   runner-loss noise can never bench a healthy vendor (the original
+   misdiagnosis behind the incident).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ── Turn statuses ──────────────────────────────────────────────────
+
+#: Turn created and persisted, before it is accepted into a runner queue.
+STATUS_CREATED: Final = "CREATED"
+#: Accepted into a runner queue; awaiting a lease claim.
+STATUS_QUEUED: Final = "QUEUED"
+#: Lease claimed by a runner; work is executing.
+STATUS_RUNNING: Final = "RUNNING"
+#: Cooperative pause requested (Phase 4 forward-compat; unused in Phase 1).
+STATUS_PAUSING: Final = "PAUSING"
+#: Cooperative pause effective (Phase 4 forward-compat; unused in Phase 1).
+STATUS_PAUSED: Final = "PAUSED"
+#: Worker returned a result.
+STATUS_COMPLETED: Final = "COMPLETED"
+#: Worker boot/task error, or lease lost (RUNNER_LOST).
+STATUS_FAILED: Final = "FAILED"
+#: Explicit user/operator abort.
+STATUS_CANCELLED: Final = "CANCELLED"
+
+#: Every legal status value (mirrors the ``ck_turns_status`` CHECK
+#: constraint on the ``turns`` table; keep the two in sync).
+ALL_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        STATUS_CREATED,
+        STATUS_QUEUED,
+        STATUS_RUNNING,
+        STATUS_PAUSING,
+        STATUS_PAUSED,
+        STATUS_COMPLETED,
+        STATUS_FAILED,
+        STATUS_CANCELLED,
+    }
+)
+
+#: Terminal statuses: no outgoing transitions, and excluded from the
+#: ``ux_turns_one_active_per_conversation`` partial-unique index so a
+#: finished turn frees the per-conversation slot.
+TERMINAL_STATUSES: Final[frozenset[str]] = frozenset(
+    {STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLED}
+)
+
+#: Non-terminal statuses that hold the per-conversation active slot.
+#: Mirrors the partial-index predicate; the orphan sweeper considers
+#: only the leased subset (:data:`SWEEPABLE_STATUSES`).
+ACTIVE_STATUSES: Final[frozenset[str]] = ALL_STATUSES - TERMINAL_STATUSES
+
+#: Statuses a runner can hold a live lease in, hence the only ones the
+#: orphan sweeper may transition to ``FAILED(RUNNER_LOST)`` on expiry.
+SWEEPABLE_STATUSES: Final[frozenset[str]] = frozenset({STATUS_RUNNING, STATUS_PAUSING})
+
+
+# ── Legal transitions ──────────────────────────────────────────────
+#
+# Keyed by source status; value is the set of allowed destination
+# statuses. Notably:
+#   * No client event appears here — disconnects touch only liveness
+#     columns, never status (design rule 1).
+#   * The only writer of each transition is documented in the design
+#     doc's state-machine table; this module enforces *legality*, while
+#     :mod:`omnigent.stores.turn_store` enforces *ownership* via fenced
+#     CAS.
+_LEGAL_TRANSITIONS: Final[dict[str, frozenset[str]]] = {
+    STATUS_CREATED: frozenset({STATUS_QUEUED, STATUS_RUNNING, STATUS_CANCELLED}),
+    # CREATED -> RUNNING covers the interactive/attach dispatch that
+    # claims a lease without an intermediate queue hop.
+    STATUS_QUEUED: frozenset({STATUS_RUNNING, STATUS_CANCELLED}),
+    STATUS_RUNNING: frozenset({STATUS_PAUSING, STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLED}),
+    # PAUSING/PAUSED are forward-compat (Phase 4). A paused turn can
+    # resume to RUNNING, be torn down, or fail on lease loss.
+    STATUS_PAUSING: frozenset({STATUS_PAUSED, STATUS_RUNNING, STATUS_FAILED, STATUS_CANCELLED}),
+    STATUS_PAUSED: frozenset({STATUS_RUNNING, STATUS_CANCELLED, STATUS_FAILED}),
+    # Terminal states have no outgoing transitions.
+    STATUS_COMPLETED: frozenset(),
+    STATUS_FAILED: frozenset(),
+    STATUS_CANCELLED: frozenset(),
+}
+
+
+# ── Failure taxonomy ───────────────────────────────────────────────
+
+#: Transport-layer failure: the client connection dropped. Set only on
+#: the observation path — never on a RUNNING turn's status. Excluded
+#: from vendor routing.
+ERROR_TRANSPORT_DISCONNECT: Final = "TRANSPORT_DISCONNECT"
+#: The runner's lease expired (heartbeat went stale). Set by the server
+#: orphan sweeper. Excluded from vendor routing — this is infra health,
+#: not a vendor fault (the original misdiagnosis).
+ERROR_RUNNER_LOST: Final = "RUNNER_LOST"
+#: The worker failed to boot/start. Vendor-attributable.
+ERROR_WORKER_BOOT_FAILURE: Final = "WORKER_BOOT_FAILURE"
+#: The worker started but the task itself errored. Vendor-attributable.
+ERROR_WORKER_TASK_FAILURE: Final = "WORKER_TASK_FAILURE"
+#: Explicit user/operator cancel. Not a fault; excluded from routing.
+ERROR_CANCELLED: Final = "CANCELLED"
+
+#: Every legal error code (mirrors the ``ck_turns_error_code`` CHECK
+#: constraint; keep the two in sync).
+ALL_ERROR_CODES: Final[frozenset[str]] = frozenset(
+    {
+        ERROR_TRANSPORT_DISCONNECT,
+        ERROR_RUNNER_LOST,
+        ERROR_WORKER_BOOT_FAILURE,
+        ERROR_WORKER_TASK_FAILURE,
+        ERROR_CANCELLED,
+    }
+)
+
+#: The subset of failure codes attributable to the worker/vendor, and
+#: therefore the **only** codes permitted to feed vendor health/routing.
+WORKER_ATTRIBUTABLE_ERROR_CODES: Final[frozenset[str]] = frozenset(
+    {ERROR_WORKER_BOOT_FAILURE, ERROR_WORKER_TASK_FAILURE}
+)
+
+
+def is_terminal(status: str) -> bool:
+    """
+    Return whether *status* is a terminal state (no outgoing transitions).
+
+    :param status: A turn status value, e.g. ``"RUNNING"``.
+    :returns: ``True`` if the status is terminal.
+    :raises ValueError: If *status* is not a known status.
+    """
+    _require_status(status)
+    return status in TERMINAL_STATUSES
+
+
+def is_valid_transition(from_status: str, to_status: str) -> bool:
+    """
+    Return whether ``from_status -> to_status`` is a legal transition.
+
+    Legality is independent of *ownership*: a transition can be legal
+    here yet still be rejected by the store's fenced compare-and-set
+    because the caller does not hold the lease. This function answers
+    only "is this edge in the state machine?".
+
+    :param from_status: Current status, e.g. ``"QUEUED"``.
+    :param to_status: Proposed next status, e.g. ``"RUNNING"``.
+    :returns: ``True`` if the edge exists in :data:`_LEGAL_TRANSITIONS`.
+    :raises ValueError: If either status is not a known status.
+    """
+    _require_status(from_status)
+    _require_status(to_status)
+    return to_status in _LEGAL_TRANSITIONS[from_status]
+
+
+def validate_transition(from_status: str, to_status: str) -> None:
+    """
+    Raise unless ``from_status -> to_status`` is a legal transition.
+
+    Use at call sites that want a hard failure on an illegal edge rather
+    than a boolean. The store layer calls this before issuing a CAS so an
+    illegal transition is a programming error caught early, distinct from
+    a *lost-lease* CAS miss (which is an expected runtime condition).
+
+    :param from_status: Current status.
+    :param to_status: Proposed next status.
+    :raises ValueError: If the transition is illegal or a status is
+        unknown.
+    """
+    if not is_valid_transition(from_status, to_status):
+        raise ValueError(
+            f"illegal turn transition {from_status!r} -> {to_status!r}; "
+            f"legal targets from {from_status!r} are "
+            f"{sorted(_LEGAL_TRANSITIONS[from_status])}"
+        )
+
+
+def is_worker_attributable(error_code: str | None) -> bool:
+    """
+    Return whether *error_code* may feed vendor health/routing.
+
+    This is the single inviolable gate behind the failure-taxonomy rule:
+    only ``WORKER_*`` codes are vendor-attributable. ``TRANSPORT_DISCONNECT``,
+    ``RUNNER_LOST``, ``CANCELLED`` and ``None`` all return ``False`` so
+    transport/infra noise can never bench a healthy vendor.
+
+    :param error_code: A failure taxonomy value, or ``None`` for a
+        successful / non-failed turn.
+    :returns: ``True`` only for worker-attributable failure codes.
+    :raises ValueError: If *error_code* is a non-``None`` value outside
+        the taxonomy (a typo'd code must fail loud, not silently slip
+        past the routing filter).
+    """
+    if error_code is None:
+        return False
+    if error_code not in ALL_ERROR_CODES:
+        raise ValueError(
+            f"unknown error_code {error_code!r}; expected one of {sorted(ALL_ERROR_CODES)} or None"
+        )
+    return error_code in WORKER_ATTRIBUTABLE_ERROR_CODES
+
+
+def is_lease_expired(lease_expires_at: int | None, now: int) -> bool:
+    """
+    Return whether a lease is expired as of *now*.
+
+    A turn with no lease set (``lease_expires_at is None``) is treated as
+    **not** expired — it has not yet been claimed, so it is not a sweep
+    candidate. The orphan sweeper additionally restricts itself to
+    :data:`SWEEPABLE_STATUSES`; this helper answers only the time
+    comparison.
+
+    Time is always supplied by the caller (the server's ``now_epoch()``)
+    rather than read internally, so a single clock governs both the
+    heartbeat write and the sweep comparison and there is no cross-host
+    skew. See the design doc's clock-skew risk note.
+
+    :param lease_expires_at: Epoch seconds the lease expires, or ``None``
+        if no lease is held.
+    :param now: Current epoch seconds, supplied by the caller.
+    :returns: ``True`` if a lease is held and ``lease_expires_at < now``.
+    """
+    if lease_expires_at is None:
+        return False
+    return lease_expires_at < now
+
+
+def _require_status(status: str) -> None:
+    """
+    Raise :class:`ValueError` if *status* is not a known status.
+
+    :param status: The status value to validate.
+    :raises ValueError: If *status* is not in :data:`ALL_STATUSES`.
+    """
+    if status not in ALL_STATUSES:
+        raise ValueError(f"unknown turn status {status!r}; expected one of {sorted(ALL_STATUSES)}")

--- a/omnigent/stores/turn_store.py
+++ b/omnigent/stores/turn_store.py
@@ -1,0 +1,604 @@
+"""
+Persistent store for server-authoritative turns.
+
+A *turn* is the durable record of a single agent response/dispatch
+(``turn_id`` == the ``resp_...`` response/task id). Promoting it to a
+first-class, leased row is what decouples a turn's lifecycle from the
+client connection: a client disconnect updates only ``attached`` /
+``last_client_seen`` and can never transition a ``RUNNING`` turn. See
+issue #466 and ``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md``.
+
+This store is the **persistence half** of Phase 1. The pure
+state-machine and failure-taxonomy logic it relies on lives in
+:mod:`omnigent.runtime.turn_state`. The runtime wiring that *calls* this
+store — the server dispatch call-site, the runner-side heartbeat task,
+and the periodic orphan-sweep scheduler — is intentionally **not** here;
+it lands in a later PR. Every method on this store is exercisable with a
+SQLite database and an injected clock, with no tunnel or asyncio.
+
+Concurrency model (both reviewers converged on this):
+
+* The **server** owns ``lease_epoch`` and the ``QUEUED -> RUNNING`` claim.
+  ``conversations.runner_id`` is *affinity* (durable routing), not a
+  lease; the lease (``lease_epoch`` / ``lease_owner`` / ``lease_expires_at``)
+  is per-turn execution ownership that expires and fences stale writers.
+* ``lease_epoch`` is bumped in exactly **two** places: a claim
+  (:meth:`claim`) and a sweeper takeover (:meth:`sweep_expired`). A
+  heartbeat renews ``lease_expires_at`` only and never bumps the epoch.
+* Every ownership-sensitive write is a **fenced compare-and-set**:
+  ``UPDATE ... WHERE id=:id AND lease_owner=:me AND lease_epoch=:epoch
+  AND status=:expected``. Zero rows updated => the caller lost the lease
+  (e.g. the sweeper already declared it ``RUNNER_LOST`` and bumped the
+  epoch) and must abort, not retry.
+
+The clock is always injected (callers pass ``now`` / ``ttl``) so a single
+server clock governs both heartbeat writes and sweep comparisons — no
+cross-host skew — and tests are deterministic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import Engine, and_, select, update
+
+from omnigent.db.db_models import SqlIdempotencyKey, SqlTurn
+from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
+from omnigent.runtime.turn_state import (
+    ERROR_RUNNER_LOST,
+    STATUS_CREATED,
+    STATUS_FAILED,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    SWEEPABLE_STATUSES,
+    is_terminal,
+    validate_transition,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Turn:
+    """
+    A server-authoritative turn record.
+
+    Mirrors :class:`omnigent.db.db_models.SqlTurn`; see that model for
+    per-column semantics. This dataclass is the read-side entity returned
+    by the store so callers don't hold a live ORM row past the session.
+
+    :param id: Turn id (== the ``resp_...`` response/task id).
+    :param conversation_id: Owning conversation/session id.
+    :param status: Lifecycle state (see
+        :mod:`omnigent.runtime.turn_state`).
+    :param error_code: Failure taxonomy value on a terminal failure, else
+        ``None``.
+    :param error_message: Optional human-readable failure detail.
+    :param vendor: Worker vendor the turn dispatched to.
+    :param intent: Send intent that created the turn
+        (``enqueue`` / ``steer`` / ``attach``).
+    :param input_json: The send payload, persisted before work starts.
+    :param lease_owner: Runner id currently owning execution, or ``None``.
+    :param lease_epoch: Monotonic fencing token.
+    :param last_heartbeat_at: Epoch seconds of the last heartbeat, or
+        ``None``.
+    :param lease_expires_at: Epoch seconds the lease expires, or ``None``.
+    :param attached: Whether a client is currently observing the stream.
+    :param last_client_seen: Epoch seconds a client was last attached, or
+        ``None``.
+    :param created_at: Epoch seconds the row was created.
+    :param start_ts: Epoch seconds the turn entered ``RUNNING``, or
+        ``None``.
+    :param end_ts: Epoch seconds the turn reached a terminal state, or
+        ``None``.
+    :param checkpoint_id: Phase 4 forward-compat; always ``None`` here.
+    """
+
+    id: str
+    conversation_id: str
+    status: str
+    error_code: str | None
+    error_message: str | None
+    vendor: str
+    intent: str
+    input_json: str
+    lease_owner: str | None
+    lease_epoch: int
+    last_heartbeat_at: int | None
+    lease_expires_at: int | None
+    attached: bool
+    last_client_seen: int | None
+    created_at: int
+    start_ts: int | None
+    end_ts: int | None
+    checkpoint_id: str | None
+
+
+def _to_turn(row: SqlTurn) -> Turn:
+    """
+    Convert a :class:`SqlTurn` ORM row to a :class:`Turn` entity.
+
+    :param row: The SQLAlchemy ORM row to convert.
+    :returns: A detached :class:`Turn` dataclass instance.
+    """
+    return Turn(
+        id=row.id,
+        conversation_id=row.conversation_id,
+        status=row.status,
+        error_code=row.error_code,
+        error_message=row.error_message,
+        vendor=row.vendor,
+        intent=row.intent,
+        input_json=row.input_json,
+        lease_owner=row.lease_owner,
+        lease_epoch=row.lease_epoch,
+        last_heartbeat_at=row.last_heartbeat_at,
+        lease_expires_at=row.lease_expires_at,
+        attached=row.attached,
+        last_client_seen=row.last_client_seen,
+        created_at=row.created_at,
+        start_ts=row.start_ts,
+        end_ts=row.end_ts,
+        checkpoint_id=row.checkpoint_id,
+    )
+
+
+def request_fingerprint(payload: str) -> str:
+    """
+    Return the SHA-256 hex digest of an idempotency request payload.
+
+    Stored alongside the idempotency key so a second use of the same key
+    with a *different* body is detected and rejected (HTTP 422) rather
+    than silently returning the wrong turn.
+
+    :param payload: The canonicalized request body to fingerprint.
+    :returns: 64-char hex SHA-256 digest.
+    """
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class IdempotencyConflictError(Exception):
+    """
+    Raised when an idempotency key is reused with a different payload.
+
+    The caller maps this to HTTP 422: the key was already bound to a turn
+    created from a different request body, so returning the stored turn
+    would silently serve the wrong work.
+
+    :param key: The conflicting idempotency key.
+    :param turn_id: The turn the key is already bound to.
+    """
+
+    def __init__(self, key: str, turn_id: str) -> None:
+        super().__init__(
+            f"idempotency key {key!r} already bound to turn {turn_id!r} "
+            f"with a different request fingerprint"
+        )
+        self.key = key
+        self.turn_id = turn_id
+
+
+class TurnStore:
+    """
+    SQLAlchemy-backed store for server-authoritative turns.
+
+    All ownership-sensitive mutations are fenced compare-and-sets that
+    return a boolean (or ``None``) indicating whether the caller still
+    held the lease, never raising on a lost-lease miss — losing a lease
+    is an expected runtime outcome, not an error.
+
+    :param storage_location: SQLAlchemy database URI, e.g.
+        ``"sqlite:///omnigent.db"`` or ``"postgresql://..."``.
+    """
+
+    def __init__(self, storage_location: str) -> None:
+        """
+        Initialize the store, creating or reusing the shared engine.
+
+        :param storage_location: SQLAlchemy database URI.
+        """
+        self._engine: Engine = get_or_create_engine(storage_location)
+        # ``immediate=True`` takes the SQLite write lock at BEGIN so the
+        # check-then-act in :meth:`upsert_idempotency_key` and the fenced
+        # CAS updates can't interleave with a racing dispatch; a no-op on
+        # PostgreSQL, which fences via the partial-unique index + the
+        # ``WHERE``-guarded UPDATE rowcount.
+        self._session = make_managed_session_maker(self._engine, immediate=True)
+
+    # ── creation / reads ───────────────────────────────────────────
+
+    def create_turn(
+        self,
+        *,
+        turn_id: str,
+        conversation_id: str,
+        vendor: str,
+        intent: str,
+        input_json: str,
+        now: int,
+    ) -> Turn:
+        """
+        Insert a new turn in ``CREATED`` and return it.
+
+        The row is persisted *before* any work is forwarded to a runner,
+        so an idempotent replay can resolve back to it and a crash before
+        dispatch leaves a recoverable record rather than lost intent.
+
+        A second active turn for the same conversation violates the
+        ``ux_turns_one_active_per_conversation`` partial-unique index and
+        raises :class:`sqlalchemy.exc.IntegrityError`; the API layer
+        converts that to a ``409 Attach-Required``.
+
+        :param turn_id: The turn id (== ``resp_...`` task id).
+        :param conversation_id: Owning conversation id.
+        :param vendor: Worker vendor, e.g. ``"claude_code"``.
+        :param intent: Send intent (``enqueue`` / ``steer`` / ``attach``).
+        :param input_json: The send payload, stored durably.
+        :param now: Current epoch seconds (injected clock).
+        :returns: The created :class:`Turn`.
+        """
+        with self._session() as session:
+            row = SqlTurn(
+                id=turn_id,
+                conversation_id=conversation_id,
+                status=STATUS_CREATED,
+                vendor=vendor,
+                intent=intent,
+                input_json=input_json,
+                lease_epoch=0,
+                attached=False,
+                created_at=now,
+            )
+            session.add(row)
+            session.flush()
+            return _to_turn(row)
+
+    def get_turn(self, turn_id: str) -> Turn | None:
+        """
+        Return the turn with id *turn_id*, or ``None`` if absent.
+
+        :param turn_id: The turn id to look up.
+        :returns: The :class:`Turn`, or ``None``.
+        """
+        with self._session() as session:
+            row = session.get(SqlTurn, turn_id)
+            return _to_turn(row) if row is not None else None
+
+    # ── lease lifecycle (fenced) ───────────────────────────────────
+
+    def claim(
+        self,
+        *,
+        turn_id: str,
+        runner_id: str,
+        now: int,
+        ttl: int,
+    ) -> int | None:
+        """
+        Claim a queued turn for *runner_id*, transitioning it to ``RUNNING``.
+
+        This is the server-side claim: it bumps ``lease_epoch`` (one of
+        only two places that does), stamps ``lease_owner`` /
+        ``lease_expires_at`` / ``start_ts``, and moves the turn to
+        ``RUNNING`` — all guarded so exactly one claim can win. The runner
+        then carries the returned epoch as a fencing token and never
+        mutates it.
+
+        The guard accepts ``CREATED`` or ``QUEUED`` as the source (an
+        interactive/attach dispatch may claim straight from ``CREATED``),
+        consistent with :data:`omnigent.runtime.turn_state` legality.
+
+        :param turn_id: The turn to claim.
+        :param runner_id: The claiming runner's id (the pinned
+            ``conversations.runner_id``).
+        :param now: Current epoch seconds (injected clock).
+        :param ttl: Lease time-to-live in seconds; ``lease_expires_at``
+            becomes ``now + ttl``.
+        :returns: The new ``lease_epoch`` on success, or ``None`` if the
+            turn was not claimable (already running/terminal, or gone).
+        """
+        with self._session() as session:
+            row = session.get(SqlTurn, turn_id)
+            if row is None:
+                return None
+            if row.status not in (STATUS_CREATED, STATUS_QUEUED):
+                # Already claimed, terminal, or paused — not claimable.
+                return None
+            validate_transition(row.status, STATUS_RUNNING)
+            new_epoch = row.lease_epoch + 1
+            # Fenced CAS: re-assert the observed status so a concurrent
+            # claim that won first leaves this one updating zero rows.
+            result = session.execute(
+                update(SqlTurn)
+                .where(
+                    and_(
+                        SqlTurn.id == turn_id,
+                        SqlTurn.status == row.status,
+                        SqlTurn.lease_epoch == row.lease_epoch,
+                    )
+                )
+                .values(
+                    status=STATUS_RUNNING,
+                    lease_owner=runner_id,
+                    lease_epoch=new_epoch,
+                    last_heartbeat_at=now,
+                    lease_expires_at=now + ttl,
+                    start_ts=now,
+                )
+            )
+            if result.rowcount != 1:
+                return None
+            return new_epoch
+
+    def heartbeat(
+        self,
+        *,
+        turn_id: str,
+        runner_id: str,
+        lease_epoch: int,
+        now: int,
+        ttl: int,
+    ) -> bool:
+        """
+        Renew the lease on a running turn, extending ``lease_expires_at``.
+
+        A heartbeat **only** pushes out ``lease_expires_at`` (to
+        ``now + ttl``) and stamps ``last_heartbeat_at``; it never bumps
+        ``lease_epoch`` and never changes ``status``. The CAS is fenced on
+        owner + epoch + sweepable status, so once the sweeper has declared
+        the turn ``RUNNER_LOST`` (bumping the epoch), the now-stale runner's
+        heartbeat updates zero rows and learns it lost the lease.
+
+        :param turn_id: The turn to heartbeat.
+        :param runner_id: The runner asserting ownership.
+        :param lease_epoch: The epoch the runner believes it holds.
+        :param now: Current epoch seconds (injected clock).
+        :param ttl: Lease time-to-live in seconds.
+        :returns: ``True`` if the lease was renewed; ``False`` if the
+            caller no longer holds it (stale epoch, wrong owner, or the
+            turn left a sweepable status).
+        """
+        with self._session() as session:
+            result = session.execute(
+                update(SqlTurn)
+                .where(
+                    and_(
+                        SqlTurn.id == turn_id,
+                        SqlTurn.lease_owner == runner_id,
+                        SqlTurn.lease_epoch == lease_epoch,
+                        SqlTurn.status.in_(tuple(SWEEPABLE_STATUSES)),
+                    )
+                )
+                .values(last_heartbeat_at=now, lease_expires_at=now + ttl)
+            )
+            return result.rowcount == 1
+
+    def complete(
+        self,
+        *,
+        turn_id: str,
+        runner_id: str,
+        lease_epoch: int,
+        terminal_status: str,
+        now: int,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> bool:
+        """
+        Transition a running turn to a terminal state under the lease.
+
+        Used by the runner supervisor for ``COMPLETED`` /
+        ``FAILED(WORKER_*)`` / ``CANCELLED``. The write is a fenced CAS on
+        owner + epoch, so a runner that was already declared ``RUNNER_LOST``
+        by the sweeper (epoch bumped) cannot overwrite the terminal record
+        — its ``complete`` returns ``False`` and it reconciles/discards
+        instead of split-braining. The reconnect path that handles that
+        rejection is specified for the wiring PR.
+
+        :param turn_id: The turn to finalize.
+        :param runner_id: The runner asserting ownership.
+        :paramlease_epoch: The epoch the runner believes it holds.
+        :param terminal_status: One of ``COMPLETED`` / ``FAILED`` /
+            ``CANCELLED``.
+        :param now: Current epoch seconds (injected clock).
+        :param error_code: Failure taxonomy value (required-by-convention
+            for ``FAILED``; ``None`` for ``COMPLETED``).
+        :param error_message: Optional human-readable detail.
+        :returns: ``True`` if the turn was finalized; ``False`` if the
+            caller no longer holds the lease.
+        :raises ValueError: If *terminal_status* is not terminal.
+        """
+        if not is_terminal(terminal_status):
+            raise ValueError(f"complete() requires a terminal status, got {terminal_status!r}")
+        with self._session() as session:
+            result = session.execute(
+                update(SqlTurn)
+                .where(
+                    and_(
+                        SqlTurn.id == turn_id,
+                        SqlTurn.lease_owner == runner_id,
+                        SqlTurn.lease_epoch == lease_epoch,
+                        SqlTurn.status.in_(tuple(SWEEPABLE_STATUSES)),
+                    )
+                )
+                .values(
+                    status=terminal_status,
+                    error_code=error_code,
+                    error_message=error_message,
+                    end_ts=now,
+                )
+            )
+            return result.rowcount == 1
+
+    def sweep_expired(self, *, now: int, limit: int = 100) -> list[str]:
+        """
+        Mark expired leased turns ``FAILED(RUNNER_LOST)`` and return their ids.
+
+        The server-side orphan sweeper. It selects sweepable turns
+        (``RUNNING`` / ``PAUSING``) whose ``lease_expires_at < now`` and
+        transitions each to ``FAILED`` with ``error_code=RUNNER_LOST``,
+        **bumping ``lease_epoch``**. The epoch bump is the fence: if the
+        runner was merely disconnected (not dead) and reconnects, its
+        heartbeat/complete CAS on the old epoch now fails, so it cannot
+        resurrect a turn the server has already given up on.
+
+        Critically, this flips **DB state only** — it does not and cannot
+        terminate runner-side execution. A disconnect shorter than the TTL
+        leaves the turn ``RUNNING`` and results flush on reconnect; only a
+        disconnect longer than the TTL surfaces as ``RUNNER_LOST`` (Phase 1:
+        surfaced, never auto-resumed). TTL sizing is therefore the single
+        knob that buys disconnect tolerance.
+
+        :param now: Current epoch seconds (injected clock).
+        :param limit: Max turns to sweep in one pass (batching for large
+            backlogs).
+        :returns: The ids of turns transitioned to ``RUNNER_LOST`` this
+            pass.
+        """
+        swept: list[str] = []
+        with self._session() as session:
+            candidates = session.execute(
+                select(SqlTurn.id, SqlTurn.lease_epoch, SqlTurn.status)
+                .where(
+                    and_(
+                        SqlTurn.status.in_(tuple(SWEEPABLE_STATUSES)),
+                        SqlTurn.lease_expires_at.is_not(None),
+                        SqlTurn.lease_expires_at < now,
+                    )
+                )
+                .order_by(SqlTurn.lease_expires_at.asc())
+                .limit(limit)
+            ).all()
+            for turn_id, epoch, status in candidates:
+                validate_transition(status, STATUS_FAILED)
+                # Fenced CAS per row: only sweep if the epoch is unchanged
+                # since we read it, so we never race a legitimate claim or
+                # a concurrent sweeper replica.
+                result = session.execute(
+                    update(SqlTurn)
+                    .where(
+                        and_(
+                            SqlTurn.id == turn_id,
+                            SqlTurn.lease_epoch == epoch,
+                            SqlTurn.status.in_(tuple(SWEEPABLE_STATUSES)),
+                        )
+                    )
+                    .values(
+                        status=STATUS_FAILED,
+                        error_code=ERROR_RUNNER_LOST,
+                        lease_epoch=epoch + 1,
+                        end_ts=now,
+                    )
+                )
+                if result.rowcount == 1:
+                    swept.append(turn_id)
+        return swept
+
+    # ── client liveness (observation only) ─────────────────────────
+
+    def mark_client_liveness(self, *, turn_id: str, attached: bool, now: int) -> None:
+        """
+        Record client attach/detach without ever touching turn lifecycle.
+
+        This is the **only** method the HTTP/SSE observation path may call,
+        and by construction its ``UPDATE ... SET`` clause writes *only*
+        ``attached`` and ``last_client_seen`` — never ``status``,
+        ``lease_*``, or any execution column. A unit test asserts the
+        emitted SQL touches nothing else. This is design rule 1 enforced in
+        code, not convention: a dropped client can never kill a turn.
+
+        :param turn_id: The turn whose client liveness changed.
+        :param attached: ``True`` on attach, ``False`` on disconnect.
+        :param now: Current epoch seconds (injected clock); recorded as
+            ``last_client_seen``.
+        """
+        with self._session() as session:
+            session.execute(
+                update(SqlTurn)
+                .where(SqlTurn.id == turn_id)
+                .values(attached=attached, last_client_seen=now)
+            )
+
+    # ── idempotency ────────────────────────────────────────────────
+
+    def lookup_idempotency_key(self, key: str) -> tuple[str, str] | None:
+        """
+        Return ``(turn_id, request_fingerprint)`` for *key*, or ``None``.
+
+        :param key: The client-generated idempotency key.
+        :returns: A ``(turn_id, request_fingerprint)`` tuple if the key is
+            known, else ``None``.
+        """
+        with self._session() as session:
+            row = session.get(SqlIdempotencyKey, key)
+            if row is None:
+                return None
+            return (row.turn_id, row.request_fingerprint)
+
+    def upsert_idempotency_key(
+        self,
+        *,
+        key: str,
+        conversation_id: str,
+        turn_id: str,
+        fingerprint: str,
+        now: int,
+    ) -> str:
+        """
+        Bind an idempotency key to a turn, or return the existing binding.
+
+        On a fresh key, inserts the binding and returns *turn_id*. On a
+        replay with a **matching** fingerprint, returns the previously
+        bound turn id (the caller then serves that turn rather than
+        creating a new one). On a replay with a **different** fingerprint,
+        raises :class:`IdempotencyConflictError` (HTTP 422).
+
+        :param key: The client-generated idempotency key.
+        :param conversation_id: Owning conversation id.
+        :param turn_id: The turn to bind on first use.
+        :param fingerprint: SHA-256 of the canonicalized request payload
+            (see :func:`request_fingerprint`).
+        :param now: Current epoch seconds (injected clock).
+        :returns: The bound turn id — *turn_id* on first use, or the
+            stored turn id on a matching replay.
+        :raises IdempotencyConflictError: On a same-key/different-body
+            reuse.
+        """
+        with self._session() as session:
+            existing = session.get(SqlIdempotencyKey, key)
+            if existing is not None:
+                if existing.request_fingerprint != fingerprint:
+                    raise IdempotencyConflictError(key, existing.turn_id)
+                return existing.turn_id
+            session.add(
+                SqlIdempotencyKey(
+                    key=key,
+                    conversation_id=conversation_id,
+                    turn_id=turn_id,
+                    request_fingerprint=fingerprint,
+                    created_at=now,
+                )
+            )
+            return turn_id
+
+    def purge_idempotency_keys_before(self, *, cutoff: int) -> int:
+        """
+        Delete idempotency keys created before *cutoff* (TTL GC).
+
+        A cheap retention sweep so the table doesn't grow unbounded; the
+        cutoff is the client retry horizon (the design suggests ~7 days).
+        Bindings are also cascade-deleted with their conversation.
+
+        :param cutoff: Epoch-seconds threshold; keys with
+            ``created_at < cutoff`` are removed.
+        :returns: The number of keys deleted.
+        """
+        from sqlalchemy import delete as sql_delete
+
+        with self._session() as session:
+            result = session.execute(
+                sql_delete(SqlIdempotencyKey).where(SqlIdempotencyKey.created_at < cutoff)
+            )
+            return result.rowcount or 0

--- a/tests/runtime/test_turn_state.py
+++ b/tests/runtime/test_turn_state.py
@@ -1,0 +1,186 @@
+"""Tests for the pure turn state-machine and failure taxonomy.
+
+Covers :mod:`omnigent.runtime.turn_state` (issue #466,
+``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md``). These are pure
+functions with no DB or transport, so the suite is an exhaustive,
+table-driven check of:
+
+1. The transition matrix: every legal edge is accepted, and a
+   representative set of illegal edges (including all
+   terminal -> anything) is rejected.
+2. No transition is keyed to a client event (encoded by the absence of
+   any client trigger in the matrix; asserted indirectly via the
+   liveness store test).
+3. The ``WORKER_*``-only routing gate: transport/runner/cancel codes are
+   excluded so they can never bench a healthy vendor.
+4. Lease-expiry classification with an injected clock.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from omnigent.runtime import turn_state as ts
+
+
+def test_all_statuses_partition_into_terminal_and_active() -> None:
+    """Terminal and active status sets partition the full status set.
+
+    A status that is neither (or both) would let a turn fall outside the
+    state machine — e.g. an "active" terminal status would hold the
+    per-conversation slot forever.
+    """
+    assert ts.TERMINAL_STATUSES | ts.ACTIVE_STATUSES == ts.ALL_STATUSES
+    assert frozenset() == ts.TERMINAL_STATUSES & ts.ACTIVE_STATUSES
+
+
+def test_sweepable_statuses_are_active_and_leasable() -> None:
+    """Only RUNNING/PAUSING are sweepable, and both are active (non-terminal).
+
+    The sweeper must never touch a terminal turn (would corrupt a
+    finished record) nor a not-yet-leased one (CREATED/QUEUED have no
+    lease to expire).
+    """
+    assert frozenset({ts.STATUS_RUNNING, ts.STATUS_PAUSING}) == ts.SWEEPABLE_STATUSES
+    assert ts.SWEEPABLE_STATUSES <= ts.ACTIVE_STATUSES
+
+
+@pytest.mark.parametrize(
+    ("from_status", "to_status"),
+    [
+        (ts.STATUS_CREATED, ts.STATUS_QUEUED),
+        (ts.STATUS_CREATED, ts.STATUS_RUNNING),
+        (ts.STATUS_CREATED, ts.STATUS_CANCELLED),
+        (ts.STATUS_QUEUED, ts.STATUS_RUNNING),
+        (ts.STATUS_QUEUED, ts.STATUS_CANCELLED),
+        (ts.STATUS_RUNNING, ts.STATUS_COMPLETED),
+        (ts.STATUS_RUNNING, ts.STATUS_FAILED),
+        (ts.STATUS_RUNNING, ts.STATUS_CANCELLED),
+        (ts.STATUS_RUNNING, ts.STATUS_PAUSING),
+        (ts.STATUS_PAUSING, ts.STATUS_PAUSED),
+        (ts.STATUS_PAUSING, ts.STATUS_RUNNING),
+        (ts.STATUS_PAUSED, ts.STATUS_RUNNING),
+        (ts.STATUS_PAUSED, ts.STATUS_FAILED),
+    ],
+)
+def test_legal_transitions_accepted(from_status: str, to_status: str) -> None:
+    """Each documented legal edge validates without raising."""
+    assert ts.is_valid_transition(from_status, to_status)
+    ts.validate_transition(from_status, to_status)  # must not raise
+
+
+@pytest.mark.parametrize("terminal", sorted(ts.TERMINAL_STATUSES))
+def test_terminal_states_have_no_outgoing_transitions(terminal: str) -> None:
+    """No terminal status may transition anywhere — the record is final."""
+    assert ts.is_terminal(terminal)
+    for target in ts.ALL_STATUSES:
+        assert not ts.is_valid_transition(terminal, target), (
+            f"terminal {terminal!r} must not transition to {target!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("from_status", "to_status"),
+    [
+        # Can't skip back to an earlier non-terminal phase.
+        (ts.STATUS_RUNNING, ts.STATUS_QUEUED),
+        (ts.STATUS_QUEUED, ts.STATUS_CREATED),
+        # QUEUED can't jump straight to a non-cancel terminal.
+        (ts.STATUS_QUEUED, ts.STATUS_COMPLETED),
+        # CREATED can't complete without running.
+        (ts.STATUS_CREATED, ts.STATUS_COMPLETED),
+        # Self-loops are not transitions.
+        (ts.STATUS_RUNNING, ts.STATUS_RUNNING),
+    ],
+)
+def test_illegal_transitions_rejected(from_status: str, to_status: str) -> None:
+    """Representative illegal edges are rejected by both predicates."""
+    assert not ts.is_valid_transition(from_status, to_status)
+    with pytest.raises(ValueError, match="illegal turn transition"):
+        ts.validate_transition(from_status, to_status)
+
+
+def test_no_client_event_drives_a_transition() -> None:
+    """The matrix is keyed only on statuses, never a client connect/disconnect.
+
+    This is design rule 1 at the type level: there is no edge a client
+    event could traverse, because attach/detach are not statuses. The
+    store-level guarantee (liveness writes touch only two columns) is
+    covered in the TurnStore tests.
+    """
+    # Every key and every target is a real status — there is no
+    # "ATTACHED"/"DETACHED" pseudo-status that a disconnect could push.
+    for src, targets in ts._LEGAL_TRANSITIONS.items():
+        assert src in ts.ALL_STATUSES
+        assert targets <= ts.ALL_STATUSES
+
+
+@pytest.mark.parametrize("unknown", ["", "running", "DONE", "ATTACHED"])
+def test_unknown_status_raises(unknown: str) -> None:
+    """An out-of-set status is a programming error and must fail loud."""
+    with pytest.raises(ValueError, match="unknown turn status"):
+        ts.is_terminal(unknown)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        (ts.ERROR_WORKER_BOOT_FAILURE, True),
+        (ts.ERROR_WORKER_TASK_FAILURE, True),
+        (ts.ERROR_TRANSPORT_DISCONNECT, False),
+        (ts.ERROR_RUNNER_LOST, False),
+        (ts.ERROR_CANCELLED, False),
+        (None, False),
+    ],
+)
+def test_is_worker_attributable(code: str | None, expected: bool) -> None:
+    """Only WORKER_* codes feed vendor routing.
+
+    The transport/runner/cancel codes returning False is the fix for the
+    original incident, where transport noise benched a healthy vendor.
+    """
+    assert ts.is_worker_attributable(code) is expected
+
+
+def test_is_worker_attributable_rejects_unknown_code() -> None:
+    """A typo'd code raises rather than silently slipping past the gate."""
+    with pytest.raises(ValueError, match="unknown error_code"):
+        ts.is_worker_attributable("WORKER_OOPS")
+
+
+def test_only_worker_codes_in_attributable_set() -> None:
+    """The attributable set is exactly the two WORKER_* codes."""
+    assert (
+        frozenset({ts.ERROR_WORKER_BOOT_FAILURE, ts.ERROR_WORKER_TASK_FAILURE})
+        == ts.WORKER_ATTRIBUTABLE_ERROR_CODES
+    )
+    assert ts.WORKER_ATTRIBUTABLE_ERROR_CODES <= ts.ALL_ERROR_CODES
+
+
+@pytest.mark.parametrize(
+    ("lease_expires_at", "now", "expected"),
+    [
+        (None, 100, False),  # unclaimed -> never expired
+        (100, 100, False),  # exactly now -> not yet expired
+        (100, 101, True),  # past expiry -> expired
+        (200, 100, False),  # future expiry -> live
+    ],
+)
+def test_is_lease_expired(lease_expires_at: int | None, now: int, expected: bool) -> None:
+    """Lease expiry is a strict ``expires_at < now`` with an injected clock."""
+    assert ts.is_lease_expired(lease_expires_at, now) is expected
+
+
+def test_transition_matrix_is_closed_over_all_statuses() -> None:
+    """Every status appears as a transition source (the matrix is total).
+
+    A missing key would make ``is_valid_transition`` raise for a real
+    status rather than return False, which would surface as a confusing
+    crash instead of a clean rejection.
+    """
+    assert set(ts._LEGAL_TRANSITIONS.keys()) == set(ts.ALL_STATUSES)
+    # And every (src, dst) pair is answerable without error.
+    for src, dst in itertools.product(ts.ALL_STATUSES, repeat=2):
+        assert isinstance(ts.is_valid_transition(src, dst), bool)

--- a/tests/stores/test_turn_store.py
+++ b/tests/stores/test_turn_store.py
@@ -1,0 +1,484 @@
+"""Tests for the server-authoritative :class:`TurnStore`.
+
+Covers :mod:`omnigent.stores.turn_store` (issue #466,
+``designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md``). The store is the
+persistence half of Phase 1; these tests exercise it against a real
+SQLite database (via the ``db_uri`` fixture, which runs the full alembic
+chain) with an **injected clock** — every call passes ``now`` explicitly,
+so behavior is deterministic and no wall-clock is read internally.
+
+Priority behaviors locked down (both design reviewers flagged these):
+
+* Fenced compare-and-set: a stale ``lease_epoch`` or wrong ``runner_id``
+  is rejected for heartbeat and terminal writes.
+* The claim is the only place (besides the sweeper) that bumps the epoch;
+  heartbeats extend expiry without bumping it.
+* The orphan sweeper marks only expired RUNNING/PAUSING turns
+  ``RUNNER_LOST`` **and bumps the epoch**, so a reconnecting "zombie"
+  runner's terminal write then CAS-fails.
+* ``mark_client_liveness`` touches only ``attached`` / ``last_client_seen``
+  — never a lifecycle column (design rule 1, enforced not by convention).
+* Idempotency: replay returns the same turn; same-key/different-body is a
+  422-class conflict.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from omnigent.db.utils import get_or_create_engine, now_epoch
+from omnigent.runtime import turn_state as ts
+from omnigent.stores.turn_store import (
+    IdempotencyConflictError,
+    TurnStore,
+    request_fingerprint,
+)
+
+_CONV_ID = "conv_turnstore_test"
+
+
+def _seed_conversation(db_uri: str, conversation_id: str) -> None:
+    """Insert a minimal ``conversations`` row to satisfy the turns FK.
+
+    ``get_or_create_engine`` enables SQLite foreign-key enforcement, so a
+    turn needs a real parent conversation. Only the NOT-NULL columns
+    without a default need values (same minimal insert the migration test
+    uses), which keeps the fixture independent of the conversation store's
+    id-generation and CHECK-constraint surface.
+
+    :param db_uri: Per-test SQLite URI.
+    :param conversation_id: The conversation id to insert.
+    """
+    engine = get_or_create_engine(db_uri)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversations (id, created_at, updated_at, "
+                "root_conversation_id) VALUES (:id, :now, :now, :id)"
+            ),
+            {"id": conversation_id, "now": now_epoch()},
+        )
+
+
+@pytest.fixture()
+def turn_store(db_uri: str) -> TurnStore:
+    """A TurnStore plus a seeded parent conversation to satisfy the FK.
+
+    :param db_uri: Per-test SQLite URI with the full migration chain.
+    :returns: A TurnStore bound to the same database.
+    """
+    _seed_conversation(db_uri, _CONV_ID)
+    return TurnStore(db_uri)
+
+
+def _make_turn(store: TurnStore, *, turn_id: str = "resp_t1", now: int = 1000) -> None:
+    """Create a CREATED turn for the seeded conversation."""
+    store.create_turn(
+        turn_id=turn_id,
+        conversation_id=_CONV_ID,
+        vendor="claude_code",
+        intent="enqueue",
+        input_json="{}",
+        now=now,
+    )
+
+
+# ── creation / reads ───────────────────────────────────────────────
+
+
+def test_create_and_get_turn(turn_store: TurnStore) -> None:
+    """A created turn round-trips with CREATED status and epoch 0."""
+    _make_turn(turn_store, turn_id="resp_t1", now=1000)
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_CREATED
+    assert turn.lease_epoch == 0
+    assert turn.lease_owner is None
+    assert turn.created_at == 1000
+    assert turn.attached is False
+
+
+def test_get_missing_turn_returns_none(turn_store: TurnStore) -> None:
+    """Looking up an unknown turn id returns None, not an error."""
+    assert turn_store.get_turn("resp_nope") is None
+
+
+# ── claim ──────────────────────────────────────────────────────────
+
+
+def test_claim_transitions_to_running_and_bumps_epoch(turn_store: TurnStore) -> None:
+    """Claiming a turn moves it to RUNNING, stamps the lease, and bumps epoch."""
+    _make_turn(turn_store, now=1000)
+    epoch = turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    assert epoch == 1
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_RUNNING
+    assert turn.lease_owner == "runner_a"
+    assert turn.lease_epoch == 1
+    assert turn.lease_expires_at == 1030
+    assert turn.start_ts == 1000
+
+
+def test_double_claim_only_one_winner(turn_store: TurnStore) -> None:
+    """A second claim on an already-RUNNING turn returns None (no takeover)."""
+    _make_turn(turn_store, now=1000)
+    first = turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    second = turn_store.claim(turn_id="resp_t1", runner_id="runner_b", now=1001, ttl=30)
+    assert first == 1
+    assert second is None
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.lease_owner == "runner_a"
+    assert turn.lease_epoch == 1
+
+
+def test_claim_missing_turn_returns_none(turn_store: TurnStore) -> None:
+    """Claiming a non-existent turn returns None rather than raising."""
+    assert turn_store.claim(turn_id="resp_nope", runner_id="r", now=1, ttl=30) is None
+
+
+# ── heartbeat ──────────────────────────────────────────────────────
+
+
+def test_heartbeat_extends_expiry_without_bumping_epoch(turn_store: TurnStore) -> None:
+    """A heartbeat pushes out lease_expires_at and never changes the epoch."""
+    _make_turn(turn_store, now=1000)
+    epoch = turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    assert epoch == 1
+    ok = turn_store.heartbeat(
+        turn_id="resp_t1", runner_id="runner_a", lease_epoch=1, now=1020, ttl=30
+    )
+    assert ok is True
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.lease_epoch == 1  # unchanged
+    assert turn.last_heartbeat_at == 1020
+    assert turn.lease_expires_at == 1050
+
+
+def test_heartbeat_with_stale_epoch_rejected(turn_store: TurnStore) -> None:
+    """A heartbeat carrying the wrong epoch is fenced out (returns False)."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    ok = turn_store.heartbeat(
+        turn_id="resp_t1", runner_id="runner_a", lease_epoch=0, now=1020, ttl=30
+    )
+    assert ok is False
+
+
+def test_heartbeat_with_wrong_owner_rejected(turn_store: TurnStore) -> None:
+    """A heartbeat from a runner that isn't the lease owner is rejected."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    ok = turn_store.heartbeat(
+        turn_id="resp_t1", runner_id="runner_b", lease_epoch=1, now=1020, ttl=30
+    )
+    assert ok is False
+
+
+# ── complete (terminal, fenced) ────────────────────────────────────
+
+
+def test_complete_finalizes_running_turn(turn_store: TurnStore) -> None:
+    """The lease holder can move RUNNING -> COMPLETED and stamp end_ts."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    ok = turn_store.complete(
+        turn_id="resp_t1",
+        runner_id="runner_a",
+        lease_epoch=1,
+        terminal_status=ts.STATUS_COMPLETED,
+        now=1010,
+    )
+    assert ok is True
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_COMPLETED
+    assert turn.end_ts == 1010
+    assert turn.error_code is None
+
+
+def test_complete_with_worker_failure_records_error_code(turn_store: TurnStore) -> None:
+    """A worker task failure isrecorded with its taxonomy code."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    ok = turn_store.complete(
+        turn_id="resp_t1",
+        runner_id="runner_a",
+        lease_epoch=1,
+        terminal_status=ts.STATUS_FAILED,
+        now=1010,
+        error_code=ts.ERROR_WORKER_TASK_FAILURE,
+        error_message="boom",
+    )
+    assert ok is True
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_FAILED
+    assert turn.error_code == ts.ERROR_WORKER_TASK_FAILURE
+    assert ts.is_worker_attributable(turn.error_code) is True
+
+
+def test_complete_with_stale_epoch_rejected(turn_store: TurnStore) -> None:
+    """A terminal write with a stale epoch is fenced out (returns False)."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    ok = turn_store.complete(
+        turn_id="resp_t1",
+        runner_id="runner_a",
+        lease_epoch=0,
+        terminal_status=ts.STATUS_COMPLETED,
+        now=1010,
+    )
+    assert ok is False
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_RUNNING  # untouched
+
+
+def test_complete_rejects_non_terminal_status(turn_store: TurnStore) -> None:
+    """Asking complete() to write a non-terminal status is a programming error."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    with pytest.raises(ValueError, match="terminal status"):
+        turn_store.complete(
+            turn_id="resp_t1",
+            runner_id="runner_a",
+            lease_epoch=1,
+            terminal_status=ts.STATUS_RUNNING,
+            now=1010,
+        )
+
+
+# ── orphan sweeper ─────────────────────────────────────────────────
+
+
+def test_sweep_marks_expired_running_turn_runner_lost(turn_store: TurnStore) -> None:
+    """An expired RUNNING turn is swept to FAILED(RUNNER_LOST) with epoch bump."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    # now (1031) is past lease_expires_at (1030).
+    swept = turn_store.sweep_expired(now=1031)
+    assert swept == ["resp_t1"]
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_FAILED
+    assert turn.error_code == ts.ERROR_RUNNER_LOST
+    assert turn.lease_epoch == 2  # bumped past the runner's epoch (1)
+    # RUNNER_LOST must NOT feed vendor routing.
+    assert ts.is_worker_attributable(turn.error_code) is False
+
+
+def test_sweep_ignores_live_lease(turn_store: TurnStore) -> None:
+    """A turn whose lease has not yet expired is left untouched."""
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    swept = turn_store.sweep_expired(now=1020)  # before expiry (1030)
+    assert swept == []
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_RUNNING
+
+
+def test_zombie_runner_complete_after_sweep_is_fenced(turn_store: TurnStore) -> None:
+    """The headline reconnect race: a swept runner can't resurrect its turn.
+
+    A runner is declared RUNNER_LOST while merely disconnected (the sweep
+    bumps the epoch). When it reconnects and tries its terminal write with
+    the *old* epoch, the fenced CAS updates zero rows, so it learns it lost
+    the lease and must reconcile/discard instead of overwriting the
+    server-authoritative RUNNER_LOST record. This is precisely the
+    split-brain the fencing token exists to prevent.
+    """
+    _make_turn(turn_store, now=1000)
+    held_epoch = turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+    assert held_epoch == 1
+    # Sweeper declares it lost (epoch -> 2).
+    assert turn_store.sweep_expired(now=1031) == ["resp_t1"]
+    # The still-alive runner reconnects and tries to complete with epoch 1.
+    ok = turn_store.complete(
+        turn_id="resp_t1",
+        runner_id="runner_a",
+        lease_epoch=held_epoch,
+        terminal_status=ts.STATUS_COMPLETED,
+        now=1040,
+    )
+    assert ok is False
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.status == ts.STATUS_FAILED
+    assert turn.error_code == ts.ERROR_RUNNER_LOST
+
+
+def test_sweep_respects_limit(turn_store: TurnStore, db_uri: str) -> None:
+    """The sweep batches: at most ``limit`` turns transition per pass.
+
+    Uses separate conversations because the partial-unique index allows
+    only one active turn per conversation.
+    """
+    for i in range(3):
+        cid = f"conv_sweep_{i}"
+        _seed_conversation(db_uri, cid)
+        turn_store.create_turn(
+            turn_id=f"resp_s{i}",
+            conversation_id=cid,
+            vendor="claude_code",
+            intent="enqueue",
+            input_json="{}",
+            now=1000,
+        )
+        turn_store.claim(turn_id=f"resp_s{i}", runner_id="runner_a", now=1000, ttl=30)
+    swept = turn_store.sweep_expired(now=1031, limit=2)
+    assert len(swept) == 2  # only the batch limit this pass
+    remaining = turn_store.sweep_expired(now=1031, limit=2)
+    assert len(remaining) == 1  # the third on the next pass
+
+
+# ── client liveness (observation only) ─────────────────────────────
+
+
+def test_mark_client_liveness_does_not_touch_lifecycle(turn_store: TurnStore) -> None:
+    """Attach/detach updates only liveness columns, never the turn's status.
+
+    This is design rule 1 — a dropped client can never kill a turn — and
+    it is the whole point of the project. We claim the turn to RUNNING,
+    then flip client liveness, and assert status / lease / epoch are all
+    unchanged while attached / last_client_seen update.
+    """
+    _make_turn(turn_store, now=1000)
+    turn_store.claim(turn_id="resp_t1", runner_id="runner_a", now=1000, ttl=30)
+
+    turn_store.mark_client_liveness(turn_id="resp_t1", attached=True, now=1005)
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.attached is True
+    assert turn.last_client_seen == 1005
+    assert turn.status == ts.STATUS_RUNNING
+    assert turn.lease_owner == "runner_a"
+    assert turn.lease_epoch == 1
+
+    # Client disconnects mid-run: still no lifecycle change.
+    turn_store.mark_client_liveness(turn_id="resp_t1", attached=False, now=1009)
+    turn = turn_store.get_turn("resp_t1")
+    assert turn is not None
+    assert turn.attached is False
+    assert turn.last_client_seen == 1009
+    assert turn.status == ts.STATUS_RUNNING  # the turn survives the disconnect
+    assert turn.lease_expires_at == 1030  # lease untouched by client liveness
+
+
+def test_mark_client_liveness_sql_touches_only_two_columns(turn_store: TurnStore) -> None:
+    """The emitted UPDATE's SET clause names ONLY attached + last_client_seen.
+
+    The behavioral test above proves status is unchanged, but the design
+    rule is stronger: the observation path must be *structurally* incapable
+    of writing any execution column. We inspect the compiled UPDATE
+    statement's SET targets directly, so a future edit that accidentally
+    adds, say, ``status`` to this method's ``.values(...)`` is caught even
+    if no behavioral test happens to exercise that column.
+    """
+    captured: list[str] = []
+
+    from sqlalchemy import event
+
+    # The store's own engine — the same one its session maker is bound to.
+    engine = turn_store._engine
+
+    def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if statement.strip().upper().startswith("UPDATE TURNS"):
+            captured.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        _make_turn(turn_store, turn_id="resp_live", now=1000)
+        turn_store.mark_client_liveness(turn_id="resp_live", attached=True, now=1005)
+    finally:
+        event.remove(engine, "before_cursor_execute", _before_cursor_execute)
+
+    assert captured, "expected an UPDATE turns statement to be emitted"
+    update_sql = captured[-1].upper()
+    set_clause = update_sql.split("SET", 1)[1].split("WHERE", 1)[0]
+    # Exactly the two liveness columns may appear in the SET clause.
+    assert "ATTACHED" in set_clause
+    assert "LAST_CLIENT_SEEN" in set_clause
+    for forbidden in ("STATUS", "LEASE_OWNER", "LEASE_EPOCH", "LEASE_EXPIRES_AT", "END_TS"):
+        assert forbidden not in set_clause, (
+            f"mark_client_liveness must never write {forbidden}; SET clause was: {set_clause}"
+        )
+
+
+# ── idempotency ────────────────────────────────────────────────────
+
+
+def test_idempotency_first_use_binds_key(turn_store: TurnStore) -> None:
+    """First use of a key binds it to the turn and returns that turn id."""
+    _make_turn(turn_store, turn_id="resp_t1", now=1000)
+    fp = request_fingerprint('{"input":"hello"}')
+    bound = turn_store.upsert_idempotency_key(
+        key="01890000-0000-7000-8000-000000000001",
+        conversation_id=_CONV_ID,
+        turn_id="resp_t1",
+        fingerprint=fp,
+        now=1000,
+    )
+    assert bound == "resp_t1"
+    looked = turn_store.lookup_idempotency_key("01890000-0000-7000-8000-000000000001")
+    assert looked == ("resp_t1", fp)
+
+
+def test_idempotency_replay_returns_same_turn(turn_store: TurnStore) -> None:
+    """Replaying the same key with the same body returns the original turn."""
+    _make_turn(turn_store, turn_id="resp_t1", now=1000)
+    key = "01890000-0000-7000-8000-000000000002"
+    fp = request_fingerprint('{"input":"hello"}')
+    turn_store.upsert_idempotency_key(
+        key=key, conversation_id=_CONV_ID, turn_id="resp_t1", fingerprint=fp, now=1000
+    )
+    # A retried send (e.g. after reconnect) re-presents the same key/body;
+    # it must resolve back to resp_t1, not mint a new turn.
+    again = turn_store.upsert_idempotency_key(
+        key=key,
+        conversation_id=_CONV_ID,
+        turn_id="resp_should_be_ignored",
+        fingerprint=fp,
+        now=1001,
+    )
+    assert again == "resp_t1"
+
+
+def test_idempotency_same_key_different_body_conflicts(turn_store: TurnStore) -> None:
+    """Reusing a key with a different payload raises (maps to HTTP 422)."""
+    _make_turn(turn_store, turn_id="resp_t1", now=1000)
+    key = "01890000-0000-7000-8000-000000000003"
+    turn_store.upsert_idempotency_key(
+        key=key,
+        conversation_id=_CONV_ID,
+        turn_id="resp_t1",
+        fingerprint=request_fingerprint('{"input":"hello"}'),
+        now=1000,
+    )
+    with pytest.raises(IdempotencyConflictError):
+        turn_store.upsert_idempotency_key(
+            key=key,
+            conversation_id=_CONV_ID,
+            turn_id="resp_t1",
+            fingerprint=request_fingerprint('{"input":"DIFFERENT"}'),
+            now=1001,
+        )
+
+
+def test_purge_idempotency_keys_before_cutoff(turn_store: TurnStore) -> None:
+    """The TTL sweep removes keys created before the cutoff and counts them."""
+    _make_turn(turn_store, turn_id="resp_t1", now=1000)
+    turn_store.upsert_idempotency_key(
+        key="01890000-0000-7000-8000-000000000010",
+        conversation_id=_CONV_ID,
+        turn_id="resp_t1",
+        fingerprint=request_fingerprint("{}"),
+        now=1000,
+    )
+    deleted = turn_store.purge_idempotency_keys_before(cutoff=2000)
+    assert deleted == 1
+    assert turn_store.lookup_idempotency_key("01890000-0000-7000-8000-000000000010") is None


### PR DESCRIPTION
## What

Sub-PR **#2** of the Phase 1 server-authoritative-turns stack (issue #466). Adds the **transport-agnostic, fully-unit-tested core** of the turn state machine and the leased `TurnStore` — the persistence layer the server dispatch path and the runner-side supervisor will call into. **No executor/tunnel/asyncio wiring yet** — that is sub-PR #3, deliberately split out because it is the invasive runtime-integration half.

Grounded in the synthesized plan (`designs/PHASE1_SERVER_AUTHORITATIVE_TURNS.md`, PR #470) and a two-model design review of the integration seam.

## Contents

**`omnigent/runtime/turn_state.py`** — pure functions, no DB/transport:
- Legal-transition matrix. **No client event can drive a transition** (design rule 1, encoded structurally — there is no `ATTACHED`/`DETACHED` pseudo-status).
- `is_worker_attributable()` — the single gate enforcing that **only `WORKER_*` codes feed vendor health/routing**. `TRANSPORT_DISCONNECT` / `RUNNER_LOST` / `CANCELLED` / `None` all return `False`. This is the fix for the original misdiagnosis (benching a healthy vendor on transport noise).
- `is_lease_expired()` with an **injected clock**.

**`omnigent/stores/turn_store.py`** — `TurnStore` with fenced compare-and-set:
- **Server owns `lease_epoch` and the `QUEUED→RUNNING` claim.** Affinity (`conversations.runner_id`) ≠ lease. The epoch is bumped in exactly **two** places: `claim()` and `sweep_expired()` takeover.
- `heartbeat()` renews `lease_expires_at` only — never bumps the epoch, never changes status. Fenced on owner + epoch + sweepable status.
- `sweep_expired()` marks expired `RUNNING`/`PAUSING` turns `FAILED(RUNNER_LOST)` **and bumps the epoch**, so a merely-disconnected runner that reconnects has its `complete()` CAS rejected — no split-brain. Flips **DB state only**; it cannot (and must not) kill runner-side execution. TTL sizing is the one knob that buys disconnect tolerance.
- `mark_client_liveness()` writes **only** `attached` / `last_client_seen` — the sole method the observation path may call.
- Idempotency `upsert` (replay → same turn; same-key/different-body → conflict) + TTL purge.

**Tests (63 passing):**
- Exhaustive transition-legality table; terminal states have no exits; `is_worker_attributable` excludes transport/runner/cancel.
- Fenced-CAS rejection on stale epoch / wrong owner for heartbeat and terminal writes.
- `claim` / `heartbeat` / `complete` / `sweep` happy paths + the **headline zombie-after-sweep reconnect race**.
- A **SQL-introspection test** asserting the liveness `UPDATE`'s `SET` clause names only the two liveness columns — design rule 1 enforced structurally, not by convention.
- Idempotency replay + same-key/different-body 422-class conflict + TTL purge.

The **clock is injected throughout** (callers pass `now`/`ttl`), so a single server clock governs both heartbeat writes and sweep comparisons (no cross-host skew) and tests are deterministic.

## Why this split isn't dead code

Both design reviewers converged on this seam: `TurnStore` + the pure state machine are exactly where the tunnel/executor will call in. Sub-PR #3 wiring is just: server dispatch calls `claim()`, a runner-side task emits heartbeat frames over the WS tunnel that the server turns into `heartbeat()` CAS writes, and a periodic scheduler calls `sweep_expired()`. No behavior rework needed; everything here is exercised by tests today.

## Stack

- #461 — design doc → `main`
- #470 — Phase 1 implementation plan → #461
- #474 — Phase 1 **schema** (models + migration + tests) → #470
- **this PR** — Phase 1 **state machine + leased TurnStore** → #474

## Test plan
- `pytest tests/runtime/test_turn_state.py tests/stores/test_turn_store.py` → 63 passed
- `ruff check` / `ruff format` clean on all four files.

Tracking issue: #466
