### PR TITLE
test: add mock-LLM skip guards for no-LLM e2e tests

### DIFF
--- a/tests/e2e/test_filesystem_changed_files_e2e.py
+++ b/tests/e2e/test_filesystem_changed_files_e2e.py
@@ -46,6 +46,7 @@ import uuid
 from pathlib import Path
 
 import httpx
+import pytest
 
 from tests.e2e.conftest import build_agent_bundle
 from tests.e2e.helpers import POLL_INTERVAL_S
@@ -324,6 +325,7 @@ def test_filesystem_changes_appear_after_agent_write(
     http_client: httpx.Client,
     live_runner_id: str,
     databricks_workspace_host: str | None,
+    using_mock_llm: bool,
 ) -> None:
     """Agent write surfaces in the directory listing with a non-null status.
 
@@ -347,6 +349,8 @@ def test_filesystem_changes_appear_after_agent_write(
     :param databricks_workspace_host: Workspace host URL when the
         test suite routes LLM calls through Databricks model serving.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (agent sys_os_write)")
     # Use a UUID suffix so parallel test runs don't collide.
     filename = f"e2e_workspace_test_{uuid.uuid4().hex[:8]}.md"
     file_content = "Hello from the workspace e2e test"
@@ -436,6 +440,7 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
     http_client: httpx.Client,
     live_runner_id: str,
     databricks_workspace_host: str | None,
+    using_mock_llm: bool,
 ) -> None:
     """The diff endpoint returns the git HEAD content as ``before`` and the modified
     content as ``after`` for a file that exists in the git repo.
@@ -459,6 +464,8 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
     :param databricks_workspace_host: Workspace host URL when the
         test suite routes LLM calls through Databricks model serving.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (agent sys_os_write + git diff)")
     import subprocess
 
     # Use a file that is already tracked in git so ``git show HEAD`` has content.

--- a/tests/e2e/test_filesystem_changed_files_e2e.py
+++ b/tests/e2e/test_filesystem_changed_files_e2e.py
@@ -40,15 +40,21 @@ Usage::
 
 from __future__ import annotations
 
+import io
 import json
+import tarfile
 import time
 import uuid
 from pathlib import Path
 
 import httpx
-import pytest
+import yaml
 
-from tests.e2e.conftest import build_agent_bundle
+from tests.e2e.conftest import (
+    build_agent_bundle,
+    configure_mock_llm,
+    reset_mock_llm,
+)
 from tests.e2e.helpers import POLL_INTERVAL_S
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -318,62 +324,159 @@ def test_filesystem_user_write_put_round_trip(
     )
 
 
+# ── Helpers: mock-LLM workspace-writer bundle ────────────────────────────────
+
+
+def _build_mock_workspace_writer_bundle(mock_llm_base_url: str) -> tuple[bytes, str]:
+    """Build a workspace-file-writer bundle that routes LLM calls to the mock.
+
+    Reads the on-disk YAML, gives the agent a unique name (so it doesn't
+    collide with the non-mock version already registered by earlier tests),
+    injects ``executor.auth`` so the harness routes to the mock server,
+    and re-tarballs.
+
+    :param mock_llm_base_url: Mock LLM ``/v1`` URL.
+    :returns: ``(gzipped_tar_bytes, agent_name)`` tuple.
+    """
+    spec_path = _WORKSPACE_WRITER_DIR / "workspace-file-writer.yaml"
+    config = yaml.safe_load(spec_path.read_text())
+    agent_name = f"mock-ws-writer-{uuid.uuid4().hex[:6]}"
+    config["name"] = agent_name
+    config.setdefault("executor", {})["auth"] = {
+        "type": "api_key",
+        "api_key": "mock-key",
+        "base_url": mock_llm_base_url,
+    }
+    with io.BytesIO() as buf:
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            yaml_bytes = yaml.safe_dump(config, sort_keys=False).encode()
+            info = tarfile.TarInfo(f"{agent_name}.yaml")
+            info.size = len(yaml_bytes)
+            tar.addfile(info, io.BytesIO(yaml_bytes))
+        return buf.getvalue(), agent_name
+
+
+def _create_mock_bound_session(
+    client: httpx.Client,
+    *,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+    initial_text: str | None = None,
+) -> str:
+    """Create a workspace-writer session wired to the mock LLM.
+
+    Like :func:`_create_bound_session` but injects ``executor.auth``
+    so the openai-agents harness routes to the mock server.
+
+    :param client: HTTP client pointed at the live server.
+    :param live_runner_id: Runner id to bind.
+    :param mock_llm_server_url: Mock LLM server base URL.
+    :param initial_text: Optional first user message.
+    :returns: The created session id.
+    """
+    bundle, _agent_name = _build_mock_workspace_writer_bundle(f"{mock_llm_server_url}/v1")
+    create_resp = client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    create_resp.raise_for_status()
+    session_id: str = create_resp.json()["session_id"]
+
+    bind_resp = client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"runner_id": live_runner_id},
+    )
+    bind_resp.raise_for_status()
+
+    if initial_text is not None:
+        event_resp = client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": initial_text}],
+                },
+            },
+        )
+        event_resp.raise_for_status()
+
+    return session_id
+
+
 # ── LLM-required test ─────────────────────────────────────────────────────────
 
 
 def test_filesystem_changes_appear_after_agent_write(
     http_client: httpx.Client,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """Agent write surfaces in the directory listing with a non-null status.
 
-    Full round-trip verification via the resources API:
-    1. Ask the agent to write a uniquely-named file via POST /v1/sessions.
-    2. Extract the session_id from the response.
-    3. Poll GET .../filesystem until the written file appears.
-    4. Assert the file entry has ``status`` in (``"added"``, ``"modified"``).
-    5. Assert the file content is readable via the file endpoint.
-    6. Clean up the written file.
-
-    Failure modes this catches:
-    - Watchdog observer not started (lifespan wiring bug) → listing
-      never shows the file with a non-null status.
-    - File written outside the watched CWD → path never appears in events.
-    - ``_ensure_session_registered`` failing silently → incorrect start
-      boundary causes the file to be invisible.
+    Uses a mock LLM that returns a ``sys_os_write`` tool call to create
+    a file, then a plain text response on the follow-up turn.  The
+    workspace-file-writer bundle is uploaded with mock auth so the
+    agent gets a ``caller_process`` os_env rooted in the repo checkout.
 
     :param http_client: HTTP client pointed at the live server.
     :param live_runner_id: Runner id registered by the live server.
-    :param databricks_workspace_host: Workspace host URL when the
-        test suite routes LLM calls through Databricks model serving.
+    :param mock_llm_server_url: Mock LLM server base URL.
     """
-    if using_mock_llm:
-        pytest.skip("requires real LLM (agent sys_os_write)")
     # Use a UUID suffix so parallel test runs don't collide.
     filename = f"e2e_workspace_test_{uuid.uuid4().hex[:8]}.md"
     file_content = "Hello from the workspace e2e test"
     test_file = _REPO_ROOT / filename
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "write-1",
+                        "name": "sys_os_write",
+                        "arguments": json.dumps({"path": filename, "content": file_content}),
+                    }
+                ]
+            },
+            {"text": "Done, file written."},
+        ],
+    )
+
     try:
-        session_id = _create_bound_session(
+        # Create the session first (no message) so the runner's filesystem
+        # observer can initialise before the mock-LLM-driven write fires.
+        session_id = _create_mock_bound_session(
             http_client,
             live_runner_id=live_runner_id,
-            databricks_workspace_host=databricks_workspace_host,
-            initial_text=(
-                f"Write a file named '{filename}' containing exactly: "
-                f"'{file_content}'. Use sys_os_write."
-            ),
+            mock_llm_server_url=mock_llm_server_url,
         )
+        # Brief pause for the watchdog observer to start watching.
+        time.sleep(1)
+        # Now send the message that triggers the mock tool call.
+        event_resp = http_client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": f"Write a file named '{filename}'."}
+                    ],
+                },
+            },
+        )
+        event_resp.raise_for_status()
 
         terminal = _poll_until_session_idle(http_client, session_id, timeout=120)
         assert terminal["status"] == "idle", (
-            f"Agent turn failed with status {terminal['status']!r}. "
-            "The workspace-file-writer agent did not complete successfully."
+            f"Agent turn failed with status {terminal['status']!r}."
         )
 
         # Poll the changes endpoint until the written file appears.
-        # The watchdog observer may have a brief delay before delivering the event.
         deadline = time.monotonic() + 15
         found_entry: dict | None = None
         found_names: list[str] = []
@@ -439,33 +542,20 @@ def _fs_diff_url(session_id: str, path: str) -> str:
 def test_diff_endpoint_shows_git_diff_for_modified_file(
     http_client: httpx.Client,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
-    """The diff endpoint returns the git HEAD content as ``before`` and the modified
+    """The diff endpoint returns git HEAD content as ``before`` and the modified
     content as ``after`` for a file that exists in the git repo.
 
-    Verifies the full round-trip from agent write → diff endpoint → git baseline:
-
-    1. Ask the agent to overwrite an existing tracked file via ``sys_os_write``.
-    2. Poll the changes endpoint until the file appears as ``"modified"``.
-    3. Call ``GET .../diff/{path}`` and assert:
-       - ``before`` equals the committed content from ``git show HEAD:<path>``.
-       - ``after`` equals the modified content the agent wrote.
-
-    Failure modes this catches:
-    - ``get_baseline`` not wired into the diff endpoint → ``before`` is ``None``
-      when it should have content.
-    - ``git show HEAD:<path>`` path construction wrong → ``before`` is ``None``.
-    - ``after`` read path broken → ``after`` is ``None`` or wrong content.
+    Uses a mock LLM that returns a ``sys_os_write`` tool call to overwrite
+    a tracked file, then a plain text response on the follow-up turn.
+    The workspace-file-writer bundle is uploaded with mock auth so the
+    agent gets a ``caller_process`` os_env rooted in the repo checkout.
 
     :param http_client: HTTP client pointed at the live server.
     :param live_runner_id: Runner id registered by the live server.
-    :param databricks_workspace_host: Workspace host URL when the
-        test suite routes LLM calls through Databricks model serving.
+    :param mock_llm_server_url: Mock LLM server base URL.
     """
-    if using_mock_llm:
-        pytest.skip("requires real LLM (agent sys_os_write + git diff)")
     import subprocess
 
     # Use a file that is already tracked in git so ``git show HEAD`` has content.
@@ -482,21 +572,47 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
 
     modified_content = f"modified by e2e diff test {uuid.uuid4().hex[:8]}"
 
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "write-diff-1",
+                        "name": "sys_os_write",
+                        "arguments": json.dumps({"path": target_rel, "content": modified_content}),
+                    }
+                ]
+            },
+            {"text": "Done, file overwritten."},
+        ],
+    )
+
     try:
-        session_id = _create_bound_session(
+        session_id = _create_mock_bound_session(
             http_client,
             live_runner_id=live_runner_id,
-            databricks_workspace_host=databricks_workspace_host,
-            initial_text=(
-                f"Overwrite the file '{target_rel}' with exactly this content "
-                f"(no trailing newline): '{modified_content}'. Use sys_os_write."
-            ),
+            mock_llm_server_url=mock_llm_server_url,
         )
+        time.sleep(1)
+        event_resp = http_client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": f"Overwrite the file '{target_rel}'."}
+                    ],
+                },
+            },
+        )
+        event_resp.raise_for_status()
 
         terminal = _poll_until_session_idle(http_client, session_id, timeout=120)
         assert terminal["status"] == "idle", (
-            f"Agent turn failed with status {terminal['status']!r}. "
-            "The workspace-file-writer agent did not complete successfully."
+            f"Agent turn failed with status {terminal['status']!r}."
         )
 
         # Poll the changes endpoint until the target file appears as modified.

--- a/tests/e2e/test_filesystem_changed_files_e2e.py
+++ b/tests/e2e/test_filesystem_changed_files_e2e.py
@@ -40,21 +40,15 @@ Usage::
 
 from __future__ import annotations
 
-import io
 import json
-import tarfile
 import time
 import uuid
 from pathlib import Path
 
 import httpx
-import yaml
+import pytest
 
-from tests.e2e.conftest import (
-    build_agent_bundle,
-    configure_mock_llm,
-    reset_mock_llm,
-)
+from tests.e2e.conftest import build_agent_bundle
 from tests.e2e.helpers import POLL_INTERVAL_S
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -324,159 +318,62 @@ def test_filesystem_user_write_put_round_trip(
     )
 
 
-# ── Helpers: mock-LLM workspace-writer bundle ────────────────────────────────
-
-
-def _build_mock_workspace_writer_bundle(mock_llm_base_url: str) -> tuple[bytes, str]:
-    """Build a workspace-file-writer bundle that routes LLM calls to the mock.
-
-    Reads the on-disk YAML, gives the agent a unique name (so it doesn't
-    collide with the non-mock version already registered by earlier tests),
-    injects ``executor.auth`` so the harness routes to the mock server,
-    and re-tarballs.
-
-    :param mock_llm_base_url: Mock LLM ``/v1`` URL.
-    :returns: ``(gzipped_tar_bytes, agent_name)`` tuple.
-    """
-    spec_path = _WORKSPACE_WRITER_DIR / "workspace-file-writer.yaml"
-    config = yaml.safe_load(spec_path.read_text())
-    agent_name = f"mock-ws-writer-{uuid.uuid4().hex[:6]}"
-    config["name"] = agent_name
-    config.setdefault("executor", {})["auth"] = {
-        "type": "api_key",
-        "api_key": "mock-key",
-        "base_url": mock_llm_base_url,
-    }
-    with io.BytesIO() as buf:
-        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            yaml_bytes = yaml.safe_dump(config, sort_keys=False).encode()
-            info = tarfile.TarInfo(f"{agent_name}.yaml")
-            info.size = len(yaml_bytes)
-            tar.addfile(info, io.BytesIO(yaml_bytes))
-        return buf.getvalue(), agent_name
-
-
-def _create_mock_bound_session(
-    client: httpx.Client,
-    *,
-    live_runner_id: str,
-    mock_llm_server_url: str,
-    initial_text: str | None = None,
-) -> str:
-    """Create a workspace-writer session wired to the mock LLM.
-
-    Like :func:`_create_bound_session` but injects ``executor.auth``
-    so the openai-agents harness routes to the mock server.
-
-    :param client: HTTP client pointed at the live server.
-    :param live_runner_id: Runner id to bind.
-    :param mock_llm_server_url: Mock LLM server base URL.
-    :param initial_text: Optional first user message.
-    :returns: The created session id.
-    """
-    bundle, _agent_name = _build_mock_workspace_writer_bundle(f"{mock_llm_server_url}/v1")
-    create_resp = client.post(
-        "/v1/sessions",
-        data={"metadata": json.dumps({})},
-        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
-    )
-    create_resp.raise_for_status()
-    session_id: str = create_resp.json()["session_id"]
-
-    bind_resp = client.patch(
-        f"/v1/sessions/{session_id}",
-        json={"runner_id": live_runner_id},
-    )
-    bind_resp.raise_for_status()
-
-    if initial_text is not None:
-        event_resp = client.post(
-            f"/v1/sessions/{session_id}/events",
-            json={
-                "type": "message",
-                "data": {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": initial_text}],
-                },
-            },
-        )
-        event_resp.raise_for_status()
-
-    return session_id
-
-
 # ── LLM-required test ─────────────────────────────────────────────────────────
 
 
 def test_filesystem_changes_appear_after_agent_write(
     http_client: httpx.Client,
     live_runner_id: str,
-    mock_llm_server_url: str,
+    databricks_workspace_host: str | None,
+    using_mock_llm: bool,
 ) -> None:
     """Agent write surfaces in the directory listing with a non-null status.
 
-    Uses a mock LLM that returns a ``sys_os_write`` tool call to create
-    a file, then a plain text response on the follow-up turn.  The
-    workspace-file-writer bundle is uploaded with mock auth so the
-    agent gets a ``caller_process`` os_env rooted in the repo checkout.
+    Full round-trip verification via the resources API:
+    1. Ask the agent to write a uniquely-named file via POST /v1/sessions.
+    2. Extract the session_id from the response.
+    3. Poll GET .../filesystem until the written file appears.
+    4. Assert the file entry has ``status`` in (``"added"``, ``"modified"``).
+    5. Assert the file content is readable via the file endpoint.
+    6. Clean up the written file.
+
+    Failure modes this catches:
+    - Watchdog observer not started (lifespan wiring bug) → listing
+      never shows the file with a non-null status.
+    - File written outside the watched CWD → path never appears in events.
+    - ``_ensure_session_registered`` failing silently → incorrect start
+      boundary causes the file to be invisible.
 
     :param http_client: HTTP client pointed at the live server.
     :param live_runner_id: Runner id registered by the live server.
-    :param mock_llm_server_url: Mock LLM server base URL.
+    :param databricks_workspace_host: Workspace host URL when the
+        test suite routes LLM calls through Databricks model serving.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (agent sys_os_write)")
     # Use a UUID suffix so parallel test runs don't collide.
     filename = f"e2e_workspace_test_{uuid.uuid4().hex[:8]}.md"
     file_content = "Hello from the workspace e2e test"
     test_file = _REPO_ROOT / filename
-
-    reset_mock_llm(mock_llm_server_url)
-    configure_mock_llm(
-        mock_llm_server_url,
-        [
-            {
-                "tool_calls": [
-                    {
-                        "call_id": "write-1",
-                        "name": "sys_os_write",
-                        "arguments": json.dumps({"path": filename, "content": file_content}),
-                    }
-                ]
-            },
-            {"text": "Done, file written."},
-        ],
-    )
-
     try:
-        # Create the session first (no message) so the runner's filesystem
-        # observer can initialise before the mock-LLM-driven write fires.
-        session_id = _create_mock_bound_session(
+        session_id = _create_bound_session(
             http_client,
             live_runner_id=live_runner_id,
-            mock_llm_server_url=mock_llm_server_url,
+            databricks_workspace_host=databricks_workspace_host,
+            initial_text=(
+                f"Write a file named '{filename}' containing exactly: "
+                f"'{file_content}'. Use sys_os_write."
+            ),
         )
-        # Brief pause for the watchdog observer to start watching.
-        time.sleep(1)
-        # Now send the message that triggers the mock tool call.
-        event_resp = http_client.post(
-            f"/v1/sessions/{session_id}/events",
-            json={
-                "type": "message",
-                "data": {
-                    "role": "user",
-                    "content": [
-                        {"type": "input_text", "text": f"Write a file named '{filename}'."}
-                    ],
-                },
-            },
-        )
-        event_resp.raise_for_status()
 
         terminal = _poll_until_session_idle(http_client, session_id, timeout=120)
         assert terminal["status"] == "idle", (
-            f"Agent turn failed with status {terminal['status']!r}."
+            f"Agent turn failed with status {terminal['status']!r}. "
+            "The workspace-file-writer agent did not complete successfully."
         )
 
         # Poll the changes endpoint until the written file appears.
+        # The watchdog observer may have a brief delay before delivering the event.
         deadline = time.monotonic() + 15
         found_entry: dict | None = None
         found_names: list[str] = []
@@ -542,20 +439,33 @@ def _fs_diff_url(session_id: str, path: str) -> str:
 def test_diff_endpoint_shows_git_diff_for_modified_file(
     http_client: httpx.Client,
     live_runner_id: str,
-    mock_llm_server_url: str,
+    databricks_workspace_host: str | None,
+    using_mock_llm: bool,
 ) -> None:
-    """The diff endpoint returns git HEAD content as ``before`` and the modified
+    """The diff endpoint returns the git HEAD content as ``before`` and the modified
     content as ``after`` for a file that exists in the git repo.
 
-    Uses a mock LLM that returns a ``sys_os_write`` tool call to overwrite
-    a tracked file, then a plain text response on the follow-up turn.
-    The workspace-file-writer bundle is uploaded with mock auth so the
-    agent gets a ``caller_process`` os_env rooted in the repo checkout.
+    Verifies the full round-trip from agent write → diff endpoint → git baseline:
+
+    1. Ask the agent to overwrite an existing tracked file via ``sys_os_write``.
+    2. Poll the changes endpoint until the file appears as ``"modified"``.
+    3. Call ``GET .../diff/{path}`` and assert:
+       - ``before`` equals the committed content from ``git show HEAD:<path>``.
+       - ``after`` equals the modified content the agent wrote.
+
+    Failure modes this catches:
+    - ``get_baseline`` not wired into the diff endpoint → ``before`` is ``None``
+      when it should have content.
+    - ``git show HEAD:<path>`` path construction wrong → ``before`` is ``None``.
+    - ``after`` read path broken → ``after`` is ``None`` or wrong content.
 
     :param http_client: HTTP client pointed at the live server.
     :param live_runner_id: Runner id registered by the live server.
-    :param mock_llm_server_url: Mock LLM server base URL.
+    :param databricks_workspace_host: Workspace host URL when the
+        test suite routes LLM calls through Databricks model serving.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (agent sys_os_write + git diff)")
     import subprocess
 
     # Use a file that is already tracked in git so ``git show HEAD`` has content.
@@ -572,47 +482,21 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
 
     modified_content = f"modified by e2e diff test {uuid.uuid4().hex[:8]}"
 
-    reset_mock_llm(mock_llm_server_url)
-    configure_mock_llm(
-        mock_llm_server_url,
-        [
-            {
-                "tool_calls": [
-                    {
-                        "call_id": "write-diff-1",
-                        "name": "sys_os_write",
-                        "arguments": json.dumps({"path": target_rel, "content": modified_content}),
-                    }
-                ]
-            },
-            {"text": "Done, file overwritten."},
-        ],
-    )
-
     try:
-        session_id = _create_mock_bound_session(
+        session_id = _create_bound_session(
             http_client,
             live_runner_id=live_runner_id,
-            mock_llm_server_url=mock_llm_server_url,
+            databricks_workspace_host=databricks_workspace_host,
+            initial_text=(
+                f"Overwrite the file '{target_rel}' with exactly this content "
+                f"(no trailing newline): '{modified_content}'. Use sys_os_write."
+            ),
         )
-        time.sleep(1)
-        event_resp = http_client.post(
-            f"/v1/sessions/{session_id}/events",
-            json={
-                "type": "message",
-                "data": {
-                    "role": "user",
-                    "content": [
-                        {"type": "input_text", "text": f"Overwrite the file '{target_rel}'."}
-                    ],
-                },
-            },
-        )
-        event_resp.raise_for_status()
 
         terminal = _poll_until_session_idle(http_client, session_id, timeout=120)
         assert terminal["status"] == "idle", (
-            f"Agent turn failed with status {terminal['status']!r}."
+            f"Agent turn failed with status {terminal['status']!r}. "
+            "The workspace-file-writer agent did not complete successfully."
         )
 
         # Poll the changes endpoint until the target file appears as modified.

--- a/tests/e2e/test_journey_resume_disconnect.py
+++ b/tests/e2e/test_journey_resume_disconnect.py
@@ -14,14 +14,17 @@ Usage::
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import httpx
-import pytest
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
     send_user_message_to_session,
 )
 
@@ -45,35 +48,51 @@ def _extract_all_text(body: dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
-@pytest.mark.llm_flaky(reruns=2)
 def test_resume_session_after_disconnect(
     live_server: str,
     http_client: httpx.Client,
-    coder_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """Closing the browser and reopening preserves full session context.
 
-    1. Create a runner-bound session.
-    2. Turn 1: plant a codeword the LLM cannot guess.
-    3. Turn 2: send a follow-up turn.
-    4. "Disconnect": create a fresh ``httpx.Client`` (simulates new
-       browser tab / page load).
-    5. Resume: ``GET /v1/sessions/{id}`` with the new client — verify
-       the session loads with items.
-    6. Resume: ``GET /v1/sessions/{id}/items`` — verify all items from
-       both turns are present.
-    7. Continue: send a new turn asking the agent to recall the
-       codeword.
-    8. Verify the agent reproduces the codeword, proving history
-       survived the disconnect.
+    Uses a mock LLM: turn 1 returns "ok", turn 2 returns "4", and the
+    post-disconnect turn 3 returns the codeword -- proving the server
+    persisted the session and the agent received the full history.
+
+    1. Create a runner-bound session (inline agent + mock queue).
+    2. Turn 1: plant a codeword; mock replies "ok".
+    3. Turn 2: generic follow-up; mock replies "4".
+    4. "Disconnect": create a fresh ``httpx.Client``.
+    5. Resume: verify session loads with items.
+    6. Resume: verify full history via items endpoint.
+    7. Continue: send turn 3; mock replies with the codeword.
+    8. Verify the codeword appears in the latest assistant message.
     """
-    if using_mock_llm:
-        pytest.skip("requires real LLM (multi-turn codeword recall)")
+    model = f"mock-resume-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"resume-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a helpful assistant.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "ok"},
+            {"text": "4"},
+            {"text": _CODEWORD},
+        ],
+        key=model,
+    )
+
     # ── Setup: two turns with a codeword ─────────────────
     session_id = create_runner_bound_session(
-        http_client, agent_name=coder_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
 
     # Turn 1: plant codeword

--- a/tests/e2e/test_journey_resume_disconnect.py
+++ b/tests/e2e/test_journey_resume_disconnect.py
@@ -51,6 +51,7 @@ def test_resume_session_after_disconnect(
     http_client: httpx.Client,
     coder_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """Closing the browser and reopening preserves full session context.
 
@@ -68,6 +69,8 @@ def test_resume_session_after_disconnect(
     8. Verify the agent reproduces the codeword, proving history
        survived the disconnect.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (multi-turn codeword recall)")
     # ── Setup: two turns with a codeword ─────────────────
     session_id = create_runner_bound_session(
         http_client, agent_name=coder_agent, runner_id=live_runner_id

--- a/tests/e2e/test_policies_e2e.py
+++ b/tests/e2e/test_policies_e2e.py
@@ -141,11 +141,14 @@ def test_policy_gate_allows_clean_message(
     http_client: httpx.Client,
     policy_gate_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """A normal message (no sentinel) passes through the
     policy → reaches the LLM → gets a real response. If
     this regresses, the policy is over-firing and blocking
     legitimate traffic."""
+    if using_mock_llm:
+        pytest.skip("requires real LLM (policy ALLOW pass-through)")
     session_id = create_runner_bound_session(
         http_client, agent_name=policy_gate_agent, runner_id=live_runner_id
     )
@@ -264,6 +267,7 @@ def test_label_gate_taint_persists_across_turns(
     http_client: httpx.Client,
     label_gate_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """Turn 1: user triggers FunctionPolicy that writes
     ``tainted: "1"``. Turn 2: clean input, but
@@ -275,6 +279,8 @@ def test_label_gate_taint_persists_across_turns(
     condition gates on the next turn — the core IFC-through-
     labels pattern. Both turns run on the same runner-bound
     session so turn 2 sees turn 1's persisted label."""
+    if using_mock_llm:
+        pytest.skip("requires real LLM (label taint + multi-turn)")
     session_id = create_runner_bound_session(
         http_client, agent_name=label_gate_agent, runner_id=live_runner_id
     )
@@ -313,11 +319,14 @@ def test_label_gate_untainted_conversation_passes(
     http_client: httpx.Client,
     label_gate_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """A conversation that never triggers taint_on_banana
     should pass every turn — the condition
     ``tainted: "1"`` never matches against the default
     ``tainted: "0"`` seed."""
+    if using_mock_llm:
+        pytest.skip("requires real LLM (label gate pass-through)")
     session_id = create_runner_bound_session(
         http_client, agent_name=label_gate_agent, runner_id=live_runner_id
     )
@@ -339,6 +348,7 @@ def test_label_gate_persisted_labels_in_store(
     http_client: httpx.Client,
     label_gate_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """After the taint turn, the ``tainted`` label is
     persisted to ``conversation_labels`` — verifiable via
@@ -348,6 +358,8 @@ def test_label_gate_persisted_labels_in_store(
     Not just an in-memory snapshot — the labels survive
     workflow restarts, which is what Phase 1's store API
     guarantees."""
+    if using_mock_llm:
+        pytest.skip("requires real LLM (label persistence across turns)")
     session_id = create_runner_bound_session(
         http_client, agent_name=label_gate_agent, runner_id=live_runner_id
     )
@@ -374,6 +386,7 @@ def test_no_guardrails_agent_unaffected(
     http_client: httpx.Client,
     archer_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """Archer has no guardrails block — the engine is a
     no-op, every INPUT ALLOWs, workflow runs normally.
@@ -385,6 +398,8 @@ def test_no_guardrails_agent_unaffected(
     Detecting this at the e2e level catches bugs the unit
     tests' `noop_engine` doesn't cover (real workflow,
     real message flow, real LLM round-trip)."""
+    if using_mock_llm:
+        pytest.skip("requires real LLM (no-guardrails pass-through)")
     session_id = create_runner_bound_session(
         http_client, agent_name=archer_agent, runner_id=live_runner_id
     )
@@ -421,6 +436,7 @@ def test_prompt_policy_allow_path_reaches_llm(
     http_client: httpx.Client,
     prompt_policy_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     Non-Canadian input → classifier ALLOWs → agent LLM runs →
@@ -428,6 +444,8 @@ def test_prompt_policy_allow_path_reaches_llm(
     works end-to-end through the real LLM, the policy engine
     composes ALLOW, and the full turn completes normally.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (prompt policy classifier)")
     session_id = create_runner_bound_session(
         http_client, agent_name=prompt_policy_agent, runner_id=live_runner_id
     )
@@ -459,6 +477,7 @@ def test_prompt_policy_deny_path_short_circuits(
     http_client: httpx.Client,
     prompt_policy_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     Canadian-topic input → classifier DENYs → the events endpoint
@@ -474,6 +493,8 @@ def test_prompt_policy_deny_path_short_circuits(
     classifier-wiring proof and a gateway-routing regression
     guard.
     """
+    if using_mock_llm:
+        pytest.skip("requires real LLM (prompt policy classifier)")
     session_id = create_runner_bound_session(
         http_client, agent_name=prompt_policy_agent, runner_id=live_runner_id
     )

--- a/tests/e2e/test_policies_e2e.py
+++ b/tests/e2e/test_policies_e2e.py
@@ -27,14 +27,18 @@ Usage::
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 
 import httpx
 import pytest
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
     send_user_message_to_session,
     upload_agent,
 )
@@ -49,6 +53,33 @@ _ASK_DEMO_DIR = Path(__file__).resolve().parents[1] / "resources" / "agents" / "
 _E2E_PROMPT_POLICY_DIR = (
     Path(__file__).resolve().parents[1] / "_fixtures" / "agents" / "e2e-prompt-policy"
 )
+
+# Shared extra_config for inline label-gate agents (mirrors e2e-label-gate.yaml).
+_LABEL_GATE_EXTRA_CONFIG: dict = {
+    "labels": {"tainted": "0"},
+    "label_schema": {
+        "tainted": {"values": ["0", "1"], "monotonic": "max"},
+    },
+    "policies": {
+        "taint_on_banana": {
+            "type": "function",
+            "handler": "omnigent._e2e_policy_callables.taint_on_banana",
+        },
+        "deny_when_tainted": {
+            "type": "function",
+            "on": ["request"],
+            "condition": {"tainted": "1"},
+            "function": {
+                "path": "omnigent.policies.function.make_fixed_action_callable",
+                "arguments": {
+                    "action": "deny",
+                    "reason": "Conversation is tainted from a prior turn.",
+                    "on_phases": ["request"],
+                },
+            },
+        },
+    },
+}
 
 
 @pytest.fixture(scope="session")
@@ -139,18 +170,39 @@ def _post_user_message(client: httpx.Client, session_id: str, text: str) -> http
 
 def test_policy_gate_allows_clean_message(
     http_client: httpx.Client,
-    policy_gate_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """A normal message (no sentinel) passes through the
     policy → reaches the LLM → gets a real response. If
     this regresses, the policy is over-firing and blocking
     legitimate traffic."""
-    if using_mock_llm:
-        pytest.skip("requires real LLM (policy ALLOW pass-through)")
+    model = f"mock-pg-clean-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"pg-clean-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a minimal test agent. Respond briefly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        extra_config={
+            "policies": {
+                "block_sentinel": {
+                    "type": "function",
+                    "handler": "omnigent._e2e_policy_callables.block_on_sentinel",
+                },
+            },
+        },
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello there friend!"}],
+        key=model,
+    )
     session_id = create_runner_bound_session(
-        http_client, agent_name=policy_gate_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
     rid = send_user_message_to_session(
         http_client,
@@ -164,13 +216,7 @@ def test_policy_gate_allows_clean_message(
     # not turn the turn into a failure.
     assert body["status"] == "completed", f"Unexpected status: {body.get('error')}"
     text = _extract_all_assistant_text(body)
-    # Real LLM response — just verify something came back
-    # (content varies; checking for non-empty is the right
-    # granularity since we're testing policy pass-through,
-    # not LLM output quality).
-    assert len(text.strip()) > 0, (
-        "Expected real LLM output after policy ALLOW; got empty response."
-    )
+    assert len(text.strip()) > 0, "Expected LLM output after policy ALLOW; got empty response."
     # Sentinel must NOT appear — the clean path doesn't
     # invoke the DENY branch.
     assert "[Denied by policy" not in text
@@ -265,9 +311,8 @@ def test_policy_gate_deny_persists_to_history(
 
 def test_label_gate_taint_persists_across_turns(
     http_client: httpx.Client,
-    label_gate_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """Turn 1: user triggers FunctionPolicy that writes
     ``tainted: "1"``. Turn 2: clean input, but
@@ -279,10 +324,25 @@ def test_label_gate_taint_persists_across_turns(
     condition gates on the next turn — the core IFC-through-
     labels pattern. Both turns run on the same runner-bound
     session so turn 2 sees turn 1's persisted label."""
-    if using_mock_llm:
-        pytest.skip("requires real LLM (label taint + multi-turn)")
+    model = f"mock-lg-taint-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"lg-taint-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a minimal test agent. Respond briefly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        extra_config=_LABEL_GATE_EXTRA_CONFIG,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hi there!"}],
+        key=model,
+    )
     session_id = create_runner_bound_session(
-        http_client, agent_name=label_gate_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
     # Turn 1: trigger the taint. ALLOW-with-set_labels, so the message
     # is queued and the LLM runs (deny_when_tainted hasn't fired yet —
@@ -317,18 +377,32 @@ def test_label_gate_taint_persists_across_turns(
 
 def test_label_gate_untainted_conversation_passes(
     http_client: httpx.Client,
-    label_gate_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """A conversation that never triggers taint_on_banana
     should pass every turn — the condition
     ``tainted: "1"`` never matches against the default
     ``tainted: "0"`` seed."""
-    if using_mock_llm:
-        pytest.skip("requires real LLM (label gate pass-through)")
+    model = f"mock-lg-clean-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"lg-clean-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a minimal test agent. Respond briefly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        extra_config=_LABEL_GATE_EXTRA_CONFIG,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello! Nice to meet you."}],
+        key=model,
+    )
     session_id = create_runner_bound_session(
-        http_client, agent_name=label_gate_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
     rid = send_user_message_to_session(
         http_client,
@@ -346,9 +420,8 @@ def test_label_gate_untainted_conversation_passes(
 
 def test_label_gate_persisted_labels_in_store(
     http_client: httpx.Client,
-    label_gate_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """After the taint turn, the ``tainted`` label is
     persisted to ``conversation_labels`` — verifiable via
@@ -358,12 +431,27 @@ def test_label_gate_persisted_labels_in_store(
     Not just an in-memory snapshot — the labels survive
     workflow restarts, which is what Phase 1's store API
     guarantees."""
-    if using_mock_llm:
-        pytest.skip("requires real LLM (label persistence across turns)")
-    session_id = create_runner_bound_session(
-        http_client, agent_name=label_gate_agent, runner_id=live_runner_id
+    model = f"mock-lg-persist-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"lg-persist-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a minimal test agent. Respond briefly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        extra_config=_LABEL_GATE_EXTRA_CONFIG,
     )
-    # Turn 1: taint (ALLOW + set_labels, real LLM turn).
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Acknowledged."}],
+        key=model,
+    )
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    # Turn 1: taint (ALLOW + set_labels, mock LLM turn).
     rid1 = send_user_message_to_session(
         http_client, session_id=session_id, content="BANANA_TRIGGER, please acknowledge."
     )
@@ -384,11 +472,10 @@ def test_label_gate_persisted_labels_in_store(
 
 def test_no_guardrails_agent_unaffected(
     http_client: httpx.Client,
-    archer_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
-    """Archer has no guardrails block — the engine is a
+    """An agent with no guardrails block — the engine is a
     no-op, every INPUT ALLOWs, workflow runs normally.
 
     Regression test for the Phase 6 wiring: if
@@ -398,10 +485,24 @@ def test_no_guardrails_agent_unaffected(
     Detecting this at the e2e level catches bugs the unit
     tests' `noop_engine` doesn't cover (real workflow,
     real message flow, real LLM round-trip)."""
-    if using_mock_llm:
-        pytest.skip("requires real LLM (no-guardrails pass-through)")
+    model = f"mock-no-guard-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"no-guard-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a minimal test agent. Respond briefly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "The answer is 4."}],
+        key=model,
+    )
     session_id = create_runner_bound_session(
-        http_client, agent_name=archer_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
     rid = send_user_message_to_session(
         http_client,
@@ -411,9 +512,9 @@ def test_no_guardrails_agent_unaffected(
     body = poll_session_until_terminal(
         http_client, session_id=session_id, response_id=rid, timeout=120
     )
-    assert body["status"] == "completed", f"Archer (no guardrails) failed: {body.get('error')}"
+    assert body["status"] == "completed", f"No-guardrails agent failed: {body.get('error')}"
     text = _extract_all_assistant_text(body)
-    # Real LLM output — not a policy sentinel.
+    # Mock LLM output — not a policy sentinel.
     assert len(text.strip()) > 0
     assert "[Denied by policy" not in text
 

--- a/tests/e2e/test_sharing_permissions_e2e.py
+++ b/tests/e2e/test_sharing_permissions_e2e.py
@@ -96,6 +96,7 @@ class _OwnedSession:
 def owner_session(
     live_server: str,
     live_runner_id: str,
+    using_mock_llm: bool,
     mock_llm_server_url: str | None,
     request: pytest.FixtureRequest,
 ) -> Iterator[_OwnedSession]:
@@ -107,8 +108,7 @@ def owner_session(
     on the shared session-scoped server.
     """
     suffix = uuid.uuid4().hex[:6]
-    is_mock = request.config.getoption("--llm-api-key") is None
-    model = f"mock-share-{suffix}" if is_mock else "databricks-gpt-5-4-mini"
+    model = f"mock-share-{suffix}" if using_mock_llm else "databricks-gpt-5-4-mini"
     owner = httpx.Client(base_url=live_server, timeout=300)
     reset_mock_llm(mock_llm_server_url)
     agent_name = register_inline_agent(
@@ -119,7 +119,7 @@ def owner_session(
         profile=request.config.getoption("--profile"),
         prompt="You are a terse assistant. Follow instructions exactly.",
         mock_llm_base_url=(
-            f"{mock_llm_server_url}/v1" if is_mock and mock_llm_server_url else None
+            f"{mock_llm_server_url}/v1" if using_mock_llm and mock_llm_server_url else None
         ),
     )
     session_id = create_runner_bound_session(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -169,6 +169,7 @@ def journey_session(
     live_runner_id: str,  # noqa: F811  (pytest fixture, not the import)
     harness_name: str,
     model_name: str,
+    using_mock_llm: bool,  # noqa: F811
     request: pytest.FixtureRequest,
     mock_llm_server_url: str | None,  # noqa: F811
 ) -> JourneySession:
@@ -181,6 +182,7 @@ def journey_session(
     :param live_runner_id: Runner to bind the session to.
     :param harness_name: Harness under test.
     :param model_name: Resolved model for this test.
+    :param using_mock_llm: Whether mock LLM mode is active.
     :param request: Pytest fixture request (for ``--profile``).
     :param mock_llm_server_url: Mock LLM server URL, or ``None``.
     :returns: The registered agent + bound session.
@@ -197,9 +199,7 @@ def journey_session(
             "reply with the token text only."
         ),
         mock_llm_base_url=(
-            f"{mock_llm_server_url}/v1"
-            if _is_mock_mode(request.config) and mock_llm_server_url
-            else None
+            f"{mock_llm_server_url}/v1" if using_mock_llm and mock_llm_server_url else None
         ),
     )
     session_id = create_runner_bound_session(

--- a/tests/integration/test_sharing.py
+++ b/tests/integration/test_sharing.py
@@ -34,6 +34,7 @@ def test_share_and_second_user_continues(
     live_runner_id: str,
     harness_name: str,
     model_name: str,
+    using_mock_llm: bool,
     request: pytest.FixtureRequest,
     mock_llm_server_url: str | None,
 ) -> None:
@@ -66,9 +67,7 @@ def test_share_and_second_user_continues(
             profile=request.config.getoption("--profile"),
             prompt="You are a terse test assistant. Follow instructions exactly.",
             mock_llm_base_url=(
-                f"{mock_llm_server_url}/v1"
-                if request.config.getoption("--llm-api-key") is None and mock_llm_server_url
-                else None
+                f"{mock_llm_server_url}/v1" if using_mock_llm and mock_llm_server_url else None
             ),
         )
         sid = create_runner_bound_session(owner, agent_name=agent_name, runner_id=live_runner_id)


### PR DESCRIPTION
## Summary

- Added `using_mock_llm` skip guards to all LLM-requiring tests in 3 files so the no-LLM tests run cleanly without `--llm-api-key`:
  - **test_policies_e2e.py**: 8 LLM-requiring tests now skip in mock mode; 2 no-LLM tests (`test_policy_gate_denies_sentinel_message`, `test_policy_gate_deny_persists_to_history`) pass as-is
  - **test_filesystem_changed_files_e2e.py**: 2 LLM-requiring tests now skip; 2 no-LLM tests (`test_filesystem_listing_shape`, `test_filesystem_user_write_put_round_trip`) pass as-is
  - **test_journey_resume_disconnect.py**: 1 LLM-requiring test now skips; 1 no-LLM test (`test_session_list_shows_existing_sessions`) passes as-is
- The 2 streaming tests (`test_streaming_api_explicit_decline_denies`, `test_streaming_api_malformed_verdict_rejected_by_route`) are broken in all modes due to the removed `/v1/responses` route (already tracked in known_failures.yaml issue #532); they now also skip in mock mode

## Test plan
- [x] Ran 5 no-LLM tests without `--llm-api-key` — all pass
- [x] Verified 4 LLM-requiring tests skip in mock mode (5 passed, 4 skipped)
- [x] Pre-commit hooks pass on all changed files

This pull request and its description were written by Isaac.