### PR TITLE
fix(#479): restore chat view when a shell exits instead of stranding

### DIFF
--- a/ap-web/src/hooks/useTerminals.test.ts
+++ b/ap-web/src/hooks/useTerminals.test.ts
@@ -12,9 +12,11 @@ import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTerminal,
+  deriveIsShellView,
   fetchTerminals,
   inventoryTerminals,
   isAgentTerminalKey,
+  PANEL_NO_TERMINAL_KEY,
   PENDING_RECONCILE_INTERVAL_MS,
   terminalInfoFromResource,
   terminalsReconcileInterval,
@@ -455,6 +457,49 @@ describe("terminalTabKey", () => {
     };
     const after: TerminalInfo = { ...before, name: "bash-renamed", session: "s2" };
     expect(terminalTabKey(before)).toBe(terminalTabKey(after));
+  });
+});
+
+describe("deriveIsShellView", () => {
+  const repl: TerminalInfo = {
+    id: "terminal_tui_main",
+    name: "tui",
+    session: "main",
+    running: true,
+  };
+  const bash: TerminalInfo = {
+    id: "terminal_bash_s1",
+    name: "bash",
+    session: "s1",
+    running: true,
+  };
+
+  it("is false outside a terminal-first session", () => {
+    expect(deriveIsShellView(false, terminalTabKey(bash), [repl, bash])).toBe(false);
+  });
+
+  it("is false when no terminal is targeted (chat / list-only view)", () => {
+    expect(deriveIsShellView(true, null, [repl, bash])).toBe(false);
+    // The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy — "open with no
+    // target" stays a pill view, not a shell view.
+    expect(deriveIsShellView(true, PANEL_NO_TERMINAL_KEY, [repl, bash])).toBe(false);
+  });
+
+  it("is false when the open view targets the agent's own terminal", () => {
+    expect(deriveIsShellView(true, terminalTabKey(repl), [repl, bash])).toBe(false);
+  });
+
+  it("is true while a live user shell is the open target", () => {
+    expect(deriveIsShellView(true, terminalTabKey(bash), [repl, bash])).toBe(true);
+  });
+
+  it("is false once the targeted shell is gone (exit / resource.deleted) — pill reappears, no stranding (#479)", () => {
+    // The shell exited: the runner deleted its resource, so it left the
+    // list while `panelInitialKey` still points at it. Without the
+    // presence check `isShellView` would stay true and the Chat/Terminal
+    // pill would stay hidden — stranding the session in terminal-only
+    // view. It must flip false so the pill reappears.
+    expect(deriveIsShellView(true, terminalTabKey(bash), [repl])).toBe(false);
   });
 });
 

--- a/ap-web/src/hooks/useTerminals.ts
+++ b/ap-web/src/hooks/useTerminals.ts
@@ -80,6 +80,41 @@ export function isAgentTerminalKey(terminalKey: string): boolean {
 }
 
 /**
+ * Whether the open terminal view is currently showing a *live* user shell —
+ * i.e. a terminal-first session has its panel open to a non-agent terminal key
+ * that still addresses a terminal present in ``terminals``.
+ *
+ * The presence check is what un-strands the UI when a shell exits: the runner
+ * deletes the shell's resource (``session.resource.deleted``) so it leaves
+ * ``terminals``, but AppShell's ``panelInitialKey`` keeps pointing at the now-
+ * dead key. Without this check the Chat/Terminal pill stays self-hidden
+ * (``isShellView``) while ``MainTerminalView`` falls back to the agent's own
+ * terminal — leaving the session stuck in terminal-only view with no way back
+ * to chat. Requiring the shell to still be present flips ``isShellView`` false
+ * the moment the shell is gone, so the pill reappears (#479).
+ *
+ * The ``PANEL_NO_TERMINAL_KEY`` sentinel ("") is falsy, so "open with no
+ * target" stays a pill view, not a shell view.
+ *
+ * :param terminalFirst: ``true`` for terminal-first sessions
+ *     (``omnigent.ui === "terminal"``).
+ * :param panelInitialKey: The open terminal-view target key (AppShell's
+ *     ``panelInitialKey``), or ``null`` / the ``PANEL_NO_TERMINAL_KEY`` sentinel.
+ * :param terminals: The full live terminal list (``useTerminals`` result —
+ *     the agent's own terminal plus user shells).
+ * :returns: ``true`` while the open view targets a present user shell.
+ */
+export function deriveIsShellView(
+  terminalFirst: boolean,
+  panelInitialKey: string | null,
+  terminals: TerminalInfo[],
+): boolean {
+  if (!terminalFirst || !panelInitialKey) return false;
+  if (isAgentTerminalKey(panelInitialKey)) return false;
+  return terminals.some((t) => terminalTabKey(t) === panelInitialKey);
+}
+
+/**
  * Project the terminal list down to the session's *inventory* — the
  * shells shown in the right-rail Shells tab, its count badge, and the
  * mobile menu entry.

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -26,8 +26,8 @@ import {
 import { useDebugMode } from "@/hooks/useDebugMode";
 import {
   AGENT_TERMINAL_IDS,
+  deriveIsShellView,
   inventoryTerminals,
-  isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
   terminalTabKey,
   useTerminals,
@@ -884,8 +884,13 @@ export function AppShell() {
   // ConnectionIndicator hides the Chat/Terminal pill while this is
   // true, and MainTerminalView renders the shell with its own close
   // affordance. The PANEL_NO_TERMINAL_KEY sentinel ("") is falsy, so
-  // "open with no target" stays a pill view.
-  const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
+  // "open with no target" stays a pill view. The shell must also still
+  // be present in `terminals`: when a shell exits the runner deletes its
+  // resource (session.resource.deleted) but `panelInitialKey` keeps
+  // pointing at the dead key, so without the presence check the pill would
+  // stay hidden and the session would strand in terminal-only view with no
+  // way back to chat (#479). See `deriveIsShellView`.
+  const isShellView = deriveIsShellView(terminalFirst, panelInitialKey, terminals);
   const terminalFirstContextValue = useMemo<TerminalFirstContextValue>(
     () => ({
       isClaudeNative,

--- a/tests/e2e_ui/shells/test_shell_exit_restores_chat.py
+++ b/tests/e2e_ui/shells/test_shell_exit_restores_chat.py
@@ -1,0 +1,93 @@
+"""E2E: closing a shell by typing ``exit`` restores the chat surface.
+
+Companion to ``test_new_shell.py`` — that suite covers *opening* a shell and
+typing into it; this file covers the *close* path the opener leaves open:
+what happens when the user types ``exit`` in the shell instead of clicking
+``MainTerminalView``'s close X.
+
+While a user shell owns the main column, ``MainTerminalView`` renders a
+"Close shell" X and ``ConnectionIndicator`` self-hides the Chat/Terminal pill
+(a "Chat" option under someone else's shell misreads as the shell being the
+agent). When the shell exits, the runner deletes its resource
+(``session.resource.deleted``) so it leaves the terminal list — but AppShell's
+panel key keeps pointing at the now-dead shell. Before the fix that left
+``isShellView`` stuck ``true``: the pill stayed hidden while
+``MainTerminalView`` fell back to the agent's own terminal, stranding the
+session in terminal-only view with no way back to chat (#479). The fix drops
+``isShellView`` false the moment the shell is gone, so the pill reappears and
+chat is reachable again.
+
+Like the opener, none of this needs an LLM turn — the user, not the agent,
+launches and exits the shell — so the test never sends a chat message.
+
+Uses the function-scoped ``terminal_session`` fixture (the same
+zsh-declaring, runner-bound session ``test_new_shell`` uses) for an
+independent session per run.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Tab key prefix for a user-created ``zsh`` shell (see test_new_shell.py):
+# ``createTerminal`` mints a ``u-<rand>`` session key, yielding the resource id
+# ``terminal_zsh_u-<rand>`` and the tab key ``terminal:terminal_zsh_u-…``.
+_USER_ZSH_KEY_RE = re.compile(r"^terminal:terminal_zsh_u-")
+
+
+def _open_new_shell(page: Page) -> None:
+    """Open the Shells tab and click the "+ New shell" row (mirrors test_new_shell).
+
+    Scopes every lookup to the desktop "Workspace" rail so it never matches the
+    hidden mobile drawer that mirrors the same controls.
+    """
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("Shells")).click()
+    # Single declared name → the row creates directly on click (no dropdown).
+    rail.get_by_role("button", name="New shell").click()
+
+
+def test_shell_exit_restores_chat_view(page: Page, terminal_session: tuple[str, str]) -> None:
+    """Typing ``exit`` in a shell restores the Chat/Terminal pill (#479).
+
+    Opens a shell, confirms the chrome-light shell view (close X, no pill),
+    then types ``exit``. The shell's resource is deleted, so the Chat/Terminal
+    pill must reappear — letting the user navigate back to chat. The pre-fix
+    bug left the pill hidden here, stranding the session in terminal-only view.
+    """
+    base_url, session_id = terminal_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+
+    # The shell takes over the main column: chrome-light shell view focused on
+    # the clicked shell, with a "Close shell" X and no Chat/Terminal pill.
+    main_terminal = page.get_by_test_id("main-terminal-view")
+    expect(main_terminal).to_be_visible(timeout=60_000)
+    expect(main_terminal).to_have_attribute("data-active-terminal", _USER_ZSH_KEY_RE)
+    expect(page.get_by_role("button", name="Close shell")).to_be_visible()
+    expect(page.get_by_role("button", name="Chat", exact=True)).to_have_count(0)
+
+    # Wait for the shell's xterm to connect before sending keystrokes — input
+    # typed before the WS attach opens is dropped.
+    terminal_view = page.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+    # Focus xterm's hidden input (a plain container click doesn't reliably
+    # focus the WebGL canvas in headless Chromium), then exit the shell.
+    terminal_view.locator("textarea.xterm-helper-textarea").focus()
+    page.keyboard.type("exit")
+    page.keyboard.press("Enter")
+
+    # The shell exited and its resource was deleted, so the shell view's
+    # "Close shell" X is gone and — the #479 fix — the Chat/Terminal pill
+    # reappears so the user can navigate back to chat. (The view itself drops
+    # back to the agent's own terminal; that fallback is covered by the
+    # MainTerminalView unit tests, so this e2e asserts only the chat-reachable
+    # contract the fix restores.)
+    expect(page.get_by_role("button", name="Close shell")).to_have_count(0, timeout=30_000)
+    expect(page.get_by_role("button", name="Chat", exact=True)).to_have_count(1, timeout=30_000)


### PR DESCRIPTION
## Summary

In a terminal-first session, exiting a user shell (e.g. typing `exit`) stranded
the UI in terminal-only view — the chat surface became unreachable. The
Chat/Terminal pill stayed hidden even though the shell was gone, so there was
no way back to chat. This fixes #479 by re-showing the pill the moment the
shell leaves the terminal list.

## Root cause

`AppShell` derived `isShellView` from the panel key alone:

```ts
const isShellView = terminalFirst && !!panelInitialKey && !isAgentTerminalKey(panelInitialKey);
```

When a shell exits, the runner deletes its resource (`session.resource.deleted`),
which removes it from the terminal list — but `panelInitialKey` is **not** reset
(it's persisted/restored per session). So `isShellView` stayed `true`
indefinitely after the shell was gone:

- `MainTerminalView` correctly fell back to the agent's own terminal.
- But `ConnectionIndicator` kept hiding the Chat/Terminal pill (its rule: hide
  "Chat" while a *user* shell is the active terminal), so chat was unreachable.

## Fix

Tighten `isShellView` to also require the targeted shell to still be present in
the terminal list. Extracted as a pure helper `deriveIsShellView` so the
presence check sits in one place alongside the agent-key check it mirrors:

```ts
export function deriveIsShellView(terminalFirst, panelInitialKey, terminals): boolean {
  if (!terminalFirst || !panelInitialKey) return false;
  if (isAgentTerminalKey(panelInitialKey)) return false;
  return terminals.some((t) => terminalTabKey(t) === panelInitialKey);
}
```

The pill reappears the moment the shell is gone, matching `MainTerminalView`'s
existing "drop back to the agent terminal" behavior. The panel key is left
untouched on purpose — it's persisted/restored per session, so an effect that
reset it on terminal removal could clobber the restore during the terminals
loading window.

## Testing

- **Unit** (`ap-web/src/hooks/useTerminals.test.ts`): `deriveIsShellView` cases,
  including a regression guard that it drops to `false` once the targeted shell
  is gone (the #479 stranding). All existing `useTerminals`, `AppShell`,
  `MainTerminalView`, and `ChatPage` suites still pass.
- **E2E UI** (`tests/e2e_ui/shells/test_shell_exit_restores_chat.py`): opens a
  shell, types `exit`, and asserts the "Close shell" X disappears and the
  Chat pill reappears — i.e. chat is reachable again. Mirrors the existing
  `test_new_shell.py` fixture/helpers.

> Note: the e2e_ui test needs a live runner + LLM creds, so it runs in the
> `e2e-ui` CI workflow (not locally). It's authored against the same fixture and
> helpers as the passing `test_new_shell.py`.

`pre-commit run --all-files` (ruff, prettier, custom test lints) and
`npm run type-check` (`tsc -b`) are clean on the changed files.

Closes #479.