### PR TITLE
feat(testing): add warn-mode test-environment guardrails

### DIFF
--- a/omnigent/testing/__init__.py
+++ b/omnigent/testing/__init__.py
@@ -1,0 +1,9 @@
+"""Test-environment safety helpers for the Omnigent suite.
+
+Houses additive guardrails that assert a test run is pointed at
+throwaway resources (a tmp/in-memory SQLite DB, no dev/prod ports)
+rather than a developer's real local instance. See
+:mod:`omnigent.testing.guardrails`.
+"""
+
+from __future__ import annotations

--- a/omnigent/testing/guardrails.py
+++ b/omnigent/testing/guardrails.py
@@ -1,0 +1,260 @@
+"""Warn-mode test-environment guardrails.
+
+A small, additive safety net that checks a test run is pointed at
+throwaway resources — running under pytest, against a tmp/in-memory
+SQLite DB, and not aimed at a known dev/prod host or port — *before*
+the suite starts mutating state.
+
+Today every check is **warn-only**: a violation logs a clear
+``TEST GUARDRAIL:`` ``WARNING`` and the run continues. The design keeps
+a single ``warn_only`` switch so a future PR can flip the default to
+``False`` and have the same checks hard-fail (raise
+:class:`TestGuardrailError`) with no other code change.
+
+Entry point: :func:`check_test_environment`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+# Prefix on every guardrail log line so violations are greppable and so a
+# future hard-fail mode can reuse the identical message.
+_WARN_PREFIX = "TEST GUARDRAIL:"
+
+# Ports we never want a test to drive: the local server default (6767),
+# the Docker server (8000), and the Vite dev server (5173). A test base
+# URL hitting any of these is almost certainly pointed at a real running
+# instance rather than an ephemeral fixture server (which binds a random
+# free port). Module-level so it's trivial to extend.
+DEV_PORTS: frozenset[int] = frozenset({6767, 8000, 5173})
+
+# Hostnames that denote a developer's own machine. A bare loopback host
+# is only flagged when paired with a dev port (handled separately), but
+# these named dev/prod hosts are always suspect for a test base URL.
+DEV_HOSTS: frozenset[str] = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",
+        "::1",
+        "host.docker.internal",
+    }
+)
+
+# Env vars that, when set, explicitly assert "this process is a test run"
+# even if pytest's own PYTEST_CURRENT_TEST isn't visible yet (it's only
+# set per-test, not at session configure time). OMNIGENT_TEST_MODE is
+# introduced by this module as the canonical, settable flag.
+_TEST_MODE_ENV_VARS = ("OMNIGENT_TEST_MODE", "OMNIGENT_ENV")
+_TEST_MODE_ENV_VALUES = frozenset({"1", "true", "test", "testing", "yes", "on"})
+
+
+class TestGuardrailError(AssertionError):
+    """Raised by :func:`check_test_environment` when ``warn_only=False``.
+
+    Subclasses :class:`AssertionError` so a future hard-fail mode reads
+    naturally as a failed test precondition. Unused while the default is
+    warn-only, but defined now so the hard-fail flip is a one-line change.
+    """
+
+    # Tell pytest this is not a test class despite the ``Test`` prefix.
+    __test__ = False
+
+
+def looks_like_pytest(env: Mapping[str, str]) -> bool:
+    """Return whether *env* indicates the process is a pytest run.
+
+    True when pytest's per-test ``PYTEST_CURRENT_TEST`` is set, when the
+    ``pytest`` module is already imported, or when an explicit test-mode
+    flag (:data:`_TEST_MODE_ENV_VARS`) is truthy.
+
+    :param env: Environment mapping to inspect (usually ``os.environ``).
+    :returns: ``True`` if this looks like a test process.
+    """
+    if env.get("PYTEST_CURRENT_TEST"):
+        return True
+    if "pytest" in _imported_modules():
+        return True
+    for name in _TEST_MODE_ENV_VARS:
+        if env.get(name, "").strip().lower() in _TEST_MODE_ENV_VALUES:
+            return True
+    return False
+
+
+def _imported_modules() -> frozenset[str]:
+    """Return the set of top-level imported module names.
+
+    Wrapped in a helper so tests can reason about it; pytest is in
+    ``sys.modules`` for the whole session once collection starts.
+    """
+    import sys
+
+    return frozenset(sys.modules)
+
+
+def looks_like_test_db(db_uri: str) -> bool:
+    """Return whether *db_uri* looks like a throwaway test database.
+
+    Accepts in-memory SQLite, file SQLite under a system temp dir, or any
+    URI whose path/name contains ``test``. Everything else (a real
+    ``~/.omnigent/chat.db``, a Postgres ``DATABASE_URL``) is treated as a
+    non-test DB.
+
+    :param db_uri: A SQLAlchemy-style URI, e.g. ``sqlite:///…`` .
+    :returns: ``True`` if the URI looks like a test DB.
+    """
+    if not db_uri:
+        return False
+    lowered = db_uri.lower()
+
+    # In-memory SQLite: `sqlite://`, `sqlite:///:memory:`, or `mode=memory`.
+    if ":memory:" in lowered or "mode=memory" in lowered:
+        return True
+    if lowered in ("sqlite://", "sqlite:///"):
+        return True
+
+    if "test" in lowered:
+        return True
+
+    path = _sqlite_path(db_uri)
+    if path is not None and _under_temp_dir(path):
+        return True
+
+    return False
+
+
+def _sqlite_path(db_uri: str) -> Path | None:
+    """Extract the filesystem path from a file-backed SQLite URI.
+
+    :param db_uri: A candidate database URI.
+    :returns: The DB file path, or ``None`` for non-file-SQLite URIs.
+    """
+    prefix = "sqlite:///"
+    if not db_uri.lower().startswith(prefix):
+        return None
+    raw = db_uri[len(prefix) :]
+    # Strip any query string (e.g. `?mode=memory&cache=shared`).
+    raw = raw.split("?", 1)[0]
+    if not raw or raw == ":memory:":
+        return None
+    return Path(raw)
+
+
+def _under_temp_dir(path: Path) -> bool:
+    """Return whether *path* lives under a system temp directory.
+
+    Compares against :func:`tempfile.gettempdir` plus the common
+    ``/tmp`` and ``/private/var`` (macOS) roots, all resolved so symlinked
+    temp dirs (macOS ``/tmp`` → ``/private/tmp``) still match.
+
+    :param path: A filesystem path (need not exist).
+    :returns: ``True`` if *path* is under a temp root.
+    """
+    candidate = _resolve(path)
+    temp_roots = {
+        _resolve(Path(tempfile.gettempdir())),
+        _resolve(Path("/tmp")),
+        _resolve(Path("/private/var/folders")),
+    }
+    return any(candidate == root or root in candidate.parents for root in temp_roots)
+
+
+def _resolve(path: Path) -> Path:
+    """Best-effort absolute resolution that tolerates missing paths."""
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def base_url_violation(base_url: str) -> str | None:
+    """Return a human-readable reason if *base_url* targets a dev host/port.
+
+    :param base_url: The test base URL, e.g. ``http://localhost:6767``.
+    :returns: A reason string when the URL is suspect, else ``None``.
+    """
+    if not base_url:
+        return None
+
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+
+    if port in DEV_PORTS:
+        return f"base_url {base_url!r} targets dev/prod port {port}"
+    if host in DEV_HOSTS and port is None:
+        # A named dev host with no explicit port (default 80/443) still
+        # smells like a real instance rather than an ephemeral fixture.
+        return f"base_url {base_url!r} targets dev host {host!r}"
+    return None
+
+
+def check_test_environment(
+    *,
+    env: Mapping[str, str] | None = None,
+    db_uri: str,
+    base_url: str | None = None,
+    warn_only: bool = True,
+) -> list[str]:
+    """Check the test environment is pointed at throwaway resources.
+
+    Runs three checks and collects a reason string for each violation:
+
+    a. the process looks like a pytest run (:func:`looks_like_pytest`);
+    b. *db_uri* looks like a test DB (:func:`looks_like_test_db`);
+    c. *base_url*, when given, does not target a dev/prod host or port
+       (:func:`base_url_violation`).
+
+    When ``warn_only`` is ``True`` (the default today) each violation is
+    logged as a ``WARNING`` prefixed with ``TEST GUARDRAIL:`` and the
+    function returns the list of reasons. When ``warn_only`` is ``False``
+    the same set of violations raises :class:`TestGuardrailError` — this
+    is the future hard-fail mode and is not used by the suite yet.
+
+    :param env: Environment mapping; defaults to ``os.environ``.
+    :param db_uri: The resolved store DB URI for this run.
+    :param base_url: Optional base URL the test will drive.
+    :param warn_only: Log instead of raise on violation (default ``True``).
+    :returns: The list of violation reason strings (empty when clean).
+    :raises TestGuardrailError: when ``warn_only=False`` and any check fails.
+    """
+    if env is None:
+        env = os.environ
+
+    violations: list[str] = []
+
+    if not looks_like_pytest(env):
+        violations.append(
+            "process does not look like a pytest run "
+            "(no PYTEST_CURRENT_TEST / OMNIGENT_TEST_MODE and pytest not imported)"
+        )
+
+    if not looks_like_test_db(db_uri):
+        violations.append(
+            f"db_uri {db_uri!r} does not look like a test DB "
+            "(expected an in-memory/tmp SQLite or a URI containing 'test')"
+        )
+
+    if base_url is not None:
+        reason = base_url_violation(base_url)
+        if reason is not None:
+            violations.append(reason)
+
+    if not violations:
+        return violations
+
+    if warn_only:
+        for reason in violations:
+            _logger.warning("%s %s", _WARN_PREFIX, reason)
+        return violations
+
+    raise TestGuardrailError(f"{_WARN_PREFIX} " + "; ".join(violations))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,29 @@ def pytest_configure(config: pytest.Config) -> None:
         worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
         _PROGRESS_LOG_PATH = os.path.join(log_dir, f"progress-{worker}.log")
 
+    _run_test_environment_guardrails(config)
+
+
+def _run_test_environment_guardrails(config: pytest.Config) -> None:
+    """Surface test-environment guardrail warnings at session start.
+
+    Warn-only: :func:`check_test_environment` logs ``TEST GUARDRAIL:``
+    warnings for anything that looks like a real (non-test) DB or a base
+    URL aimed at a dev/prod host or port, and never raises in this mode.
+    A future PR can flip ``warn_only=False`` to make these hard
+    preconditions — this call site needs no change for that.
+
+    The resolved DB URI mirrors how a run would pick one: an explicit
+    ``OMNIGENT_DATABASE_URI`` wins (so pointing the suite at a real DB
+    warns loudly), else we fall back to the per-worker tmp MLflow SQLite
+    set just above — a representative throwaway DB that passes cleanly.
+    """
+    from omnigent.testing.guardrails import check_test_environment
+
+    db_uri = os.environ.get("OMNIGENT_DATABASE_URI") or os.environ.get("MLFLOW_TRACKING_URI", "")
+    base_url = config.getoption("--omnigent-server-url", default=None)
+    check_test_environment(db_uri=db_uri, base_url=base_url, warn_only=True)
+
 
 def pytest_unconfigure(config: pytest.Config) -> None:
     """Remove the per-worker MLflow tmpdir created in pytest_configure.

--- a/tests/testing/test_guardrails.py
+++ b/tests/testing/test_guardrails.py
@@ -1,0 +1,204 @@
+"""Unit tests for the warn-mode test-environment guardrails.
+
+In-process only: no server, no browser. Exercises the pass case, each
+violation's warning, and the contract that ``warn_only=True`` never
+raises. Also covers the hard-fail path so a future flip of the default
+is already verified.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from omnigent.testing.guardrails import (
+    DEV_PORTS,
+    TestGuardrailError,
+    base_url_violation,
+    check_test_environment,
+    looks_like_pytest,
+    looks_like_test_db,
+)
+
+# An env that asserts a test run without relying on the ambient
+# PYTEST_CURRENT_TEST (which pytest only sets per-test).
+_TEST_ENV = {"OMNIGENT_TEST_MODE": "1"}
+_TMP_DB = "sqlite:////tmp/pytest-abc/test.db"
+
+
+def _guardrail_warnings(records: list[logging.LogRecord]) -> list[str]:
+    """Return the messages of records emitted by the guardrail logger."""
+    return [
+        r.getMessage()
+        for r in records
+        if r.name == "omnigent.testing.guardrails" and "TEST GUARDRAIL:" in r.getMessage()
+    ]
+
+
+# ── pass case ────────────────────────────────────────────
+
+
+def test_clean_environment_emits_no_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A test process + tmp DB + ephemeral base URL is clean."""
+    with caplog.at_level(logging.WARNING):
+        violations = check_test_environment(
+            env=_TEST_ENV,
+            db_uri=_TMP_DB,
+            base_url="http://127.0.0.1:54321",
+            warn_only=True,
+        )
+    assert violations == []
+    assert _guardrail_warnings(caplog.records) == []
+
+
+@pytest.mark.parametrize(
+    "db_uri",
+    [
+        "sqlite://",
+        "sqlite:///:memory:",
+        "sqlite:///file::memory:?cache=shared",
+        "sqlite:////tmp/foo/test.db",
+        "postgresql://localhost/test_db",
+        "sqlite:////var/data/my_test_store.db",
+    ],
+)
+def test_looks_like_test_db_accepts_throwaway_uris(db_uri: str) -> None:
+    assert looks_like_test_db(db_uri) is True
+
+
+@pytest.mark.parametrize(
+    "db_uri",
+    [
+        "",
+        "sqlite:////home/alice/.omnigent/chat.db",
+        "postgresql://prod-host:5432/omnigent",
+    ],
+)
+def test_looks_like_test_db_rejects_real_uris(db_uri: str) -> None:
+    assert looks_like_test_db(db_uri) is False
+
+
+def test_looks_like_pytest_via_flag() -> None:
+    assert looks_like_pytest({"OMNIGENT_TEST_MODE": "1"}) is True
+    assert looks_like_pytest({"PYTEST_CURRENT_TEST": "x::y (call)"}) is True
+
+
+# ── each violation emits a warning ───────────────────────
+
+
+def test_non_test_process_warns(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A process with no test signal emits the process-check warning.
+
+    ``looks_like_pytest`` consults ``sys.modules`` (pytest is always
+    imported while these tests run), so we stub the module-set helper to
+    simulate a non-test process, then confirm the violation is logged and
+    warn mode still returns rather than raising.
+    """
+    from omnigent.testing import guardrails
+
+    monkeypatch.setattr(guardrails, "_imported_modules", frozenset)
+    with caplog.at_level(logging.WARNING):
+        violations = check_test_environment(
+            env={},
+            db_uri=_TMP_DB,
+            warn_only=True,
+        )
+    warnings = _guardrail_warnings(caplog.records)
+    assert any("does not look like a pytest run" in w for w in warnings)
+    assert any("pytest run" in v for v in violations)
+
+
+def test_real_db_warns(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        check_test_environment(
+            env=_TEST_ENV,
+            db_uri="sqlite:////home/alice/.omnigent/chat.db",
+            warn_only=True,
+        )
+    warnings = _guardrail_warnings(caplog.records)
+    assert any("does not look like a test DB" in w for w in warnings)
+
+
+@pytest.mark.parametrize("port", sorted(DEV_PORTS))
+def test_dev_port_base_url_warns(port: int, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        violations = check_test_environment(
+            env=_TEST_ENV,
+            db_uri=_TMP_DB,
+            base_url=f"http://localhost:{port}",
+            warn_only=True,
+        )
+    warnings = _guardrail_warnings(caplog.records)
+    assert any(f"port {port}" in w for w in warnings)
+    assert any(str(port) in v for v in violations)
+
+
+def test_dev_host_no_port_warns() -> None:
+    assert base_url_violation("http://localhost") is not None
+    assert base_url_violation("http://host.docker.internal") is not None
+
+
+def test_ephemeral_base_url_is_clean() -> None:
+    # Random free port on loopback -> the fixture-server shape. Clean.
+    assert base_url_violation("http://127.0.0.1:49152") is None
+
+
+def test_multiple_violations_each_warn(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        violations = check_test_environment(
+            env=_TEST_ENV,
+            db_uri="sqlite:////home/alice/.omnigent/chat.db",
+            base_url="http://localhost:8000",
+            warn_only=True,
+        )
+    warnings = _guardrail_warnings(caplog.records)
+    assert len(violations) == 2
+    assert len(warnings) == 2
+
+
+# ── warn_only=True never raises ──────────────────────────
+
+
+def test_warn_only_never_raises() -> None:
+    """Every violation at once must not raise when warn_only=True."""
+    # Strip both the flag and PYTEST_CURRENT_TEST so even the process
+    # check has its best shot at a violation; warn mode must still return.
+    violations = check_test_environment(
+        env={},
+        db_uri="sqlite:////home/alice/.omnigent/chat.db",
+        base_url="http://localhost:6767",
+        warn_only=True,
+    )
+    assert isinstance(violations, list)
+    # DB + base_url violations are deterministic regardless of sys.modules.
+    assert any("test DB" in v for v in violations)
+    assert any("6767" in v for v in violations)
+
+
+# ── future hard-fail mode (warn_only=False) ──────────────
+
+
+def test_hard_fail_raises_on_violation() -> None:
+    with pytest.raises(TestGuardrailError) as exc:
+        check_test_environment(
+            env=_TEST_ENV,
+            db_uri="sqlite:////home/alice/.omnigent/chat.db",
+            warn_only=False,
+        )
+    assert "TEST GUARDRAIL:" in str(exc.value)
+
+
+def test_hard_fail_passes_when_clean() -> None:
+    # No exception, returns empty list.
+    assert (
+        check_test_environment(
+            env=_TEST_ENV,
+            db_uri=_TMP_DB,
+            base_url="http://127.0.0.1:49152",
+            warn_only=False,
+        )
+        == []
+    )


### PR DESCRIPTION
## Summary

Adds an additive, **warn-only** test-environment guardrail (`omnigent/testing/guardrails.py`) that checks a test run is pointed at throwaway resources *before* the suite mutates state:

- **process check** — looks like a pytest run (`PYTEST_CURRENT_TEST` / `pytest` imported / `OMNIGENT_TEST_MODE`)
- **DB check** — `db_uri` is in-memory/tmp SQLite or contains `test`
- **base-URL check** — not aimed at a known dev/prod host or port (`DEV_PORTS = {6767, 8000, 5173}`)

Wired into `tests/conftest.py` `pytest_configure` (warn-only). Each violation logs a `TEST GUARDRAIL:` WARNING; **nothing raises** in this PR.

## Warn now, hard-fail later

A single `warn_only` switch (default `True`) gates log-vs-raise. A future PR flips the default to `False` to make these hard preconditions (`TestGuardrailError`) with no change to the call site. The hard-fail path is already covered by tests.

## Verification
```
$ uv run pytest tests/testing/test_guardrails.py -q   # 22 passed
$ uv run ruff check omnigent/testing/ tests/testing/   # All checks passed!
$ uv run python -c 'import omnigent.testing.guardrails'  # import OK, no side effects
```