### PR TITLE
fix(runner): periodic in-run reaping of orphaned terminals, bridge dirs, and harness leftovers (Layer 3)

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -36,6 +36,7 @@ import queue
 import re
 import secrets
 import shlex
+import shutil
 import stat
 import sys
 import tempfile
@@ -59,6 +60,7 @@ if TYPE_CHECKING:
 from omnigent.inner.bundle_skills import claude_native_skill_args
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.os_env import OSEnvironment, create_os_environment
+from omnigent.inner.terminal import _process_alive as _owner_pid_alive
 from omnigent.reasoning_effort import CLAUDE_EFFORTS
 from omnigent.tools.base import Tool, ToolContext
 from omnigent.tools.builtins.os_env import build_os_env_tools
@@ -79,6 +81,7 @@ _BRIDGE_ROOT = _BRIDGE_ROOT_PARENT / "claude-native"
 _CONFIG_FILE = "bridge.json"
 _SERVER_FILE = "server.json"
 _STATE_FILE = "state.json"
+_OWNER_PID_FILENAME = "owner.pid"
 _HOOKS_FILE = "hooks.jsonl"
 _RECENT_LOCAL_COMMAND_LINE_LIMIT = 200
 _RECENT_LOCAL_COMMAND_WINDOW_S = 10.0
@@ -719,6 +722,10 @@ def prepare_bridge_dir(
     if launch_model is not None:
         payload["launch_model"] = launch_model
     _write_json_file(bridge_dir / _CONFIG_FILE, payload)
+    # Owner-pid marker for the periodic dead-peer prune (O6). See
+    # inner/terminal.py for the owner.pid convention.
+    with contextlib.suppress(OSError):
+        (bridge_dir / _OWNER_PID_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
     # Keep ``_PERMISSION_HOOK_FILE`` — the PermissionRequest command hook
     # reads the Omnigent server URL from it at runtime, so wiping it on re-prep
     # breaks approval routing on reattach/rebind. ``build_hook_settings``
@@ -733,6 +740,65 @@ def prepare_bridge_dir(
         with contextlib.suppress(FileNotFoundError):
             (bridge_dir / filename).unlink()
     return bridge_dir
+
+
+def cleanup_bridge_dir(bridge_id: str) -> bool:
+    """
+    Remove the entire per-session bridge directory for *bridge_id*.
+
+    Called on conversation teardown (O6): unlike clearing individual
+    state files, this rmtrees the whole dir so config, sockets, and the
+    owner marker do not accumulate.
+
+    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``.
+    :returns: ``True`` when a directory was removed, ``False`` when
+        none existed (idempotent).
+    """
+    bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+    if not bridge_dir.exists():
+        return False
+    shutil.rmtree(bridge_dir, ignore_errors=True)
+    return not bridge_dir.exists()
+
+
+def prune_orphaned_bridge_dirs() -> int:
+    """
+    Remove claude-native bridge dirs whose owner process is provably dead.
+
+    The in-run analog of terminal/process orphan sweeps: scans
+    ``_BRIDGE_ROOT`` and rmtrees each dir whose ``owner.pid`` marker names
+    a process that no longer exists. Conservative in the dangerous direction
+    (a reused/foreign pid reads as alive and is left), with a TOCTOU
+    re-check immediately before removal. Dirs with no marker are left
+    untouched (older versions / not ours).
+
+    Reuses the canonical liveness predicate from
+    ``inner/terminal.py:_process_alive`` via ``_owner_pid_alive``.
+
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    root = _BRIDGE_ROOT
+    if not root.exists():
+        return 0
+    pruned = 0
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        marker = entry / _OWNER_PID_FILENAME
+        try:
+            pid = int(marker.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            continue
+        if _owner_pid_alive(pid):
+            continue
+        # TOCTOU re-check immediately before removal: a pid reused by a
+        # live process between the read and now reads as alive and is
+        # skipped. See inner/terminal.py:_process_alive for the rule.
+        if _owner_pid_alive(pid):
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        pruned += 1
+    return pruned
 
 
 def ensure_claude_workspace_trusted(workspace: Path) -> None:

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
 import secrets
+import shutil
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -13,11 +15,14 @@ from pathlib import Path
 
 import tomllib
 
+from omnigent.inner.terminal import _process_alive as _owner_pid_alive
+
 CODEX_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.codex_native.bridge_id"
 CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
 
 _STATE_FILE = "state.json"
+_OWNER_PID_FILENAME = "owner.pid"
 # Must match ``_CONFIG_FILE`` in ``claude_native_bridge.py`` because
 # ``serve-mcp`` reads this filename for the token.
 _MCP_CONFIG_FILE = "bridge.json"
@@ -112,7 +117,72 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
     bridge_dir = bridge_dir_for_bridge_id(bridge_id)
     bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(bridge_dir, 0o700)
+    # Record the creating process pid so the periodic dead-peer sweep
+    # can prune this dir only when its owner is provably dead (O6).
+    # Mirrors inner/terminal.py's owner.pid convention.
+    with contextlib.suppress(OSError):
+        (bridge_dir / _OWNER_PID_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
     return bridge_dir
+
+
+def cleanup_bridge_dir(bridge_id: str) -> bool:
+    """
+    Remove the entire per-session bridge directory for *bridge_id*.
+
+    Called on conversation teardown (O6): unlike ``clear_bridge_state``
+    (which only unlinks ``state.json``), this rmtrees the whole dir so
+    codex-home, sockets, mcp/policy config, and the owner marker do not
+    accumulate.
+
+    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``.
+    :returns: ``True`` when a directory was removed, ``False`` when
+        none existed (idempotent).
+    """
+    bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+    if not bridge_dir.exists():
+        return False
+    shutil.rmtree(bridge_dir, ignore_errors=True)
+    return not bridge_dir.exists()
+
+
+def prune_orphaned_bridge_dirs() -> int:
+    """
+    Remove codex-native bridge dirs whose owner process is provably dead.
+
+    The in-run analog of terminal/process orphan sweeps: scans
+    ``bridge_root()`` and rmtrees each dir whose ``owner.pid`` marker
+    names a process that no longer exists. Conservative in the dangerous
+    direction (a reused/foreign pid reads as alive and is left), with a
+    TOCTOU re-check immediately before removal. Dirs with no marker are
+    left untouched (older versions / not ours).
+
+    Reuses the canonical liveness predicate from
+    ``inner/terminal.py:_process_alive`` via ``_owner_pid_alive``.
+
+    :returns: The number of orphaned bridge dirs removed.
+    """
+    root = bridge_root()
+    if not root.exists():
+        return 0
+    pruned = 0
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        marker = entry / _OWNER_PID_FILENAME
+        try:
+            pid = int(marker.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            continue
+        if _owner_pid_alive(pid):
+            continue
+        # TOCTOU re-check immediately before removal: a pid reused by a
+        # live process between the read and now reads as alive and is
+        # skipped. See inner/terminal.py:_process_alive for the rule.
+        if _owner_pid_alive(pid):
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        pruned += 1
+    return pruned
 
 
 def write_mcp_bridge_config(bridge_dir: Path) -> None:

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -554,15 +554,35 @@ def reap_orphaned_terminals() -> int:
             continue
         socket_path = entry / "tmux.sock"
         if socket_path.exists():
-            with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+            # Re-check liveness immediately before the kill (TOCTOU): a
+            # PID reused by a live process between the read above and now
+            # reads as alive, so we skip and never kill a live owner.
+            if _process_alive(pid):
+                continue
+            try:
                 subprocess.run(
                     ["tmux", "-S", str(socket_path), "kill-server"],
                     # kill-server on an already-dead server exits non-zero;
-                    # that is the common case for half-torn-down orphans.
+                    # that is the common case for half-torn-down orphans, so
+                    # a non-zero exit still counts as "no server left".
                     check=False,
                     capture_output=True,
                     timeout=_REAP_KILL_TIMEOUT_S,
                 )
+            except subprocess.TimeoutExpired:
+                # The server is wedged but ALIVE. Do NOT rmtree: deleting
+                # tmux.sock now would orphan a running server with no
+                # socket path, making it permanently unreapable. Leave the
+                # dir for the next sweep to retry against the real socket.
+                logger.warning(
+                    "kill-server timed out for %s; leaving dir for next sweep",
+                    socket_path,
+                )
+                continue
+            except OSError:
+                # tmux missing/unspawnable: dir removal is still safe
+                # (no live server backing this socket).
+                pass
         shutil.rmtree(entry, ignore_errors=True)
         reaped += 1
     return reaped

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -923,6 +923,11 @@ def create_app(
     app.add_event_handler("startup", _start_pm)
     app.add_event_handler("shutdown", _stop_pm)
 
+    # Exposed so the periodic dead-peer sweep (Layer 3), wired in
+    # _run_tunnel_from_env, can drive the process-manager orphan sweep
+    # in-run (not just at boot).
+    app.state.process_manager = pm
+
     return app
 
 
@@ -1021,6 +1026,31 @@ async def _run_tunnel_from_env() -> None:
             ),
             name=f"runner-idle-monitor:{runner_id}",
         )
+    from omnigent.claude_native_bridge import (
+        prune_orphaned_bridge_dirs as _prune_claude_bridge_dirs,
+    )
+    from omnigent.codex_native_bridge import (
+        prune_orphaned_bridge_dirs as _prune_codex_bridge_dirs,
+    )
+    from omnigent.inner.terminal import reap_orphaned_terminals as _reap_orphaned_terminals
+
+    _pm = app.state.process_manager
+
+    async def _sweep_pass() -> None:
+        await _run_dead_peer_sweep_pass(
+            process_manager=_pm,
+            reap_orphaned_terminals=_reap_orphaned_terminals,
+            prune_codex_bridge_dirs=_prune_codex_bridge_dirs,
+            prune_claude_bridge_dirs=_prune_claude_bridge_dirs,
+        )
+
+    sweep_task = asyncio.create_task(
+        _run_dead_peer_sweep_monitor(
+            interval_s=_load_dead_peer_sweep_interval_s(),
+            run_pass=_sweep_pass,
+        ),
+        name=f"runner-dead-peer-sweep:{runner_id}",
+    )
     if parent_pid is not None:
         # Orphan guard runs on a dedicated daemon thread, not the event
         # loop: if the loop wedges during shutdown (harness mid-boot when
@@ -1037,6 +1067,7 @@ async def _run_tunnel_from_env() -> None:
     wait_tasks = {tunnel_task, stop_task}
     if idle_task is not None:
         wait_tasks.add(idle_task)
+    wait_tasks.add(sweep_task)
     try:
         done, _ = await asyncio.wait(
             wait_tasks,
@@ -1054,6 +1085,8 @@ async def _run_tunnel_from_env() -> None:
         if idle_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await idle_task
+        with contextlib.suppress(asyncio.CancelledError):
+            await sweep_task
         await app.router.shutdown()
 
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -16,7 +16,7 @@ import signal
 import sys
 import threading
 import time
-from collections.abc import Callable, Generator
+from collections.abc import Awaitable, Callable, Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -28,6 +28,7 @@ from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_P
 if TYPE_CHECKING:
     from omnigent.runner.app import ResolvedSpec
     from omnigent.runner.transports.ws_tunnel.serve import _ASGIApp
+    from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 
 _RUNNER_SERVER_URL_ENV_VAR = "RUNNER_SERVER_URL"
 _RUNNER_PREWARM_SPEC_PATH_ENV_VAR = "RUNNER_PREWARM_SPEC_PATH"
@@ -35,6 +36,8 @@ _RUNNER_VERSION = "0.1.0"
 _RUNNER_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
 _DEFAULT_RUNNER_IDLE_TIMEOUT_S = 60 * 60
 _RUNNER_IDLE_MONITOR_MAX_POLL_INTERVAL_S = 60.0
+_DEAD_PEER_SWEEP_INTERVAL_ENV_VAR = "OMNIGENT_DEAD_PEER_SWEEP_INTERVAL_S"
+_DEFAULT_DEAD_PEER_SWEEP_INTERVAL_S = 300.0
 _logger = logging.getLogger(__name__)
 
 
@@ -155,6 +158,108 @@ async def _run_inactivity_monitor(
             request_shutdown()
             return
         await asyncio.sleep(min(poll_interval_s, idle_timeout_s - elapsed_s))
+
+
+def _load_dead_peer_sweep_interval_s() -> float:
+    """Load the periodic dead-peer sweep interval from the environment.
+
+    Reads ``OMNIGENT_DEAD_PEER_SWEEP_INTERVAL_S`` (seconds). Unset
+    defaults to :data:`_DEFAULT_DEAD_PEER_SWEEP_INTERVAL_S`. ``0`` disables
+    the sweep. A negative or non-numeric value fails loud at startup so the
+    operator does not get silently different lifecycle behaviour.
+
+    :returns: Interval in seconds, e.g. ``300.0``; ``0.0`` disables.
+    :raises RuntimeError: If the value is negative or non-numeric.
+    """
+    raw = os.environ.get(_DEAD_PEER_SWEEP_INTERVAL_ENV_VAR)
+    if raw is None or not raw.strip():
+        return _DEFAULT_DEAD_PEER_SWEEP_INTERVAL_S
+    try:
+        interval_s = float(raw.strip())
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{_DEAD_PEER_SWEEP_INTERVAL_ENV_VAR} must be a non-negative number of seconds"
+        ) from exc
+    if interval_s < 0:
+        raise RuntimeError(
+            f"{_DEAD_PEER_SWEEP_INTERVAL_ENV_VAR} must be a non-negative number of seconds"
+        )
+    return interval_s
+
+
+async def _run_dead_peer_sweep_pass(
+    *,
+    process_manager: HarnessProcessManager | None,
+    reap_orphaned_terminals: Callable[[], int],
+    prune_codex_bridge_dirs: Callable[[], int],
+    prune_claude_bridge_dirs: Callable[[], int],
+) -> None:
+    """Run one periodic dead-peer reclamation pass (Layer 3).
+
+    Reuses the same conservative, owner-PID-gated primitives the runner
+    already runs at boot — but in-run, so resources that Layers 1-2 miss
+    are still collected. Each primitive reaps ONLY peers whose owner PID
+    is provably dead (terminal/bridge ``owner.pid`` markers, process
+    manager ``AP_PID`` sentinel), with a TOCTOU re-check before any kill
+    and the conservative rule that a reused/foreign PID reads as alive.
+    Never time/idle-based.
+
+    Each primitive is isolated so one failure cannot abort the others
+    (defense-in-depth: a missed primitive is retried next interval).
+
+    .. note::
+        ``_sweep_orphans`` is a private method of :class:`HarnessProcessManager`
+        that is the existing in-process orphan sweep already invoked by
+        ``start()``. Using it here is intentional.
+
+    :param process_manager: The runner's :class:`HarnessProcessManager`;
+        its ``_sweep_orphans`` reclaims crashed-AP instance dirs.
+        If ``None``, the process-manager step is skipped.
+    :param reap_orphaned_terminals: ``inner.terminal.reap_orphaned_terminals``.
+    :param prune_codex_bridge_dirs: ``codex_native_bridge.prune_orphaned_bridge_dirs``.
+    :param prune_claude_bridge_dirs: ``claude_native_bridge.prune_orphaned_bridge_dirs``.
+    :returns: None.
+    """
+    if process_manager is not None:
+        try:
+            await process_manager._sweep_orphans()
+        except Exception:
+            _logger.exception("dead-peer sweep: process-manager orphan sweep failed")
+    for label, fn in (
+        ("terminals", reap_orphaned_terminals),
+        ("codex-bridge", prune_codex_bridge_dirs),
+        ("claude-bridge", prune_claude_bridge_dirs),
+    ):
+        try:
+            await asyncio.to_thread(fn)
+        except Exception:
+            _logger.exception("dead-peer sweep: %s prune failed", label)
+
+
+async def _run_dead_peer_sweep_monitor(
+    *,
+    interval_s: float,
+    run_pass: Callable[[], Awaitable[None]],
+    poll_interval_s: float | None = None,
+) -> None:
+    """Periodically run the dead-peer sweep pass (Layer 3 loop).
+
+    Runs one pass immediately, then every ``interval_s`` seconds. A
+    non-positive ``interval_s`` disables the monitor. Cancellable like the
+    inactivity monitor.
+
+    :param interval_s: Seconds between sweep passes, e.g. ``300.0``.
+        ``0`` disables.
+    :param run_pass: Zero-arg coroutine that runs one sweep pass.
+    :param poll_interval_s: Test override for the sleep cadence.
+    :returns: None.
+    """
+    if interval_s <= 0:
+        return
+    sleep_s = poll_interval_s if poll_interval_s is not None else interval_s
+    while True:
+        await run_pass()
+        await asyncio.sleep(sleep_s)
 
 
 class _RunnerDatabricksAuth(httpx.Auth):

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -1276,6 +1276,23 @@ class SessionResourceRegistry:
                     session_id,
                 )
 
+        # O6: reap the conversation's native bridge dirs.  Bridge dirs are
+        # keyed by conversation id (bridge_dir_for_bridge_id), so the
+        # conversation-level reap is the right place.  Best-effort and
+        # isolated: a bridge cleanup failure must never propagate (this
+        # runs on the explicit-delete and harness-release paths).
+        from omnigent import claude_native_bridge as _claude_native_bridge
+        from omnigent import codex_native_bridge as _codex_native_bridge
+
+        for _bridge_module in (_codex_native_bridge, _claude_native_bridge):
+            try:
+                _bridge_module.cleanup_bridge_dir(session_id)
+            except Exception:
+                _logger.exception(
+                    "Error cleaning up native bridge dir for session=%s",
+                    session_id,
+                )
+
     def has_primary_env(self, session_id: str) -> bool:
         """Check if a primary env has been materialized.
 

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -882,6 +882,47 @@ def test_reap_orphaned_terminals_kills_server_for_dead_owner_socket(
     assert kill_calls == [["tmux", "-S", str(socket_path), "kill-server"]]
 
 
+def test_reap_orphaned_terminals_keeps_dir_when_kill_server_times_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead-owner dir whose ``kill-server`` times out is left for the
+    next sweep (B11).
+
+    If we rmtree the socket dir after a failed kill, a still-running
+    tmux server loses its socket path and becomes permanently
+    unreapable. So on a TimeoutExpired the dir (and tmux.sock) must
+    survive and the reaped count must not include it.
+
+    :param tmp_path: Fake temp root the sweep scans.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+
+    def _timeout_run(argv: list[str], **kwargs: object) -> SimpleNamespace:
+        """Simulate a wedged tmux server: kill-server times out."""
+        raise TimeoutError(argv)
+
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: tmp_path)
+    monkeypatch.setattr(terminal_mod, "_tmux_available", lambda: True)
+    monkeypatch.setattr(
+        terminal_mod,
+        "subprocess",
+        SimpleNamespace(run=_timeout_run, TimeoutExpired=TimeoutError),
+    )
+    dead_dir = _write_instance_dir(tmp_path, "omnigent-terminal-wedged", _dead_pid())
+    socket_path = dead_dir / "tmux.sock"
+    socket_path.touch()
+
+    reaped = terminal_mod.reap_orphaned_terminals()
+
+    # Nothing was successfully reaped: the dir and its socket survive so
+    # the next sweep can retry the kill against a real socket.
+    assert reaped == 0
+    assert dead_dir.exists()
+    assert socket_path.exists()
+
+
 @pytest.mark.skipif(
     sys.platform not in ("linux", "darwin"),
     reason="sandbox backends only resolve on Linux (bwrap) or macOS (seatbelt)",

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -1082,3 +1082,43 @@ def test_resolve_environment_runner_workspace_overrides_absolute_spec_cwd(
     # Compare via realpath because tmp_path on macOS goes through
     # /var → /private/var symlinks.
     assert os.path.realpath(env.cwd) == os.path.realpath(workspace)
+
+
+# ── O6: bridge-dir cleanup on conversation teardown ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cleanup_session_removes_native_bridge_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cleanup_session reaps the conversation's native bridge dirs (O6).
+
+    Bridge dirs are keyed by conversation id, so the conversation-level
+    reap is the right hook.  A bridge cleanup error must not propagate
+    out of cleanup_session.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import omnigent.claude_native_bridge as claude_bridge
+    import omnigent.codex_native_bridge as codex_bridge
+
+    cleaned: list[tuple[str, str]] = []
+
+    def _codex_cleanup(bridge_id: str) -> bool:
+        cleaned.append(("codex", bridge_id))
+        return True
+
+    def _claude_cleanup(bridge_id: str) -> bool:
+        cleaned.append(("claude", bridge_id))
+        raise RuntimeError("boom")  # must be swallowed by cleanup_session
+
+    monkeypatch.setattr(codex_bridge, "cleanup_bridge_dir", _codex_cleanup)
+    monkeypatch.setattr(claude_bridge, "cleanup_bridge_dir", _claude_cleanup)
+
+    registry = SessionResourceRegistry(terminal_registry=None)
+
+    await registry.cleanup_session("conv_bridge")
+
+    assert ("codex", "conv_bridge") in cleaned
+    assert ("claude", "conv_bridge") in cleaned

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -1338,3 +1338,126 @@ def test_agent_cache_dest_normal_id_round_trips(tmp_path: Path) -> None:
     dest = _agent_cache_dest(cache_root, "ag_abc123", "3")
 
     assert dest == cache_root / "ag_abc123-v3"
+
+
+# ---------------------------------------------------------------------------
+# Dead-peer sweep pass + monitor + interval loader (Layer 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dead_peer_sweep_pass_runs_all_primitives_and_isolates_failures() -> None:
+    """One sweep pass runs the pm orphan sweep, the terminal reap, and
+    both bridge prunes; a failure in one must not stop the others
+    (defense-in-depth, Layer 3).
+
+    :returns: None.
+    """
+    from omnigent.runner._entry import _run_dead_peer_sweep_pass
+
+    calls: list[str] = []
+
+    class _FakePM:
+        async def _sweep_orphans(self) -> None:
+            calls.append("pm")
+            raise RuntimeError("pm boom")  # isolated
+
+    def _reap_terminals() -> int:
+        calls.append("terminals")
+        return 0
+
+    def _prune_codex() -> int:
+        calls.append("codex")
+        raise RuntimeError("codex boom")  # isolated
+
+    def _prune_claude() -> int:
+        calls.append("claude")
+        return 0
+
+    await _run_dead_peer_sweep_pass(
+        process_manager=_FakePM(),
+        reap_orphaned_terminals=_reap_terminals,
+        prune_codex_bridge_dirs=_prune_codex,
+        prune_claude_bridge_dirs=_prune_claude,
+    )
+
+    assert set(calls) == {"pm", "terminals", "codex", "claude"}
+
+
+@pytest.mark.asyncio
+async def test_dead_peer_sweep_monitor_invokes_pass_then_can_be_cancelled() -> None:
+    """The monitor loop calls run_pass at least once, then sleeps; it is
+    cleanly cancellable (mirrors the idle-monitor task lifecycle).
+
+    :returns: None.
+    """
+    from omnigent.runner._entry import _run_dead_peer_sweep_monitor
+
+    passes = 0
+    seen = asyncio.Event()
+
+    async def _run_pass() -> None:
+        nonlocal passes
+        passes += 1
+        seen.set()
+
+    task = asyncio.create_task(
+        _run_dead_peer_sweep_monitor(
+            interval_s=300.0,
+            run_pass=_run_pass,
+            poll_interval_s=0.001,
+        )
+    )
+    await asyncio.wait_for(seen.wait(), timeout=1.0)
+    task.cancel()
+    with __import__("contextlib").suppress(asyncio.CancelledError):
+        await task
+    assert passes >= 1
+
+
+@pytest.mark.asyncio
+async def test_dead_peer_sweep_monitor_disabled_when_interval_zero() -> None:
+    """interval_s == 0 disables the monitor (returns without sweeping).
+
+    :returns: None.
+    """
+    from omnigent.runner._entry import _run_dead_peer_sweep_monitor
+
+    called = False
+
+    async def _run_pass() -> None:
+        nonlocal called
+        called = True
+
+    await _run_dead_peer_sweep_monitor(interval_s=0.0, run_pass=_run_pass)
+    assert called is False
+
+
+def test_load_dead_peer_sweep_interval_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defaults to the production interval when the env var is unset.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    from omnigent.runner._entry import (
+        _DEFAULT_DEAD_PEER_SWEEP_INTERVAL_S,
+        _load_dead_peer_sweep_interval_s,
+    )
+
+    monkeypatch.delenv("OMNIGENT_DEAD_PEER_SWEEP_INTERVAL_S", raising=False)
+    assert _load_dead_peer_sweep_interval_s() == float(_DEFAULT_DEAD_PEER_SWEEP_INTERVAL_S)
+
+
+def test_load_dead_peer_sweep_interval_rejects_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A negative or non-numeric value fails loud at startup.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :returns: None.
+    """
+    from omnigent.runner._entry import _load_dead_peer_sweep_interval_s
+
+    monkeypatch.setenv("OMNIGENT_DEAD_PEER_SWEEP_INTERVAL_S", "-5")
+    with pytest.raises(RuntimeError):
+        _load_dead_peer_sweep_interval_s()

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import io
 import logging
 import os
@@ -1410,7 +1411,7 @@ async def test_dead_peer_sweep_monitor_invokes_pass_then_can_be_cancelled() -> N
     )
     await asyncio.wait_for(seen.wait(), timeout=1.0)
     task.cancel()
-    with __import__("contextlib").suppress(asyncio.CancelledError):
+    with contextlib.suppress(asyncio.CancelledError):
         await task
     assert passes >= 1
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4962,3 +4962,79 @@ def test_wait_for_claude_prompt_ready_surfaces_terminal_output_on_timeout(
     assert "did not become ready" in message
     assert "Last terminal output:" in message
     assert "JSON Parse error: Unrecognized token '<'" in message
+
+
+def test_prepare_bridge_dir_writes_owner_pid_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare_bridge_dir records the creating pid for owner-pid-gated
+    pruning (O6)."""
+    import os
+
+    from omnigent.claude_native_bridge import prepare_bridge_dir
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._BRIDGE_ROOT",
+        tmp_path / "claude-native",
+    )
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    bridge_dir = prepare_bridge_dir("conv_owner", workspace=tmp_path)
+    assert (bridge_dir / "owner.pid").read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_cleanup_bridge_dir_removes_the_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cleanup_bridge_dir rmtrees the per-session dir (O6)."""
+    from omnigent.claude_native_bridge import cleanup_bridge_dir, prepare_bridge_dir
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._BRIDGE_ROOT",
+        tmp_path / "claude-native",
+    )
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    bridge_dir = prepare_bridge_dir("conv_cleanup", workspace=tmp_path)
+    assert bridge_dir.exists()
+
+    assert cleanup_bridge_dir("conv_cleanup") is True
+    assert not bridge_dir.exists()
+    assert cleanup_bridge_dir("conv_cleanup") is False
+
+
+def test_prune_orphaned_bridge_dirs_only_dead_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prune removes only provably-dead-owner dirs; live and unmarked
+    survive (owner-pid invariant, O6)."""
+    import os
+    import subprocess
+    import sys
+
+    from omnigent.claude_native_bridge import prune_orphaned_bridge_dirs
+
+    root = tmp_path / "claude-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = prune_orphaned_bridge_dirs()
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -211,9 +211,7 @@ def test_prepare_bridge_dir_writes_owner_pid_marker(
 
     from omnigent.codex_native_bridge import prepare_bridge_dir
 
-    monkeypatch.setattr(
-        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
-    )
+    monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native")
     bridge_dir = prepare_bridge_dir("bridge_owner")
     marker = bridge_dir / "owner.pid"
     assert marker.read_text(encoding="utf-8").strip() == str(os.getpid())
@@ -226,9 +224,7 @@ def test_cleanup_bridge_dir_removes_the_dir(
     """cleanup_bridge_dir rmtrees the per-session dir (O6)."""
     from omnigent.codex_native_bridge import cleanup_bridge_dir, prepare_bridge_dir
 
-    monkeypatch.setattr(
-        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
-    )
+    monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native")
     bridge_dir = prepare_bridge_dir("bridge_cleanup")
     assert bridge_dir.exists()
 
@@ -255,9 +251,7 @@ def test_prune_orphaned_bridge_dirs_only_dead_owners(
         prune_orphaned_bridge_dirs,
     )
 
-    monkeypatch.setattr(
-        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
-    )
+    monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native")
     root = bridge_root()
     root.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -199,3 +199,84 @@ def test_clear_active_turn_id_if_matches_no_state_returns_true(bridge_dir: Path)
     """
     # bridge_dir exists (fixture) but no state.json was written.
     assert clear_active_turn_id_if_matches(bridge_dir, "turn_1") is True
+
+
+def test_prepare_bridge_dir_writes_owner_pid_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare_bridge_dir records the creating process pid so the
+    periodic sweep can prune the dir only when its owner is dead (O6)."""
+    import os
+
+    from omnigent.codex_native_bridge import prepare_bridge_dir
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
+    )
+    bridge_dir = prepare_bridge_dir("bridge_owner")
+    marker = bridge_dir / "owner.pid"
+    assert marker.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_cleanup_bridge_dir_removes_the_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cleanup_bridge_dir rmtrees the per-session dir (O6)."""
+    from omnigent.codex_native_bridge import cleanup_bridge_dir, prepare_bridge_dir
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
+    )
+    bridge_dir = prepare_bridge_dir("bridge_cleanup")
+    assert bridge_dir.exists()
+
+    removed = cleanup_bridge_dir("bridge_cleanup")
+
+    assert removed is True
+    assert not bridge_dir.exists()
+    # Idempotent: a second call is a safe no-op.
+    assert cleanup_bridge_dir("bridge_cleanup") is False
+
+
+def test_prune_orphaned_bridge_dirs_only_dead_owners(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prune removes only dirs whose owner pid is provably dead;
+    live-owner and unmarked dirs survive (owner-pid invariant, O6)."""
+    import os
+    import subprocess
+    import sys
+
+    from omnigent.codex_native_bridge import (
+        bridge_root,
+        prune_orphaned_bridge_dirs,
+    )
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native"
+    )
+    root = bridge_root()
+    root.mkdir(parents=True, exist_ok=True)
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+
+    live_dir = root / "liveowner"
+    live_dir.mkdir()
+    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    unmarked_dir = root / "unmarked"
+    unmarked_dir.mkdir()
+
+    pruned = prune_orphaned_bridge_dirs()
+
+    assert pruned == 1
+    assert not dead_dir.exists()
+    assert live_dir.exists()
+    assert unmarked_dir.exists()


### PR DESCRIPTION
## Summary

Layer 3 of the runner lifecycle work (#561): reclaim leftover terminals,
native bridge dirs, and harness orphans in-run, instead of only at the next
runner restart. Plus a terminal-reap correctness fix.

## Changes

- B11: reap_orphaned_terminals keeps the instance dir when tmux kill-server
  times out, instead of removing it unconditionally. Deleting tmux.sock while
  the server is wedged but alive would orphan a running server with no socket
  path, making it permanently unreapable. A TOCTOU owner-pid recheck guards
  against killing a reused-pid live owner. (omnigent/inner/terminal.py)
- O6 bridge-dir lifecycle: per-session codex and claude bridge dirs now write
  an owner.pid marker on create, and each module exposes cleanup_bridge_dir
  (rmtree one dir) and prune_orphaned_bridge_dirs (rmtree dirs whose owner pid
  is dead, with a TOCTOU recheck). Previously only individual state files were
  unlinked, so the dirs accumulated indefinitely.
  (omnigent/codex_native_bridge.py, omnigent/claude_native_bridge.py)
- O6 wiring: cleanup_session removes the conversation's bridge dirs on teardown
  (best-effort), so an ended conversation's dir is reclaimed while the runner
  is still alive (the periodic prune below only catches dirs from a dead
  runner). (omnigent/runner/resource_registry.py)
- periodic dead-peer sweep: a background monitor runs, every
  OMNIGENT_DEAD_PEER_SWEEP_INTERVAL_S seconds (default 300, <= 0 disables), a
  single pass that invokes the existing dead-owner-gated reclaimers
  (reap_orphaned_terminals, the process-manager orphan sweep, and both bridge
  prunes). The pass isolates each primitive and runs the blocking ones off the
  event loop. (omnigent/runner/_entry.py)

## Safety

Every reclaimer keys off process exit or an owner pid that is provably dead.
There is no wall-clock or idle reaping, so a live or dormant session is never
torn down. A bridge dir owned by a live process (including a local REPL on the
same host) is skipped by the prune. The sweep monitor self-disables at
interval <= 0 and is cancelled and awaited on shutdown.

## Tests

Unit tests in the matching suites: B11 keep-dir-on-timeout (tests/inner),
bridge owner.pid marker plus cleanup plus dead-owner prune for both modules
(tests/test_codex_native_bridge.py, tests/test_claude_native_bridge.py),
cleanup_session bridge removal (tests/runner), and the sweep pass isolation
plus interval loader (tests/runner). ruff check and ruff format are clean. No
e2e is added: this is a robustness fix with no new user-facing surface.

## Note

Independent of #562 (Layer 2); both branch from main and touch
omnigent/runner/_entry.py, so whichever merges second needs a small rebase.
