### PR TITLE
fix(#517): allowlist OMNIGENT_CLAUDE_SDK_NO_SANDBOX so the bypass reaches the harness (part 2)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -269,6 +269,15 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # …" for a key the CLI just saved to the file. Not a secret (a boolean
         # flag); safe to propagate.
         "OMNIGENT_DISABLE_KEYRING",
+        # claude-sdk sandbox bypass flag. A diagnostic knob (not a
+        # secret — a plain boolean) read inside the harness to decide
+        # whether to wrap the brain CLI in sandbox-exec. Without it in
+        # the allowlist the daemon→runner env strip drops it, so a bare
+        # ``OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …`` had no
+        # effect (the operator also had to set
+        # ``OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX``).
+        # Safe to propagate: not a secret.
+        "OMNIGENT_CLAUDE_SDK_NO_SANDBOX",
         # Testing knob: override the context window size for compaction
         # trigger threshold. Not a secret — a plain integer.
         "AP_CONTEXT_WINDOW_OVERRIDE",

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1016,6 +1016,7 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         "DATABRICKS_TOKEN": "dapi-secret",
         "AWS_SECRET_ACCESS_KEY": "aws-secret",
         "SOME_RANDOM_VAR": "x",
+        "OMNIGENT_CLAUDE_SDK_NO_SANDBOX": "1",
     }
 
     env = _build_runner_env(
@@ -1044,6 +1045,11 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
     # needs it to allow --dangerously-skip-permissions under root in
     # sandbox containers. Only the baked host image ever sets it.
     assert env["IS_SANDBOX"] == "1"
+    # The claude-sdk sandbox bypass flag forwards — it is read inside the
+    # harness, so a bare ``OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …``
+    # must reach the runner without also forcing
+    # ``OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX``.
+    assert env["OMNIGENT_CLAUDE_SDK_NO_SANDBOX"] == "1"
     # Non-harness secrets are stripped — the point of the allowlist.
     assert "DATABRICKS_TOKEN" not in env
     assert "AWS_SECRET_ACCESS_KEY" not in env


### PR DESCRIPTION
## Summary

#517 reports two stacked bugs that make a sandboxed `claude-sdk` agent crash on macOS instead of running. This PR fixes **part 2** (the bypass-flag reachability half) — the clean, unambiguous half — and defers **part 1** (auto-detect + degrade) to the maintainers with a design-decision writeup below.

### Part 2 — what this PR fixes

`OMNIGENT_CLAUDE_SDK_NO_SANDBOX` is the documented diagnostic flag that skips the brain-CLI `sandbox-exec` wrap. It's read inside the harness by `_sandbox_disabled_by_env()` (`omnigent/inner/claude_sdk_executor.py:473`), which returns the unwrapped CLI + a WARNING when it's set — the graceful-degrade path.

But the daemon→runner env strip in `_build_runner_env` (`omnigent/host/connect.py`) only forwards vars in `_RUNNER_ENV_ALLOWLIST`, and `OMNIGENT_CLAUDE_SDK_NO_SANDBOX` was **not** in that allowlist. So a bare `OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …` was silently stripped before it reached the harness — the flag had no effect unless the operator *also* set `OMNIGENT_RUNNER_ENV_PASSTHROUGH=OMNIGENT_CLAUDE_SDK_NO_SANDBOX`. The documented escape hatch was broken.

**Fix:** add `OMNIGENT_CLAUDE_SDK_NO_SANDBOX` to `_RUNNER_ENV_ALLOWLIST`. It's a diagnostic boolean, not a secret, so it slots right into the allowlist's existing "not-a-secret, must-propagate" entries (next to `OMNIGENT_DISABLE_KEYRING` / `AP_CONTEXT_WINDOW_OVERRIDE`). Extended `test_build_runner_env_allowlists_host_env_and_strips_secrets` to assert it forwards.

**Immediate user impact:** on macOS with the standalone Claude installer, `OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …` now actually skips the wrap, so the `PermissionError: Operation not permitted: '/Users/<user>/.local/bin/claude'` crash from part 1 no longer fires. (Part 1 below is about making that degrade *automatic* so the flag isn't required.)

### Part 1 — deferred to maintainers (design decision)

Part 1 is the auto-detect: "on macOS, when the CLI resolves under an un-grantable home subtree, skip the wrap with a warning instead of crashing." I deliberately did **not** implement it here because it's a security-relevant design decision that benefits from maintainer judgment, and the two options have real tradeoffs:

**Option A — grant the binary's own install tree (keeps the sandbox).** Add the resolved CLI binary's directory to the sandbox read roots so the `sandbox-exec` profile can read (and exec) its own binary, and the wrap succeeds with the sandbox still active. **More secure** (the CLI supervisor stays confined) and **fixes the default crash with no flag**. But: seatbelt `read_roots` only emit `file-read*` (`omnigent/inner/seatbelt_sandbox.py:819-820`), **not `process-exec*`** — so this needs exec-permission handling, plus symlink + versioned-dir semantics (`~/.local/bin/claude` → `~/.local/share/claude/versions/<ver>/claude`), and a decision about how much of the install tree to grant. Real seatbelt depth.

**Option B — auto-detect + degrade (the issue's suggestion).** Detect "macOS + the resolved binary's directory isn't covered by the sandbox's granted roots (cwd / scratch / read_roots / write_roots / `~/.claude/*`)" and return the unwrapped CLI + a WARNING, reusing the existing `_sandbox_disabled_by_env()` degrade shape. **Smaller diff, no sandbox-surface expansion**, but the CLI supervisor runs unwrapped (file/shell access still stays confined because the `os_env` `sys_os_*` tools activate their own sandbox independently — see the issue's analysis). Needs a "is this path covered?" predicate over the sandbox's granted roots.

Either way it's a focused-but-non-trivial change on the macOS seatbelt path with a design call I'd rather the maintainers make than guess on. I can pick it up in a follow-up once there's a preferred direction. **Part 2 lands independently** and is valuable on its own (restores the documented bypass flag — the immediate macOS-crash workaround).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

(Note: this *does* fix a bug — a documented flag that silently didn't work — but it's a one-line allowlist correction + test, so I've kept it under Refactor/chore rather than Bug fix; happy to retag if you'd prefer Bug fix.)

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

```
uv run ruff format . && uv run ruff check --fix .   # clean
uv run pytest tests/host -q                          # 191 passed (incl. the extended allowlist test)
uv run mypy omnigent/host/connect.py                  # clean (0 errors in the touched file)
uv run mypy omnigent                                  # 0 new errors in connect.py (1254 pre-existing across the package, all in unrelated files — wizard.py etc.)
```

The extended `test_build_runner_env_allowlists_host_env_and_strips_secrets` directly asserts `OMNIGENT_CLAUDE_SDK_NO_SANDBOX` now forwards through `_build_runner_env` (it was previously dropped, which is the bug). The existing `test_prepare_claude_cli_path_bypasses_wrapper_when_env_set` already covers the harness-side behavior (`_sandbox_disabled_by_env` → unwrapped CLI + warning) that this flag unlocks; no new harness test is needed because the harness code is unchanged — only the env propagation was fixed.

No behavior change beyond the one extra allowlisted var, so the e2e requirement does not apply.

## ELI5

There's an env var, `OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1`, that tells the claude-sdk harness "don't wrap the Claude CLI in the macOS sandbox." It's the official escape hatch for when the sandbox wrap itself is what's breaking (which, on macOS with the standalone Claude installer, it is — the sandbox can't read its own binary and the spawn crashes).

The problem: that flag was being **stripped** before it ever reached the harness. The runner only inherits a specific allowlist of env vars, and this flag wasn't on it — so setting it did nothing unless you also set a second "please pass this through" flag. The escape hatch was wired shut.

This PR adds the flag to the allowlist. One line (+ a test that proves it now arrives). Now `OMNIGENT_CLAUDE_SDK_NO_SANDBOX=1 omnigent run …` actually works on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
