### PR TITLE
fix(antigravity): stop orphaning the native agent + leaking session state on a failed build

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4337,7 +4337,7 @@ def resume(
 _HARNESS_CHOICES_HELP = (
     "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
     "'cursor', "
-    "'openai-agents', 'open-responses', or 'pi'"
+    "'openai-agents', 'open-responses', 'pi', or 'antigravity'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."
 _RUN_HARNESS_HELP = (

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -772,8 +772,12 @@ class AntigravityExecutor(Executor):
         signature = (model, system_prompt, self._tool_signature(tools))
         state = self._session_states.get(session_key)
         if state is None:
+            # A brand-new session's state is NOT registered until the agent is
+            # fully built below, so a construction failure (bad creds, a host
+            # without the SDK's required glibc, SDK drift) leaves no dead,
+            # agent-less entry accumulating in ``_session_states`` turn after
+            # turn. A reused session is already registered.
             state = _AntigravitySessionState()
-            self._session_states[session_key] = state
 
         if state.agent is not None and state.agent_signature == signature:
             return state, False
@@ -786,9 +790,23 @@ class AntigravityExecutor(Executor):
         agent = await self._open_agent(
             state, model=model, system_prompt=system_prompt, tools=tools
         )
+        # Record the opened agent on the state BEFORE the (failure-prone)
+        # conversation access: ``_open_agent`` has already entered the agent's
+        # async context, which spawns the native ``localharness`` subprocess, so
+        # if anything after this point raises, the agent must still be reachable
+        # by ``close()`` / ``close_session()`` for teardown — otherwise that
+        # subprocess orphans. If wiring the conversation fails, reap it here.
         state.agent = agent
-        state.conversation = agent.conversation
+        try:
+            state.conversation = agent.conversation
+        except Exception:
+            await self._close_agent(agent)
+            state.agent = None
+            state.conversation = None
+            raise
         state.agent_signature = signature
+        # Register only once the agent is fully built (see the no-state branch).
+        self._session_states[session_key] = state
         return state, True
 
     async def _open_agent(

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -1001,6 +1001,63 @@ async def test_close_session_closes_agent(monkeypatch: pytest.MonkeyPatch) -> No
     assert agent.closed is True
 
 
+@pytest.mark.asyncio
+async def test_open_agent_failure_leaves_no_session_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed agent build registers no dead, agent-less ``_session_states`` row.
+
+    Otherwise every turn on an un-buildable host (bad creds / missing glibc /
+    SDK drift) would accumulate a permanent empty entry that close_session never
+    reaps.
+    """
+    _install_fake_sdk(monkeypatch, scripts=[[_text_step("ok")]])
+    executor = AntigravityExecutor()
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("agent construction failed")
+
+    monkeypatch.setattr(executor, "_open_agent", _boom)
+
+    events = await _drain(executor, [{"role": "user", "content": "hi", "session_id": "s1"}])
+    assert any(isinstance(e, ExecutorError) for e in events)
+    assert executor._session_states == {}
+
+
+@pytest.mark.asyncio
+async def test_conversation_access_failure_reaps_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``agent.conversation`` raises after ``__aenter__``, the entered agent
+    (and its native subprocess) is torn down rather than orphaned, and no
+    session state is registered."""
+    _install_fake_sdk(monkeypatch, scripts=[[_text_step("ok")]])
+    executor = AntigravityExecutor()
+
+    class _BadConversationAgent:
+        def __init__(self) -> None:
+            self.closed = False
+
+        @property
+        def conversation(self) -> Any:
+            raise RuntimeError("conversation unavailable")
+
+        async def __aexit__(self, *_args: object) -> None:
+            self.closed = True
+
+    bad_agent = _BadConversationAgent()
+
+    async def _open(*_args: Any, **_kwargs: Any) -> Any:
+        return bad_agent
+
+    monkeypatch.setattr(executor, "_open_agent", _open)
+
+    events = await _drain(executor, [{"role": "user", "content": "hi", "session_id": "s1"}])
+    assert any(isinstance(e, ExecutorError) for e in events)
+    assert bad_agent.closed is True  # _close_agent reaped the entered agent
+    assert executor._session_states == {}
+
+
 # ── Interrupt (cancellation) tests — real deterministic sync gates ──────
 
 


### PR DESCRIPTION
## Summary

A bug-bash of the Antigravity (Google Gemini) SDK integration — fanned out across the executor streaming/tool-bridge, auth/spawn-env routing, model routing/spec-compat, and cross-harness parity — surfaced two genuine **resource-correctness** bugs in `AntigravityExecutor._ensure_agent` plus a CLI discoverability gap. All three are self-contained to the antigravity integration and clearly correct.

### 1. Native `localharness` subprocess orphaned on a failed agent build (HIGH)
`_open_agent` enters the SDK agent's async context, which **spawns the bundled native `localharness` subprocess**. The code then accessed `agent.conversation` *before* recording the agent on the session state. If that access raised (SDK drift, a property error), the freshly-entered agent was never stored, so `close()` / `close_session()` could not tear it down — the subprocess orphaned.

**Fix:** store the agent on the state *before* the failure-prone conversation access, and reap it directly (`_close_agent`) if that access fails.

### 2. `_session_states` accumulates dead, agent-less entries (MEDIUM)
The empty `_AntigravitySessionState` was registered in `_session_states` *before* `_open_agent` ran. On a host that can't build the agent (bad credentials, the SDK's required glibc ≳2.36 absent, SDK drift), **every turn** left a permanent agent-less entry that `close_session` never reaps — an unbounded dict leak.

**Fix:** register the session only once the agent is fully built.

### 3. `--harness` help omits `antigravity` (LOW — discoverability)
`antigravity` is registered and runnable everywhere else (`_HARNESS_MODULES`, `AgentHarnessType`, model-override plumbing, the web brain-harness labels) but was missing from `_HARNESS_CHOICES_HELP`, so it was invisible in `omnigent run --help`. Added it to the advertised list.

## Tests
- Added `test_open_agent_failure_leaves_no_session_state` — a failed build registers no dead `_session_states` row.
- Added `test_conversation_access_failure_reaps_agent` — the entered agent is torn down (not orphaned) when the conversation access fails.
- Full antigravity + model-override suites pass (`181 passed`); CLI suite green (`154 passed`); `ruff check` / `ruff format` clean.

## Notes / out of scope
The swarm also flagged items deliberately left for follow-up:
- **`sys_list_models` over-reports OpenAI-family models for antigravity** (it's mapped to `OPENAI_FAMILY` in the shared catalog/provider maps despite being Gemini-native). This is a known sharp edge with a dedicated cleanup PR planned; the change lives in shared `model_catalog` / `provider_config` / `workflow` code, so it's kept out of this focused fix to avoid blast radius.
- The default model id `gemini-3.5-flash` is **not** in the static model catalog, but it is deliberately pinned across the executor default, unit/e2e tests, docs, and the dev skill — so it was treated as intentional (the catalog snapshot may simply lag) rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvpEu9g4YAYMk5bJfY3Gvi)_