### PR TITLE
feat(ap-web): render Markdown task lists in the file editor

### DIFF
--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -847,13 +847,15 @@
   gap: 0.5em;
   margin: 0.25em 0;
 }
-/* The checkbox lives in a contenteditable=false <label>; keep it from
-   stretching and nudge it down to sit on the first text line (line-height 1.7). */
+/* The checkbox lives in a contenteditable=false <label>. Give the label the
+   height of one content line (paragraph line-height: 1.7) and center the
+   checkbox within it, so it sits on the first text line at any font size
+   instead of relying on a fixed margin nudge. */
 .tiptap-md-content .ProseMirror ul[data-type="taskList"] > li > label {
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
-  margin-top: 0.2em;
+  height: 1.7em;
   user-select: none;
 }
 .tiptap-md-content .ProseMirror ul[data-type="taskList"] > li > label input[type="checkbox"] {

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -826,6 +826,56 @@
 .tiptap-md-content .ProseMirror li {
   margin: 0.25em 0;
 }
+/* GitHub-style task lists (`- [ ]` / `- [x]`), rendered by
+   @tiptap/extension-list's TaskList/TaskItem (registered in
+   MarkdownRichTextViewer.tsx). TaskList renders <ul data-type="taskList">;
+   each item is drawn by TaskItem's node-view as
+   <li data-checked><label><input type=checkbox><span></span></label><div>…</div></li>
+   — note the live editor DOM carries data-checked on the <li> but NOT
+   data-type (that only appears on the static renderHTML/clipboard path), so we
+   target items as `ul[data-type="taskList"] > li`. The data-attribute selector
+   out-specifies the plain ul/li rules above: drop the inherited disc marker and
+   lay the checkbox out beside the content instead of stacking on top of it. */
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] {
+  list-style: none;
+  padding-left: 0;
+  margin: 0.5em 0;
+}
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] > li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+  margin: 0.25em 0;
+}
+/* The checkbox lives in a contenteditable=false <label>; keep it from
+   stretching and nudge it down to sit on the first text line (line-height 1.7). */
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] > li > label {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-top: 0.2em;
+  user-select: none;
+}
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] > li > label input[type="checkbox"] {
+  width: 0.95em;
+  height: 0.95em;
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--primary);
+}
+/* Content column: the <div> wraps the item's paragraph(s). Collapse the
+   paragraph's default vertical margin so a single-line item hugs the checkbox. */
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] > li > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] > li > div > p {
+  margin: 0;
+}
+/* Nested checklists tuck under their parent item, not the page margin. */
+.tiptap-md-content .ProseMirror ul[data-type="taskList"] > li ul[data-type="taskList"] {
+  margin: 0.25em 0 0;
+}
 .tiptap-md-content .ProseMirror blockquote {
   border-left: 3px solid var(--border);
   padding-left: 1em;

--- a/ap-web/src/shell/MarkdownEditorToolbar.tsx
+++ b/ap-web/src/shell/MarkdownEditorToolbar.tsx
@@ -21,6 +21,7 @@ import {
   Italic,
   List,
   ListOrdered,
+  ListTodo,
   Pilcrow,
   Quote,
   Redo2,
@@ -36,6 +37,8 @@ import "@tiptap/markdown";
 // augmentation so editor.chain() includes table commands (insertTable, etc.)
 // without pulling the full extension into the runtime bundle.
 import type {} from "@tiptap/extension-table";
+// Same trick for the list package's command augmentation (toggleTaskList).
+import type {} from "@tiptap/extension-list";
 import { TableMap, cellAround, colCount, findTable, isInTable } from "@tiptap/pm/tables";
 import { cn } from "@/lib/utils";
 
@@ -259,6 +262,7 @@ export function ToolbarPlugin({
       isItalic: ctx.editor?.isActive("italic") ?? false,
       isStrike: ctx.editor?.isActive("strike") ?? false,
       isCode: ctx.editor?.isActive("code") ?? false,
+      isTaskList: ctx.editor?.isActive("taskList") ?? false,
     }),
   });
 
@@ -311,6 +315,7 @@ export function ToolbarPlugin({
     isItalic,
     isStrike,
     isCode,
+    isTaskList,
   } = editorState ?? {};
 
   // Auto-save status pill (replaces the explicit Save button). ⌘S / clicking
@@ -435,6 +440,13 @@ export function ToolbarPlugin({
         onClick={() => editor?.chain().focus().toggleOrderedList().run()}
       >
         <ListOrdered className="size-3.5" />
+      </ToolbarBtn>
+      <ToolbarBtn
+        active={isTaskList}
+        title="Task list"
+        onClick={() => editor?.chain().focus().toggleTaskList().run()}
+      >
+        <ListTodo className="size-3.5" />
       </ToolbarBtn>
       <Divider />
       <TableBtn editor={editor} />

--- a/ap-web/src/shell/MarkdownRichTextViewer.test.tsx
+++ b/ap-web/src/shell/MarkdownRichTextViewer.test.tsx
@@ -31,6 +31,10 @@ vi.mock("@tiptap/extension-table", () => ({
   TableCell: {},
   TableHeader: {},
 }));
+vi.mock("@tiptap/extension-list", () => ({
+  TaskList: {},
+  TaskItem: { configure: vi.fn().mockReturnValue({}) },
+}));
 vi.mock("./TipTapGitHubAlert", () => ({ GitHubAlertBlockquote: {} }));
 vi.mock("./TipTapHtmlPassthrough", () => ({ HtmlPassthrough: {} }));
 vi.mock("./tiptapMarkdownPatches", () => ({ installMarkdownSerializerPatch: vi.fn() }));

--- a/ap-web/src/shell/MarkdownRichTextViewer.tsx
+++ b/ap-web/src/shell/MarkdownRichTextViewer.tsx
@@ -21,6 +21,7 @@ import { AlertTriangleIcon, Check, Copy, MessageSquareOffIcon } from "lucide-rea
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
+import { TaskItem, TaskList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";
@@ -265,6 +266,15 @@ function MarkdownRichTextViewerInner({
       // markdown handlers would shadow the GitHub-flavored replacements
       // below (duplicate extension names: first wins).
       StarterKit.configure({ link: false, blockquote: false }),
+      // Task lists (GitHub `- [ ]` / `- [x]`). StarterKit ships
+      // BulletList/OrderedList/ListItem but NOT TaskList/TaskItem, so without
+      // these two the markdown parser drops the checkbox and renders a plain
+      // bullet. Registering them (a) makes @tiptap/markdown pick up TaskList's
+      // built-in `- [ ]` marked tokenizer so the syntax parses into checkbox
+      // items, and (b) round-trips back to identical markdown via their
+      // built-in renderMarkdown. nested:true lets Tab indent sub-checklists.
+      TaskList,
+      TaskItem.configure({ nested: true }),
       Table.configure({ resizable: true }),
       TableRow,
       TableCell,

--- a/ap-web/src/shell/TipTapTaskList.test.ts
+++ b/ap-web/src/shell/TipTapTaskList.test.ts
@@ -21,15 +21,22 @@ import { TaskItem, TaskList } from "@tiptap/extension-list";
 import StarterKit from "@tiptap/starter-kit";
 
 let editor: Editor | null = null;
+let host: HTMLElement | null = null;
 afterEach(() => {
   editor?.destroy();
   editor = null;
+  host?.remove();
+  host = null;
 });
 
-/** Mounted editor matching the viewer's task-list configuration. */
+/** Mounted editor matching the viewer's task-list configuration. The host is
+ *  attached to the document so commands that focus the editor (e.g. the
+ *  checkbox-toggle node-view) can commit their transactions. */
 function makeEditor(markdown: string): Editor {
+  host = document.createElement("div");
+  document.body.appendChild(host);
   return new Editor({
-    element: document.createElement("div"),
+    element: host,
     extensions: [
       StarterKit.configure({ link: false, blockquote: false }),
       TaskList,
@@ -73,6 +80,30 @@ describe("task lists", () => {
   it("round-trips task-list markdown byte-faithfully", () => {
     editor = makeEditor(TASK_MD);
     expect(editor.getMarkdown().trim()).toBe(TASK_MD);
+  });
+
+  it("toggling a checkbox updates the marker and re-serializes to markdown", () => {
+    editor = makeEditor(TASK_MD);
+    const dom = editor.view.dom;
+    const boxesOf = () => dom.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+    const itemsOf = () => dom.querySelectorAll("li[data-checked]");
+
+    // Click the first box ("Buy milk", unchecked). TaskItem's node-view listens
+    // for the checkbox `change` event; jsdom's .click() flips `checked` and
+    // dispatches it, mirroring a real user click.
+    boxesOf()[0].click();
+
+    expect(boxesOf()[0].checked).toBe(true);
+    expect(itemsOf()[0].getAttribute("data-checked")).toBe("true");
+    // The flip must reach the document, not just the DOM checkbox: re-serialize.
+    expect(editor.getMarkdown().trim()).toBe("- [x] Buy milk\n- [x] Ship the PR");
+
+    // Unchecking the second box ("Ship the PR") round-trips the other way.
+    boxesOf()[1].click();
+
+    expect(boxesOf()[1].checked).toBe(false);
+    expect(itemsOf()[1].getAttribute("data-checked")).toBe("false");
+    expect(editor.getMarkdown().trim()).toBe("- [x] Buy milk\n- [ ] Ship the PR");
   });
 
   it("leaves plain bullet lists as plain lists (no checkbox promotion)", () => {

--- a/ap-web/src/shell/TipTapTaskList.test.ts
+++ b/ap-web/src/shell/TipTapTaskList.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for GitHub-style task lists (`- [ ]` / `- [x]`) in the markdown
+ * editor.
+ *
+ * TaskList/TaskItem come from @tiptap/extension-list and ship their own
+ * markdown tokenizer + parse/serialise handlers; MarkdownRichTextViewer just
+ * registers them (StarterKit does not). These tests pin that wiring:
+ *   - task syntax parses into a <ul data-type="taskList"> of checkbox items
+ *   - checkbox state tracks `[ ]` vs `[x]`
+ *   - the list round-trips back to identical markdown
+ *   - plain bullet lists are NOT promoted to task lists
+ *
+ * Like the GitHub-alert tests, these mount a real TipTap Editor (real schema,
+ * real @tiptap/markdown parsing) so a regression in either direction fails.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import { TaskItem, TaskList } from "@tiptap/extension-list";
+import StarterKit from "@tiptap/starter-kit";
+
+let editor: Editor | null = null;
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+/** Mounted editor matching the viewer's task-list configuration. */
+function makeEditor(markdown: string): Editor {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [
+      StarterKit.configure({ link: false, blockquote: false }),
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      Markdown,
+    ],
+    content: markdown,
+    contentType: "markdown",
+  });
+}
+
+const TASK_MD = "- [ ] Buy milk\n- [x] Ship the PR";
+
+describe("task lists", () => {
+  it("parses `- [ ]` / `- [x]` into a checkbox list", () => {
+    editor = makeEditor(TASK_MD);
+    const list = editor.view.dom.querySelector('ul[data-type="taskList"]');
+    expect(list).not.toBeNull();
+
+    // TaskItem's node-view draws each item as a bare <li> (data-checked, no
+    // data-type) inside the taskList <ul>, so match direct-child <li>s.
+    const items = list!.querySelectorAll(":scope > li");
+    expect(items).toHaveLength(2);
+    expect(list!.textContent).toContain("Buy milk");
+    expect(list!.textContent).toContain("Ship the PR");
+  });
+
+  it("reflects checked state on both the checkbox and data-checked", () => {
+    editor = makeEditor(TASK_MD);
+    // Node-view stamps data-checked (true/false) on each task <li>.
+    const items = editor.view.dom.querySelectorAll("li[data-checked]");
+    const boxes = editor.view.dom.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].checked).toBe(false);
+    expect(boxes[1].checked).toBe(true);
+    expect(items[0].getAttribute("data-checked")).toBe("false");
+    expect(items[1].getAttribute("data-checked")).toBe("true");
+  });
+
+  it("round-trips task-list markdown byte-faithfully", () => {
+    editor = makeEditor(TASK_MD);
+    expect(editor.getMarkdown().trim()).toBe(TASK_MD);
+  });
+
+  it("leaves plain bullet lists as plain lists (no checkbox promotion)", () => {
+    const md = "- apples\n- oranges";
+    editor = makeEditor(md);
+    // No task-list markup...
+    expect(editor.view.dom.querySelector('ul[data-type="taskList"]')).toBeNull();
+    expect(editor.view.dom.querySelector('input[type="checkbox"]')).toBeNull();
+    // ...and a plain <ul> survives the round-trip.
+    expect(editor.view.dom.querySelector("ul")).not.toBeNull();
+    expect(editor.getMarkdown().trim()).toBe(md);
+  });
+});

--- a/tests/e2e_ui/files/test_markdown_task_lists.py
+++ b/tests/e2e_ui/files/test_markdown_task_lists.py
@@ -1,0 +1,102 @@
+"""E2E: GitHub task lists render as checkboxes in the markdown rich-text editor.
+
+Counterpart to ``test_markdown_github_alerts.py``: this pins the GitHub-flavored
+*task list* construct — list items opening with ``[ ]`` / ``[x]``. The
+``TaskList`` / ``TaskItem`` nodes (from ``@tiptap/extension-list``, registered in
+``MarkdownRichTextViewer.tsx``) turn those into a ``<ul data-type="taskList">``
+whose items are drawn by a node-view as ``<li>`` carrying ``data-checked`` and an
+``<input type="checkbox">`` — distinct from a plain bullet list, which stays an
+ordinary ``<ul>`` with no checkboxes.
+
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_MARKDOWN_FILE_PATH = "tasks.md"
+
+# An unchecked + a checked task item, then a plain bullet list. The plain list
+# proves the checkbox treatment comes from the ``[ ]`` / ``[x]`` markers, not
+# from bullet lists in general.
+_MARKDOWN_CONTENT = """\
+# Checklist
+
+- [ ] Buy milk
+- [x] Ship the PR
+
+Groceries:
+
+- apples
+- oranges
+"""
+
+
+@pytest.fixture
+def seeded_tasks_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_MARKDOWN_FILE_PATH}",
+        json={"content": _MARKDOWN_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def test_task_lists_render_as_checkboxes(
+    page: Page,
+    seeded_tasks_session: tuple[str, str],
+) -> None:
+    """``- [ ]`` / ``- [x]`` render as a checkbox list; plain bullets do not."""
+    base_url, session_id = seeded_tasks_session
+    page.goto(f"{base_url}/c/{session_id}?file={_MARKDOWN_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    editor = file_viewer.locator("[contenteditable='true']")
+    expect(editor).to_be_visible(timeout=10_000)
+
+    # The task list renders as a single dedicated <ul data-type="taskList">.
+    task_list = editor.locator('ul[data-type="taskList"]')
+    expect(task_list).to_have_count(1)
+
+    # Two items, each with a checkbox; order follows the source: Buy milk
+    # (unchecked) then Ship the PR (checked).
+    checkboxes = task_list.locator('input[type="checkbox"]')
+    expect(checkboxes).to_have_count(2)
+    expect(checkboxes.nth(0)).not_to_be_checked()
+    expect(checkboxes.nth(1)).to_be_checked()
+    expect(task_list).to_contain_text("Buy milk")
+    expect(task_list).to_contain_text("Ship the PR")
+
+    # The raw checkbox syntax is consumed — the rendered editor shows the
+    # checkboxes, never the literal "[ ]" / "[x]" markers.
+    expect(task_list).not_to_contain_text("[ ]")
+    expect(task_list).not_to_contain_text("[x]")
+
+    # The plain bullet list stays an ordinary list: no taskList typing and no
+    # checkbox inside it.
+    plain = editor.locator('ul:not([data-type="taskList"])').filter(has_text="apples")
+    expect(plain).to_have_count(1)
+    expect(plain.locator('input[type="checkbox"]')).to_have_count(0)
+
+    # Source toggle: the raw markers are visible verbatim in the source view.
+    file_viewer.get_by_role("button", name="Source view").click()
+    expect(file_viewer.locator("[contenteditable='true']")).to_have_count(0)
+    expect(file_viewer.get_by_text("- [x] Ship the PR", exact=False)).to_be_visible(timeout=10_000)


### PR DESCRIPTION
## Summary

Render GitHub-style Markdown task lists (`- [ ]` / `- [x]`) as interactive checkboxes in the `ap-web` markdown file editor (`MarkdownRichTextViewer`). The editor registered StarterKit's bullet/ordered lists but not `TaskList`/`TaskItem`, so task syntax fell back to plain bullets and the checkbox was dropped.

- Register `TaskList` + `TaskItem` from the already-present `@tiptap/extension-list` (no new dependency). This also activates `@tiptap/markdown`'s built-in `- [ ]` marked tokenizer, so task lists parse into checkbox items and round-trip back to identical markdown via the nodes' own `renderMarkdown`.
- Style the node-view (`ul[data-type="taskList"] > li`): drop the inherited disc bullet and lay the checkbox out beside the content. (The live editor `<li>` carries `data-checked` but not `data-type`, so items are targeted via the typed `<ul>` wrapper.)
- Add a "Task list" toolbar toggle (`toggleTaskList`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added two tests:

- `ap-web/src/shell/TipTapTaskList.test.ts` — Vitest, 4 cases: `- [ ]`/`- [x]` parse into a `taskList` of checkbox items, checked-state tracks the marker, byte-faithful markdown round-trip, and plain bullet lists are not promoted to task lists.
- `tests/e2e_ui/files/test_markdown_task_lists.py` — Playwright: seeds a markdown file via the filesystem endpoint (no agent run), opens it in a real browser, and asserts the rendered `ul[data-type="taskList"]` checkboxes and their checked state, that the `[ ]`/`[x]` syntax is consumed, that a plain bullet list stays plain, and that Source view shows the raw markers. This satisfies the `E2E UI Required` check for UI changes.

Commands run (Node 20, fresh `npm ci`, against the current `main` base):

- `npm run format:check` — pass
- `npx tsc -p tsconfig.app.json --noEmit` — pass
- `npx vitest run src/shell/TipTapTaskList.test.ts src/shell/MarkdownRichTextViewer.test.tsx src/shell/MarkdownEditorToolbar.test.tsx` — 29/29 pass
- `uv run pytest tests/e2e_ui/files/test_markdown_task_lists.py --ui-skip-build` — 1 passed

No new dependency: `@tiptap/extension-list` was already pinned at `3.23.4`.
