### PR TITLE
fix(#386): file browser shows workspace after host reconnect, before first message

### DIFF
--- a/ap-web/src/hooks/useHostFilesystem.ts
+++ b/ap-web/src/hooks/useHostFilesystem.ts
@@ -110,7 +110,10 @@ const MAX_PAGES = 50;
  *   when the page cap was hit with more entries still pending.
  * @throws FetchError carrying the HTTP status on a non-OK response.
  */
-async function fetchHostFilesystem(hostId: string, path: string): Promise<HostDirectoryListing> {
+export async function fetchHostFilesystem(
+  hostId: string,
+  path: string,
+): Promise<HostDirectoryListing> {
   const baseUrl = buildHostFilesystemUrl(hostId, path);
   const entries: HostFilesystemEntry[] = [];
   let after: string | null = null;

--- a/ap-web/src/hooks/useWorkspaceChangedFiles.test.tsx
+++ b/ap-web/src/hooks/useWorkspaceChangedFiles.test.tsx
@@ -6,12 +6,27 @@ import type { ReactNode } from "react";
 
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useSessionRunnerOnline: vi.fn(),
+  useSessionHostOnline: vi.fn(),
 }));
 vi.mock("@/store/chatStore", () => ({
   useChatStore: vi.fn(),
 }));
+// useSession feeds the host-filesystem fallback (host id + workspace path).
+// Default to no session so the fallback stays disabled for the pre-existing
+// gating tests; the fallback-specific tests override the mock per-test.
+vi.mock("@/hooks/useSession", () => ({
+  useSession: vi.fn(),
+}));
+// fetchHostFilesystem is the host-daemon listing used by the offline fallback.
+// Mocked so the fallback tests assert the call args without a real network.
+vi.mock("@/hooks/useHostFilesystem", () => ({
+  fetchHostFilesystem: vi.fn(),
+}));
 
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSessionRunnerOnline, useSessionHostOnline } from "@/hooks/RunnerHealthProvider";
+import { useSession } from "@/hooks/useSession";
+import { fetchHostFilesystem } from "@/hooks/useHostFilesystem";
+import type { Session } from "@/lib/types";
 import { useChatStore } from "@/store/chatStore";
 import {
   MAX_RUNNER_OFFLINE_RETRIES,
@@ -27,9 +42,13 @@ import {
   useWorkspaceEnvironment,
   useWorkspaceFileExists,
   useWorkspaceFileSearch,
+  type WorkspaceFile,
 } from "./useWorkspaceChangedFiles";
 
 const onlineMock = vi.mocked(useSessionRunnerOnline);
+const hostOnlineMock = vi.mocked(useSessionHostOnline);
+const sessionMock = vi.mocked(useSession);
+const hostFsMock = vi.mocked(fetchHostFilesystem);
 const chatStoreMock = vi.mocked(useChatStore);
 const fetchMock = vi.fn();
 
@@ -154,8 +173,24 @@ beforeEach(() => {
   // assume sessionActive is false (initial fetch from `enabled`, no
   // polling). The trailing-invalidate test overrides per-call.
   stubChatStore();
+  // Default: host liveness unknown and no session snapshot → the
+  // host-filesystem fallback stays disabled, preserving the pre-existing
+  // gating behaviour. Fallback tests override these per-test.
+  hostOnlineMock.mockReturnValue(undefined);
+  sessionMock.mockReturnValue({ session: null, isLoading: false, error: null });
+  hostFsMock.mockReset();
 });
 
+/** Build a minimal host-bound session snapshot for the fallback tests. */
+function hostSession(hostId: string | null, workspace: string | null) {
+  return {
+    session: { hostId, workspace } as unknown as Session,
+    isLoading: false,
+    error: null,
+  };
+}
+
+// afterEach kept here so the hostSession helper stays in module scope.
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
@@ -496,6 +531,203 @@ describe("useWorkspaceDirectory gating", () => {
     );
     await flushMicrotasks();
 
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── Host-filesystem fallback (runner offline, host online) ───────────────────
+//
+// After the host reconnects but before the first message re-initializes the
+// runner, the runner-backed /filesystem endpoints are gated off. The file
+// browser falls back to the host-filesystem API (no runner required) so the
+// workspace tree isn't empty. These tests mock the session snapshot + host
+// liveness so the fallback engages, and assert it routes to fetchHostFilesystem
+// with the workspace's absolute path.
+
+function AllFilesDataProbe({
+  id,
+  onData,
+}: {
+  id: string | undefined;
+  onData: (data: { available: boolean; data: WorkspaceFile[] } | undefined) => void;
+}) {
+  const query = useWorkspaceAllFiles(id);
+  useEffect(() => {
+    if (query.isSuccess) onData(query.data);
+  }, [query.isSuccess, query.data, onData]);
+  return null;
+}
+
+function AllFilesErrorProbe({
+  id,
+  onError,
+}: {
+  id: string | undefined;
+  onError: (err: Error | null | undefined) => void;
+}) {
+  const query = useWorkspaceAllFiles(id);
+  useEffect(() => {
+    if (query.isError) onError(query.error);
+  }, [query.isError, query.error, onError]);
+  return null;
+}
+
+function hostEntry(name: string, type: "file" | "directory", absRoot: string) {
+  return {
+    name,
+    path: `${absRoot}/${name}`,
+    type,
+    bytes: type === "file" ? 7 : null,
+    modified_at: 42,
+  };
+}
+
+describe("useWorkspaceAllFiles host-filesystem fallback", () => {
+  it("lists the workspace root via the host filesystem when the runner is offline and the host is online", async () => {
+    // Repro of #386: host reconnected, runner not yet re-initialized. The
+    // runner-backed query would be gated off (no fetch); instead the hook
+    // falls back to the host daemon and returns a non-empty tree.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    sessionMock.mockReturnValue(hostSession("host_1", "/home/u/ws"));
+    hostFsMock.mockResolvedValue({
+      entries: [
+        hostEntry("src", "directory", "/home/u/ws"),
+        hostEntry("README.md", "file", "/home/u/ws"),
+      ],
+      truncated: false,
+    });
+
+    const results: Array<{ available: boolean; data: WorkspaceFile[] }> = [];
+    render(
+      <Wrap>
+        <AllFilesDataProbe
+          id="conv_reconnect"
+          onData={(d) => results.push(d as { available: boolean; data: WorkspaceFile[] })}
+        />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(hostFsMock).toHaveBeenCalled());
+    // The host listing is requested with the workspace's absolute path.
+    expect(hostFsMock.mock.calls[0]).toEqual(["host_1", "/home/u/ws"]);
+    // The runner endpoint is NOT hit (the runner is offline).
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Absolute paths are mapped to workspace-relative for the tree.
+    await waitFor(() =>
+      expect(results.at(-1)).toEqual({
+        available: true,
+        data: [
+          { path: "src", name: "src", type: "directory", bytes: null, modified_at: 42 },
+          { path: "README.md", name: "README.md", type: "file", bytes: 7, modified_at: 42 },
+        ],
+      }),
+    );
+  });
+
+  it("does not fall back when the host is also offline", async () => {
+    // Runner offline AND host down → nothing can serve the tree. No fetch at
+    // all (preserves the pre-reconnect empty/asleep state rather than a
+    // doomed host request that would 409).
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(false);
+    sessionMock.mockReturnValue(hostSession("host_1", "/home/u/ws"));
+
+    render(
+      <Wrap>
+        <AllFilesProbe id="conv_down" />
+      </Wrap>,
+    );
+    await flushMicrotasks();
+
+    expect(hostFsMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back for a non-host-bound session", async () => {
+    // Cloud-only / local sessions have no host_id → no host filesystem to
+    // fall back to. The runner gate keeps the query disabled as before.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    sessionMock.mockReturnValue(hostSession(null, null));
+
+    render(
+      <Wrap>
+        <AllFilesProbe id="conv_cloud" />
+      </Wrap>,
+    );
+    await flushMicrotasks();
+
+    expect(hostFsMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("translates a host-offline 409 into RunnerOfflineError (reconnect hint, not raw error)", async () => {
+    // The host went offline between the liveness check and the fetch → the
+    // host endpoint 409s. The fallback must surface RunnerOfflineError so the
+    // panel shows the reconnect hint, not "Failed to load: 409".
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    sessionMock.mockReturnValue(hostSession("host_1", "/home/u/ws"));
+    const hostDownErr = Object.assign(new Error("host is offline"), { status: 409 });
+    hostFsMock.mockRejectedValue(hostDownErr);
+
+    const errors: Array<Error | null | undefined> = [];
+    render(
+      <Wrap>
+        <AllFilesErrorProbe id="conv_reconnect" onError={(e) => errors.push(e)} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(errors.at(-1)).toBeInstanceOf(RunnerOfflineError));
+    // The runner endpoint is never hit (runner is offline).
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates a non-409 host failure as a raw error (not RunnerOfflineError)", async () => {
+    // A 500 from the host is a real failure, not "host offline" — surface it
+    // so it isn't misread as the reconnect-hint path.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    sessionMock.mockReturnValue(hostSession("host_1", "/home/u/ws"));
+    const hostErr = Object.assign(new Error("host I/O failed"), { status: 502 });
+    hostFsMock.mockRejectedValue(hostErr);
+
+    const errors: Array<Error | null | undefined> = [];
+    render(
+      <Wrap>
+        <AllFilesErrorProbe id="conv_io" onError={(e) => errors.push(e)} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(errors.at(-1)).toBeInstanceOf(Error));
+    expect(errors.at(-1)).not.toBeInstanceOf(RunnerOfflineError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWorkspaceDirectory host-filesystem fallback", () => {
+  it("lists a subdirectory via the host filesystem when the runner is offline", async () => {
+    // Lazy-expand path: a directory expanded while the runner is offline
+    // also falls back to the host daemon so the tree is browsable, not just
+    // a flat root listing.
+    onlineMock.mockReturnValue(false);
+    hostOnlineMock.mockReturnValue(true);
+    sessionMock.mockReturnValue(hostSession("host_1", "/home/u/ws"));
+    hostFsMock.mockResolvedValue({
+      entries: [hostEntry("app.ts", "file", "/home/u/ws/src")],
+      truncated: false,
+    });
+
+    render(
+      <Wrap>
+        <DirectoryProbe id="conv_reconnect" path="src" />
+      </Wrap>,
+    );
+    await waitFor(() => expect(hostFsMock).toHaveBeenCalled());
+
+    // The subdir is resolved under the workspace root as an absolute path.
+    expect(hostFsMock.mock.calls[0]).toEqual(["host_1", "/home/u/ws/src"]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/ap-web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/ap-web/src/hooks/useWorkspaceChangedFiles.ts
@@ -16,7 +16,9 @@
 
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { type HostFilesystemEntry, fetchHostFilesystem } from "@/hooks/useHostFilesystem";
+import { useSession } from "@/hooks/useSession";
 import { authenticatedFetch } from "@/lib/identity";
 import { useChatStore } from "@/store/chatStore";
 
@@ -305,18 +307,29 @@ export function useWorkspaceAllFiles(
   });
   const sessionActive = useSessionActive(conversationId);
   useTrailingInvalidate(conversationId, sessionActive, "workspace-all-files");
+  const fallback = useHostFilesystemFallback(conversationId);
   return useQuery({
-    queryKey: ["workspace-all-files", conversationId],
-    queryFn: () => fetchWorkspaceAllFiles(conversationId!),
+    // Encode the source in the key so the host-fallback cache and the runner
+    // cache never collide (see useWorkspaceDirectory for the same reason).
+    queryKey: [
+      "workspace-all-files",
+      conversationId,
+      fallback.enabled ? { host: fallback.hostId, ws: fallback.workspace } : "runner",
+    ],
+    queryFn: fallback.enabled
+      ? () => fetchHostWorkspaceAllFiles(fallback.hostId!, fallback.workspace!)
+      : () => fetchWorkspaceAllFiles(conversationId!),
     enabled:
       queryEnabled &&
       !!conversationId &&
-      runnerOnline !== false &&
-      environmentQuery.data?.available === true,
+      (fallback.enabled
+        ? true
+        : runnerOnline !== false && environmentQuery.data?.available === true),
     // Capped-backoff retry of the runner-offline case (see
     // shouldRetryRunnerOffline). The asleep-vs-empty decision is made by
-    // the session's `failed` status downstream, not by retries.
-    retry: shouldRetryRunnerOffline,
+    // the session's `failed` status downstream, not by retries. The host
+    // fallback is a one-shot best-effort read of on-disk state; don't retry.
+    retry: fallback.enabled ? false : shouldRetryRunnerOffline,
     retryDelay: runnerOfflineRetryDelay,
     staleTime: 5_000,
   });
@@ -617,6 +630,141 @@ export function useWorkspaceEnvironment(
   });
 }
 
+// ── Host-filesystem fallback (runner offline) ─────────────────────────────────
+//
+// When the host has reconnected to the server but the backend runner for a
+// session has not been re-initialized yet (i.e. before the first post-reconnect
+// message), the runner-backed `/filesystem` endpoints 503 and the workspace
+// queries are disabled (see the `runnerOnline !== false` gates above), so the
+// file browser shows "No files in workspace" even though the host is up and
+// the workspace directory still exists on disk. The host-filesystem API
+// (`GET /v1/hosts/{id}/filesystem`) talks to the host daemon directly — no
+// runner required — so we fall back to it for the root listing and lazy
+// directory expansion while the runner is known offline, and switch back to
+// the runner endpoints once the runner comes back online (first message).
+
+/**
+ * Resolve the session's host id and absolute workspace path from its snapshot.
+ *
+ * The host-filesystem endpoint needs the host id (which host owns the dir) and
+ * an absolute path on that host (the endpoint does not speak workspace-relative
+ * paths). Both live on the single-session snapshot cached under
+ * `["session", id]`, shared with the chat stream bind, so this is usually a
+ * cache hit. Returns `null` for either field when the session isn't host-bound
+ * or has no workspace, which disables the fallback.
+ */
+function useSessionHostWorkspace(conversationId: string | undefined): {
+  hostId: string | null;
+  workspace: string | null;
+} {
+  const { session } = useSession(conversationId ?? null);
+  return { hostId: session?.hostId ?? null, workspace: session?.workspace ?? null };
+}
+
+/**
+ * Whether the host-filesystem fallback should drive the workspace queries for
+ * this session right now: only when the runner is *known* offline (`false`,
+ * not the pre-liveness `undefined` that gates a still-booting runner), the
+ * host itself is reachable, and the session is host-bound with a workspace.
+ */
+function useHostFilesystemFallback(conversationId: string | undefined): {
+  enabled: boolean;
+  hostId: string | null;
+  workspace: string | null;
+} {
+  const runnerOnline = useSessionRunnerOnline(conversationId);
+  const hostOnline = useSessionHostOnline(conversationId);
+  const { hostId, workspace } = useSessionHostWorkspace(conversationId);
+  const enabled =
+    runnerOnline === false && hostOnline === true && hostId !== null && workspace !== null;
+  return { enabled, hostId, workspace };
+}
+
+/**
+ * Normalize a workspace root so it has exactly one trailing slash for the
+ * prefix strip below (``/Users/u/ws`` → ``/Users/u/ws/``).
+ */
+function withTrailingSlash(absPath: string): string {
+  return absPath.replace(/\/+$/, "") + "/";
+}
+
+/**
+ * Map host-filesystem entries (absolute paths) into `WorkspaceFile[]` with
+ * workspace-relative `path`s, the shape `buildTree` and the folder tree expect.
+ *
+ * Entries outside the workspace root (shouldn't happen for a workspace listing
+ * but defensive against a host that returns parent/sibling entries) are
+ * dropped rather than remapped to a basename — a misleading relative path
+ * could feed `buildTree`/FileViewer and open a file that doesn't exist under
+ * the workspace. "other" entry types are also dropped — the tree only knows
+ * files and directories.
+ */
+function mapHostEntriesToWorkspaceFiles(
+  entries: HostFilesystemEntry[],
+  workspaceAbs: string,
+): WorkspaceFile[] {
+  const prefix = withTrailingSlash(workspaceAbs);
+  return entries
+    .filter((e) => (e.type === "file" || e.type === "directory") && e.path.startsWith(prefix))
+    .map((e) => ({
+      path: e.path.slice(prefix.length),
+      name: e.name,
+      type: e.type === "directory" ? "directory" : "file",
+      bytes: e.bytes,
+      modified_at: e.modified_at,
+    }));
+}
+
+/**
+ * Fetch the workspace root via the host-filesystem API (runner offline).
+ *
+ * Paginates to completion via `fetchHostFilesystem` (same helper the
+ * new-session workspace picker uses) and wraps the result in the
+ * `WorkspaceAllFilesResult` shape so the consuming hook is agnostic to the
+ * source. A 409 (host went offline between the liveness check and the fetch)
+ * throws `RunnerOfflineError` so the panel falls through to the reconnect
+ * hint rather than a raw "Failed to load".
+ */
+async function fetchHostWorkspaceAllFiles(
+  hostId: string,
+  workspaceAbs: string,
+): Promise<WorkspaceAllFilesResult> {
+  try {
+    const listing = await fetchHostFilesystem(hostId, workspaceAbs);
+    return { available: true, data: mapHostEntriesToWorkspaceFiles(listing.entries, workspaceAbs) };
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 409) throw new RunnerOfflineError();
+    throw err;
+  }
+}
+
+/**
+ * Fetch a workspace subdirectory via the host-filesystem API (runner offline),
+ * returning `WorkspaceFile[]` in the same shape as `fetchWorkspaceDirectory`.
+ */
+async function fetchHostWorkspaceDirectory(
+  dirPath: string,
+  hostId: string,
+  workspaceAbs: string,
+): Promise<WorkspaceFile[]> {
+  // Strip any leading slash off the workspace-relative dirPath so it joins
+  // cleanly under the workspace root (a leading slash would produce a
+  // double slash that encodes to an empty middle segment and 404s). The
+  // tree contract already passes relative paths, but this keeps the helper
+  // robust independent of the caller.
+  const rel = dirPath.replace(/^\/+/, "");
+  const absDir = `${withTrailingSlash(workspaceAbs)}${rel}`;
+  try {
+    const listing = await fetchHostFilesystem(hostId, absDir);
+    return mapHostEntriesToWorkspaceFiles(listing.entries, workspaceAbs);
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 409) throw new RunnerOfflineError();
+    throw err;
+  }
+}
+
 /**
  * Fetch the contents of a specific workspace directory on demand.
  *
@@ -626,10 +774,24 @@ export function useWorkspaceEnvironment(
  */
 export function useWorkspaceDirectory(conversationId: string | undefined, dirPath: string | null) {
   const runnerOnline = useSessionRunnerOnline(conversationId);
+  const fallback = useHostFilesystemFallback(conversationId);
   return useQuery({
-    queryKey: ["workspace-dir", conversationId, dirPath],
-    queryFn: () => fetchWorkspaceDirectory(conversationId!, dirPath!),
-    enabled: !!conversationId && !!dirPath && runnerOnline !== false,
+    // Encode the source in the key so the host-fallback cache and the runner
+    // cache never collide (a stale host listing must not surface after the
+    // runner is back online and vice versa).
+    queryKey: [
+      "workspace-dir",
+      conversationId,
+      dirPath,
+      fallback.enabled ? { host: fallback.hostId, ws: fallback.workspace } : "runner",
+    ],
+    queryFn: fallback.enabled
+      ? () => fetchHostWorkspaceDirectory(dirPath!, fallback.hostId!, fallback.workspace!)
+      : () => fetchWorkspaceDirectory(conversationId!, dirPath!),
+    enabled: !!conversationId && !!dirPath && (fallback.enabled || runnerOnline !== false),
+    // The host fallback is a one-shot best-effort read of on-disk state; don't
+    // retry it on failure (the runner coming back online switches the source).
+    retry: fallback.enabled ? false : undefined,
     staleTime: 5_000,
   });
 }

--- a/tests/e2e_ui/files/test_file_browser_runner_offline.py
+++ b/tests/e2e_ui/files/test_file_browser_runner_offline.py
@@ -1,0 +1,151 @@
+"""E2E: file browser degrades gracefully when the runner is offline.
+
+Companion to issue #386 — "File browser shows 'No files in workspace'
+after the host is reconnected to the server and before you send a new
+message (because runner is not created yet)".
+
+The fix routes the workspace queries to the **host-filesystem API** when
+the runner is known offline but the host itself is online, so the tree
+isn't empty after a host reconnect and before the first message. That
+fallback only engages for *host-bound* sessions (the host daemon is a
+separate online entity that can serve ``GET /v1/hosts/{id}/filesystem``
+without a runner). The host-fallback mapping logic is covered
+unit-level by ``ap-web/src/hooks/useWorkspaceChangedFiles.test.tsx``
+("host-filesystem fallback" suites) — the e2e_ui fixture spawns a
+*direct* (tunnel-bound) runner with no managed host, so it cannot
+reproduce the host-reconnect scenario end-to-end.
+
+What this test *can* cover in a real browser is the adjacent code path:
+the file browser hooks must handle the runner-offline state without
+crashing or surfacing a raw "Failed to load" error. After killing the
+runner and reloading the page (the reconnect analog — session history
+loads, runner not yet re-initialized), the Files panel must still render
+a graceful state. This guards the precondition the host-fallback builds
+on (the offline branch in ``useWorkspaceAllFiles`` /
+``useWorkspaceDirectory``) against regressing into an unhandled error.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import time
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# A deterministic file seeded into the workspace so the Files tab has
+# content to show while the runner is online (proving the panel works
+# before we take the runner offline).
+_SEED_FILE = "runner_offline_probe.md"
+_SEED_CONTENT = "# probe\nrunner-offline file browser smoke test\n"
+
+
+def _find_runner_pids() -> list[int]:
+    """Find PIDs running the runner entry point (``omnigent.runner._entry``)."""
+    result = subprocess.run(
+        ["pgrep", "-f", "omnigent.runner._entry"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [int(line.strip()) for line in result.stdout.strip().splitlines() if line.strip()]
+
+
+def test_file_browser_handles_runner_offline(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """File browser renders a graceful state after the runner is killed + reloaded.
+
+    Seeds a file, verifies it appears in the Files tab while the runner is
+    online, kills the runner, waits for ``runner_online: false``, then
+    reloads (the post-reconnect analog where history loads but the runner
+    is not yet re-initialized). Asserts the Files panel still renders and
+    does NOT show a raw "Failed to load" error — the offline branch must
+    degrade gracefully rather than surfacing an unhandled failure.
+    """
+    live_server, session_id = seeded_session
+
+    # Seed the file into the session workspace so the Files tab has a
+    # visible entry while the runner is online.
+    seed_resp = httpx.put(
+        f"{live_server}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_SEED_FILE}",
+        json={"content": f"{_SEED_CONTENT}\n", "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    seed_resp.raise_for_status()
+
+    page.goto(f"{live_server}/c/{session_id}")
+    open_right_rail(page)
+
+    composer = page.get_by_placeholder("Ask the agent anything…")
+    expect(composer).to_be_visible()
+
+    # Match the suite's convention: a single generous timeout for the
+    # file-browser assertions below (slow CI turns + cold loads).
+    expect.set_options(timeout=15_000)
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    # The Files tab is present by default. Switch to it and wait for the
+    # seeded file to appear — proves the file browser works online first.
+    rail.get_by_role("tab", name=re.compile("Files")).click()
+    expect(rail.get_by_text(re.compile(re.escape(_SEED_FILE)))).to_be_visible()
+
+    # Verify the health endpoint reports online before the kill.
+    health_before = httpx.get(
+        f"{live_server}/health?session_id={session_id}",
+        timeout=5,
+    ).json()
+    assert health_before.get("session", {}).get("runner_online") is True, (
+        f"runner_online should be true before kill, got: {health_before}"
+    )
+
+    # Kill the runner (sibling of the server, not a child).
+    runner_pids = _find_runner_pids()
+    assert runner_pids, "No runner processes found to kill"
+    for pid in runner_pids:
+        os.kill(pid, signal.SIGKILL)
+
+    # Poll until the health endpoint reports the runner offline.
+    health_after: dict[str, object] = {}
+    for _attempt in range(10):
+        time.sleep(0.5)
+        health_after = httpx.get(
+            f"{live_server}/health?session_id={session_id}",
+            timeout=5,
+        ).json()
+        if health_after.get("session", {}).get("runner_online") is False:
+            break
+    assert health_after.get("session", {}).get("runner_online") is False, (
+        f"runner_online should be false after kill, got: {health_after}"
+    )
+
+    # Reload the page — the reconnect analog: session history loads from
+    # the server, but the runner is not yet re-initialized (no message has
+    # been sent). This is exactly the state the #386 fix targets; here the
+    # fixture's session isn't host-bound so the host-fallback doesn't
+    # engage, but the offline branch must still degrade gracefully.
+    page.reload()
+    expect(page).to_have_url(re.compile(rf"/c/{re.escape(session_id)}"), timeout=15_000)
+    expect(composer).to_be_visible(timeout=15_000)
+
+    # Re-open the rail (its open state is per-conversation and may collapse
+    # after reload) and switch back to the Files tab.
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("Files")).click(timeout=15_000)
+
+    # The panel must render a graceful offline state — NOT a raw "Failed to
+    # load" error. The host-fallback would show the tree for a host-bound
+    # session; this direct-runner fixture shows the empty state, which is
+    # the correct non-host degradation. Either way, no unhandled error.
+    expect(page.get_by_text(re.compile("Failed to load"))).to_have_count(0)
+    # The Files panel body is still present (the tab content rendered).
+    expect(rail).to_be_visible()


### PR DESCRIPTION
## Summary

Fixes #386.

After a host reconnects to the server but **before the first post-reconnect message** re-initializes the backend runner, the runner-backed `/filesystem` endpoints 503 and the workspace queries are gated off (`runnerOnline !== false`), so the file browser shows **"No files in workspace"** even though the host is up and the workspace directory still exists on disk.

## Approach

Fall back to the **host-filesystem API** (`GET /v1/hosts/{host_id}/filesystem`, served by the host daemon — **no runner required**) for the root listing *and* lazy directory expansion when the runner is known offline but the host itself is online and the session is host-bound with a workspace:

```
fallback.enabled = runnerOnline === false && hostOnline === true && hostId !== null && workspace !== null
```

Host entries (absolute paths) are mapped to workspace-relative `WorkspaceFile[]` so they feed the existing `buildTree`/`FolderTree` unchanged. The `queryKey` encodes the source (`{host, ws}` vs `"runner"`) so the offline and online caches never collide; when the runner comes back online (first message), the hooks switch back to the runner endpoints automatically — no manual invalidation needed.

Applied to both `useWorkspaceAllFiles` and `useWorkspaceDirectory` so the offline tree is fully browsable, not just a flat root. `fetchHostFilesystem` was exported from `useHostFilesystem.ts` for reuse (it already paginates to completion).

This is a **different design from the prior closed attempt (#438)**, which showed a "reconnect" hint instead of the empty state. Showing the actual files (via the host that is already back online) is strictly more useful to the user than a hint — they can browse/open files while waiting to send the first message. A hint can be layered on top later if desired; this keeps the workspace visible.

## Files changed

| File | Change |
|------|--------|
| `ap-web/src/hooks/useHostFilesystem.ts` | Export `fetchHostFilesystem` for reuse (was module-private). |
| `ap-web/src/hooks/useWorkspaceChangedFiles.ts` | Host-filesystem fallback for `useWorkspaceAllFiles` + `useWorkspaceDirectory` + helpers (`useHostFilesystemFallback`, `mapHostEntriesToWorkspaceFiles`, `fetchHostWorkspaceAllFiles/Directory`). Out-of-root entries are dropped (not remapped to a misleading basename); `dirPath` is leading-slash-guarded. |
| `ap-web/src/hooks/useWorkspaceChangedFiles.test.tsx` | 6 new vitest cases covering the fallback: host-fs called with `(hostId, absWorkspace)`, runner endpoint not hit, mapped relative paths, no fallback when host also offline, no fallback for non-host-bound sessions, **409 → `RunnerOfflineError`** (reconnect hint, not raw error), and non-409 host failure propagates as a raw error. |
| `tests/e2e_ui/files/test_file_browser_runner_offline.py` | e2e_ui smoke: seeds a file, verifies it shows while the runner is online, kills the runner, reloads, and asserts the Files panel degrades gracefully (no raw "Failed to load"). |

## Test coverage & limitations

- **Vitest (the real coverage of the host-fallback logic):** 6 new cases in `useWorkspaceChangedFiles.test.tsx` — 86 passed. Covers the enable-condition, the host-fs routing, the absolute→relative mapping, the 409→`RunnerOfflineError` translation, and non-409 propagation.
- **e2e_ui:** `tests/e2e_ui/files/test_file_browser_runner_offline.py` covers the **adjacent** graceful-degradation behavior — the file browser must not crash or surface a raw error after the runner is killed and the page reloads. The e2e_ui fixture spawns a **direct (tunnel-bound) runner with no managed host**, so `session.hostId` is null and the **host-fallback path cannot engage in the e2e environment** — the full host-reconnect scenario is covered at the hook level by vitest, not end-to-end. This is honestly disclosed in the test's docstring. The test does not invoke the LLM (no `llm_flaky` marker).
- **`E2E UI Required` gate:** an e2e_ui test is present (`tests/e2e_ui/files/test_file_browser_runner_offline.py`) and follows the suite conventions (`live_server` / `seeded_session` fixtures, `open_right_rail`, `expect.set_options(timeout=15_000)`). It cannot be fully validated locally without the Databricks LLM gateway the suite needs; it is correct-by-construction against `conftest.py`.

## /check

- `npx tsc -b` — clean
- `npx prettier --check .` — clean
- `npx vitest run` — 171 files / 2840 tests passed (full suite, no regressions)
- `uv run ruff format` / `ruff check` — clean
- `uv run mypy` — 1233 pre-existing errors (unchanged baseline; this change touches no `omnigent/` Python)
- `uv run pre-commit run --files <changed>` — all passed
- exfil-scan (`DIFF_FILE` run of `.github/scripts/security-scan/exfil-scan.py`) — passed (no `exec(`/`eval(`/`__import__(` tokens in added lines)

## CodeRabbit

Addressed all worthwhile findings from a pre-push review: added the missing 409/non-409 error-path tests (M1), dropped out-of-root entries instead of remapping to a basename (L2), and leading-slash-guarded `dirPath` (L4). Skipped as out-of-scope/bounded: the `pgrep` runner-kill mirrors the established `test_stale_stream.py` pattern and the suite runs serially (M2); the brief stale-cache flash on a fast online→offline→online cycle is bounded and minor (L1); the redundant `useSessionRunnerOnline` read is cosmetic (L3); `expect.set_options` is the suite convention (L5); truncated-listing surfacing is consistent with the runner path (L6).

Co-Authored-By: Claude <noreply@anthropic.com>
