### PR TITLE
fix(runner): pi native terminal auto-create honors agent os_env.sandbox

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -725,6 +725,7 @@ async def _auto_create_pi_terminal(
     publish_event: Callable[[str, dict[str, Any]], None],
     *,
     server_client: httpx.AsyncClient | None,
+    agent_spec: AgentSpec | ResolvedSpec | None = None,
 ) -> SessionResourceView:
     """
     Auto-create a Pi terminal for a pi-native session.
@@ -798,13 +799,23 @@ async def _auto_create_pi_terminal(
             cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
             pi_env.update(cred_env)
             pi_args.extend(cred_args)
+    # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
+    # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
+    # and ``parent_os_env`` below, launch_required_terminal falls back to
+    # _default_sandbox_for_platform (linux_bwrap), overriding the YAML config.
+    agent_os_env = _agent_os_env_from_spec(agent_spec)
     terminal_view = await resource_registry.launch_required_terminal(
         session_id=session_id,
         terminal_name="pi",
         session_key="main",
         resource_role=PI_NATIVE_TERMINAL_ROLE,
+        parent_os_env=agent_os_env,
         spec=TerminalEnvSpec(
-            os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+            os_env=OSEnvSpec(
+                type="caller_process",
+                cwd=workspace,
+                sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+            ),
             command=pi_command,
             args=pi_args,
             env=pi_env,
@@ -5429,11 +5440,16 @@ def create_runner_app(
                 if not _has_pi_terminal:
                     _publish_terminal_pending(_publish_event, session_id, True)
                     try:
+                        try:
+                            _pi_spec = await _resolve_session_agent_spec(session_id)
+                        except OmnigentError:
+                            _pi_spec = None
                         await _auto_create_pi_terminal(
                             session_id,
                             resource_registry,
                             _publish_event,
                             server_client=server_client,
+                            agent_spec=_pi_spec,
                         )
                     except Exception as exc:
                         _logger.exception(
@@ -10601,11 +10617,16 @@ def create_runner_app(
                         content=session_resource_view_to_dict(existing),
                     )
                 try:
+                    try:
+                        _pi_ensure_spec = await _resolve_session_agent_spec(session_id)
+                    except OmnigentError:
+                        _pi_ensure_spec = None
                     terminal_view = await _auto_create_pi_terminal(
                         session_id,
                         resource_registry,
                         _publish_event,
                         server_client=server_client,
+                        agent_spec=_pi_ensure_spec,
                     )
                 except Exception as exc:
                     _logger.exception(

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -10375,6 +10375,7 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
             session_key: str,
             spec: Any,
             resource_role: str | None = None,
+            parent_os_env: Any = None,
         ) -> SessionResourceView:
             """Record the launch and return a terminal resource view."""
             captured["terminal_name"] = terminal_name
@@ -10405,6 +10406,114 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
     assert captured["spec"].command == "pi"
     # The fresh terminal is surfaced on the live stream for the Terminal toggle.
     assert any(evt.get("type") == "session.resource.created" for evt in published)
+
+
+@pytest.mark.asyncio
+async def test_auto_create_pi_terminal_inherits_agent_sandbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Pi-native auto-create must honour the agent's ``os_env.sandbox``.
+
+    Regression for the sandbox-override bug: the pi-native auto-create path
+    built a fresh ``TerminalEnvSpec`` whose ``os_env`` carried no ``sandbox``
+    and passed no ``parent_os_env``, so ``launch_required_terminal`` fell back
+    to ``_default_sandbox_for_platform`` (``linux_bwrap`` on Linux) and ignored
+    the agent YAML.  A pi-native agent that declares
+    ``os_env.sandbox.type: none`` was wrongly forced into bwrap, which failed
+    on a hardened host.
+
+    Asserts the launched terminal spec's ``os_env.sandbox`` is the agent's
+    ``none`` sandbox (not the platform default) and that the agent's ``os_env``
+    is threaded through as the launch ``parent_os_env`` so the rest of the
+    policy (egress_rules / env_passthrough) is also inherited.
+
+    :param tmp_path: Pytest-provided temporary directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    import omnigent.pi_native as pi_native
+    import omnigent.pi_native_bridge as pi_native_bridge
+    import omnigent.pi_native_credentials as pi_native_credentials
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setattr(pi_native_bridge, "_BRIDGE_ROOT", tmp_path / "pi-bridge")
+    monkeypatch.setattr(pi_native, "resolve_pi_executable", lambda: "pi")
+    monkeypatch.setattr(pi_native_credentials, "resolve_pi_native_provider", lambda: None)
+
+    async def _fake_launch_config(**_kwargs: Any) -> _PiNativeLaunchConfig:
+        return _PiNativeLaunchConfig(
+            workspace=tmp_path,
+            server_url="http://127.0.0.1:8000",
+            terminal_launch_args=None,
+            external_session_id=None,
+        )
+
+    monkeypatch.setattr("omnigent.runner.app._pi_native_launch_config", _fake_launch_config)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        """Captures the launched terminal spec and parent os_env."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """Record the spec + parent_os_env and return a resource view."""
+            del terminal_name, session_key
+            captured["spec"] = spec
+            captured["parent_os_env"] = parent_os_env
+            return SessionResourceView(
+                id="terminal_pi_main",
+                type="terminal",
+                session_id=session_id,
+                name="pi:main",
+                metadata={"terminal_name": "pi", "session_key": "main", "running": True},
+            )
+
+    # An agent that declares sandbox: none (runs unconfined; outer
+    # container/VM is the security boundary).
+    agent_os_env = OSEnvSpec(
+        type="caller_process",
+        cwd=".",
+        sandbox=OSEnvSandboxSpec(type="none"),
+    )
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="pi_code",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "pi-native", "model": "pi-default"},
+        ),
+        os_env=agent_os_env,
+    )
+
+    await _auto_create_pi_terminal(
+        "conv_pi_sandbox_none",
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, _evt: None,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+        agent_spec=agent_spec,
+    )
+
+    launched_sandbox = captured["spec"].os_env.sandbox
+    assert launched_sandbox is not None, (
+        "auto-create dropped the agent's sandbox; launch_required_terminal will "
+        "fall back to _default_sandbox_for_platform (bwrap), overriding sandbox: none"
+    )
+    assert launched_sandbox.type == "none"
+    # The whole os_env is threaded through as the inheritance parent.
+    assert captured["parent_os_env"] is agent_os_env
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Complete the native-terminal sandbox-inheritance fix for the pi path. #175
fixed the codex, claude, and REPL auto-create terminals to honor the agent's
os_env.sandbox, but _auto_create_pi_terminal was missed: it still built its
terminal OSEnvSpec with no sandbox and no parent_os_env. A pi-native agent
declaring sandbox: none therefore fell back to the platform default
(linux_bwrap), which cannot start on a hardened container, so the pi terminal
failed to launch. Same defect class as #173, on the one auto-create path #175
did not cover. (Flagged by the Polly review on #175.)

## Changes (omnigent/runner/app.py)

- _auto_create_pi_terminal: add an agent_spec parameter; resolve
  agent_os_env = _agent_os_env_from_spec(agent_spec); set
  sandbox=(agent_os_env.sandbox if agent_os_env is not None else None) on the
  terminal OSEnvSpec and pass parent_os_env=agent_os_env into
  launch_required_terminal. Mirrors _auto_create_codex_terminal and
  _auto_create_claude_terminal exactly.
- Both _auto_create_pi_terminal call sites resolve the session agent spec
  (guarded by try/except OmnigentError, falling back to None) and thread it
  through, matching the codex ensure path.

## Tests

test_auto_create_pi_terminal_inherits_agent_sandbox (in
tests/runner/test_app_sessions_native.py), mirroring the codex/claude
sandbox-inheritance tests: a pi agent with os_env.sandbox.type: none yields a
terminal whose os_env.sandbox is none (not the platform default) and the agent
os_env as parent_os_env. Red before the change, green after. The existing pi
launch test's fake registry was updated to accept the new parent_os_env kwarg.
ruff check and ruff format are clean.

Related: #173, #175.
