### PR TITLE
Fix Render persistent data disk mount

### DIFF
--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -22,8 +22,9 @@ The `render.yaml` blueprint at the repo root defines:
   `render.yaml` (`image.creds`); once public, the pull is anonymous.
 - **omnigent-db** (`basic-256mb` managed Postgres) — `DATABASE_URL` is injected
   into the service automatically
-- **artifact-data** (10 GB persistent disk) — mounted at `/data/artifacts` so
-  agent bundle storage survives redeploys
+- **artifact-data** (10 GB persistent disk) — mounted at `/data` so server
+  config, first-boot credentials, cookie secrets, and agent artifacts survive
+  redeploys. Artifacts live under `/data/artifacts`.
 
 ## Quickstart (built-in accounts — the default)
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,5 @@
 # Render blueprint: web service (pulls the CI image — it ships the gitignored
-# web UI bundle a source build can't) + managed Postgres + artifact disk.
+# web UI bundle a source build can't) + managed Postgres + data disk.
 # Defaults to built-in `accounts` auth (multi-user, no IdP). Full walkthrough:
 # deploy/render/README.md.
 
@@ -15,7 +15,7 @@ services:
     healthCheckPath: /health
     disk:
       name: artifact-data
-      mountPath: /data/artifacts
+      mountPath: /data
       sizeGB: 10
     envVars:
       - key: DATABASE_URL

--- a/uv.lock
+++ b/uv.lock
@@ -2432,7 +2432,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2590,7 +2590,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "vertex", "m
 
 [[package]]
 name = "omnigent-client"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -2607,7 +2607,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.1.0" },
+    { name = "omnigent-client", specifier = "==0.1.1" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },
@@ -2893,11 +2893,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Mount the Render persistent disk at `/data` so `/data/config.yaml` and first-boot server state survive restarts.
- Keep artifacts under `/data/artifacts` and update the Render deploy guide to describe the persistent layout.
- Refresh `uv.lock` for the release branch so locked dependency installation passes in CI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `git diff --check` locally and parsed `render.yaml` with `python3`/PyYAML. No unit or integration tests were added because this changes a Render blueprint mount path and matching deployment documentation. Refreshed `uv.lock` with `UV_INDEX_URL=https://pypi.org/simple PIP_INDEX_URL=https://pypi.org/simple uv lock` after CI reported the release branch lockfile was stale under `uv sync --locked`.
