### PR TITLE
fix(runner): crash-safe subprocess and terminal reaping (codex pgid reaper, harness group-kill, shutdown drain, concurrent close)

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -30,9 +30,11 @@ from omnigent.inner.codex_executor import (
     _databricks_codex_auth_command,
     _databricks_codex_base_url,
     _databricks_codex_config_overrides,
+    _deregister_appserver_pgid,
     _find_codex_cli,
     _populate_codex_home_config,
     _provider_codex_config_overrides,
+    _register_appserver_pgid,
 )
 from omnigent.inner.databricks_executor import _read_databrickscfg, _read_databrickscfg_host
 
@@ -576,6 +578,8 @@ class CodexNativeAppServer:
             cwd=str(self.cwd),
             start_new_session=(os.name == "posix"),
         )
+        if os.name == "posix" and self.proc.pid is not None:
+            _register_appserver_pgid(self.proc.pid)  # crash backstop (O1)
         self.recent_stderr = []
         self.stderr_task = asyncio.create_task(
             self._stderr_loop(),
@@ -705,6 +709,11 @@ class CodexNativeAppServer:
 
         :returns: None.
         """
+        _pgid = (
+            self.proc.pid
+            if (self.proc is not None and os.name == "posix" and self.proc.pid is not None)
+            else None
+        )
         if self.proc is not None and self.proc.returncode is None:
             _terminate_process_tree(self.proc)
             try:
@@ -716,6 +725,8 @@ class CodexNativeAppServer:
             self.stderr_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self.stderr_task
+        if _pgid is not None:
+            _deregister_appserver_pgid(_pgid)
         self.proc = None
         self.stderr_task = None
 

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -363,7 +363,7 @@ def _install_appserver_reaper() -> None:
     def _make_handler(signum: int):
         previous = signal.getsignal(signum)
 
-        def _handler(sig, frame):  # noqa: ANN001 - stdlib signal handler shape
+        def _handler(sig, frame):
             _reap_registered_appserver_pgids()
             if callable(previous):
                 previous(sig, frame)

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -8,6 +8,7 @@ Omnigent tools to Codex as App Server ``dynamicTools``.
 from __future__ import annotations
 
 import asyncio
+import atexit
 import base64
 import json
 import logging
@@ -294,6 +295,95 @@ def _kill_process_tree(process: _Process | None) -> None:
             return
     with suppress(ProcessLookupError, Exception):
         process.kill()
+
+
+# ---------------------------------------------------------------------------
+# Codex app-server crash backstop (O1)
+# ---------------------------------------------------------------------------
+#
+# Both codex app-server spawn sites (this module's _AppServerSession.start and
+# omnigent/codex_native_app_server.py CodexNativeAppServer.start) launch the
+# child with start_new_session=True, so each child is its own process-group
+# leader (pgid == child pid) and its serve-mcp / policy-hook grandchildren live
+# in that group. The happy-path close()s already killpg that group. This
+# registry is the crash backstop: a host crash, SIGKILL of this interpreter, or
+# a SIGTERM/SIGINT would otherwise orphan the whole codex tree (these children
+# are in their OWN session, so they are NOT reaped by the runner's harness-group
+# kill). Modelled on seatbelt_sandbox._cleanup_profile_files (atexit.register
+# at module import).
+_APPSERVER_PGIDS: set[int] = set()
+
+
+def _register_appserver_pgid(pgid: int) -> None:
+    """Record a live app-server process-group id for crash-time reaping."""
+    _APPSERVER_PGIDS.add(pgid)
+
+
+def _deregister_appserver_pgid(pgid: int) -> None:
+    """Drop a pgid after a clean close so the reaper never double-kills it.
+
+    Critical: after a clean close the OS may reuse the pid (hence pgid), so
+    signalling a deregistered group could hit an unrelated process.
+    """
+    _APPSERVER_PGIDS.discard(pgid)
+
+
+def _reap_registered_appserver_pgids() -> None:
+    """SIGKILL every still-registered app-server group; best-effort, drains.
+
+    Runs at interpreter exit (atexit) and on a fatal signal. Drains the set so
+    a subsequent reap (e.g. atexit after a signal handler already ran) is a
+    no-op. Each kill is isolated: a group that already exited
+    (ProcessLookupError) or one we cannot signal (PermissionError) is skipped.
+    """
+    while _APPSERVER_PGIDS:
+        pgid = _APPSERVER_PGIDS.pop()
+        if os.name != "posix":
+            continue
+        with suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(pgid, signal.SIGKILL)
+
+
+def _install_appserver_reaper() -> None:
+    """Install the atexit + SIGTERM/SIGINT app-server reaper, once.
+
+    The signal handlers CHAIN to any previously-installed handler so this never
+    clobbers the harness runner's own signal-driven graceful shutdown — it
+    reaps the app-server groups first, then re-raises into the prior handler.
+    Idempotent so repeated imports in the same interpreter do not stack handlers.
+    """
+    global _APPSERVER_REAPER_INSTALLED
+    if _APPSERVER_REAPER_INSTALLED:
+        return
+    _APPSERVER_REAPER_INSTALLED = True
+    atexit.register(_reap_registered_appserver_pgids)
+    if os.name != "posix":
+        return
+
+    def _make_handler(signum: int):
+        previous = signal.getsignal(signum)
+
+        def _handler(sig, frame):  # noqa: ANN001 - stdlib signal handler shape
+            _reap_registered_appserver_pgids()
+            if callable(previous):
+                previous(sig, frame)
+            elif previous == signal.SIG_DFL:
+                # Restore default and re-raise so the process still dies as it
+                # would have (e.g. SIGTERM -> terminate) after we reaped.
+                signal.signal(sig, signal.SIG_DFL)
+                os.kill(os.getpid(), sig)
+
+        return _handler
+
+    for _signum in (signal.SIGTERM, signal.SIGINT):
+        with suppress(ValueError, OSError):
+            # ValueError: not on the main thread (e.g. a worker import) -> the
+            # atexit hook still covers the common interpreter-exit case.
+            signal.signal(_signum, _make_handler(_signum))
+
+
+_APPSERVER_REAPER_INSTALLED = False
+_install_appserver_reaper()
 
 
 def _find_codex_cli() -> str | None:
@@ -1184,6 +1274,9 @@ class _CodexAppServerSession:
                 start_new_session=(os.name == "posix"),
                 cwd=self._cwd or os.getcwd(),
             )
+            if os.name == "posix" and self._proc.pid is not None:
+                # Own session leader: pgid == pid. Crash backstop (O1).
+                _register_appserver_pgid(self._proc.pid)
             self._reader_task = asyncio.create_task(self._reader_loop())
             self._stderr_task = asyncio.create_task(self._stderr_loop())
             await self._request(
@@ -1204,6 +1297,11 @@ class _CodexAppServerSession:
             raise
 
     async def close(self) -> None:
+        _pgid = (
+            self._proc.pid
+            if (self._proc is not None and os.name == "posix" and self._proc.pid is not None)
+            else None
+        )
         current_loop = asyncio.get_running_loop()
         if self._loop is not None and self._loop is not current_loop:
             if self._proc is not None and self._proc.returncode is None:
@@ -1219,6 +1317,8 @@ class _CodexAppServerSession:
             self.thread_id = None
             self.active_turn_id = None
             self._cleanup_process_cwd()
+            if _pgid is not None:
+                _deregister_appserver_pgid(_pgid)
             return
 
         if self._proc is not None and self._proc.returncode is None:
@@ -1256,6 +1356,8 @@ class _CodexAppServerSession:
         self.active_turn_id = None
         self._recent_events.clear()
         self._cleanup_process_cwd()
+        if _pgid is not None:
+            _deregister_appserver_pgid(_pgid)
 
     def _cleanup_process_cwd(self) -> None:
         if self._codex_home_dir is not None:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -336,8 +336,11 @@ def _reap_registered_appserver_pgids() -> None:
     no-op. Each kill is isolated: a group that already exited
     (ProcessLookupError) or one we cannot signal (PermissionError) is skipped.
     """
-    while _APPSERVER_PGIDS:
-        pgid = _APPSERVER_PGIDS.pop()
+    while True:
+        try:
+            pgid = _APPSERVER_PGIDS.pop()
+        except KeyError:
+            break
         if os.name != "posix":
             continue
         with suppress(ProcessLookupError, PermissionError, OSError):
@@ -347,10 +350,25 @@ def _reap_registered_appserver_pgids() -> None:
 def _install_appserver_reaper() -> None:
     """Install the atexit + SIGTERM/SIGINT app-server reaper, once.
 
-    The signal handlers CHAIN to any previously-installed handler so this never
-    clobbers the harness runner's own signal-driven graceful shutdown — it
-    reaps the app-server groups first, then re-raises into the prior handler.
-    Idempotent so repeated imports in the same interpreter do not stack handlers.
+    Live reap paths (in order of reliability):
+    (a) atexit hook — fires on normal interpreter exit; the primary path
+        for the happy-path ``CodexExecutor.close()`` callers.
+    (b) harness hard-exit hook — ``_runner._arm_hard_exit`` calls
+        ``_reap_registered_appserver_pgids()`` immediately before
+        ``os._exit()`` so the codex groups are killed even when the
+        runner is force-exiting after a wedged graceful shutdown.
+
+    The SIGTERM/SIGINT signal handlers installed below are a best-effort
+    fallback for processes that do NOT replace them (e.g. plain scripts,
+    unit tests).  In production the asyncio event loop (runner process)
+    and uvicorn (harness process) both install their OWN SIGTERM/SIGINT
+    handlers at startup — replacing this module's handler — so these
+    handlers are typically NOT the live reap path in those processes.
+    They are still installed so that reap works in any interpreter that
+    does not run an event loop.  They CHAIN to whatever was previously
+    installed so they never clobber the loop's own graceful-shutdown
+    handler.  Idempotent so repeated imports in the same interpreter do
+    not stack handlers.
     """
     global _APPSERVER_REAPER_INSTALLED
     if _APPSERVER_REAPER_INSTALLED:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -963,11 +963,13 @@ async def _run_tunnel_from_env() -> None:
         if idle_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await idle_task
-        await app.router.shutdown()
-        # Signal the parent-death killer that graceful drain (pm.shutdown /
-        # terminal_registry.shutdown via _stop_pm) has completed, so it skips
-        # the os._exit backstop (B2).
-        drained_event.set()
+        try:
+            await app.router.shutdown()
+        finally:
+            # Signal the parent-death killer that graceful drain (pm.shutdown /
+            # terminal_registry.shutdown via _stop_pm) has completed, so it skips
+            # the os._exit backstop (B2).
+            drained_event.set()
 
 
 def _install_signal_handlers(

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -454,8 +454,9 @@ def _run_parent_death_killer(
     request_shutdown: Callable[[], None],
     *,
     adopted: threading.Event | None = None,
+    drained: threading.Event | None = None,
     poll_interval_s: float = 0.5,
-    grace_s: float = 2.0,
+    drain_timeout_s: float = 20.0,
     exit_fn: Callable[[int], None] = os._exit,
 ) -> None:
     """Force the runner to exit once its parent (host daemon) dies.
@@ -466,9 +467,13 @@ def _run_parent_death_killer(
     shutdown wedges the event loop — so an event-loop watchdog would never
     fire and the WS tunnel would stay open, leaving the server seeing the
     runner online forever. On detecting the parent's death this requests a
-    graceful shutdown, then after *grace_s* hard-exits as a backstop. When
-    graceful shutdown wins the race the process is already gone and this
-    daemon thread dies with it, so the hard exit is a no-op in practice.
+    graceful shutdown, then waits up to *drain_timeout_s* for the loop to
+    signal *drained* (set after ``app.router.shutdown()`` ->
+    ``pm.shutdown()`` / ``registry.shutdown()`` completes). If the drain
+    completes it returns WITHOUT hard-exiting, so terminals/subprocesses are
+    reaped cleanly. ``os._exit`` via *exit_fn* remains only as the final
+    backstop for a wedged drain — its worst case equals the old flat-grace
+    behaviour.
 
     When *adopted* is set the watch ends without tearing the runner down:
     the launcher (CLI) intentionally exited — e.g. the user detached from
@@ -483,10 +488,13 @@ def _run_parent_death_killer(
     :param adopted: Event set when the runner has been adopted; once set,
         the watcher returns without requesting shutdown. ``None`` disables
         adoption (watch until parent death).
+    :param drained: Event the loop sets once graceful shutdown has fully
+        completed. ``None`` keeps the old behaviour (wait the full timeout,
+        then hard-exit) for callers/tests that do not wire a drain signal.
     :param poll_interval_s: Seconds between parent-liveness probes, e.g.
         ``0.5``.
-    :param grace_s: Seconds to allow graceful shutdown before the hard
-        exit, e.g. ``2.0``.
+    :param drain_timeout_s: Bounded seconds to allow graceful drain before
+        the hard exit, e.g. ``20.0``.
     :param exit_fn: Hard-exit function, defaults to :func:`os._exit`;
         injectable so tests can observe it without killing the runner.
     :returns: None.
@@ -500,8 +508,13 @@ def _run_parent_death_killer(
     if adopted is not None and adopted.is_set():
         return
     request_shutdown()
-    time.sleep(grace_s)
-    # os._exit skips buffer flushing, so flush logs first for diagnosability.
+    if drained is not None:
+        if drained.wait(drain_timeout_s):
+            # Graceful shutdown completed; the process is exiting cleanly.
+            return
+    else:
+        time.sleep(drain_timeout_s)
+    # Drain wedged (or no drain signal wired): force the process down.
     with contextlib.suppress(Exception):
         sys.stderr.flush()
     exit_fn(0)
@@ -916,16 +929,17 @@ async def _run_tunnel_from_env() -> None:
             ),
             name=f"runner-idle-monitor:{runner_id}",
         )
+    drained_event = threading.Event()
     if parent_pid is not None:
         # Orphan guard runs on a dedicated daemon thread, not the event
         # loop: if the loop wedges during shutdown (harness mid-boot when
         # the host dies), an event-loop watchdog could never fire. The
-        # thread requests graceful shutdown via the loop, then hard-exits
-        # as a backstop. See _run_parent_death_killer.
+        # thread requests graceful shutdown via the loop, then waits for
+        # drained_event before the hard-exit backstop. See _run_parent_death_killer.
         threading.Thread(
             target=_run_parent_death_killer,
             args=(parent_pid, lambda: loop.call_soon_threadsafe(stop_event.set)),
-            kwargs={"adopted": adopted_event},
+            kwargs={"adopted": adopted_event, "drained": drained_event},
             name=f"runner-parent-killer:{parent_pid}",
             daemon=True,
         ).start()
@@ -950,6 +964,10 @@ async def _run_tunnel_from_env() -> None:
             with contextlib.suppress(asyncio.CancelledError):
                 await idle_task
         await app.router.shutdown()
+        # Signal the parent-death killer that graceful drain (pm.shutdown /
+        # terminal_registry.shutdown via _stop_pm) has completed, so it skips
+        # the os._exit backstop (B2).
+        drained_event.set()
 
 
 def _install_signal_handlers(

--- a/omnigent/runtime/harnesses/_runner.py
+++ b/omnigent/runtime/harnesses/_runner.py
@@ -39,6 +39,7 @@ package shape and §Process management.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib
 import os
 import signal
@@ -49,6 +50,8 @@ from types import FrameType
 
 import uvicorn
 from fastapi import FastAPI
+
+from omnigent.inner.codex_executor import _reap_registered_appserver_pgids
 
 # uvicorn log level for harness subprocesses. ``"warning"`` keeps
 # the per-process noise low (AP and the harness wrap both emit
@@ -186,6 +189,8 @@ def _arm_hard_exit(reason: str, sig: int = signal.SIGTERM) -> None:
             file=sys.stderr,
             flush=True,
         )
+        with contextlib.suppress(Exception):
+            _reap_registered_appserver_pgids()
         os._exit(128 + int(sig))
 
     threading.Thread(target=_hard_exit, name="harness-hard-exit", daemon=True).start()

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -826,6 +826,12 @@ class HarnessProcessManager:
             stdout=None,
             stderr=None,
             env=effective_env,
+            # Own session/process group so _close_entry can group-kill the
+            # harness and any same-group children as a crash backstop,
+            # independent of the inner executor's close succeeding (O5). The
+            # child re-arms PR_SET_PDEATHSIG in-process after exec, which tracks
+            # the parent process and is unaffected by the new session.
+            start_new_session=(os.name == "posix"),
         )
         await _wait_for_socket_bind(process, socket_path, harness, conversation_id)
 
@@ -878,6 +884,16 @@ class HarnessProcessManager:
                 entry.process.kill()
                 await entry.process.wait()
         close_subprocess_transport(entry.process)
+        # Backstop (O5): the harness ran in its own session (start_new_session),
+        # so killpg its group to reap any same-group child the per-process
+        # SIGTERM/SIGKILL above (or a throwing inner-executor close) left behind.
+        # This targets ONLY the harness's own new-session group (pgid == the
+        # harness pid), never the runner's group. Codex inner children live in
+        # their OWN session and are covered by O1's atexit/signal reaper -- the
+        # two backstops are complementary.
+        if os.name == "posix" and entry.process.pid is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                os.killpg(entry.process.pid, signal.SIGKILL)
         # Best-effort socket cleanup. uvicorn's atexit usually
         # handles this when SIGTERM lands cleanly, but a
         # hard-killed runner won't.

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -732,9 +732,10 @@ class HarnessProcessManager:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._reaper_task
             self._reaper_task = None
-        # Snapshot then iterate — release mutates ``_entries``.
-        for conv_id in list(self._entries):
-            await self.release(conv_id)
+        # Snapshot then release all concurrently — release() takes
+        # _registry_lock per call and is self-contained, so concurrent
+        # gather is safe and avoids N×grace-period serial stalls.
+        await asyncio.gather(*[self.release(cid) for cid in list(self._entries)])
         # Best-effort cleanup of our instance dir. If a subprocess
         # we couldn't kill is still holding a socket file, the
         # rmtree leaves it behind; the next Omnigent boot's orphan

--- a/omnigent/terminals/registry.py
+++ b/omnigent/terminals/registry.py
@@ -502,10 +502,11 @@ class TerminalRegistry:
     async def shutdown(self) -> None:
         """Tear down every registered terminal across all conversations.
 
-        Called from the FastAPI server's lifespan shutdown handler.
-        Iterates every conversation slot and closes each instance,
-        bounded by ``_CLOSE_TIMEOUT_S`` per instance. Best-effort —
-        a stuck instance shouldn't block the rest of Omnigent shutdown.
+        Called from the FastAPI server's lifespan shutdown handler. Closes
+        every instance CONCURRENTLY (each bounded by ``_CLOSE_TIMEOUT_S`` and
+        isolated) so an N-terminal shutdown fits the runner's bounded
+        parent-death drain window instead of taking N x the per-close timeout
+        (B7). Best-effort -- a stuck or throwing instance never blocks the rest.
         """
         with self._lock:
             slots = list(self._by_conversation.items())
@@ -513,24 +514,32 @@ class TerminalRegistry:
             # AP-shutdown clears all instance locks too — every
             # conversation's terminals are being torn down.
             self._instance_locks.clear()
-        for conversation_id, slot in slots:
-            for (name, key), instance in slot.items():
-                try:
-                    await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "shutdown: close timed out for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
-                except Exception:
-                    logger.exception(
-                        "shutdown: close failed for %s:%s in conv %s",
-                        name,
-                        key,
-                        conversation_id,
-                    )
+
+        async def _close_one(conversation_id: str, name: str, key: str, instance: object) -> None:
+            try:
+                await asyncio.wait_for(instance.close(), timeout=_CLOSE_TIMEOUT_S)  # type: ignore[union-attr]
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "shutdown: close timed out for %s:%s in conv %s",
+                    name,
+                    key,
+                    conversation_id,
+                )
+            except Exception:
+                logger.exception(
+                    "shutdown: close failed for %s:%s in conv %s",
+                    name,
+                    key,
+                    conversation_id,
+                )
+
+        tasks = [
+            _close_one(conversation_id, name, key, instance)
+            for conversation_id, slot in slots
+            for (name, key), instance in slot.items()
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)
 
     def active_conversation_ids(self) -> list[str]:
         """Return ids of conversations with at least one registered terminal.

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -2599,3 +2599,56 @@ def test_model_provider_override_with_gateway_raises() -> None:
             model="some-model",
             model_provider_override="Databricks",
         )
+
+
+# ---------------------------------------------------------------------------
+# O1: codex app-server crash-safe pgid reaper
+# ---------------------------------------------------------------------------
+
+
+def test_appserver_pgid_registry_reaps_then_drains(monkeypatch):
+    """A registered app-server pgid is SIGKILL'd by the reaper and the
+    set is drained, so a clean deregister can't double-kill (O1)."""
+    import omnigent.inner.codex_executor as ce
+
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(ce.os, "killpg", lambda pgid, sig: killed.append((pgid, sig)))
+
+    ce._register_appserver_pgid(4242)
+    ce._reap_registered_appserver_pgids()
+
+    assert killed == [(4242, ce.signal.SIGKILL)]
+    # Reaper drained the set: a second reap is a no-op (no double-kill).
+    killed.clear()
+    ce._reap_registered_appserver_pgids()
+    assert killed == []
+
+
+def test_appserver_pgid_deregister_prevents_reap(monkeypatch):
+    """A cleanly-closed app-server deregisters its pgid, so the atexit
+    reaper never signals an already-reaped (and possibly PID-reused)
+    group (O1)."""
+    import omnigent.inner.codex_executor as ce
+
+    killed: list[int] = []
+    monkeypatch.setattr(ce.os, "killpg", lambda pgid, sig: killed.append(pgid))
+
+    ce._register_appserver_pgid(5151)
+    ce._deregister_appserver_pgid(5151)
+    ce._reap_registered_appserver_pgids()
+
+    assert killed == []
+
+
+def test_reap_appserver_pgids_tolerates_dead_group(monkeypatch):
+    """A group that already exited (ProcessLookupError) is skipped and the
+    set still drains — reaping is strictly best-effort (O1)."""
+    import omnigent.inner.codex_executor as ce
+
+    def _boom(pgid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(ce.os, "killpg", _boom)
+    ce._register_appserver_pgid(6262)
+    ce._reap_registered_appserver_pgids()  # must not raise
+    ce._reap_registered_appserver_pgids()  # drained; still no raise

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -778,7 +778,7 @@ def test_run_parent_death_killer_requests_shutdown_then_hard_exits() -> None:
         os.getppid() + 100000,  # already "orphaned"
         lambda: events.append("shutdown"),
         poll_interval_s=0.01,
-        grace_s=0.01,
+        drain_timeout_s=0.01,
         exit_fn=lambda code: (events.append("exit"), exit_calls.append(code)),
     )
 
@@ -808,7 +808,7 @@ def test_run_parent_death_killer_stands_down_when_adopted() -> None:
         lambda: events.append("shutdown"),
         adopted=adopted,
         poll_interval_s=0.01,
-        grace_s=0.01,
+        drain_timeout_s=0.01,
         exit_fn=lambda code: events.append("exit"),
     )
 
@@ -816,6 +816,52 @@ def test_run_parent_death_killer_stands_down_when_adopted() -> None:
         f"an adopted runner must not tear down, but observed {events}; the "
         "web UI would lose a still-live agent on a clean detach"
     )
+
+
+def test_run_parent_death_killer_exits_after_drain_without_hard_exit() -> None:
+    """When graceful drain signals completion within the timeout, the killer
+    returns WITHOUT hard-exiting -- pm/registry shutdown ran to completion (B2)."""
+    import threading
+
+    events: list[str] = []
+    drained = threading.Event()
+
+    def _request_shutdown() -> None:
+        events.append("shutdown")
+        drained.set()  # simulate the loop completing app.router.shutdown()
+
+    _run_parent_death_killer(
+        os.getppid() + 100000,  # already orphaned
+        _request_shutdown,
+        drained=drained,
+        poll_interval_s=0.01,
+        drain_timeout_s=5.0,
+        exit_fn=lambda code: events.append("exit"),
+    )
+
+    assert events == ["shutdown"], (
+        f"a completed drain must not hard-exit, observed {events}"
+    )
+
+
+def test_run_parent_death_killer_hard_exits_when_drain_times_out() -> None:
+    """If the drain never completes within the bounded timeout, the killer
+    still hard-exits as the final backstop (B2)."""
+    import threading
+
+    events: list[str] = []
+    drained = threading.Event()  # never set => drain "wedged"
+
+    _run_parent_death_killer(
+        os.getppid() + 100000,
+        lambda: events.append("shutdown"),
+        drained=drained,
+        poll_interval_s=0.01,
+        drain_timeout_s=0.05,
+        exit_fn=lambda code: (events.append("exit"), None)[1],
+    )
+
+    assert events == ["shutdown", "exit"]
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -7,6 +7,7 @@ import io
 import logging
 import os
 import tarfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -797,8 +798,6 @@ def test_run_parent_death_killer_stands_down_when_adopted() -> None:
 
     :returns: None.
     """
-    import threading
-
     events: list[str] = []
     adopted = threading.Event()
     adopted.set()
@@ -821,8 +820,6 @@ def test_run_parent_death_killer_stands_down_when_adopted() -> None:
 def test_run_parent_death_killer_exits_after_drain_without_hard_exit() -> None:
     """When graceful drain signals completion within the timeout, the killer
     returns WITHOUT hard-exiting -- pm/registry shutdown ran to completion (B2)."""
-    import threading
-
     events: list[str] = []
     drained = threading.Event()
 
@@ -847,8 +844,6 @@ def test_run_parent_death_killer_exits_after_drain_without_hard_exit() -> None:
 def test_run_parent_death_killer_hard_exits_when_drain_times_out() -> None:
     """If the drain never completes within the bounded timeout, the killer
     still hard-exits as the final backstop (B2)."""
-    import threading
-
     events: list[str] = []
     drained = threading.Event()  # never set => drain "wedged"
 

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -836,9 +836,7 @@ def test_run_parent_death_killer_exits_after_drain_without_hard_exit() -> None:
         exit_fn=lambda code: events.append("exit"),
     )
 
-    assert events == ["shutdown"], (
-        f"a completed drain must not hard-exit, observed {events}"
-    )
+    assert events == ["shutdown"], f"a completed drain must not hard-exit, observed {events}"
 
 
 def test_run_parent_death_killer_hard_exits_when_drain_times_out() -> None:

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -810,3 +810,56 @@ async def test_orphan_sweep_escalates_to_sigkill(
 
     assert calls == 2
     assert killed == [(12345, signal.SIGTERM), (12345, signal.SIGKILL)]
+
+
+# ── O5: harness session leadership + group-kill backstop ──────
+
+
+async def test_spawned_harness_is_session_leader(
+    manager: HarnessProcessManager,
+) -> None:
+    """The harness subprocess is spawned in its own session (O5), so
+    _close_entry can group-kill it without touching the runner's group."""
+    if os.name != "posix":
+        pytest.skip("process groups are POSIX-only")
+    await manager.start()
+    try:
+        client = await manager.get_client("conv_a", _TEST_HARNESS_NAME)
+        pid = (await client.get("/pid")).json()["pid"]
+        # start_new_session => the child is its own session/group leader.
+        assert os.getpgid(pid) == pid
+    finally:
+        await manager.shutdown()
+
+
+async def test_close_entry_group_kills_as_backstop(
+    manager: HarnessProcessManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_close_entry killpg's the harness's own group even when the normal
+    per-process teardown is made to look successful, proving the backstop is
+    independent of the inner-executor close (O5)."""
+    if os.name != "posix":
+        pytest.skip("process groups are POSIX-only")
+    from omnigent.runtime.harnesses import process_manager as pm_mod
+
+    killed_groups: list[int] = []
+    real_killpg = os.killpg
+    monkeypatch.setattr(
+        pm_mod.os,
+        "killpg",
+        lambda pgid, sig: (killed_groups.append(pgid), real_killpg(pgid, sig))[1],
+    )
+    await manager.start()
+    try:
+        client = await manager.get_client("conv_a", _TEST_HARNESS_NAME)
+        pid = (await client.get("/pid")).json()["pid"]
+        await manager.release("conv_a")
+        assert pid in killed_groups
+        for _ in range(20):
+            if not _pid_alive(pid):
+                break
+            await asyncio.sleep(0.05)
+        assert not _pid_alive(pid)
+    finally:
+        await manager.shutdown()

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -832,6 +832,68 @@ async def test_spawned_harness_is_session_leader(
         await manager.shutdown()
 
 
+async def test_shutdown_releases_entries_concurrently(
+    manager: HarnessProcessManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """shutdown() releases all entries concurrently, not serially.
+
+    With N entries each whose close takes ~grace_s, a serial loop
+    would take N*grace_s.  Concurrent gather completes in ~1*grace_s.
+    We inject a slow fake _close_entry and assert the wall-clock
+    elapsed is closer to 1x than N-serial.
+    """
+    from omnigent.runtime.harnesses import process_manager as pm_mod
+
+    GRACE_S = 0.15
+    N = 3
+
+    released: list[str] = []
+
+    async def slow_close(entry: pm_mod._SubprocessEntry) -> None:
+        await asyncio.sleep(GRACE_S)
+        released.append(entry.harness)  # harness field stores conv_id in fake entries
+
+    monkeypatch.setattr(manager, "_close_entry", slow_close)
+
+    # Inject N fake entries directly into the registry so we don't need
+    # real subprocesses.  We abuse the harness field to carry the conv_id.
+    import unittest.mock as mock
+
+    await manager.start()
+    try:
+        for i in range(N):
+            cid = f"conv_fake_{i}"
+            fake_process = mock.MagicMock()
+            fake_process.returncode = 0
+            fake_process.pid = i + 1
+            fake_client = mock.MagicMock()
+            fake_client.aclose = mock.AsyncMock()
+            entry = pm_mod._SubprocessEntry(
+                process=fake_process,
+                client=fake_client,
+                socket_path=manager.instance_dir / f"conv-fake-{i}.sock",
+                harness=cid,  # overloaded to track which entry closed
+            )
+            manager._entries[cid] = entry
+
+        t0 = asyncio.get_event_loop().time()
+        await manager.shutdown()
+        elapsed = asyncio.get_event_loop().time() - t0
+
+        # All entries released
+        assert set(released) == {f"conv_fake_{i}" for i in range(N)}
+        # Elapsed should be ~1*GRACE_S (concurrent), not N*GRACE_S (serial).
+        # Allow generous headroom (2x) to avoid CI flakiness.
+        assert elapsed < GRACE_S * 2, (
+            f"shutdown took {elapsed:.3f}s — expected ~{GRACE_S:.2f}s (concurrent); "
+            f"serial would take ~{N * GRACE_S:.2f}s"
+        )
+    finally:
+        # shutdown already called above; reset state so fixture teardown is safe
+        manager._started = False
+
+
 async def test_close_entry_group_kills_as_backstop(
     manager: HarnessProcessManager,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/terminals/test_registry.py
+++ b/tests/terminals/test_registry.py
@@ -846,3 +846,55 @@ def test_multiple_terminals_per_conversation(tmp_path: Path) -> None:
 
     for (name, key), inst in instances.items():
         assert reg.get("conv_a", name, key) is inst
+
+
+async def test_shutdown_closes_instances_concurrently(tmp_path: Path) -> None:
+    """shutdown closes all terminals concurrently (asyncio.gather), so total
+    time is ~one close, not the serial sum -- otherwise a multi-terminal
+    shutdown blows the parent-death drain window and leaks (B7)."""
+    reg = TerminalRegistry()
+
+    overlap = {"max_in_flight": 0, "in_flight": 0}
+    barrier = asyncio.Event()
+
+    def _make_instance(name: str) -> TerminalInstance:
+        inst = TerminalInstance(
+            name=name,
+            session_key="s1",
+            socket_path=tmp_path / f"{name}.sock",
+            private_dir=tmp_path / name,
+            running=True,
+        )
+
+        async def _close() -> None:
+            overlap["in_flight"] += 1
+            overlap["max_in_flight"] = max(overlap["max_in_flight"], overlap["in_flight"])
+            # Yield so a serial implementation would never see in_flight > 1.
+            await barrier.wait()
+            overlap["in_flight"] -= 1
+
+        inst.close = _close  # type: ignore[method-assign]
+        return inst
+
+    reg._by_conversation["conv_a"] = {
+        ("t1", "s1"): _make_instance("t1"),
+        ("t2", "s1"): _make_instance("t2"),
+    }
+    reg._by_conversation["conv_b"] = {("t3", "s1"): _make_instance("t3")}
+
+    async def _release_soon() -> None:
+        # Let all three close() coroutines reach the barrier, then release.
+        for _ in range(50):
+            if overlap["max_in_flight"] >= 3:
+                break
+            await asyncio.sleep(0.01)
+        barrier.set()
+
+    releaser = asyncio.create_task(_release_soon())
+    await reg.shutdown()
+    await releaser
+
+    assert overlap["max_in_flight"] >= 2, (
+        "shutdown closed terminals serially; expected concurrent closes (B7)"
+    )
+    assert reg.active_conversation_ids() == []


### PR DESCRIPTION
## Summary

Crash-safe, deterministic teardown for the runner so it stops accumulating<br>orphaned codex app-server process groups, tmux servers, and sockets.<br>Addresses the first four root causes in omnigent-ai/omnigent#561.

## Changes

* codex app-server reaper: a process-wide registry of live app-server<br>process-group ids, killed by an atexit hook and by the harness hard-exit<br>path before os.\_exit. Registered on spawn, deregistered on clean close.<br>(omnigent/inner/codex_executor.py, omnigent/codex_native_app_server.py,<br>omnigent/runtime/harnesses/\_runner.py)
* harness spawn group plus backstop kill: the harness subprocess is spawned<br>with start_new_session so it leads its own group; \_close_entry group-kills<br>that group as a backstop independent of the inner executor close. Codex<br>inner children live in their own session and are covered by the reaper<br>above, so the two backstops are complementary, not redundant.<br>(omnigent/runtime/harnesses/process_manager.py)
* parent-death drain: the parent-death killer waits on a drained event with a<br>bounded timeout so pm.shutdown and registry.shutdown actually run before the<br>os.\_exit backstop. (omnigent/runner/\_entry.py)
* concurrent shutdown: TerminalRegistry.shutdown and<br>HarnessProcessManager.shutdown close/release concurrently instead of<br>serially, so a multi-terminal shutdown fits the drain window.<br>(omnigent/terminals/registry.py, omnigent/runtime/harnesses/process_manager.py)

## Safety

All reaping keys off process exit or an owner pid that is provably gone. There<br>is no wall-clock or idle reaping, so a live or dormant session is never torn<br>down. The group-kill targets only the harness's own new session group; codex<br>inner children are in their own session and handled by the reaper. Each<br>backstop is independent of the others and of the normal close path.

## Tests

Unit tests added in the matching suites: codex pgid register/reap/deregister<br>(tests/inner), harness session-leader and close-entry group-kill plus the<br>parent-death drain (tests/runtime, tests/runner), concurrent shutdown<br>(tests/terminals, tests/runtime). tests/inner, tests/runtime, tests/runner and<br>tests/terminals pass locally; ruff check and ruff format are clean. No e2e is<br>added: this is a robustness fix with no new user-facing surface.

## Follow-ups (not in this PR)

* replace the lsof socket-holder probe with a /proc scan (lsof is absent on<br>the hardened container), tracked under omnigent-ai/omnigent#561.
* a periodic in-run dead-peer sweep and bridge-dir cleanup.