### PR TITLE
fix(runner): don't mark a chat failed when a native terminal exits while idle

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4661,6 +4661,22 @@ def create_runner_app(
         if event.lifecycle != TerminalLifecycle.REQUIRED:
             return
 
+        # A native agent terminal (Claude Code / pi) is long-lived: it stays
+        # up across turns and goes ``idle`` once a turn finishes. When its pane
+        # disappears while the session was last seen ``idle``, the work for the
+        # current turn was already delivered and the process simply exited —
+        # a clean shutdown, not a failure. Flipping the chat to ``failed`` here
+        # was the source of spurious "failed" sessions in the UI (the terminal
+        # exited, but nothing actually failed). Only the resource is gone; the
+        # runner going offline is surfaced via the normal liveness path
+        # (``runner_online: false`` → reconnect hint), so we release the
+        # harness subprocess and stop. A mid-turn exit (``session_was_idle`` is
+        # False because the last edge was ``running``) and a boot failure (no
+        # status ever observed) both still fall through to ``failed``.
+        if event.session_was_idle:
+            _release_failed_required_terminal_session(event.session_id)
+            return
+
         output = _format_required_terminal_exit_output(event)
         _publish_event(
             event.session_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4625,8 +4625,12 @@ def create_runner_app(
             )
         return "\n".join(parts)
 
-    def _release_failed_required_terminal_session(session_id: str) -> None:
-        """Release the harness subprocess for a session whose runtime died."""
+    def _release_required_terminal_session(session_id: str) -> None:
+        """Release the harness subprocess after its required terminal exited.
+
+        Pure subprocess cleanup — publishes no ``failed`` lifecycle events, so
+        it is safe on both the crash and the clean-shutdown paths.
+        """
         if process_manager is None:
             return
 
@@ -4665,7 +4669,7 @@ def create_runner_app(
         # cleanly, so don't flip the chat to ``failed`` (the spurious-"failed"
         # bug). Still release the harness; liveness surfaces the offline runner.
         if event.session_was_idle:
-            _release_failed_required_terminal_session(event.session_id)
+            _release_required_terminal_session(event.session_id)
             return
 
         output = _format_required_terminal_exit_output(event)
@@ -4685,7 +4689,7 @@ def create_runner_app(
             status="failed",
             output=output,
         )
-        _release_failed_required_terminal_session(event.session_id)
+        _release_required_terminal_session(event.session_id)
 
     resource_registry.set_terminal_exit_publisher(_publish_terminal_exit)
 
@@ -9663,6 +9667,13 @@ def create_runner_app(
                 )
             message_body = dict(body)
             message_body["conversation_id"] = conversation_id
+
+            # A new message means a turn is (about to be) in flight. Mark the
+            # native session running now so a pane crash before the PTY
+            # watcher's first ``running`` edge isn't misread as a clean
+            # shutdown against the prior turn's stale ``idle`` memo.
+            if _is_native_harness(conversation_id):
+                resource_registry.note_session_turn_started(conversation_id)
 
             # Take an arrival slot, then wait at the FIFO gate so this
             # conversation's messages reach the turn-vs-buffer decision in

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4661,18 +4661,9 @@ def create_runner_app(
         if event.lifecycle != TerminalLifecycle.REQUIRED:
             return
 
-        # A native agent terminal (Claude Code / pi) is long-lived: it stays
-        # up across turns and goes ``idle`` once a turn finishes. When its pane
-        # disappears while the session was last seen ``idle``, the work for the
-        # current turn was already delivered and the process simply exited —
-        # a clean shutdown, not a failure. Flipping the chat to ``failed`` here
-        # was the source of spurious "failed" sessions in the UI (the terminal
-        # exited, but nothing actually failed). Only the resource is gone; the
-        # runner going offline is surfaced via the normal liveness path
-        # (``runner_online: false`` → reconnect hint), so we release the
-        # harness subprocess and stop. A mid-turn exit (``session_was_idle`` is
-        # False because the last edge was ``running``) and a boot failure (no
-        # status ever observed) both still fall through to ``failed``.
+        # Exit while idle = the turn already finished and the pane shut down
+        # cleanly, so don't flip the chat to ``failed`` (the spurious-"failed"
+        # bug). Still release the harness; liveness surfaces the offline runner.
         if event.session_was_idle:
             _release_failed_required_terminal_session(event.session_id)
             return

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -113,6 +113,14 @@ class TerminalExitEvent:
         specs may contain credentials or other launch-only secrets.
     :param cwd: Working directory used to launch the terminal, if known.
     :param last_output: Last visible pane text captured before exit, if any.
+    :param session_was_idle: Whether the session's last PTY-derived status
+        edge was ``idle`` when the terminal exited. A native agent terminal
+        (Claude Code / pi) is long-lived and goes ``idle`` once its turn
+        completes, so an exit observed while idle is a clean shutdown after
+        the work was delivered — not a turn failure. ``False`` (the default)
+        when the session was last seen ``running`` or no PTY status was ever
+        observed, so a genuine mid-turn crash and a boot failure both still
+        fail the session.
     """
 
     session_id: str
@@ -124,6 +132,7 @@ class TerminalExitEvent:
     args_count: int | None = None
     cwd: str | None = None
     last_output: str | None = None
+    session_was_idle: bool = False
 
 
 def _trim_terminal_exit_output(text: str | None) -> str | None:
@@ -266,6 +275,14 @@ class SessionResourceRegistry:
         # → running / ``Stop`` → idle bracketing. Set by the runner via
         # :meth:`set_session_status_publisher`.
         self._session_status_publisher: Callable[[str, str], None] | None = None
+        # Latest PTY-derived session-status edge per session id, recorded by
+        # the native agent terminal's activity watcher (running / idle). Read
+        # by :meth:`_handle_terminal_exit` to tell a clean shutdown (the agent
+        # finished its turn → idle, then the pane closed) from a mid-turn crash
+        # (still running when the pane vanished). Writes happen on the watcher
+        # daemon thread; a single-key ``str`` assignment is atomic under the
+        # GIL, so no lock is taken on the hot activity path.
+        self._last_session_status: dict[str, str] = {}
         # Optional callback invoked on the event loop when a watched terminal
         # disappears unexpectedly. The callback receives the terminal's
         # lifecycle relationship so the runner can decide whether the owning
@@ -943,6 +960,9 @@ class SessionResourceRegistry:
             # re-emit ``running`` every poll.
             if emit_status and status_publisher is not None and last_status["value"] != "running":
                 last_status["value"] = "running"
+                # Remember the live status so a terminal exit observed while a
+                # turn is in flight is correctly read as a mid-turn crash.
+                self._last_session_status[session_id] = "running"
                 loop.call_soon_threadsafe(status_publisher, session_id, "running")
 
         def _on_exit() -> None:
@@ -996,6 +1016,9 @@ class SessionResourceRegistry:
             # output mutates the pane (which flips back to ``running``).
             if status_publisher is not None and last_status["value"] != "idle":
                 last_status["value"] = "idle"
+                # Remember that the agent's turn completed: a later pane exit
+                # observed while idle is a clean shutdown, not a turn failure.
+                self._last_session_status[session_id] = "idle"
                 loop.call_soon_threadsafe(status_publisher, session_id, "idle")
             # Clear the activity throttle so the next working episode emits
             # its first pulse immediately, keeping the activity badge
@@ -1042,6 +1065,13 @@ class SessionResourceRegistry:
             lifecycle = observed
 
         command, args_count, cwd, last_output = _terminal_exit_diagnostics(instance)
+        # A native agent terminal is long-lived and goes ``idle`` once its
+        # turn finishes; an exit observed while idle means the pane closed
+        # after the work was delivered (clean shutdown), so the owning session
+        # must not be flipped to ``failed``. Anything else (last seen
+        # ``running``, or never observed) stays a failure so a real mid-turn
+        # crash and a boot failure both surface.
+        session_was_idle = self._last_session_status.pop(session_id, None) == "idle"
 
         if self._terminal_registry is not None:
             try:
@@ -1067,6 +1097,7 @@ class SessionResourceRegistry:
                     args_count=args_count,
                     cwd=cwd,
                     last_output=last_output,
+                    session_was_idle=session_was_idle,
                 )
             )
 
@@ -1151,6 +1182,12 @@ class SessionResourceRegistry:
                 lifecycle = self._terminal_lifecycles.pop((source_session_id, terminal_id), None)
                 if lifecycle is not None:
                     self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
+            # The PTY-status memo follows the pane to its new owner so a
+            # post-transfer exit is still classified against the right
+            # session's last status.
+            moved_status = self._last_session_status.pop(source_session_id, None)
+            if moved_status is not None:
+                self._last_session_status[target_session_id] = moved_status
             try:
                 await entry.instance.set_conversation_link(
                     self._terminal_registry.conversation_link_for_id(target_session_id)
@@ -1190,6 +1227,7 @@ class SessionResourceRegistry:
 
         :param session_id: Session/conversation identifier.
         """
+        self._last_session_status.pop(session_id, None)
         with self._lock:
             primary = self._primary_envs.pop(session_id, None)
             stale_role_keys = [key for key in self._terminal_roles if key[0] == session_id]

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -271,10 +271,11 @@ class SessionResourceRegistry:
         # → running / ``Stop`` → idle bracketing. Set by the runner via
         # :meth:`set_session_status_publisher`.
         self._session_status_publisher: Callable[[str, str], None] | None = None
-        # Latest PTY-derived status (running/idle) per session, set by the
-        # native agent watcher. Lets :meth:`_handle_terminal_exit` tell a clean
-        # shutdown (idle) from a mid-turn crash. Written from the watcher thread;
-        # a single-key str assignment is atomic under the GIL, so no lock.
+        # Latest PTY-derived status (running/idle) per session. Lets
+        # :meth:`_handle_terminal_exit` tell a clean shutdown (idle) from a
+        # mid-turn crash. Written from the watcher thread and the turn-start
+        # hook; all access goes through the ``_*_session_status_memo`` helpers
+        # under ``self._lock``.
         self._last_session_status: dict[str, str] = {}
         # Optional callback invoked on the event loop when a watched terminal
         # disappears unexpectedly. The callback receives the terminal's
@@ -337,6 +338,28 @@ class SessionResourceRegistry:
         :param publisher: Callable receiving a :class:`TerminalExitEvent`.
         """
         self._terminal_exit_publisher = publisher
+
+    def _set_session_status_memo(self, session_id: str, status: str) -> None:
+        """Record the session's latest PTY status for exit classification."""
+        with self._lock:
+            self._last_session_status[session_id] = status
+
+    def _take_session_status_memo(self, session_id: str) -> str | None:
+        """Pop and return the session's recorded PTY status (or ``None``)."""
+        with self._lock:
+            return self._last_session_status.pop(session_id, None)
+
+    def note_session_turn_started(self, session_id: str) -> None:
+        """Mark a session as having an in-flight turn.
+
+        Closes the window between a new turn starting and the watcher's first
+        ``running`` edge: without it, a crash in that gap would read the prior
+        turn's stale ``idle`` and be misclassified as a clean shutdown. The
+        watcher flips the memo back to ``idle`` once the turn completes.
+
+        :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
+        """
+        self._set_session_status_memo(session_id, "running")
 
     @property
     def terminal_registry(self) -> TerminalRegistry | None:
@@ -954,7 +977,7 @@ class SessionResourceRegistry:
             if emit_status and status_publisher is not None and last_status["value"] != "running":
                 last_status["value"] = "running"
                 # Track for exit classification: a pane exit now reads as a crash.
-                self._last_session_status[session_id] = "running"
+                self._set_session_status_memo(session_id, "running")
                 loop.call_soon_threadsafe(status_publisher, session_id, "running")
 
         def _on_exit() -> None:
@@ -1009,7 +1032,9 @@ class SessionResourceRegistry:
             if status_publisher is not None and last_status["value"] != "idle":
                 last_status["value"] = "idle"
                 # Track for exit classification: a pane exit now reads as clean.
-                self._last_session_status[session_id] = "idle"
+                # Edge ordering: the watcher thread runs idle/exit serially, so
+                # this idle commits before any later on_exit reads the memo.
+                self._set_session_status_memo(session_id, "idle")
                 loop.call_soon_threadsafe(status_publisher, session_id, "idle")
             # Clear the activity throttle so the next working episode emits
             # its first pulse immediately, keeping the activity badge
@@ -1058,7 +1083,7 @@ class SessionResourceRegistry:
         command, args_count, cwd, last_output = _terminal_exit_diagnostics(instance)
         # Idle = clean shutdown after the turn finished. Anything else (running,
         # or never observed → boot failure) stays a failure.
-        session_was_idle = self._last_session_status.pop(session_id, None) == "idle"
+        session_was_idle = self._take_session_status_memo(session_id) == "idle"
 
         if self._terminal_registry is not None:
             try:
@@ -1170,10 +1195,12 @@ class SessionResourceRegistry:
                 if lifecycle is not None:
                     self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
             # Move the PTY-status memo with the pane so a post-transfer exit is
-            # classified against the right session.
-            moved_status = self._last_session_status.pop(source_session_id, None)
-            if moved_status is not None:
-                self._last_session_status[target_session_id] = moved_status
+            # classified against the right session. Don't clobber a status the
+            # target already has from its own terminal.
+            with self._lock:
+                moved_status = self._last_session_status.pop(source_session_id, None)
+                if moved_status is not None and target_session_id not in self._last_session_status:
+                    self._last_session_status[target_session_id] = moved_status
             try:
                 await entry.instance.set_conversation_link(
                     self._terminal_registry.conversation_link_for_id(target_session_id)
@@ -1213,7 +1240,7 @@ class SessionResourceRegistry:
 
         :param session_id: Session/conversation identifier.
         """
-        self._last_session_status.pop(session_id, None)
+        self._take_session_status_memo(session_id)
         with self._lock:
             primary = self._primary_envs.pop(session_id, None)
             stale_role_keys = [key for key in self._terminal_roles if key[0] == session_id]

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -113,14 +113,10 @@ class TerminalExitEvent:
         specs may contain credentials or other launch-only secrets.
     :param cwd: Working directory used to launch the terminal, if known.
     :param last_output: Last visible pane text captured before exit, if any.
-    :param session_was_idle: Whether the session's last PTY-derived status
-        edge was ``idle`` when the terminal exited. A native agent terminal
-        (Claude Code / pi) is long-lived and goes ``idle`` once its turn
-        completes, so an exit observed while idle is a clean shutdown after
-        the work was delivered — not a turn failure. ``False`` (the default)
-        when the session was last seen ``running`` or no PTY status was ever
-        observed, so a genuine mid-turn crash and a boot failure both still
-        fail the session.
+    :param session_was_idle: Whether the session's last PTY-derived status was
+        ``idle`` at exit. ``True`` marks a clean shutdown after the turn
+        finished; ``False`` (the default — last seen ``running``, or never
+        observed) keeps a mid-turn crash or boot failure a failure.
     """
 
     session_id: str
@@ -275,13 +271,10 @@ class SessionResourceRegistry:
         # → running / ``Stop`` → idle bracketing. Set by the runner via
         # :meth:`set_session_status_publisher`.
         self._session_status_publisher: Callable[[str, str], None] | None = None
-        # Latest PTY-derived session-status edge per session id, recorded by
-        # the native agent terminal's activity watcher (running / idle). Read
-        # by :meth:`_handle_terminal_exit` to tell a clean shutdown (the agent
-        # finished its turn → idle, then the pane closed) from a mid-turn crash
-        # (still running when the pane vanished). Writes happen on the watcher
-        # daemon thread; a single-key ``str`` assignment is atomic under the
-        # GIL, so no lock is taken on the hot activity path.
+        # Latest PTY-derived status (running/idle) per session, set by the
+        # native agent watcher. Lets :meth:`_handle_terminal_exit` tell a clean
+        # shutdown (idle) from a mid-turn crash. Written from the watcher thread;
+        # a single-key str assignment is atomic under the GIL, so no lock.
         self._last_session_status: dict[str, str] = {}
         # Optional callback invoked on the event loop when a watched terminal
         # disappears unexpectedly. The callback receives the terminal's
@@ -960,8 +953,7 @@ class SessionResourceRegistry:
             # re-emit ``running`` every poll.
             if emit_status and status_publisher is not None and last_status["value"] != "running":
                 last_status["value"] = "running"
-                # Remember the live status so a terminal exit observed while a
-                # turn is in flight is correctly read as a mid-turn crash.
+                # Track for exit classification: a pane exit now reads as a crash.
                 self._last_session_status[session_id] = "running"
                 loop.call_soon_threadsafe(status_publisher, session_id, "running")
 
@@ -1016,8 +1008,7 @@ class SessionResourceRegistry:
             # output mutates the pane (which flips back to ``running``).
             if status_publisher is not None and last_status["value"] != "idle":
                 last_status["value"] = "idle"
-                # Remember that the agent's turn completed: a later pane exit
-                # observed while idle is a clean shutdown, not a turn failure.
+                # Track for exit classification: a pane exit now reads as clean.
                 self._last_session_status[session_id] = "idle"
                 loop.call_soon_threadsafe(status_publisher, session_id, "idle")
             # Clear the activity throttle so the next working episode emits
@@ -1065,12 +1056,8 @@ class SessionResourceRegistry:
             lifecycle = observed
 
         command, args_count, cwd, last_output = _terminal_exit_diagnostics(instance)
-        # A native agent terminal is long-lived and goes ``idle`` once its
-        # turn finishes; an exit observed while idle means the pane closed
-        # after the work was delivered (clean shutdown), so the owning session
-        # must not be flipped to ``failed``. Anything else (last seen
-        # ``running``, or never observed) stays a failure so a real mid-turn
-        # crash and a boot failure both surface.
+        # Idle = clean shutdown after the turn finished. Anything else (running,
+        # or never observed → boot failure) stays a failure.
         session_was_idle = self._last_session_status.pop(session_id, None) == "idle"
 
         if self._terminal_registry is not None:
@@ -1182,9 +1169,8 @@ class SessionResourceRegistry:
                 lifecycle = self._terminal_lifecycles.pop((source_session_id, terminal_id), None)
                 if lifecycle is not None:
                     self._terminal_lifecycles[(target_session_id, terminal_id)] = lifecycle
-            # The PTY-status memo follows the pane to its new owner so a
-            # post-transfer exit is still classified against the right
-            # session's last status.
+            # Move the PTY-status memo with the pane so a post-transfer exit is
+            # classified against the right session.
             moved_status = self._last_session_status.pop(source_session_id, None)
             if moved_status is not None:
                 self._last_session_status[target_session_id] = moved_status

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -8953,6 +8953,117 @@ async def test_required_terminal_exit_publishes_deleted_and_failed(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path: Path) -> None:
+    """
+    A required terminal that exits while the session is idle is a clean shutdown.
+
+    The native agent terminal is long-lived and goes ``idle`` once its turn
+    completes. When the pane then disappears, the work for that turn was already
+    delivered, so the runner must NOT publish ``session.status: failed`` — doing
+    so was the source of spurious "failed" chats in the UI. The terminal
+    resource is still removed and the harness subprocess released; the runner
+    going offline is surfaced separately via liveness, not a failure.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.app import _session_event_queues_ref
+    from tests.runner.helpers import make_test_terminal_instance
+
+    parent_id = f"conv_parent_idle_exit_{uuid.uuid4().hex[:12]}"
+    conv_id = f"conv_idle_exit_{uuid.uuid4().hex[:12]}"
+    parent_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    terminal_registry = TerminalRegistry()
+    instance = make_test_terminal_instance("worker", "main", tmp_path)
+    instance.command = "worker-cli"
+    instance.launch_cwd = str(tmp_path)
+    terminal_registry._by_conversation.setdefault(conv_id, {})[("worker", "main")] = instance
+    callbacks: dict[str, Any] = {}
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del on_idle, on_activity, idle_threshold_s, poll_interval_s, replace
+        callbacks["on_exit"] = on_exit
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+    pm._sessions.add(conv_id)
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        terminal_registry=terminal_registry,
+    )
+    resource_registry = app.state.session_resource_registry
+    runner_app._session_inboxes_ref[parent_id] = parent_inbox
+    runner_app.register_child_session(
+        conv_id,
+        parent_session_id=parent_id,
+        title="worker:main",
+        tool="worker",
+        session_name="main",
+    )
+    runner_app.register_subagent_work(
+        parent_session_id=parent_id,
+        child_session_id=conv_id,
+        agent="worker",
+        title="main",
+    )
+
+    try:
+        await resource_registry.observe_required_terminal(
+            conv_id,
+            "worker",
+            "main",
+            instance,
+        )
+        # The session reached idle (turn completed) before the pane vanished.
+        resource_registry._last_session_status[conv_id] = "idle"
+        on_exit = callbacks.get("on_exit")
+        assert callable(on_exit)
+        on_exit()
+        # The harness subprocess release is the terminal's last lifecycle step;
+        # wait on it as the settle signal, then inspect the published events.
+        for _ in range(1000):
+            if pm.released:
+                break
+            await asyncio.sleep(0)
+        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+        parent_events = _drain_session_event_queue(_session_event_queues_ref.get(parent_id))
+    finally:
+        _session_event_queues_ref.pop(conv_id, None)
+        _session_event_queues_ref.pop(parent_id, None)
+        runner_app.unregister_subagent_work(conv_id)
+        runner_app.unregister_child_session(conv_id)
+        runner_app._session_inboxes_ref.pop(parent_id, None)
+
+    # The terminal resource is still removed...
+    assert terminal_registry.get(conv_id, "worker", "main") is None
+    assert {
+        "type": "session.resource.deleted",
+        "resource_id": "terminal_worker_main",
+        "resource_type": "terminal",
+        "session_id": conv_id,
+    } in queued_events
+    # ...but no failure is published, and the parent is not woken as failed.
+    assert [
+        event
+        for event in queued_events
+        if event.get("type") == "session.status" and event.get("status") == "failed"
+    ] == []
+    assert parent_events == []
+    assert parent_inbox.empty()
+    # The harness subprocess is still released — the terminal is gone.
+    assert pm.released == [conv_id]
+
+
+@pytest.mark.asyncio
 async def test_events_effort_change_on_native_session_types_slash_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -527,6 +527,87 @@ async def test_required_terminal_exit_without_observed_status_is_failure(tmp_pat
     assert exits[0].session_was_idle is False
 
 
+@pytest.mark.asyncio
+async def test_required_terminal_exit_after_new_turn_is_failure(tmp_path: Path) -> None:
+    """A crash right after a new turn starts (before the watcher's first
+    ``running`` edge) is a failure, not a stale clean shutdown.
+
+    ``note_session_turn_started`` resets the prior turn's ``idle`` memo so the
+    turn-boundary window can't silently swallow a real crash.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_turn", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    callbacks = await _observe_native_agent_terminal_and_capture(
+        registry, terminal_registry, instance, "conv_turn"
+    )
+
+    # The previous turn finished (idle), then a new message starts a turn and
+    # the pane crashes before the watcher emits its next ``running`` edge.
+    on_idle = callbacks["on_idle"]
+    assert callable(on_idle)
+    on_idle()
+    registry.note_session_turn_started("conv_turn")
+    on_exit = callbacks["on_exit"]
+    assert callable(on_exit)
+    on_exit()
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert len(exits) == 1
+    assert exits[0].session_was_idle is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_session_clears_status_memo(tmp_path: Path) -> None:
+    """``cleanup_session`` drops the session's PTY-status memo.
+
+    :param tmp_path: Temporary directory (unused beyond registry construction).
+    """
+    del tmp_path
+    registry = SessionResourceRegistry()
+    registry.note_session_turn_started("conv_cleanup")
+    assert "conv_cleanup" in registry._last_session_status
+
+    await registry.cleanup_session("conv_cleanup")
+
+    assert "conv_cleanup" not in registry._last_session_status
+
+
+@pytest.mark.asyncio
+async def test_transfer_terminal_moves_status_memo(tmp_path: Path) -> None:
+    """Transferring a terminal moves its PTY-status memo to the new owner.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    view = await registry.launch_required_terminal(
+        "conv_src",
+        "codex",
+        "main",
+        TerminalEnvSpec(command="codex", args=["--remote", "ws://127.0.0.1:1234"]),
+        resource_role=CODEX_NATIVE_TERMINAL_ROLE,
+    )
+    registry.note_session_turn_started("conv_src")
+
+    moved = await registry.transfer_terminal("conv_src", "conv_dst", view.id)
+
+    assert moved is not None
+    assert "conv_src" not in registry._last_session_status
+    assert registry._last_session_status.get("conv_dst") == "running"
+
+
 def test_get_resource_finds_default() -> None:
     """get_resource finds the default environment."""
     reg = SessionResourceRegistry()

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -16,6 +16,7 @@ from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpe
 from omnigent.inner.os_env import EditEntry, OpResult, OSEnvironment
 from omnigent.inner.terminal import TerminalInstance
 from omnigent.runner.resource_registry import (
+    CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
     TerminalExitEvent,
@@ -352,6 +353,178 @@ async def test_auxiliary_terminal_exit_publishes_resource_exit_only(tmp_path: Pa
     assert exits[0].cwd == str(tmp_path)
     assert exits[0].last_output == "startup failed\nretry login"
     assert terminal_registry.get("conv_exit", "sidecar", "s1") is None
+
+
+async def _observe_native_agent_terminal_and_capture(
+    registry: SessionResourceRegistry,
+    terminal_registry: TerminalRegistry,
+    instance: object,
+    session_id: str,
+) -> dict[str, object]:
+    """Observe *instance* as the native agent terminal, capturing its watcher.
+
+    Returns the captured ``on_idle`` / ``on_activity`` / ``on_exit`` callbacks
+    so a test can drive the PTY-status edges directly.
+    """
+    callbacks: dict[str, object] = {}
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del idle_threshold_s, poll_interval_s, replace
+        callbacks["on_idle"] = on_idle
+        callbacks["on_activity"] = on_activity
+        callbacks["on_exit"] = on_exit
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
+    # A status publisher is required for the native agent terminal's watcher to
+    # wire its running/idle edges (and thus record the PTY status).
+    registry.set_session_status_publisher(lambda _sid, _status: None)
+    await registry.observe_required_terminal(
+        session_id,
+        instance.name,  # type: ignore[attr-defined]
+        instance.session_key,  # type: ignore[attr-defined]
+        instance,
+        resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
+    )
+    return callbacks
+
+
+@pytest.mark.asyncio
+async def test_required_terminal_exit_while_idle_is_clean_shutdown(tmp_path: Path) -> None:
+    """A required terminal that exits after going idle is not a failure.
+
+    The native agent terminal is long-lived: it goes ``idle`` when its turn
+    finishes. A pane exit observed while idle means the work was already
+    delivered and the process simply shut down, so the exit event must carry
+    ``session_was_idle=True`` — the runner uses that to avoid flipping the chat
+    to ``failed`` (the spurious-"failed"-session bug).
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_idle", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    callbacks = await _observe_native_agent_terminal_and_capture(
+        registry, terminal_registry, instance, "conv_idle"
+    )
+
+    # The agent worked, then its turn completed (pane quiesced → idle).
+    on_activity = callbacks["on_activity"]
+    on_idle = callbacks["on_idle"]
+    assert callable(on_activity) and callable(on_idle)
+    on_activity()
+    on_idle()
+    # Then the pane disappeared (e.g. Claude Code exited cleanly).
+    on_exit = callbacks["on_exit"]
+    assert callable(on_exit)
+    on_exit()
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert len(exits) == 1
+    assert exits[0].lifecycle == TerminalLifecycle.REQUIRED
+    assert exits[0].session_was_idle is True
+
+
+@pytest.mark.asyncio
+async def test_required_terminal_exit_while_running_is_failure(tmp_path: Path) -> None:
+    """A required terminal that vanishes mid-turn is still a failure.
+
+    When the last PTY-status edge was ``running``, the pane disappeared while
+    a turn was in flight — a genuine crash — so the exit event reports
+    ``session_was_idle=False`` and the runner keeps failing the session.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_run", {})[("claude", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    registry.set_terminal_exit_publisher(_publish_exit)
+    callbacks = await _observe_native_agent_terminal_and_capture(
+        registry, terminal_registry, instance, "conv_run"
+    )
+
+    on_activity = callbacks["on_activity"]
+    assert callable(on_activity)
+    on_activity()
+    on_exit = callbacks["on_exit"]
+    assert callable(on_exit)
+    on_exit()
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert len(exits) == 1
+    assert exits[0].session_was_idle is False
+
+
+@pytest.mark.asyncio
+async def test_required_terminal_exit_without_observed_status_is_failure(tmp_path: Path) -> None:
+    """A required terminal that never reported a PTY status fails on exit.
+
+    A boot failure (the process dies before producing any pane activity) leaves
+    no recorded status, so the exit defaults to ``session_was_idle=False`` and
+    the session still fails — only a positively-observed ``idle`` suppresses the
+    failure.
+
+    :param tmp_path: Temporary directory for fake terminal paths.
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("worker", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_boot", {})[("worker", "main")] = instance
+    exits: list[TerminalExitEvent] = []
+    exit_published = asyncio.Event()
+    callbacks: dict[str, object] = {}
+
+    def _publish_exit(event: TerminalExitEvent) -> None:
+        exits.append(event)
+        exit_published.set()
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del on_idle, on_activity, idle_threshold_s, poll_interval_s, replace
+        callbacks["on_exit"] = on_exit
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
+    registry.set_terminal_exit_publisher(_publish_exit)
+
+    await registry.observe_required_terminal("conv_boot", "worker", "main", instance)
+    on_exit = callbacks["on_exit"]
+    assert callable(on_exit)
+    on_exit()
+    await asyncio.wait_for(exit_published.wait(), timeout=1.0)
+
+    assert len(exits) == 1
+    assert exits[0].session_was_idle is False
 
 
 def test_get_resource_finds_default() -> None:

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -585,14 +585,41 @@ async def test_cleanup_session_clears_status_memo(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_transfer_terminal_moves_status_memo(tmp_path: Path) -> None:
+async def test_transfer_terminal_moves_status_memo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Transferring a terminal moves its PTY-status memo to the new owner.
 
+    Fakes the launch (no real tmux/process) and the conversation-link update,
+    mirroring ``test_terminal_resource_role_moves_on_transfer``.
+
     :param tmp_path: Temporary directory for fake terminal paths.
+    :param monkeypatch: Pytest monkeypatch fixture.
     """
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
-    view = await registry.launch_required_terminal(
+    instance = make_test_terminal_instance("codex", "main", tmp_path)
+
+    async def _fake_launch(
+        conversation_id: str,
+        terminal_name: str,
+        session_key: str,
+        spec: TerminalEnvSpec,
+        **kwargs: object,
+    ) -> TerminalInstance:
+        del spec, kwargs
+        terminal_registry._by_conversation.setdefault(conversation_id, {})[
+            (terminal_name, session_key)
+        ] = instance
+        return instance
+
+    async def _no_status_link(_link: str) -> None:
+        """Avoid tmux calls while transfer updates the conversation link."""
+
+    monkeypatch.setattr(terminal_registry, "launch", _fake_launch)
+    monkeypatch.setattr(instance, "set_conversation_link", _no_status_link)
+
+    view = await registry.launch_auxiliary_terminal(
         "conv_src",
         "codex",
         "main",


### PR DESCRIPTION
## Summary

Some chats showed up as **failed** in the UI even though nothing actually failed — exactly the "the terminal is failed sometimes" symptom.

Root cause: a *required* native agent terminal (Claude Code / pi) is long-lived and goes `idle` once its turn completes. When its tmux pane later disappears, the runner's `_publish_terminal_exit` **unconditionally** published `session.status: failed` with `required_terminal_exited` ("Required terminal exited unexpectedly"). So a session whose work had already been delivered flipped to `failed` whenever the terminal shut down cleanly (e.g. Claude Code exited normally, the pane was reaped, etc.).

This PR makes the runner distinguish a clean shutdown from a real crash:

- The `SessionResourceRegistry` now records the latest PTY-derived session-status edge per session (the native-agent activity watcher's `running` / `idle`) and carries `session_was_idle` on `TerminalExitEvent`.
- `_publish_terminal_exit` suppresses the `failed` status (and the parent sub-agent failure wake) when the session was **idle** at exit — it still removes the terminal resource and releases the harness subprocess. The runner going offline is surfaced via the normal liveness path (`runner_online: false` → reconnect hint), not a failure.
- A **mid-turn** exit (last status `running` → genuine crash) and a **boot failure** (no status ever observed) both still fail the session, so real failures keep surfacing.

## Test plan

- [x] `tests/runner/test_resource_registry.py` — new cases: idle exit → `session_was_idle=True`; running exit → `False`; never-observed exit → `False`. Existing transfer/auxiliary/cleanup tests still pass.
- [x] `tests/runner/test_app_sessions_native.py` — new `test_required_terminal_exit_while_idle_does_not_fail_session` asserts no `session.status: failed`, no parent wake, resource still deleted, harness still released. Existing `test_required_terminal_exit_publishes_deleted_and_failed` (running/never-observed default) still passes.
- [x] `ruff check` clean on changed files; `pyrefly check` clean on `resource_registry.py` (pre-existing unrelated errors remain in `app.py`).