### PR TITLE
Fix Render persistent data disk mount

### DIFF
--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -8123,6 +8123,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -17412,12 +17421,21 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -8123,15 +8123,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -17421,21 +17412,12 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
       "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
+        "node": ">= 6"
       }
     },
     "node_modules/yargs": {

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -22,8 +22,9 @@ The `render.yaml` blueprint at the repo root defines:
   `render.yaml` (`image.creds`); once public, the pull is anonymous.
 - **omnigent-db** (`basic-256mb` managed Postgres) — `DATABASE_URL` is injected
   into the service automatically
-- **artifact-data** (10 GB persistent disk) — mounted at `/data/artifacts` so
-  agent bundle storage survives redeploys
+- **artifact-data** (10 GB persistent disk) — mounted at `/data` so server
+  config, first-boot credentials, cookie secrets, and agent artifacts survive
+  redeploys. Artifacts live under `/data/artifacts`.
 
 ## Quickstart (built-in accounts — the default)
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,5 @@
 # Render blueprint: web service (pulls the CI image — it ships the gitignored
-# web UI bundle a source build can't) + managed Postgres + artifact disk.
+# web UI bundle a source build can't) + managed Postgres + data disk.
 # Defaults to built-in `accounts` auth (multi-user, no IdP). Full walkthrough:
 # deploy/render/README.md.
 
@@ -15,7 +15,7 @@ services:
     healthCheckPath: /health
     disk:
       name: artifact-data
-      mountPath: /data/artifacts
+      mountPath: /data
       sizeGB: 10
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Summary

- Mount the Render persistent disk at `/data` so `/data/config.yaml` and first-boot server state survive restarts.
- Keep artifacts under `/data/artifacts` and update the Render deploy guide to describe the persistent layout.
- Refresh `uv.lock` for the release branch so locked dependency installation passes in CI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `git diff --check` locally and parsed `render.yaml` with `python3`/PyYAML. No unit or integration tests were added because this changes a Render blueprint mount path and matching deployment documentation. Refreshed `uv.lock` with `UV_INDEX_URL=https://pypi.org/simple PIP_INDEX_URL=https://pypi.org/simple uv lock` after CI reported the release branch lockfile was stale under `uv sync --locked`.