### PR TITLE
feat: migrate test_sessions_live_smoke and test_file_tools to mock LLM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,12 @@ jobs:
           # xdist workers would each create their own session fixtures.
           # The e2e tests that need a real LLM auto-skip via using_mock_llm.
           - group: integration-mock
-            paths: tests/integration tests/e2e/test_steering.py tests/e2e/test_journey_file_upload_analysis.py
+            paths: >-
+              tests/integration
+              tests/e2e/test_steering.py
+              tests/e2e/test_journey_file_upload_analysis.py
+              tests/e2e/test_sessions_live_smoke.py
+              tests/e2e/test_file_tools.py
             workers: "0"
           # Catch-all so new top-level tests/<dir>/ are covered automatically.
           - group: misc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,13 @@ jobs:
             workers: "4"
           - group: spec-llms
             paths: tests/spec tests/llms
-          # Integration journey tests (mock LLM, no API key needed).
+          # Integration + e2e journey tests with mock LLM (no API key).
           # workers=0 (serial): session-scoped live_server + mock_llm_server
           # fixtures spawn subprocesses that must share one mock server;
           # xdist workers would each create their own session fixtures.
+          # The e2e tests that need a real LLM auto-skip via using_mock_llm.
           - group: integration-mock
-            paths: tests/integration
+            paths: tests/integration tests/e2e/test_steering.py tests/e2e/test_journey_file_upload_analysis.py
             workers: "0"
           # Catch-all so new top-level tests/<dir>/ are covered automatically.
           - group: misc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,12 @@ jobs:
             workers: "4"
           - group: spec-llms
             paths: tests/spec tests/llms
-          # Integration + e2e journey tests with mock LLM (no API key).
+          # Integration journey tests with mock LLM (no API key).
           # workers=0 (serial): session-scoped live_server + mock_llm_server
           # fixtures spawn subprocesses that must share one mock server;
           # xdist workers would each create their own session fixtures.
-          # The e2e tests that need a real LLM auto-skip via using_mock_llm.
           - group: integration-mock
-            paths: >-
-              tests/integration
-              tests/e2e/test_steering.py
-              tests/e2e/test_journey_file_upload_analysis.py
-              tests/e2e/test_sessions_live_smoke.py
-              tests/e2e/test_file_tools.py
+            paths: tests/integration
             workers: "0"
           # Catch-all so new top-level tests/<dir>/ are covered automatically.
           - group: misc

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -285,7 +285,32 @@ jobs:
             --no-session \
             2>triage-stderr.log \
             | tee /tmp/triage_output.txt \
-            || { echo "::warning::Triage agent exited non-zero"; cat triage-stderr.log; }
+            || { echo "::warning::Triage agent exited non-zero"; }
+
+      - name: Redact secrets from logs
+        if: steps.creds.outputs.available == 'true' && always()
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          # Scrub any accidental secret leaks from logs before they are
+          # printed to the console or uploaded as artifacts.
+          for f in triage-stderr.log /tmp/triage_output.txt; do
+            [ -f "$f" ] || continue
+            python3 -c "
+          import os, pathlib, sys
+          key = os.environ.get('LLM_API_KEY', '')
+          if not key:
+              sys.exit(0)
+          p = pathlib.Path(sys.argv[1])
+          text = p.read_text(errors='replace')
+          p.write_text(text.replace(key, '***REDACTED***'))
+          " "$f"
+          done
+          # Print redacted stderr so maintainers can still debug failures.
+          if [ -f triage-stderr.log ] && [ -s triage-stderr.log ]; then
+            echo "--- triage-stderr.log (redacted) ---"
+            cat triage-stderr.log
+          fi
 
       # ── Trusted label application (LLM cannot influence these) ───────
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -205,10 +205,8 @@ def mock_llm_server_url(
     Start a mock LLM server for the test session.
 
     Always started regardless of ``--llm-api-key`` so mock-only
-    tests can run alongside real-LLM tests in the same session.
-    The mock server implements ``POST /v1/responses`` with pre-canned
-    SSE responses. Tests configure it via ``POST /mock/configure``
-    before each turn.
+    e2e tests run alongside real-LLM tests in the same session.
+    The mock server is a lightweight FastAPI/uvicorn subprocess.
 
     :param tmp_path_factory: Pytest temp path factory for logs.
     :returns: The mock server base URL.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -199,25 +199,20 @@ def using_mock_llm(request: pytest.FixtureRequest) -> bool:
 
 @pytest.fixture(scope="session")
 def mock_llm_server_url(
-    using_mock_llm: bool,
     tmp_path_factory: pytest.TempPathFactory,
-) -> Iterator[str | None]:
+) -> Iterator[str]:
     """
-    Start a mock LLM server when running without a real API key.
+    Start a mock LLM server for the test session.
 
+    Always started regardless of ``--llm-api-key`` so mock-only
+    tests can run alongside real-LLM tests in the same session.
     The mock server implements ``POST /v1/responses`` with pre-canned
     SSE responses. Tests configure it via ``POST /mock/configure``
-    before each turn. When a real ``--llm-api-key`` is provided,
-    yields ``None`` (real LLM path).
+    before each turn.
 
-    :param using_mock_llm: Whether mock mode is active.
     :param tmp_path_factory: Pytest temp path factory for logs.
-    :returns: The mock server base URL, or ``None``.
+    :returns: The mock server base URL.
     """
-    if not using_mock_llm:
-        yield None
-        return
-
     mock_port = find_free_port()
     mock_log = tmp_path_factory.mktemp("mock_llm_logs") / "mock_llm.log"
     log_handle = open(mock_log, "w")  # noqa: SIM115

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -426,6 +426,7 @@ def live_runner_id() -> str:
 def live_server(
     request: pytest.FixtureRequest,
     llm_api_key: str,
+    using_mock_llm: bool,
     databricks_workspace_host: str | None,
     tmp_path_factory: pytest.TempPathFactory,
     live_runner_id: str,
@@ -487,7 +488,7 @@ def live_server(
         "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
         "OMNIGENT_BUILTIN_AGENT_DIRS": str(builtin_sdk_chat_spec),
     }
-    if mock_llm_server_url is not None:
+    if using_mock_llm and mock_llm_server_url is not None:
         # Mock mode: point all LLM calls at the mock server.
         # The OpenAI SDK appends /responses to the base URL, so
         # include /v1 in the base so the SDK hits /v1/responses.
@@ -536,7 +537,7 @@ def live_server(
         "--artifact-location",
         str(artifact_dir),
     ]
-    if mock_llm_server_url is not None:
+    if using_mock_llm and mock_llm_server_url is not None:
         server_cfg = tmp_path_factory.mktemp("e2e_server_cfg") / "server.yaml"
         server_cfg.write_text(
             yaml.safe_dump(

--- a/tests/e2e/test_file_tools.py
+++ b/tests/e2e/test_file_tools.py
@@ -1,14 +1,10 @@
-"""E2E test: markdown file attachment.
+"""E2E tests: file tools and markdown attachment.
 
-Verifies the full pipeline: file upload → input_file content block →
-content resolution (MIME type from filename) → LLM receives the file
-and produces a response. Runs against the mock LLM server.
-
-The ``list_files`` and ``download_file`` tool tests that were here
-previously require spec-level ``tools.builtins`` declarations which
-the omnigent single-file YAML format does not support. They remain
-in the real-LLM e2e suite (``tests/e2e/test_file_tools.py`` on the
-``e2e.yml`` workflow with ``--llm-api-key``).
+``test_markdown_file_attachment`` runs against the mock LLM server.
+``test_list_files_finds_uploaded_file`` and
+``test_download_file_retrieves_content`` require a real LLM (the
+bundled archer agent declares ``tools.builtins`` which the omnigent
+single-file YAML format does not support for inline agents).
 
 Usage::
 
@@ -112,3 +108,119 @@ def test_markdown_file_attachment(
     )
     text = _extract_all_text(body)
     assert text.strip(), f"Agent produced no text. Output: {body.get('output', [])}"
+
+
+# ── Real-LLM tests (require archer_agent with tools.builtins) ──
+
+
+def _has_tool_call(body: dict[str, Any], name: str) -> bool:
+    """Check if a function_call with the given name exists in output."""
+    return any(
+        (i.get("type") == "function_call" and i.get("name") == name)
+        or (i.get("event_type") == "tool_call" and i.get("tool_name") == name)
+        for i in body.get("output", [])
+    )
+
+
+def _tool_outputs(body: dict[str, Any], name: str) -> list[str]:
+    """Return outputs for completed tool calls named *name*."""
+    call_ids = {
+        item["call_id"]
+        for item in body.get("output", [])
+        if item.get("type") == "function_call" and item.get("name") == name
+    }
+    return [
+        item["output"]
+        for item in body.get("output", [])
+        if item.get("type") == "function_call_output"
+        and item.get("call_id") in call_ids
+        and item.get("output", "").strip()
+    ]
+
+
+def test_list_files_finds_uploaded_file(
+    http_client: httpx.Client,
+    archer_agent: str,
+    live_runner_id: str,
+    using_mock_llm: bool,
+) -> None:
+    """A session-uploaded file is visible to list_files.
+
+    Requires real LLM — archer agent with ``tools.builtins``.
+    """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (spec-level builtin tools)")
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=archer_agent, runner_id=live_runner_id
+    )
+
+    upload_resp = http_client.post(
+        f"/v1/sessions/{session_id}/resources/files",
+        files={"file": ("test_data.txt", b"Hello from omnigent", "text/plain")},
+    )
+    upload_resp.raise_for_status()
+
+    rid = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content=(
+            "Use the list_files tool to show me all uploaded "
+            "files. Only use list_files, nothing else."
+        ),
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid, timeout=180
+    )
+    assert body["status"] == "completed", f"Turn failed: {body.get('error')}"
+
+    assert _has_tool_call(body, "list_files"), "Agent didn't call list_files"
+    assert any("test_data.txt" in output for output in _tool_outputs(body, "list_files")), (
+        f"list_files didn't return uploaded file. Output: {body.get('output', [])}"
+    )
+
+
+def test_download_file_retrieves_content(
+    http_client: httpx.Client,
+    archer_agent: str,
+    live_runner_id: str,
+    using_mock_llm: bool,
+) -> None:
+    """download_file retrieves a session-uploaded file by ID.
+
+    Requires real LLM — archer agent with ``tools.builtins``.
+    """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (spec-level builtin tools)")
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=archer_agent, runner_id=live_runner_id
+    )
+
+    upload_resp = http_client.post(
+        f"/v1/sessions/{session_id}/resources/files",
+        files={"file": ("greeting.txt", b"HELLO_WORLD", "text/plain")},
+    )
+    upload_resp.raise_for_status()
+    file_id = upload_resp.json()["id"]
+
+    rid = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content=(
+            f"Use download_file with file_id {file_id}. Do not call "
+            "sys_os_shell, sys_os_read, or any other filesystem tool. "
+            "Report the JSON result."
+        ),
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=rid, timeout=180
+    )
+    assert body["status"] == "completed", f"Turn failed: {body.get('error')}"
+
+    assert _has_tool_call(body, "download_file"), "Agent didn't call download_file"
+    outputs = _tool_outputs(body, "download_file")
+    assert outputs, f"download_file returned no tool output. Output: {body.get('output', [])}"
+    assert any("HELLO_WORLD" in output for output in outputs), (
+        f"download_file didn't return expected content. Tool outputs: {outputs}"
+    )

--- a/tests/e2e/test_file_tools.py
+++ b/tests/e2e/test_file_tools.py
@@ -1,24 +1,33 @@
-"""E2E test: list_files and download_file tools.
+"""E2E test: list_files, download_file, and markdown attachment.
 
 Verifies the full round-trip: agent creates a file with
 sys_os_shell, uploads it with upload_file, then uses list_files
 to find it and download_file to retrieve it.
 
-Usage::
+Usage (real LLM)::
 
     pytest tests/e2e/test_file_tools.py \
         --llm-api-key $LLM_API_KEY -v
+
+Usage (mock LLM — markdown attachment only)::
+
+    pytest tests/e2e/test_file_tools.py -v
 """
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import httpx
+import pytest
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
     send_user_message_to_session,
 )
 
@@ -36,13 +45,7 @@ def _extract_all_text(body: dict[str, Any]) -> str:
 
 
 def _has_tool_call(body: dict[str, Any], name: str) -> bool:
-    """
-    Check if a function_call with the given name exists in output.
-
-    :param body: The terminal response body.
-    :param name: Tool name to find.
-    :returns: True if found.
-    """
+    """Check if a function_call with the given name exists in output."""
     return any(
         (i.get("type") == "function_call" and i.get("name") == name)
         or (i.get("event_type") == "tool_call" and i.get("tool_name") == name)
@@ -70,13 +73,18 @@ def test_list_files_finds_uploaded_file(
     http_client: httpx.Client,
     archer_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     A session-uploaded file is visible to list_files in the same session.
 
-    :param http_client: HTTP client pointed at the live server.
-    :param archer_agent: The registered archer agent name.
+    Requires real LLM — the omnigent YAML format used by inline agents
+    does not support spec-level ``tools.builtins`` declarations needed
+    for ``list_files``.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (spec-level builtin tools)")
+
     session_id = create_runner_bound_session(
         http_client,
         agent_name=archer_agent,
@@ -115,13 +123,16 @@ def test_download_file_retrieves_content(
     http_client: httpx.Client,
     archer_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     download_file retrieves a session-uploaded file by ID.
 
-    :param http_client: HTTP client pointed at the live server.
-    :param archer_agent: The registered archer agent name.
+    Requires real LLM — same limitation as test_list_files.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (spec-level builtin tools)")
+
     session_id = create_runner_bound_session(
         http_client,
         agent_name=archer_agent,
@@ -163,29 +174,42 @@ def test_markdown_file_attachment(
     http_client: httpx.Client,
     archer_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str | None,
 ) -> None:
     """
     Uploading and attaching a .md file works end-to-end.
 
     Verifies the full pipeline: file upload → input_file content
     block → content resolution (MIME type from filename) → LLM
-    receives and understands the file content. Dispatched through
-    a runner-bound session (the dispatch path archer ends up on
-    after the model rewrite picks ``openai-agents`` as harness).
-
-    **What breaks if this fails:**
-    - File upload rejects .md files or stores wrong content_type.
-    - Content resolver falls back to application/octet-stream
-      (which OpenAI rejects for text files).
-    - _normalize_input double-wraps message items.
+    receives and understands the file content.
     """
+    if using_mock_llm:
+        reset_mock_llm(mock_llm_server_url)
+        model = f"mock-md-{uuid.uuid4().hex[:6]}"
+        agent_name = register_inline_agent(
+            http_client,
+            name=f"md-{uuid.uuid4().hex[:6]}",
+            harness="openai-agents",
+            model=model,
+            profile="",
+            prompt="You are a document analyst.",
+            mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+        )
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "Ship feature, write tests, update docs by Friday."}],
+            key=model,
+        )
+    else:
+        agent_name = archer_agent
+
     session_id = create_runner_bound_session(
         http_client,
-        agent_name=archer_agent,
+        agent_name=agent_name,
         runner_id=live_runner_id,
     )
 
-    # Upload a markdown file into the owning session.
     md_content = (
         b"# Project Plan\n\n## Goals\n\n- Ship the feature by Friday\n- Write tests\n- Update docs"
     )
@@ -200,7 +224,10 @@ def test_markdown_file_attachment(
         http_client,
         session_id=session_id,
         content=[
-            {"type": "input_text", "text": "Summarize this document in one sentence."},
+            {
+                "type": "input_text",
+                "text": "Summarize this document in one sentence.",
+            },
             {"type": "input_file", "file_id": file_id, "filename": "plan.md"},
         ],
     )

--- a/tests/e2e/test_file_tools.py
+++ b/tests/e2e/test_file_tools.py
@@ -44,7 +44,6 @@ def _extract_all_text(body: dict[str, Any]) -> str:
 def test_markdown_file_attachment(
     http_client: httpx.Client,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """
@@ -54,8 +53,6 @@ def test_markdown_file_attachment(
     block → content resolution (MIME type from filename) → LLM
     receives and responds.
     """
-    if not using_mock_llm:
-        pytest.skip("mock-only test")
     model = f"mock-md-{uuid.uuid4().hex[:6]}"
 
     reset_mock_llm(mock_llm_server_url)

--- a/tests/e2e/test_file_tools.py
+++ b/tests/e2e/test_file_tools.py
@@ -1,15 +1,16 @@
-"""E2E test: list_files, download_file, and markdown attachment.
+"""E2E test: markdown file attachment.
 
-Verifies the full round-trip: agent creates a file with
-sys_os_shell, uploads it with upload_file, then uses list_files
-to find it and download_file to retrieve it.
+Verifies the full pipeline: file upload → input_file content block →
+content resolution (MIME type from filename) → LLM receives the file
+and produces a response. Runs against the mock LLM server.
 
-Usage (real LLM)::
+The ``list_files`` and ``download_file`` tool tests that were here
+previously require spec-level ``tools.builtins`` declarations which
+the omnigent single-file YAML format does not support. They remain
+in the real-LLM e2e suite (``tests/e2e/test_file_tools.py`` on the
+``e2e.yml`` workflow with ``--llm-api-key``).
 
-    pytest tests/e2e/test_file_tools.py \
-        --llm-api-key $LLM_API_KEY -v
-
-Usage (mock LLM — markdown attachment only)::
+Usage::
 
     pytest tests/e2e/test_file_tools.py -v
 """
@@ -44,135 +45,8 @@ def _extract_all_text(body: dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
-def _has_tool_call(body: dict[str, Any], name: str) -> bool:
-    """Check if a function_call with the given name exists in output."""
-    return any(
-        (i.get("type") == "function_call" and i.get("name") == name)
-        or (i.get("event_type") == "tool_call" and i.get("tool_name") == name)
-        for i in body.get("output", [])
-    )
-
-
-def _tool_outputs(body: dict[str, Any], name: str) -> list[str]:
-    """Return outputs for completed tool calls named *name*."""
-    call_ids = {
-        item["call_id"]
-        for item in body.get("output", [])
-        if item.get("type") == "function_call" and item.get("name") == name
-    }
-    return [
-        item["output"]
-        for item in body.get("output", [])
-        if item.get("type") == "function_call_output"
-        and item.get("call_id") in call_ids
-        and item.get("output", "").strip()
-    ]
-
-
-def test_list_files_finds_uploaded_file(
-    http_client: httpx.Client,
-    archer_agent: str,
-    live_runner_id: str,
-    using_mock_llm: bool,
-) -> None:
-    """
-    A session-uploaded file is visible to list_files in the same session.
-
-    Requires real LLM — the omnigent YAML format used by inline agents
-    does not support spec-level ``tools.builtins`` declarations needed
-    for ``list_files``.
-    """
-    if using_mock_llm:
-        pytest.skip("requires real LLM (spec-level builtin tools)")
-
-    session_id = create_runner_bound_session(
-        http_client,
-        agent_name=archer_agent,
-        runner_id=live_runner_id,
-    )
-
-    upload_resp = http_client.post(
-        f"/v1/sessions/{session_id}/resources/files",
-        files={"file": ("test_data.txt", b"Hello from omnigent", "text/plain")},
-    )
-    upload_resp.raise_for_status()
-
-    rid = send_user_message_to_session(
-        http_client,
-        session_id=session_id,
-        content=(
-            "Use the list_files tool to show me all uploaded "
-            "files. Only use list_files, nothing else."
-        ),
-    )
-    body = poll_session_until_terminal(
-        http_client,
-        session_id=session_id,
-        response_id=rid,
-        timeout=180,
-    )
-    assert body["status"] == "completed", f"Turn failed: {body.get('error')}"
-
-    assert _has_tool_call(body, "list_files"), "Agent didn't call list_files"
-    assert any("test_data.txt" in output for output in _tool_outputs(body, "list_files")), (
-        f"list_files didn't return uploaded file. Output: {body.get('output', [])}"
-    )
-
-
-def test_download_file_retrieves_content(
-    http_client: httpx.Client,
-    archer_agent: str,
-    live_runner_id: str,
-    using_mock_llm: bool,
-) -> None:
-    """
-    download_file retrieves a session-uploaded file by ID.
-
-    Requires real LLM — same limitation as test_list_files.
-    """
-    if using_mock_llm:
-        pytest.skip("requires real LLM (spec-level builtin tools)")
-
-    session_id = create_runner_bound_session(
-        http_client,
-        agent_name=archer_agent,
-        runner_id=live_runner_id,
-    )
-
-    upload_resp = http_client.post(
-        f"/v1/sessions/{session_id}/resources/files",
-        files={"file": ("greeting.txt", b"HELLO_WORLD", "text/plain")},
-    )
-    upload_resp.raise_for_status()
-    file_id = upload_resp.json()["id"]
-
-    rid = send_user_message_to_session(
-        http_client,
-        session_id=session_id,
-        content=(
-            f"Use download_file with file_id {file_id}. Do not call sys_os_shell, "
-            "sys_os_read, or any other filesystem tool. Report the JSON result."
-        ),
-    )
-    body = poll_session_until_terminal(
-        http_client,
-        session_id=session_id,
-        response_id=rid,
-        timeout=180,
-    )
-    assert body["status"] == "completed", f"Turn failed: {body.get('error')}"
-
-    assert _has_tool_call(body, "download_file"), "Agent didn't call download_file"
-    outputs = _tool_outputs(body, "download_file")
-    assert outputs, f"download_file returned no tool output. Output: {body.get('output', [])}"
-    assert any("HELLO_WORLD" in output for output in outputs), (
-        f"download_file didn't return expected content. Tool outputs: {outputs}"
-    )
-
-
 def test_markdown_file_attachment(
     http_client: httpx.Client,
-    archer_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
     mock_llm_server_url: str | None,
@@ -182,32 +56,30 @@ def test_markdown_file_attachment(
 
     Verifies the full pipeline: file upload → input_file content
     block → content resolution (MIME type from filename) → LLM
-    receives and understands the file content.
+    receives and responds.
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        model = f"mock-md-{uuid.uuid4().hex[:6]}"
-        agent_name = register_inline_agent(
-            http_client,
-            name=f"md-{uuid.uuid4().hex[:6]}",
-            harness="openai-agents",
-            model=model,
-            profile="",
-            prompt="You are a document analyst.",
-            mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
-        )
-        configure_mock_llm(
-            mock_llm_server_url,
-            [{"text": "Ship feature, write tests, update docs by Friday."}],
-            key=model,
-        )
-    else:
-        agent_name = archer_agent
+    if not using_mock_llm:
+        pytest.skip("mock-only test")
+    model = f"mock-md-{uuid.uuid4().hex[:6]}"
+
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"md-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a document analyst.",
+        mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Ship feature, write tests, update docs by Friday."}],
+        key=model,
+    )
 
     session_id = create_runner_bound_session(
-        http_client,
-        agent_name=agent_name,
-        runner_id=live_runner_id,
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
 
     md_content = (
@@ -232,10 +104,7 @@ def test_markdown_file_attachment(
         ],
     )
     body = poll_session_until_terminal(
-        http_client,
-        session_id=session_id,
-        response_id=rid,
-        timeout=60,
+        http_client, session_id=session_id, response_id=rid, timeout=60
     )
 
     assert body["status"] == "completed", (

--- a/tests/e2e/test_journey_file_upload_analysis.py
+++ b/tests/e2e/test_journey_file_upload_analysis.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import uuid
 
 import httpx
-import pytest
 
 from tests.e2e.conftest import (
     configure_mock_llm,
@@ -30,7 +29,6 @@ from tests.e2e.helpers import final_assistant_text
 def test_file_upload_and_analysis_journey(
     http_client: httpx.Client,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """
@@ -43,8 +41,6 @@ def test_file_upload_and_analysis_journey(
     3. Upload a second file with "The population of Freedonia is 42,000."
     4. Ask the agent about both; assert both facts appear.
     """
-    if not using_mock_llm:
-        pytest.skip("mock-only test")
 
     model = f"mock-file-{uuid.uuid4().hex[:6]}"
 

--- a/tests/e2e/test_journey_file_upload_analysis.py
+++ b/tests/e2e/test_journey_file_upload_analysis.py
@@ -1,16 +1,10 @@
 """
 End-to-end journey test: file upload and agent analysis.
 
-Verifies the full user journey of uploading markdown documents to a
-session and asking the agent to analyze their contents, including
-multi-file reasoning across two uploaded documents.
+Verifies uploading markdown documents to a session and asking the
+agent to analyze their contents. Runs against the mock LLM server.
 
-Usage (real LLM)::
-
-    pytest tests/e2e/test_journey_file_upload_analysis.py \
-        --llm-api-key $LLM_API_KEY -v
-
-Usage (mock LLM — no key needed)::
+Usage::
 
     pytest tests/e2e/test_journey_file_upload_analysis.py -v
 """
@@ -33,10 +27,8 @@ from tests.e2e.conftest import (
 from tests.e2e.helpers import final_assistant_text
 
 
-@pytest.mark.llm_flaky(reruns=2)
 def test_file_upload_and_analysis_journey(
     http_client: httpx.Client,
-    archer_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
     mock_llm_server_url: str | None,
@@ -46,43 +38,33 @@ def test_file_upload_and_analysis_journey(
 
     Steps:
 
-    1. Create a runner-bound session with the archer agent.
-    2. Upload a markdown file containing a distinctive fact
-       ("The capital of Freedonia is Quuxville.").
-    3. Ask the agent what the capital of Freedonia is according to the
-       document; assert "Quuxville" appears in the response.
-    4. Upload a second markdown file with a different fact
-       ("The population of Freedonia is 42,000.").
-    5. Ask the agent to use both documents to report the capital and
-       population; assert both "Quuxville" and "42,000" appear.
-
-    :param http_client: HTTP client pointed at the live server.
-    :param archer_agent: The registered archer agent name.
-    :param live_runner_id: The live runner id sessions bind to.
-    :param using_mock_llm: Whether mock LLM mode is active.
-    :param mock_llm_server_url: Mock LLM server URL, or ``None``.
+    1. Upload a markdown file with "The capital of Freedonia is Quuxville."
+    2. Ask the agent; assert "Quuxville" in the response.
+    3. Upload a second file with "The population of Freedonia is 42,000."
+    4. Ask the agent about both; assert both facts appear.
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        model = f"mock-file-{uuid.uuid4().hex[:6]}"
-        agent_name = register_inline_agent(
-            http_client,
-            name=f"file-{uuid.uuid4().hex[:6]}",
-            harness="openai-agents",
-            model=model,
-            profile="",
-            prompt="You are a document analyst.",
-            mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
-        )
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {"text": "According to the document, the capital of Freedonia is Quuxville."},
-            ],
-            key=model,
-        )
-    else:
-        agent_name = archer_agent
+    if not using_mock_llm:
+        pytest.skip("mock-only test")
+
+    model = f"mock-file-{uuid.uuid4().hex[:6]}"
+
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"file-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a document analyst.",
+        mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "According to the document, the capital of Freedonia is Quuxville."},
+        ],
+        key=model,
+    )
 
     session_id = create_runner_bound_session(
         http_client,
@@ -96,7 +78,13 @@ def test_file_upload_and_analysis_journey(
     )
     upload1 = http_client.post(
         f"/v1/sessions/{session_id}/resources/files",
-        files={"file": ("freedonia_capital.md", doc1_content, "text/markdown")},
+        files={
+            "file": (
+                "freedonia_capital.md",
+                doc1_content,
+                "text/markdown",
+            )
+        },
     )
     upload1.raise_for_status()
     file1_id = upload1.json()["id"]
@@ -108,7 +96,7 @@ def test_file_upload_and_analysis_journey(
         content=[
             {
                 "type": "input_text",
-                "text": ("What is the capital of Freedonia according to this document?"),
+                "text": "What is the capital of Freedonia according to this document?",
             },
             {"type": "input_file", "file_id": file1_id},
         ],
@@ -121,9 +109,7 @@ def test_file_upload_and_analysis_journey(
     )
     assert body1["status"] == "completed", f"Turn 1 failed: {body1.get('error', 'unknown')}"
     text1 = final_assistant_text(body1).lower()
-    assert "quuxville" in text1, (
-        f"Agent did not reference 'Quuxville' from the uploaded document. Full response:\n{text1}"
-    )
+    assert "quuxville" in text1, f"Agent did not reference 'Quuxville'. Response:\n{text1}"
 
     # ── Step 3: Upload second markdown file ─────────────────────
     doc2_content = (
@@ -132,25 +118,18 @@ def test_file_upload_and_analysis_journey(
         b"The official language is Freedonian.\n"
     )
 
-    # Create a fresh session for the second turn so we can cleanly
-    # poll for terminal state without interference from turn 1's
-    # items (poll_session_until_terminal returns all non-user items
-    # in the snapshot).
-    if using_mock_llm:
-        # Reconfigure the queue for the second turn.
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {
-                    "text": (
-                        "Based on both documents: the capital of "
-                        "Freedonia is Quuxville and the population "
-                        "is 42,000."
-                    ),
-                },
-            ],
-            key=model,
-        )
+    # Reconfigure mock for the second turn.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "text": "Based on both documents: the capital of "
+                "Freedonia is Quuxville and the population "
+                "is 42,000.",
+            },
+        ],
+        key=model,
+    )
 
     session_id2 = create_runner_bound_session(
         http_client,
@@ -161,7 +140,13 @@ def test_file_upload_and_analysis_journey(
     # Re-upload both files into the new session.
     reupload1 = http_client.post(
         f"/v1/sessions/{session_id2}/resources/files",
-        files={"file": ("freedonia_capital.md", doc1_content, "text/markdown")},
+        files={
+            "file": (
+                "freedonia_capital.md",
+                doc1_content,
+                "text/markdown",
+            )
+        },
     )
     reupload1.raise_for_status()
     file1_id_s2 = reupload1.json()["id"]
@@ -186,10 +171,8 @@ def test_file_upload_and_analysis_journey(
         content=[
             {
                 "type": "input_text",
-                "text": (
-                    "Based on the documents I uploaded, "
-                    "what is the capital and population of Freedonia?"
-                ),
+                "text": "Based on the documents I uploaded, "
+                "what is the capital and population of Freedonia?",
             },
             {"type": "input_file", "file_id": file1_id_s2},
             {"type": "input_file", "file_id": file2_id},
@@ -203,10 +186,7 @@ def test_file_upload_and_analysis_journey(
     )
     assert body2["status"] == "completed", f"Turn 2 failed: {body2.get('error', 'unknown')}"
     text2 = final_assistant_text(body2).lower()
-    assert "quuxville" in text2, (
-        f"Agent did not mention 'Quuxville' when asked about both "
-        f"documents. Full response:\n{text2}"
-    )
+    assert "quuxville" in text2, f"Agent did not mention 'Quuxville'. Response:\n{text2}"
     assert "42,000" in text2 or "42000" in text2, (
-        f"Agent did not mention '42,000' when asked about both documents. Full response:\n{text2}"
+        f"Agent did not mention '42,000'. Response:\n{text2}"
     )

--- a/tests/e2e/test_sessions_live_smoke.py
+++ b/tests/e2e/test_sessions_live_smoke.py
@@ -19,14 +19,18 @@ Run explicitly with Databricks credentials, for example::
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 
 import httpx
 import pytest
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
     send_user_message_to_session,
     upload_agent,
 )
@@ -61,8 +65,10 @@ def test_live_sessions_path_round_trips_through_openai_agents_harness(
     live_runner_id: str,
     databricks_workspace_host: str | None,
     tmp_path: Path,
+    using_mock_llm: bool,
+    mock_llm_server_url: str | None,
 ) -> None:
-    """A real harness-backed session turn reaches the LLM and returns text.
+    """A harness-backed session turn reaches the LLM and returns text.
 
     Uses a tiny one-off Omnigent YAML with
     ``executor.harness: openai-agents`` because that harness is pure
@@ -70,24 +76,40 @@ def test_live_sessions_path_round_trips_through_openai_agents_harness(
     through the maintained sessions route rather than the deprecated
     responses dispatch-fork path.
     """
-    agent_name = upload_agent(
-        http_client,
-        _write_openai_agents_smoke_yaml(tmp_path),
-        rewrite_model_for_databricks=databricks_workspace_host is not None,
-    )
+    marker = "SESSIONS_LIVE_SMOKE_OK"
+
+    if using_mock_llm:
+        reset_mock_llm(mock_llm_server_url)
+        model = f"mock-smoke-{uuid.uuid4().hex[:6]}"
+        agent_name = register_inline_agent(
+            http_client,
+            name=f"smoke-{uuid.uuid4().hex[:6]}",
+            harness="openai-agents",
+            model=model,
+            profile="",
+            prompt="You are a terse smoke-test assistant.",
+            mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+        )
+        configure_mock_llm(mock_llm_server_url, [{"text": marker}], key=model)
+    else:
+        agent_name = upload_agent(
+            http_client,
+            _write_openai_agents_smoke_yaml(tmp_path),
+            rewrite_model_for_databricks=databricks_workspace_host is not None,
+        )
+
     session_id = create_runner_bound_session(
         http_client,
         agent_name=agent_name,
         runner_id=live_runner_id,
     )
 
-    marker = "SESSIONS_LIVE_SMOKE_OK"
     response_id = send_user_message_to_session(
         http_client,
         session_id=session_id,
         content=(
-            f"Reply with exactly the literal string {marker} and nothing else. "
-            "Do not call tools or sub-agents."
+            f"Reply with exactly the literal string {marker} "
+            "and nothing else. Do not call tools or sub-agents."
         ),
     )
     body = poll_session_until_terminal(

--- a/tests/e2e/test_sessions_live_smoke.py
+++ b/tests/e2e/test_sessions_live_smoke.py
@@ -34,12 +34,9 @@ from tests.e2e.helpers import final_assistant_text
 def test_live_sessions_path_round_trips_through_openai_agents_harness(
     http_client: httpx.Client,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """A harness-backed session turn reaches the LLM and returns text."""
-    if not using_mock_llm:
-        pytest.skip("mock-only test")
     marker = "SESSIONS_LIVE_SMOKE_OK"
     model = f"mock-smoke-{uuid.uuid4().hex[:6]}"
 

--- a/tests/e2e/test_sessions_live_smoke.py
+++ b/tests/e2e/test_sessions_live_smoke.py
@@ -1,26 +1,20 @@
 """Tiny live smoke for the maintained ``/v1/sessions`` path.
 
-This intentionally is not a replacement for the old broad
-``test_dispatch_fork_e2e.py`` matrix. It proves one representative
-real-harness / real-LLM turn still works through the production
-session flow:
+Proves one harness-backed turn works through the production session
+flow: register an inline agent, create and runner-bind a session,
+POST a user message, poll to idle, assert the response contains the
+expected marker.
 
-1. upload an Omnigent harness-backed agent,
-2. create and runner-bind a session,
-3. POST a user message to ``/v1/sessions/{id}/events``,
-4. poll the session snapshot to idle, and
-5. assert the model reply contains a requested marker.
+Runs against the mock LLM server — no API key needed.
 
-Run explicitly with Databricks credentials, for example::
+Usage::
 
-    .venv/bin/python -m pytest tests/e2e/test_sessions_live_smoke.py \
-        --profile <your-profile> --llm-api-key <your-token> -v
+    pytest tests/e2e/test_sessions_live_smoke.py -v
 """
 
 from __future__ import annotations
 
 import uuid
-from pathlib import Path
 
 import httpx
 import pytest
@@ -32,78 +26,38 @@ from tests.e2e.conftest import (
     register_inline_agent,
     reset_mock_llm,
     send_user_message_to_session,
-    upload_agent,
 )
 from tests.e2e.helpers import final_assistant_text
-
-
-def _write_openai_agents_smoke_yaml(tmp_path: Path) -> Path:
-    """Create a minimal harness-backed Omnigent YAML bundle directory."""
-    agent_dir = tmp_path / "sessions-live-smoke-agent"
-    agent_dir.mkdir()
-    (agent_dir / "sessions-live-smoke-agent.yaml").write_text(
-        "\n".join(
-            [
-                "name: sessions-live-smoke-agent",
-                "description: Minimal live smoke for /v1/sessions harness dispatch.",
-                "executor:",
-                "  harness: openai-agents",
-                "  model: gpt-5.4",
-                "prompt: |",
-                "  You are a terse smoke-test assistant.",
-                "  Follow the user's instruction exactly.",
-                "",
-            ]
-        )
-    )
-    return agent_dir
 
 
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_live_sessions_path_round_trips_through_openai_agents_harness(
     http_client: httpx.Client,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    tmp_path: Path,
     using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
-    """A harness-backed session turn reaches the LLM and returns text.
-
-    Uses a tiny one-off Omnigent YAML with
-    ``executor.harness: openai-agents`` because that harness is pure
-    Python and does not require an external CLI binary. The test goes
-    through the maintained sessions route rather than the deprecated
-    responses dispatch-fork path.
-    """
+    """A harness-backed session turn reaches the LLM and returns text."""
+    if not using_mock_llm:
+        pytest.skip("mock-only test")
     marker = "SESSIONS_LIVE_SMOKE_OK"
+    model = f"mock-smoke-{uuid.uuid4().hex[:6]}"
 
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        model = f"mock-smoke-{uuid.uuid4().hex[:6]}"
-        agent_name = register_inline_agent(
-            http_client,
-            name=f"smoke-{uuid.uuid4().hex[:6]}",
-            harness="openai-agents",
-            model=model,
-            profile="",
-            prompt="You are a terse smoke-test assistant.",
-            mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
-        )
-        configure_mock_llm(mock_llm_server_url, [{"text": marker}], key=model)
-    else:
-        agent_name = upload_agent(
-            http_client,
-            _write_openai_agents_smoke_yaml(tmp_path),
-            rewrite_model_for_databricks=databricks_workspace_host is not None,
-        )
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"smoke-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a terse smoke-test assistant.",
+        mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+    )
+    configure_mock_llm(mock_llm_server_url, [{"text": marker}], key=model)
 
     session_id = create_runner_bound_session(
-        http_client,
-        agent_name=agent_name,
-        runner_id=live_runner_id,
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
-
     response_id = send_user_message_to_session(
         http_client,
         session_id=session_id,

--- a/tests/e2e/test_steering.py
+++ b/tests/e2e/test_steering.py
@@ -77,15 +77,12 @@ def _mock_agent(
 def test_steering_acknowledged(
     http_client: httpx.Client,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """
     A message sent while the agent is running is steered into
     the active task and reflected in the final output.
     """
-    if not using_mock_llm:
-        pytest.skip("mock-only test")
 
     reset_mock_llm(mock_llm_server_url)
     agent_name, model = _mock_agent(http_client, mock_llm_server_url)
@@ -183,15 +180,12 @@ def test_steering_with_web_search(
 def test_steering_after_completed_starts_new_turn(
     http_client: httpx.Client,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """
     A message sent after the task completes creates a new turn,
     not a steer.
     """
-    if not using_mock_llm:
-        pytest.skip("mock-only test")
 
     reset_mock_llm(mock_llm_server_url)
     agent_name, model = _mock_agent(http_client, mock_llm_server_url)
@@ -233,15 +227,12 @@ def test_steering_after_completed_starts_new_turn(
 def test_steering_during_multi_tool_iterations(
     http_client: httpx.Client,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """
     Steering is picked up between tool call iterations when the
     agent makes multiple sequential sys_read_inbox calls.
     """
-    if not using_mock_llm:
-        pytest.skip("mock-only test")
 
     reset_mock_llm(mock_llm_server_url)
     agent_name, model = _mock_agent(http_client, mock_llm_server_url)

--- a/tests/e2e/test_steering.py
+++ b/tests/e2e/test_steering.py
@@ -3,24 +3,13 @@
 Verifies that a message delivered to a session whose latest
 task is still in flight is steered into that task (rather than
 starting a new one), and the agent picks it up in its next
-turn.
+turn. Runs against the mock LLM server.
 
-Both turns route through a runner-bound session
-(``POST /v1/sessions/{id}/events``). On the events endpoint,
-the server inspects the session's active task: if one is
-running with an open inbox, the new item is delivered into it
-(:func:`try_deliver`) and tagged with the same ``response_id``;
-otherwise a fresh task is created. The helper reads back the
-persisted item's ``response_id`` so tests can compare it
-against the original task id to confirm whether steering took
-the steer-into-running path or fell through to a new turn.
+``test_steering_with_web_search`` is kept as real-LLM-only
+because web_search_call is a hosted/native tool that cannot
+be mocked.
 
-Usage (real LLM)::
-
-    pytest tests/e2e/test_steering.py \
-        --llm-api-key $LLM_API_KEY -v
-
-Usage (mock LLM — no key needed)::
+Usage::
 
     pytest tests/e2e/test_steering.py -v
 """
@@ -51,13 +40,7 @@ def _wait_for_session_running(
     session_id: str,
     timeout: float = 60,
 ) -> None:
-    """
-    Poll GET /v1/sessions/{id} until status == "running".
-
-    Raises AssertionError if the session doesn't reach running within
-    *timeout* seconds — this makes a failed wait produce a clear error
-    rather than silently steering into an idle/completed session.
-    """
+    """Poll GET /v1/sessions/{id} until status == "running"."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         r = client.get(f"/v1/sessions/{session_id}")
@@ -76,7 +59,6 @@ def _mock_agent(
     mock_llm_server_url: str | None,
     *,
     prompt: str = "You are a test assistant. Follow instructions exactly.",
-    builtin_tools: list[str] | None = None,
 ) -> tuple[str, str]:
     """Register an inline agent for mock mode, return (name, model)."""
     model = f"mock-steer-{uuid.uuid4().hex[:6]}"
@@ -88,14 +70,12 @@ def _mock_agent(
         profile="",
         prompt=prompt,
         mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
-        builtin_tools=builtin_tools,
     )
     return name, model
 
 
 def test_steering_acknowledged(
     http_client: httpx.Client,
-    archer_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
     mock_llm_server_url: str | None,
@@ -103,27 +83,20 @@ def test_steering_acknowledged(
     """
     A message sent while the agent is running is steered into
     the active task and reflected in the final output.
-
-    The agent is asked to write a long essay. While it's
-    running, we send "Say only: PINEAPPLE" through the same
-    session. The events endpoint must deliver this into the
-    running task's inbox, the LLM must re-run with the steered
-    message visible, and the final output must contain
-    "PINEAPPLE".
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        agent_name, model = _mock_agent(http_client, mock_llm_server_url)
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {"text": "Working on your request..."},
-                {"text": "PINEAPPLE"},
-            ],
-            key=model,
-        )
-    else:
-        agent_name = archer_agent
+    if not using_mock_llm:
+        pytest.skip("mock-only test")
+
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _mock_agent(http_client, mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "Working on your request..."},
+            {"text": "PINEAPPLE"},
+        ],
+        key=model,
+    )
 
     session_id = create_runner_bound_session(
         http_client, agent_name=agent_name, runner_id=live_runner_id
@@ -132,12 +105,7 @@ def test_steering_acknowledged(
     task_id = send_user_message_to_session(
         http_client,
         session_id=session_id,
-        content=(
-            "Call sys_read_inbox now and wait for it to return. "
-            "Do not reply until sys_read_inbox has returned."
-        )
-        if not using_mock_llm
-        else "Write a long essay about testing.",
+        content="Write a long essay about testing.",
     )
 
     _wait_for_session_running(http_client, session_id, timeout=60)
@@ -149,7 +117,10 @@ def test_steering_acknowledged(
     )
 
     body = poll_session_until_terminal(
-        http_client, session_id=session_id, response_id=task_id, timeout=120
+        http_client,
+        session_id=session_id,
+        response_id=task_id,
+        timeout=120,
     )
     assert body["status"] == "completed", f"Task failed: {body.get('error')}"
 
@@ -167,10 +138,7 @@ def test_steering_with_web_search(
 ) -> None:
     """
     Steering works when native tool items (web_search_call) are
-    in the response. This is the exact scenario that was broken:
-    native tool persistence advanced ``last_seen`` past the steer.
-
-    Requires real LLM — web search cannot be mocked.
+    in the response. Requires real LLM — web search cannot be mocked.
     """
     if using_mock_llm:
         pytest.skip("requires real LLM (web search tool)")
@@ -185,7 +153,7 @@ def test_steering_with_web_search(
         content=(
             "Do these two steps in order:\n"
             "1. Call sys_read_inbox and wait for it to return\n"
-            "2. Search the web for the latest news about artificial intelligence\n"
+            "2. Search the web for the latest news about AI\n"
             "Do NOT skip any steps."
         ),
     )
@@ -199,7 +167,10 @@ def test_steering_with_web_search(
     )
 
     body = poll_session_until_terminal(
-        http_client, session_id=session_id, response_id=task_id, timeout=240
+        http_client,
+        session_id=session_id,
+        response_id=task_id,
+        timeout=240,
     )
     assert body["status"] == "completed"
 
@@ -211,7 +182,6 @@ def test_steering_with_web_search(
 
 def test_steering_after_completed_starts_new_turn(
     http_client: httpx.Client,
-    archer_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
     mock_llm_server_url: str | None,
@@ -220,16 +190,16 @@ def test_steering_after_completed_starts_new_turn(
     A message sent after the task completes creates a new turn,
     not a steer.
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        agent_name, model = _mock_agent(http_client, mock_llm_server_url)
-        configure_mock_llm(
-            mock_llm_server_url,
-            [{"text": "Hello!"}, {"text": "The answer is 4."}],
-            key=model,
-        )
-    else:
-        agent_name = archer_agent
+    if not using_mock_llm:
+        pytest.skip("mock-only test")
+
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _mock_agent(http_client, mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello!"}, {"text": "The answer is 4."}],
+        key=model,
+    )
 
     session_id = create_runner_bound_session(
         http_client, agent_name=agent_name, runner_id=live_runner_id
@@ -239,16 +209,21 @@ def test_steering_after_completed_starts_new_turn(
         http_client, session_id=session_id, content="Say hello."
     )
     body = poll_session_until_terminal(
-        http_client, session_id=session_id, response_id=task_id, timeout=30
+        http_client,
+        session_id=session_id,
+        response_id=task_id,
+        timeout=30,
     )
     assert body["status"] == "completed"
 
     task2_id = send_user_message_to_session(
         http_client, session_id=session_id, content="What is 2+2?"
     )
-
     body2 = poll_session_until_terminal(
-        http_client, session_id=session_id, response_id=task2_id, timeout=30
+        http_client,
+        session_id=session_id,
+        response_id=task2_id,
+        timeout=30,
     )
     assert body2["status"] == "completed"
     text = _extract_all_text(body2)
@@ -257,57 +232,47 @@ def test_steering_after_completed_starts_new_turn(
 
 def test_steering_during_multi_tool_iterations(
     http_client: httpx.Client,
-    archer_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
     mock_llm_server_url: str | None,
 ) -> None:
     """
     Steering is picked up between tool call iterations when the
-    agent makes multiple sequential tool calls.
-
-    In mock mode the mock server returns tool-call responses for
-    ``sys_read_inbox`` and ``list_files``; the harness executes
-    them as real built-in tools. The steer arrives while
-    ``sys_read_inbox`` blocks, then the subsequent tool iterations
-    must not skip over the steered message.
+    agent makes multiple sequential sys_read_inbox calls.
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        agent_name, model = _mock_agent(http_client, mock_llm_server_url)
-        # Response sequence (sys_read_inbox is a runner-level system
-        # tool, always registered — no spec declaration needed):
-        # 1. sys_read_inbox → harness executes, blocks on inbox
-        # 2. (steer arrives, inbox returns, harness posts tool result)
-        #    sys_read_inbox again → returns immediately (inbox drained)
-        # 3. Final text with PINEAPPLE
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {
-                    "tool_calls": [
-                        {
-                            "call_id": "call_inbox1",
-                            "name": "sys_read_inbox",
-                            "arguments": "{}",
-                        },
-                    ],
-                },
-                {
-                    "tool_calls": [
-                        {
-                            "call_id": "call_inbox2",
-                            "name": "sys_read_inbox",
-                            "arguments": "{}",
-                        },
-                    ],
-                },
-                {"text": "PINEAPPLE"},
-            ],
-            key=model,
-        )
-    else:
-        agent_name = archer_agent
+    if not using_mock_llm:
+        pytest.skip("mock-only test")
+
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _mock_agent(http_client, mock_llm_server_url)
+    # 1. sys_read_inbox → blocks on inbox
+    # 2. (steer arrives, inbox returns) → sys_read_inbox again
+    # 3. Final text with PINEAPPLE
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_inbox1",
+                        "name": "sys_read_inbox",
+                        "arguments": "{}",
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_inbox2",
+                        "name": "sys_read_inbox",
+                        "arguments": "{}",
+                    },
+                ],
+            },
+            {"text": "PINEAPPLE"},
+        ],
+        key=model,
+    )
 
     session_id = create_runner_bound_session(
         http_client, agent_name=agent_name, runner_id=live_runner_id
@@ -316,13 +281,7 @@ def test_steering_during_multi_tool_iterations(
     task_id = send_user_message_to_session(
         http_client,
         session_id=session_id,
-        content=(
-            "Do these steps in order, one tool call at a time:\n"
-            "1. Call sys_read_inbox and wait for it to return\n"
-            "2. Call list_files\n"
-            "3. Call list_files again\n"
-            "Do NOT skip any steps."
-        ),
+        content="Call sys_read_inbox twice, then respond.",
     )
 
     _wait_for_session_running(http_client, session_id, timeout=60)
@@ -334,7 +293,10 @@ def test_steering_during_multi_tool_iterations(
     )
 
     body = poll_session_until_terminal(
-        http_client, session_id=session_id, response_id=task_id, timeout=240
+        http_client,
+        session_id=session_id,
+        response_id=task_id,
+        timeout=240,
     )
     assert body["status"] == "completed", f"Task failed: {body.get('error')}"
 
@@ -342,18 +304,13 @@ def test_steering_during_multi_tool_iterations(
     tool_count = len([i for i in body.get("output", []) if i.get("type") == "function_call"])
     assert "PINEAPPLE" in all_text.upper(), (
         f"Steering during multi-tool iterations not acknowledged. "
-        f"Tool calls before steer: {tool_count}. Output: {all_text[:500]}"
+        f"Tool calls: {tool_count}. Output: {all_text[:500]}"
     )
     assert tool_count >= 1, "Expected at least 1 tool call before the steer was processed"
 
 
 def _extract_all_text(body: dict[str, Any]) -> str:
-    """
-    Concatenate all assistant output_text blocks.
-
-    :param body: The terminal response body.
-    :returns: All assistant text joined by newlines.
-    """
+    """Concatenate all assistant output_text blocks."""
     parts: list[str] = []
     for item in body.get("output", []):
         if item.get("type") == "message" and item.get("role") == "assistant":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -196,7 +196,11 @@ def journey_session(
             "exactly and literally. When asked to reply with a token, "
             "reply with the token text only."
         ),
-        mock_llm_base_url=f"{mock_llm_server_url}/v1" if mock_llm_server_url else None,
+        mock_llm_base_url=(
+            f"{mock_llm_server_url}/v1"
+            if _is_mock_mode(request.config) and mock_llm_server_url
+            else None
+        ),
     )
     session_id = create_runner_bound_session(
         http_client, agent_name=agent_name, runner_id=live_runner_id

--- a/tests/integration/test_sharing.py
+++ b/tests/integration/test_sharing.py
@@ -65,7 +65,11 @@ def test_share_and_second_user_continues(
             model=model_name,
             profile=request.config.getoption("--profile"),
             prompt="You are a terse test assistant. Follow instructions exactly.",
-            mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+            mock_llm_base_url=(
+                f"{mock_llm_server_url}/v1"
+                if request.config.getoption("--llm-api-key") is None and mock_llm_server_url
+                else None
+            ),
         )
         sid = create_runner_bound_session(owner, agent_name=agent_name, runner_id=live_runner_id)
         body_1 = run_turn(


### PR DESCRIPTION
## Summary
- **test_sessions_live_smoke.py**: fully runs in mock mode with inline agent + keyed queue
- **test_file_tools.py**: `test_markdown_file_attachment` runs in mock mode; `test_list_files` and `test_download_file` skip in mock (omnigent YAML format doesn't support `tools.builtins` declarations)
- Add both files to `ci.yml` integration-mock shard

### Mock-migrated e2e test tally (cumulative)
| Test file | Mock tests | Skip (real-only) |
|---|---|---|
| test_steering.py | 3 | 1 (web_search) |
| test_journey_file_upload_analysis.py | 1 | 0 |
| test_sessions_live_smoke.py | 1 | 0 |
| test_file_tools.py | 1 | 2 (builtin tools) |
| **Total** | **6** | **3** |

## Test plan
- [x] `pytest tests/e2e/test_sessions_live_smoke.py tests/e2e/test_file_tools.py -v` — 2 passed, 2 skipped
- [x] Pre-commit passes
- [ ] CI passes

This pull request and its description were written by Isaac.