### PR TITLE
fix(cli): register antigravity in config-CLI harness help + default prompt (parity with cursor)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4306,9 +4306,13 @@ def resume(
 # choose model/harness without editing the agent file. See
 # ``omnigent.chat.run_chat`` for how local-agent options get baked
 # into a materialized copy of the spec before the server starts.
+# Order mirrors the ``omnigent setup`` harness flow so the two surfaces read
+# the same: the provider families (Claude, then Codex/OpenAI, then Pi — see
+# ``_run_configure_harnesses_interactive``'s ``families`` list), then Cursor,
+# then Antigravity.
 _HARNESS_CHOICES_HELP = (
-    "'antigravity', 'claude' (alias for 'claude-sdk'), 'claude-sdk', "
-    "'codex', 'cursor', 'openai-agents', 'open-responses', or 'pi'"
+    "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
+    "'openai-agents', 'open-responses', 'pi', 'cursor', or 'antigravity'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
 _RUN_HARNESS_HELP = (
@@ -4329,11 +4333,11 @@ _FORK_HELP = "Fork an existing session by id and open the REPL on the fork."
 _LOG_HELP = "Write a JSON dump of the conversation to ~/.omnigent/logs/ on exit."
 
 
+# Keyed in the ``omnigent setup`` harness order (Claude, Codex, then the
+# Cursor / Antigravity rows — see ``_HARNESS_CHOICES_HELP`` above and
+# ``_run_configure_harnesses_interactive``); pi has no branded prompt and
+# falls back to ``_DEFAULT_HARNESS_PROMPT``.
 _DEFAULT_HARNESS_PROMPTS = {
-    "antigravity": (
-        "You are Antigravity, running through Omnigent. "
-        "Help the user with software engineering tasks."
-    ),
     "claude-sdk": (
         "You are Claude Code, running through Omnigent. "
         "Help the user with software engineering tasks."
@@ -4343,6 +4347,10 @@ _DEFAULT_HARNESS_PROMPTS = {
     ),
     "cursor": (
         "You are Cursor, running through Omnigent. Help the user with software engineering tasks."
+    ),
+    "antigravity": (
+        "You are Antigravity, running through Omnigent. "
+        "Help the user with software engineering tasks."
     ),
 }
 _DEFAULT_HARNESS_PROMPT = "You are a helpful coding agent running through Omnigent."

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4307,9 +4307,8 @@ def resume(
 # ``omnigent.chat.run_chat`` for how local-agent options get baked
 # into a materialized copy of the spec before the server starts.
 _HARNESS_CHOICES_HELP = (
-    "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
-    "'cursor', "
-    "'openai-agents', 'open-responses', or 'pi'"
+    "'antigravity', 'claude' (alias for 'claude-sdk'), 'claude-sdk', "
+    "'codex', 'cursor', 'openai-agents', 'open-responses', or 'pi'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
 _RUN_HARNESS_HELP = (
@@ -4331,6 +4330,10 @@ _LOG_HELP = "Write a JSON dump of the conversation to ~/.omnigent/logs/ on exit.
 
 
 _DEFAULT_HARNESS_PROMPTS = {
+    "antigravity": (
+        "You are Antigravity, running through Omnigent. "
+        "Help the user with software engineering tasks."
+    ),
     "claude-sdk": (
         "You are Claude Code, running through Omnigent. "
         "Help the user with software engineering tasks."

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2010,6 +2010,21 @@ def test_harness_choices_help_lists_cursor_and_antigravity() -> None:
         assert f"'{harness}'" in _HARNESS_CHOICES_HELP, _HARNESS_CHOICES_HELP
 
 
+def test_harness_choices_help_orders_by_setup_flow() -> None:
+    """The ``--harness`` help lists choices in the ``omnigent setup`` order.
+
+    Source of truth for the order is ``_run_configure_harnesses_interactive``:
+    it builds the menu as ``families = [ANTHROPIC_FAMILY, OPENAI_FAMILY,
+    PI_SURFACE]`` (Claude, Codex, Pi) followed by the Cursor then Antigravity
+    rows. The help string mirrors that family-then-SDK sequence so the two
+    surfaces read the same. Assert the representative ids appear in that order
+    (without pinning exact punctuation/spacing, which would be brittle).
+    """
+    order = ["claude-sdk", "codex", "pi", "cursor", "antigravity"]
+    positions = [_HARNESS_CHOICES_HELP.index(f"'{harness}'") for harness in order]
+    assert positions == sorted(positions), (order, positions, _HARNESS_CHOICES_HELP)
+
+
 @pytest.mark.parametrize(
     ("harness", "brand"),
     [

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -20,11 +20,15 @@ from click import ClickException
 from click.testing import CliRunner, Result
 
 from omnigent.cli import (
+    _DEFAULT_HARNESS_PROMPT,
+    _DEFAULT_HARNESS_PROMPTS,
     _GLOBAL_CONFIG_KEYS,
+    _HARNESS_CHOICES_HELP,
     _adopt_ambient_credentials,
     _announce_auto_configured_credentials,
     _bundle,
     _bundled_example_path,
+    _default_harness_prompt,
     _dispatch_run,
     _ensure_sqlite_parent_dir,
     _expand_config_env_vars,
@@ -44,6 +48,7 @@ from omnigent.cli import (
     _resolve_first_run_plan,
     _save_global_config,
     _start_cli_runner_process,
+    _validate_harness,
     _warn_missing_harness_dependencies,
     cli,
 )
@@ -1979,6 +1984,107 @@ def test_materialize_harness_launcher_file_writes_omnigent_yaml() -> None:
     # turn through the Databricks gateway. A "profile" key here means the
     # removed baking behavior came back.
     assert "profile" not in raw["executor"], raw["executor"]
+
+
+def test_harness_choices_help_lists_cursor_and_antigravity() -> None:
+    """The ``--harness`` choices help advertises both SDK harnesses.
+
+    ``_HARNESS_CHOICES_HELP`` is the user-facing discoverability surface for
+    ``omnigent run --harness`` / the bare-harness launch. Cursor was wired in
+    with its feature PR; antigravity (a peer in-process SDK harness, accepted by
+    ``_validate_harness`` via ``OMNIGENT_HARNESSES``) must be advertised the
+    same way so the two have parity. Pin every user-facing SDK choice so a
+    future edit can't silently drop one.
+    """
+    for harness in ("antigravity", "claude-sdk", "codex", "cursor", "openai-agents", "pi"):
+        assert f"'{harness}'" in _HARNESS_CHOICES_HELP, _HARNESS_CHOICES_HELP
+
+
+@pytest.mark.parametrize(
+    ("harness", "brand"),
+    [
+        ("antigravity", "Antigravity"),
+        ("cursor", "Cursor"),
+    ],
+)
+def test_default_harness_prompt_branded_for_cursor_and_antigravity(
+    harness: str, brand: str
+) -> None:
+    """Both SDK harnesses get a branded bare-launch prompt, not the fallback.
+
+    Mirrors the claude-sdk/codex entries: a no-AGENT launch of either harness
+    should introduce itself by name rather than fall back to the generic
+    ``_DEFAULT_HARNESS_PROMPT``.
+    """
+    prompt = _default_harness_prompt(harness)
+    assert prompt != _DEFAULT_HARNESS_PROMPT
+    assert brand in prompt
+    assert harness in _DEFAULT_HARNESS_PROMPTS
+
+
+@pytest.mark.parametrize(
+    "harness",
+    ["cursor", "antigravity", "agy", "google-antigravity"],
+)
+def test_validate_harness_accepts_cursor_and_antigravity(harness: str) -> None:
+    """``_validate_harness`` accepts cursor, antigravity, and the agy aliases.
+
+    These are registered in ``OMNIGENT_HARNESSES`` (canonical ids) and
+    ``HARNESS_ALIASES`` (``agy`` / ``google-antigravity`` → ``antigravity``),
+    so the CLI must not reject them as unsupported.
+    """
+    _validate_harness(harness)  # must not raise
+
+
+def test_materialize_harness_launcher_file_antigravity_uses_branded_prompt() -> None:
+    """A bare antigravity launch materializes a branded, family-less spec.
+
+    Parity check with the claude launcher test above: the antigravity harness
+    has no ``providers:`` family, so its launcher carries just ``harness`` /
+    ``model`` (no profile) and — unlike claude-sdk/codex/pi — no ``os_env``
+    block (antigravity is not in ``_OS_ENV_HARNESSES``). The ``agy`` alias
+    resolves to the canonical ``antigravity`` spelling for the file + executor.
+    """
+    generated = _materialize_harness_launcher_file(
+        harness="agy",
+        model="gemini-3-flash",
+        system_prompt=None,
+    )
+
+    assert generated.name == "antigravity.yaml"
+    raw = yaml.safe_load(generated.read_text())
+    assert raw == {
+        "name": "agy",
+        "prompt": _DEFAULT_HARNESS_PROMPTS["antigravity"],
+        "executor": {
+            "harness": "antigravity",
+            "model": "gemini-3-flash",
+        },
+    }
+
+
+@pytest.mark.parametrize("harness", ["cursor", "antigravity", "agy"])
+def test_run_with_agent_accepts_cursor_and_antigravity(
+    monkeypatch: pytest.MonkeyPatch, harness: str
+) -> None:
+    """``--harness cursor|antigravity|agy`` clears validation and dispatches.
+
+    Proves the two SDK harnesses (and the ``agy`` alias) are selectable through
+    the run CLI exactly like ``openai-agents-sdk`` — validation passes and the
+    run is dispatched; the canonical rewrite happens later at override
+    materialization.
+    """
+    monkeypatch.setattr("omnigent.cli._load_global_config", dict)
+    run_chat = Mock()
+    monkeypatch.setattr("omnigent.chat.run_chat", run_chat)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "tests/resources/examples/hello_world.yaml", "--harness", harness],
+    )
+
+    assert result.exit_code == 0, result.output
+    run_chat.assert_called_once()
 
 
 def test_run_without_agent_drops_into_configure_when_unconfigured(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1993,10 +1993,20 @@ def test_harness_choices_help_lists_cursor_and_antigravity() -> None:
     ``omnigent run --harness`` / the bare-harness launch. Cursor was wired in
     with its feature PR; antigravity (a peer in-process SDK harness, accepted by
     ``_validate_harness`` via ``OMNIGENT_HARNESSES``) must be advertised the
-    same way so the two have parity. Pin every user-facing SDK choice so a
-    future edit can't silently drop one.
+    same way so the two have parity. Pin every choice the help advertises (the
+    canonical harness ids plus the ``claude`` alias) so a future edit can't
+    silently drop one.
     """
-    for harness in ("antigravity", "claude-sdk", "codex", "cursor", "openai-agents", "pi"):
+    for harness in (
+        "antigravity",
+        "claude",
+        "claude-sdk",
+        "codex",
+        "cursor",
+        "openai-agents",
+        "open-responses",
+        "pi",
+    ):
         assert f"'{harness}'" in _HARNESS_CHOICES_HELP, _HARNESS_CHOICES_HELP
 
 


### PR DESCRIPTION
## What

Audits and completes the **config-CLI registration** for the `cursor` and `antigravity` harnesses so both can be configured and launched via the `omnigent` CLI with full parity to the older harnesses (claude-sdk/claude-native, codex/codex-native, pi, openai-agents).

## Findings (audit)

**Cursor** (the in-process Cursor SDK harness on `main`, authenticated via `CURSOR_API_KEY`) was **already fully wired** into the config CLI:
- `_HARNESS_MODULES` registry, `OMNIGENT_HARNESSES` allowlist (`_validate_harness`), readiness (`harness_is_configured` special-cases `CURSOR_KEY`), the interactive `omnigent setup` harness menu + drill-in (`_manage_cursor_harness`), `harness_install` (`CURSOR_KEY` / `_HARNESS_INSTALL`), `_HARNESS_CHOICES_HELP`, and `_DEFAULT_HARNESS_PROMPTS`.
- Its absence from `provider_config._HARNESS_FAMILY` is **intentional, not a gap**: cursor has no anthropic/openai provider family (documented in `omnigent/onboarding/cursor_auth.py`), so it deliberately sits outside the family machinery and must **not** be added there. No change made.

**Antigravity** (in-process Google Antigravity SDK harness) was wired into most surfaces (registry, allowlist, `_HARNESS_FAMILY`→openai, SDK readiness, the `agy`/`google-antigravity` aliases, the interactive setup menu + `_manage_antigravity_harness`) but — having been added before some CLI surfaces existed — was **missing two** that cursor had:

1. **`_HARNESS_CHOICES_HELP`** — the user-facing `--harness` discoverability help listed `cursor` but not `antigravity`, even though `_validate_harness` already accepts it via `OMNIGENT_HARNESSES`. → added `'antigravity'`.
2. **`_DEFAULT_HARNESS_PROMPTS`** — a bare `omnigent run --harness antigravity` fell back to the generic prompt instead of a branded one like cursor/codex/claude-sdk. → added a branded antigravity prompt.

## Tests

New `tests/cli/test_cli.py` cases assert that **both** cursor and antigravity (and the `agy` / `google-antigravity` aliases) are advertised in the `--harness` help, get a branded default prompt, pass `_validate_harness`, materialize a correct family-less launcher YAML, and dispatch through `omnigent run`.

## Gates

- `ruff format --check` — pass
- `ruff check` — pass (imports auto-sorted)
- `mypy omnigent/cli.py` — no new errors (the 2 `import-not-found` errors for `internal_beta`/`lakebox` are pre-existing on `main` and unrelated; mypy is not in the pre-commit gate)
- `pytest tests/cli/test_cli.py` (164) + harness/onboarding suites (96) — all pass

## Scope

Changes limited to config-CLI registration in `omnigent/cli.py` + tests. No refactors, no new patterns — the antigravity additions copy the established cursor/codex/claude-sdk shape.

> Note: the task brief referenced base branch `master`; the repo's actual default branch is `main`, which this PR targets.