### PR TITLE
fix(#173): thread agent os_env sandbox into native terminal auto-create

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -725,6 +725,7 @@ async def _auto_create_pi_terminal(
     publish_event: Callable[[str, dict[str, Any]], None],
     *,
     server_client: httpx.AsyncClient | None,
+    agent_spec: AgentSpec | ResolvedSpec | None = None,
 ) -> SessionResourceView:
     """
     Auto-create a Pi terminal for a pi-native session.
@@ -798,13 +799,21 @@ async def _auto_create_pi_terminal(
             cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
             pi_env.update(cred_env)
             pi_args.extend(cred_args)
+    # Inherit the agent's declared sandbox (egress_rules / env_passthrough)
+    # so the native Pi TUI runs inside the session's sandbox rather than
+    # outside it — mirrors create_session_terminal's os_env threading (#173).
+    agent_os_env = getattr(agent_spec, "os_env", None) if agent_spec is not None else None
     terminal_view = await resource_registry.launch_required_terminal(
         session_id=session_id,
         terminal_name="pi",
         session_key="main",
         resource_role=PI_NATIVE_TERMINAL_ROLE,
         spec=TerminalEnvSpec(
-            os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+            os_env=OSEnvSpec(
+                type="caller_process",
+                cwd=workspace,
+                sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+            ),
             command=pi_command,
             args=pi_args,
             env=pi_env,
@@ -1179,6 +1188,10 @@ async def _auto_create_codex_terminal(
     # claude-native, whose terminal IS the agent process. On failure, close
     # the listener and app-server here: the background forwarder task (which
     # otherwise owns their teardown) has not been created yet.
+    # Inherit the agent's declared sandbox (egress_rules / env_passthrough)
+    # so the native Codex TUI runs inside the session's sandbox rather than
+    # outside it — mirrors create_session_terminal's os_env threading (#173).
+    agent_os_env = getattr(agent_spec, "os_env", None) if agent_spec is not None else None
     try:
         terminal_view = await resource_registry.launch_auxiliary_terminal(
             session_id=session_id,
@@ -1186,7 +1199,11 @@ async def _auto_create_codex_terminal(
             session_key="main",
             resource_role=CODEX_NATIVE_TERMINAL_ROLE,
             spec=TerminalEnvSpec(
-                os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+                os_env=OSEnvSpec(
+                    type="caller_process",
+                    cwd=workspace,
+                    sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+                ),
                 command=app_server.codex_path,
                 # Fresh sessions pass no thread id so the TUI creates the
                 # thread and the background task adopts it. Resume sessions
@@ -1849,6 +1866,7 @@ async def _auto_create_claude_terminal(
     bundle_dir: Path | None = None,
     agent_name: str | None = None,
     skills_filter: str | list[str] = "all",
+    agent_spec: AgentSpec | ResolvedSpec | None = None,
 ) -> SessionResourceView:
     """
     Auto-create a Claude Code terminal for a claude-native session.
@@ -2259,8 +2277,17 @@ async def _auto_create_claude_terminal(
         api_key_helper=claude_config.api_key_helper if claude_config is not None else None,
     )
 
+    # Inherit the agent's declared sandbox (egress_rules / env_passthrough)
+    # so the claude-native terminal runs inside the session's sandbox rather
+    # than outside it — mirrors create_session_terminal's os_env threading
+    # (#173).
+    agent_os_env = getattr(agent_spec, "os_env", None) if agent_spec is not None else None
     env_spec = TerminalEnvSpec(
-        os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=workspace,
+            sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+        ),
         command="claude",
         args=list(claude_args),
         # Tool Search env plus ucode gateway env (ANTHROPIC_BASE_URL
@@ -2408,6 +2435,7 @@ async def _auto_create_repl_terminal(
     publish_event: Callable[[str, dict[str, Any]], None],
     *,
     server_client: httpx.AsyncClient,
+    agent_spec: AgentSpec | ResolvedSpec | None = None,
 ) -> SessionResourceView:
     """
     Auto-create an Omnigent REPL terminal for a runner-hosted SDK session.
@@ -2453,8 +2481,16 @@ async def _auto_create_repl_terminal(
     started_at = time.monotonic()
     workspace = os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
     server_url = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767")
+    # Inherit the agent's declared sandbox (egress_rules / env_passthrough)
+    # so the hosted REPL runs inside the session's sandbox rather than
+    # outside it — mirrors create_session_terminal's os_env threading (#173).
+    agent_os_env = getattr(agent_spec, "os_env", None) if agent_spec is not None else None
     env_spec = TerminalEnvSpec(
-        os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=workspace,
+            sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+        ),
         # The runner's interpreter is the venv with omnigent installed;
         # ``python -m omnigent`` avoids depending on the console script
         # being on the tmux pane's PATH.
@@ -5261,6 +5297,7 @@ def create_runner_app(
                             bundle_dir=_native_bundle_dir,
                             agent_name=_native_agent_name,
                             skills_filter=_native_skills_filter,
+                            agent_spec=_native_spec,
                         )
                     except Exception as exc:
                         _logger.exception(
@@ -5373,6 +5410,7 @@ def create_runner_app(
                             resource_registry,
                             _publish_event,
                             server_client=server_client,
+                            agent_spec=spec_entry,
                         )
                     except Exception as exc:
                         _logger.exception(
@@ -5418,6 +5456,7 @@ def create_runner_app(
                             resource_registry,
                             _publish_event,
                             server_client=server_client,
+                            agent_spec=spec,
                         )
                     except Exception:
                         # Unlike the native branches, the REPL terminal is a
@@ -10448,11 +10487,16 @@ def create_runner_app(
                     claude_terminal_id,
                 )
                 try:
+                    _ensure_claude_spec = await _resolve_session_agent_spec(session_id)
+                except OmnigentError:
+                    _ensure_claude_spec = None
+                try:
                     terminal_view = await _auto_create_claude_terminal(
                         session_id,
                         resource_registry,
                         _publish_event,
                         server_client=server_client,
+                        agent_spec=_ensure_claude_spec,
                     )
                 except Exception as exc:
                     _logger.exception(
@@ -10533,11 +10577,16 @@ def create_runner_app(
                         content=session_resource_view_to_dict(existing),
                     )
                 try:
+                    _pi_ensure_spec = await _resolve_session_agent_spec(session_id)
+                except OmnigentError:
+                    _pi_ensure_spec = None
+                try:
                     terminal_view = await _auto_create_pi_terminal(
                         session_id,
                         resource_registry,
                         _publish_event,
                         server_client=server_client,
+                        agent_spec=_pi_ensure_spec,
                     )
                 except Exception as exc:
                     _logger.exception(
@@ -10865,11 +10914,16 @@ def create_runner_app(
                 # the entry unconditionally and tears the instance down.
                 await registry.close(session_id, _REPL_TERMINAL_NAME, _REPL_TERMINAL_SESSION_KEY)
                 try:
+                    _repl_spec = await _resolve_session_agent_spec(session_id)
+                except OmnigentError:
+                    _repl_spec = None
+                try:
                     await _auto_create_repl_terminal(
                         session_id,
                         resource_registry,
                         _publish_event,
                         server_client=server_client,
+                        agent_spec=_repl_spec,
                     )
                 except Exception:
                     # Broad catch, same rationale as the session-create

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -10304,12 +10304,17 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
     raises ``AttributeError`` here in CI instead of crashing in production the
     moment a real pi-native session boots.
 
+    Also guards #173: the agent's declared ``os_env.sandbox`` must reach the
+    launched terminal's ``os_env`` (egress_rules / env_passthrough), not the
+    platform-default sandbox backend.
+
     :param tmp_path: Pytest-provided temporary directory.
     :param monkeypatch: Pytest monkeypatch fixture.
     """
     import omnigent.pi_native as pi_native
     import omnigent.pi_native_bridge as pi_native_bridge
     import omnigent.pi_native_credentials as pi_native_credentials
+    from omnigent.inner.datamodel import AgentDef, OSEnvSandboxSpec, OSEnvSpec
 
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
     monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
@@ -10361,11 +10366,28 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
 
     published: list[dict[str, Any]] = []
 
+    # #173: the agent's declared os_env.sandbox must reach the launched
+    # terminal (egress_rules / env_passthrough), via the ResolvedSpec
+    # __getattr__ delegation the codex caller (agent_spec=spec_entry) relies on.
+    sandbox = OSEnvSandboxSpec(
+        type="darwin_seatbelt",
+        egress_rules=["* api.github.com/**"],
+        env_passthrough=["DATABRICKS_TOKEN"],
+    )
+    agent_spec = ResolvedSpec(
+        spec=AgentDef(
+            name="hardened",
+            os_env=OSEnvSpec(type="caller_process", cwd=str(tmp_path), sandbox=sandbox),
+        ),
+        workdir=tmp_path,
+    )
+
     await _auto_create_pi_terminal(
         "conv_pi",
         _FakeResourceRegistry(),  # type: ignore[arg-type]
         lambda _sid, evt: published.append(evt),
         server_client=NullServerClient(),  # type: ignore[arg-type]
+        agent_spec=agent_spec,
     )
 
     # Required lifecycle (parity with claude-native), correct terminal identity.
@@ -10375,6 +10397,11 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
     assert captured["spec"].command == "pi"
     # The fresh terminal is surfaced on the live stream for the Terminal toggle.
     assert any(evt.get("type") == "session.resource.created" for evt in published)
+    # #173: the agent's declared sandbox reaches the launched terminal's
+    # os_env.sandbox (egress_rules / env_passthrough), not the platform default.
+    assert captured["spec"].os_env.sandbox is sandbox
+    assert captured["spec"].os_env.sandbox.egress_rules == ["* api.github.com/**"]
+    assert captured["spec"].os_env.sandbox.env_passthrough == ["DATABRICKS_TOKEN"]
 
 
 @pytest.mark.asyncio
@@ -12049,6 +12076,96 @@ async def test_auto_create_repl_terminal_launches_attach_and_stamps_label(
     assert published_events[0]["resource"]["id"] == "terminal_tui_main"
 
 
+@pytest.mark.asyncio
+async def test_auto_create_repl_terminal_threads_agent_os_env_sandbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The REPL terminal inherits the agent's declared ``os_env.sandbox`` (#173).
+
+    Regression: ``_auto_create_repl_terminal`` built its ``OSEnvSpec`` from a
+    bare ``caller_process`` cwd with no sandbox, so a session whose YAML
+    declared an egress allow-list ran its hosted REPL completely outside the
+    agent's sandbox. The resolved agent spec's ``os_env.sandbox`` (egress_rules
+    / env_passthrough / sandbox type) must land on the launched terminal's
+    ``os_env.sandbox`` — mirroring ``create_session_terminal``'s threading. A
+    ``ResolvedSpec`` wrapper exercises the ``__getattr__`` delegation that the
+    codex auto-create caller (``agent_spec=spec_entry``) relies on.
+
+    :param tmp_path: Temporary directory for the fake runner workspace.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent.inner.datamodel import AgentDef, OSEnvSandboxSpec, OSEnvSpec
+
+    session_id = "conv_repl_sandbox"
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(workspace))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+
+    sandbox = OSEnvSandboxSpec(
+        type="darwin_seatbelt",
+        egress_rules=["* api.github.com/**"],
+        env_passthrough=["DATABRICKS_TOKEN"],
+    )
+    agent = AgentDef(
+        name="hardened",
+        os_env=OSEnvSpec(type="caller_process", cwd=str(workspace), sandbox=sandbox),
+    )
+    agent_spec = ResolvedSpec(spec=agent, workdir=workspace)
+
+    launched_specs: list[Any] = []
+
+    class _FakeResourceRegistry:
+        """Resource registry that records the launched REPL terminal spec."""
+
+        async def launch_auxiliary_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+        ) -> SessionResourceView:
+            assert terminal_name == "tui"
+            assert session_key == "main"
+            assert resource_role == OMNIGENT_REPL_TERMINAL_ROLE
+            launched_specs.append(spec)
+            return SessionResourceView(
+                id="terminal_tui_main",
+                type="terminal",
+                session_id=session_id,
+                name="tui",
+            )
+
+    class _PatchRecordingServerClient:
+        def __init__(self) -> None:
+            self.patches: list[_RecordedPatch] = []
+
+        async def patch(self, url: str, **kwargs: Any) -> httpx.Response:
+            self.patches.append(_RecordedPatch(url=url, json=kwargs.get("json") or {}))
+            return httpx.Response(200, json={}, request=httpx.Request("PATCH", url))
+
+    await _auto_create_repl_terminal(
+        session_id,
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, event: None,
+        server_client=_PatchRecordingServerClient(),  # type: ignore[arg-type]
+        agent_spec=agent_spec,
+    )
+
+    assert len(launched_specs) == 1
+    launched = launched_specs[0]
+    # The agent's sandbox reaches the launched terminal's os_env by reference:
+    # the OSEnvSpec is built with ``sandbox=agent_os_env.sandbox``, where
+    # ``agent_os_env`` is the agent spec's ``os_env`` (resolved through
+    # ``ResolvedSpec.__getattr__`` here).
+    assert launched.os_env.sandbox is sandbox
+    assert launched.os_env.sandbox.egress_rules == ["* api.github.com/**"]
+    assert launched.os_env.sandbox.env_passthrough == ["DATABRICKS_TOKEN"]
+
+
 @pytest.mark.parametrize(
     ("harness", "sub_agent_name", "expect_created"),
     [
@@ -12113,9 +12230,10 @@ async def test_create_session_repl_terminal_dispatch(
         publish_event: Any,
         *,
         server_client: Any,
+        **_kwargs: Any,
     ) -> SessionResourceView:
         """Record the dispatch instead of launching a real tmux pane."""
-        del resource_registry, publish_event, server_client
+        del resource_registry, publish_event, server_client, _kwargs
         created_sessions.append(session_id)
         return SessionResourceView(
             id="terminal_tui_main",

--- a/tests/runner/test_terminal_resource_attach_ws.py
+++ b/tests/runner/test_terminal_resource_attach_ws.py
@@ -331,6 +331,7 @@ def test_runner_resource_attach_recreates_dead_repl_terminal(
         publish_event: object,
         *,
         server_client: object,
+        **_kwargs: object,
     ) -> SessionResourceView:
         """
         Stand-in for ``_auto_create_repl_terminal`` that registers a


### PR DESCRIPTION
## Summary

The native-terminal auto-create helpers built their `OSEnvSpec` from a bare
`caller_process` cwd with **no `sandbox`**, so a session whose YAML declared an
egress allow-list / env passthrough (or `sandbox: none`) ran its native TUI —
or hosted REPL — under the **platform-default sandbox backend** instead of the
agent's configured sandbox. `create_session_terminal` already threaded the
agent's `os_env.sandbox` through; the `_auto_create_*_terminal` paths were
missed by that fix. Fixes #173.

Concretely: Polly's `claude_code` / `codex` sub-agents declare
`os_env.sandbox.type: none` (they run unconfined inside the outer container).
Because auto-create dropped the agent's `os_env.sandbox`, the native terminal
fell back to `linux_bwrap`, which can't start on a self-hosted host runner in an
unprivileged container — so the worker fails with
`OSError: linux_bwrap sandbox requires the 'bwrap' binary on PATH.` despite the
agent asking for `sandbox: none`.

## Where

All four native-terminal auto-create paths in `omnigent/runner/app.py`:

- `_auto_create_codex_terminal`
- `_auto_create_claude_terminal`
- `_auto_create_repl_terminal`
- `_auto_create_pi_terminal`

The issue's "Where" lists codex + claude; `_auto_create_repl_terminal` and
`_auto_create_pi_terminal` have the **identical** bare-`OSEnvSpec` gap (same
file, same pattern), so they're fixed here too — otherwise the issue's general
claim ("any native sub-agent's declared sandbox is ignored by the auto-create
paths") would still hold for two of the four.

## Fix

Resolve the agent's `os_env` from the agent spec and set `OSEnvSpec.sandbox` to
its declared sandbox (`egress_rules` / `env_passthrough` / sandbox type),
mirroring `create_session_terminal`:

```python
agent_os_env = getattr(agent_spec, "os_env", None) if agent_spec is not None else None
...
os_env=OSEnvSpec(
    type="caller_process",
    cwd=workspace,
    sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
),
```

Each helper gains an `agent_spec: AgentSpec | ResolvedSpec | None = None` kwarg;
the callers resolve it via the existing `_resolve_session_agent_spec`
(`spec_entry` for the create-dispatch callers; best-effort `None` on
`OmnigentError` for the ensure/recreate paths). `sandbox` defaults to `None`, so
sessions without a declared agent behave exactly as before.

### Why not `parent_os_env`

The issue's "Suggested fix" proposes passing **both** `sandbox=...` and
`parent_os_env=agent_os_env`, mirroring `create_session_terminal`. I omitted
`parent_os_env` deliberately — it's a no-op on this path:

`build_terminal_os_env_spec` consults `parent_os_env_spec` **only** when
`spec.os_env` is `"inherit"` / `None`. When `spec.os_env` is a concrete
`OSEnvSpec`, the effective os_env is a clone of `spec.os_env` and
`parent_os_env` is **ignored**. The auto-create specs are always concrete
`caller_process` `OSEnvSpec`s, so `parent_os_env` would be dead code here.
`create_session_terminal` passes `parent_os_env` for its `os_env: inherit`
declared-terminal case — a path the auto-create helpers don't have.

Setting `sandbox` on the spec itself is therefore both necessary and
sufficient, and it keeps the diff minimal (passing `parent_os_env` would force
a large test-fake ripple for zero behavioral change). If a maintainer prefers
the literal `parent_os_env` mirroring for consistency/future-proofing, it's a
trivial follow-up — happy to add it.

## Testing

- **`test_auto_create_repl_terminal_threads_agent_os_env_sandbox`** (new):
  asserts the declared sandbox (`egress_rules` / `env_passthrough`) reaches the
  launched terminal's `os_env.sandbox`, via a `ResolvedSpec` wrapper —
  exercises the `__getattr__` delegation the codex caller (`agent_spec=spec_entry`)
  relies on.
- **`test_auto_create_pi_terminal_launches_required_terminal`** (extended):
  now passes an `agent_spec` with a declared sandbox and asserts it reaches the
  launched terminal's `os_env.sandbox`.
- **`_fake_auto_create_repl` / `fake_auto_create`**: accept the new `agent_spec`
  kwarg (`**_kwargs`) so the dispatch and recreate tests still pass.

`ruff format` / `ruff check` clean on the changed files; the full
`tests/runner/test_app_sessions_native.py` (172) and
`tests/runner/test_terminal_resource_attach_ws.py` (9) suites pass; `mypy`
introduces no new errors vs. baseline (mypy is not a CI gate). No frontend
touched, so no `ap-web` type-check.

I left a claim comment on the issue before starting.

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
