### PR TITLE
fix(#433): defer IME compositionend reset so Safari's confirming Enter doesn't submit

### DIFF
--- a/tests/e2e_ui/chat/test_ime_composition_safari.py
+++ b/tests/e2e_ui/chat/test_ime_composition_safari.py
@@ -1,0 +1,196 @@
+"""IME composition guard against Safari's compositionend-before-Enter order.
+
+Covers issue #433 (PR #567): Safari fires ``compositionend`` BEFORE the
+``keydown(Enter)`` that confirmed the composition, and that keydown reports
+``isComposing=false`` / ``keyCode=13`` (not the ``229`` IME-processing
+fallback). The #132 guard (``isComposing`` ref + ``keyCode === 229``) missed
+it because the synchronous ``isComposing=false`` reset in the
+``compositionEnd`` handler had already cleared the flag by the time the
+confirming keydown fired. The fix defers the reset to the next macrotask
+(``setTimeout(0)``) in both live composers (``ChatPage`` + the new-chat
+landing screen) so the confirming Enter still observes composition active
+and is ignored.
+
+These tests drive the **chat** composer (``ChatPage.tsx``) in a real
+browser. Playwright's real keyboard cannot emit composition events, so the
+Safari order is modeled with synthetic ``CompositionEvent`` /
+``KeyboardEvent`` dispatched via ``page.evaluate`` on the composer
+``<textarea>`` (React's root-level delegation picks them up). The Safari
+test asserts the confirming Enter does NOT submit mid-composition (the
+composer keeps its draft and no user bubble / Working indicator appears),
+then asserts a deliberate Enter after the deferred reset flush DOES
+submit. The Chrome-order test is the non-regression guard: the confirming
+Enter fired mid-composition (``isComposing=true``) must still be ignored.
+
+Like the rest of the ``tests/e2e_ui`` suite, this requires the live
+Databricks LLM gateway the harness boots against — see
+``tests/e2e_ui/conftest.py``. The negative assertions don't depend on the
+LLM responding (submission is blocked client-side before any request),
+but the deliberate-Enter positive assertion optimistically renders a user
+bubble, and the run is dispatched to the real runner.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+_COMPOSER_LABEL = "Message the agent"
+_USER_BUBBLE = '[data-testid="message-bubble"][data-role="user"]'
+_WORKING = '[data-testid="working-indicator"]'
+
+# JS that drives Safari's compositionend-before-Enter order on the chat
+# composer. Dispatches compositionstart → (value set via the React-aware
+# native setter) → compositionend → keydown(Enter) with the Safari-confirming
+# signature (isComposing=false, keyCode=13). The deferred reset in the
+# compositionEnd handler keeps isComposingRef true through this keydown, so
+# the IME guard in handleKeyDown ignores it. Returns nothing.
+_SAFARI_ORDER_JS = """
+() => {
+  const ta = document.querySelector('textarea[aria-label="Message the agent"]');
+  const proto = window.HTMLTextAreaElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+  ta.focus();
+  ta.dispatchEvent(new CompositionEvent('compositionstart', {
+    bubbles: true, data: '',
+  }));
+  setter.call(ta, 'オムニジェント');
+  ta.dispatchEvent(new Event('input', { bubbles: true }));
+  ta.dispatchEvent(new CompositionEvent('compositionend', {
+    bubbles: true, data: 'オムニジェント',
+  }));
+  // Safari's confirming keydown: fires AFTER compositionend, with
+  // isComposing=false / keyCode=13 (NOT the 229 IME-processing fallback).
+  ta.dispatchEvent(new KeyboardEvent('keydown', {
+    key: 'Enter', code: 'Enter', keyCode: 13, isComposing: false,
+    bubbles: true, cancelable: true,
+  }));
+}
+"""
+
+# Chrome/Firefox order: the confirming keydown fires DURING composition, so
+# isComposing=true. The #132 guard already catches this; the test is a
+# non-regression guard for #567's deferred reset (it must not clear the flag
+# before this keydown). Returns nothing.
+_CHROME_ORDER_JS = """
+() => {
+  const ta = document.querySelector('textarea[aria-label="Message the agent"]');
+  const proto = window.HTMLTextAreaElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+  ta.focus();
+  ta.dispatchEvent(new CompositionEvent('compositionstart', {
+    bubbles: true, data: '',
+  }));
+  setter.call(ta, 'オムニジェント');
+  ta.dispatchEvent(new Event('input', { bubbles: true }));
+  // Chrome's confirming keydown: fires DURING composition, isComposing=true.
+  ta.dispatchEvent(new KeyboardEvent('keydown', {
+    key: 'Enter', code: 'Enter', keyCode: 229, isComposing: true,
+    bubbles: true, cancelable: true,
+  }));
+  ta.dispatchEvent(new CompositionEvent('compositionend', {
+    bubbles: true, data: 'オムニジェント',
+  }));
+}
+"""
+
+# A single deliberate Enter after the deferred reset has flushed. Used by
+# both tests to confirm the composer still sends normally once composition
+# has fully ended (the guard is not over-suppressing). Returns nothing.
+_DELIBERATE_ENTER_JS = """
+() => {
+  const ta = document.querySelector('textarea[aria-label="Message the agent"]');
+  ta.dispatchEvent(new KeyboardEvent('keydown', {
+    key: 'Enter', code: 'Enter', keyCode: 13, isComposing: false,
+    bubbles: true, cancelable: true,
+  }));
+}
+"""
+
+# Flush the deferred isComposing reset. Real browsers clamp setTimeout(0) to
+# ~4ms; 50ms is a safe margin that still keeps the test fast.
+_FLUSH_JS = "() => new Promise((resolve) => setTimeout(resolve, 50))"
+
+
+def _composer(page: Page):
+    """Locator for the chat composer textarea (aria-label)."""
+    return page.get_by_label(_COMPOSER_LABEL)
+
+
+@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)
+def test_safari_compositionend_before_enter_does_not_submit(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Safari fires compositionend before the confirming Enter; Enter is suppressed.
+
+    The confirming keydown reports ``isComposing=false`` / ``keyCode=13`` (not
+    229), which the #132 guard missed once the synchronous
+    ``compositionEnd`` reset had cleared the flag. The deferred reset (#567)
+    keeps ``isComposingRef`` true through this keydown, so ``handleKeyDown``
+    bails on the IME guard and ``submit()`` never runs.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` — the chat composer
+        lives at ``/c/{session_id}``.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = _composer(page)
+    expect(composer).to_be_visible()
+
+    # Safari order: compositionstart → value → compositionend → Enter.
+    page.evaluate(_SAFARI_ORDER_JS)
+
+    # Enter was suppressed mid-composition: the draft is still in the
+    # composer, no user bubble was added, and no run started (no Working
+    # indicator). submit() would have cleared the value and appended a user
+    # bubble synchronously, so these are strong negative signals.
+    expect(composer).to_have_value("オムニジェント")
+    expect(page.locator(_USER_BUBBLE)).to_have_count(0)
+    expect(page.locator(_WORKING)).to_have_count(0)
+
+    # After the deferred reset flushes, a deliberate Enter sends normally —
+    # the guard is not over-suppressing. The optimistic user bubble is the
+    # submission signal (it renders before the LLM responds).
+    page.evaluate(_FLUSH_JS)
+    page.evaluate(_DELIBERATE_ENTER_JS)
+    expect(page.locator(_USER_BUBBLE)).to_have_count(1, timeout=15_000)
+
+
+@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)
+def test_chrome_composition_keydown_during_composition_does_not_submit(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Chrome-order confirming Enter (during composition) is ignored (#132 non-regression).
+
+    Chrome/Firefox fire the confirming keydown DURING composition with
+    ``isComposing=true``, which #132 already caught. This test guards #567's
+    deferred reset: it must not clear ``isComposingRef`` before this mid-
+    composition keydown (a microtask reset would have). The deliberate Enter
+    after the flush sends normally.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)``.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = _composer(page)
+    expect(composer).to_be_visible()
+
+    # Chrome order: compositionstart → value → Enter (isComposing=true)
+    # → compositionend.
+    page.evaluate(_CHROME_ORDER_JS)
+
+    # Mid-composition Enter was ignored: draft preserved, no user bubble,
+    # no run started.
+    expect(composer).to_have_value("オムニジェント")
+    expect(page.locator(_USER_BUBBLE)).to_have_count(0)
+    expect(page.locator(_WORKING)).to_have_count(0)
+
+    # After compositionend's deferred reset flushes, a deliberate Enter
+    # sends the draft.
+    page.evaluate(_FLUSH_JS)
+    page.evaluate(_DELIBERATE_ENTER_JS)
+    expect(page.locator(_USER_BUBBLE)).to_have_count(1, timeout=15_000)

--- a/tests/e2e_ui/chat/test_ime_composition_safari.py
+++ b/tests/e2e_ui/chat/test_ime_composition_safari.py
@@ -1,14 +1,13 @@
 """IME composition guard against Safari's compositionend-before-Enter order.
 
-Covers issue #433 (PR #567): Safari fires ``compositionend`` BEFORE the
-``keydown(Enter)`` that confirmed the composition, and that keydown reports
-``isComposing=false`` / ``keyCode=13`` (not the ``229`` IME-processing
-fallback). The #132 guard (``isComposing`` ref + ``keyCode === 229``) missed
-it because the synchronous ``isComposing=false`` reset in the
-``compositionEnd`` handler had already cleared the flag by the time the
-confirming keydown fired. The fix defers the reset to the next macrotask
-(``setTimeout(0)``) in both live composers (``ChatPage`` + the new-chat
-landing screen) so the confirming Enter still observes composition active
+Safari fires ``compositionend`` BEFORE the ``keydown(Enter)`` that confirmed
+the composition, and that keydown looks ordinary: ``isComposing=false`` /
+``keyCode=13``, not the ``229`` IME-processing fallback. The composer's IME
+guard (``isComposing`` ref + ``keyCode === 229``) therefore missed it while
+the ``compositionEnd`` handler reset the flag synchronously, and the
+confirming Enter submitted mid-composition. Both live composers (``ChatPage``
++ the new-chat landing screen) now defer that reset to the next macrotask
+(``setTimeout(0)``) so the confirming Enter still observes composition active
 and is ignored.
 
 These tests drive the **chat** composer (``ChatPage.tsx``) in a real
@@ -69,8 +68,8 @@ _SAFARI_ORDER_JS = """
 """
 
 # Chrome/Firefox order: the confirming keydown fires DURING composition, so
-# isComposing=true. The #132 guard already catches this; the test is a
-# non-regression guard for #567's deferred reset (it must not clear the flag
+# isComposing=true. The base IME guard already catches this; the test is a
+# non-regression guard for the deferred reset (it must not clear the flag
 # before this keydown). Returns nothing.
 _CHROME_ORDER_JS = """
 () => {
@@ -125,10 +124,10 @@ def test_safari_compositionend_before_enter_does_not_submit(
     """Safari fires compositionend before the confirming Enter; Enter is suppressed.
 
     The confirming keydown reports ``isComposing=false`` / ``keyCode=13`` (not
-    229), which the #132 guard missed once the synchronous
-    ``compositionEnd`` reset had cleared the flag. The deferred reset (#567)
-    keeps ``isComposingRef`` true through this keydown, so ``handleKeyDown``
-    bails on the IME guard and ``submit()`` never runs.
+    229), which the IME guard missed while the ``compositionEnd`` reset was
+    synchronous. The deferred reset keeps ``isComposingRef`` true through this
+    keydown, so ``handleKeyDown`` bails on the IME guard and ``submit()``
+    never runs.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` — the chat composer
@@ -163,13 +162,13 @@ def test_chrome_composition_keydown_during_composition_does_not_submit(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Chrome-order confirming Enter (during composition) is ignored (#132 non-regression).
+    """Chrome-order confirming Enter (during composition) is ignored.
 
     Chrome/Firefox fire the confirming keydown DURING composition with
-    ``isComposing=true``, which #132 already caught. This test guards #567's
-    deferred reset: it must not clear ``isComposingRef`` before this mid-
-    composition keydown (a microtask reset would have). The deliberate Enter
-    after the flush sends normally.
+    ``isComposing=true``, which the base IME guard already caught. This test
+    guards the deferred reset: it must not clear ``isComposingRef`` before this
+    mid-composition keydown (a microtask reset would have). The deliberate
+    Enter after the flush sends normally.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)``.

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -150,6 +150,15 @@ describe("Composer Codex goal control", () => {
   });
 });
 
+/**
+ * Flush the deferred isComposing reset queued by compositionend. In real
+ * browsers the reset lands within ~one macrotask; in jsdom we await a 0ms
+ * timeout to model that gap before firing the next deliberate Enter. #433.
+ */
+async function flushCompositionReset() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 describe("Composer slash-command menu", () => {
   beforeEach(() => {
     // Two skills so the menu has skill rows distinct from the built-ins.
@@ -243,7 +252,7 @@ describe("Composer slash-command menu", () => {
     expect(onSend).toHaveBeenCalledWith("hello there", undefined);
   });
 
-  it("does not send when Enter confirms active IME composition", () => {
+  it("does not send when Enter confirms active IME composition", async () => {
     const onSend = vi.fn();
     render(<Composer {...composerProps({ onSend })} />);
     const ta = textarea();
@@ -253,7 +262,32 @@ describe("Composer slash-command menu", () => {
     fireEvent.keyDown(ta, { key: "Enter" });
     expect(onSend).not.toHaveBeenCalled();
 
+    // compositionend defers the isComposing reset to the next macrotask so the
+    // Safari confirming Enter (next test) still observes composition active.
+    // Here the confirming Enter already fired mid-composition above; the next
+    // Enter is a deliberate send, but only once the deferred reset flushes.
     fireEvent.compositionEnd(ta);
+    await flushCompositionReset();
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("オムニジェント", undefined);
+  });
+
+  it("does not send when Safari fires the confirming Enter after compositionend (#433)", async () => {
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    const ta = textarea();
+    fireEvent.compositionStart(ta);
+    fireEvent.change(ta, { target: { value: "オムニジェント" } });
+
+    // Safari order: compositionend BEFORE the confirming keydown, which reports
+    // isComposing=false / keyCode=13 (not the 229 fallback) — the #132 guard
+    // misses it. The deferred reset keeps isComposing true through this keydown.
+    fireEvent.compositionEnd(ta);
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+
+    // After the deferred reset flushes, a deliberate Enter sends normally.
+    await flushCompositionReset();
     fireEvent.keyDown(ta, { key: "Enter" });
     expect(onSend).toHaveBeenCalledWith("オムニジェント", undefined);
   });

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -151,9 +151,8 @@ describe("Composer Codex goal control", () => {
 });
 
 /**
- * Flush the deferred isComposing reset queued by compositionend. In real
- * browsers the reset lands within ~one macrotask; in jsdom we await a 0ms
- * timeout to model that gap before firing the next deliberate Enter. #433.
+ * Flush the deferred isComposing reset queued by compositionend — one
+ * macrotask, matching the gap before a user's next deliberate Enter.
  */
 async function flushCompositionReset() {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -272,21 +271,46 @@ describe("Composer slash-command menu", () => {
     expect(onSend).toHaveBeenCalledWith("オムニジェント", undefined);
   });
 
-  it("does not send when Safari fires the confirming Enter after compositionend (#433)", async () => {
+  it("does not send when Safari fires the confirming Enter after compositionend", async () => {
     const onSend = vi.fn();
     render(<Composer {...composerProps({ onSend })} />);
     const ta = textarea();
     fireEvent.compositionStart(ta);
     fireEvent.change(ta, { target: { value: "オムニジェント" } });
 
-    // Safari order: compositionend BEFORE the confirming keydown, which reports
-    // isComposing=false / keyCode=13 (not the 229 fallback) — the #132 guard
-    // misses it. The deferred reset keeps isComposing true through this keydown.
+    // Safari order: compositionend BEFORE the confirming keydown, which looks
+    // ordinary (isComposing=false, keyCode=13). Only the deferred reset keeps
+    // the guard armed through this keydown.
     fireEvent.compositionEnd(ta);
     fireEvent.keyDown(ta, { key: "Enter" });
     expect(onSend).not.toHaveBeenCalled();
 
     // After the deferred reset flushes, a deliberate Enter sends normally.
+    await flushCompositionReset();
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("オムニジェント", undefined);
+  });
+
+  it("keeps the guard armed when a new composition starts before the deferred reset flushes", async () => {
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    const ta = textarea();
+    fireEvent.compositionStart(ta);
+    fireEvent.change(ta, { target: { value: "オムニ" } });
+
+    // Safari segment switch: compositionend then a new compositionstart before
+    // the queued reset runs. compositionstart must cancel it — otherwise the
+    // stale flush clears the flag during the second composition.
+    fireEvent.compositionEnd(ta);
+    fireEvent.compositionStart(ta);
+    await flushCompositionReset();
+
+    fireEvent.change(ta, { target: { value: "オムニジェント" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+
+    // Ending the second composition re-arms the reset, so the next Enter sends.
+    fireEvent.compositionEnd(ta);
     await flushCompositionReset();
     fireEvent.keyDown(ta, { key: "Enter" });
     expect(onSend).toHaveBeenCalledWith("オムニジェント", undefined);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3884,6 +3884,9 @@ export function Composer({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
+  // Timer for the deferred compositionend reset below; cancelled when a new
+  // composition starts so a stale flush can't disarm the IME guard.
+  const composingResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Highlight overlay mirroring the textarea; scroll-synced so the tinted
   // `/skill` token stays aligned once the draft grows past the visible rows.
   const backdropRef = useRef<HTMLDivElement>(null);
@@ -4792,19 +4795,23 @@ export function Composer({
               else resetCursor();
             }}
             onCompositionStart={() => {
+              // Safari can start a new composition (segment switch) before the
+              // previous compositionend's deferred reset runs — drop it, or it
+              // clears the flag mid-composition.
+              if (composingResetRef.current !== null) {
+                clearTimeout(composingResetRef.current);
+                composingResetRef.current = null;
+              }
               isComposingRef.current = true;
             }}
             onCompositionEnd={() => {
-              // Safari dispatches compositionend BEFORE the keydown of the
-              // Enter that confirmed the composition, and that keydown reports
-              // isComposing=false / keyCode=13 (not the 229 IME fallback) — so
-              // the #132 IME guard in handleKeyDown would let it through and
-              // submit the message. Defer the reset to the next macrotask so
-              // the confirming keydown still observes composition active and is
-              // ignored. The deferred reset flushes well before a user's next
-              // deliberate Enter (or a click-to-confirm), so neither regresses.
-              // #433
-              setTimeout(() => {
+              // Safari fires compositionend BEFORE the keydown of the Enter
+              // that confirmed the composition, and that keydown looks
+              // ordinary (isComposing=false, keyCode=13, not the 229 IME
+              // fallback). Defer the reset a macrotask so the IME guard in
+              // handleKeyDown still sees composition active and ignores it.
+              composingResetRef.current = setTimeout(() => {
+                composingResetRef.current = null;
                 isComposingRef.current = false;
               }, 0);
             }}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4795,7 +4795,18 @@ export function Composer({
               isComposingRef.current = true;
             }}
             onCompositionEnd={() => {
-              isComposingRef.current = false;
+              // Safari dispatches compositionend BEFORE the keydown of the
+              // Enter that confirmed the composition, and that keydown reports
+              // isComposing=false / keyCode=13 (not the 229 IME fallback) — so
+              // the #132 IME guard in handleKeyDown would let it through and
+              // submit the message. Defer the reset to the next macrotask so
+              // the confirming keydown still observes composition active and is
+              // ignored. The deferred reset flushes well before a user's next
+              // deliberate Enter (or a click-to-confirm), so neither regresses.
+              // #433
+              setTimeout(() => {
+                isComposingRef.current = false;
+              }, 0);
             }}
             onKeyDown={handleKeyDown}
             onBlur={() => {

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -168,6 +168,15 @@ async function waitForWorkspaceSeed(): Promise<void> {
   );
 }
 
+/**
+ * Flush the deferred isComposing reset queued by compositionend. In real
+ * browsers the reset lands within ~one macrotask; in jsdom we await a 0ms
+ * timeout to model that gap before firing the next deliberate Enter. #433.
+ */
+async function flushCompositionReset(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 /** Open the git-worktree popover so its branch fields mount. */
 function openWorktree(): void {
   fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
@@ -354,7 +363,40 @@ describe("NewChatLandingScreen create flow", () => {
     expect(authenticatedFetch).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
 
+    // compositionend defers the isComposing reset to the next macrotask so the
+    // Safari confirming Enter (next test) still observes composition active.
+    // Here the confirming Enter already fired mid-composition above; the next
+    // Enter is a deliberate create, but only once the deferred reset flushes.
     fireEvent.compositionEnd(input);
+    await flushCompositionReset();
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
+  });
+
+  it("does not create a session when Safari fires the confirming Enter after compositionend (#433)", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    const input = screen.getByTestId("new-chat-landing-input");
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "オムニジェント" } });
+
+    // Safari order: compositionend BEFORE the confirming keydown, which reports
+    // isComposing=false / keyCode=13 (not the 229 fallback) — the #132 guard
+    // misses it. The deferred reset keeps isComposing true through this keydown.
+    fireEvent.compositionEnd(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    // After the deferred reset flushes, a deliberate Enter creates the session.
+    await flushCompositionReset();
     fireEvent.keyDown(input, { key: "Enter" });
 
     await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -169,9 +169,8 @@ async function waitForWorkspaceSeed(): Promise<void> {
 }
 
 /**
- * Flush the deferred isComposing reset queued by compositionend. In real
- * browsers the reset lands within ~one macrotask; in jsdom we await a 0ms
- * timeout to model that gap before firing the next deliberate Enter. #433.
+ * Flush the deferred isComposing reset queued by compositionend — one
+ * macrotask, matching the gap before a user's next deliberate Enter.
  */
 async function flushCompositionReset(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -375,7 +374,7 @@ describe("NewChatLandingScreen create flow", () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
   });
 
-  it("does not create a session when Safari fires the confirming Enter after compositionend (#433)", async () => {
+  it("does not create a session when Safari fires the confirming Enter after compositionend", async () => {
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ id: "conv_new" }),
@@ -387,15 +386,49 @@ describe("NewChatLandingScreen create flow", () => {
     fireEvent.compositionStart(input);
     fireEvent.change(input, { target: { value: "オムニジェント" } });
 
-    // Safari order: compositionend BEFORE the confirming keydown, which reports
-    // isComposing=false / keyCode=13 (not the 229 fallback) — the #132 guard
-    // misses it. The deferred reset keeps isComposing true through this keydown.
+    // Safari order: compositionend BEFORE the confirming keydown, which looks
+    // ordinary (isComposing=false, keyCode=13). Only the deferred reset keeps
+    // the guard armed through this keydown.
     fireEvent.compositionEnd(input);
     fireEvent.keyDown(input, { key: "Enter" });
     expect(authenticatedFetch).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
 
     // After the deferred reset flushes, a deliberate Enter creates the session.
+    await flushCompositionReset();
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
+  });
+
+  it("keeps the guard armed when a new composition starts before the deferred reset flushes", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    const input = screen.getByTestId("new-chat-landing-input");
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "オムニ" } });
+
+    // Safari segment switch: compositionend then a new compositionstart before
+    // the queued reset runs. compositionstart must cancel it — otherwise the
+    // stale flush clears the flag during the second composition.
+    fireEvent.compositionEnd(input);
+    fireEvent.compositionStart(input);
+    await flushCompositionReset();
+
+    fireEvent.change(input, { target: { value: "オムニジェント" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    // Ending the second composition re-arms the reset, so the next Enter
+    // creates the session.
+    fireEvent.compositionEnd(input);
     await flushCompositionReset();
     fireEvent.keyDown(input, { key: "Enter" });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1812,6 +1812,9 @@ export function NewChatLandingScreen() {
   const voiceSnapshotRef = useRef("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
+  // Timer for the deferred compositionend reset below; cancelled when a new
+  // composition starts so a stale flush can't disarm the IME guard.
+  const composingResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // maxRows 9 = 180px of 20px lines, matching the composer's 200px
   // border-box max (180px content + 16px top / 4px bottom padding).
   useAutoGrowTextarea(textareaRef, message, 9);
@@ -3212,16 +3215,22 @@ export function NewChatLandingScreen() {
                 dismissMention();
               }}
               onCompositionStart={() => {
+                // Safari can start a new composition (segment switch) before
+                // the previous compositionend's deferred reset runs — drop it,
+                // or it clears the flag mid-composition.
+                if (composingResetRef.current !== null) {
+                  clearTimeout(composingResetRef.current);
+                  composingResetRef.current = null;
+                }
                 isComposingRef.current = true;
               }}
               onCompositionEnd={() => {
-                // Safari dispatches compositionend BEFORE the confirming
-                // Enter's keydown (isComposing=false, keyCode=13, not 229),
-                // so a synchronous reset would let that Enter slip past the
-                // IME guard and create the session mid-composition. Defer the
-                // reset to the next macrotask so the confirming keydown still
-                // observes composition active. #433
-                setTimeout(() => {
+                // Safari fires compositionend BEFORE the confirming Enter's
+                // keydown, which looks ordinary (isComposing=false,
+                // keyCode=13, not 229). Defer the reset a macrotask so the IME
+                // guard still sees composition active and ignores that Enter.
+                composingResetRef.current = setTimeout(() => {
+                  composingResetRef.current = null;
                   isComposingRef.current = false;
                 }, 0);
               }}

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3215,7 +3215,15 @@ export function NewChatLandingScreen() {
                 isComposingRef.current = true;
               }}
               onCompositionEnd={() => {
-                isComposingRef.current = false;
+                // Safari dispatches compositionend BEFORE the confirming
+                // Enter's keydown (isComposing=false, keyCode=13, not 229),
+                // so a synchronous reset would let that Enter slip past the
+                // IME guard and create the session mid-composition. Defer the
+                // reset to the next macrotask so the confirming keydown still
+                // observes composition active. #433
+                setTimeout(() => {
+                  isComposingRef.current = false;
+                }, 0);
               }}
               onKeyDown={(e) => {
                 if (isImeCompositionKeyEvent(e, isComposingRef.current)) {


### PR DESCRIPTION
Fixes #433.

## Problem

Pressing `Enter` to confirm a Japanese (or other IME) composition submits the message immediately instead of just confirming the conversion candidate.

The chat and new-chat inputs already ignored Enter during an active IME composition via #132 (`isComposing` + the `keyCode: 229` fallback). But **Safari dispatches `compositionend` *before* the `keydown` of the Enter that confirmed the composition**, and that keydown reports `isComposing=false` / `keyCode=13` (not `229`). With the existing synchronous `isComposing=false` reset in `compositionEnd`, the flag was already false when the confirming `keydown` fired, so it slipped past the guard and submitted. (Chrome/Firefox fire the confirming `keydown` *during* composition with `isComposing=true`, so #132 already covers them.)

This is the well-documented Safari IME gotcha — see [Square's write-up](https://developer.squareup.com/blog/understanding-composition-browser-events/) and the W3C `compositionend`/`input` ordering discussion.

## Fix

Defer the `isComposing=false` reset to the next macrotask in the `compositionEnd` handlers of both live inputs:

- `ap-web/src/pages/ChatPage.tsx` (the chat composer)
- `ap-web/src/shell/NewChatDialog.tsx` (the new-chat landing input)

The confirming `keydown` still observes composition active and is ignored; the deferred reset flushes within ~one macrotask, well before a user's next deliberate Enter — so neither the deliberate send nor a click-to-confirm regresses. `setTimeout(..., 0)` (macrotask) rather than `queueMicrotask` because Safari dispatches `compositionend` and the confirming `keydown` as separate tasks, so a microtask would reset too early.

`PromptInputTextarea` (`ap-web/src/components/ai-elements/prompt-input.tsx`) shares the same pattern but has **no live usages** (grep finds zero callers outside its own file), so it is left untouched to keep this PR tight.

## Tests

Both files already had Chrome-order IME tests; the synchronous reset made the deliberate-Enter-after-`compositionEnd` assertion hold without an await. Updated those to await the deferred reset flush, and added a Safari-order test to each:

- `ChatPage.composer.test.tsx` — `does not send when Safari fires the confirming Enter after compositionend (#433)`
- `NewChatDialog.flow.test.tsx` — `does not create a session when Safari fires the confirming Enter after compositionend (#433)`

Both model the Safari order: `compositionStart` → `compositionEnd` → `keyDown(Enter)` (no send) → flush → `keyDown(Enter)` (sends).

## Validation

- `npx vitest run src/pages/ChatPage.composer.test.tsx src/shell/NewChatDialog.flow.test.tsx` → 81 passed, 1 skipped (pre-existing skip)
- `npx tsc -b` → clean (no type errors)
- `npx oxlint` on the changed files → no new findings (pre-existing `no-array-index-key` / `no-await-in-loop` / `no-constant-binary-expression` warnings exist on `main` at lines this PR does not touch; left as-is to keep scope tight — happy to address separately if wanted)

## Scope notes

- Branched from latest `upstream/main` (includes #393's new-chat restructure); the `compositionEnd` handler edit auto-merged cleanly.
- Claimed the issue in #433 before starting.