### PR TITLE
feat(examples): give the bundled Polly & Debby agents Hindsight memory

### DIFF
--- a/examples/debby/config.yaml
+++ b/examples/debby/config.yaml
@@ -110,6 +110,19 @@ prompt: |
   the partners' content is the substance — your job is to fan out, lay it
   out, and (on request) run the debate.
 
+  ## Long-term memory
+
+  You have Hindsight memory tools (`hindsight_recall`, `hindsight_retain`) that
+  persist across sessions. Use them when available (they may be absent if memory
+  isn't configured; just proceed normally then):
+  - Call `hindsight_recall` before fanning out on a topic you may have explored
+    with this user before, so you can frame the partners with what's already
+    known and avoid retreading old ground.
+  - Call `hindsight_retain` when the user shares a durable preference, constraint,
+    or a conclusion they landed on (e.g. "I'm building for mobile-first", "we
+    decided against microservices"). Never claim you saved something unless
+    `hindsight_retain` actually ran.
+
 async: true
 cancellable: true
 
@@ -146,3 +159,15 @@ tools:
   agents:
     - claude
     - gpt
+  # Long-term memory via Hindsight (https://github.com/vectorize-io/hindsight).
+  # Optional: needs `pip install omnigent[hindsight]` + HINDSIGHT_API_KEY. Skipped
+  # if the extra isn't installed (Debby runs unchanged); no-ops with an error at
+  # call time if the key is unset. No api_key is baked — the tool reads
+  # HINDSIGHT_API_KEY from the environment. bank_id pins a stable memory bank.
+  builtins:
+    - name: hindsight_recall
+      bank_id: debby
+    - name: hindsight_retain
+      bank_id: debby
+    - name: hindsight_reflect
+      bank_id: debby

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -249,6 +249,21 @@ prompt: |
   - Do not infer success from git status alone — read the sub-agent's reported
     result and run the test / lint / typecheck gates yourself.
 
+  ## Long-term memory
+
+  You have Hindsight memory tools (`hindsight_recall`, `hindsight_retain`,
+  `hindsight_reflect`) that persist across sessions — your conversation context
+  does not. Use them when available (they may be absent if memory isn't
+  configured; just proceed normally then):
+  - Call `hindsight_recall` at the start of non-trivial work to surface durable
+    project facts you've learned before — repo conventions, the test/lint/
+    typecheck commands, architecture decisions, recurring pitfalls, human
+    preferences.
+  - Call `hindsight_retain` when you learn a durable fact worth reusing in future
+    sessions (e.g. "tests run via `uv run pytest`", "this repo deploys from
+    `main` only"). Don't store transient task state. Never claim you saved
+    something unless `hindsight_retain` actually ran and returned success.
+
 async: true
 cancellable: true
 timers: true
@@ -282,6 +297,19 @@ tools:
     - claude_code
     - codex
     - pi
+  # Long-term memory via Hindsight (https://github.com/vectorize-io/hindsight).
+  # Optional: needs `pip install omnigent[hindsight]` + HINDSIGHT_API_KEY. If the
+  # extra isn't installed these tools are skipped and Polly runs unchanged; if the
+  # key is unset they no-op with an error at call time. No api_key is baked here —
+  # the tool reads HINDSIGHT_API_KEY from the environment. bank_id pins a stable,
+  # inspectable memory bank.
+  builtins:
+    - name: hindsight_recall
+      bank_id: polly
+    - name: hindsight_retain
+      bank_id: polly
+    - name: hindsight_reflect
+      bank_id: polly
 
 # Mechanism-layer enforcement — runner-side tool gate, no server change.
 guardrails:

--- a/examples/remy/config.yaml
+++ b/examples/remy/config.yaml
@@ -1,0 +1,53 @@
+# Remy — an assistant that remembers.
+#
+# Remy uses Hindsight long-term memory so what you tell it in one run is
+# available in every future run. Before answering it recalls what it already
+# knows about you; when you share a durable fact it retains it; and it can
+# reflect over everything it has stored.
+#
+# Memory is keyed by the agent id, so all of Remy's runs share one memory bank.
+#
+# Setup:
+#   pip install 'omnigent[hindsight]'
+#   export HINDSIGHT_API_KEY=hsk_...        # https://ui.hindsight.vectorize.io
+#
+# Usage:
+#   omnigent run examples/remy
+#
+# Remy runs on the Claude Agent SDK harness, so configure a Claude provider
+# first (e.g. `omnigent setup`, or export ANTHROPIC_API_KEY).
+
+spec_version: 1
+name: remy
+description: >-
+  A helpful assistant with long-term memory. Remy recalls what it already knows
+  before answering, retains durable facts you share, and can reflect over its
+  memory — powered by Hindsight.
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are Remy, a helpful assistant with long-term memory powered by Hindsight.
+
+  Use your memory tools deliberately:
+  - Call `hindsight_recall` BEFORE answering anything that might depend on what
+    you already know about the user or past conversations.
+  - Call `hindsight_retain` whenever the user shares a durable fact, preference,
+    or decision worth remembering across sessions (not transient chit-chat).
+  - Call `hindsight_reflect` when the user asks you to summarize or reason about
+    what you know overall, rather than retrieve specific facts.
+
+  Weave recalled memories into your answer naturally — don't dump raw tool
+  output. If recall returns nothing relevant, just answer normally.
+
+tools:
+  builtins:
+    - name: hindsight_recall
+      api_key: ${HINDSIGHT_API_KEY}
+    - name: hindsight_retain
+      api_key: ${HINDSIGHT_API_KEY}
+    - name: hindsight_reflect
+      api_key: ${HINDSIGHT_API_KEY}

--- a/examples/remy/config.yaml
+++ b/examples/remy/config.yaml
@@ -32,11 +32,17 @@ executor:
 prompt: |
   You are Remy, a helpful assistant with long-term memory powered by Hindsight.
 
+  Your conversation context is wiped between sessions — the ONLY way you
+  remember anything is by calling these tools. Acknowledging a fact in chat does
+  NOT save it.
+
   Use your memory tools deliberately:
   - Call `hindsight_recall` BEFORE answering anything that might depend on what
     you already know about the user or past conversations.
-  - Call `hindsight_retain` whenever the user shares a durable fact, preference,
-    or decision worth remembering across sessions (not transient chit-chat).
+  - When the user shares a durable fact, preference, or decision — or asks you
+    to remember something — you MUST call `hindsight_retain`. Never say you have
+    saved or will remember something unless `hindsight_retain` actually ran and
+    returned success in this turn.
   - Call `hindsight_reflect` when the user asks you to summarize or reason about
     what you know overall, rather than retrieve specific facts.
 

--- a/examples/remy/config.yaml
+++ b/examples/remy/config.yaml
@@ -43,11 +43,17 @@ prompt: |
   Weave recalled memories into your answer naturally — don't dump raw tool
   output. If recall returns nothing relevant, just answer normally.
 
+# bank_id pins a stable, human-readable memory bank. Omit it and the bank
+# defaults to the agent id (per-agent isolation) — handy, but opaque to find
+# in Hindsight. A fixed name keeps Remy's memory in one easy-to-inspect bank.
 tools:
   builtins:
     - name: hindsight_recall
       api_key: ${HINDSIGHT_API_KEY}
+      bank_id: remy
     - name: hindsight_retain
       api_key: ${HINDSIGHT_API_KEY}
+      bank_id: remy
     - name: hindsight_reflect
       api_key: ${HINDSIGHT_API_KEY}
+      bank_id: remy

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -249,6 +249,12 @@ _LOCAL_DAEMON_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
         "GROQ_API_KEY",
+        # Hindsight memory built-in tools authenticate runner-side; the key must
+        # survive the CLI→daemon hop to be forwarded on to the runner (the
+        # daemon→runner forward-list in connect.HARNESS_CREDENTIAL_ENV_VARS does
+        # the second hop). Same dual-list pattern as ANTHROPIC_/OPENAI_API_KEY.
+        "HINDSIGHT_API_KEY",
+        "HINDSIGHT_API_URL",
         "MISTRAL_API_KEY",
         "OMNIGENT_DATABASE_URI",
         "OPENAI_API_KEY",

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -306,6 +306,14 @@ HARNESS_CREDENTIAL_ENV_VARS: frozenset[str] = frozenset(
         "GEMINI_API_KEY",
         "GIT_TOKEN",
         "GIT_USERNAME",
+        # HINDSIGHT_API_KEY / _API_URL authenticate the Hindsight memory built-in
+        # tools (hindsight_retain / recall / reflect) to the user's memory store.
+        # Like the provider keys above, these are credentials the host owner sets
+        # precisely so their runners can use them — the tools run runner-side and
+        # read them from the env (no secret is baked into the agent spec). Absent
+        # from the host env → simply not forwarded, and the tools degrade.
+        "HINDSIGHT_API_KEY",
+        "HINDSIGHT_API_URL",
     }
 )
 

--- a/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
+++ b/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
@@ -19,6 +19,9 @@ from omnigent_client import tool
 _TOOL_CLASSES: dict[str, tuple[str, str]] = {
     "download_file": ("omnigent.tools.builtins.download_file", "DownloadFileTool"),
     "export_agent": ("omnigent.tools.builtins.export_agent", "ExportAgentTool"),
+    "hindsight_recall": ("omnigent.tools.builtins.hindsight", "HindsightRecallTool"),
+    "hindsight_reflect": ("omnigent.tools.builtins.hindsight", "HindsightReflectTool"),
+    "hindsight_retain": ("omnigent.tools.builtins.hindsight", "HindsightRetainTool"),
     "list_files": ("omnigent.tools.builtins.list_files", "ListFilesTool"),
     "search_conversations": (
         "omnigent.tools.builtins.search_conversations",

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -222,6 +222,12 @@ _WEB_FETCH_TOOLS = frozenset({"web_fetch"})
 # web_search known-failure.
 _WEB_SEARCH_TOOLS = frozenset({"web_search"})
 
+# Hindsight long-term memory builtins. Runner-local (like web_search) so that a
+# wrapped harness's (claude-sdk / codex / cursor / pi) tool call resolves to the
+# spec-configured Hindsight tool via its ``invoke``. Without this entry the call
+# falls through to the harness, which has no such tool, and silently no-ops.
+_HINDSIGHT_TOOLS = frozenset({"hindsight_retain", "hindsight_recall", "hindsight_reflect"})
+
 # Priority 5f.2: sys_list_models — runner-local because provider resolution
 # reads the runner host's config/credentials, same as the spawn paths.
 _LIST_MODELS_TOOLS = frozenset({"sys_list_models"})
@@ -294,6 +300,9 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     | _AGENT_TOOLS
     | _POLICY_TOOLS
     | _TERMINAL_TOOLS
+    # Memory builtins are relayed to native harnesses too — unlike web_search,
+    # native harnesses have no built-in long-term memory of their own.
+    | _HINDSIGHT_TOOLS
 )
 
 # sys_agent_list: locally-authored agent config YAMLs live under this
@@ -319,6 +328,7 @@ _ALL_LOCAL_TOOLS = (
     | _SESSION_QUERY_TOOLS
     | _WEB_FETCH_TOOLS
     | _WEB_SEARCH_TOOLS
+    | _HINDSIGHT_TOOLS
     | _TIMER_TOOLS
     | _TASK_LIFECYCLE_TOOLS
     | _SKILL_TOOLS
@@ -1935,6 +1945,68 @@ async def _execute_web_search_tool(
     ctx = ToolContext(
         task_id=task_id or "web_search",
         agent_id=agent_id or "web_search",
+        conversation_id=conversation_id,
+    )
+    return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
+
+
+def _hindsight_config_from_spec(agent_spec: Any | None, tool_name: str) -> dict[str, str]:
+    """
+    Return a Hindsight builtin's config dict from the parent spec.
+
+    Mirrors ``ToolManager._register_builtin_tools``: scans ``spec.tools.builtins``
+    for the entry named *tool_name* (e.g. ``"hindsight_recall"``) and returns its
+    ``config`` (api_key, bank_id, etc.). Empty dict when declared bare or absent.
+
+    :param agent_spec: Parent agent's spec, or ``None``.
+    :param tool_name: The Hindsight tool name to look up.
+    :returns: The builtin's config dict.
+    """
+    if agent_spec is None:
+        return {}
+    tools = getattr(agent_spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    for entry in builtins:
+        if getattr(entry, "name", None) == tool_name:
+            return getattr(entry, "config", None) or {}
+    return {}
+
+
+async def _execute_hindsight_tool(
+    args: dict[str, Any],
+    *,
+    tool_name: str,
+    agent_spec: Any | None,
+    conversation_id: str | None = None,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+) -> str:
+    """
+    Dispatch a Hindsight memory tool call (retain / recall / reflect).
+
+    Builds the tool from the spec's builtin config and runs its synchronous
+    ``invoke`` off the event loop (it makes a blocking HTTP call to Hindsight).
+    The bank is resolved inside the tool from ``config.bank_id`` → ``ctx.agent_id``
+    → ``ctx.conversation_id``, so the real ``agent_id`` is threaded through here.
+
+    :param args: Parsed LLM arguments (``content`` for retain, ``query`` otherwise).
+    :param tool_name: The Hindsight tool name being dispatched.
+    :param agent_spec: Parent agent's spec; carries the Hindsight builtin config.
+    :param conversation_id: Parent session id, threaded into the context.
+    :param task_id: Calling task id, threaded into the context.
+    :param agent_id: Calling agent id — the default memory bank.
+    :returns: The tool's string result, or an error string.
+    """
+    from omnigent.tools.base import ToolContext
+    from omnigent.tools.builtins import get_builtin_tool
+
+    config = _hindsight_config_from_spec(agent_spec, tool_name)
+    tool = get_builtin_tool(tool_name, config)
+    if tool is None:
+        return f"Hindsight tool {tool_name!r} is not available."
+    ctx = ToolContext(
+        task_id=task_id or tool_name,
+        agent_id=agent_id or tool_name,
         conversation_id=conversation_id,
     )
     return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
@@ -3595,6 +3667,15 @@ async def execute_tool(
         elif tool_name in _WEB_SEARCH_TOOLS:
             output = await _execute_web_search_tool(
                 args,
+                agent_spec=agent_spec,
+                conversation_id=conversation_id,
+                task_id=task_id,
+                agent_id=agent_id,
+            )
+        elif tool_name in _HINDSIGHT_TOOLS:
+            output = await _execute_hindsight_tool(
+                args,
+                tool_name=tool_name,
                 agent_spec=agent_spec,
                 conversation_id=conversation_id,
                 task_id=task_id,

--- a/omnigent/spec/AGENTSPEC.md
+++ b/omnigent/spec/AGENTSPEC.md
@@ -185,6 +185,12 @@ tools:
       # the agent id), budget (low | mid | high), max_tokens, tags, recall_tags
 ```
 
+Tell your agent in its `prompt` to actually use these tools — e.g. "recall before
+answering; when the user shares a durable fact you MUST call hindsight_retain, and
+never claim you saved something unless the tool ran." Models otherwise tend to
+acknowledge a fact in chat without persisting it. See `examples/remy` for a
+working prompt.
+
 ---
 
 ## Instructions

--- a/omnigent/spec/AGENTSPEC.md
+++ b/omnigent/spec/AGENTSPEC.md
@@ -166,31 +166,6 @@ tools:
     - web_fetch                            # no config needed
 ```
 
-**`hindsight_retain` / `hindsight_recall` / `hindsight_reflect` — long-term
-memory:** Persist and recall memory across runs via
-[Hindsight](https://github.com/vectorize-io/hindsight). Requires the optional
-`hindsight` extra (`pip install 'omnigent[hindsight]'`). The memory bank
-defaults to the agent's id, so a single declaration isolates memory per agent.
-
-```yaml
-tools:
-  builtins:
-    - name: hindsight_recall               # search long-term memory
-      api_key: ${HINDSIGHT_API_KEY}
-    - name: hindsight_retain               # store to long-term memory
-      api_key: ${HINDSIGHT_API_KEY}
-    - name: hindsight_reflect              # synthesize an answer from memory
-      api_key: ${HINDSIGHT_API_KEY}
-      # optional: api_url (defaults to Hindsight Cloud), bank_id (defaults to
-      # the agent id), budget (low | mid | high), max_tokens, tags, recall_tags
-```
-
-Tell your agent in its `prompt` to actually use these tools — e.g. "recall before
-answering; when the user shares a durable fact you MUST call hindsight_retain, and
-never claim you saved something unless the tool ran." Models otherwise tend to
-acknowledge a fact in chat without persisting it. See `examples/remy` for a
-working prompt.
-
 ---
 
 ## Instructions

--- a/omnigent/spec/AGENTSPEC.md
+++ b/omnigent/spec/AGENTSPEC.md
@@ -166,6 +166,25 @@ tools:
     - web_fetch                            # no config needed
 ```
 
+**`hindsight_retain` / `hindsight_recall` / `hindsight_reflect` — long-term
+memory:** Persist and recall memory across runs via
+[Hindsight](https://github.com/vectorize-io/hindsight). Requires the optional
+`hindsight` extra (`pip install 'omnigent[hindsight]'`). The memory bank
+defaults to the agent's id, so a single declaration isolates memory per agent.
+
+```yaml
+tools:
+  builtins:
+    - name: hindsight_recall               # search long-term memory
+      api_key: ${HINDSIGHT_API_KEY}
+    - name: hindsight_retain               # store to long-term memory
+      api_key: ${HINDSIGHT_API_KEY}
+    - name: hindsight_reflect              # synthesize an answer from memory
+      api_key: ${HINDSIGHT_API_KEY}
+      # optional: api_url (defaults to Hindsight Cloud), bank_id (defaults to
+      # the agent id), budget (low | mid | high), max_tokens, tags, recall_tags
+```
+
 ---
 
 ## Instructions

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -164,6 +164,66 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
     return ExportAgentTool()
 
 
+def _require_hindsight() -> None:
+    """
+    Validate that the Hindsight client SDK is installed.
+
+    ``hindsight-client`` is an optional dependency (the ``hindsight`` extra),
+    so the memory tools probe for it at construction time and fail with an
+    actionable message rather than an opaque ImportError mid-run. Mirrors the
+    Modal sandbox launcher's ``_ensure_sdk``.
+
+    :raises ImportError: When ``hindsight-client`` is not installed.
+    """
+    try:
+        import hindsight_client  # noqa: F401  # presence probe only
+    except ImportError as exc:
+        raise ImportError(
+            "The 'hindsight-client' SDK is required for the Hindsight memory "
+            "tools (hindsight_retain / hindsight_recall / hindsight_reflect). "
+            "Install it with `pip install 'omnigent[hindsight]'`."
+        ) from exc
+
+
+def _create_hindsight_retain(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for HindsightRetainTool.
+
+    :param config: Tool config (Hindsight api_key, bank_id, etc.).
+    :returns: A HindsightRetainTool instance.
+    """
+    _require_hindsight()
+    from omnigent.tools.builtins.hindsight import HindsightRetainTool
+
+    return HindsightRetainTool(config=config)
+
+
+def _create_hindsight_recall(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for HindsightRecallTool.
+
+    :param config: Tool config (Hindsight api_key, bank_id, etc.).
+    :returns: A HindsightRecallTool instance.
+    """
+    _require_hindsight()
+    from omnigent.tools.builtins.hindsight import HindsightRecallTool
+
+    return HindsightRecallTool(config=config)
+
+
+def _create_hindsight_reflect(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for HindsightReflectTool.
+
+    :param config: Tool config (Hindsight api_key, bank_id, etc.).
+    :returns: A HindsightReflectTool instance.
+    """
+    _require_hindsight()
+    from omnigent.tools.builtins.hindsight import HindsightReflectTool
+
+    return HindsightReflectTool(config=config)
+
+
 # Unified registry for every reserved builtin name. The value
 # is either a factory callable (for user-enablable tools) or
 # ``None`` for framework-owned names that occupy the name-space
@@ -186,6 +246,11 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "download_file": _create_download_file,
     "search_conversations": _create_search_conversations,
     "export_agent": _create_export_agent,
+    # Hindsight long-term memory (optional ``hindsight`` extra). Each factory
+    # probes for ``hindsight-client`` and fails with an install hint if absent.
+    "hindsight_retain": _create_hindsight_retain,
+    "hindsight_recall": _create_hindsight_recall,
+    "hindsight_reflect": _create_hindsight_reflect,
     # Framework-owned: need runtime context. ``web_fetch`` is
     # constructed by ToolManager before reaching this registry.
     # ``list_comments`` and ``update_comment`` are auto-registered by

--- a/omnigent/tools/builtins/hindsight.py
+++ b/omnigent/tools/builtins/hindsight.py
@@ -20,10 +20,11 @@ Usage in config.yaml::
         - name: hindsight_reflect
           api_key: ${HINDSIGHT_API_KEY}
 
-Config keys (all optional except ``api_key``):
+Config keys (all optional):
 
-- ``api_key``: Hindsight API key (or set it via ``${HINDSIGHT_API_KEY}``).
-- ``api_url``: API base URL. Defaults to Hindsight Cloud.
+- ``api_key``: Hindsight API key. Falls back to the ``HINDSIGHT_API_KEY`` env
+  var when omitted (lets bundled agents enable memory without baking a secret).
+- ``api_url``: API base URL. Falls back to ``HINDSIGHT_API_URL``, else Hindsight Cloud.
 - ``bank_id``: Memory bank to read/write. Defaults to ``ctx.agent_id``.
 - ``budget``: recall/reflect budget level — ``low`` / ``mid`` / ``high``.
 - ``max_tokens``: max tokens for recall results.
@@ -35,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from omnigent.tools.base import Tool, ToolContext
@@ -84,17 +86,27 @@ class _HindsightToolBase(Tool):
         if self._cached_client is not None:
             return self._cached_client
 
-        api_key = self._config.get("api_key")
+        # Spec config takes precedence; fall back to the environment. The env
+        # fallback lets bundled agents (e.g. polly / debby) enable memory by
+        # declaring the tool with no `api_key:` — they can't bake a secret into
+        # a shared config, and a literal `${HINDSIGHT_API_KEY}` would crash the
+        # client-side env expansion when the var is unset. Explicit configs
+        # (e.g. remy's `api_key: ${HINDSIGHT_API_KEY}`) are unaffected.
+        api_key = self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY")
         if not api_key:
             raise ValueError(
-                "Hindsight memory tools require an 'api_key' in the tool config "
-                "(e.g. api_key: ${HINDSIGHT_API_KEY})."
+                "Hindsight memory tools require an API key. Set the "
+                "HINDSIGHT_API_KEY environment variable, or pass api_key in the "
+                "tool config (e.g. api_key: ${HINDSIGHT_API_KEY})."
             )
 
         import hindsight_client
 
+        base_url = (
+            self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL") or _DEFAULT_API_URL
+        )
         self._cached_client = hindsight_client.Hindsight(
-            base_url=self._config.get("api_url") or _DEFAULT_API_URL,
+            base_url=base_url,
             api_key=api_key,
             timeout=30.0,
         )

--- a/omnigent/tools/builtins/hindsight.py
+++ b/omnigent/tools/builtins/hindsight.py
@@ -1,0 +1,291 @@
+"""Built-in tools: Hindsight long-term memory.
+
+Exposes Hindsight's retain / recall / reflect operations as three built-in
+tools so an agent can persist and recall memory across runs. Hindsight
+(https://github.com/vectorize-io/hindsight) is an open-source agent-memory
+system; the client SDK is an optional dependency (``omnigent[hindsight]``).
+
+The memory bank is resolved per invocation from the agent spec config, falling
+back to the run's identity in :class:`ToolContext` — so a single declaration
+isolates memory per agent (or per conversation) out of the box.
+
+Usage in config.yaml::
+
+    tools:
+      builtins:
+        - name: hindsight_recall
+          api_key: ${HINDSIGHT_API_KEY}
+        - name: hindsight_retain
+          api_key: ${HINDSIGHT_API_KEY}
+        - name: hindsight_reflect
+          api_key: ${HINDSIGHT_API_KEY}
+
+Config keys (all optional except ``api_key``):
+
+- ``api_key``: Hindsight API key (or set it via ``${HINDSIGHT_API_KEY}``).
+- ``api_url``: API base URL. Defaults to Hindsight Cloud.
+- ``bank_id``: Memory bank to read/write. Defaults to ``ctx.agent_id``.
+- ``budget``: recall/reflect budget level — ``low`` / ``mid`` / ``high``.
+- ``max_tokens``: max tokens for recall results.
+- ``tags`` / ``recall_tags``: comma-separated tags for retain / recall.
+- ``recall_tags_match``: ``any`` / ``all`` / ``any_strict`` / ``all_strict``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from omnigent.tools.base import Tool, ToolContext
+
+if TYPE_CHECKING:
+    from hindsight_client import Hindsight
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
+
+# Banks already ensured-to-exist this process, so ``retain`` doesn't issue a
+# redundant create_bank on every call. Module-level (not per-instance) because
+# ToolManager builds a fresh tool instance per agent load.
+_CREATED_BANKS: set[str] = set()
+
+
+def _csv(value: str | None) -> list[str] | None:
+    """Parse a comma-separated config string into a tag list, or None."""
+    if not value:
+        return None
+    tags = [t.strip() for t in value.split(",") if t.strip()]
+    return tags or None
+
+
+class _HindsightToolBase(Tool):
+    """Shared client/bank resolution for the Hindsight memory tools.
+
+    The name starts with an underscore so the builtin-discovery test
+    (``_all_builtin_tool_subclasses``) skips it — only the three concrete
+    tools below are user-facing.
+
+    :param config: Spec-level config from config.yaml (see module docstring).
+    """
+
+    def __init__(self, config: dict[str, str] | None = None) -> None:
+        self._config = config or {}
+        self._cached_client: Hindsight | None = None
+
+    def _client(self) -> Hindsight:
+        """Build (and cache) a Hindsight client from the spec config.
+
+        Imports ``hindsight_client`` lazily so merely importing this module
+        (e.g. for ``description()`` during tool discovery) never requires the
+        optional dependency.
+        """
+        if self._cached_client is not None:
+            return self._cached_client
+
+        api_key = self._config.get("api_key")
+        if not api_key:
+            raise ValueError(
+                "Hindsight memory tools require an 'api_key' in the tool config "
+                "(e.g. api_key: ${HINDSIGHT_API_KEY})."
+            )
+
+        import hindsight_client
+
+        self._cached_client = hindsight_client.Hindsight(
+            base_url=self._config.get("api_url") or _DEFAULT_API_URL,
+            api_key=api_key,
+            timeout=30.0,
+        )
+        return self._cached_client
+
+    def _bank(self, ctx: ToolContext) -> str:
+        """Resolve the memory bank: config override → agent id → conversation id."""
+        bank = self._config.get("bank_id") or ctx.agent_id or ctx.conversation_id
+        if not bank:
+            raise ValueError(
+                "No Hindsight bank could be resolved (no bank_id, agent_id, or conversation_id)."
+            )
+        return bank
+
+    def _budget(self) -> str:
+        return self._config.get("budget", "mid")
+
+    def _max_tokens(self) -> int:
+        return int(self._config.get("max_tokens", "4096"))
+
+    def _ensure_bank(self, client: Hindsight, bank: str) -> None:
+        """Create the bank once per process; tolerate it already existing."""
+        if bank in _CREATED_BANKS:
+            return
+        try:
+            client.create_bank(bank_id=bank, name=bank)
+        except Exception as e:
+            # Bank likely already exists; treat as created either way. Logged at
+            # debug so a real auth/network failure is visible here rather than
+            # only surfacing later on the retain call.
+            _logger.debug("create_bank(%r) failed (assuming it exists): %s", bank, e)
+        _CREATED_BANKS.add(bank)
+
+
+class HindsightRetainTool(_HindsightToolBase):
+    """Store information in Hindsight long-term memory."""
+
+    @classmethod
+    def name(cls) -> str:
+        return "hindsight_retain"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Store information in long-term memory (Hindsight) for later "
+            "retrieval — facts, preferences, decisions, or anything that "
+            "should be remembered across conversations."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "The information to store in long-term memory.",
+                        },
+                    },
+                    "required": ["content"],
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        try:
+            content = json.loads(arguments).get("content") if arguments else None
+            if not content:
+                return "Error: 'content' parameter is required."
+            client = self._client()
+            bank = self._bank(ctx)
+            self._ensure_bank(client, bank)
+            kwargs: dict[str, Any] = {"bank_id": bank, "content": content}
+            tags = _csv(self._config.get("tags"))
+            if tags:
+                kwargs["tags"] = tags
+            client.retain(**kwargs)
+            return "Stored to long-term memory."
+        except Exception as e:
+            _logger.error("Hindsight retain failed: %s", e)
+            return f"Hindsight retain failed: {e}"
+
+
+class HindsightRecallTool(_HindsightToolBase):
+    """Search Hindsight long-term memory."""
+
+    @classmethod
+    def name(cls) -> str:
+        return "hindsight_recall"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Search long-term memory (Hindsight) for relevant information — "
+            "previously stored facts, preferences, or context. Returns the "
+            "matching memories, or a note that none were found."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query to find relevant memories.",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        try:
+            query = json.loads(arguments).get("query") if arguments else None
+            if not query:
+                return "Error: 'query' parameter is required."
+            client = self._client()
+            bank = self._bank(ctx)
+            kwargs: dict[str, Any] = {
+                "bank_id": bank,
+                "query": query,
+                "budget": self._budget(),
+                "max_tokens": self._max_tokens(),
+            }
+            recall_tags = _csv(self._config.get("recall_tags"))
+            if recall_tags:
+                kwargs["tags"] = recall_tags
+                kwargs["tags_match"] = self._config.get("recall_tags_match", "any")
+            response = client.recall(**kwargs)
+            memories = [r.text for r in (response.results or [])]
+            if not memories:
+                return "No relevant memories found."
+            return "\n".join(f"- {m}" for m in memories)
+        except Exception as e:
+            _logger.error("Hindsight recall failed: %s", e)
+            return f"Hindsight recall failed: {e}"
+
+
+class HindsightReflectTool(_HindsightToolBase):
+    """Synthesize a reasoned answer from Hindsight long-term memory."""
+
+    @classmethod
+    def name(cls) -> str:
+        return "hindsight_reflect"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Synthesize a reasoned answer from long-term memory (Hindsight). "
+            "Use this for a coherent summary or reasoned response about what "
+            "is known, rather than raw memory facts."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The question to reflect on using stored memories.",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        try:
+            query = json.loads(arguments).get("query") if arguments else None
+            if not query:
+                return "Error: 'query' parameter is required."
+            client = self._client()
+            bank = self._bank(ctx)
+            response = client.reflect(bank_id=bank, query=query, budget=self._budget())
+            return response.text or "No relevant memories found."
+        except Exception as e:
+            _logger.error("Hindsight reflect failed: %s", e)
+            return f"Hindsight reflect failed: {e}"

--- a/omnigent/tools/builtins/hindsight.py
+++ b/omnigent/tools/builtins/hindsight.py
@@ -139,9 +139,11 @@ class HindsightRetainTool(_HindsightToolBase):
     @classmethod
     def description(cls) -> str:
         return (
-            "Store information in long-term memory (Hindsight) for later "
-            "retrieval — facts, preferences, decisions, or anything that "
-            "should be remembered across conversations."
+            "Persist information to long-term memory (Hindsight) so it survives "
+            "across conversations and sessions. Call this whenever the user "
+            "shares a durable fact, preference, or decision, or asks you to "
+            "remember something — conversation context alone is lost between "
+            "sessions, so acknowledging a fact in chat does NOT save it."
         )
 
     def get_schema(self) -> dict[str, Any]:
@@ -193,8 +195,10 @@ class HindsightRecallTool(_HindsightToolBase):
     def description(cls) -> str:
         return (
             "Search long-term memory (Hindsight) for relevant information — "
-            "previously stored facts, preferences, or context. Returns the "
-            "matching memories, or a note that none were found."
+            "previously stored facts, preferences, or context. Call this BEFORE "
+            "answering anything that may depend on what you already know about "
+            "the user or past sessions. Returns the matching memories, or a note "
+            "that none were found."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -295,7 +295,22 @@ class ToolManager:
         :meth:`_create_builtin` instead.
         """
         for entry in self._spec.tools.builtins:
-            tool = self._create_builtin(entry.name, entry.config)
+            try:
+                tool = self._create_builtin(entry.name, entry.config)
+            except ImportError as e:
+                # A built-in backed by an OPTIONAL extra (e.g. the Hindsight
+                # memory tools need ``omnigent[hindsight]``) raises ImportError
+                # from its factory when the extra isn't installed. Skip it with
+                # a clear warning rather than failing the whole agent load — so
+                # bundled agents that declare an optional-dep tool still run on a
+                # base install. The tool simply isn't advertised to the model.
+                _logger.warning(
+                    "Built-in tool %r needs an optional dependency that isn't "
+                    "installed — skipping: %s",
+                    entry.name,
+                    e,
+                )
+                continue
             if tool is None:
                 _logger.warning(
                     "Unknown built-in tool %r — skipping. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,10 @@ antigravity = ["google-antigravity>=0.1,<1"]
 # cursor` users need this extra (`omnigent[cursor]`). Was a baseline dependency;
 # now opt-in to keep the default install lean.
 cursor = ["cursor-sdk>=0.1.7"]
+# Hindsight long-term memory built-in tools (hindsight_retain / _recall /
+# _reflect). The tools import the client lazily, so only users who enable a
+# Hindsight memory tool need this extra.
+hindsight = ["hindsight-client>=0.4.0"]
 databricks = [
     # Floor matches what core code was tested against when the SDK was a
     # default dependency (it moved here from `dependencies` above).
@@ -156,6 +160,10 @@ dev = [
     # mlflow is now opt-in (the `tracing` / `databricks` extras), but the
     # telemetry + tracing test suites need it, so keep it in the dev set.
     "mlflow>=3,<4",
+    # hindsight-client is opt-in (the `hindsight` extra), but the Hindsight
+    # memory tool tests import + mock it, so keep it in the dev set (same
+    # rationale as mlflow above).
+    "hindsight-client>=0.4.0",
     "pytest-asyncio>=0.21",
     "pytest-xdist>=3.6",
     # Line coverage during the unit-test matrix. Each CI shard writes its
@@ -476,6 +484,12 @@ ignore_missing_imports = true
 # posture as modal above.
 [[tool.mypy.overrides]]
 module = "daytona.*"
+ignore_missing_imports = true
+
+# hindsight-client is an optional dep (the `hindsight` extra); the memory
+# built-in tools import it lazily so the base install never needs it.
+[[tool.mypy.overrides]]
+module = "hindsight_client.*"
 ignore_missing_imports = true
 
 # cwsandbox is an optional dep (the `cwsandbox` extra); same lazy-import

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -218,6 +218,10 @@ def test_build_host_daemon_env_local_preserves_server_credentials(
     monkeypatch.setenv("OPENAI_BASE_URL", "https://example.databricks.com/serving-endpoints")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
     monkeypatch.setenv("OMNIGENT_DATABASE_URI", "postgresql://u:pw@h/db")
+    # Hindsight memory creds must survive this hop to reach the runner (the
+    # daemon→runner forward-list does the second hop).
+    monkeypatch.setenv("HINDSIGHT_API_KEY", "hsk-mem")
+    monkeypatch.setenv("HINDSIGHT_API_URL", "https://api.hindsight.vectorize.io")
     monkeypatch.setenv("GITHUB_TOKEN", "unrelated-github-secret")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "unrelated-aws-secret")
 
@@ -228,6 +232,8 @@ def test_build_host_daemon_env_local_preserves_server_credentials(
     assert env["OPENAI_BASE_URL"] == "https://example.databricks.com/serving-endpoints"
     assert env["ANTHROPIC_API_KEY"] == "test-anthropic-key"
     assert env["OMNIGENT_DATABASE_URI"] == "postgresql://u:pw@h/db"
+    assert env["HINDSIGHT_API_KEY"] == "hsk-mem"
+    assert env["HINDSIGHT_API_URL"] == "https://api.hindsight.vectorize.io"
     assert "GITHUB_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env
     assert empty_string_env["OPENAI_API_KEY"] == "test-key"

--- a/tests/e2e/omnigent/test_bundled_agent_memory.py
+++ b/tests/e2e/omnigent/test_bundled_agent_memory.py
@@ -1,0 +1,75 @@
+"""The bundled Polly & Debby agents ship with Hindsight long-term memory.
+
+Pure spec-load + config checks — no LLM, no credentials. Guards two things:
+
+1. Each bundle declares the three Hindsight memory builtins, pinned to a stable
+   bank (``polly`` / ``debby``).
+2. Memory is safe on a base install: the builtins bake NO ``${...}`` secret, so
+   the client-side env expansion (``omnigent run``) never crashes when
+   ``HINDSIGHT_API_KEY`` is unset. (Breaker we deliberately avoid — see the
+   hindsight env-var fallback.)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.cli import _expand_config_env_vars
+from omnigent.spec import expand_env_vars, load
+from omnigent.spec.types import AgentSpec
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_HINDSIGHT_TOOLS = {"hindsight_retain", "hindsight_recall", "hindsight_reflect"}
+
+
+@pytest.fixture(scope="module", params=["polly", "debby"])
+def bundle(request: pytest.FixtureRequest) -> tuple[str, AgentSpec, dict]:
+    name = request.param
+    root = _REPO_ROOT / "examples" / name
+    spec = load(root)
+    raw = yaml.safe_load((root / "config.yaml").read_text())
+    return name, spec, raw
+
+
+def test_declares_the_three_memory_tools(bundle: tuple[str, AgentSpec, dict]) -> None:
+    name, spec, _ = bundle
+    builtins = {b.name for b in spec.tools.builtins}
+    assert builtins >= _HINDSIGHT_TOOLS, (
+        f"{name} is missing memory tools: {_HINDSIGHT_TOOLS - builtins}"
+    )
+
+
+def test_memory_pinned_to_stable_bank(bundle: tuple[str, AgentSpec, dict]) -> None:
+    name, spec, _ = bundle
+    for b in spec.tools.builtins:
+        if b.name in _HINDSIGHT_TOOLS:
+            assert (b.config or {}).get("bank_id") == name, f"{b.name} should pin bank_id={name!r}"
+
+
+def test_orchestration_still_intact(bundle: tuple[str, AgentSpec, dict]) -> None:
+    # Adding memory must not disturb the sub-agent roster.
+    name, spec, _ = bundle
+    expected = {"polly": ["claude_code", "codex", "pi"], "debby": ["claude", "gpt"]}[name]
+    assert sorted(spec.tools.agents) == expected
+
+
+def test_no_baked_secret_in_builtins(bundle: tuple[str, AgentSpec, dict]) -> None:
+    # No ${VAR} anywhere in the memory tool configs — the key comes from the env
+    # at runtime, so an unset key can never crash spec parsing / env expansion.
+    _, spec, _ = bundle
+    for b in spec.tools.builtins:
+        for key, value in (b.config or {}).items():
+            assert "${" not in value and "$" not in value, (
+                f"{b.name}.{key} bakes an env ref: {value!r}"
+            )
+
+
+def test_run_safe_when_key_unset(bundle: tuple[str, AgentSpec, dict], monkeypatch) -> None:
+    # Reproduce the client-side expansion `omnigent run` does, with the key unset.
+    # It must NOT raise (an unset ${HINDSIGHT_API_KEY} would — but we bake none).
+    monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)
+    _, _, raw = bundle
+    _expand_config_env_vars(raw, expand_env_vars)  # should not raise

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1076,6 +1076,8 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
         "OPENAI_API_KEY": "sk-o",
         "OPENAI_BASE_URL": "https://gateway.example.com/openai",
         "GEMINI_API_KEY": "g-key",
+        "HINDSIGHT_API_KEY": "hsk-mem",
+        "HINDSIGHT_API_URL": "https://api.hindsight.vectorize.io",
     }
 
     env = _build_runner_env(
@@ -1095,6 +1097,9 @@ def test_build_runner_env_forwards_harness_credentials_and_endpoints() -> None:
         "OPENAI_API_KEY",
         "OPENAI_BASE_URL",
         "GEMINI_API_KEY",
+        # Hindsight memory tools authenticate runner-side via these.
+        "HINDSIGHT_API_KEY",
+        "HINDSIGHT_API_URL",
     ):
         # Pins each conventional name into the default set — dropping
         # one breaks that harness's credentials on managed sandboxes.

--- a/tests/runner/test_hindsight_local_dispatch.py
+++ b/tests/runner/test_hindsight_local_dispatch.py
@@ -1,0 +1,103 @@
+"""Tests for routing the Hindsight memory builtins through runner-local dispatch.
+
+Without runner-local dispatch a wrapped harness's (claude-sdk / codex / …) call
+to hindsight_retain falls through to the harness, which has no such tool, and
+silently no-ops. These lock in that the tools dispatch locally, are relayed to
+native harnesses, and resolve the bank from the threaded agent identity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnigent.runner.tool_dispatch import (
+    _ALL_LOCAL_TOOLS,
+    _HINDSIGHT_TOOLS,
+    _NATIVE_RELAY_BUILTIN_TOOLS,
+    _execute_hindsight_tool,
+    should_dispatch_locally,
+)
+
+
+def _spec(config: dict[str, str], name: str = "hindsight_retain") -> SimpleNamespace:
+    return SimpleNamespace(
+        executor=SimpleNamespace(model="claude-opus-4-8"),
+        tools=SimpleNamespace(builtins=[SimpleNamespace(name=name, config=config)]),
+    )
+
+
+def test_hindsight_tool_set_is_exactly_the_three() -> None:
+    assert set(_HINDSIGHT_TOOLS) == {"hindsight_retain", "hindsight_recall", "hindsight_reflect"}
+
+
+@pytest.mark.parametrize("name", ["hindsight_retain", "hindsight_recall", "hindsight_reflect"])
+def test_hindsight_tools_are_runner_local(name: str) -> None:
+    assert name in _ALL_LOCAL_TOOLS
+    assert should_dispatch_locally(name) is True
+
+
+@pytest.mark.parametrize("name", ["hindsight_retain", "hindsight_recall", "hindsight_reflect"])
+def test_hindsight_tools_relayed_to_native_harnesses(name: str) -> None:
+    # Unlike web_search, native harnesses have no built-in memory of their own.
+    assert name in _NATIVE_RELAY_BUILTIN_TOOLS
+
+
+def test_retain_dispatch_uses_agent_id_as_bank() -> None:
+    """With no config bank_id, the bank defaults to the threaded agent_id."""
+    client = MagicMock()
+    spec = _spec({"api_key": "hsk_test"})
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = asyncio.run(
+            _execute_hindsight_tool(
+                {"content": "DuckDB is my favorite db"},
+                tool_name="hindsight_retain",
+                agent_spec=spec,
+                conversation_id="conv_1",
+                agent_id="ag_remy",
+            )
+        )
+    assert result == "Stored to long-term memory."
+    assert client.retain.call_args.kwargs["bank_id"] == "ag_remy"
+    assert client.retain.call_args.kwargs["content"] == "DuckDB is my favorite db"
+
+
+def test_recall_dispatch_honors_config_bank_id() -> None:
+    """An explicit config bank_id overrides the agent_id default."""
+    client = MagicMock()
+    response = MagicMock()
+    response.results = [MagicMock(text="DuckDB is my favorite db")]
+    client.recall.return_value = response
+    spec = _spec({"api_key": "hsk_test", "bank_id": "remy-ui-test"}, name="hindsight_recall")
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = asyncio.run(
+            _execute_hindsight_tool(
+                {"query": "favorite db"},
+                tool_name="hindsight_recall",
+                agent_spec=spec,
+                conversation_id="conv_1",
+                agent_id="ag_remy",
+            )
+        )
+    assert "DuckDB" in result
+    assert client.recall.call_args.kwargs["bank_id"] == "remy-ui-test"
+
+
+def test_dispatch_missing_api_key_returns_error() -> None:
+    spec = _spec({})  # no api_key
+    result = asyncio.run(
+        _execute_hindsight_tool(
+            {"content": "x"},
+            tool_name="hindsight_retain",
+            agent_spec=spec,
+            agent_id="ag_remy",
+        )
+    )
+    assert "api_key" in result.lower()
+    # never echoes the success string when it couldn't store
+    assert result != "Stored to long-term memory."
+    json.dumps(result)  # result is a plain string

--- a/tests/tools/builtins/test_hindsight.py
+++ b/tests/tools/builtins/test_hindsight.py
@@ -1,0 +1,226 @@
+"""Tests for the Hindsight long-term memory built-in tools.
+
+The Hindsight client (``hindsight-client``, the optional ``hindsight`` extra,
+kept in the ``dev`` set) is mocked by patching ``hindsight_client.Hindsight`` —
+no network. Covers registry wiring, schema shape, bank resolution from
+``ToolContext``, and the invoke paths for retain / recall / reflect.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins import get_builtin_tool
+from omnigent.tools.builtins import hindsight as hindsight_mod
+from omnigent.tools.builtins.hindsight import (
+    HindsightRecallTool,
+    HindsightReflectTool,
+    HindsightRetainTool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_created_banks() -> None:
+    """Reset the process-level bank cache so create_bank assertions isolate."""
+    hindsight_mod._CREATED_BANKS.clear()
+    yield
+    hindsight_mod._CREATED_BANKS.clear()
+
+
+def _mock_client() -> MagicMock:
+    client = MagicMock()
+    client.retain = MagicMock()
+    client.recall = MagicMock()
+    client.reflect = MagicMock()
+    client.create_bank = MagicMock()
+    return client
+
+
+def _recall_response(texts: list[str]) -> MagicMock:
+    response = MagicMock()
+    response.results = [MagicMock(text=t) for t in texts]
+    return response
+
+
+def _reflect_response(text: str) -> MagicMock:
+    response = MagicMock()
+    response.text = text
+    return response
+
+
+def _cfg(**extra: str) -> dict[str, str]:
+    return {"api_key": "hsk_test", **extra}
+
+
+# ---------------------------------------------------------------------------
+# Registry + schema
+# ---------------------------------------------------------------------------
+
+
+def test_registry_returns_the_three_tools() -> None:
+    assert isinstance(get_builtin_tool("hindsight_retain", _cfg()), HindsightRetainTool)
+    assert isinstance(get_builtin_tool("hindsight_recall", _cfg()), HindsightRecallTool)
+    assert isinstance(get_builtin_tool("hindsight_reflect", _cfg()), HindsightReflectTool)
+
+
+def test_names_and_descriptions() -> None:
+    assert HindsightRetainTool.name() == "hindsight_retain"
+    assert HindsightRecallTool.name() == "hindsight_recall"
+    assert HindsightReflectTool.name() == "hindsight_reflect"
+    # description() must work without instantiation (used by tool discovery).
+    assert "memory" in HindsightRecallTool.description().lower()
+
+
+@pytest.mark.parametrize(
+    ("cls", "param"),
+    [
+        (HindsightRetainTool, "content"),
+        (HindsightRecallTool, "query"),
+        (HindsightReflectTool, "query"),
+    ],
+)
+def test_schema_shape(cls: type, param: str) -> None:
+    schema = cls(_cfg()).get_schema()
+    assert schema["type"] == "function"
+    fn = schema["function"]
+    assert fn["name"] == cls.name()
+    assert param in fn["parameters"]["properties"]
+    assert fn["parameters"]["required"] == [param]
+
+
+# ---------------------------------------------------------------------------
+# Retain
+# ---------------------------------------------------------------------------
+
+
+def test_retain_stores_and_creates_bank(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    tool = HindsightRetainTool(_cfg(bank_id="alice"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = tool.invoke(json.dumps({"content": "I prefer dark mode."}), tool_ctx)
+    assert result == "Stored to long-term memory."
+    client.retain.assert_called_once_with(bank_id="alice", content="I prefer dark mode.")
+    client.create_bank.assert_called_once_with(bank_id="alice", name="alice")
+
+
+def test_retain_bank_defaults_to_agent_id(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    tool = HindsightRetainTool(_cfg())  # no bank_id
+    with patch("hindsight_client.Hindsight", return_value=client):
+        tool.invoke(json.dumps({"content": "x"}), tool_ctx)
+    # conftest tool_ctx has agent_id="agent_test"
+    assert client.retain.call_args.kwargs["bank_id"] == "agent_test"
+
+
+def test_retain_with_tags(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    tool = HindsightRetainTool(_cfg(bank_id="b", tags="env:prod, team:core"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        tool.invoke(json.dumps({"content": "x"}), tool_ctx)
+    assert client.retain.call_args.kwargs["tags"] == ["env:prod", "team:core"]
+
+
+def test_retain_missing_content_returns_error(tool_ctx: ToolContext) -> None:
+    tool = HindsightRetainTool(_cfg())
+    assert "content" in tool.invoke(json.dumps({}), tool_ctx).lower()
+
+
+# ---------------------------------------------------------------------------
+# Recall
+# ---------------------------------------------------------------------------
+
+
+def test_recall_returns_bullet_list(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.recall.return_value = _recall_response(["likes tea", "lives in NYC"])
+    tool = HindsightRecallTool(_cfg(bank_id="b"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = tool.invoke(json.dumps({"query": "about the user"}), tool_ctx)
+    assert result == "- likes tea\n- lives in NYC"
+
+
+def test_recall_empty_returns_fallback(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.recall.return_value = _recall_response([])
+    tool = HindsightRecallTool(_cfg(bank_id="b"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = tool.invoke(json.dumps({"query": "anything"}), tool_ctx)
+    assert result == "No relevant memories found."
+
+
+def test_recall_passes_budget_max_tokens_and_tags(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.recall.return_value = _recall_response(["m"])
+    tool = HindsightRecallTool(
+        _cfg(
+            bank_id="b",
+            budget="high",
+            max_tokens="2048",
+            recall_tags="scope:global",
+            recall_tags_match="all",
+        )
+    )
+    with patch("hindsight_client.Hindsight", return_value=client):
+        tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    kwargs = client.recall.call_args.kwargs
+    assert kwargs["budget"] == "high"
+    assert kwargs["max_tokens"] == 2048
+    assert kwargs["tags"] == ["scope:global"]
+    assert kwargs["tags_match"] == "all"
+
+
+def test_recall_does_not_create_bank(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.recall.return_value = _recall_response(["m"])
+    tool = HindsightRecallTool(_cfg(bank_id="b"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    client.create_bank.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Reflect
+# ---------------------------------------------------------------------------
+
+
+def test_reflect_returns_answer(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.reflect.return_value = _reflect_response("You like tea and live in NYC.")
+    tool = HindsightReflectTool(_cfg(bank_id="b"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = tool.invoke(json.dumps({"query": "what do you know?"}), tool_ctx)
+    assert result == "You like tea and live in NYC."
+    assert client.reflect.call_args.kwargs["bank_id"] == "b"
+
+
+def test_reflect_empty_returns_fallback(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.reflect.return_value = _reflect_response("")
+    tool = HindsightReflectTool(_cfg(bank_id="b"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert result == "No relevant memories found."
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_key_returns_error(tool_ctx: ToolContext) -> None:
+    tool = HindsightRecallTool({})  # no api_key
+    result = tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert "api_key" in result.lower()
+
+
+def test_client_exception_is_caught(tool_ctx: ToolContext) -> None:
+    client = _mock_client()
+    client.recall.side_effect = RuntimeError("network down")
+    tool = HindsightRecallTool(_cfg(bank_id="b"))
+    with patch("hindsight_client.Hindsight", return_value=client):
+        result = tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert result.startswith("Hindsight recall failed:")

--- a/tests/tools/builtins/test_hindsight.py
+++ b/tests/tools/builtins/test_hindsight.py
@@ -211,10 +211,32 @@ def test_reflect_empty_returns_fallback(tool_ctx: ToolContext) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_missing_api_key_returns_error(tool_ctx: ToolContext) -> None:
-    tool = HindsightRecallTool({})  # no api_key
+def test_missing_api_key_returns_error(tool_ctx: ToolContext, monkeypatch) -> None:
+    monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)  # no config key AND no env key
+    tool = HindsightRecallTool({})
     result = tool.invoke(json.dumps({"query": "q"}), tool_ctx)
-    assert "api_key" in result.lower()
+    assert "api_key" in result.lower() or "hindsight_api_key" in result.lower()
+
+
+def test_api_key_falls_back_to_env(tool_ctx: ToolContext, monkeypatch) -> None:
+    # No api_key in config — the tool reads HINDSIGHT_API_KEY from the env.
+    monkeypatch.setenv("HINDSIGHT_API_KEY", "hsk_from_env")
+    client = _mock_client()
+    client.recall.return_value = _recall_response(["m"])
+    tool = HindsightRecallTool({"bank_id": "b"})  # note: no api_key
+    with patch("hindsight_client.Hindsight", return_value=client) as mock_cls:
+        tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert mock_cls.call_args.kwargs["api_key"] == "hsk_from_env"
+
+
+def test_config_api_key_takes_precedence_over_env(tool_ctx: ToolContext, monkeypatch) -> None:
+    monkeypatch.setenv("HINDSIGHT_API_KEY", "hsk_from_env")
+    client = _mock_client()
+    client.recall.return_value = _recall_response(["m"])
+    tool = HindsightRecallTool(_cfg(bank_id="b"))  # _cfg sets api_key=hsk_test
+    with patch("hindsight_client.Hindsight", return_value=client) as mock_cls:
+        tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert mock_cls.call_args.kwargs["api_key"] == "hsk_test"
 
 
 def test_client_exception_is_caught(tool_ctx: ToolContext) -> None:

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -120,6 +120,11 @@ def test_builtin_names_size_matches_registry() -> None:
                 "download_file",
                 "search_conversations",
                 "export_agent",
+                # Hindsight long-term memory tools (optional `hindsight`
+                # extra; factories probe for hindsight-client).
+                "hindsight_retain",
+                "hindsight_recall",
+                "hindsight_reflect",
                 # Framework-owned (need runtime context, not
                 # user-instantiable). Policy ASKs surface as
                 # MCP-shape elicitations on the SSE stream and

--- a/tests/tools/test_builtin_optional_dep.py
+++ b/tests/tools/test_builtin_optional_dep.py
@@ -1,0 +1,55 @@
+"""Graceful degradation for built-ins backed by an optional extra.
+
+The Hindsight memory tools need the optional ``omnigent[hindsight]`` extra; their
+registry factories raise ``ImportError`` when ``hindsight-client`` isn't
+installed. A bundled agent (polly / debby) that declares them must still LOAD on
+a base install — the tool is skipped, not fatal. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import omnigent.tools.builtins as builtins_mod
+from omnigent.spec.types import AgentSpec, BuiltinToolConfig, ToolsConfig
+from omnigent.tools import ToolManager
+
+
+def _spec_with(*builtins: tuple[str, dict[str, str]]) -> AgentSpec:
+    return AgentSpec(
+        spec_version=1,
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name=n, config=c) for n, c in builtins]),
+    )
+
+
+def _boom() -> None:
+    raise ImportError("hindsight-client is not installed")
+
+
+def test_missing_optional_dep_skips_tool_without_breaking_load(monkeypatch, caplog) -> None:
+    # Simulate `hindsight-client` being absent (CI installs it via the dev extra).
+    monkeypatch.setattr(builtins_mod, "_require_hindsight", _boom)
+
+    spec = _spec_with(
+        ("hindsight_recall", {"bank_id": "polly"}),
+        ("upload_file", {}),  # a normal builtin declared alongside it
+    )
+
+    with caplog.at_level(logging.WARNING):
+        mgr = ToolManager(spec)  # must NOT raise
+
+    names = mgr.get_tool_names()
+    # The optional-dep tool is skipped...
+    assert "hindsight_recall" not in names
+    # ...but a co-declared normal builtin still registers, and the agent loaded.
+    assert "upload_file" in names
+    assert "hindsight_recall" in caplog.text
+    assert "optional dependency" in caplog.text
+
+
+def test_optional_dep_present_registers_the_tool(monkeypatch) -> None:
+    # With the extra installed (no patch), the tool registers normally. CI has
+    # hindsight-client in the dev set, so _require_hindsight() is a no-op here.
+    spec = _spec_with(("hindsight_recall", {"bank_id": "polly"}))
+    mgr = ToolManager(spec)
+    assert "hindsight_recall" in mgr.get_tool_names()

--- a/uv.lock
+++ b/uv.lock
@@ -1606,6 +1606,23 @@ wheels = [
 ]
 
 [[package]]
+name = "hindsight-client"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/4e/f69ed24d930e6fc958eea3ffa86dffce5a0ed81128346235d68e28c1ca89/hindsight_client-0.8.1.tar.gz", hash = "sha256:d5fbd248a0245428dbb92a332c0f88cc432fe1b8477dc2e8a0dff0ff2582ec1c", size = 107822, upload-time = "2026-06-09T12:56:00.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c2/fe0b792445686527d018d1274136c0356dcc6e0d8aef55c9c9337271870b/hindsight_client-0.8.1-py3-none-any.whl", hash = "sha256:6fc08474ebc24377e0630634519780308d19c31819b922bc252cce04519bbd49", size = 269298, upload-time = "2026-06-09T12:55:59.252Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2745,6 +2762,7 @@ daytona = [
 ]
 dev = [
     { name = "filelock" },
+    { name = "hindsight-client" },
     { name = "mlflow" },
     { name = "mypy" },
     { name = "pathspec" },
@@ -2762,6 +2780,9 @@ dev = [
 ]
 e2b = [
     { name = "e2b" },
+]
+hindsight = [
+    { name = "hindsight-client" },
 ]
 modal = [
     { name = "modal" },
@@ -2796,6 +2817,8 @@ requires-dist = [
     { name = "ftfy", specifier = ">=6.0" },
     { name = "google-antigravity", marker = "extra == 'antigravity'", specifier = ">=0.1,<1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0,<3" },
+    { name = "hindsight-client", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.4.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "keyring", specifier = ">=24,<26" },
     { name = "mcp", specifier = ">=1.0,<2" },
@@ -2843,7 +2866,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "modal", "daytona", "cwsandbox", "e2b", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "modal", "daytona", "cwsandbox", "e2b", "tracing", "agents-sdk", "antigravity", "cursor", "hindsight", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"


### PR DESCRIPTION
> **⚠️ Stacked on #526 — draft until that merges.**
> This PR builds on the Hindsight memory tools from #526. GitHub can't base a cross-fork PR on a fork branch, so until #526 lands in `main` this diff also contains #526's commits. **Review #526 first.** Once it merges I'll rebase onto `main`, the diff will collapse to just the changes below, and I'll mark this ready.

Follow-up to #526 / resolves the second half of #369 (@dbczumar: *"we'd love to explore adding memory to some of our built-in agents"*).

Wires Hindsight long-term memory into the two bundled agents — **Polly** and **Debby** — so they remember across sessions, while staying safe on a plain `pip install omnigent` (no extra, no key).

## The changes on top of #526

- **`examples/polly` / `examples/debby`** — declare the `hindsight_*` builtins on the root orchestrator (sub-agents stay ephemeral), pinned to a stable bank (`polly` / `debby`), with **no baked `api_key`** — the key comes from `HINDSIGHT_API_KEY` at runtime. A short `## Memory` prompt section tells each agent when to recall/retain.
- **Graceful degradation** (`ToolManager._register_builtin_tools`) — a builtin whose optional extra is missing raises `ImportError`; it's now caught and skipped with a warning instead of failing the whole agent load. So bundled agents that declare an optional-dep tool still run on a base install.
- **Env-key resolution** — the tools read `HINDSIGHT_API_KEY`/`HINDSIGHT_API_URL` from the environment when not in spec config (bundled agents can't bake a secret, and a literal `${HINDSIGHT_API_KEY}` would crash client-side env expansion when unset).
- **Credential forwarding** (`cli.py` + `host/connect.py`) — `HINDSIGHT_API_KEY`/`HINDSIGHT_API_URL` are added to the host→daemon and daemon→runner allowlists, the same dual-list pattern `ANTHROPIC_`/`OPENAI_API_KEY` already use, so the runner-side tools can authenticate.

## Safety (the whole point)

| Scenario | Behavior |
|---|---|
| `pip install omnigent` (no extra), no key | Polly/Debby **load and run unchanged** — memory tools skipped with a warning |
| `omnigent[hindsight]`, no key | Tools load; a memory call returns a graceful error string — no crash |
| `omnigent[hindsight]` + `HINDSIGHT_API_KEY` set | Memory works; bank `polly`/`debby` |

## Verified

- Deterministic tests: graceful-degradation (simulated missing client), env-fallback + precedence, Polly/Debby spec shape + no-baked-secret + env-expansion-safe-when-unset, and both env-forwarding hops (`tests/cli/test_backend.py`, `tests/host/test_connect.py`).
- **Live end-to-end:** `omnigent run examples/polly` against a real Hindsight server — `hindsight_retain` returned `Stored to long-term memory.` and the fact landed in the `polly` bank. (This is also how the credential-forwarding gap above was found.)
- `ruff` / `pre-commit` clean; commits DCO-signed.
