### PR TITLE
test: migrate simple-echo e2e tests to mock LLM

### DIFF
--- a/tests/e2e/test_agents_sdk_basic.py
+++ b/tests/e2e/test_agents_sdk_basic.py
@@ -1,23 +1,18 @@
-"""E2E test: OpenAI Agents SDK executor with openai-coder agent.
+"""E2E test: OpenAI Agents SDK executor basics (mock LLM).
 
 Verifies that the AgentsSdkExecutor runs single-turn and
-multi-turn conversations with a real LLM. Uses the openai-coder
-agent which has sub-agents, skills, and web search.
+multi-turn conversations correctly. An inline agent is registered
+pointing at the mock LLM server; the mock response queue supplies
+the expected answers directly.
 
 Both turns route through a runner-bound session — the alpha
 runner-state contract requires ``conversations.runner_id``
 to be set before dispatch, so we create the session and PATCH a
 runner before any ``/events`` POST.
 
-In mock-LLM mode, an inline agent is registered pointing at the
-mock server instead of the bundled openai-coder agent (which has
-sub-agents/skills the mock cannot drive). The mock response queue
-supplies the expected answers directly.
-
 Usage::
 
-    pytest tests/e2e/test_agents_sdk_basic.py \
-        --llm-api-key $LLM_API_KEY -v
+    pytest tests/e2e/test_agents_sdk_basic.py -v
 """
 
 from __future__ import annotations
@@ -57,9 +52,7 @@ def _extract_all_text(body: dict[str, Any]) -> str:
 
 def test_agents_sdk_single_turn_completes(
     http_client: httpx.Client,
-    openai_coder_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str,
 ) -> None:
     """
@@ -77,21 +70,18 @@ def test_agents_sdk_single_turn_completes(
     - If ``TurnComplete`` is never yielded, the response
       stays in ``in_progress`` forever and the poll times out.
     """
-    if using_mock_llm:
-        model = f"mock-basic-single-{uuid.uuid4().hex[:6]}"
-        reset_mock_llm(mock_llm_server_url)
-        agent_name = register_inline_agent(
-            http_client,
-            name=f"basic-single-{uuid.uuid4().hex[:6]}",
-            harness="openai-agents",
-            model=model,
-            profile="",
-            prompt="You are a helpful math assistant.",
-            mock_llm_base_url=f"{mock_llm_server_url}/v1",
-        )
-        configure_mock_llm(mock_llm_server_url, [{"text": "The answer is 4."}], key=model)
-    else:
-        agent_name = openai_coder_agent
+    model = f"mock-basic-single-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"basic-single-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a helpful math assistant.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    configure_mock_llm(mock_llm_server_url, [{"text": "The answer is 4."}], key=model)
 
     session_id = create_runner_bound_session(
         http_client,
@@ -119,9 +109,7 @@ def test_agents_sdk_single_turn_completes(
 
 def test_agents_sdk_multi_turn_remembers(
     http_client: httpx.Client,
-    openai_coder_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str,
 ) -> None:
     """
@@ -140,28 +128,25 @@ def test_agents_sdk_multi_turn_remembers(
     - If the workflow doesn't load prior items into ``messages``,
       the executor receives an empty history.
     """
-    if using_mock_llm:
-        model = f"mock-basic-multi-{uuid.uuid4().hex[:6]}"
-        reset_mock_llm(mock_llm_server_url)
-        agent_name = register_inline_agent(
-            http_client,
-            name=f"basic-multi-{uuid.uuid4().hex[:6]}",
-            harness="openai-agents",
-            model=model,
-            profile="",
-            prompt="You are a helpful assistant.",
-            mock_llm_base_url=f"{mock_llm_server_url}/v1",
-        )
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {"text": "OK, noted."},
-                {"text": "Your name is Zephyr and you live in Portland."},
-            ],
-            key=model,
-        )
-    else:
-        agent_name = openai_coder_agent
+    model = f"mock-basic-multi-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"basic-multi-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a helpful assistant.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "OK, noted."},
+            {"text": "Your name is Zephyr and you live in Portland."},
+        ],
+        key=model,
+    )
 
     session_id = create_runner_bound_session(
         http_client,

--- a/tests/e2e/test_agents_sdk_basic.py
+++ b/tests/e2e/test_agents_sdk_basic.py
@@ -9,6 +9,11 @@ runner-state contract requires ``conversations.runner_id``
 to be set before dispatch, so we create the session and PATCH a
 runner before any ``/events`` POST.
 
+In mock-LLM mode, an inline agent is registered pointing at the
+mock server instead of the bundled openai-coder agent (which has
+sub-agents/skills the mock cannot drive). The mock response queue
+supplies the expected answers directly.
+
 Usage::
 
     pytest tests/e2e/test_agents_sdk_basic.py \
@@ -17,13 +22,17 @@ Usage::
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import httpx
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
     send_user_message_to_session,
 )
 
@@ -50,6 +59,8 @@ def test_agents_sdk_single_turn_completes(
     http_client: httpx.Client,
     openai_coder_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """
     Basic smoke test: the Agents SDK executor runs a single
@@ -66,9 +77,25 @@ def test_agents_sdk_single_turn_completes(
     - If ``TurnComplete`` is never yielded, the response
       stays in ``in_progress`` forever and the poll times out.
     """
+    if using_mock_llm:
+        model = f"mock-basic-single-{uuid.uuid4().hex[:6]}"
+        reset_mock_llm(mock_llm_server_url)
+        agent_name = register_inline_agent(
+            http_client,
+            name=f"basic-single-{uuid.uuid4().hex[:6]}",
+            harness="openai-agents",
+            model=model,
+            profile="",
+            prompt="You are a helpful math assistant.",
+            mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        )
+        configure_mock_llm(mock_llm_server_url, [{"text": "The answer is 4."}], key=model)
+    else:
+        agent_name = openai_coder_agent
+
     session_id = create_runner_bound_session(
         http_client,
-        agent_name=openai_coder_agent,
+        agent_name=agent_name,
         runner_id=live_runner_id,
     )
     response_id = send_user_message_to_session(
@@ -94,6 +121,8 @@ def test_agents_sdk_multi_turn_remembers(
     http_client: httpx.Client,
     openai_coder_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """
     Two-turn conversation: the agent remembers turn 1 content
@@ -111,9 +140,32 @@ def test_agents_sdk_multi_turn_remembers(
     - If the workflow doesn't load prior items into ``messages``,
       the executor receives an empty history.
     """
+    if using_mock_llm:
+        model = f"mock-basic-multi-{uuid.uuid4().hex[:6]}"
+        reset_mock_llm(mock_llm_server_url)
+        agent_name = register_inline_agent(
+            http_client,
+            name=f"basic-multi-{uuid.uuid4().hex[:6]}",
+            harness="openai-agents",
+            model=model,
+            profile="",
+            prompt="You are a helpful assistant.",
+            mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        )
+        configure_mock_llm(
+            mock_llm_server_url,
+            [
+                {"text": "OK, noted."},
+                {"text": "Your name is Zephyr and you live in Portland."},
+            ],
+            key=model,
+        )
+    else:
+        agent_name = openai_coder_agent
+
     session_id = create_runner_bound_session(
         http_client,
-        agent_name=openai_coder_agent,
+        agent_name=agent_name,
         runner_id=live_runner_id,
     )
 

--- a/tests/e2e/test_cancel_history.py
+++ b/tests/e2e/test_cancel_history.py
@@ -17,6 +17,7 @@ import time
 from typing import Any
 
 import httpx
+import pytest
 
 from tests.e2e.conftest import (
     create_runner_bound_session,
@@ -175,6 +176,7 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
     http_client: httpx.Client,
     archer_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     Cancel an archer response and verify the follow-up sees the
@@ -199,6 +201,13 @@ def test_cancel_appends_history_marker_and_followup_sees_it(
     - If the marker text is missing or malformed, the follow-up
       LLM won't know a cancellation happened.
     """
+    if using_mock_llm:
+        pytest.skip(
+            "cancel-with-followup requires real streaming generation; "
+            "the mock gate/interrupt interaction does not reliably "
+            "reproduce the cancellation flow"
+        )
+
     # Step 1: open a session, send a broad question that will take time.
     session_id = create_runner_bound_session(
         http_client, agent_name=archer_agent, runner_id=live_runner_id
@@ -263,6 +272,7 @@ def test_cancel_mid_tool_call_followup_succeeds(
     http_client: httpx.Client,
     archer_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     Cancel a response while tools are executing, then verify the
@@ -280,6 +290,12 @@ def test_cancel_mid_tool_call_followup_succeeds(
       every subsequent message in the conversation fails with
       ``[llm] failed``.
     """
+    if using_mock_llm:
+        pytest.skip(
+            "cancel-mid-tool-call requires real tool execution (web_search) "
+            "that the mock LLM cannot orchestrate"
+        )
+
     # Step 1: open session; ask archer to use tools (web_search triggers tool calls).
     session_id = create_runner_bound_session(
         http_client, agent_name=archer_agent, runner_id=live_runner_id

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -1,4 +1,4 @@
-"""E2E tests for ``POST /v1/sessions/{id}/fork`` against a real LLM.
+"""E2E tests for ``POST /v1/sessions/{id}/fork`` (mock LLM).
 
 Exercises the fork flows the route/store unit tests can only mock:
 
@@ -11,7 +11,8 @@ Exercises the fork flows the route/store unit tests can only mock:
    and cannot produce codeword 2).
 3. **Fork + agent switch** (``agent_id``) — fork into a different
    built-in agent and verify the clone binds the target agent while
-   still carrying the source history.
+   still carrying the source history. (Skipped under mock LLM — needs
+   a built-in claude-sdk agent target.)
 
 All flows route through runner-bound sessions (the alpha runner-state
 contract), mirroring how the Web UI drives the fork: create → fork →
@@ -19,8 +20,7 @@ contract), mirroring how the Web UI drives the fork: create → fork →
 
 Usage::
 
-    pytest tests/e2e/test_sessions_fork_e2e.py \
-        --llm-api-key $LLM_API_KEY -v
+    pytest tests/e2e/test_sessions_fork_e2e.py -v
 """
 
 from __future__ import annotations
@@ -202,9 +202,7 @@ def _fork_session(
 
 def test_full_fork_replays_whole_history(
     http_client: httpx.Client,
-    coder_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str,
 ) -> None:
     """
@@ -219,23 +217,18 @@ def test_full_fork_replays_whole_history(
       first turn (e.g. history-prompt building skips pre-fork items) →
       the agent can't produce the codewords (second assertion).
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        agent_name, model = _register_mock_fork_agent(
-            http_client, mock_llm_server_url, prefix="full"
-        )
-        # Two seed turns ("OK" each), then a post-fork recall turn.
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {"text": "OK"},
-                {"text": "OK"},
-                {"text": f"Your projects are {_CODEWORD_1} and {_CODEWORD_2}."},
-            ],
-            key=model,
-        )
-    else:
-        agent_name = coder_agent
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _register_mock_fork_agent(http_client, mock_llm_server_url, prefix="full")
+    # Two seed turns ("OK" each), then a post-fork recall turn.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "OK"},
+            {"text": "OK"},
+            {"text": f"Your projects are {_CODEWORD_1} and {_CODEWORD_2}."},
+        ],
+        key=model,
+    )
 
     source_id = _seed_two_codeword_turns(
         http_client, agent_name=agent_name, runner_id=live_runner_id
@@ -272,9 +265,7 @@ def test_full_fork_replays_whole_history(
 
 def test_fork_from_middle_truncates_context(
     http_client: httpx.Client,
-    coder_agent: str,
     live_runner_id: str,
-    using_mock_llm: bool,
     mock_llm_server_url: str,
 ) -> None:
     """
@@ -295,24 +286,19 @@ def test_fork_from_middle_truncates_context(
       produce codeword 2 (it is NOT in the truncated context, so a
       correct fork cannot emit that exact token pair).
     """
-    if using_mock_llm:
-        reset_mock_llm(mock_llm_server_url)
-        agent_name, model = _register_mock_fork_agent(
-            http_client, mock_llm_server_url, prefix="mid"
-        )
-        # Two seed turns ("OK" each), then a post-fork recall turn
-        # that only mentions codeword 1 (codeword 2 was truncated).
-        configure_mock_llm(
-            mock_llm_server_url,
-            [
-                {"text": "OK"},
-                {"text": "OK"},
-                {"text": f"Your project is {_CODEWORD_1}."},
-            ],
-            key=model,
-        )
-    else:
-        agent_name = coder_agent
+    reset_mock_llm(mock_llm_server_url)
+    agent_name, model = _register_mock_fork_agent(http_client, mock_llm_server_url, prefix="mid")
+    # Two seed turns ("OK" each), then a post-fork recall turn
+    # that only mentions codeword 1 (codeword 2 was truncated).
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": "OK"},
+            {"text": "OK"},
+            {"text": f"Your project is {_CODEWORD_1}."},
+        ],
+        key=model,
+    )
 
     source_id = _seed_two_codeword_turns(
         http_client, agent_name=agent_name, runner_id=live_runner_id

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -25,13 +25,18 @@ Usage::
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import httpx
+import pytest
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
     send_user_message_to_session,
 )
 
@@ -113,6 +118,30 @@ def _first_assistant_response_id(client: httpx.Client, session_id: str) -> str:
     raise AssertionError(f"no assistant message found in session {session_id!r}")
 
 
+def _register_mock_fork_agent(
+    client: httpx.Client,
+    mock_llm_server_url: str,
+    *,
+    prefix: str,
+) -> tuple[str, str]:
+    """Register an inline agent for mock-mode fork tests.
+
+    :returns: ``(agent_name, model)`` — the model doubles as the
+        keyed-queue key on the mock LLM server.
+    """
+    model = f"mock-fork-{prefix}-{uuid.uuid4().hex[:6]}"
+    agent_name = register_inline_agent(
+        client,
+        name=f"fork-{prefix}-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt="You are a terse assistant. When asked to recall, repeat codewords exactly.",
+        mock_llm_base_url=f"{mock_llm_server_url}/v1",
+    )
+    return agent_name, model
+
+
 def _seed_two_codeword_turns(
     client: httpx.Client,
     *,
@@ -175,6 +204,8 @@ def test_full_fork_replays_whole_history(
     http_client: httpx.Client,
     coder_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """
     A full fork (no truncation) carries BOTH turns into the clone's
@@ -188,8 +219,26 @@ def test_full_fork_replays_whole_history(
       first turn (e.g. history-prompt building skips pre-fork items) →
       the agent can't produce the codewords (second assertion).
     """
+    if using_mock_llm:
+        reset_mock_llm(mock_llm_server_url)
+        agent_name, model = _register_mock_fork_agent(
+            http_client, mock_llm_server_url, prefix="full"
+        )
+        # Two seed turns ("OK" each), then a post-fork recall turn.
+        configure_mock_llm(
+            mock_llm_server_url,
+            [
+                {"text": "OK"},
+                {"text": "OK"},
+                {"text": f"Your projects are {_CODEWORD_1} and {_CODEWORD_2}."},
+            ],
+            key=model,
+        )
+    else:
+        agent_name = coder_agent
+
     source_id = _seed_two_codeword_turns(
-        http_client, agent_name=coder_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
 
     fork = _fork_session(http_client, source_id, runner_id=live_runner_id)
@@ -225,6 +274,8 @@ def test_fork_from_middle_truncates_context(
     http_client: httpx.Client,
     coder_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """
     Forking at the FIRST assistant response drops the second turn.
@@ -244,8 +295,27 @@ def test_fork_from_middle_truncates_context(
       produce codeword 2 (it is NOT in the truncated context, so a
       correct fork cannot emit that exact token pair).
     """
+    if using_mock_llm:
+        reset_mock_llm(mock_llm_server_url)
+        agent_name, model = _register_mock_fork_agent(
+            http_client, mock_llm_server_url, prefix="mid"
+        )
+        # Two seed turns ("OK" each), then a post-fork recall turn
+        # that only mentions codeword 1 (codeword 2 was truncated).
+        configure_mock_llm(
+            mock_llm_server_url,
+            [
+                {"text": "OK"},
+                {"text": "OK"},
+                {"text": f"Your project is {_CODEWORD_1}."},
+            ],
+            key=model,
+        )
+    else:
+        agent_name = coder_agent
+
     source_id = _seed_two_codeword_turns(
-        http_client, agent_name=coder_agent, runner_id=live_runner_id
+        http_client, agent_name=agent_name, runner_id=live_runner_id
     )
     first_response_id = _first_assistant_response_id(http_client, source_id)
 
@@ -311,6 +381,7 @@ def test_fork_with_agent_switch_carries_history(
     http_client: httpx.Client,
     claude_coder_agent: str,
     live_runner_id: str,
+    using_mock_llm: bool,
 ) -> None:
     """
     Forking with ``agent_id`` binds the TARGET agent and keeps history.
@@ -327,6 +398,12 @@ def test_fork_with_agent_switch_carries_history(
     - The switch path drops the copied items → the codeword is missing
       from the fork's items / the agent can't recall it.
     """
+    if using_mock_llm:
+        pytest.skip(
+            "fork-with-agent-switch requires a built-in claude-sdk agent "
+            "as target; the mock LLM cannot drive the claude-sdk harness"
+        )
+
     source_id = create_runner_bound_session(
         http_client, agent_name=claude_coder_agent, runner_id=live_runner_id
     )


### PR DESCRIPTION
## Summary
- Migrate `test_agents_sdk_basic.py` (2 tests: single-turn, multi-turn) to run against mock LLM using inline agents and keyed response queues
- Migrate `test_sessions_fork_e2e.py` (2 of 3 tests: full fork, fork-from-middle) to mock LLM with pre-configured codeword responses
- Add `pytest.skip` for 3 tests that cannot work with mock: fork-with-agent-switch (requires built-in claude-sdk target), cancel-with-followup and cancel-mid-tool-call (mock gate/interrupt interaction unreliable)

## Test plan
- [x] `test_agents_sdk_single_turn_completes` — PASSED (mock)
- [x] `test_agents_sdk_multi_turn_remembers` — PASSED (mock)
- [x] `test_full_fork_replays_whole_history` — PASSED (mock)
- [x] `test_fork_from_middle_truncates_context` — PASSED (mock)
- [x] `test_fork_with_agent_switch_carries_history` — SKIPPED (needs claude-sdk built-in)
- [x] `test_cancel_appends_history_marker_and_followup_sees_it` — SKIPPED (gate/interrupt complex)
- [x] `test_cancel_mid_tool_call_followup_succeeds` — SKIPPED (needs real tool execution)

This pull request and its description were written by Isaac.