### PR TITLE
feat(pi): make event_timeout configurable via providers config

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1315,6 +1315,7 @@ class PiExecutor(Executor):
         bundle_dir: pathlib.Path | None = None,
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
+        event_timeout: float | None = None,
     ) -> None:
         """Create a PiExecutor.
 
@@ -1369,6 +1370,10 @@ class PiExecutor(Executor):
             so Pi sees zero skills; a list adds ``--no-skills`` plus
             ``--skill`` for each named bundle skill — names not
             present in the bundle are silently skipped.
+        :param event_timeout: Seconds to wait for each JSONL line from
+            Pi's stdout before treating the turn as stalled. ``None``
+            uses the default of 120 seconds. Increase for slow local
+            models that take longer between tokens.
         """
         resolved_pi = pi_path or _find_pi_cli()
         if not resolved_pi:
@@ -1414,6 +1419,7 @@ class PiExecutor(Executor):
         # ``_build_env_and_dir`` copies ``self._extra_args`` so this
         # extension is read-only after init.
         self._extra_args.extend(_resolve_pi_skill_args(skills_filter, bundle_dir))
+        self._event_timeout: float = event_timeout if event_timeout is not None else 120.0
         # Set by Session._wire_sdk_executor().
         self._tool_executor: ToolExecutor | None = None
 
@@ -1871,7 +1877,7 @@ class PiExecutor(Executor):
         message_usages: list[dict[str, Any]] = []  # type: ignore[explicit-any]
 
         while True:
-            line = await rpc.read_line(timeout=120.0)
+            line = await rpc.read_line(timeout=self._event_timeout)
             if line is None:
                 if not streamed_any and not response_text:
                     stderr = "\n".join(rpc._stderr_lines) if rpc._stderr_lines else ""

--- a/omnigent/inner/pi_harness.py
+++ b/omnigent/inner/pi_harness.py
@@ -95,6 +95,7 @@ _ENV_GATEWAY_BASE_URL = "HARNESS_PI_GATEWAY_BASE_URL"
 _ENV_GATEWAY_BASE_URLS = "HARNESS_PI_GATEWAY_BASE_URLS"
 _ENV_GATEWAY_AUTH_COMMAND = "HARNESS_PI_GATEWAY_AUTH_COMMAND"
 _ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_PI_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
+_ENV_EVENT_TIMEOUT = "HARNESS_PI_EVENT_TIMEOUT"
 
 # Truthy strings the wrap accepts for boolean env vars. Must
 # match the claude-sdk and codex wraps' parsers for consistency
@@ -211,6 +212,13 @@ def _build_pi_executor() -> Executor:
     bundle_dir = Path(bundle_dir_raw) if bundle_dir_raw else None
     agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
     agent_name = agent_name_raw or None
+    event_timeout: float | None = None
+    event_timeout_raw = os.environ.get(_ENV_EVENT_TIMEOUT, "").strip()
+    if event_timeout_raw:
+        try:
+            event_timeout = float(event_timeout_raw)
+        except ValueError:
+            pass
     return PiExecutor(
         cwd=os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE"),
         os_env=_resolve_os_env(),
@@ -225,6 +233,7 @@ def _build_pi_executor() -> Executor:
         bundle_dir=bundle_dir,
         agent_name=agent_name,
         skills_filter=_resolve_skills_filter(),
+        event_timeout=event_timeout,
     )
 
 

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -285,6 +285,7 @@ class ProviderEntry:
     model_provider: str | None = None
     display_name: str | None = None
     default_families: frozenset[str] = frozenset()
+    event_timeout: float | None = None
 
     @property
     def default(self) -> bool:
@@ -789,6 +790,17 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
             f"provider {name!r} (kind {kind!r}) configures no 'anthropic' or 'openai' family.",
             code=ErrorCode.INVALID_INPUT,
         )
+    event_timeout_raw = raw.get("event_timeout")
+    event_timeout: float | None = None
+    if event_timeout_raw is not None:
+        try:
+            event_timeout = float(event_timeout_raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise OmnigentError(
+                f"provider {name!r}: 'event_timeout' must be a number (seconds), "
+                f"got {event_timeout_raw!r}.",
+                code=ErrorCode.INVALID_INPUT,
+            )
     return ProviderEntry(
         name=name,
         kind=kind,
@@ -796,6 +808,7 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
         default_families=_parse_default_families(
             name, default_raw, set(families), pi_capable=True
         ),
+        event_timeout=event_timeout,
     )
 
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -830,6 +830,8 @@ def _apply_provider_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
         catalog_default = _catalog_default_model(auth_family)
         if catalog_default is not None:
             env["HARNESS_PI_MODEL"] = catalog_default
+    if entry.event_timeout is not None:
+        env["HARNESS_PI_EVENT_TIMEOUT"] = str(entry.event_timeout)
     if "HARNESS_PI_MODEL" not in env:
         # Fail loud only when the catalog has no default for the chosen family
         # (genuinely unknown — should not happen for a known family).


### PR DESCRIPTION
## Summary

- Adds an `event_timeout` field to inline-family provider entries (`key`/`gateway`/`local`) in `~/.omnigent/config.yaml`
- Threads the value through `ProviderEntry` → `_apply_provider_to_pi()` → `HARNESS_PI_EVENT_TIMEOUT` → `_build_pi_executor()` → `PiExecutor`
- Replaces the hardcoded 120s per-line read timeout in `PiExecutor.run_turn()` with the configured value

**Example config:**
\`\`\`yaml
providers:
  local-llama:
    kind: local
    event_timeout: 300   # seconds; default is 120
    anthropic:
      base_url: http://localhost:8080
      ...
\`\`\`

Useful for slow local models that take longer between tokens and would otherwise cause the executor to treat a still-running turn as stalled.

## Test plan

- [ ] Set `event_timeout: 300` on a local provider and confirm `HARNESS_PI_EVENT_TIMEOUT=300.0` appears in the pi harness subprocess env
- [ ] Verify a slow local model turn completes without timing out at 120s
- [ ] Verify default (no `event_timeout` set) still uses 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)