### PR TITLE
docs: refresh Docker _BuiltApp docstring

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -72,12 +72,14 @@ class _ResolvedConfig:
 
 @dataclass(frozen=True)
 class _BuiltApp:
-    """The bind address resolved alongside the built app.
+    """The FastAPI app plus resolved bind settings.
 
-    ``build_app`` resolves HOST/PORT as a side effect of wiring the app
-    (they feed ``detect_base_url`` for accounts mode), so it returns
-    them here for ``main()`` to hand to ``uvicorn.run`` — keeping a
-    single config-resolution pass.
+    ``_resolve_config`` handles config loading, database URL normalization,
+    artifact directory setup, auth defaults, and HOST/PORT resolution before
+    migrations run. ``main()`` then runs migrations explicitly and calls
+    ``build_app`` to construct the app from that resolved config. Returning
+    HOST/PORT with the app keeps the handoff to ``uvicorn.run`` explicit
+    without requiring a second config-resolution pass.
     """
 
     app: FastAPI


### PR DESCRIPTION
## Summary

- Refresh the stale `_BuiltApp` docstring in `deploy/docker/entrypoint.py` so it matches the current startup structure introduced in #506.
- The old text wrongly attributed HOST/PORT resolution to `build_app`; resolution now lives in `_resolve_config`. The new docstring documents the real flow: `_resolve_config` resolves config + bind settings, `main()` runs migrations explicitly, then `build_app` constructs the FastAPI app from the resolved config.
- Docstring-only change — no behavior, control flow, types, or non-comment code touched (+8/-6 on one file).

Follow-up to #506.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Docstring-only edit, so no new tests are warranted; existing entrypoint coverage guards against any accidental behavior/import change. Commands run (all green):

- `uv run ruff check deploy/docker/entrypoint.py tests/deploy/test_docker_entrypoint_import.py`
- `uvx pyrefly check deploy/docker/entrypoint.py tests/deploy/test_docker_entrypoint_import.py` — 0 errors
- `uv run pytest tests/deploy/test_docker_entrypoint_import.py` — 1 passed

The import-inertness contract (`from __future__ import annotations` + `TYPE_CHECKING`-gated `FastAPI`) is unaffected by a docstring change.
