### PR TITLE
test: migrate e2e tests to mock LLM (tool calls + policies)

### DIFF
--- a/tests/e2e/test_non_git_changed_files_e2e.py
+++ b/tests/e2e/test_non_git_changed_files_e2e.py
@@ -282,18 +282,7 @@ def non_git_client(non_git_server: str) -> Iterator[httpx.Client]:
 
 
 def _build_mock_workspace_writer_bundle(mock_llm_base_url: str) -> bytes:
-    """Read the on-disk workspace-file-writer YAML, inject mock auth, and tarball it.
-
-    The bundled agent spec has no ``executor.auth`` block, so the harness
-    resolves auth from the agent config (not the server env).  When
-    running against the mock LLM server we need to point the executor at
-    the mock endpoint with a dummy API key.
-
-    :param mock_llm_base_url: Root URL of the mock LLM server,
-        e.g. ``"http://localhost:9999"``.
-    :returns: Gzipped tar archive bytes suitable for the session upload
-        endpoint.
-    """
+    """Read the on-disk workspace-file-writer YAML, inject mock auth, tarball."""
     yaml_path = _WORKSPACE_WRITER_DIR / "workspace-file-writer.yaml"
     spec = yaml.safe_load(yaml_path.read_text())
     spec.setdefault("executor", {})["auth"] = {
@@ -301,14 +290,12 @@ def _build_mock_workspace_writer_bundle(mock_llm_base_url: str) -> bytes:
         "api_key": "mock-key",
         "base_url": f"{mock_llm_base_url}/v1",
     }
-
-    patched_yaml = yaml.dump(spec, sort_keys=False).encode()
-
+    patched = yaml.dump(spec, sort_keys=False).encode()
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         info = tarfile.TarInfo(name="./workspace-file-writer.yaml")
-        info.size = len(patched_yaml)
-        tar.addfile(info, io.BytesIO(patched_yaml))
+        info.size = len(patched)
+        tar.addfile(info, io.BytesIO(patched))
     return buf.getvalue()
 
 
@@ -316,7 +303,7 @@ def _create_session(
     client: httpx.Client,
     *,
     runner_id: str,
-    mock_llm_server_url: str | None,
+    mock_llm_server_url: str,
 ) -> str:
     """Upload the workspace-writer agent and create a bound session.
 
@@ -326,16 +313,11 @@ def _create_session(
 
     :param client: HTTP client pointed at the non-git server.
     :param runner_id: Runner id to bind the session to.
-    :param mock_llm_server_url: Mock LLM server URL for injecting
-        ``executor.auth`` into the bundle.
+    :param mock_llm_server_url: Mock LLM server URL used to inject
+        mock auth into the agent bundle.
     :returns: The new session id, e.g. ``"conv_abc123"``.
     """
-    if mock_llm_server_url is not None:
-        bundle = _build_mock_workspace_writer_bundle(mock_llm_server_url)
-    else:
-        from tests.e2e.conftest import build_agent_bundle
-
-        bundle = build_agent_bundle(_WORKSPACE_WRITER_DIR)
+    bundle = _build_mock_workspace_writer_bundle(mock_llm_server_url)
     create_resp = client.post(
         "/v1/sessions",
         data={"metadata": json.dumps({})},


### PR DESCRIPTION
## Summary
- Migrate `test_non_git_changed_files_e2e` (2 tests) to use mock LLM with `sys_os_write` tool call responses for create/edit file scenarios; update the `non_git_server` fixture to route through mock LLM in mock mode
- Migrate `test_policies_e2e` (5 tests) to use mock LLM text responses: `test_policy_gate_allows_clean_message`, `test_label_gate_taint_persists_across_turns`, `test_label_gate_untainted_conversation_passes`, `test_label_gate_persisted_labels_in_store`, `test_no_guardrails_agent_unaffected`
- Skip `test_prompt_policy_allow_path_reaches_llm` and `test_prompt_policy_deny_path_short_circuits` under mock (require real LLM classifier)
- Skip all `test_sub_agent_phase3_e2e` (3 tests) and `test_subagent_autowake_e2e` (2 tests) under mock — parent and child agents share the same model key (`gpt-5.4`), so mock queue ordering is nondeterministic across the interleaved parent/child requests

## Test plan
- [x] `pre-commit run --files` passes on all changed files
- [x] `pytest tests/e2e/test_policies_e2e.py tests/e2e/test_non_git_changed_files_e2e.py tests/e2e/test_sub_agent_phase3_e2e.py tests/e2e/test_subagent_autowake_e2e.py -v --timeout=120 --no-skip-known` — 9 passed, 7 skipped, 3 failed (pre-existing streaming SSE failures unrelated to this PR)
- [ ] CI green

This pull request and its description were written by Isaac.

## ELI5

<!-- Optional: explain the change in plain language. -->

## Diagram

```mermaid
flowchart LR
  A[Before] --> B[Change]
  B --> C[After]
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Autoformat added this section; please add commands run or explain why coverage is sufficient.
