### PR TITLE
fix(runner): stop mangling callable tool import paths into the workdir (policy tool_call gap #525)

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2956,6 +2956,14 @@ class _SessionSnapshot:
     sub_agent_name: str | None = None
 
 
+# Match the language constant the omnigent YAML translator stamps on
+# callable-backed tools (omnigent/spec/omnigent.py:OMNIGENT_TOOL_LANGUAGE).
+# Duplicated rather than imported to avoid pulling the heavy translator
+# module in for one string — same rationale as
+# omnigent/tools/local_callable.py.
+_OMNIGENT_CALLABLE_LANGUAGE = "omnigent-python-callable"
+
+
 def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
     if workdir is None or spec is None:
         return spec
@@ -2966,7 +2974,17 @@ def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
     changed = False
     for info in local_tools:
         path = getattr(info, "path", None)
-        if path and not Path(path).is_absolute():
+        # Only file-based local tools carry a workdir-relative path
+        # (e.g. ``tools/python/foo.py``). Callable-backed tools store a
+        # dotted import path (``pkg.mod.func``) in the same field; joining
+        # that to the workdir corrupts it into a bogus filesystem path, the
+        # import fails, the tool never registers, and any tool_call policy
+        # narrowed to it can never fire.
+        if (
+            path
+            and getattr(info, "language", None) != _OMNIGENT_CALLABLE_LANGUAGE
+            and not Path(path).is_absolute()
+        ):
             resolved_tools.append(dataclasses.replace(info, path=str((workdir / path).resolve())))
             changed = True
         else:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2956,12 +2956,30 @@ class _SessionSnapshot:
     sub_agent_name: str | None = None
 
 
-# Match the language constant the omnigent YAML translator stamps on
-# callable-backed tools (omnigent/spec/omnigent.py:OMNIGENT_TOOL_LANGUAGE).
-# Duplicated rather than imported to avoid pulling the heavy translator
-# module in for one string — same rationale as
-# omnigent/tools/local_callable.py.
+# Language constant the omnigent YAML translator stamps on callable-backed
+# tools (omnigent/spec/omnigent.py:OMNIGENT_TOOL_LANGUAGE). Duplicated rather
+# than imported to avoid pulling the heavy translator module in for one
+# string — same rationale as omnigent/tools/local_callable.py.
 _OMNIGENT_CALLABLE_LANGUAGE = "omnigent-python-callable"
+
+
+def _looks_like_file_path(path: str) -> bool:
+    """
+    Return whether *path* is a filesystem path rather than a dotted import.
+
+    File-based local tools are discovered as ``tools/python/foo.py`` /
+    ``tools/typescript/foo.ts`` — always carrying a path separator and a
+    source extension (see :func:`omnigent.spec.parser._discover_local_tools`).
+    Callable-backed tools store a dotted import path (``pkg.mod.func``) in the
+    same field — no separator, no source extension. This structural test is
+    the primary guard so a rename of the callable-tool *language* string can
+    never reintroduce the workdir-mangling bug.
+
+    :param path: A :class:`LocalToolInfo` ``path`` value.
+    :returns: ``True`` when *path* is a file path safe to resolve onto the
+        workdir; ``False`` for dotted import paths.
+    """
+    return "/" in path or os.sep in path or path.endswith((".py", ".ts"))
 
 
 def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
@@ -2974,15 +2992,16 @@ def _spec_with_workdir_paths(spec: Any, workdir: Path | None) -> Any:
     changed = False
     for info in local_tools:
         path = getattr(info, "path", None)
-        # Only file-based local tools carry a workdir-relative path
-        # (e.g. ``tools/python/foo.py``). Callable-backed tools store a
-        # dotted import path (``pkg.mod.func``) in the same field; joining
-        # that to the workdir corrupts it into a bogus filesystem path, the
-        # import fails, the tool never registers, and any tool_call policy
-        # narrowed to it can never fire.
+        # Only resolve genuine file paths onto the workdir. Callable-backed
+        # tools store a dotted import path (``pkg.mod.func``) in the same
+        # field; joining that to the workdir corrupts it, the import fails,
+        # the tool never registers, and any tool_call policy narrowed to it
+        # can never fire. The structural file-vs-dotted check is the primary
+        # guard; the language check is belt-and-suspenders.
         if (
             path
             and getattr(info, "language", None) != _OMNIGENT_CALLABLE_LANGUAGE
+            and _looks_like_file_path(path)
             and not Path(path).is_absolute()
         ):
             resolved_tools.append(dataclasses.replace(info, path=str((workdir / path).resolve())))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -730,6 +730,7 @@ def register_inline_agent(
     prompt: str,
     mock_llm_base_url: str | None = None,
     builtin_tools: list[str] | None = None,
+    extra_config: dict[str, Any] | None = None,
 ) -> str:
     """
     Register a single-file omnigent agent built in-memory.
@@ -751,6 +752,9 @@ def register_inline_agent(
         instead of ``api.openai.com``.
     :param builtin_tools: When set, add a ``tools.builtins`` list to
         the agent spec, e.g. ``["list_files", "upload_file"]``.
+    :param extra_config: When set, top-level keys shallow-merged into
+        the agent YAML before upload (e.g. ``tools`` and ``policies``).
+        ``name``/``prompt``/``executor`` stay helper-controlled.
     :returns: The agent name (use the return value, not the *name*
         argument, they differ on rerun attempts).
     """
@@ -779,6 +783,14 @@ def register_inline_agent(
     }
     if builtin_tools:
         config["tools"] = {"builtins": builtin_tools}
+    if extra_config:
+        for key, value in extra_config.items():
+            config[key] = value
+        # Reapply identity keys so a stray override can't desync the
+        # agent name the caller gets back from later turns.
+        config["name"] = name
+        config["prompt"] = prompt
+        config["executor"] = executor
     with io.BytesIO() as buf:
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
             yaml_bytes = yaml.dump(config).encode()

--- a/tests/e2e/test_tool_call_policy_e2e.py
+++ b/tests/e2e/test_tool_call_policy_e2e.py
@@ -1,0 +1,162 @@
+"""
+E2E proof that a YAML ``tool_call`` DENY policy blocks a user
+function tool end-to-end under the mock-LLM session-native path.
+
+Drives the full openai-agents runner topology: an inline agent
+declares a ``type: function`` tool (``calculate``, a dotted
+callable) plus a ``type: function`` policy that DENYs the
+``calculate`` tool at the ``tool_call`` phase. The mock LLM is
+scripted to call ``calculate`` and then acknowledge the denial.
+
+The bug this guards against: the runner's ``_spec_with_workdir_paths``
+used to join the agent workdir onto every local tool's ``path`` —
+including the dotted import path of a callable-backed tool. That
+corrupted ``tests.x.calculate`` into ``<workdir>/tests.x.calculate``,
+the import failed, the tool never registered, and the LLM's call hit
+"Tool calculate not found" — so the TOOL_CALL policy never even ran
+(no tool to deny). The fix leaves dotted callable paths untouched, the
+tool registers, and the policy DENY surfaces as the tool output.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import httpx
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+
+# Unique reason string — chosen so its presence proves OUR policy
+# fired, not an incidental denial from another path.
+_DENY_REASON = "TOOL_BAN_TEST_SENTINEL_XYZQ"
+
+
+def _tool_outputs(body: dict[str, Any]) -> list[str]:
+    """Pull every ``function_call_output`` payload from a response body."""
+    return [
+        item.get("output", "")
+        for item in body.get("output", [])
+        if item.get("type") == "function_call_output"
+    ]
+
+
+def _all_text(body: dict[str, Any]) -> str:
+    """Concatenate every assistant message text block in a response body."""
+    parts: list[str] = []
+    for item in body.get("output", []):
+        if item.get("type") == "message":
+            for block in item.get("content", []):
+                text = block.get("text")
+                if text:
+                    parts.append(text)
+    return "\n".join(parts)
+
+
+def test_tool_call_deny_blocks_callable_tool(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str | None,
+) -> None:
+    """
+    A ``tool_call:calculate`` DENY policy intercepts the tool, returns
+    the deny sentinel as the tool output, and the real callable never
+    runs.
+
+    Asserts:
+
+    - The session completes (the deny path doesn't crash the turn).
+    - The deny sentinel is the ``calculate`` tool output.
+    - The real answer ``12`` never appears in any tool output (the
+      callable was short-circuited, not executed).
+    """
+    model = f"mock-toolpolicy-{uuid.uuid4().hex[:6]}"
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = register_inline_agent(
+        http_client,
+        name=f"toolpolicy-{uuid.uuid4().hex[:6]}",
+        harness="openai-agents",
+        model=model,
+        profile="",
+        prompt=(
+            "Use calculate to answer. If the tool output starts with "
+            "'[Denied by policy' or mentions a denial, reply that the "
+            "calculation was denied. Do not retry."
+        ),
+        mock_llm_base_url=(f"{mock_llm_server_url}/v1" if mock_llm_server_url else None),
+        extra_config={
+            "tools": {
+                "calculate": {
+                    "type": "function",
+                    "description": "Evaluate a math expression.",
+                    "callable": (
+                        "tests.resources.examples._shared.tool_functions.calculate"
+                    ),
+                },
+            },
+            "policies": {
+                "deny_calculate_tool": {
+                    "type": "function",
+                    "on": ["tool_call:calculate"],
+                    "function": {
+                        "path": "omnigent.policies.function.make_fixed_action_callable",
+                        "arguments": {
+                            "action": "deny",
+                            "reason": _DENY_REASON,
+                            "on_phases": ["tool_call"],
+                            "on_tools": ["calculate"],
+                        },
+                    },
+                },
+            },
+        },
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_calc1",
+                        "name": "calculate",
+                        "arguments": '{"expression": "6 + 6"}',
+                    },
+                ],
+            },
+            {"text": "the calculation was denied"},
+        ],
+        key=model,
+    )
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    response_id = send_user_message_to_session(
+        http_client, session_id=session_id, content="What is 6 + 6?"
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=60
+    )
+
+    assert body.get("status") == "completed", (
+        f"turn did not complete cleanly: status={body.get('status')!r} "
+        f"error={body.get('error')!r}"
+    )
+
+    outs = _tool_outputs(body)
+    assert any(_DENY_REASON in o or "Denied by policy" in o for o in outs), (
+        f"DENY sentinel missing from tool outputs — the tool_call policy "
+        f"did not fire (tool may have failed to register).\n"
+        f"tool outputs: {outs}\ntext: {_all_text(body)}"
+    )
+    assert not any("12" in o for o in outs), (
+        f"the real calculate ran (answer '12' leaked) — the DENY did not "
+        f"short-circuit dispatch.\ntool outputs: {outs}"
+    )

--- a/tests/e2e/test_tool_call_policy_e2e.py
+++ b/tests/e2e/test_tool_call_policy_e2e.py
@@ -96,9 +96,7 @@ def test_tool_call_deny_blocks_callable_tool(
                 "calculate": {
                     "type": "function",
                     "description": "Evaluate a math expression.",
-                    "callable": (
-                        "tests.resources.examples._shared.tool_functions.calculate"
-                    ),
+                    "callable": ("tests.resources.examples._shared.tool_functions.calculate"),
                 },
             },
             "policies": {
@@ -146,12 +144,11 @@ def test_tool_call_deny_blocks_callable_tool(
     )
 
     assert body.get("status") == "completed", (
-        f"turn did not complete cleanly: status={body.get('status')!r} "
-        f"error={body.get('error')!r}"
+        f"turn did not complete cleanly: status={body.get('status')!r} error={body.get('error')!r}"
     )
 
     outs = _tool_outputs(body)
-    assert any(_DENY_REASON in o or "Denied by policy" in o for o in outs), (
+    assert any(_DENY_REASON in o for o in outs), (
         f"DENY sentinel missing from tool outputs — the tool_call policy "
         f"did not fire (tool may have failed to register).\n"
         f"tool outputs: {outs}\ntext: {_all_text(body)}"

--- a/tests/runner/test_app_spec_workdir_paths.py
+++ b/tests/runner/test_app_spec_workdir_paths.py
@@ -1,0 +1,84 @@
+"""Tests for ``_spec_with_workdir_paths`` local-tool path resolution.
+
+The runner resolves workdir-relative tool paths to absolute paths so
+bundle-deployed file-based tools (``tools/python/foo.py``) load from the
+extracted image. Callable-backed tools (``language ==
+"omnigent-python-callable"``) store a DOTTED IMPORT PATH in the same
+field — that must be left untouched. Joining a dotted path onto the
+workdir corrupts ``pkg.mod.func`` into ``<workdir>/pkg.mod.func``, the
+import fails, the tool never registers, and any ``tool_call`` policy
+narrowed to it can never fire. These tests fail loudly if that
+distinction regresses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnigent.runner.app import _spec_with_workdir_paths
+from omnigent.spec.types import AgentSpec, LocalToolInfo
+
+
+def _spec_with_tools(tools: list[LocalToolInfo]) -> AgentSpec:
+    """Minimal AgentSpec carrying only the local tools under test."""
+    return AgentSpec(spec_version=1, name="probe", local_tools=tools)
+
+
+def test_callable_dotted_path_left_untouched() -> None:
+    """A dotted callable path survives workdir resolution unchanged.
+
+    The bug: the workdir got prepended onto the dotted import path, so
+    the tool failed to import and never registered — defeating any
+    tool_call policy on it.
+    """
+    spec = _spec_with_tools(
+        [
+            LocalToolInfo(
+                name="calculate",
+                path="tests.resources.examples._shared.tool_functions.calculate",
+                language="omnigent-python-callable",
+            )
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, Path("/tmp/agent-image"))
+
+    assert resolved.local_tools[0].path == (
+        "tests.resources.examples._shared.tool_functions.calculate"
+    )
+
+
+def test_file_based_relative_path_resolved_to_workdir(tmp_path: Path) -> None:
+    """A file-based tool's relative path IS joined onto the workdir."""
+    spec = _spec_with_tools(
+        [
+            LocalToolInfo(
+                name="arxiv_search",
+                path="tools/python/arxiv_search.py",
+                language="python",
+            )
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    assert resolved.local_tools[0].path == str(
+        (tmp_path / "tools/python/arxiv_search.py").resolve()
+    )
+
+
+def test_absolute_path_left_untouched(tmp_path: Path) -> None:
+    """An already-absolute file path is not re-joined."""
+    spec = _spec_with_tools(
+        [
+            LocalToolInfo(
+                name="arxiv_search",
+                path="/abs/tools/python/arxiv_search.py",
+                language="python",
+            )
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    assert resolved.local_tools[0].path == "/abs/tools/python/arxiv_search.py"

--- a/tests/runner/test_app_spec_workdir_paths.py
+++ b/tests/runner/test_app_spec_workdir_paths.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from omnigent.runner.app import _spec_with_workdir_paths
 from omnigent.spec.types import AgentSpec, LocalToolInfo
 
@@ -82,3 +84,30 @@ def test_absolute_path_left_untouched(tmp_path: Path) -> None:
     resolved = _spec_with_workdir_paths(spec, tmp_path)
 
     assert resolved.local_tools[0].path == "/abs/tools/python/arxiv_search.py"
+
+
+@pytest.mark.parametrize("language", ["omnigent-python-callable", "python", None])
+def test_dotted_path_untouched_regardless_of_language(
+    tmp_path: Path, language: str | None
+) -> None:
+    """A dotted import path survives even if its language field is wrong.
+
+    The structural file-vs-dotted discriminator must win over the language
+    string so a translator rename of the callable-tool language can't
+    silently reintroduce the workdir-mangling bug.
+    """
+    spec = _spec_with_tools(
+        [
+            LocalToolInfo(
+                name="calculate",
+                path="tests.resources.examples._shared.tool_functions.calculate",
+                language=language,  # type: ignore[arg-type]
+            )
+        ]
+    )
+
+    resolved = _spec_with_workdir_paths(spec, tmp_path)
+
+    assert resolved.local_tools[0].path == (
+        "tests.resources.examples._shared.tool_functions.calculate"
+    )


### PR DESCRIPTION
## Summary

A YAML `tool_call` DENY policy never fired for a **callable-backed function tool** under the session-native runner path (openai-agents harness). The deny sentinel was missing and the turn failed with "Tool `<name>` not found" — which read like a policy-wiring gap (issue #525, gap #2 / known-failure cluster #476).

The real cause is **upstream of policy enforcement, in tool registration**. The runner's `_spec_with_workdir_paths` joined the agent workdir onto every local tool's `path` — including the **dotted import path** of an `omnigent-python-callable` tool. That corrupted `pkg.mod.func` into `<workdir>/pkg.mod.func`, the import raised `ModuleNotFoundError`, the tool never registered, and the LLM's call hit "Tool not found". With no tool to dispatch, the TOOL_CALL policy never ran.

## Diagnosis

The prior investigation's premise ("the real tool ran / enforcement never engaged") was inaccurate. Instrumenting the dispatch path showed:

- `execute_tool` was **never reached** for the tool — it failed at registration.
- Runner log: workdir-mangle of `path='tests...calculate'` into `<workdir>/tests...calculate`, then `ModuleNotFoundError`, then `Tool calculate not found in agent Omnigent`.
- The `PolicyEngine` and `RunnerToolPolicyGate` both correctly return DENY in isolation — the wiring was fine; only registration was broken.

After the fix, the same probe shows the TOOL_CALL policy firing (`action=DENY`) and the `[Denied by policy: ...]` sentinel surfacing as the tool output.

## Fix

`_spec_with_workdir_paths` now skips `omnigent-python-callable` tools (their `path` is a dotted import, not a workdir-relative file) and only resolves the relative file paths of file-based (`python`) tools — which is what the join was for.

## Scope

- **tool_call phase**: fixed and covered by tests.
- **sub_agent phase** (same cluster): *separate matter, not addressed here.* Named inline sub-agents are reachable only via the generic `sys_session_send` builtin in the current architecture — there is no per-name `worker(...)` tool schema. The old `test_policy_denies_sub_agent_by_name` (and its `_make_tool_executor_bridge` / "Gap 8" references) targets an architecture that no longer exists; denying a named sub-agent now means a policy on `sys_session_send`, which is a larger design change.
- **output phase**: unaffected by this change.

## Tests

- `tests/runner/test_app_spec_workdir_paths.py` — unit coverage: callable dotted paths survive untouched; file-based relative paths still resolve to the workdir; absolute paths untouched.
- `tests/e2e/test_tool_call_policy_e2e.py` — mock-LLM e2e proving a `tool_call:calculate` DENY blocks the callable tool and surfaces the deny sentinel, and the real answer never leaks. Verified to **fail without the fix** (`Tool calculate not found`) and **pass with it**.

The scratch reproduction and the throwaway `conftest.py` probe edits have been removed; the only retained `conftest.py` change is the `extra_config` parameter on `register_inline_agent`, which the real regression test depends on.

## Gates run

- `tests/policies` + `tests/runtime/policies`: **746 passed**.
- `tests/runner` (full): **914 passed**, 4 xfailed; the 7 failures are pre-existing codex-native CLI-dependent tests (confirmed failing on a clean tree, unrelated to this change).
- `tests/e2e/test_policies_e2e.py`: pre-existing failures require a real LLM (`gpt-4o`), confirmed identical on a clean tree.
