### PR TITLE
fix(#524): remove dead /v1/responses test helper + stale refs (item 1)

### DIFF
--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -431,15 +431,6 @@ async def wait_for_completion(
     raise AssertionError(f"Response {response_id} did not reach terminal status")
 
 
-@dataclass
-class ApiResponse:
-    """Result of an API call — avoids returning positional tuples."""
-
-    status_code: int
-    # Any: JSON response bodies are inherently heterogeneous dicts.
-    body: dict[str, Any]
-
-
 class FakeRunnerWebSocket:
     """
     Minimal WebSocket object accepted by ``TunnelRegistry.register``.
@@ -549,8 +540,8 @@ def build_agent_bundle(
         "spec_version": 1,
         "name": name,
         # LLM config is required for the real workflow to execute.
-        # The model value must match the agent name used in
-        # create_test_response(model=...).
+        # The model value must match the agent ``name`` above so
+        # tests that target this agent reach this workflow.
         "llm": {
             "model": name,
             # api_key is required by spec validation; the workflow
@@ -755,53 +746,6 @@ async def create_test_session(
     snapshot = await client.get(f"/v1/sessions/{session_id}")
     assert snapshot.status_code == 200, f"session snapshot failed: {snapshot.text}"
     return snapshot.json()
-
-
-async def create_test_response(
-    client: httpx.AsyncClient,
-    model: str = "test-agent",
-    input_text: str = "Hello",
-    background: bool = True,
-    stream: bool = False,
-    instructions: str | None = None,
-    previous_response_id: str | None = None,
-    store: bool | None = None,
-    conversation: dict[str, str] | None = None,
-    reasoning: dict[str, str] | None = None,
-    tools: list[dict[str, Any]] | None = None,
-) -> ApiResponse:
-    """
-    Create a response via the API and return an ApiResponse.
-
-    Defaults to background=True so the endpoint returns immediately
-    without blocking on task completion.
-
-    :param tools: Optional list of client-side tool schemas in
-        standard OpenAI function format, e.g.
-        ``[{"type": "function", "function": {"name": "get_weather", ...}}]``.
-    """
-    payload: dict[str, Any] = {
-        "model": model,
-        "input": input_text,
-        "background": background,
-        "stream": stream,
-    }
-    if instructions is not None:
-        payload["instructions"] = instructions
-    if previous_response_id is not None:
-        payload["previous_response_id"] = previous_response_id
-    if store is not None:
-        payload["store"] = store
-    if conversation is not None:
-        payload["conversation"] = conversation
-    if reasoning is not None:
-        payload["reasoning"] = reasoning
-    if tools is not None:
-        payload["tools"] = tools
-    resp = await client.post("/v1/responses", json=payload)
-    body = resp.json()
-    assert "id" in body, f"POST /v1/responses returned {resp.status_code}: {body}"
-    return ApiResponse(status_code=resp.status_code, body=body)
 
 
 class CapturingRunnerClient:

--- a/tests/server/integration/test_routes_sessions_aliases.py
+++ b/tests/server/integration/test_routes_sessions_aliases.py
@@ -43,10 +43,9 @@ async def _create_session(
 
     ``GET /v1/sessions`` filters to conversations with ``agent_id IS
     NOT NULL`` (i.e. real sessions). The legacy ``POST /v1/responses``
-    path used by ``create_test_response`` does NOT bind an agent id,
-    so its conversations are invisible to this route. Tests that
-    need a session in the listing must go through ``POST /v1/
-    sessions`` instead.
+    path does NOT bind an agent id, so its conversations are
+    invisible to this route. Tests that need a session in the
+    listing must go through ``POST /v1/sessions`` instead.
 
     :param client: HTTP client wired to the test app.
     :param name: Agent name to write into the uploaded bundle, e.g.


### PR DESCRIPTION
## Summary

After the `/v1/responses` server routes were fully removed, the test suite still carried dead infrastructure referencing them. This PR deletes the orphaned pieces and fixes the stale references (item 1 of #524):

- **`create_test_response`** (`tests/server/helpers.py`) POSTed to the removed `/v1/responses` endpoint. It was not imported anywhere, not re-exported in `__all__`, and had **zero callers** across the repo — fully orphaned.
- **`ApiResponse`** (the `@dataclass` it returned) had **zero usage outside `create_test_response`** itself — mutually orphaned, so both are deleted together.
- A comment in `build_agent_bundle` and a docstring in `test_routes_sessions_aliases.py` still named `create_test_response`; updated to drop the dead-helper reference while keeping the legacy-path context that explains *why* tests must go through `/v1/sessions`.

Net: `+5 / −62`, pure deletion + comment accuracy.

### Scope: item 1 only — items 2 & 3 deferred

#524 names three cleanups. This PR does the one that's safe and self-contained; the other two are deliberately left to maintainers with rationale:

- **Item 2 — legacy poll branch / dead e2e tests (deferred).** `tests/e2e/conftest.py::poll_for_pending_tool_calls` has a `session_id is None` branch that hits the removed `GET /v1/responses/{response_id}`; two gated e2e tests (`test_claude_coder_client_tools.py`, `test_tool_dispatch_workflow_client_side_e2e.py`) POST to the removed route and poll via `session_id=None`. These are fully dead under the current server, but they exercise specific scenarios (dispatch-workflow sentinel round-trip, coder client tools) whose live equivalents need real per-cluster credentials and a maintainer-driven migration — not something a no-creds external PR can verify. Left for the maintainers.
- **Item 3 — SDK `ResponsesNamespace` (out of scope).** `sdks/python-client/omnigent_client/_responses.py` is a shipped-but-`DeprecationWarning`-tagged public namespace wired into the client at `_client.py:86`. Removing it is an SDK-major breaking change, which is exactly the deferral #524 itself calls out. Not touched.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

No behavior change — pure dead-code deletion + comment/docstring accuracy, so the e2e requirement does not apply (refactor/chore exemption).

```
uv run ruff format . && uv run ruff check --fix .        # clean
uv run pytest tests/server -n 4 --dist=worksteal         # 1721 passed, 3 xfailed
uv run pytest tests/server/integration/test_routes_sessions_aliases.py -q   # 6 passed (the file whose docstring was edited)
```

mypy omitted intentionally: zero `omnigent/` source changed (test-only PR), so the type-check delta is definitionally 0.

**Pre-existing failures (unrelated, verified on baseline):** 3 tests in `tests/server` fail identically on `upstream/main` with this PR's diff stashed — `test_hosts_routes.py::test_hosts_not_mounted_without_host_store`, `test_hosts_routes.py::test_get_host_not_mounted`, and `test_sessions_permission_request_hook.py::test_top_level_elicitations_route_is_not_mounted`. They concern host-store / elicitation route mounting under a local config env, not `/v1/responses` or the touched helpers. Confirmed not a regression.

## ELI5

The `/v1/responses` API endpoint was deleted in an earlier change. Two test helpers that only existed to call that endpoint — and the little wrapper class one of them returned — were left behind, unused. This PR deletes them and updates two comments that still mentioned the deleted helper by name. Nothing the app actually does changes; it's just taking out the trash so the test file doesn't read like the endpoint still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
