### PR TITLE
docs: add AI agent framework language to README for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="38" valign="middle" /> Omnigent
 
-### A meta-harness for all your AI agents
+### The open-source AI agent framework and meta-harness for all your AI agents.
 
-Omnigent provides a common layer over Claude Code, Codex, Cursor, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, keep them in check with policies and sandboxing, and collaborate in real time on the same live session, from any device.
+Omnigent is an open-source **AI agent framework** and meta-harness that gives you a common orchestration layer over Claude Code, Codex, Cursor, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/omnigent-ai/omnigent/blob/main/LICENSE)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)


### PR DESCRIPTION
## Summary

Two surgical edits to README.md to improve Google keyword alignment:

- **Subtitle**: updated from `A meta-harness for all your AI agents` to `The open-source AI agent framework and meta-harness for all your AI agents.` — adds both *AI agent framework* and *open-source* to the above-the-fold text.
- **Opening paragraph**: rephrased to open with `Omnigent is an open-source **AI agent framework** and meta-harness…` — gives crawlers a clear, bolded keyword signal in the first prose sentence.

No product content, feature descriptions, links, badges, images, or other sections were changed.

## Why

The phrase *AI agent framework* appeared zero times in the README before this change. It is the primary search query used by developers evaluating tools in this space. Adding it to the subtitle and opening sentence improves discoverability without altering any product messaging.