### PR TITLE
test(terminals): add registry→tmux behavioral I/O coverage for sys_terminal_*

### DIFF
--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -246,11 +246,15 @@ async def test_send_and_read_after_close_report_not_running(
     socket.
     """
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
-    assert await instance.is_alive()
+    alive = await instance.is_alive()
+    assert alive
 
-    assert await reg.close("conv_a", "bash", "s1") is True
+    close_result = await reg.close("conv_a", "bash", "s1")
+    assert close_result is True
     assert instance.running is False
-    assert await instance.is_alive() is False
+    alive_after_close = await instance.is_alive()
+    assert alive_after_close is False
 
-    assert "error" in await instance.send(text="echo too_late", keys="Enter")
+    send_result = await instance.send(text="echo too_late", keys="Enter")
+    assert "error" in send_result
     assert "error" in await instance.read()

--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -45,6 +45,17 @@ def _dewrap(screen: str) -> str:
     return screen.replace("\n", "")
 
 
+def _echo_only_on_run(marker: str) -> str:
+    """An ``echo`` whose *typed* form can't contain *marker* — only its output can.
+
+    The empty ``""`` splits the literal in the keystroke echo (and in any
+    ``_dewrap`` join of the wrapped command line), so a needle search proves
+    the command produced output rather than merely that it was typed.
+    """
+    mid = len(marker) // 2
+    return f'echo {marker[:mid]}""{marker[mid:]}'
+
+
 def _bash_spec(cwd: Path, *, allow_cwd_override: bool = False) -> TerminalEnvSpec:
     return TerminalEnvSpec(
         command="bash",
@@ -190,22 +201,38 @@ async def test_cwd_override_anchors_live_shell_in_subdirectory(
 async def test_ctrl_c_interrupts_running_command(
     reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
-    """``keys="C-c"`` interrupts a running foreground command."""
+    """``keys="C-c"`` interrupts a running foreground command.
+
+    Affirmative, not merely "the prompt recovered": C-c is sent only after
+    the foreground job's own output proves it is executing (not still at an
+    empty prompt), the sleep is long enough that an ineffective C-c leaves
+    the recovery echo queued behind it past the poll budget, and the job's
+    post-sleep marker must be absent — so a no-op C-c fails the test.
+    """
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
 
-    await instance.send(text="sleep 120", keys="Enter")
-    # Let bash fork `sleep` before interrupting; a C-c that lands first
-    # only edits the command line. Roomy for loaded CI.
-    await asyncio.sleep(1.0)
+    running = _echo_only_on_run("FOREGROUND_RUNNING")
+    not_interrupted = _echo_only_on_run("SLEEP_FINISHED_NOT_INTERRUPTED")
+    await instance.send(text=f"{running} && sleep 120 && {not_interrupted}", keys="Enter")
+
+    started = await _read_until(instance, "FOREGROUND_RUNNING")
+    assert "FOREGROUND_RUNNING" in started, (
+        "foreground job never started, so C-c would land on an empty prompt and "
+        f"prove nothing. Last pane:\n{started!r}"
+    )
 
     interrupt = await instance.send(text=None, keys="C-c")
     assert interrupt.get("status") == "sent", f"C-c send failed: {interrupt!r}"
 
-    await instance.send(text="echo INTERRUPT_RECOVERED_OK", keys="Enter")
+    await instance.send(text=_echo_only_on_run("INTERRUPT_RECOVERED_OK"), keys="Enter")
     screen = await _read_until(instance, "INTERRUPT_RECOVERED_OK")
     assert "INTERRUPT_RECOVERED_OK" in screen, (
-        "marker echo did not appear after C-c, so the foreground `sleep` was "
-        f"never interrupted. Last pane:\n{screen!r}"
+        "recovery echo never ran, so the foreground `sleep` was not interrupted "
+        f"and still holds the shell. Last pane:\n{screen!r}"
+    )
+    assert "SLEEP_FINISHED_NOT_INTERRUPTED" not in screen, (
+        "the sleep ran to completion, so C-c did not interrupt the foreground "
+        f"command list. Last pane:\n{screen!r}"
     )
 
 

--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -236,36 +236,6 @@ async def test_ctrl_c_interrupts_running_command(
     )
 
 
-async def test_parallel_sessions_have_isolated_shell_state(
-    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
-) -> None:
-    """Two sessions of the same terminal don't share shell state.
-
-    Stronger than the socket-identity checks in ``test_registry.py``: a
-    regression collapsing ``(name, key)`` to ``name`` surfaces here as
-    cross-talk between the two panes.
-    """
-    spec = _bash_spec(tmp_path)
-    s1 = await reg.launch("conv_a", "bash", "s1", spec)
-    s2 = await reg.launch("conv_a", "bash", "s2", spec)
-
-    assert s1 is not s2
-    assert s1.socket_path != s2.socket_path
-
-    await s1.send(text="SESSION_TAG=alpha_one", keys="Enter")
-    await s2.send(text="SESSION_TAG=beta_two", keys="Enter")
-    await s1.send(text="echo TAG=$SESSION_TAG", keys="Enter")
-    await s2.send(text="echo TAG=$SESSION_TAG", keys="Enter")
-
-    s1_screen = await _read_until(s1, "TAG=alpha_one")
-    s2_screen = await _read_until(s2, "TAG=beta_two")
-
-    assert "TAG=alpha_one" in s1_screen, f"s1 lost its own value. Pane:\n{s1_screen!r}"
-    assert "TAG=beta_two" in s2_screen, f"s2 lost its own value. Pane:\n{s2_screen!r}"
-    assert "beta_two" not in s1_screen, f"s1 sees s2's value. Pane:\n{s1_screen!r}"
-    assert "alpha_one" not in s2_screen, f"s2 sees s1's value. Pane:\n{s2_screen!r}"
-
-
 async def test_send_and_read_after_close_report_not_running(
     reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:

--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -1,36 +1,27 @@
-"""
-Behavioral I/O tests for :class:`omnigent.terminals.TerminalRegistry`
-driven against a real tmux.
+"""Behavioral I/O tests for :class:`TerminalRegistry` against a real tmux.
 
-These complement :mod:`tests.terminals.test_registry` (which pins the
-registry's *lifecycle* invariants — launch / get / close / list /
-cleanup / shutdown — but never sends a keystroke or reads a byte) and
-:mod:`tests.tools.builtins.test_sys_terminal` (which drives the same
-behaviors through the ``sys_terminal_*`` tool envelopes). The module
-here exercises the load-bearing capabilities that
-``sys_terminal_*`` adds over a one-shot ``sys_os_shell`` — interactive
-state that survives across calls, cwd anchoring of the live shell,
-control-key delivery, and per-session isolation — at the tightest
-layer that still touches a real tmux: ``TerminalRegistry.launch`` →
-``TerminalInstance.send`` / ``.read``.
+These complement :mod:`tests.terminals.test_registry` (registry
+lifecycle, no keystrokes) and :mod:`tests.tools.builtins.test_sys_terminal`
+(the same behaviors through the ``sys_terminal_*`` tool envelopes) by
+driving ``TerminalRegistry.launch`` → ``TerminalInstance.send`` / ``.read``
+directly: interactive state that survives across calls, cwd anchoring of
+the live shell, control-key delivery, and per-session isolation.
 
-Why this layer (not the e2e suite): the equivalent end-to-end
-coverage in ``tests/e2e/test_sys_terminal_e2e.py`` is fully suppressed
-in ``tests/known_failures.yaml`` (cluster ``terminal-d6``, "requires
-running runner") because it needs a live runner shard and a real LLM.
-These tests reach the same tmux behaviors deterministically — no
-runner, no LLM, no flakiness from prose — so the capability keeps
-durable coverage in the normal ``tests/terminals`` CI shard, which
-installs tmux (see ``.github/workflows/ci.yml``).
+The equivalent end-to-end coverage in ``tests/e2e/test_sys_terminal_e2e.py``
+is suppressed in ``tests/known_failures.yaml`` because it needs a live
+runner and a real LLM. These reach the same tmux behaviors with neither,
+so the capability keeps coverage in the ``tests/terminals`` CI shard
+(which installs tmux).
 
-Every test launches a real tmux and is skipped when tmux is not on
-PATH. ``send`` is asynchronous from the shell's perspective (tmux
-delivers keystrokes, the shell renders on its own clock), so reads
-poll with a bounded budget rather than asserting on a single capture.
+Skipped when tmux is absent. ``send`` is asynchronous from the shell's
+view, so reads poll on a bounded budget rather than asserting a single
+capture.
 """
 
 from __future__ import annotations
 
+import asyncio
+import shlex
 import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -46,30 +37,11 @@ pytestmark = pytest.mark.skipif(
     reason="tmux not installed; registry I/O tests need a real tmux on PATH",
 )
 
-# Bounded poll budget for a marker to render in the pane. tmux delivers
-# send-keys and the shell echoes on its own clock; a fixed sleep either
-# wastes time or races. 5s comfortably covers a cold bash prompt plus
-# echo on a loaded CI box while keeping a hung shell from stalling the
-# suite. The matching round-trip test in
-# ``tests/tools/builtins/test_sys_terminal.py`` uses a ~2s budget; this
-# is deliberately roomier because some tests here chain two sends.
 _MARKER_BUDGET_S = 5.0
 _POLL_INTERVAL_S = 0.1
 
 
 def _bash_spec(cwd: Path, *, allow_cwd_override: bool = False) -> TerminalEnvSpec:
-    """A minimal bash :class:`TerminalEnvSpec` anchored at *cwd*, sandbox off.
-
-    Sandbox is forced to ``none`` so the test doesn't depend on
-    bwrap / seatbelt availability — these tests exercise tmux I/O,
-    not sandboxing (covered elsewhere). The cwd is set on the
-    terminal's own ``os_env`` so the launched shell starts there.
-
-    :param cwd: Directory the spawned shell starts in.
-    :param allow_cwd_override: Whether per-launch ``cwd_override`` is
-        permitted. Defaults to ``False`` (matches the spec default).
-    :returns: A :class:`TerminalEnvSpec` ready to launch.
-    """
     return TerminalEnvSpec(
         command="bash",
         allow_cwd_override=allow_cwd_override,
@@ -87,22 +59,15 @@ async def _read_until(
     *,
     budget_s: float = _MARKER_BUDGET_S,
 ) -> str:
-    """Poll ``instance.read`` until *needle* shows in the pane or budget elapses.
+    """Poll ``instance.read`` until *needle* appears or the budget elapses.
 
-    :param instance: The launched terminal to read from.
-    :param needle: Substring expected to appear in the pane capture.
-    :param budget_s: Total seconds to poll before giving up.
-    :returns: The last pane ``screen`` text observed — contains
-        *needle* on success, or the final capture (for a useful
-        failure message) on timeout.
+    Returns the last pane text seen — containing *needle* on success, or
+    the final capture (for a useful failure message) on timeout.
     """
-    import asyncio
-
     waited = 0.0
     screen = ""
     while waited < budget_s:
-        result = await instance.read()
-        screen = result.get("screen", "")
+        screen = (await instance.read()).get("screen", "")
         if needle in screen:
             return screen
         await asyncio.sleep(_POLL_INTERVAL_S)
@@ -110,250 +75,145 @@ async def _read_until(
     return screen
 
 
+def _path_tail(*parts: str) -> str:
+    """Join path segments into a tmux-pwd needle.
+
+    Matching a two-segment tail (parent/leaf) rather than a bare leaf
+    keeps the assertion off a basename-only shell prompt and off the
+    macOS ``/var`` → ``/private/var`` symlink rewrite, both of which
+    would otherwise let a test pass without the real pwd in the pane.
+    """
+    return str(Path(*parts))
+
+
 @pytest.fixture
 def reg() -> TerminalRegistry:
-    """A fresh registry per test."""
     return TerminalRegistry()
 
 
 @pytest.fixture
-async def cleanup(reg: TerminalRegistry) -> AsyncIterator[None]:
-    """Close every terminal at test exit, even when an assertion fails.
-
-    Declared to depend on ``reg`` so its teardown runs before the
-    registry fixture is discarded — otherwise a failed assertion
-    mid-test would leak a live tmux server.
-
-    :param reg: The registry fixture whose terminals get torn down.
-    :yields: ``None`` — the value is unused; the fixture exists for
-        its teardown side effect.
-    """
+async def shutdown_terminals(reg: TerminalRegistry) -> AsyncIterator[None]:
+    """Close every terminal at test exit, even when an assertion fails."""
     yield
     await reg.shutdown()
 
 
-# ── Interactive state persistence ─────────────────────────────
-
-
 async def test_shell_state_persists_across_separate_sends(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
     """A variable set in one ``send`` is still set in a later ``send``.
 
-    This is the load-bearing capability ``sys_terminal_*`` adds over a
-    one-shot ``sys_os_shell``: the shell is a single long-lived process
-    across calls, so state (here a shell variable) set by the first
-    send is visible to the second. A naive "spawn a fresh shell per
-    send" implementation would pass every lifecycle test in
-    :mod:`tests.terminals.test_registry` yet fail here, because the
-    second send would run in a shell that never saw the assignment.
-
-    Mirrors the suppressed
-    ``test_sys_terminal_persists_across_turns_e2e`` (which proves the
-    same thing across two LLM turns) at the registry→tmux layer.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture.
-    :param tmp_path: Per-test working directory for the shell.
+    The capability ``sys_terminal_*`` adds over a one-shot ``sys_os_shell``:
+    one long-lived shell across calls. A "fresh shell per send" regression
+    passes every lifecycle test yet fails here.
     """
-    del cleanup
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
 
-    # First send establishes state; second send observes it. Two
-    # distinct send() calls — not one compound command — so the test
-    # actually proves cross-call persistence.
     await instance.send(text="MARKER_VAR=persisted_value", keys="Enter")
     await instance.send(text="echo VAR_IS_$MARKER_VAR", keys="Enter")
 
     screen = await _read_until(instance, "VAR_IS_persisted_value")
     assert "VAR_IS_persisted_value" in screen, (
-        "Shell variable set in the first send was not visible in the "
-        "second. The shell is supposed to be one long-lived process "
-        "across send() calls; if this fails, each send is spawning a "
-        f"fresh shell (state lost). Last pane:\n{screen!r}"
+        "variable from the first send was not visible in the second — each "
+        f"send is spawning a fresh shell. Last pane:\n{screen!r}"
     )
 
 
 async def test_working_directory_change_persists_across_sends(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
-    """A ``cd`` in one send is reflected by ``pwd`` in a later send.
-
-    The directory-state analogue of the variable-persistence test —
-    and the exact behavior the suppressed persistence e2e asserts
-    (``cd /tmp`` in turn 1, ``pwd`` shows ``/tmp`` in turn 2). Proving
-    it here at the tmux layer removes the dependency on a live runner.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture.
-    :param tmp_path: Working directory; a ``subdir`` is created to cd into.
-    """
-    del cleanup
+    """A ``cd`` in one send is reflected by ``pwd`` in a later send."""
     subdir = tmp_path / "nested_dir"
     subdir.mkdir()
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
 
-    await instance.send(text=f"cd {subdir}", keys="Enter")
+    await instance.send(text=f"cd {shlex.quote(str(subdir))}", keys="Enter")
     await instance.send(text="pwd", keys="Enter")
 
-    # macOS resolves /var -> /private/var; accept either spelling by
-    # matching the leaf directory name, which is unambiguous here.
-    screen = await _read_until(instance, "nested_dir")
-    assert "nested_dir" in screen, (
-        "cd from the first send did not persist into the second send's "
-        f"pwd. The session lost its working directory. Last pane:\n{screen!r}"
-    )
-
-
-# ── cwd anchoring of the live shell ───────────────────────────
-
-
-async def test_launched_shell_starts_in_spec_cwd(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
-) -> None:
-    """``pwd`` in a freshly launched shell reports the spec's cwd.
-
-    Unit tests in ``tests/tools/builtins/test_sys_terminal.py`` pin
-    ``_resolve_cwd``'s precedence logic in isolation, but nothing at
-    this layer proves the resolved cwd actually anchors the *live*
-    shell. This drives ``pwd`` against the real tmux and asserts the
-    shell landed where the spec said — the behavioral half of the
-    suppressed ``test_sys_terminal_cwd_default_is_workspace_e2e``.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture.
-    :param tmp_path: The directory the spec anchors the shell to.
-    """
-    del cleanup
-    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
-
-    await instance.send(text="pwd", keys="Enter")
-
-    leaf = tmp_path.name
-    screen = await _read_until(instance, leaf)
-    assert leaf in screen, (
-        f"Launched shell's pwd did not report the spec cwd {tmp_path}. "
-        f"The terminal landed somewhere other than its configured cwd. "
+    needle = _path_tail(tmp_path.name, "nested_dir")
+    screen = await _read_until(instance, needle)
+    assert needle in screen, (
+        f"cd from the first send did not persist into the second send's pwd. "
         f"Last pane:\n{screen!r}"
     )
 
 
-async def test_cwd_override_anchors_live_shell_in_subdirectory(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+async def test_launched_shell_starts_in_spec_cwd(
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
-    """A per-launch ``cwd_override`` starts the live shell in that subdir.
+    """``pwd`` in a freshly launched shell reports the spec's cwd.
 
-    Complements the disallowed-override *rejection* test in the tool
-    suite: here the override is allowed and we prove it actually moves
-    the spawned shell's cwd (``pwd`` reports the subdirectory and the
-    instance records it on ``launch_cwd``). The override is contained
-    to a subdirectory of the spec cwd, matching
-    ``build_terminal_os_env_spec``'s containment guard.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture.
-    :param tmp_path: Spec cwd; a ``workdir`` subdir is the override target.
+    The behavioral half of ``_resolve_cwd``'s precedence logic, which is
+    unit-tested in isolation but never proven against a live shell.
     """
-    del cleanup
+    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
+
+    await instance.send(text="pwd", keys="Enter")
+
+    needle = _path_tail(tmp_path.parent.name, tmp_path.name)
+    screen = await _read_until(instance, needle)
+    assert needle in screen, (
+        f"launched shell's pwd did not report the spec cwd {tmp_path}. Last pane:\n{screen!r}"
+    )
+
+
+async def test_cwd_override_anchors_live_shell_in_subdirectory(
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
+) -> None:
+    """A per-launch ``cwd_override`` starts the live shell in that subdir."""
     override_dir = tmp_path / "workdir"
     override_dir.mkdir()
-    spec = _bash_spec(tmp_path, allow_cwd_override=True)
 
     instance = await reg.launch(
         "conv_a",
         "bash",
         "s1",
-        spec,
+        _bash_spec(tmp_path, allow_cwd_override=True),
         cwd_override=str(override_dir),
     )
 
-    # The instance records the resolved launch cwd; assert it points
-    # at the override target (resolved for the macOS /var symlink).
     assert instance.launch_cwd is not None
     assert Path(instance.launch_cwd).name == "workdir", (
-        f"launch_cwd did not reflect the cwd_override; got "
-        f"{instance.launch_cwd!r}, expected a path ending in 'workdir'."
+        f"launch_cwd did not reflect the cwd_override; got {instance.launch_cwd!r}"
     )
 
     await instance.send(text="pwd", keys="Enter")
-    screen = await _read_until(instance, "workdir")
-    assert "workdir" in screen, (
-        "cwd_override did not anchor the live shell: pwd never reported "
-        f"the override subdirectory. Last pane:\n{screen!r}"
-    )
-
-
-# ── Control-key delivery ──────────────────────────────────────
+    needle = _path_tail(tmp_path.name, "workdir")
+    screen = await _read_until(instance, needle)
+    assert needle in screen, f"cwd_override did not anchor the live shell. Last pane:\n{screen!r}"
 
 
 async def test_ctrl_c_interrupts_running_command(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
-    """``keys="C-c"`` interrupts a running foreground command.
-
-    Exercises the ``send`` path's control-key handling (``text=None``,
-    ``keys="C-c"``) against a live shell — the interactive capability
-    that distinguishes ``sys_terminal_*`` from a one-shot command run.
-    A long ``sleep`` is started, interrupted with C-c, and a marker
-    echo afterward proves the shell returned to its prompt rather than
-    staying blocked in the sleep.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture.
-    :param tmp_path: Working directory for the shell.
-    """
-    import asyncio
-
-    del cleanup
+    """``keys="C-c"`` interrupts a running foreground command."""
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
 
-    # Start a long-running foreground command, then let it actually
-    # begin before interrupting (a C-c that lands before the shell
-    # forks `sleep` would just edit the command line).
     await instance.send(text="sleep 120", keys="Enter")
-    await asyncio.sleep(0.4)
+    # Let bash fork `sleep` before interrupting; a C-c that lands first
+    # only edits the command line. Roomy for loaded CI.
+    await asyncio.sleep(1.0)
 
-    # Interrupt: no literal text, just the control key.
     interrupt = await instance.send(text=None, keys="C-c")
-    assert interrupt.get("status") == "sent", (
-        f"send of C-c did not report status='sent': {interrupt!r}"
-    )
+    assert interrupt.get("status") == "sent", f"C-c send failed: {interrupt!r}"
 
-    # If the interrupt worked, the shell is back at a prompt and this
-    # echo runs promptly. If C-c was swallowed, the echo sits behind a
-    # 120s sleep and the marker never shows within the budget.
     await instance.send(text="echo INTERRUPT_RECOVERED_OK", keys="Enter")
     screen = await _read_until(instance, "INTERRUPT_RECOVERED_OK")
     assert "INTERRUPT_RECOVERED_OK" in screen, (
-        "Marker echo did not appear after C-c, so the interrupt didn't "
-        "return the shell to its prompt — the foreground `sleep` was "
+        "marker echo did not appear after C-c, so the foreground `sleep` was "
         f"never interrupted. Last pane:\n{screen!r}"
     )
 
 
-# ── Parallel-session isolation (driven by real I/O) ───────────
-
-
 async def test_parallel_sessions_have_isolated_shell_state(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
     """Two sessions of the same terminal don't share shell state.
 
-    ``test_registry.py`` proves distinct session keys yield distinct
-    instances and sockets (object identity); this proves the stronger
-    *behavioral* property the design promises — independent tmux
-    sessions running in parallel — by setting the same variable name to
-    different values in each and confirming each session reports only
-    its own value. A registry bug that collapsed ``(name, key)`` to
-    ``name`` (one shared tmux) would surface here as cross-talk even if
-    the socket-identity assertions elsewhere still passed.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture.
-    :param tmp_path: Working directory shared by both sessions (state
-        isolation is per-shell-process, not per-cwd).
+    Stronger than the socket-identity checks in ``test_registry.py``: a
+    regression collapsing ``(name, key)`` to ``name`` surfaces here as
+    cross-talk between the two panes.
     """
-    del cleanup
     spec = _bash_spec(tmp_path)
     s1 = await reg.launch("conv_a", "bash", "s1", spec)
     s2 = await reg.launch("conv_a", "bash", "s2", spec)
@@ -361,7 +221,6 @@ async def test_parallel_sessions_have_isolated_shell_state(
     assert s1 is not s2
     assert s1.socket_path != s2.socket_path
 
-    # Same variable name, different values, one per session.
     await s1.send(text="SESSION_TAG=alpha_one", keys="Enter")
     await s2.send(text="SESSION_TAG=beta_two", keys="Enter")
     await s1.send(text="echo TAG=$SESSION_TAG", keys="Enter")
@@ -370,60 +229,27 @@ async def test_parallel_sessions_have_isolated_shell_state(
     s1_screen = await _read_until(s1, "TAG=alpha_one")
     s2_screen = await _read_until(s2, "TAG=beta_two")
 
-    assert "TAG=alpha_one" in s1_screen, (
-        f"Session s1 did not report its own value. Pane:\n{s1_screen!r}"
-    )
-    assert "TAG=beta_two" in s2_screen, (
-        f"Session s2 did not report its own value. Pane:\n{s2_screen!r}"
-    )
-    # The load-bearing isolation assertion: neither session sees the
-    # other's value. Cross-talk here means the two session keys are
-    # backed by a single shared tmux session.
-    assert "beta_two" not in s1_screen, (
-        "Session s1's pane shows session s2's value — the two session "
-        f"keys are not isolated. s1 pane:\n{s1_screen!r}"
-    )
-    assert "alpha_one" not in s2_screen, (
-        "Session s2's pane shows session s1's value — the two session "
-        f"keys are not isolated. s2 pane:\n{s2_screen!r}"
-    )
-
-
-# ── Read-after-close error contract ───────────────────────────
+    assert "TAG=alpha_one" in s1_screen, f"s1 lost its own value. Pane:\n{s1_screen!r}"
+    assert "TAG=beta_two" in s2_screen, f"s2 lost its own value. Pane:\n{s2_screen!r}"
+    assert "beta_two" not in s1_screen, f"s1 sees s2's value. Pane:\n{s1_screen!r}"
+    assert "alpha_one" not in s2_screen, f"s2 sees s1's value. Pane:\n{s2_screen!r}"
 
 
 async def test_send_and_read_after_close_report_not_running(
-    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+    reg: TerminalRegistry, shutdown_terminals: None, tmp_path: Path
 ) -> None:
     """Once closed, the instance's ``send`` / ``read`` error cleanly.
 
-    ``test_registry.py`` proves ``close`` removes the registry *entry*;
-    this proves the *instance* object refuses I/O afterward instead of
-    talking to a dead tmux socket. The ``send`` tool path surfaces this
-    as a "not running" error to the LLM, so the instance-level contract
-    matters: a stale read against a killed server must not hang or
-    return garbage.
-
-    :param reg: Fresh registry.
-    :param cleanup: Teardown side-effect fixture (idempotent with the
-        explicit close below).
-    :param tmp_path: Working directory for the shell.
+    ``test_registry.py`` proves ``close`` removes the registry entry; this
+    proves the instance refuses I/O afterward instead of talking to a dead
+    socket.
     """
-    del cleanup
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
     assert await instance.is_alive()
 
-    closed = await reg.close("conv_a", "bash", "s1")
-    assert closed is True
-
+    assert await reg.close("conv_a", "bash", "s1") is True
     assert instance.running is False
     assert await instance.is_alive() is False
 
-    send_result = await instance.send(text="echo too_late", keys="Enter")
-    assert "error" in send_result, (
-        f"send after close should return an error envelope, got {send_result!r}"
-    )
-    read_result = await instance.read()
-    assert "error" in read_result, (
-        f"read after close should return an error envelope, got {read_result!r}"
-    )
+    assert "error" in await instance.send(text="echo too_late", keys="Enter")
+    assert "error" in await instance.read()

--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -21,7 +21,6 @@ capture.
 from __future__ import annotations
 
 import asyncio
-import shlex
 import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -39,6 +38,11 @@ pytestmark = pytest.mark.skipif(
 
 _MARKER_BUDGET_S = 5.0
 _POLL_INTERVAL_S = 0.1
+
+
+def _dewrap(screen: str) -> str:
+    """Join the pane's ``-x 80`` soft-wrapped rows so a needle straddling the wrap matches."""
+    return screen.replace("\n", "")
 
 
 def _bash_spec(cwd: Path, *, allow_cwd_override: bool = False) -> TerminalEnvSpec:
@@ -67,7 +71,7 @@ async def _read_until(
     waited = 0.0
     screen = ""
     while waited < budget_s:
-        screen = (await instance.read()).get("screen", "")
+        screen = _dewrap((await instance.read()).get("screen", ""))
         if needle in screen:
             return screen
         await asyncio.sleep(_POLL_INTERVAL_S)
@@ -127,7 +131,7 @@ async def test_working_directory_change_persists_across_sends(
     subdir.mkdir()
     instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
 
-    await instance.send(text=f"cd {shlex.quote(str(subdir))}", keys="Enter")
+    await instance.send(text="cd nested_dir", keys="Enter")
     await instance.send(text="pwd", keys="Enter")
 
     needle = _path_tail(tmp_path.name, "nested_dir")

--- a/tests/terminals/test_registry_io.py
+++ b/tests/terminals/test_registry_io.py
@@ -1,0 +1,429 @@
+"""
+Behavioral I/O tests for :class:`omnigent.terminals.TerminalRegistry`
+driven against a real tmux.
+
+These complement :mod:`tests.terminals.test_registry` (which pins the
+registry's *lifecycle* invariants — launch / get / close / list /
+cleanup / shutdown — but never sends a keystroke or reads a byte) and
+:mod:`tests.tools.builtins.test_sys_terminal` (which drives the same
+behaviors through the ``sys_terminal_*`` tool envelopes). The module
+here exercises the load-bearing capabilities that
+``sys_terminal_*`` adds over a one-shot ``sys_os_shell`` — interactive
+state that survives across calls, cwd anchoring of the live shell,
+control-key delivery, and per-session isolation — at the tightest
+layer that still touches a real tmux: ``TerminalRegistry.launch`` →
+``TerminalInstance.send`` / ``.read``.
+
+Why this layer (not the e2e suite): the equivalent end-to-end
+coverage in ``tests/e2e/test_sys_terminal_e2e.py`` is fully suppressed
+in ``tests/known_failures.yaml`` (cluster ``terminal-d6``, "requires
+running runner") because it needs a live runner shard and a real LLM.
+These tests reach the same tmux behaviors deterministically — no
+runner, no LLM, no flakiness from prose — so the capability keeps
+durable coverage in the normal ``tests/terminals`` CI shard, which
+installs tmux (see ``.github/workflows/ci.yml``).
+
+Every test launches a real tmux and is skipped when tmux is not on
+PATH. ``send`` is asynchronous from the shell's perspective (tmux
+delivers keystrokes, the shell renders on its own clock), so reads
+poll with a bounded budget rather than asserting on a single capture.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
+from omnigent.inner.terminal import TerminalInstance
+from omnigent.terminals import TerminalRegistry
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("tmux") is None,
+    reason="tmux not installed; registry I/O tests need a real tmux on PATH",
+)
+
+# Bounded poll budget for a marker to render in the pane. tmux delivers
+# send-keys and the shell echoes on its own clock; a fixed sleep either
+# wastes time or races. 5s comfortably covers a cold bash prompt plus
+# echo on a loaded CI box while keeping a hung shell from stalling the
+# suite. The matching round-trip test in
+# ``tests/tools/builtins/test_sys_terminal.py`` uses a ~2s budget; this
+# is deliberately roomier because some tests here chain two sends.
+_MARKER_BUDGET_S = 5.0
+_POLL_INTERVAL_S = 0.1
+
+
+def _bash_spec(cwd: Path, *, allow_cwd_override: bool = False) -> TerminalEnvSpec:
+    """A minimal bash :class:`TerminalEnvSpec` anchored at *cwd*, sandbox off.
+
+    Sandbox is forced to ``none`` so the test doesn't depend on
+    bwrap / seatbelt availability — these tests exercise tmux I/O,
+    not sandboxing (covered elsewhere). The cwd is set on the
+    terminal's own ``os_env`` so the launched shell starts there.
+
+    :param cwd: Directory the spawned shell starts in.
+    :param allow_cwd_override: Whether per-launch ``cwd_override`` is
+        permitted. Defaults to ``False`` (matches the spec default).
+    :returns: A :class:`TerminalEnvSpec` ready to launch.
+    """
+    return TerminalEnvSpec(
+        command="bash",
+        allow_cwd_override=allow_cwd_override,
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=str(cwd),
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+
+
+async def _read_until(
+    instance: TerminalInstance,
+    needle: str,
+    *,
+    budget_s: float = _MARKER_BUDGET_S,
+) -> str:
+    """Poll ``instance.read`` until *needle* shows in the pane or budget elapses.
+
+    :param instance: The launched terminal to read from.
+    :param needle: Substring expected to appear in the pane capture.
+    :param budget_s: Total seconds to poll before giving up.
+    :returns: The last pane ``screen`` text observed — contains
+        *needle* on success, or the final capture (for a useful
+        failure message) on timeout.
+    """
+    import asyncio
+
+    waited = 0.0
+    screen = ""
+    while waited < budget_s:
+        result = await instance.read()
+        screen = result.get("screen", "")
+        if needle in screen:
+            return screen
+        await asyncio.sleep(_POLL_INTERVAL_S)
+        waited += _POLL_INTERVAL_S
+    return screen
+
+
+@pytest.fixture
+def reg() -> TerminalRegistry:
+    """A fresh registry per test."""
+    return TerminalRegistry()
+
+
+@pytest.fixture
+async def cleanup(reg: TerminalRegistry) -> AsyncIterator[None]:
+    """Close every terminal at test exit, even when an assertion fails.
+
+    Declared to depend on ``reg`` so its teardown runs before the
+    registry fixture is discarded — otherwise a failed assertion
+    mid-test would leak a live tmux server.
+
+    :param reg: The registry fixture whose terminals get torn down.
+    :yields: ``None`` — the value is unused; the fixture exists for
+        its teardown side effect.
+    """
+    yield
+    await reg.shutdown()
+
+
+# ── Interactive state persistence ─────────────────────────────
+
+
+async def test_shell_state_persists_across_separate_sends(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """A variable set in one ``send`` is still set in a later ``send``.
+
+    This is the load-bearing capability ``sys_terminal_*`` adds over a
+    one-shot ``sys_os_shell``: the shell is a single long-lived process
+    across calls, so state (here a shell variable) set by the first
+    send is visible to the second. A naive "spawn a fresh shell per
+    send" implementation would pass every lifecycle test in
+    :mod:`tests.terminals.test_registry` yet fail here, because the
+    second send would run in a shell that never saw the assignment.
+
+    Mirrors the suppressed
+    ``test_sys_terminal_persists_across_turns_e2e`` (which proves the
+    same thing across two LLM turns) at the registry→tmux layer.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture.
+    :param tmp_path: Per-test working directory for the shell.
+    """
+    del cleanup
+    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
+
+    # First send establishes state; second send observes it. Two
+    # distinct send() calls — not one compound command — so the test
+    # actually proves cross-call persistence.
+    await instance.send(text="MARKER_VAR=persisted_value", keys="Enter")
+    await instance.send(text="echo VAR_IS_$MARKER_VAR", keys="Enter")
+
+    screen = await _read_until(instance, "VAR_IS_persisted_value")
+    assert "VAR_IS_persisted_value" in screen, (
+        "Shell variable set in the first send was not visible in the "
+        "second. The shell is supposed to be one long-lived process "
+        "across send() calls; if this fails, each send is spawning a "
+        f"fresh shell (state lost). Last pane:\n{screen!r}"
+    )
+
+
+async def test_working_directory_change_persists_across_sends(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """A ``cd`` in one send is reflected by ``pwd`` in a later send.
+
+    The directory-state analogue of the variable-persistence test —
+    and the exact behavior the suppressed persistence e2e asserts
+    (``cd /tmp`` in turn 1, ``pwd`` shows ``/tmp`` in turn 2). Proving
+    it here at the tmux layer removes the dependency on a live runner.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture.
+    :param tmp_path: Working directory; a ``subdir`` is created to cd into.
+    """
+    del cleanup
+    subdir = tmp_path / "nested_dir"
+    subdir.mkdir()
+    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
+
+    await instance.send(text=f"cd {subdir}", keys="Enter")
+    await instance.send(text="pwd", keys="Enter")
+
+    # macOS resolves /var -> /private/var; accept either spelling by
+    # matching the leaf directory name, which is unambiguous here.
+    screen = await _read_until(instance, "nested_dir")
+    assert "nested_dir" in screen, (
+        "cd from the first send did not persist into the second send's "
+        f"pwd. The session lost its working directory. Last pane:\n{screen!r}"
+    )
+
+
+# ── cwd anchoring of the live shell ───────────────────────────
+
+
+async def test_launched_shell_starts_in_spec_cwd(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """``pwd`` in a freshly launched shell reports the spec's cwd.
+
+    Unit tests in ``tests/tools/builtins/test_sys_terminal.py`` pin
+    ``_resolve_cwd``'s precedence logic in isolation, but nothing at
+    this layer proves the resolved cwd actually anchors the *live*
+    shell. This drives ``pwd`` against the real tmux and asserts the
+    shell landed where the spec said — the behavioral half of the
+    suppressed ``test_sys_terminal_cwd_default_is_workspace_e2e``.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture.
+    :param tmp_path: The directory the spec anchors the shell to.
+    """
+    del cleanup
+    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
+
+    await instance.send(text="pwd", keys="Enter")
+
+    leaf = tmp_path.name
+    screen = await _read_until(instance, leaf)
+    assert leaf in screen, (
+        f"Launched shell's pwd did not report the spec cwd {tmp_path}. "
+        f"The terminal landed somewhere other than its configured cwd. "
+        f"Last pane:\n{screen!r}"
+    )
+
+
+async def test_cwd_override_anchors_live_shell_in_subdirectory(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """A per-launch ``cwd_override`` starts the live shell in that subdir.
+
+    Complements the disallowed-override *rejection* test in the tool
+    suite: here the override is allowed and we prove it actually moves
+    the spawned shell's cwd (``pwd`` reports the subdirectory and the
+    instance records it on ``launch_cwd``). The override is contained
+    to a subdirectory of the spec cwd, matching
+    ``build_terminal_os_env_spec``'s containment guard.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture.
+    :param tmp_path: Spec cwd; a ``workdir`` subdir is the override target.
+    """
+    del cleanup
+    override_dir = tmp_path / "workdir"
+    override_dir.mkdir()
+    spec = _bash_spec(tmp_path, allow_cwd_override=True)
+
+    instance = await reg.launch(
+        "conv_a",
+        "bash",
+        "s1",
+        spec,
+        cwd_override=str(override_dir),
+    )
+
+    # The instance records the resolved launch cwd; assert it points
+    # at the override target (resolved for the macOS /var symlink).
+    assert instance.launch_cwd is not None
+    assert Path(instance.launch_cwd).name == "workdir", (
+        f"launch_cwd did not reflect the cwd_override; got "
+        f"{instance.launch_cwd!r}, expected a path ending in 'workdir'."
+    )
+
+    await instance.send(text="pwd", keys="Enter")
+    screen = await _read_until(instance, "workdir")
+    assert "workdir" in screen, (
+        "cwd_override did not anchor the live shell: pwd never reported "
+        f"the override subdirectory. Last pane:\n{screen!r}"
+    )
+
+
+# ── Control-key delivery ──────────────────────────────────────
+
+
+async def test_ctrl_c_interrupts_running_command(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """``keys="C-c"`` interrupts a running foreground command.
+
+    Exercises the ``send`` path's control-key handling (``text=None``,
+    ``keys="C-c"``) against a live shell — the interactive capability
+    that distinguishes ``sys_terminal_*`` from a one-shot command run.
+    A long ``sleep`` is started, interrupted with C-c, and a marker
+    echo afterward proves the shell returned to its prompt rather than
+    staying blocked in the sleep.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture.
+    :param tmp_path: Working directory for the shell.
+    """
+    import asyncio
+
+    del cleanup
+    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
+
+    # Start a long-running foreground command, then let it actually
+    # begin before interrupting (a C-c that lands before the shell
+    # forks `sleep` would just edit the command line).
+    await instance.send(text="sleep 120", keys="Enter")
+    await asyncio.sleep(0.4)
+
+    # Interrupt: no literal text, just the control key.
+    interrupt = await instance.send(text=None, keys="C-c")
+    assert interrupt.get("status") == "sent", (
+        f"send of C-c did not report status='sent': {interrupt!r}"
+    )
+
+    # If the interrupt worked, the shell is back at a prompt and this
+    # echo runs promptly. If C-c was swallowed, the echo sits behind a
+    # 120s sleep and the marker never shows within the budget.
+    await instance.send(text="echo INTERRUPT_RECOVERED_OK", keys="Enter")
+    screen = await _read_until(instance, "INTERRUPT_RECOVERED_OK")
+    assert "INTERRUPT_RECOVERED_OK" in screen, (
+        "Marker echo did not appear after C-c, so the interrupt didn't "
+        "return the shell to its prompt — the foreground `sleep` was "
+        f"never interrupted. Last pane:\n{screen!r}"
+    )
+
+
+# ── Parallel-session isolation (driven by real I/O) ───────────
+
+
+async def test_parallel_sessions_have_isolated_shell_state(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """Two sessions of the same terminal don't share shell state.
+
+    ``test_registry.py`` proves distinct session keys yield distinct
+    instances and sockets (object identity); this proves the stronger
+    *behavioral* property the design promises — independent tmux
+    sessions running in parallel — by setting the same variable name to
+    different values in each and confirming each session reports only
+    its own value. A registry bug that collapsed ``(name, key)`` to
+    ``name`` (one shared tmux) would surface here as cross-talk even if
+    the socket-identity assertions elsewhere still passed.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture.
+    :param tmp_path: Working directory shared by both sessions (state
+        isolation is per-shell-process, not per-cwd).
+    """
+    del cleanup
+    spec = _bash_spec(tmp_path)
+    s1 = await reg.launch("conv_a", "bash", "s1", spec)
+    s2 = await reg.launch("conv_a", "bash", "s2", spec)
+
+    assert s1 is not s2
+    assert s1.socket_path != s2.socket_path
+
+    # Same variable name, different values, one per session.
+    await s1.send(text="SESSION_TAG=alpha_one", keys="Enter")
+    await s2.send(text="SESSION_TAG=beta_two", keys="Enter")
+    await s1.send(text="echo TAG=$SESSION_TAG", keys="Enter")
+    await s2.send(text="echo TAG=$SESSION_TAG", keys="Enter")
+
+    s1_screen = await _read_until(s1, "TAG=alpha_one")
+    s2_screen = await _read_until(s2, "TAG=beta_two")
+
+    assert "TAG=alpha_one" in s1_screen, (
+        f"Session s1 did not report its own value. Pane:\n{s1_screen!r}"
+    )
+    assert "TAG=beta_two" in s2_screen, (
+        f"Session s2 did not report its own value. Pane:\n{s2_screen!r}"
+    )
+    # The load-bearing isolation assertion: neither session sees the
+    # other's value. Cross-talk here means the two session keys are
+    # backed by a single shared tmux session.
+    assert "beta_two" not in s1_screen, (
+        "Session s1's pane shows session s2's value — the two session "
+        f"keys are not isolated. s1 pane:\n{s1_screen!r}"
+    )
+    assert "alpha_one" not in s2_screen, (
+        "Session s2's pane shows session s1's value — the two session "
+        f"keys are not isolated. s2 pane:\n{s2_screen!r}"
+    )
+
+
+# ── Read-after-close error contract ───────────────────────────
+
+
+async def test_send_and_read_after_close_report_not_running(
+    reg: TerminalRegistry, cleanup: None, tmp_path: Path
+) -> None:
+    """Once closed, the instance's ``send`` / ``read`` error cleanly.
+
+    ``test_registry.py`` proves ``close`` removes the registry *entry*;
+    this proves the *instance* object refuses I/O afterward instead of
+    talking to a dead tmux socket. The ``send`` tool path surfaces this
+    as a "not running" error to the LLM, so the instance-level contract
+    matters: a stale read against a killed server must not hang or
+    return garbage.
+
+    :param reg: Fresh registry.
+    :param cleanup: Teardown side-effect fixture (idempotent with the
+        explicit close below).
+    :param tmp_path: Working directory for the shell.
+    """
+    del cleanup
+    instance = await reg.launch("conv_a", "bash", "s1", _bash_spec(tmp_path))
+    assert await instance.is_alive()
+
+    closed = await reg.close("conv_a", "bash", "s1")
+    assert closed is True
+
+    assert instance.running is False
+    assert await instance.is_alive() is False
+
+    send_result = await instance.send(text="echo too_late", keys="Enter")
+    assert "error" in send_result, (
+        f"send after close should return an error envelope, got {send_result!r}"
+    )
+    read_result = await instance.read()
+    assert "error" in read_result, (
+        f"read after close should return an error envelope, got {read_result!r}"
+    )


### PR DESCRIPTION
test(terminals): add registry→tmux behavioral I/O coverage for sys_terminal_*

## What & why

The task brief asked me to add coverage for the `sys_terminal_*` / `TerminalRegistry` → tmux capability, on the premise that it had **zero coverage anywhere**.

**That premise turned out to be outdated.** Substantial coverage already exists and runs in the normal `tests/terminals tests/tools` / `tests/inner` CI shards (`.github/workflows/ci.yml` installs tmux):

- `tests/terminals/test_registry.py` — real-tmux launch / get / close / list / isolation / cleanup / shutdown lifecycle, plus pure bookkeeping.
- `tests/tools/builtins/test_sys_terminal.py` — real-tmux launch→send→read→close round trip, idempotency, multi-session sockets, `_resolve_cwd` precedence, concurrent-send per-instance lock.
- `tests/inner/test_terminal.py` — send chunking, launch env stripping, idle detector, orphan reap.

I verified all existing tests pass locally, and that `ci.yml` runs these shards with tmux installed (so they are not silently skipped in CI).

## The genuine gap I filled

The **interactive** behaviors — the load-bearing capabilities `sys_terminal_*` adds over a one-shot `sys_os_shell` — only existed in the **fully-suppressed** `tests/e2e/test_sys_terminal_e2e.py` (suppressed in `tests/known_failures.yaml`, cluster `terminal-d6`, "requires running runner"). `test_registry.py` never sends a keystroke or reads a byte.

This PR adds **`tests/terminals/test_registry_io.py`** (6 tests), driving `TerminalRegistry.launch` → `TerminalInstance.send`/`.read` against a real tmux at the tightest reliable layer — no runner, no LLM, deterministic. Skipped when tmux is absent (matches the conventions of the sibling tests). Covers:

| Test | Behavior | Mirrors suppressed e2e |
|------|----------|------------------------|
| `test_shell_state_persists_across_separate_sends` | var set in send 1 visible in send 2 | `persists_across_turns_e2e` |
| `test_working_directory_change_persists_across_sends` | `cd` in send 1, `pwd` in send 2 | `persists_across_turns_e2e` |
| `test_launched_shell_starts_in_spec_cwd` | live shell anchors to spec cwd | `cwd_default_is_workspace_e2e` |
| `test_cwd_override_anchors_live_shell_in_subdirectory` | `cwd_override` moves the live shell | (new behavioral coverage) |
| `test_ctrl_c_interrupts_running_command` | `keys="C-c"` interrupts a foreground command | `send_keys_drives_interactive_e2e` |
| `test_send_and_read_after_close_report_not_running` | post-close `send`/`read` return error envelopes | — |

## Removed: redundant parallel-isolation test

A follow-up audit dropped `test_parallel_sessions_have_isolated_shell_state` (commit `54925d9`). It only added keystroke-level cross-talk on top of the `(name, session_key)` isolation property **already guarded twice on main**:

- `tests/terminals/test_registry.py::test_distinct_session_keys_get_distinct_instances`
- `tests/tools/builtins/test_sys_terminal.py::test_multiple_sessions_per_terminal_are_independent`

Those two are cheaper (no tmux-keystroke flake surface) and fully cover the isolation guarantee, so the I/O-level duplicate earned its keep nowhere. The shared helpers it used (`_dewrap`, `_read_until`, `_echo_only_on_run`, `_bash_spec`, `_path_tail`) are all still used by the retained tests and were kept.

## Defect found?

**No.** I drove every behavior against real tmux during investigation and the capability works correctly end-to-end (persistence, cwd default + override, C-c, isolation, close teardown). No product fix needed — every change in this PR is to the test file.

## Follow-up commits (review + flake hardening)

After the initial commit, two issues were addressed so the file is load-stable and the assertions are honest:

1. **80-column wrap flake (CI `Pytest (repl-sdk)`).** The pane is created at `-x 80`. A long `pwd` (longer under xdist's `popen-gwN/` tmp paths) soft-wraps mid-path, splitting a two-segment path needle across physical lines, so a contiguous-substring match never succeeded regardless of the existing poll budget — intermittent red under parallel load. Fixed by joining the soft-wrapped rows (`_dewrap`) before matching, so every send-then-snapshot assertion matches the logical line the shell produced. Reproduced the old failure deterministically under a long `--basetemp` (identical CI signature) and confirmed the fix passes there.

2. **C-c false-pass closed.** `test_ctrl_c_interrupts_running_command` could pass without proving an interrupt: if C-c landed on an empty prompt (job not yet executing), the recovery echo still printed. It now (a) sends C-c only after the foreground job's **own output** proves it is executing, (b) chains `echo … && sleep 120 && echo NOT_INTERRUPTED` so a successful SIGINT short-circuits the post-sleep marker, and (c) asserts both that the recovery marker **appears** and that the not-interrupted marker is **absent**. Markers are emitted via a helper that splits the literal (`echo FOREGROUN""D_RUNNING`) so a needle can only match real command output, never the keystroke echo. Verified with a mutation (no-op C-c → test fails) and a negative control (no interrupt → not-interrupted marker present), so the assertion has teeth.

## Comments / style

The file keeps a module docstring, one docstring per test, and docstrings on the helpers (`_dewrap`, `_echo_only_on_run`, `_read_until`, `_path_tail`) as documentation; there are no inline `#` comments. The earlier noisy inline comments were removed.

## What is and isn't covered

- **Covered (now durable, in normal CI):** registry-level interactive send/read, state persistence, cwd anchoring (default + override), control keys, close error contract — in addition to the pre-existing lifecycle / tool-envelope / inner-mechanics coverage. Parallel `(name, session_key)` isolation stays covered by `test_registry.py` + `test_sys_terminal.py` (see "Removed" above).
- **Not covered here (by design):** the live-LLM + runner path (`test_sys_terminal_e2e.py`), which remains suppressed pending the `terminal-d6` runner-shard work — out of scope per the brief. Sandboxed (bwrap/seatbelt) terminal launches: forced `sandbox=none` here since these tests exercise tmux I/O, not sandboxing (covered elsewhere). The omnigent-YAML `terminals:` → `AgentSpec.terminals` threading and `ToolManager` registration already have unit coverage.

## Gates

- `ruff check` + `ruff format`: clean.
- `pytest tests/terminals/test_registry_io.py -v`: 6 passed.
- Stress (after both follow-up fixes): full file green at serial 20× and parallel `-n auto` 6×, plus serial 30× / parallel 10× on the prior fix — 0 failures, no FD exhaustion. The 80-col flake fix additionally verified deterministic under a wrapping `--basetemp` (old behavior fails, fixed passes).
- Scope limited to the one new test file. No CI workflow files touched.

Note: pre-existing failures in `tests/terminals/test_ws_bridge.py` are environmental (deeply-nested worktree path exceeds the macOS unix-socket name limit; those tests pass `tmp_path` directly as the socket dir). Confirmed present without my change. My tests use short temp paths and are unaffected.
