### PR TITLE
test: verify reviewer-assign skips non-fork PRs (please ignore, will close)

### DIFF
--- a/deploy/NOASSIGN_TEST.md
+++ b/deploy/NOASSIGN_TEST.md
@@ -1,0 +1,4 @@
+# Reviewer-assign no-op test
+
+Throwaway same-repo (non-fork) PR to verify auto-assign-reviewer.yml does NOT
+request reviewers on non-fork PRs. Will be closed after verifying.


### PR DESCRIPTION
Dummy same-repo (non-fork) PR touching `/deploy/` (an owned area). Expectation: the merged `Auto-assign Reviewer` workflow **skips** it (non-fork guard), so **no reviewers are requested**. Will be closed after verification.