### PR TITLE
feat(sandbox): rewrite OpenShell launcher onto the gRPC SDK; add connect + server-managed

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,6 +78,9 @@ deploy/
 ├── e2b/               ← E2B sandbox-provider guide (boots from a pre-built
 │   └── README.md         E2B template); NOT a server deploy target.
 │
+├── openshell/         ← NVIDIA OpenShell sandbox-provider guide (self-hosted
+│   └── README.md         gRPC gateway, on-prem/air-gapped); NOT a server target.
+│
 └── docker/            ← common Docker image + compose stack
     ├── Dockerfile         multi-stage slim image (node web build → python builder → runtime)
     ├── docker-compose.yaml   omnigent + postgres for any Docker host

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -150,6 +150,18 @@ FROM node:${NODE_VERSION}-slim AS node-runtime
 # coding-harness CLIs (claude / codex / pi) so claude-sdk, claude-native,
 # codex, and pi agents can run in managed sandboxes without an in-sandbox
 # install. No SPA, no psycopg, no server entrypoint.
+#
+# Also carries two additions required only by the NVIDIA OpenShell provider
+# (deploy/openshell/README.md) and inert for the root-based providers
+# (Modal / Daytona / CoreWeave):
+#   - iproute2 / nftables: OpenShell puts each sandbox in its own network
+#     namespace and routes egress through a policy proxy; the supervisor
+#     shells out to `ip` to build that netns and refuses to start a sandbox
+#     without it. The other providers create no namespaces, so it sits unused.
+#   - a non-root `sandbox` user/group: OpenShell drops privileges to a user
+#     literally named `sandbox` before running the agent (defense in depth)
+#     and fails closed if it is absent. The other providers run as root and
+#     never reference it.
 FROM python:${PYTHON_VERSION}-slim AS host
 ARG NPM_CONFIG_REGISTRY=
 ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY}
@@ -167,7 +179,15 @@ ENV PYTHONUNBUFFERED=1 \
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git tmux bubblewrap curl ca-certificates \
+      iproute2 nftables \
  && rm -rf /var/lib/apt/lists/*
+
+# OpenShell-required non-root user (see the header note). UID/GID in the high
+# range per OpenShell's bring-your-own-container guidance, so that without
+# user-namespace remapping the sandbox user maps to an unprivileged, unused
+# host id. Unused by the root-based providers.
+RUN groupadd -g 1000660000 sandbox \
+ && useradd -m -u 1000660000 -g sandbox sandbox
 
 # Git credential helper for private repositories over HTTPS: answers
 # `git credential get` from GIT_TOKEN / GIT_USERNAME in the

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -55,7 +55,7 @@ from omnigent.onboarding.sandboxes.base import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from openshell import ExecResult, SandboxClient
+    from openshell import ExecResult
 
 HOST_IMAGE_ENV_VAR: str = "OMNIGENT_OPENSHELL_HOST_IMAGE"
 """Environment variable overriding :data:`DEFAULT_HOST_IMAGE` for
@@ -232,6 +232,10 @@ class _OpenShellClient:
                 ):
                     pass
             except Exception:
+                # Fire-and-forget daemon pump: exec_stream raises (gRPC
+                # cancellation / SandboxError) when the in-sandbox host exits
+                # or the sandbox is deleted — the expected end of this thread,
+                # with no caller left to surface it to.
                 pass
 
         thread = threading.Thread(target=_pump, name=f"openshell-host-{name}", daemon=True)

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -2,35 +2,48 @@
 NVIDIA OpenShell sandbox launcher.
 
 Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
-for `NVIDIA OpenShell <https://github.com/NVIDIA/openshell>`_ sandboxes.
-OpenShell provides AI-agent sandboxes via Docker containers exposed
-through a FastAPI REST API. The integration talks to the OpenShell HTTP
-API directly through ``httpx`` (already a base Omnigent dependency), so
-there is no provider SDK extra to install.
+for `NVIDIA OpenShell <https://github.com/NVIDIA/openshell>`_ sandboxes
+on top of the official ``openshell`` Python SDK. Same posture as the
+Modal, Daytona, and CoreWeave launchers: the SDK is an optional
+dependency (``pip install 'omnigent[openshell]'``) imported lazily, so
+the provider can be listed and the module probed without it.
 
-Platform notes that shape this launcher:
+OpenShell is self-hosted: a gateway control plane manages sandbox
+lifecycle on a configured compute driver (Docker, Podman, microVM,
+Kubernetes), filling the gap for on-prem and air-gapped deployments
+where cloud providers are unavailable.
 
-- **Self-hosted.** OpenShell runs on the user's own infrastructure via
-  Docker, making it suitable for on-prem deployments where cloud
-  providers (Modal, Daytona, E2B) are unavailable.
-- **API-driven.** All operations use OpenShell's REST API: sandbox
-  create/delete for lifecycle, command execution for running code, and
-  file upload/download for wheel shipping.
-- **No local port forwarding.** OpenShell does not provide a
-  local-to-sandbox port forward for the in-sandbox App OAuth callback.
-  The CLI therefore skips that auth step automatically.
+Notes that shape this launcher:
+
+- **gRPC, not REST.** OpenShell's control plane is a gRPC service; the
+  ``openshell`` SDK wraps it. The launcher connects through
+  :meth:`SandboxClient.from_active_cluster`, which resolves the active
+  gateway (its endpoint, TLS material, and OIDC token) from the gateway
+  selected by ``openshell gateway select`` — i.e. ``$OPENSHELL_GATEWAY``
+  or ``~/.config/openshell/active_gateway``. There is no base-URL knob.
+- **Custom host image.** Omnigent boots its prebaked host image, which
+  rides in ``SandboxSpec.template.image``. The SDK's public ``create``
+  takes only a ``SandboxSpec`` and does not re-export the spec
+  protobufs, so the spec is built from the generated ``openshell._proto``
+  module — the only path to a non-default image.
+- **No file-transfer RPC.** OpenShell exposes command execution but no
+  upload primitive, so :meth:`put` streams the file's bytes to ``cat``
+  over the exec channel's stdin — the same approach NVIDIA's own
+  LangChain backend uses.
+- **No local port forwarding.** OpenShell has no local→sandbox port
+  forward for the in-sandbox App OAuth callback, so the CLI skips that
+  auth step automatically (``supports_local_port_forward = False``).
 """
 
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
-from pathlib import Path
-from typing import Any, ClassVar
-from urllib.parse import quote
+import shlex
+from collections.abc import Callable, Sequence
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 import click
-import httpx
 
 from omnigent.onboarding.sandboxes.base import (
     DEFAULT_HOST_IMAGE,
@@ -39,8 +52,10 @@ from omnigent.onboarding.sandboxes.base import (
     host_image_wheel_install_command,
 )
 
-BASE_URL_ENV_VAR: str = "OPENSHELL_BASE_URL"
-"""OpenShell server base URL, e.g. ``http://localhost:8000``."""
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from openshell import ExecResult, SandboxClient
 
 HOST_IMAGE_ENV_VAR: str = "OMNIGENT_OPENSHELL_HOST_IMAGE"
 """Environment variable overriding :data:`DEFAULT_HOST_IMAGE` for
@@ -50,116 +65,236 @@ SANDBOX_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_OPENSHELL_SANDBOX_ENV"
 """Comma-separated server-process environment variable names injected
 into created OpenShell sandboxes."""
 
-_DEFAULT_SANDBOX_CPU = 2
-_DEFAULT_SANDBOX_MEMORY_MB = 4096
-_REQUEST_TIMEOUT_S = 30.0
-_PROVISION_TIMEOUT_S = 300.0
+GATEWAY_ENV_VAR: str = "OPENSHELL_GATEWAY"
+"""Gateway name read by the SDK's :meth:`SandboxClient.from_active_cluster`;
+overrides ``~/.config/openshell/active_gateway``."""
+
+_READY_TIMEOUT_S = 300
+_EXEC_TIMEOUT_S = 300
+# A foreground host (`omnigent host`) is held open until Ctrl-C, so its
+# exec stream must not hit a gRPC deadline mid-session — give it a long
+# ceiling. The pidfile records the in-sandbox pid so Ctrl-C can kill the
+# remote process (cancelling the local stream doesn't stop it).
+_FOREGROUND_TIMEOUT_S = 7 * 24 * 3600
+_FOREGROUND_PIDFILE = "/tmp/oa-openshell-foreground.pid"
+
+# OpenShell runs the agent as the non-root ``sandbox`` user (its image
+# contract; see deploy/docker/Dockerfile), whose home is ``/home/sandbox``.
+# The host image keeps ``WORKDIR /root`` for the root-based providers, so we
+# pin every exec's cwd + ``$HOME`` to the sandbox user's writable home here
+# rather than changing the shared image — otherwise ``omnigent host`` resolves
+# its config under ``/root`` (unreadable to the sandbox user) and crashes, and
+# the managed flow's ``$HOME/workspace`` lands somewhere unwritable.
+_SANDBOX_HOME = "/home/sandbox"
+
+_T = TypeVar("_T")
 
 
-class _OpenShellAPIError(RuntimeError):
-    """Provider-boundary error with a user-facing message."""
+def _ensure_sdk() -> None:
+    """Verify the openshell SDK is importable, with an install hint when not."""
+    try:
+        import openshell  # noqa: F401
+    except ImportError as exc:
+        raise click.ClickException(
+            "The openshell SDK is required for the 'openshell' sandbox provider. "
+            "Install it with `pip install 'omnigent[openshell]'`, then select a "
+            "gateway with `openshell gateway select <name>` (or set OPENSHELL_GATEWAY)."
+        ) from exc
 
 
 class _OpenShellClient:
-    """Small synchronous OpenShell HTTP API client."""
+    """Thin wrapper over the ``openshell`` gRPC SandboxClient.
 
-    def __init__(self, *, base_url: str) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._client = httpx.Client(timeout=_REQUEST_TIMEOUT_S)
+    Owns the launcher's contact with the SDK: it builds the create
+    spec, maps the public sandbox name back to the id ``exec`` needs,
+    and translates SDK / gRPC errors into ``click.ClickException`` so
+    the launcher surface stays clean.
+    """
+
+    def __init__(self, *, cluster: str | None = None) -> None:
+        _ensure_sdk()
+        from openshell import SandboxClient, SandboxError
+
+        try:
+            self._client: SandboxClient = SandboxClient.from_active_cluster(cluster=cluster)
+        except SandboxError as exc:
+            raise click.ClickException(
+                f"Could not connect to an OpenShell gateway: {exc}. Select one with "
+                "`openshell gateway select <name>` (or set OPENSHELL_GATEWAY)."
+            ) from exc
+        # Petname (public handle) -> opaque sandbox id, which exec needs.
+        self._ids: dict[str, str] = {}
+        # Daemon threads holding long-lived exec streams open (see
+        # exec_background): OpenShell kills an exec's processes when the
+        # ExecSandbox RPC returns, so a backgrounded host must be kept on
+        # an open stream for its lifetime.
+        self._bg_threads: list[object] = []
 
     def close(self) -> None:
-        """Close the underlying HTTP connection pool."""
+        """Release the gRPC channel and any bearer-auth resources."""
         self._client.close()
 
-    def create_sandbox(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Create a sandbox and return the response object."""
-        return self._request_json("POST", "/sandboxes", json=payload, timeout=_PROVISION_TIMEOUT_S)
+    def create_sandbox(self, *, image: str, env: dict[str, str]) -> str:
+        """Create a sandbox from *image*, wait until ready, return its name."""
+        from openshell._proto import openshell_pb2
 
-    def execute(self, sandbox_id: str, command: str, timeout: int = 300) -> dict[str, Any]:
-        """Execute a command in a sandbox and return the result."""
-        return self._request_json(
-            "POST",
-            f"/sandboxes/{_url_component(sandbox_id)}/execute",
-            json={"command": command, "timeout": timeout},
-            timeout=max(float(timeout) + 10.0, _REQUEST_TIMEOUT_S),
+        spec = openshell_pb2.SandboxSpec(
+            template=openshell_pb2.SandboxTemplate(image=image),
+            environment=env or {},
+        )
+        ref = self._guard(
+            "OpenShell sandbox creation failed",
+            lambda: self._client.create(spec=spec),
+        )
+        ready = self._guard(
+            "OpenShell sandbox did not become ready",
+            lambda: self._client.wait_ready(ref.name, timeout_seconds=_READY_TIMEOUT_S),
+        )
+        sandbox_name: str = ready.name
+        self._ids[sandbox_name] = ready.id
+        return sandbox_name
+
+    def execute(
+        self,
+        name: str,
+        command: Sequence[str],
+        *,
+        stdin: bytes | None = None,
+        timeout: int = _EXEC_TIMEOUT_S,
+    ) -> ExecResult:
+        """Run *command* (argv) in the sandbox and return its ExecResult."""
+        sandbox_id = self._id_for(name)
+        return self._guard(
+            f"Remote command failed on OpenShell sandbox '{name}'",
+            lambda: self._client.exec(
+                sandbox_id,
+                command,
+                stdin=stdin,
+                timeout_seconds=timeout,
+                workdir=_SANDBOX_HOME,
+                env={"HOME": _SANDBOX_HOME},
+            ),
         )
 
-    def upload_file(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
-        """Upload one file to an absolute path in the sandbox."""
-        with local_path.open("rb") as file_obj:
-            files = {"file": (local_path.name, file_obj, "application/octet-stream")}
-            self._request(
-                "POST",
-                f"/sandboxes/{_url_component(sandbox_id)}/upload",
-                files=files,
-                data={"path": remote_path},
-            )
+    def run_foreground(self, name: str, command: Sequence[str], *, timeout: int) -> int:
+        """Stream a command's output to the terminal; return its exit code."""
+        import grpc
+        from openshell import ExecChunk, ExecResult, SandboxError
 
-    def get_status(self, sandbox_id: str) -> dict[str, Any]:
-        """Get the status of a sandbox."""
-        return self._request_json("GET", f"/sandboxes/{_url_component(sandbox_id)}/status")
-
-    def delete_sandbox(self, sandbox_id: str) -> None:
-        """Delete a sandbox. Missing sandboxes are treated as gone."""
+        sandbox_id = self._id_for(name)
+        exit_code = 0
         try:
-            self._request("DELETE", f"/sandboxes/{_url_component(sandbox_id)}")
-        except _OpenShellAPIError as exc:
-            if "HTTP 404" not in str(exc):
-                raise
-
-    def _request_json(
-        self, method: str, endpoint: str, timeout: float | None = None, **kwargs: Any
-    ) -> dict[str, Any]:
-        response = self._request(method, endpoint, timeout=timeout, **kwargs)
-        try:
-            data = response.json()
-        except ValueError as exc:
-            raise _OpenShellAPIError(
-                f"openshell {method} {endpoint} returned invalid JSON"
+            for item in self._client.exec_stream(
+                sandbox_id,
+                command,
+                timeout_seconds=timeout,
+                workdir=_SANDBOX_HOME,
+                env={"HOME": _SANDBOX_HOME},
+            ):
+                if isinstance(item, ExecResult):
+                    exit_code = int(item.exit_code)
+                elif isinstance(item, ExecChunk):
+                    click.echo(
+                        item.data.decode("utf-8", errors="replace"),
+                        nl=False,
+                        err=item.stream != "stdout",
+                    )
+        except (grpc.RpcError, SandboxError) as exc:
+            raise click.ClickException(
+                f"Foreground command failed on OpenShell sandbox '{name}': {exc}"
             ) from exc
-        if not isinstance(data, dict):
-            raise _OpenShellAPIError(
-                f"openshell {method} {endpoint} returned a non-object response"
-            )
-        return data
+        return exit_code
 
-    def _request(
-        self, method: str, endpoint: str, timeout: float | None = None, **kwargs: Any
-    ) -> httpx.Response:
-        url = self._url(endpoint)
-        effective_timeout = timeout if timeout is not None else _REQUEST_TIMEOUT_S
-        try:
-            response = self._client.request(method, url, timeout=effective_timeout, **kwargs)
-        except httpx.HTTPError as exc:
-            raise _OpenShellAPIError(f"openshell {method} {endpoint} failed: {exc}") from exc
-        if response.status_code >= 400:
-            raise self._response_error(method, endpoint, response)
-        return response
+    def exec_background(self, name: str, command: Sequence[str], *, timeout: int) -> None:
+        """
+        Start a long-lived foreground command, holding its exec stream open.
 
-    def _url(self, endpoint: str) -> str:
-        return self._base_url + endpoint
+        OpenShell terminates an exec's process tree when the ``ExecSandbox``
+        RPC returns, so the usual ``setsid nohup … &`` detach (which works on
+        Modal/CoreWeave) is reaped immediately. Instead we run the command in
+        the FOREGROUND of an ``exec_stream`` drained on a daemon thread: the
+        stream stays open for the process's lifetime, so OpenShell keeps it
+        alive. The thread ends when the process exits or the sandbox is
+        deleted (the stream then errors out).
+        """
+        import threading
 
-    def _response_error(
-        self, method: str, endpoint: str, response: httpx.Response
-    ) -> _OpenShellAPIError:
-        try:
-            text = response.text
-        except httpx.ResponseNotRead:
-            text = response.read().decode("utf-8", errors="replace")
-        snippet = text.strip()[:1024]
-        detail = f": {snippet}" if snippet else ""
-        return _OpenShellAPIError(
-            f"openshell {method} {endpoint} failed with HTTP {response.status_code}{detail}"
+        sandbox_id = self._id_for(name)
+
+        def _pump() -> None:
+            try:
+                for _ in self._client.exec_stream(
+                    sandbox_id,
+                    command,
+                    timeout_seconds=timeout,
+                    workdir=_SANDBOX_HOME,
+                    env={"HOME": _SANDBOX_HOME},
+                ):
+                    pass
+            except Exception:
+                pass
+
+        thread = threading.Thread(target=_pump, name=f"openshell-host-{name}", daemon=True)
+        thread.start()
+        self._bg_threads.append(thread)
+
+    def get_status(self, name: str) -> None:
+        """Resolve a sandbox by name (validates access) and cache its id."""
+        ref = self._guard(
+            f"Could not resolve OpenShell sandbox '{name}'",
+            lambda: self._client.get(name),
         )
+        self._ids[name] = ref.id
+
+    def delete_sandbox(self, name: str) -> None:
+        """Delete a sandbox; a missing sandbox is treated as already gone."""
+        import grpc
+        from openshell import SandboxError
+
+        try:
+            self._client.delete(name)
+        except grpc.RpcError as exc:
+            if isinstance(exc, grpc.Call) and exc.code() == grpc.StatusCode.NOT_FOUND:
+                self._ids.pop(name, None)
+                return
+            raise click.ClickException(
+                f"Failed to delete OpenShell sandbox '{name}': {exc}"
+            ) from exc
+        except SandboxError as exc:
+            raise click.ClickException(
+                f"Failed to delete OpenShell sandbox '{name}': {exc}"
+            ) from exc
+        self._ids.pop(name, None)
+
+    def _id_for(self, name: str) -> str:
+        cached = self._ids.get(name)
+        if cached is None:
+            ref = self._guard(
+                f"Could not resolve OpenShell sandbox '{name}'",
+                lambda: self._client.get(name),
+            )
+            cached = ref.id
+            self._ids[name] = cached
+        return cached
+
+    def _guard(self, message: str, call: Callable[[], _T]) -> _T:
+        """Run an SDK *call*, surfacing gRPC / SandboxError as ClickException."""
+        import grpc
+        from openshell import SandboxError
+
+        try:
+            return call()
+        except (grpc.RpcError, SandboxError) as exc:
+            raise click.ClickException(f"{message}: {exc}") from exc
 
 
 class OpenShellSandboxLauncher(SandboxLauncher):
     """
-    :class:`SandboxLauncher` for NVIDIA OpenShell sandboxes.
+    :class:`SandboxLauncher` for NVIDIA OpenShell, over the ``openshell`` SDK.
 
-    All primitives use OpenShell's REST API: sandbox create/delete for
-    lifecycle, command execution for running code, and file upload for
-    wheel shipping.
+    Lifecycle and transport map onto the SDK's gRPC client: create /
+    wait-ready / delete for the sandbox, command execution for running
+    code, and an exec-over-stdin stream for shipping wheels.
     """
 
     provider: ClassVar[str] = "openshell"
@@ -170,97 +305,132 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         *,
         image: str | None = None,
         env: Sequence[str] | None = None,
-        base_url: str | None = None,
-        cpu: int | None = None,
-        memory_mb: int | None = None,
+        cluster: str | None = None,
     ) -> None:
+        """
+        :param image: Registry image to provision from
+            (``sandbox.openshell.image``); ``None`` resolves
+            :data:`HOST_IMAGE_ENV_VAR` then the official host image.
+        :param env: Server-process env var NAMES to inject into every
+            sandbox (``sandbox.openshell.env``); ``None`` resolves
+            :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR`.
+        :param cluster: Gateway name to connect to
+            (``sandbox.openshell.cluster``); ``None`` lets the SDK
+            resolve the active gateway (``$OPENSHELL_GATEWAY`` or
+            ``~/.config/openshell/active_gateway``).
+        """
         self._image_ref = image
         self._env_names = tuple(env) if env is not None else None
-        self._base_url = base_url
-        self._cpu = cpu
-        self._memory_mb = memory_mb
+        self._cluster = cluster
         self._client: _OpenShellClient | None = None
 
     def prepare(self) -> None:
-        """Verify OpenShell server URL is available."""
-        if not (self._base_url or os.environ.get(BASE_URL_ENV_VAR)):
-            raise click.ClickException(
-                "No OpenShell server configured. Set OPENSHELL_BASE_URL to "
-                "the OpenShell server address (e.g. http://localhost:8000)."
-            )
+        """Preflight: the SDK must be installed and a gateway resolvable."""
+        _ensure_sdk()
+        # Constructing the client resolves the active gateway from on-disk
+        # state, failing fast with a remediation hint before remote work.
+        self._openshell()
 
     def provision(self, name: str) -> str:
-        """Create a new OpenShell sandbox from the host image."""
-        resolved_ref = self._image_ref or os.environ.get(HOST_IMAGE_ENV_VAR) or DEFAULT_HOST_IMAGE
-        payload: dict[str, Any] = {
-            "image": resolved_ref,
-            "name": name,
-        }
-        cpu = self._cpu or _DEFAULT_SANDBOX_CPU
-        memory = self._memory_mb or _DEFAULT_SANDBOX_MEMORY_MB
-        payload["cpu"] = cpu
-        payload["memory_mb"] = memory
+        """Create a sandbox from the host image and wait until it is ready."""
+        image = self._image_ref or os.environ.get(HOST_IMAGE_ENV_VAR) or DEFAULT_HOST_IMAGE
         env_vars = self._resolve_sandbox_env()
-        if env_vars:
-            payload["env"] = env_vars
-        click.echo(f"▸ Creating OpenShell sandbox from {resolved_ref}")
-        try:
-            sandbox = self._openshell().create_sandbox(payload)
-        except _OpenShellAPIError as exc:
-            raise click.ClickException(f"OpenShell sandbox creation failed: {exc}") from exc
-        sandbox_id = sandbox.get("id") or sandbox.get("sandbox_id") or sandbox.get("name")
-        if not isinstance(sandbox_id, str) or not sandbox_id:
-            raise click.ClickException("OpenShell sandbox creation returned no sandbox identifier")
-        click.echo(f"  → created {sandbox_id}")
-        return sandbox_id
+        click.echo(f"▸ Creating OpenShell sandbox from {image}")
+        # OpenShell assigns its own petname; the requested `name` is advisory.
+        sandbox_name = self._openshell().create_sandbox(image=image, env=env_vars)
+        click.echo(f"  → created {sandbox_name}")
+        return sandbox_name
 
     def attach(self, sandbox_id: str) -> None:
-        """Validate access to an existing OpenShell sandbox."""
+        """Validate access to an existing OpenShell sandbox by name."""
         click.echo(f"▸ Reusing existing OpenShell sandbox '{sandbox_id}'")
-        try:
-            self._openshell().get_status(sandbox_id)
-        except _OpenShellAPIError as exc:
-            raise click.ClickException(
-                f"Could not attach to OpenShell sandbox '{sandbox_id}': {exc}"
-            ) from exc
+        self._openshell().get_status(sandbox_id)
 
     def keep_alive(self, sandbox_id: str) -> None:
         """No idle auto-stop management is exposed by the OpenShell API."""
         click.echo(f"  → OpenShell sandbox '{sandbox_id}' remains active until destroyed")
 
     def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
-        """Run a shell command in the sandbox and capture its output."""
-        try:
-            result = self._openshell().execute(sandbox_id, command)
-        except _OpenShellAPIError as exc:
-            raise click.ClickException(
-                f"Remote command failed on OpenShell sandbox '{sandbox_id}': {exc}"
-            ) from exc
-        stdout = result.get("stdout", "")
-        stderr = result.get("stderr", "")
-        exit_code = result.get("exit_code", 1)
-        if stdout:
-            click.echo(stdout, nl=False)
-        if stderr:
-            click.echo(stderr, nl=False, err=True)
-        if check and exit_code != 0:
+        """Run ``bash -lc <command>`` in the sandbox and capture its output."""
+        # The server's managed-host launch detaches the in-sandbox host with a
+        # ``setsid nohup omnigent host … & echo launched`` idiom and expects it
+        # to keep running after this call returns. On OpenShell a backgrounded
+        # exec process is killed the moment the exec returns, so run it instead
+        # as a foreground command on a held-open stream (exec_background); the
+        # host then survives to dial back and register.
+        stripped = command.rstrip()
+        if stripped.endswith("& echo launched") and "omnigent host" in stripped:
+            # Drop the detach scaffolding (``setsid nohup … & echo launched``):
+            # the command must run in the FOREGROUND of the held-open stream,
+            # or OpenShell reaps it the instant the exec returns. The output
+            # redirect (``> … 2>&1 < /dev/null``) is kept so the stream stays
+            # quiet while the host runs for the session's lifetime.
+            foreground = stripped[: -len("& echo launched")].rstrip()
+            foreground = foreground.replace("setsid nohup ", "")
+            self._openshell().exec_background(
+                sandbox_id, ["bash", "-lc", foreground], timeout=_FOREGROUND_TIMEOUT_S
+            )
+            return RemoteCommandResult(returncode=0, stdout="launched\n", stderr="")
+        result = self._openshell().execute(sandbox_id, ["bash", "-lc", command])
+        if result.stdout:
+            click.echo(result.stdout, nl=False)
+        if result.stderr:
+            click.echo(result.stderr, nl=False, err=True)
+        if check and result.exit_code != 0:
             raise click.ClickException(
                 f"Remote command failed on OpenShell sandbox '{sandbox_id}' "
-                f"(exit {exit_code}): {command}"
+                f"(exit {result.exit_code}): {command}"
             )
-        return RemoteCommandResult(returncode=exit_code, stdout=stdout, stderr=stderr)
+        return RemoteCommandResult(
+            returncode=result.exit_code, stdout=result.stdout, stderr=result.stderr
+        )
 
     def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
-        """Copy a local file into the sandbox."""
-        try:
-            self._openshell().upload_file(sandbox_id, local_path, remote_path)
-        except _OpenShellAPIError as exc:
+        """Copy a local file into the sandbox by piping its bytes to ``cat``."""
+        content = local_path.read_bytes()
+        parent = shlex.quote(str(PurePosixPath(remote_path).parent))
+        dest = shlex.quote(remote_path)
+        result = self._openshell().execute(
+            sandbox_id,
+            ["bash", "-c", f"mkdir -p {parent} && cat > {dest}"],
+            stdin=content,
+        )
+        if result.exit_code != 0:
             raise click.ClickException(
-                f"File upload to OpenShell sandbox '{sandbox_id}' failed: {exc}"
-            ) from exc
+                f"File upload to OpenShell sandbox '{sandbox_id}' failed "
+                f"(exit {result.exit_code}): {result.stderr.strip()}"
+            )
+
+    def exec_foreground(self, sandbox_id: str, command: str) -> int:
+        """
+        Run *command* in the sandbox, streaming its output, until it exits.
+
+        Holds ``omnigent host`` open for ``omnigent sandbox connect``;
+        Ctrl-C kills the remote process and re-raises ``KeyboardInterrupt``.
+        """
+        client = self._openshell()
+        # `exec` keeps the recorded pid across the shell swap, so a Ctrl-C
+        # can kill the remote process — cancelling the local gRPC stream
+        # stops our reads but doesn't stop the remote command.
+        remote = f"echo $$ > {shlex.quote(_FOREGROUND_PIDFILE)} && exec {command}"
+        try:
+            return client.run_foreground(
+                sandbox_id, ["bash", "-lc", remote], timeout=_FOREGROUND_TIMEOUT_S
+            )
+        except KeyboardInterrupt:
+            click.echo("\n  → detaching; stopping the remote process")
+            client.execute(
+                sandbox_id,
+                [
+                    "bash",
+                    "-lc",
+                    f"kill $(cat {shlex.quote(_FOREGROUND_PIDFILE)}) 2>/dev/null || true",
+                ],
+            )
+            raise
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:
-        """Remote command that overlays shipped wheels onto the host image."""
+        """Overlay shipped wheels onto the prebaked host image."""
         return host_image_wheel_install_command(remote_tgz_path)
 
     def terminate(self, sandbox_id: str) -> None:
@@ -274,13 +444,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
 
     def _openshell(self) -> _OpenShellClient:
         if self._client is None:
-            base_url = self._base_url or os.environ.get(BASE_URL_ENV_VAR)
-            if not base_url:
-                raise click.ClickException(
-                    "No OpenShell server configured. Set OPENSHELL_BASE_URL to "
-                    "the OpenShell server address (e.g. http://localhost:8000)."
-                )
-            self._client = _OpenShellClient(base_url=base_url)
+            self._client = _OpenShellClient(cluster=self._cluster)
         return self._client
 
     def _resolve_sandbox_env(self) -> dict[str, str]:
@@ -303,7 +467,3 @@ class OpenShellSandboxLauncher(SandboxLauncher):
                 )
             resolved[name] = value
         return resolved
-
-
-def _url_component(value: str) -> str:
-    return quote(value, safe="")

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -32,7 +32,7 @@ stores into ``create_app``):
    ``<data_dir>/config.yaml``)::
 
        sandbox:
-         provider: modal          # lakebox | modal | daytona | islo
+         provider: modal          # lakebox|modal|daytona|cwsandbox|islo|openshell
          server_url: https://omnigent.example.com
          modal:                   # optional block
            image: docker.io/me/omnigent-host:latest  # default: official image
@@ -54,6 +54,11 @@ stores into ``create_app``):
            vcpus: 2
            memory_mb: 4096
            disk_gb: 20
+         openshell:               # optional block (provider: openshell)
+           image: docker.io/me/omnigent-host:latest  # default: official image
+           env: [OPENAI_API_KEY, GIT_TOKEN]  # SERVER env var NAMES injected
+                                             # as sandbox env
+           cluster: my-gateway              # optional OpenShell gateway name
 
    The image defaults to the official prebaked host image
    (``ghcr.io/omnigent-ai/omnigent-host:latest``; see
@@ -65,9 +70,13 @@ stores into ``create_app``):
    launcher reads ``DAYTONA_API_KEY`` (plus optional
    ``DAYTONA_API_URL`` / ``DAYTONA_TARGET``), and the Islo launcher
    reads ``ISLO_API_KEY`` (plus optional ``ISLO_BASE_URL``) from the
-   server process environment. ``modal``, ``daytona``, and ``islo``
-   have managed-launch support; ``lakebox`` parses but rejects at
-   launch.
+   server process environment. The OpenShell launcher needs no API key:
+   it connects to the gateway made active with ``openshell gateway
+   select`` (``$OPENSHELL_GATEWAY`` / ``~/.config/openshell/active_gateway``,
+   or ``sandbox.openshell.cluster``), so the server process needs
+   OpenShell gateway access. ``modal``, ``daytona``, ``cwsandbox``,
+   ``islo``, and ``openshell`` have managed-launch support; ``lakebox``
+   parses but rejects at launch.
 
 2. **Direct construction** (embedding deployments): build
    :class:`ManagedSandboxConfig` with a custom
@@ -121,10 +130,10 @@ _logger = logging.getLogger(__name__)
 # ManagedSandboxConfig directly are not constrained by either set —
 # their launcher factory IS the support.)
 SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
-    {"lakebox", "modal", "daytona", "cwsandbox", "islo", "e2b"}
+    {"lakebox", "modal", "daytona", "cwsandbox", "islo", "e2b", "openshell"}
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
-    {"modal", "daytona", "cwsandbox", "islo", "e2b"}
+    {"modal", "daytona", "cwsandbox", "islo", "e2b", "openshell"}
 )
 
 # How long a managed launch waits for the sandboxed host to register
@@ -156,6 +165,13 @@ DAYTONA_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 # deleted by managed-session teardown; use the same 7-day policy bound
 # as Daytona for long-lived hosts and stale-token cleanup.
 ISLO_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# Launch-token lifetime for the YAML openshell path. OpenShell sandboxes
+# run until deleted (no platform lifetime cap), so the bound is policy,
+# not platform: the same 7-day window as Daytona/Islo keeps a long-lived
+# sandbox re-authenticating across tunnel reconnects while still expiring
+# tokens of sandboxes nobody deleted. A relaunch mints a fresh token.
+OPENSHELL_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 
 # The cwsandbox launch-token TTL is NOT a constant: CW Sandbox's lifetime is
 # operator-overridable (OMNIGENT_CWSANDBOX_MAX_LIFETIME_S), so the TTL is
@@ -628,6 +644,13 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
         # outlives the (operator-overridable) sandbox lifetime — mirrors
         # the cwsandbox path.
         token_ttl_s = managed_token_ttl_s()
+    elif provider == "openshell":
+        launcher_factory = _openshell_launcher_factory(
+            image=_parse_provider_image(raw, "openshell"),
+            env=_parse_provider_env(raw, "openshell"),
+            cluster=_parse_provider_string(raw, "openshell", "cluster"),
+        )
+        token_ttl_s = OPENSHELL_MANAGED_TOKEN_TTL_S
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -983,6 +1006,36 @@ def _islo_launcher_factory(
             memory_mb=memory_mb,
             disk_gb=disk_gb,
         )
+
+    return _build
+
+
+def _openshell_launcher_factory(
+    *,
+    image: str | None,
+    env: list[str] | None,
+    cluster: str | None,
+) -> Callable[[], SandboxLauncher]:
+    """
+    Build the launcher factory for the YAML ``provider: openshell`` path.
+
+    :param image: Registry image reference with omnigent pre-installed,
+        e.g. ``"docker.io/me/omnigent-host:latest"``, or ``None`` to use
+        the official prebaked host image (env-overridable).
+    :param env: Names of server-process environment variables injected
+        into every sandbox, e.g. ``["OPENAI_API_KEY", "GIT_TOKEN"]``, or
+        ``None`` to resolve from the launcher's env-var fallback.
+    :param cluster: OpenShell gateway name to connect to, or ``None`` to
+        use the active gateway (``$OPENSHELL_GATEWAY`` /
+        ``~/.config/openshell/active_gateway``).
+    :returns: A factory producing parameterized OpenShell launchers.
+    """
+
+    def _build() -> SandboxLauncher:
+        """Construct the OpenShell launcher (lazy SDK import inside)."""
+        from omnigent.onboarding.sandboxes.openshell import OpenShellSandboxLauncher
+
+        return OpenShellSandboxLauncher(image=image, env=env, cluster=cluster)
 
     return _build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,10 @@ cwsandbox = ["cwsandbox>=0.24,<1"]
 # server-managed `sandbox.provider: e2b`).
 # Same lazy-import posture as above.
 e2b = ["e2b>=2.26,<3"]
+# NVIDIA OpenShell launcher (`omnigent sandbox --provider openshell`).
+# Self-hosted gRPC gateway; the SDK pulls grpcio + protobuf. Same
+# lazy-import posture as above. Pre-1.0 SDK: pin minor.
+openshell = ["openshell>=0.0.7,<1"]
 # MLflow tracing is opt-in: tracing is disabled by default and the
 # server degrades gracefully when mlflow is absent, so the (heavy) mlflow
 # dependency only installs for users who want it (`omnigent[tracing]`).
@@ -488,6 +492,17 @@ ignore_missing_imports = true
 # modal above.
 [[tool.mypy.overrides]]
 module = "e2b.*"
+ignore_missing_imports = true
+
+# openshell is an optional dep (the `openshell` extra); same lazy-import
+# posture as modal above. grpc rides in via the openshell SDK and is not
+# a base dependency, so its imports are unresolved in the default env too.
+[[tool.mypy.overrides]]
+module = "openshell.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "grpc.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/onboarding/sandboxes/test_openshell.py
+++ b/tests/onboarding/sandboxes/test_openshell.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import click
@@ -11,176 +14,137 @@ import pytest
 
 from omnigent.onboarding.sandboxes.base import DEFAULT_HOST_IMAGE
 from omnigent.onboarding.sandboxes.openshell import (
-    BASE_URL_ENV_VAR,
     HOST_IMAGE_ENV_VAR,
     SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
     OpenShellSandboxLauncher,
     _OpenShellClient,
 )
 
+# ── Shared fakes ────────────────────────────────────────────
+
 
 @dataclass
-class _HttpRequest:
-    """One recorded fake HTTP request."""
+class _FakeExecResult:
+    """Stands in for ``openshell.ExecResult``."""
 
-    method: str
-    url: str
-    kwargs: dict[str, Any]
-
-
-class _FakeResponse:
-    """Minimal ``httpx.Response`` stand-in for client tests."""
-
-    def __init__(self, status_code: int, data: dict[str, Any], text: str = "") -> None:
-        self.status_code = status_code
-        self._data = data
-        self.text = text
-
-    def json(self) -> dict[str, Any]:
-        return self._data
+    exit_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
 
 
-class _FakeHTTPClient:
-    """Recorder for the subset of ``httpx.Client`` used by ``_OpenShellClient``."""
+@dataclass
+class _FakeExecChunk:
+    """Stands in for ``openshell.ExecChunk`` (one stdout/stderr fragment)."""
 
-    def __init__(self) -> None:
-        self.requests: list[_HttpRequest] = []
-        self.closed = False
-        self.next_response: _FakeResponse | None = None
+    stream: str
+    data: bytes
 
-    def request(
-        self,
-        method: str,
-        url: str,
-        *,
-        timeout: float | None = None,
-        **kwargs: Any,
-    ) -> _FakeResponse:
-        self.requests.append(_HttpRequest(method=method, url=url, kwargs=kwargs))
-        if self.next_response is not None:
-            resp = self.next_response
-            self.next_response = None
-            return resp
-        return _FakeResponse(200, {"id": "sb-1", "ok": True})
 
-    def close(self) -> None:
-        self.closed = True
+# ── Launcher-level fake (the _OpenShellClient wrapper) ──────
+#
+# The launcher tests monkeypatch ``launcher._openshell`` to return this
+# recorder, exercising the launcher's logic without the SDK.
 
 
 @dataclass
 class _FakeOpenShellAPI:
-    """Recorder for the launcher-facing OpenShell API client."""
+    """Recorder for the launcher-facing OpenShell wrapper."""
 
-    create_payloads: list[dict[str, Any]] = field(default_factory=list)
-    exec_calls: list[tuple[str, str]] = field(default_factory=list)
-    uploads: list[tuple[str, Path, str]] = field(default_factory=list)
-    deleted: list[str] = field(default_factory=list)
+    create_kwargs: list[dict[str, Any]] = field(default_factory=list)
+    exec_calls: list[tuple[str, list[str], bytes | None]] = field(default_factory=list)
     statuses: list[str] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
     closed: bool = False
+    exec_result: _FakeExecResult = field(default_factory=_FakeExecResult)
+    created_name: str = "petname-test"
+    foreground_calls: list[tuple[str, list[str]]] = field(default_factory=list)
+    foreground_exit_code: int = 0
+    foreground_raises: BaseException | None = None
 
-    def create_sandbox(self, payload: dict[str, Any]) -> dict[str, Any]:
-        self.create_payloads.append(dict(payload))
-        return {"id": "sb-test-123"}
+    def create_sandbox(self, *, image: str, env: dict[str, str]) -> str:
+        self.create_kwargs.append({"image": image, "env": env})
+        return self.created_name
 
-    def execute(self, sandbox_id: str, command: str, timeout: int = 300) -> dict[str, Any]:
-        self.exec_calls.append((sandbox_id, command))
-        return {"stdout": "out\n", "stderr": "err\n", "exit_code": 0}
+    def run_foreground(self, name: str, command: list[str], *, timeout: int) -> int:
+        self.foreground_calls.append((name, list(command)))
+        if self.foreground_raises is not None:
+            raise self.foreground_raises
+        return self.foreground_exit_code
 
-    def upload_file(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
-        self.uploads.append((sandbox_id, local_path, remote_path))
+    def execute(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        stdin: bytes | None = None,
+        timeout: int = 300,
+    ) -> _FakeExecResult:
+        self.exec_calls.append((name, list(command), stdin))
+        return self.exec_result
 
-    def get_status(self, sandbox_id: str) -> dict[str, Any]:
-        self.statuses.append(sandbox_id)
-        return {"status": "running"}
+    def get_status(self, name: str) -> None:
+        self.statuses.append(name)
 
-    def delete_sandbox(self, sandbox_id: str) -> None:
-        self.deleted.append(sandbox_id)
+    def delete_sandbox(self, name: str) -> None:
+        self.deleted.append(name)
 
     def close(self) -> None:
         self.closed = True
 
 
-def test_prepare_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Preflight fails when ``OPENSHELL_BASE_URL`` is absent."""
-    monkeypatch.delenv(BASE_URL_ENV_VAR, raising=False)
-    with pytest.raises(click.ClickException, match="OPENSHELL_BASE_URL"):
-        OpenShellSandboxLauncher().prepare()
-
-    monkeypatch.setenv(BASE_URL_ENV_VAR, "http://localhost:8000")
-    OpenShellSandboxLauncher().prepare()
-
-
-def test_prepare_accepts_constructor_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Constructor ``base_url`` satisfies the preflight check."""
-    monkeypatch.delenv(BASE_URL_ENV_VAR, raising=False)
-    OpenShellSandboxLauncher(base_url="http://localhost:8000").prepare()
+# ── Launcher behavior ───────────────────────────────────────
 
 
 def test_provision_creates_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Provisioning sends image, cpu, and memory in the create payload."""
-    fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(
-        base_url="http://localhost:8000",
-        image="custom-image:latest",
-        cpu=4,
-        memory_mb=8192,
-    )
+    """Provisioning passes the image + env to create and returns the name."""
+    fake = _FakeOpenShellAPI(created_name="petname-abc")
+    launcher = OpenShellSandboxLauncher(image="custom-image:latest")
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
-    sandbox_id = launcher.provision("test-host")
+    sandbox_name = launcher.provision("test-host")
 
-    assert sandbox_id == "sb-test-123"
-    assert fake.create_payloads == [
-        {
-            "image": "custom-image:latest",
-            "name": "test-host",
-            "cpu": 4,
-            "memory_mb": 8192,
-        }
-    ]
+    assert sandbox_name == "petname-abc"
+    assert fake.create_kwargs == [{"image": "custom-image:latest", "env": {}}]
 
 
 def test_provision_uses_default_image(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without an explicit image, the official host image is used."""
     monkeypatch.delenv(HOST_IMAGE_ENV_VAR, raising=False)
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     launcher.provision("host")
 
-    [payload] = fake.create_payloads
-    assert payload["image"] == DEFAULT_HOST_IMAGE
+    [created] = fake.create_kwargs
+    assert created["image"] == DEFAULT_HOST_IMAGE
 
 
 def test_provision_uses_image_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     """Host image can be overridden via environment variable."""
     monkeypatch.setenv(HOST_IMAGE_ENV_VAR, "docker.io/custom/host:1")
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     launcher.provision("host")
 
-    [payload] = fake.create_payloads
-    assert payload["image"] == "docker.io/custom/host:1"
+    [created] = fake.create_kwargs
+    assert created["image"] == "docker.io/custom/host:1"
 
 
 def test_provision_with_env_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Configured env vars are injected into the sandbox create payload."""
+    """Configured env vars are injected into the sandbox create spec."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("GIT_TOKEN", "ghp-test")
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(
-        base_url="http://localhost:8000",
-        env=["OPENAI_API_KEY", "GIT_TOKEN"],
-    )
+    launcher = OpenShellSandboxLauncher(env=["OPENAI_API_KEY", "GIT_TOKEN"])
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     launcher.provision("host")
 
-    [payload] = fake.create_payloads
-    assert payload["env"] == {"OPENAI_API_KEY": "sk-test", "GIT_TOKEN": "ghp-test"}
+    [created] = fake.create_kwargs
+    assert created["env"] == {"OPENAI_API_KEY": "sk-test", "GIT_TOKEN": "ghp-test"}
 
 
 def test_provision_env_passthrough_via_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -188,38 +152,38 @@ def test_provision_env_passthrough_via_env_var(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "OPENAI_API_KEY")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     launcher.provision("host")
 
-    [payload] = fake.create_payloads
-    assert payload["env"] == {"OPENAI_API_KEY": "sk-test"}
+    [created] = fake.create_kwargs
+    assert created["env"] == {"OPENAI_API_KEY": "sk-test"}
 
 
-def test_provision_env_passthrough_missing_var_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_provision_env_passthrough_missing_var_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     """A configured but unset env name aborts before creating a sandbox."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000", env=["OPENAI_API_KEY"])
+    launcher = OpenShellSandboxLauncher(env=["OPENAI_API_KEY"])
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     with pytest.raises(click.ClickException, match="OPENAI_API_KEY"):
         launcher.provision("host")
-    assert fake.create_payloads == []
+    assert fake.create_kwargs == []
 
 
 def test_run_captures_output(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``run`` captures stdout, stderr, and exit code from the API response."""
-    fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    """``run`` wraps the command in ``bash -lc`` and captures output."""
+    fake = _FakeOpenShellAPI(
+        exec_result=_FakeExecResult(exit_code=0, stdout="out\n", stderr="err\n")
+    )
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     result = launcher.run("sb-1", "echo hello")
 
-    assert fake.exec_calls == [("sb-1", "echo hello")]
+    assert fake.exec_calls == [("sb-1", ["bash", "-lc", "echo hello"], None)]
     assert result.returncode == 0
     assert result.stdout == "out\n"
     assert result.stderr == "err\n"
@@ -227,14 +191,8 @@ def test_run_captures_output(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_run_check_raises_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
     """``run`` with ``check=True`` raises on non-zero exit."""
-    fake = _FakeOpenShellAPI()
-
-    def _failing_execute(sandbox_id: str, command: str, timeout: int = 300) -> dict:
-        fake.exec_calls.append((sandbox_id, command))
-        return {"stdout": "", "stderr": "error\n", "exit_code": 1}
-
-    fake.execute = _failing_execute  # type: ignore[assignment]
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    fake = _FakeOpenShellAPI(exec_result=_FakeExecResult(exit_code=1, stderr="boom\n"))
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     with pytest.raises(click.ClickException, match="exit 1"):
@@ -243,40 +201,52 @@ def test_run_check_raises_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_run_no_check_allows_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
     """``run`` with ``check=False`` returns the result even on non-zero exit."""
-    fake = _FakeOpenShellAPI()
-
-    def _failing_execute(sandbox_id: str, command: str, timeout: int = 300) -> dict:
-        fake.exec_calls.append((sandbox_id, command))
-        return {"stdout": "", "stderr": "error\n", "exit_code": 1}
-
-    fake.execute = _failing_execute  # type: ignore[assignment]
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    fake = _FakeOpenShellAPI(exec_result=_FakeExecResult(exit_code=1, stderr="boom\n"))
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     result = launcher.run("sb-1", "false", check=False)
 
     assert result.returncode == 1
-    assert result.stderr == "error\n"
+    assert result.stderr == "boom\n"
 
 
 def test_put_uploads_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``put`` delegates to the client's upload_file method."""
+    """``put`` streams the file's bytes to ``cat`` over the exec channel."""
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     local_file = tmp_path / "wheels.tgz"
     local_file.write_bytes(b"fake-tarball")
 
-    launcher.put("sb-1", local_file, "/tmp/wheels.tgz")
+    launcher.put("sb-1", local_file, "/tmp/oa/wheels.tgz")
 
-    assert fake.uploads == [("sb-1", local_file, "/tmp/wheels.tgz")]
+    [(name, command, stdin)] = fake.exec_calls
+    assert name == "sb-1"
+    assert command[:2] == ["bash", "-c"]
+    assert "mkdir -p /tmp/oa &&" in command[2]
+    assert "cat > /tmp/oa/wheels.tgz" in command[2]
+    assert stdin == b"fake-tarball"
+
+
+def test_put_raises_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``put`` raises when the remote ``cat`` exits non-zero."""
+    fake = _FakeOpenShellAPI(exec_result=_FakeExecResult(exit_code=1, stderr="denied"))
+    launcher = OpenShellSandboxLauncher()
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    local_file = tmp_path / "wheels.tgz"
+    local_file.write_bytes(b"data")
+
+    with pytest.raises(click.ClickException, match="File upload"):
+        launcher.put("sb-1", local_file, "/tmp/wheels.tgz")
 
 
 def test_attach_validates_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
     """``attach`` checks sandbox status via the API."""
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
     launcher.attach("sb-1")
@@ -287,53 +257,283 @@ def test_attach_validates_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_terminate_deletes_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
     """``terminate`` calls delete and cleans up the client."""
     fake = _FakeOpenShellAPI()
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     monkeypatch.setattr(launcher, "_openshell", lambda: fake)
-    monkeypatch.setattr(launcher, "_client", fake)  # So terminate can close it
+    monkeypatch.setattr(launcher, "_client", fake)  # so terminate can close it
 
     launcher.terminate("sb-1")
 
     assert fake.deleted == ["sb-1"]
+    assert fake.closed is True
 
 
 def test_wheel_install_command() -> None:
     """``wheel_install_command`` delegates to the shared helper."""
-    launcher = OpenShellSandboxLauncher(base_url="http://localhost:8000")
+    launcher = OpenShellSandboxLauncher()
     cmd = launcher.wheel_install_command("/tmp/oa-wheels.tgz")
     assert "pip install" in cmd
     assert "/tmp/oa-wheels.tgz" in cmd
 
 
-def test_client_create_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The HTTP client sends a POST to /sandboxes."""
-    import omnigent.onboarding.sandboxes.openshell as openshell_mod
+def test_exec_foreground_returns_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``exec_foreground`` records the pid and runs the command under ``exec``."""
+    fake = _FakeOpenShellAPI(foreground_exit_code=0)
+    launcher = OpenShellSandboxLauncher()
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
 
-    fake = _FakeHTTPClient()
-    monkeypatch.setattr(openshell_mod.httpx, "Client", lambda **kwargs: fake)
+    rc = launcher.exec_foreground("sb-1", "omnigent host --server https://s")
 
-    client = _OpenShellClient(base_url="http://localhost:8000/")
-
-    result = client.create_sandbox({"image": "python:3.11"})
-    assert result == {"id": "sb-1", "ok": True}
-
-    assert len(fake.requests) == 1
-    assert fake.requests[0].method == "POST"
-    assert fake.requests[0].url == "http://localhost:8000/sandboxes"
+    assert rc == 0
+    [(name, command)] = fake.foreground_calls
+    assert name == "sb-1"
+    assert command[:2] == ["bash", "-lc"]
+    assert command[2].startswith("echo $$ >")
+    assert "exec omnigent host --server https://s" in command[2]
 
 
-def test_client_delete_ignores_404(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_exec_foreground_ctrl_c_kills_remote(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ctrl-C during a foreground host kills the remote process and re-raises."""
+    fake = _FakeOpenShellAPI(foreground_raises=KeyboardInterrupt())
+    launcher = OpenShellSandboxLauncher()
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    with pytest.raises(KeyboardInterrupt):
+        launcher.exec_foreground("sb-1", "omnigent host --server https://s")
+
+    # The interrupt handler issued a best-effort kill of the recorded pid.
+    assert any("kill $(cat" in command[2] for _name, command, _stdin in fake.exec_calls)
+
+
+# ── _OpenShellClient wrapper against a faked SDK ────────────
+#
+# These exercise the real wrapper (spec building, name->id mapping,
+# error translation) by injecting a stub `openshell` SDK — the SDK is
+# an optional dependency the test env does not install, and real
+# sandboxes only exist behind a live gateway.
+
+
+@dataclass
+class _SDKState:
+    """Shared recorder for the faked SDK."""
+
+    connect_error: bool = False
+    delete_not_found: bool = False
+    created_spec: Any = None
+    waited: tuple[str, int | None] | None = None
+    got: list[str] = field(default_factory=list)
+    execs: list[tuple[str, list[str], bytes | None]] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+    closed: bool = False
+    exec_result: _FakeExecResult = field(default_factory=_FakeExecResult)
+    stream_calls: list[tuple[str, list[str]]] = field(default_factory=list)
+    stream_chunks: list[tuple[str, bytes]] = field(default_factory=list)
+    stream_exit_code: int = 0
+    last_workdir: str | None = None
+    last_env: dict[str, str] | None = None
+
+
+@pytest.fixture
+def sdk(monkeypatch: pytest.MonkeyPatch) -> _SDKState:
+    """Inject a fake ``openshell`` SDK (+ ``openshell._proto`` and ``grpc``)."""
+    state = _SDKState()
+
+    class _SandboxError(RuntimeError):
+        pass
+
+    @dataclass
+    class _SandboxRef:
+        id: str
+        name: str
+
+    # Fake grpc surface used by delete_sandbox / _guard.
+    class _RpcError(Exception):
+        pass
+
+    class _NotFound(_RpcError):
+        def __init__(self, code: str) -> None:
+            super().__init__("not found")
+            self._code = code
+
+        def code(self) -> str:
+            return self._code
+
+    class _StatusCode:
+        NOT_FOUND = "NOT_FOUND"
+
+    class _SandboxClient:
+        @classmethod
+        def from_active_cluster(cls, *, cluster: str | None = None, **_: Any) -> _SandboxClient:
+            if state.connect_error:
+                raise _SandboxError("no active gateway configured")
+            return cls()
+
+        def create(self, *, spec: Any) -> _SandboxRef:
+            state.created_spec = spec
+            return _SandboxRef(id="id-1", name="petname-new")
+
+        def wait_ready(self, name: str, *, timeout_seconds: int | None = None) -> _SandboxRef:
+            state.waited = (name, timeout_seconds)
+            return _SandboxRef(id="id-1", name=name)
+
+        def get(self, name: str) -> _SandboxRef:
+            state.got.append(name)
+            return _SandboxRef(id=f"id-for-{name}", name=name)
+
+        def exec(
+            self,
+            sandbox_id: str,
+            command: Any,
+            *,
+            stdin: bytes | None = None,
+            timeout_seconds: int | None = None,
+            workdir: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> _FakeExecResult:
+            state.execs.append((sandbox_id, list(command), stdin))
+            state.last_workdir = workdir
+            state.last_env = env
+            return state.exec_result
+
+        def exec_stream(
+            self,
+            sandbox_id: str,
+            command: Any,
+            *,
+            timeout_seconds: int | None = None,
+            workdir: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> Any:
+            state.stream_calls.append((sandbox_id, list(command)))
+            state.last_workdir = workdir
+            state.last_env = env
+            for stream, data in state.stream_chunks:
+                yield _FakeExecChunk(stream=stream, data=data)
+            yield _FakeExecResult(exit_code=state.stream_exit_code)
+
+        def delete(self, name: str) -> None:
+            state.deleted.append(name)
+            if state.delete_not_found:
+                raise _NotFound(_StatusCode.NOT_FOUND)
+
+        def close(self) -> None:
+            state.closed = True
+
+    fake_grpc = SimpleNamespace(RpcError=_RpcError, Call=_NotFound, StatusCode=_StatusCode)
+
+    # Fake spec protobufs: record kwargs as attributes for assertions.
+    class _Template:
+        def __init__(self, **kw: Any) -> None:
+            self.__dict__.update(kw)
+
+    class _Spec:
+        def __init__(self, **kw: Any) -> None:
+            self.__dict__.update(kw)
+
+    fake_pb2 = SimpleNamespace(SandboxSpec=_Spec, SandboxTemplate=_Template)
+
+    openshell_mod = types.ModuleType("openshell")
+    openshell_mod.SandboxClient = _SandboxClient  # type: ignore[attr-defined]
+    openshell_mod.SandboxError = _SandboxError  # type: ignore[attr-defined]
+    openshell_mod.ExecResult = _FakeExecResult  # type: ignore[attr-defined]
+    openshell_mod.ExecChunk = _FakeExecChunk  # type: ignore[attr-defined]
+    proto_mod = types.ModuleType("openshell._proto")
+    proto_mod.openshell_pb2 = fake_pb2  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "openshell", openshell_mod)
+    monkeypatch.setitem(sys.modules, "openshell._proto", proto_mod)
+    monkeypatch.setitem(sys.modules, "grpc", fake_grpc)
+    return state
+
+
+def test_prepare_requires_gateway(sdk: _SDKState) -> None:
+    """Preflight surfaces a remediation hint when no gateway resolves."""
+    sdk.connect_error = True
+    with pytest.raises(click.ClickException, match="openshell gateway select"):
+        OpenShellSandboxLauncher().prepare()
+
+
+def test_prepare_succeeds_with_gateway(sdk: _SDKState) -> None:
+    """Preflight passes when the SDK resolves an active gateway."""
+    OpenShellSandboxLauncher().prepare()
+
+
+def test_client_create_sandbox(sdk: _SDKState) -> None:
+    """create_sandbox builds a spec with the image, waits ready, returns name."""
+    client = _OpenShellClient()
+    name = client.create_sandbox(image="ghcr.io/x/host:1", env={"A": "1"})
+
+    assert name == "petname-new"
+    assert sdk.created_spec.template.image == "ghcr.io/x/host:1"
+    assert sdk.created_spec.environment == {"A": "1"}
+    assert sdk.waited == ("petname-new", 300)
+
+
+def test_client_execute_maps_name_to_id(sdk: _SDKState) -> None:
+    """exec uses the opaque sandbox id, resolved from the petname."""
+    client = _OpenShellClient()
+    client.create_sandbox(image="img", env={})
+
+    client.execute("petname-new", ["echo", "hi"])
+
+    # Cached from create — no extra get() needed; exec keyed by id.
+    assert sdk.execs[-1][0] == "id-1"
+    assert sdk.got == []
+
+
+def test_client_execute_resolves_unknown_name(sdk: _SDKState) -> None:
+    """An un-cached name is resolved to its id via get() before exec."""
+    client = _OpenShellClient()
+
+    client.execute("other-box", ["ls"])
+
+    assert sdk.got == ["other-box"]
+    assert sdk.execs[-1][0] == "id-for-other-box"
+
+
+def test_client_execute_pins_sandbox_home(sdk: _SDKState) -> None:
+    """
+    Execs run with cwd + ``$HOME`` set to the non-root sandbox user's home.
+
+    OpenShell runs as the ``sandbox`` user; without this the host image's
+    ``/root`` cwd/home is unreadable to it and ``omnigent host`` crashes.
+    """
+    client = _OpenShellClient()
+
+    client.execute("box", ["printf", "%s", "$HOME"])
+
+    assert sdk.last_workdir == "/home/sandbox"
+    assert sdk.last_env == {"HOME": "/home/sandbox"}
+
+
+def test_client_delete_ignores_not_found(sdk: _SDKState) -> None:
     """Deleting a missing sandbox is treated as success (idempotent)."""
-    import omnigent.onboarding.sandboxes.openshell as openshell_mod
+    sdk.delete_not_found = True
+    client = _OpenShellClient()
 
-    fake = _FakeHTTPClient()
-    fake.next_response = _FakeResponse(404, {}, text="not found")
-    monkeypatch.setattr(openshell_mod.httpx, "Client", lambda **kwargs: fake)
-
-    client = _OpenShellClient(base_url="http://localhost:8000")
-
-    # The 404 triggers _response_error which raises _OpenShellAPIError
-    # containing "HTTP 404", which delete_sandbox catches.
     client.delete_sandbox("gone-sandbox")
 
-    assert len(fake.requests) == 1
-    assert fake.requests[0].method == "DELETE"
+    assert sdk.deleted == ["gone-sandbox"]
+
+
+def test_client_connect_error_raises(sdk: _SDKState) -> None:
+    """A gateway-resolution failure surfaces as a ClickException."""
+    sdk.connect_error = True
+    with pytest.raises(click.ClickException, match="OpenShell gateway"):
+        _OpenShellClient()
+
+
+def test_client_run_foreground_streams_and_returns_exit(
+    sdk: _SDKState, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """run_foreground streams stdout/stderr chunks and returns the exit code."""
+    sdk.stream_chunks = [("stdout", b"hello\n"), ("stderr", b"warn\n")]
+    sdk.stream_exit_code = 3
+    client = _OpenShellClient()
+
+    code = client.run_foreground("other-box", ["bash", "-lc", "echo hi"], timeout=60)
+
+    assert code == 3
+    assert sdk.stream_calls[-1] == ("id-for-other-box", ["bash", "-lc", "echo hi"])
+    out, err = capsys.readouterr()
+    assert "hello" in out
+    assert "warn" in err

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -191,6 +191,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.vcpus: int | None = None
         self.memory_mb: int | None = None
         self.disk_gb: int | None = None
+        self.cluster: str | None = None
         self.prepared = False
         self.provisioned_names: list[str] = []
         self.commands: list[str] = []
@@ -412,6 +413,37 @@ def install_fake_e2b_launcher(
         return fake
 
     monkeypatch.setattr(e2b_mod, "E2BSandboxLauncher", _ctor)
+
+
+def install_fake_openshell_launcher(
+    monkeypatch: Any,  # pytest.MonkeyPatch — Any avoids importing pytest in a helpers module
+    fake: FakeSandboxLauncher,
+) -> None:
+    """
+    Substitute the fake for ``OpenShellSandboxLauncher`` at its public seam.
+
+    The managed flow constructs ``OpenShellSandboxLauncher(image=…,
+    env=…, cluster=…)``; the shim records those constructor args on the
+    fake and hands it back, so production code runs unmodified against it.
+
+    :param monkeypatch: The test's ``pytest.MonkeyPatch``.
+    :param fake: The fake launcher to substitute.
+    """
+    import omnigent.onboarding.sandboxes.openshell as openshell_mod
+
+    def _ctor(
+        *,
+        image: str | None = None,
+        env: list[str] | None = None,
+        cluster: str | None = None,
+    ) -> FakeSandboxLauncher:
+        """Stand-in constructor recording the construction wiring."""
+        fake.image = image
+        fake.env = env
+        fake.cluster = cluster
+        return fake
+
+    monkeypatch.setattr(openshell_mod, "OpenShellSandboxLauncher", _ctor)
 
 
 async def wait_for_completion(

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -18,6 +18,7 @@ from omnigent.server.managed_hosts import (
     DAYTONA_MANAGED_TOKEN_TTL_S,
     ISLO_MANAGED_TOKEN_TTL_S,
     MODAL_MANAGED_TOKEN_TTL_S,
+    OPENSHELL_MANAGED_TOKEN_TTL_S,
     ManagedSandboxConfig,
     RepoWorkspace,
     launch_managed_host,
@@ -38,6 +39,7 @@ from tests.server.helpers import (
     install_fake_e2b_launcher,
     install_fake_islo_launcher,
     install_fake_modal_launcher,
+    install_fake_openshell_launcher,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -326,6 +328,56 @@ def test_parse_e2b_template_rejects_non_string(monkeypatch: pytest.MonkeyPatch) 
         )
 
 
+def test_parse_valid_openshell_config_builds_parameterized_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The documented openshell YAML shape parses into a config whose
+    factory constructs OpenShell launchers carrying image, env names,
+    and the optional gateway cluster.
+    """
+    cfg = parse_sandbox_config(
+        {
+            "provider": "openshell",
+            "server_url": "https://srv.example.com/",
+            "openshell": {
+                "image": "docker.io/me/omnigent-host:latest",
+                "env": ["OPENAI_API_KEY", "GIT_TOKEN"],
+                "cluster": "my-gateway",
+            },
+        }
+    )
+    assert cfg is not None
+    assert cfg.server_url == "https://srv.example.com"
+    assert cfg.token_ttl_s == OPENSHELL_MANAGED_TOKEN_TTL_S
+    assert cfg.managed_launch_supported is True
+    assert cfg.provider == "openshell"
+    fake = FakeSandboxLauncher()
+    install_fake_openshell_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.image == "docker.io/me/omnigent-host:latest"
+    assert fake.env == ["OPENAI_API_KEY", "GIT_TOKEN"]
+    assert fake.cluster == "my-gateway"
+
+
+def test_parse_openshell_without_section_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    `provider: openshell` + `server_url` is a complete config: optional
+    constructor fields reach the launcher as None so its env-var
+    fallbacks / official-image default / active-gateway apply.
+    """
+    cfg = parse_sandbox_config({"provider": "openshell", "server_url": "https://s.example.com"})
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_openshell_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.image is None
+    assert fake.env is None
+    assert fake.cluster is None
+
+
 @pytest.mark.parametrize(
     ("raw", "expected_fragment"),
     [
@@ -382,6 +434,23 @@ def test_parse_e2b_template_rejects_non_string(monkeypatch: pytest.MonkeyPatch) 
         (
             {"provider": "islo", "server_url": "https://s", "islo": {"memory_mb": "large"}},
             "sandbox.islo.memory_mb",
+        ),
+        # openshell section present but malformed.
+        (
+            {"provider": "openshell", "server_url": "https://s", "openshell": "x"},
+            "sandbox.openshell",
+        ),
+        (
+            {"provider": "openshell", "server_url": "https://s", "openshell": {"image": "  "}},
+            "sandbox.openshell.image",
+        ),
+        (
+            {"provider": "openshell", "server_url": "https://s", "openshell": {"env": ["", "X"]}},
+            "sandbox.openshell.env",
+        ),
+        (
+            {"provider": "openshell", "server_url": "https://s", "openshell": {"cluster": "  "}},
+            "sandbox.openshell.cluster",
         ),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -2766,6 +2766,9 @@ e2b = [
 modal = [
     { name = "modal" },
 ]
+openshell = [
+    { name = "openshell" },
+]
 tracing = [
     { name = "mlflow" },
 ]
@@ -2809,6 +2812,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0,<3" },
     { name = "openai-agents", specifier = ">=0.0.17" },
     { name = "openai-agents", marker = "extra == 'agents-sdk'", specifier = ">=0.1,<1" },
+    { name = "openshell", marker = "extra == 'openshell'", specifier = ">=0.0.7,<1" },
     { name = "opentelemetry-distro", marker = "extra == 'databricks'", specifier = ">=0,<1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20,<2" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20,<2" },
@@ -2843,7 +2847,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "modal", "daytona", "cwsandbox", "e2b", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "modal", "daytona", "cwsandbox", "e2b", "openshell", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"
@@ -2917,6 +2921,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/48/ba0ad614c66d88100d61b9ddaf0793022a425b5b958c0139c2f1c7473764/openai_agents-0.17.4.tar.gz", hash = "sha256:6af9afd4b40de23493c9ab285c28cd4e8fd088240af6e96e2dee45826ad568fd", size = 5409840, upload-time = "2026-05-26T08:55:10.459Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/89/adf09ec269d4de1c7be37c747d8488aac51b58d5589a9c1dd55f3c1e8e05/openai_agents-0.17.4-py3-none-any.whl", hash = "sha256:feea8264c9812bba7c526a01f6efd4f8c0efdb348c2233c36ff9c292a9d465af", size = 842963, upload-time = "2026-05-26T08:55:08.767Z" },
+]
+
+[[package]]
+name = "openshell"
+version = "0.0.59"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/b6/999900082742355cae6ed09db7d7a60ec9db1fdb858427a7af7a9a18667d/openshell-0.0.59-py3-none-macosx_13_0_arm64.whl", hash = "sha256:37c8384c655959bfc3b92ee8c0399fa2fa867fd56253f93d9ef3959d8a2e2aa1", size = 16035032, upload-time = "2026-06-09T20:07:48.427Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/97/e7b63bbf1a35a194d0bbb3303d0430956ef2a58448080b766118fdd58d63/openshell-0.0.59-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:41ce707edb16b02ae63e20945242814e6708f4609b48e0123db3b61393cf8c4f", size = 19477386, upload-time = "2026-06-09T20:08:20.632Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/04/12f49e4f6d4fc1f63538c61152b9487ea007220c1bb18588ac40a9459057/openshell-0.0.59-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:8dd7d719d528af1cdff322f8a326d2f69ac85f56e7fee0b63c84537175c75ab4", size = 20267425, upload-time = "2026-06-09T20:08:48.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR #227 added an `OpenShellSandboxLauncher`, but it targeted a REST API that NVIDIA
OpenShell does not expose (OpenShell is **gRPC-only**), and it shipped without the
`connect` / server-managed wiring or the host-image contract — so the provider
wasn't usable end to end. PR #227 was merged but missed these; this PR adds them on
top of current `main` (alongside the e2b provider that landed since). It leaves
`main`'s existing `deploy/openshell/README.md` untouched.

- **gRPC SDK rewrite** — the launcher now wraps the official `openshell` Python SDK
  (`SandboxClient.from_active_cluster()` → `CreateSandbox` / `wait_ready` /
  `ExecSandbox` / `DeleteSandbox`), gated behind the `openshell` extra and imported
  lazily (same posture as modal / daytona / cwsandbox). It connects through the
  gateway selected by `openshell gateway select`, not a base URL. File shipping is
  exec-over-stdin, since OpenShell has no upload RPC.
- **`omnigent sandbox connect`** — `exec_foreground` streams the in-sandbox host's
  output and propagates exit codes; Ctrl-C kills the remote process.
- **Server-managed hosts** — `sandbox.provider: openshell` wired into
  `managed_hosts.py` (provider sets, `_openshell_launcher_factory`, config parsing,
  token TTL). OpenShell reaps a detached process when its exec returns, so the host
  is held open on a daemon-thread foreground exec.
- **Host-image contract** — the `host` Docker target now carries the non-root
  `sandbox` user + `iproute2`/`nftables` that OpenShell's supervisor requires (inert
  for the root-based providers); the launcher pins each exec's cwd / `$HOME` to
  `/home/sandbox` so the image's `/root` default still works for the others.
- **Deploy index** — `deploy/README.md` now lists the existing `openshell/` guide in
  its tree (it wasn't listed before).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

- Unit tests (faked SDK / launcher, no gateway needed) cover provision, run, file
  upload, foreground streaming, attach, terminate, env passthrough, error handling,
  and managed-config parsing. `pytest tests/onboarding/sandboxes/test_openshell.py
  tests/server/test_managed_hosts.py` → 99 passed; `ruff` + `mypy` clean.
- Validated **end to end against a live OpenShell gateway on an amd64 Linux host**:
  launcher primitives (provision → run → put → terminate) and `exec_foreground`, plus
  a full `host_type:"managed"` session that provisioned a sandbox on the gateway,
  started `omnigent host` in it, dialed back over the tunnel, spawned a runner, and
  completed a real agent turn from inside the sandbox.

> Note: `uv.lock` is not regenerated here (PyPI access is restricted in this
> environment); CI / a maintainer should regenerate it so the `openshell` extra's
> `openshell>=0.0.7,<1` pin lands in the lock.
