### PR TITLE
fix(claude-native): hold assistant commit until its streamed deltas forward

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -10,7 +10,7 @@ import logging
 import os
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -56,6 +56,167 @@ _HOOKS_FILE = "hooks.jsonl"
 # file is reset and the reader restarts from 0. Generous because one
 # prose answer can be hundreds of chunks.
 _MAX_SEEN_DELTA_KEYS = 5000
+
+# How long an assistant ``message`` transcript item may be held back
+# waiting for its streamed deltas to be forwarded first. The transcript
+# and the deltas file have independent writers (Claude's session loop vs
+# the MessageDisplay hook), so a short reply's transcript record can hit
+# disk a poll BEFORE its deltas — inverting the deltas-before-done
+# ordering every downstream consumer assumes (server in-flight
+# suppression, web preview replacement) and rendering the message twice.
+# ~8 polls at the 0.25s default: far above the real one-poll race window,
+# small enough that an unmatched item (deltas dropped by the best-effort
+# hook, or a multi-text-block message whose per-block item text never
+# byte-equals the whole-message delta stream) posts with barely
+# noticeable delay — and an unmatched item has no preview to duplicate.
+_ASSISTANT_ITEM_DELTA_HOLD_S = 2.0
+
+# Caps on the delta-ordering bookkeeping (forwarded delta texts per
+# message_id, first-held timestamps per source_id). Entries are consumed
+# on match / never revisited after post, so these are backstops against
+# pathological sessions, not working-set sizes.
+_MAX_DELTA_ORDERING_ENTRIES = 256
+
+
+@dataclass
+class _ForwardedDeltaText:
+    """
+    Forwarded streamed-text accumulation for one assistant message.
+
+    :param parts: Forwarded delta strings in arrival order, e.g.
+        ``["Hello ", "world"]``.
+    :param final: Whether the message's ``final: true`` chunk has been
+        forwarded — only then is ``"".join(parts)`` the complete text
+        and safe to byte-compare against a transcript item's text.
+    """
+
+    parts: list[str] = field(default_factory=list)
+    final: bool = False
+
+
+@dataclass
+class _DeltaOrderingState:
+    """
+    Cross-poll state enforcing deltas-before-done item ordering.
+
+    Mutated in place by :func:`_forward_available_deltas` (accumulates
+    forwarded chunk text per ``message_id``) and consumed by
+    :func:`_forward_available_items` via
+    :func:`_hold_assistant_item_for_deltas` (matches an assistant
+    ``message`` item to its already-forwarded delta stream by byte-equal
+    text — the same content join key the server's ``inflight_text``
+    uses, since the transcript carries no ``message_id``).
+
+    :param texts: ``message_id`` → forwarded delta text state. An entry
+        is popped when an item matches it.
+    :param held_since: ``source_id`` → monotonic time the item was first
+        held. Kept after the timeout releases the item (so retries of a
+        failed post aren't re-held); bounded, and never revisited once
+        the item lands in ``seen_source_ids``.
+    """
+
+    texts: dict[str, _ForwardedDeltaText] = field(default_factory=dict)
+    held_since: dict[str, float] = field(default_factory=dict)
+
+
+def _hold_monotonic() -> float:
+    """
+    Monotonic clock for the assistant-item hold timeout.
+
+    Thin indirection so tests can drive the timeout deterministically
+    without patching the process-global ``time.monotonic`` (see the
+    no-global-singleton-patch test rule). Patch THIS helper instead.
+
+    :returns: Seconds from an unspecified monotonic epoch.
+    """
+    return time.monotonic()
+
+
+def _item_output_text(data: dict[str, Any]) -> str | None:
+    """
+    Join the ``output_text`` blocks of a message item's content.
+
+    :param data: Item payload, e.g. ``{"role": "assistant", "content":
+        [{"type": "output_text", "text": "Hi"}]}``.
+    :returns: The joined text, or ``None`` when the item carries none.
+    """
+    content = data.get("content")
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "output_text":
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    if not parts:
+        return None
+    return "".join(parts)
+
+
+def _hold_assistant_item_for_deltas(
+    item: ClaudeTranscriptItem,
+    ordering: _DeltaOrderingState | None,
+    bridge_dir: Path,
+) -> bool:
+    """
+    Decide whether to defer an assistant message item to a later poll.
+
+    Restores the deltas-before-done ordering invariant at the source:
+    an assistant ``message`` item is posted only once a complete
+    (``final``-seen) forwarded delta stream byte-equals its text, or
+    after :data:`_ASSISTANT_ITEM_DELTA_HOLD_S`. Holding returns ``True``
+    and the caller stops the batch at this item (cursor unadvanced), so
+    later transcript items can't overtake it. Items that can't have a
+    streamed preview — tool calls, user messages, text-less messages,
+    sessions where the MessageDisplay hook never fired (no deltas
+    file) — are never held.
+
+    The timeout's failure direction is safe: a message whose deltas
+    never arrive has no live preview, so posting it late renders it
+    once, exactly like a non-streamed message.
+
+    :param item: The transcript item about to be posted.
+    :param ordering: Shared ordering state, or ``None`` to disable
+        holding (parsing-only test paths).
+    :param bridge_dir: Native Claude bridge directory (for the
+        deltas-file existence check).
+    :returns: ``True`` to hold the item (and the rest of the batch)
+        until the next poll; ``False`` to post it now.
+    """
+    if ordering is None:
+        return False
+    if item.item_type != "message" or item.data.get("role") != "assistant":
+        return False
+    text = _item_output_text(item.data)
+    if not text:
+        return False
+    if not (bridge_dir / MESSAGE_DELTAS_FILE).exists():
+        return False
+    for message_id, entry in ordering.texts.items():
+        if entry.final and "".join(entry.parts) == text:
+            # Deltas fully forwarded — consume the stream (a later
+            # identical-text message must match its own) and post.
+            ordering.texts.pop(message_id)
+            ordering.held_since.pop(item.source_id, None)
+            return False
+    now = _hold_monotonic()
+    first_held = ordering.held_since.setdefault(item.source_id, now)
+    while len(ordering.held_since) > _MAX_DELTA_ORDERING_ENTRIES:
+        del ordering.held_since[next(iter(ordering.held_since))]
+    if now - first_held >= _ASSISTANT_ITEM_DELTA_HOLD_S:
+        # Timestamp deliberately kept: if the post below fails and
+        # retries next poll, the elapsed check releases it immediately
+        # instead of re-holding for another full timeout.
+        _logger.debug(
+            "Posting assistant transcript item without matching forwarded "
+            "deltas after %.1fs hold; source_id=%s",
+            _ASSISTANT_ITEM_DELTA_HOLD_S,
+            item.source_id,
+        )
+        return False
+    return True
+
 
 # Seconds of transcript inactivity after which we publish ``idle`` for
 # a sub-agent. The transcript is the only signal we have for sub-agent
@@ -491,6 +652,13 @@ async def forward_claude_transcript_to_session(
     # prevents re-reads on the normal path.
     delta_state = _read_delta_forward_state(bridge_dir)
     seen_delta_keys: dict[tuple[str, int], None] = {}
+    # Deltas-before-done ordering across the two independent tails: the
+    # deltas forwarder records each message's forwarded text here, and
+    # the items forwarder holds an assistant message item until its
+    # text matches a complete forwarded stream (or a short timeout).
+    # Per-process like ``seen_delta_keys``; survives /clear and /fork
+    # rotations (message_ids belong to the long-lived Claude process).
+    delta_ordering = _DeltaOrderingState()
     item_retries = _PostRetryTracker()
     status_retries = _PostRetryTracker()
     subagent_start_retries = _PostRetryTracker()
@@ -623,12 +791,18 @@ async def forward_claude_transcript_to_session(
                     # — would land just AFTER its done event and re-create the
                     # already-finalized preview on the client (duplicate bubble
                     # + a stale trailing preview). See the web reconciler.
+                    # Within-poll order alone can't cover the cross-poll race
+                    # (transcript record flushed, hook delta write not yet) —
+                    # ``delta_ordering`` closes that: the items forwarder
+                    # holds an assistant message until its forwarded deltas
+                    # byte-match, or a short timeout expires.
                     delta_state = await _forward_available_deltas(
                         client=client,
                         session_id=current_session_id,
                         bridge_dir=bridge_dir,
                         state=delta_state,
                         seen_keys=seen_delta_keys,
+                        ordering=delta_ordering,
                     )
                     state = await _forward_available_items(
                         client=client,
@@ -639,6 +813,7 @@ async def forward_claude_transcript_to_session(
                         retry_tracker=item_retries,
                         skip_user_messages=skip_user_messages,
                         dedupe=dedupe,
+                        ordering=delta_ordering,
                     )
                     hook_state = await _forward_available_status_events(
                         client=client,
@@ -2444,6 +2619,7 @@ async def _forward_available_items(
     retry_tracker: _PostRetryTracker,
     skip_user_messages: bool = False,
     dedupe: _ForwardDedupeState,
+    ordering: _DeltaOrderingState | None = None,
 ) -> TranscriptForwardState:
     """
     Forward currently available transcript items after ``state``.
@@ -2457,6 +2633,13 @@ async def _forward_available_items(
         transcript item posts.
     :param dedupe: Last usage / context-window / model values POSTed;
         mutated in place to suppress duplicate ``external_*`` events.
+    :param ordering: Delta-ordering state shared with
+        :func:`_forward_available_deltas`. An assistant ``message``
+        item whose streamed deltas haven't fully forwarded yet is held
+        (batch stops at it, cursor unadvanced) until they have or a
+        short timeout expires — see
+        :func:`_hold_assistant_item_for_deltas`. ``None`` disables
+        holding.
     :returns: The updated transcript cursor state. On post failure it
         is the last durable cursor so retries don't re-post successful
         items.
@@ -2485,6 +2668,12 @@ async def _forward_available_items(
             seen_source_ids.append(item.source_id)
             seen.add(item.source_id)
             continue
+        # Deltas-before-done: an assistant message whose streamed deltas
+        # haven't been forwarded yet is deferred to a later poll. Stop
+        # the whole batch here (cursor stays before this item) so later
+        # items can't overtake it.
+        if _hold_assistant_item_for_deltas(item, ordering, bridge_dir):
+            return updated
         retry_key = f"item:{item.source_id}"
         if retry_tracker.retry_delay_s(retry_key) is not None:
             return updated
@@ -2911,6 +3100,7 @@ async def _forward_available_deltas(
     bridge_dir: Path,
     state: DeltaForwardState,
     seen_keys: dict[tuple[str, int], None],
+    ordering: _DeltaOrderingState | None = None,
 ) -> DeltaForwardState:
     """
     Forward newly appended assistant-text deltas to the active session.
@@ -2931,6 +3121,13 @@ async def _forward_available_deltas(
     :param seen_keys: In-memory ``(message_id, index)`` dedupe ring,
         mutated in place. Guards the rare file-truncation rewind where
         the reader restarts from offset ``0``.
+    :param ordering: Delta-ordering state, mutated in place: each
+        forwarded chunk's text accumulates under its ``message_id`` so
+        :func:`_hold_assistant_item_for_deltas` can match the message's
+        transcript item by byte-equal text. Accumulated on read (not
+        POST success) — a dropped chunk means the item should post
+        after the attempt, not wait on text that will never complete.
+        ``None`` disables tracking.
     :returns: The updated delta cursor state (offset advanced past the
         records just read).
     """
@@ -2956,6 +3153,13 @@ async def _forward_available_deltas(
         # limit.
         while len(seen_keys) > _MAX_SEEN_DELTA_KEYS:
             del seen_keys[next(iter(seen_keys))]
+        if ordering is not None:
+            entry = ordering.texts.setdefault(delta.message_id, _ForwardedDeltaText())
+            entry.parts.append(delta.delta)
+            if delta.final:
+                entry.final = True
+            while len(ordering.texts) > _MAX_DELTA_ORDERING_ENTRIES:
+                del ordering.texts[next(iter(ordering.texts))]
         try:
             await _post_external_output_text_delta(client, session_id=session_id, delta=delta)
         except httpx.HTTPError as exc:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -57,24 +57,19 @@ _HOOKS_FILE = "hooks.jsonl"
 # prose answer can be hundreds of chunks.
 _MAX_SEEN_DELTA_KEYS = 5000
 
-# How long an assistant ``message`` transcript item may be held back
-# waiting for its streamed deltas to be forwarded first. The transcript
-# and the deltas file have independent writers (Claude's session loop vs
-# the MessageDisplay hook), so a short reply's transcript record can hit
-# disk a poll BEFORE its deltas — inverting the deltas-before-done
-# ordering every downstream consumer assumes (server in-flight
-# suppression, web preview replacement) and rendering the message twice.
-# ~8 polls at the 0.25s default: far above the real one-poll race window,
-# small enough that an unmatched item (deltas dropped by the best-effort
-# hook, or a multi-text-block message whose per-block item text never
-# byte-equals the whole-message delta stream) posts with barely
-# noticeable delay — and an unmatched item has no preview to duplicate.
+# Max time an assistant ``message`` item is held waiting for its
+# streamed deltas to forward first. The transcript and deltas file have
+# independent writers, so a short reply's record can hit disk a poll
+# BEFORE its deltas — inverting the deltas-before-done order and
+# rendering the message twice. ~8 polls at 0.25s: well past the one-poll
+# race, short enough that an unmatched item (dropped deltas, or a
+# multi-block message that never byte-equals the whole-message stream)
+# posts with barely noticeable delay — and has no preview to duplicate.
 _ASSISTANT_ITEM_DELTA_HOLD_S = 2.0
 
-# Caps on the delta-ordering bookkeeping (forwarded delta texts per
-# message_id, first-held timestamps per source_id). Entries are consumed
-# on match / never revisited after post, so these are backstops against
-# pathological sessions, not working-set sizes.
+# Cap on the delta-ordering bookkeeping. Entries are consumed on match /
+# never revisited after post, so this is a backstop against pathological
+# sessions, not a working-set size.
 _MAX_DELTA_ORDERING_ENTRIES = 256
 
 
@@ -85,9 +80,9 @@ class _ForwardedDeltaText:
 
     :param parts: Forwarded delta strings in arrival order, e.g.
         ``["Hello ", "world"]``.
-    :param final: Whether the message's ``final: true`` chunk has been
-        forwarded — only then is ``"".join(parts)`` the complete text
-        and safe to byte-compare against a transcript item's text.
+    :param final: Whether the ``final: true`` chunk has forwarded — only
+        then is ``"".join(parts)`` the complete text, safe to byte-compare
+        against a transcript item.
     """
 
     parts: list[str] = field(default_factory=list)
@@ -99,20 +94,16 @@ class _DeltaOrderingState:
     """
     Cross-poll state enforcing deltas-before-done item ordering.
 
-    Mutated in place by :func:`_forward_available_deltas` (accumulates
-    forwarded chunk text per ``message_id``) and consumed by
-    :func:`_forward_available_items` via
-    :func:`_hold_assistant_item_for_deltas` (matches an assistant
-    ``message`` item to its already-forwarded delta stream by byte-equal
-    text — the same content join key the server's ``inflight_text``
-    uses, since the transcript carries no ``message_id``).
+    Filled by :func:`_forward_available_deltas` (forwarded chunk text per
+    ``message_id``) and consumed by :func:`_hold_assistant_item_for_deltas`,
+    which matches an assistant ``message`` item to its forwarded stream by
+    byte-equal text (the transcript carries no ``message_id``).
 
-    :param texts: ``message_id`` → forwarded delta text state. An entry
-        is popped when an item matches it.
-    :param held_since: ``source_id`` → monotonic time the item was first
-        held. Kept after the timeout releases the item (so retries of a
-        failed post aren't re-held); bounded, and never revisited once
-        the item lands in ``seen_source_ids``.
+    :param texts: ``message_id`` → forwarded delta text state. Popped
+        when an item matches it.
+    :param held_since: ``source_id`` → monotonic time first held. Kept
+        after the timeout releases the item so a failed post's retry
+        isn't re-held; bounded.
     """
 
     texts: dict[str, _ForwardedDeltaText] = field(default_factory=dict)
@@ -123,9 +114,8 @@ def _hold_monotonic() -> float:
     """
     Monotonic clock for the assistant-item hold timeout.
 
-    Thin indirection so tests can drive the timeout deterministically
-    without patching the process-global ``time.monotonic`` (see the
-    no-global-singleton-patch test rule). Patch THIS helper instead.
+    Indirection so tests patch THIS, not the process-global
+    ``time.monotonic`` (see the no-global-singleton-patch test rule).
 
     :returns: Seconds from an unspecified monotonic epoch.
     """
@@ -162,19 +152,14 @@ def _hold_assistant_item_for_deltas(
     """
     Decide whether to defer an assistant message item to a later poll.
 
-    Restores the deltas-before-done ordering invariant at the source:
-    an assistant ``message`` item is posted only once a complete
-    (``final``-seen) forwarded delta stream byte-equals its text, or
-    after :data:`_ASSISTANT_ITEM_DELTA_HOLD_S`. Holding returns ``True``
-    and the caller stops the batch at this item (cursor unadvanced), so
-    later transcript items can't overtake it. Items that can't have a
-    streamed preview — tool calls, user messages, text-less messages,
-    sessions where the MessageDisplay hook never fired (no deltas
-    file) — are never held.
-
-    The timeout's failure direction is safe: a message whose deltas
-    never arrive has no live preview, so posting it late renders it
-    once, exactly like a non-streamed message.
+    Enforces deltas-before-done: an assistant ``message`` item posts only
+    once a complete (``final``-seen) forwarded stream byte-equals its
+    text, or after :data:`_ASSISTANT_ITEM_DELTA_HOLD_S`. Holding returns
+    ``True`` and the caller stops the batch here (cursor unadvanced) so
+    later items can't overtake it. Items that can't have a preview — tool
+    calls, user/text-less messages, no-deltas-file sessions — never hold.
+    The timeout is safe: a message whose deltas never arrive has no live
+    preview, so a late post renders once, like any non-streamed message.
 
     :param item: The transcript item about to be posted.
     :param ordering: Shared ordering state, or ``None`` to disable
@@ -196,7 +181,7 @@ def _hold_assistant_item_for_deltas(
     for message_id, entry in ordering.texts.items():
         if entry.final and "".join(entry.parts) == text:
             # Deltas fully forwarded — consume the stream (a later
-            # identical-text message must match its own) and post.
+            # identical-text message matches its own) and post.
             ordering.texts.pop(message_id)
             ordering.held_since.pop(item.source_id, None)
             return False
@@ -205,9 +190,8 @@ def _hold_assistant_item_for_deltas(
     while len(ordering.held_since) > _MAX_DELTA_ORDERING_ENTRIES:
         del ordering.held_since[next(iter(ordering.held_since))]
     if now - first_held >= _ASSISTANT_ITEM_DELTA_HOLD_S:
-        # Timestamp deliberately kept: if the post below fails and
-        # retries next poll, the elapsed check releases it immediately
-        # instead of re-holding for another full timeout.
+        # Timestamp kept: a failed post's retry next poll is released
+        # immediately by the elapsed check, not re-held for a full timeout.
         _logger.debug(
             "Posting assistant transcript item without matching forwarded "
             "deltas after %.1fs hold; source_id=%s",
@@ -653,11 +637,11 @@ async def forward_claude_transcript_to_session(
     delta_state = _read_delta_forward_state(bridge_dir)
     seen_delta_keys: dict[tuple[str, int], None] = {}
     # Deltas-before-done ordering across the two independent tails: the
-    # deltas forwarder records each message's forwarded text here, and
-    # the items forwarder holds an assistant message item until its
-    # text matches a complete forwarded stream (or a short timeout).
-    # Per-process like ``seen_delta_keys``; survives /clear and /fork
-    # rotations (message_ids belong to the long-lived Claude process).
+    # deltas forwarder records each message's forwarded text, the items
+    # forwarder holds an assistant item until its text matches a complete
+    # forwarded stream (or a short timeout). Per-process like
+    # ``seen_delta_keys``; survives /clear and /fork (message_ids belong
+    # to the long-lived Claude process).
     delta_ordering = _DeltaOrderingState()
     item_retries = _PostRetryTracker()
     status_retries = _PostRetryTracker()
@@ -791,11 +775,10 @@ async def forward_claude_transcript_to_session(
                     # — would land just AFTER its done event and re-create the
                     # already-finalized preview on the client (duplicate bubble
                     # + a stale trailing preview). See the web reconciler.
-                    # Within-poll order alone can't cover the cross-poll race
-                    # (transcript record flushed, hook delta write not yet) —
-                    # ``delta_ordering`` closes that: the items forwarder
-                    # holds an assistant message until its forwarded deltas
-                    # byte-match, or a short timeout expires.
+                    # Within-poll order can't cover the cross-poll race
+                    # (transcript flushed, hook delta write not yet);
+                    # ``delta_ordering`` closes it by holding the assistant
+                    # item until its deltas byte-match or a timeout expires.
                     delta_state = await _forward_available_deltas(
                         client=client,
                         session_id=current_session_id,
@@ -2634,12 +2617,10 @@ async def _forward_available_items(
     :param dedupe: Last usage / context-window / model values POSTed;
         mutated in place to suppress duplicate ``external_*`` events.
     :param ordering: Delta-ordering state shared with
-        :func:`_forward_available_deltas`. An assistant ``message``
-        item whose streamed deltas haven't fully forwarded yet is held
-        (batch stops at it, cursor unadvanced) until they have or a
-        short timeout expires — see
-        :func:`_hold_assistant_item_for_deltas`. ``None`` disables
-        holding.
+        :func:`_forward_available_deltas`. An assistant ``message`` item
+        whose deltas haven't fully forwarded is held (batch stops, cursor
+        unadvanced) until they have or a timeout expires — see
+        :func:`_hold_assistant_item_for_deltas`. ``None`` disables holding.
     :returns: The updated transcript cursor state. On post failure it
         is the last durable cursor so retries don't re-post successful
         items.
@@ -2668,10 +2649,9 @@ async def _forward_available_items(
             seen_source_ids.append(item.source_id)
             seen.add(item.source_id)
             continue
-        # Deltas-before-done: an assistant message whose streamed deltas
-        # haven't been forwarded yet is deferred to a later poll. Stop
-        # the whole batch here (cursor stays before this item) so later
-        # items can't overtake it.
+        # Deltas-before-done: defer an assistant message whose deltas
+        # haven't forwarded yet. Stop the batch here (cursor before this
+        # item) so later items can't overtake it.
         if _hold_assistant_item_for_deltas(item, ordering, bridge_dir):
             return updated
         retry_key = f"item:{item.source_id}"
@@ -3122,12 +3102,10 @@ async def _forward_available_deltas(
         mutated in place. Guards the rare file-truncation rewind where
         the reader restarts from offset ``0``.
     :param ordering: Delta-ordering state, mutated in place: each
-        forwarded chunk's text accumulates under its ``message_id`` so
-        :func:`_hold_assistant_item_for_deltas` can match the message's
-        transcript item by byte-equal text. Accumulated on read (not
-        POST success) — a dropped chunk means the item should post
-        after the attempt, not wait on text that will never complete.
-        ``None`` disables tracking.
+        forwarded chunk's text accumulates under its ``message_id`` for
+        :func:`_hold_assistant_item_for_deltas` to byte-match. Accumulated
+        on read, not POST success — a dropped chunk should let the item
+        post, not wait on text that never completes. ``None`` disables it.
     :returns: The updated delta cursor state (offset advanced past the
         records just read).
     """

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5042,6 +5042,492 @@ async def test_post_external_output_text_delta_sends_expected_payload(tmp_path: 
     ]
 
 
+# ── deltas-before-done ordering (assistant item hold-back) ────────────
+
+
+def _write_assistant_transcript(path: Path, uuid: str, text: str) -> None:
+    """
+    Append one assistant text record to a Claude transcript JSONL file.
+
+    :param path: Transcript file path.
+    :param uuid: Record uuid, e.g. ``"u1"``.
+    :param text: Assistant text block content, e.g. ``"Hello world"``.
+    :returns: None.
+    """
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "uuid": uuid,
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": text}],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+
+def _transcript_state_for(transcript_path: Path) -> forwarder.TranscriptForwardState:
+    """
+    Build a fresh transcript cursor state for ``transcript_path``.
+
+    :param transcript_path: Transcript file the state points at.
+    :returns: A zero-cursor :class:`TranscriptForwardState`.
+    """
+    return forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_assistant_item_held_until_its_deltas_forward(tmp_path: Path) -> None:
+    """
+    An assistant item whose deltas haven't fully forwarded is deferred.
+
+    The transcript record and the deltas file have independent writers,
+    so the record can hit disk a poll before the message's chunks
+    (commit-before-delta). If the item posted first, the client would
+    render the committed text AND build a late `live:` preview from the
+    trailing chunks — the duplicate-bubble bug. This drives the real
+    race through both forwarders: with only a non-final chunk forwarded
+    the item must be held (no `external_conversation_item` POST, cursor
+    unadvanced); once the final chunk forwards and the joined text
+    byte-equals the item's, the item posts AFTER the deltas.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "Hello world")
+    # Only the first chunk has been written by the hook so far.
+    _write_deltas_file(
+        bridge_dir, [{"message_id": "m1", "index": 0, "final": False, "delta": "Hello "}]
+    )
+
+    ordering = forwarder._DeltaOrderingState()
+    seen_deltas: dict[tuple[str, int], None] = {}
+    captured: list[_CapturedDeltaPost] = []
+    async with _delta_capture_client(captured) as client:
+        delta_state = await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=forwarder.DeltaForwardState(),
+            seen_keys=seen_deltas,
+            ordering=ordering,
+        )
+        item_state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=_transcript_state_for(transcript_path),
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+        # Held: the item was NOT posted and the durable cursor did not
+        # advance past it, so the next poll re-reads it.
+        assert [c.body["type"] for c in captured] == ["external_output_text_delta"]
+        assert item_state.byte_offset == 0
+        assert item_state.seen_source_ids == ()
+
+        # Next poll: the hook's final chunk lands, completing the text.
+        _write_deltas_file(
+            bridge_dir, [{"message_id": "m1", "index": 1, "final": True, "delta": "world"}]
+        )
+        await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=delta_state,
+            seen_keys=seen_deltas,
+            ordering=ordering,
+        )
+        item_state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=item_state,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+
+    # The item posted AFTER both of its chunks — the ordering every
+    # downstream suppression layer assumes. Content asserted (not just
+    # counts) to prove the matched item is the right one.
+    item_posts = [c.body for c in captured if c.body["type"] == "external_conversation_item"]
+    assert len(item_posts) == 1
+    assert item_posts[0]["data"]["item_data"]["content"] == [
+        {"type": "output_text", "text": "Hello world"}
+    ]
+    assert [c.body["type"] for c in captured][:2] == [
+        "external_output_text_delta",
+        "external_output_text_delta",
+    ]
+    assert item_state.byte_offset == transcript_path.stat().st_size
+    # The matched stream was consumed: a later identical-text message
+    # must match its own deltas, not this stale entry.
+    assert ordering.texts == {}
+
+
+@pytest.mark.asyncio
+async def test_assistant_item_posts_after_hold_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An item whose deltas never arrive posts once the hold timeout expires.
+
+    Deltas are best-effort (the hook can drop them; a multi-text-block
+    message's per-block item text never byte-equals the whole-message
+    stream), so the hold must be bounded or such messages would never
+    persist. Past ``_ASSISTANT_ITEM_DELTA_HOLD_S`` the item posts even
+    with no matching stream — safe, because with no forwarded deltas
+    there is no live preview to duplicate.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "Hello world")
+    # Deltas file exists (hook active) but carries an UNRELATED stream,
+    # so the item can never match by text.
+    _write_deltas_file(
+        bridge_dir, [{"message_id": "m9", "index": 0, "final": True, "delta": "other"}]
+    )
+    clock = {"now": 100.0}
+    monkeypatch.setattr(forwarder, "_hold_monotonic", lambda: clock["now"])
+
+    ordering = forwarder._DeltaOrderingState()
+    captured: list[_CapturedDeltaPost] = []
+    async with _delta_capture_client(captured) as client:
+        await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=forwarder.DeltaForwardState(),
+            seen_keys={},
+            ordering=ordering,
+        )
+        state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=_transcript_state_for(transcript_path),
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+        assert [c.body["type"] for c in captured] == ["external_output_text_delta"]
+        assert state.byte_offset == 0  # held
+
+        clock["now"] = 100.0 + forwarder._ASSISTANT_ITEM_DELTA_HOLD_S
+        state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+
+    item_posts = [c.body for c in captured if c.body["type"] == "external_conversation_item"]
+    assert len(item_posts) == 1
+    assert item_posts[0]["data"]["item_data"]["content"] == [
+        {"type": "output_text", "text": "Hello world"}
+    ]
+    assert state.byte_offset == transcript_path.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_assistant_item_not_held_without_deltas_file(tmp_path: Path) -> None:
+    """
+    A session whose MessageDisplay hook never fired is never held.
+
+    With no deltas file there can be no live preview, hence no
+    duplicate — holding would only add latency to every assistant
+    message. The item must post on the first poll.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "Hello world")
+
+    captured: list[_CapturedDeltaPost] = []
+    async with _delta_capture_client(captured) as client:
+        state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=_transcript_state_for(transcript_path),
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=forwarder._DeltaOrderingState(),
+        )
+
+    item_posts = [c.body for c in captured if c.body["type"] == "external_conversation_item"]
+    assert len(item_posts) == 1
+    assert state.byte_offset == transcript_path.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_assistant_item_stays_held_until_true_final_chunk(tmp_path: Path) -> None:
+    """
+    The commit stays held while a NON-final chunk lands after it.
+
+    Per-chunk hooks are independent subprocesses, so any chunk — not just
+    the final one — can be forwarded AFTER the commit is already ready and
+    held (the observed ``D D C D`` race where the trailing ``D`` is not the
+    final chunk). The hold must wait for the message's ``final`` chunk to
+    byte-match, NOT release on "another delta arrived"; otherwise the late
+    non-final chunk would build a second ``live:`` preview after the commit
+    already rendered.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "Hello big world")
+
+    ordering = forwarder._DeltaOrderingState()
+    seen: dict[tuple[str, int], None] = {}
+    delta_state = forwarder.DeltaForwardState()
+    item_state = _transcript_state_for(transcript_path)
+    captured: list[_CapturedDeltaPost] = []
+
+    async def _poll(client: httpx.AsyncClient) -> None:
+        nonlocal delta_state, item_state
+        delta_state = await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=delta_state,
+            seen_keys=seen,
+            ordering=ordering,
+        )
+        item_state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=item_state,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+
+    async with _delta_capture_client(captured) as client:
+        # Poll 1: only the first (non-final) chunk; the commit is ready.
+        _write_deltas_file(
+            bridge_dir, [{"message_id": "m1", "index": 0, "final": False, "delta": "Hello "}]
+        )
+        await _poll(client)
+        assert item_state.byte_offset == 0  # held — no final chunk yet
+
+        # Poll 2: a SECOND non-final chunk lands AFTER the commit — still held.
+        _write_deltas_file(
+            bridge_dir, [{"message_id": "m1", "index": 1, "final": False, "delta": "big "}]
+        )
+        await _poll(client)
+        assert item_state.byte_offset == 0  # STILL held: stream not final
+        assert not [c for c in captured if c.body["type"] == "external_conversation_item"]
+
+        # Poll 3: the true final chunk lands → byte-matches → released.
+        _write_deltas_file(
+            bridge_dir, [{"message_id": "m1", "index": 2, "final": True, "delta": "world"}]
+        )
+        await _poll(client)
+
+    # Commit posts only AFTER all three deltas — the order downstream assumes.
+    assert [c.body["type"] for c in captured] == [
+        "external_output_text_delta",
+        "external_output_text_delta",
+        "external_output_text_delta",
+        "external_conversation_item",
+    ]
+    item = next(c.body for c in captured if c.body["type"] == "external_conversation_item")
+    assert item["data"]["item_data"]["content"] == [
+        {"type": "output_text", "text": "Hello big world"}
+    ]
+    assert item_state.byte_offset == transcript_path.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_assistant_item_held_when_final_seen_but_chunk_missing(tmp_path: Path) -> None:
+    """
+    Seeing the ``final`` chunk is not enough — the join must byte-equal.
+
+    If a middle chunk was dropped (or not yet forwarded), the concatenated
+    forwarded text does not equal the commit text, so the item must stay
+    held even though ``final`` was seen — never released on the ``final``
+    flag alone. This is why the release gate requires BOTH ``entry.final``
+    and the byte-equal check.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "Hello big world")
+    # Forward index 0 and the FINAL index 2 — but NOT the middle index 1.
+    _write_deltas_file(
+        bridge_dir,
+        [
+            {"message_id": "m1", "index": 0, "final": False, "delta": "Hello "},
+            {"message_id": "m1", "index": 2, "final": True, "delta": "world"},
+        ],
+    )
+
+    ordering = forwarder._DeltaOrderingState()
+    captured: list[_CapturedDeltaPost] = []
+    async with _delta_capture_client(captured) as client:
+        await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=forwarder.DeltaForwardState(),
+            seen_keys={},
+            ordering=ordering,
+        )
+        item_state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=_transcript_state_for(transcript_path),
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+
+    # final WAS seen, but join "Hello world" != commit "Hello big world".
+    assert ordering.texts["m1"].final is True
+    assert "".join(ordering.texts["m1"].parts) == "Hello world"
+    assert item_state.byte_offset == 0  # held despite the final flag
+    assert not [c for c in captured if c.body["type"] == "external_conversation_item"]
+
+
+@pytest.mark.asyncio
+async def test_two_identical_text_items_each_match_own_stream(tmp_path: Path) -> None:
+    """
+    Two assistant messages with identical text are matched by count.
+
+    Consume-once: the first commit pops one matching stream, the second
+    pops the other — both post, neither blocks nor steals from the other,
+    and the ordering state ends empty. Identical text renders identically,
+    so which physical stream a commit consumes does not matter.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "OK")
+    _write_assistant_transcript(transcript_path, "u2", "OK")
+    _write_deltas_file(
+        bridge_dir,
+        [
+            {"message_id": "mA", "index": 0, "final": True, "delta": "OK"},
+            {"message_id": "mB", "index": 0, "final": True, "delta": "OK"},
+        ],
+    )
+
+    ordering = forwarder._DeltaOrderingState()
+    captured: list[_CapturedDeltaPost] = []
+    async with _delta_capture_client(captured) as client:
+        await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=forwarder.DeltaForwardState(),
+            seen_keys={},
+            ordering=ordering,
+        )
+        item_state = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=_transcript_state_for(transcript_path),
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=ordering,
+        )
+
+    item_posts = [c.body for c in captured if c.body["type"] == "external_conversation_item"]
+    assert len(item_posts) == 2  # both released, neither blocked
+    assert all(
+        p["data"]["item_data"]["content"] == [{"type": "output_text", "text": "OK"}]
+        for p in item_posts
+    )
+    assert ordering.texts == {}  # both streams consumed (consume-once)
+    assert item_state.byte_offset == transcript_path.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_without_hold_commit_posts_before_final_delta(tmp_path: Path) -> None:
+    """
+    Break-the-feature guard: with the hold disabled the bug reproduces.
+
+    ``ordering=None`` disables the hold (the pre-fix behaviour). In the
+    inverted race the commit then posts immediately, landing BEFORE the
+    message's final delta — the exact ordering that builds a duplicate
+    ``live:`` preview. Paired with
+    ``test_assistant_item_held_until_its_deltas_forward`` (hold on → commit
+    posts AFTER its deltas), this pins the hold as the thing that fixes it.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
+    transcript_path = tmp_path / "session.jsonl"
+    _write_assistant_transcript(transcript_path, "u1", "Hello world")
+    _write_deltas_file(
+        bridge_dir, [{"message_id": "m1", "index": 0, "final": False, "delta": "Hello "}]
+    )
+
+    seen: dict[tuple[str, int], None] = {}
+    delta_state = forwarder.DeltaForwardState()
+    captured: list[_CapturedDeltaPost] = []
+    async with _delta_capture_client(captured) as client:
+        delta_state = await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=delta_state,
+            seen_keys=seen,
+            ordering=None,
+        )
+        await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=_transcript_state_for(transcript_path),
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=forwarder._ForwardDedupeState(),
+            ordering=None,
+        )
+        # Bug: with no hold the commit posts immediately, before the final chunk.
+        assert [c.body["type"] for c in captured] == [
+            "external_output_text_delta",
+            "external_conversation_item",
+        ]
+        _write_deltas_file(
+            bridge_dir, [{"message_id": "m1", "index": 1, "final": True, "delta": "world"}]
+        )
+        await forwarder._forward_available_deltas(
+            client=client,
+            session_id="conv_x",
+            bridge_dir=bridge_dir,
+            state=delta_state,
+            seen_keys=seen,
+            ordering=None,
+        )
+
+    # The final delta lands AFTER the commit — the inverted order that dupes.
+    types = [c.body["type"] for c in captured]
+    commit_idx = types.index("external_conversation_item")
+    final_delta_idx = max(i for i, t in enumerate(types) if t == "external_output_text_delta")
+    assert commit_idx < final_delta_idx
+
+
 # ── session cost reconciliation (max(S, C)) ───────────────────────────
 
 

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5090,15 +5090,11 @@ async def test_assistant_item_held_until_its_deltas_forward(tmp_path: Path) -> N
     """
     An assistant item whose deltas haven't fully forwarded is deferred.
 
-    The transcript record and the deltas file have independent writers,
-    so the record can hit disk a poll before the message's chunks
-    (commit-before-delta). If the item posted first, the client would
-    render the committed text AND build a late `live:` preview from the
-    trailing chunks — the duplicate-bubble bug. This drives the real
-    race through both forwarders: with only a non-final chunk forwarded
-    the item must be held (no `external_conversation_item` POST, cursor
-    unadvanced); once the final chunk forwards and the joined text
-    byte-equals the item's, the item posts AFTER the deltas.
+    Drives the real commit-before-delta race: with only a non-final chunk
+    forwarded the item is held (no POST, cursor unadvanced); once the final
+    chunk forwards and the joined text byte-equals the item's, it posts
+    AFTER the deltas. Posting first would dupe (committed text + a late
+    ``live:`` preview from the trailing chunks).
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"
@@ -5184,12 +5180,10 @@ async def test_assistant_item_posts_after_hold_timeout(
     """
     An item whose deltas never arrive posts once the hold timeout expires.
 
-    Deltas are best-effort (the hook can drop them; a multi-text-block
-    message's per-block item text never byte-equals the whole-message
-    stream), so the hold must be bounded or such messages would never
-    persist. Past ``_ASSISTANT_ITEM_DELTA_HOLD_S`` the item posts even
-    with no matching stream — safe, because with no forwarded deltas
-    there is no live preview to duplicate.
+    Deltas are best-effort (dropped chunks, multi-block messages that never
+    byte-match), so the hold must be bounded or such items would never
+    persist. Past ``_ASSISTANT_ITEM_DELTA_HOLD_S`` it posts with no match —
+    safe, since no forwarded deltas means no live preview to duplicate.
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"
@@ -5251,9 +5245,8 @@ async def test_assistant_item_not_held_without_deltas_file(tmp_path: Path) -> No
     """
     A session whose MessageDisplay hook never fired is never held.
 
-    With no deltas file there can be no live preview, hence no
-    duplicate — holding would only add latency to every assistant
-    message. The item must post on the first poll.
+    No deltas file means no live preview, hence no duplicate — holding
+    would only add latency. The item posts on the first poll.
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"
@@ -5282,13 +5275,10 @@ async def test_assistant_item_stays_held_until_true_final_chunk(tmp_path: Path) 
     """
     The commit stays held while a NON-final chunk lands after it.
 
-    Per-chunk hooks are independent subprocesses, so any chunk — not just
-    the final one — can be forwarded AFTER the commit is already ready and
-    held (the observed ``D D C D`` race where the trailing ``D`` is not the
-    final chunk). The hold must wait for the message's ``final`` chunk to
-    byte-match, NOT release on "another delta arrived"; otherwise the late
-    non-final chunk would build a second ``live:`` preview after the commit
-    already rendered.
+    Any chunk, not just the final one, can land after the commit (the
+    observed ``D D C D`` race). The hold must wait for the ``final`` chunk
+    to byte-match, NOT release on "another delta arrived" — else the late
+    non-final chunk builds a second ``live:`` preview after the commit.
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"
@@ -5362,11 +5352,9 @@ async def test_assistant_item_held_when_final_seen_but_chunk_missing(tmp_path: P
     """
     Seeing the ``final`` chunk is not enough — the join must byte-equal.
 
-    If a middle chunk was dropped (or not yet forwarded), the concatenated
-    forwarded text does not equal the commit text, so the item must stay
-    held even though ``final`` was seen — never released on the ``final``
-    flag alone. This is why the release gate requires BOTH ``entry.final``
-    and the byte-equal check.
+    A dropped middle chunk leaves the joined text != commit text, so the
+    item stays held despite ``final`` being seen. This is why the release
+    gate requires BOTH ``entry.final`` and the byte-equal check.
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"
@@ -5414,10 +5402,9 @@ async def test_two_identical_text_items_each_match_own_stream(tmp_path: Path) ->
     """
     Two assistant messages with identical text are matched by count.
 
-    Consume-once: the first commit pops one matching stream, the second
-    pops the other — both post, neither blocks nor steals from the other,
-    and the ordering state ends empty. Identical text renders identically,
-    so which physical stream a commit consumes does not matter.
+    Consume-once: the first commit pops one stream, the second pops the
+    other — both post, ordering ends empty. Identical text renders
+    identically, so which physical stream a commit consumes doesn't matter.
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"
@@ -5468,12 +5455,9 @@ async def test_without_hold_commit_posts_before_final_delta(tmp_path: Path) -> N
     """
     Break-the-feature guard: with the hold disabled the bug reproduces.
 
-    ``ordering=None`` disables the hold (the pre-fix behaviour). In the
-    inverted race the commit then posts immediately, landing BEFORE the
-    message's final delta — the exact ordering that builds a duplicate
-    ``live:`` preview. Paired with
-    ``test_assistant_item_held_until_its_deltas_forward`` (hold on → commit
-    posts AFTER its deltas), this pins the hold as the thing that fixes it.
+    ``ordering=None`` (pre-fix behaviour): the commit posts immediately,
+    BEFORE the final delta — the exact order that dupes the ``live:``
+    preview. Paired with the hold-on test, this pins the hold as the fix.
     """
     bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b1", workspace=tmp_path)
     transcript_path = tmp_path / "session.jsonl"


### PR DESCRIPTION
### Problem
A native Claude assistant message is surfaced two ways with **no shared id**: streamed text deltas (live preview, from the MessageDisplay hook) and the committed transcript item. The two files have independent writers, so a delta chunk can be forwarded **after** the commit — the client then renders the committed bubble *and* a second `live:` preview from the late chunk: a transient duplicate.

### Fix
Hold the assistant message item in the forwarder until its complete (`final`-seen) delta stream **byte-equals** its text (or a ~2 s timeout), forcing deltas-before-commit so no chunk lands after the commit. The hold only *delays* the commit (never suppresses a preview), and matches on complete byte-equal text — so the failure direction is safe and identical-text messages stay interchangeable.

### Why not just reconcile by content?
A non-final chunk is only a *prefix* of the commit, so content/prefix matching can't safely attribute a mid-stream chunk — and prefix matching mis-identifies messages that share common prefixes (`"Let me…"`, `"Done."`). Claude exposes no shared id across the two streams, so forcing the ordering is the only sound fix.

### How it works

Two independent writers race into the forwarder's per-poll tail:

```
Claude process
   │
   ├──> session loop ──────────> transcript.jsonl      (the "commit" / output_item.done)
   │
   └──> MessageDisplay hook ───> message_deltas.jsonl  (the live "live:" preview chunks)
```

Each poll forwards deltas first, accumulates them per `message_id`, and the items
forwarder holds the assistant commit until its deltas catch up:

```
                         ┌─────────────────────────── one poll ───────────────────────────┐

  message_deltas.jsonl ──► _forward_available_deltas ──► POST external_output_text_delta
                                      │                          (chunks forwarded first)
                                      │ accumulates per message_id
                                      ▼
                          ┌──────────────────────────────┐
                          │   _DeltaOrderingState          │
                          │   texts: {                     │
                          │     "m1": parts=["Hello ",     │
                          │            "world"], final=T   │
                          │   }                            │
                          └──────────────────────────────┘
                                      │ byte-equal match?
                                      ▼
  transcript.jsonl ──────► _forward_available_items ──► _hold_assistant_item_for_deltas
                                                                  │
                                          ┌───────────────────────┴───────────────────────┐
                                       HOLD (True)                                    POST (False)
                          stop batch here, cursor unadvanced              post external_conversation_item
                          → re-read same item next poll                   → commit lands AFTER its deltas
```

The hold decision (`_hold_assistant_item_for_deltas`):

```
is it an assistant message with text?  ── no ──► POST  (tool calls, user msgs, empty)
        │ yes
deltas file exists (hook ever fired)?  ── no ──► POST  (no preview possible → no dupe)
        │ yes
∃ stream where final==True AND
   "".join(parts) == item.text ?        ── yes ─► consume (pop) the stream, POST
        │ no
held longer than 2s timeout?            ── yes ─► POST anyway (bounded; safe — no
        │ no                                       forwarded deltas = no preview to dupe)
        ▼
      HOLD
```

The failure direction is always safe: the hold only *delays* a commit, never suppresses a preview — so the worst case is a slightly late message, never a duplicate.

### Tests
non-final chunk after the commit → held until the true final · `final`-seen-but-incomplete → byte-equal required · identical-content consume-once · timeout release · never held without a deltas file · break-the-feature (no hold → commit before final delta).

*This pull request and its description were written by Isaac, the AI coding assistant.*
