### PR TITLE
Fix Cursor model switch display aliases

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -71,6 +71,13 @@ ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # typ
 # ``None``).
 _DEFAULT_CURSOR_MODEL = "auto"
 
+# Cursor-facing UI surfaces can expose human labels while the SDK only accepts
+# catalog ids. Keep the small compatibility map here so stale session overrides
+# and CLI/web free-text paths converge before agent creation.
+_CURSOR_MODEL_ALIASES: dict[str, str] = {
+    "composer": "composer-2.5",
+}
+
 # Upper bound (seconds) on one bridged-tool call: generous (sub-agent dispatches
 # can run for minutes) but finite, so a wedged tool surfaces a timeout error
 # instead of blocking the SDK's daemon callback thread forever.
@@ -80,12 +87,22 @@ _TOOL_CALL_TIMEOUT_S = 1800.0
 def _resolve_model(model: str | None) -> str:
     """Resolve the cursor model id, dropping ids cursor can't honor.
 
-    cursor-sdk accepts only Cursor model ids (``auto``, ``gpt-5``,
+    cursor-sdk accepts only Cursor model ids (``auto``, ``default``,
     ``composer-2.5``, ...), so a gateway-routed model id (carried by a spec
-    authored for another harness) falls back to cursor's auto-select. ``None``
-    likewise resolves to ``auto`` (the SDK requires a model).
+    authored for another harness) falls back to cursor's auto-select. Known
+    display labels from UI/free-text switchers are translated to SDK ids before
+    agent creation. ``None`` likewise resolves to ``auto`` (the SDK requires a
+    model).
     """
-    if not model or model.startswith(("databricks-", "databricks/")):
+    requested = (model or "").strip()
+    if not requested:
+        return _DEFAULT_CURSOR_MODEL
+
+    alias = _CURSOR_MODEL_ALIASES.get(requested.lower())
+    if alias is not None:
+        return alias
+
+    if requested.startswith(("databricks-", "databricks/")):
         if model:
             # Warn, not debug: the requested model is silently NOT honored, and
             # a debug line is invisible in the harness subprocess — so a user who
@@ -93,11 +110,11 @@ def _resolve_model(model: str | None) -> str:
             logger.warning(
                 "CursorExecutor: requested model %r is not a Cursor model id; "
                 "falling back to %r auto-select.",
-                model,
+                requested,
                 _DEFAULT_CURSOR_MODEL,
             )
         return _DEFAULT_CURSOR_MODEL
-    return model
+    return requested
 
 
 def _tools_fingerprint(tools: list[ToolSpec]) -> str:

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -27,6 +27,7 @@ from omnigent.inner.cursor_executor import (
     _sdk_message_to_events,
 )
 from omnigent.inner.executor import (
+    ExecutorConfig,
     ExecutorError,
     Message,
     ReasoningChunk,
@@ -172,6 +173,14 @@ def test_resolve_model_drops_databricks_and_defaults_to_auto() -> None:
     assert _resolve_model("databricks-claude-sonnet-4-6") == "auto"
     assert _resolve_model("databricks/kimi") == "auto"
     assert _resolve_model(None) == "auto"
+
+
+def test_resolve_model_maps_cursor_display_label_to_sdk_id() -> None:
+    # The web/free-text model switch path can persist a display label. Cursor
+    # SDK rejects "Composer" but accepts the catalog id.
+    assert _resolve_model("Composer") == "composer-2.5"
+    assert _resolve_model(" composer ") == "composer-2.5"
+    assert _resolve_model("composer-2.5") == "composer-2.5"
 
 
 def test_resolve_model_warns_when_dropping_a_pinned_model(
@@ -449,6 +458,38 @@ async def test_databricks_model_resolved_to_auto(monkeypatch: pytest.MonkeyPatch
     finally:
         await executor.close()
     assert state["create_models"] == ["auto"]
+
+
+async def test_cursor_display_label_model_resolved_before_agent_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    executor = CursorExecutor(model="Composer", api_key="crsr_x")
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    assert state["create_models"] == ["composer-2.5"]
+
+
+async def test_cursor_display_label_config_override_resolved_before_agent_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    executor = CursorExecutor(model="default", api_key="crsr_x")
+    try:
+        _ = [
+            e
+            async for e in executor.run_turn(
+                [_user("hi")],
+                [],
+                "SYS",
+                config=ExecutorConfig(model="Composer"),
+            )
+        ]
+    finally:
+        await executor.close()
+    assert state["create_models"] == ["composer-2.5"]
 
 
 async def test_api_key_threaded_to_create(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- normalize Cursor model display label overrides such as `Composer` to the SDK id `composer-2.5` before creating the Cursor agent
- trim Cursor model overrides while preserving the existing Databricks-to-auto fallback
- add fake-SDK regression coverage for constructor and per-turn config model overrides

Fixes #547

## Tests
- `PYTHONPATH=... .venv/bin/python -m pytest -p pytest_harness_option --confcutdir=tests/inner tests/inner/test_cursor_executor.py -q` (35 passed; used cached package paths because full `uv --extra dev` setup could not fetch PyPI in this sandbox)
