### PR TITLE
fix(#509): default new-session workspace from selected agent's cwd

### DIFF
--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -54,6 +54,9 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     skills: list[SkillSummary] = []
     terminals: list[str] = []
     harness: str | None = None
+    # Default working directory from os_env.cwd (None until the spec
+    # loads); the new-session picker defaults the workspace field to it.
+    default_workspace: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -91,6 +94,11 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         # Kind for the Add Agent picker (Codex vs Claude). Stays None
         # when the bundle can't be loaded (the except below).
         harness = loaded.spec.executor.harness_kind
+        # The agent's configured working directory, if any — the
+        # new-session picker defaults the workspace field to it so the
+        # user need not already know the agent's required path (#509).
+        if loaded.spec.os_env is not None:
+            default_workspace = loaded.spec.os_env.cwd
     except Exception:  # noqa: BLE001 — spec load failure must not break the list
         _logger.debug(
             "Failed to load spec for agent %s; mcp_servers/skills will be empty",
@@ -115,6 +123,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         # by a same-named ``omnigent run`` upload, but lets a newer
         # upload supersede the latter.
         builtin=agent.session_id is None and agent.id == builtin_agent_id(agent.name),
+        default_workspace=default_workspace,
     )
 
 

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -349,6 +349,9 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
     # Harness/kind for the UI; None until the spec loads (mirrors the
     # GET /v1/agents catalog so both endpoints report it consistently).
     harness: str | None = None
+    # Default working directory from os_env.cwd (mirrors the
+    # GET /v1/agents catalog); None until the spec loads.
+    default_workspace: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -365,6 +368,11 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
             # Declared terminal names, in spec order — the Web UI
             # gates its "new terminal" affordance on this list.
             terminals = list(loaded.spec.terminals or {})
+            # The agent's configured working directory, if any —
+            # mirrors GET /v1/agents so both endpoints report it
+            # consistently (#509).
+            if loaded.spec.os_env is not None:
+                default_workspace = loaded.spec.os_env.cwd
             # Bundled skills only (mirrors GET /v1/agents); the merged
             # bundled + host-discovered set lives on the session snapshot.
             skills = [
@@ -418,4 +426,5 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
         policies=policies,
         skills=skills,
         terminals=terminals,
+        default_workspace=default_workspace,
     )

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -271,6 +271,15 @@ class AgentObject(BaseModel):
         a user-registered template is superseded by a newer
         same-named upload. Always ``False`` for session-scoped
         agents.
+    :param default_workspace: The agent's default working
+        directory, from ``spec.os_env.cwd`` — the directory the
+        agent is configured to run in and (under
+        ``working_directory_scope``) may require. The Web UI's
+        new-session picker defaults the workspace field to this
+        when the agent is selected, without clobbering a
+        user-edited value, so a user need not already know the
+        agent's required path. ``None`` when the spec declares
+        no ``os_env.cwd`` or when the bundle cannot be loaded.
     """
 
     id: str
@@ -287,6 +296,7 @@ class AgentObject(BaseModel):
     skills: list[SkillSummary] = Field(default_factory=list)
     terminals: list[str] = Field(default_factory=list)
     builtin: bool = False
+    default_workspace: str | None = None
 
 
 # ── Session Policies ───────────────────────────────────────────

--- a/openapi.json
+++ b/openapi.json
@@ -60,6 +60,18 @@
             "title": "Created At",
             "type": "integer"
           },
+          "default_workspace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The agent's default working directory, from `spec.os_env.cwd` \u2014 the directory the agent is configured to run in and (under `working_directory_scope`) may require. The Web UI's new-session picker defaults the workspace field to this when the agent is selected, without clobbering a user-edited value, so a user need not already know the agent's required path. `None` when the spec declares no `os_env.cwd` or when the bundle cannot be loaded.",
+            "title": "Default Workspace"
+          },
           "description": {
             "anyOf": [
               {

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1668,6 +1668,112 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_defaults_workspace_from_agent_cwd(seeded_session: tuple[str, str]) -> None:
+    """Selecting an agent defaults the workspace to its os_env.cwd (#509).
+
+    Two custom agents, each with a different ``default_workspace``
+    (exposed from ``spec.os_env.cwd``), are offered. The auto-selected
+    first agent's cwd must win over the host's seeded recent workspace
+    as the working-directory default, and switching to the second agent
+    must follow its cwd — without the user ever opening the file browser.
+    On Send the second agent's cwd reaches ``POST /v1/sessions`` as
+    ``workspace``. Mirrors the issue's example: selecting ``custom_agent``
+    defaults to ``/opt/custom``; selecting ``another_custom_agent``
+    defaults to ``/home/path``.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_default_workspace_from_agent_cwd(base_url, session_id))
+
+
+async def _drive_default_workspace_from_agent_cwd(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page,
+                created_session_id=session_id,
+                create_bodies=create_bodies,
+                agents_body=json.dumps(
+                    {
+                        "data": [
+                            {
+                                "id": "ag_custom",
+                                "name": "custom_agent",
+                                "display_name": "Custom",
+                                "description": "An agent bound to /opt/custom",
+                                "harness": None,
+                                "skills": [],
+                                "default_workspace": "/opt/custom",
+                            },
+                            {
+                                "id": "ag_another",
+                                "name": "another_custom_agent",
+                                "display_name": "Another",
+                                "description": "An agent bound to /home/path",
+                                "harness": None,
+                                "skills": [],
+                                "default_workspace": "/home/path",
+                            },
+                        ]
+                    }
+                ),
+            )
+
+            # Neutralize agent discovery so only the two stubbed agents
+            # feed the picker.
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            # Seed a recent workspace for the stubbed host. The agent's
+            # os_env.cwd must OVERRIDE this as the default — the chip
+            # showing "custom" (not "repo") proves the override (#509).
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            # custom_agent auto-selects (first in stub order); its cwd
+            # /opt/custom is the workspace default, not the seeded /work/repo.
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "custom"
+            )
+
+            # Switch to the second agent — the workspace must follow its cwd.
+            # Both are custom agents, so they live in the "Custom agents"
+            # submenu; drill in before picking.
+            await page.get_by_test_id("new-chat-landing-agent-select").click()
+            await page.get_by_test_id("new-chat-landing-custom-agents").click()
+            await page.get_by_test_id("new-chat-landing-agent-ag_another").click()
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "path"
+            )
+
+            await page.get_by_test_id("new-chat-landing-input").fill("work in the agent's dir")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_another", body
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/home/path", body
+        finally:
+            await browser.close()
+
+
 def test_start_session_bypass_sandbox(seeded_session: tuple[str, str]) -> None:
     """Arming DANGEROUS Codex full-bypass rides along to the create.
 

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -652,6 +652,7 @@ def build_agent_bundle(
     guardrails: dict[str, Any] | None = None,
     terminals: dict[str, Any] | None = None,
     include_llm: bool = True,
+    os_env: dict[str, Any] | None = None,
 ) -> bytes:
     """
     Build a minimal valid agent bundle (tar.gz) for testing.
@@ -687,6 +688,10 @@ def build_agent_bundle(
         ``None`` omits it (the agent has no terminal access).
     :param include_llm: Whether to include the default ``llm:`` block.
         Set ``False`` for model-less harness tests.
+    :param os_env: Optional ``os_env:`` block written verbatim into
+        the spec, e.g. ``{"cwd": "/opt/custom", "sandbox": {"type":
+        "none"}}``. ``None`` omits it. Used to exercise
+        ``default_workspace`` exposure from ``spec.os_env.cwd`` (#509).
     :returns: A gzipped tar archive containing the generated
         ``config.yaml`` plus optional sub-agent and skill files.
     """
@@ -710,6 +715,8 @@ def build_agent_bundle(
         config["guardrails"] = guardrails
     if terminals is not None:
         config["terminals"] = terminals
+    if os_env is not None:
+        config["os_env"] = os_env
     if executor is not None:
         config["executor"] = dict(executor)
         config["executor"].setdefault("config", {}).setdefault("harness", "claude-sdk")

--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -216,6 +216,59 @@ async def test_list_builtin_agents_exposes_declared_terminals_from_spec(
     assert entry["terminals"] == ["shell", "py"]
 
 
+async def test_list_builtin_agents_exposes_default_workspace_from_spec_os_env_cwd(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/agents`` reports ``default_workspace`` from
+    ``spec.os_env.cwd`` so the new-session picker can default the
+    workspace field to the agent's required path (#509).
+
+    Absent ``os_env:`` (or a null ``cwd``) reports ``None`` — the
+    picker then leaves any host-seeded value in place instead of
+    blanking it.
+    """
+    bundle = build_agent_bundle(
+        name="cwd-agent",
+        os_env={"cwd": "/opt/custom", "sandbox": {"type": "none"}},
+    )
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="b4c1e0f27a5d43989c6f0e21ab7d5c38",
+        name="cwd-agent",
+        bundle=bundle,
+    )
+    # A bundle with no os_env block — the field must read back as None,
+    # not absent, so the picker's `?? null` normalisation is exercised.
+    bare_bundle = build_agent_bundle(name="bare-agent")
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="d92f6a13c7e84b0195af2d6b0e17c4a5",
+        name="bare-agent",
+        bundle=bare_bundle,
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    cwd_entry = next(
+        a for a in resp.json()["data"] if a["id"] == "b4c1e0f27a5d43989c6f0e21ab7d5c38"
+    )
+    # The cwd traversed spec → AgentObject verbatim; the picker defaults
+    # the workspace field to this when the agent is selected.
+    assert cwd_entry["default_workspace"] == "/opt/custom"
+    bare_entry = next(
+        a for a in resp.json()["data"] if a["id"] == "d92f6a13c7e84b0195af2d6b0e17c4a5"
+    )
+    # No os_env → None (not missing), so the picker's host-seeded value
+    # is left untouched.
+    assert bare_entry["default_workspace"] is None
+
+
 async def test_list_builtin_agents_exposes_bundled_skills_from_spec(
     agent_store: SqlAlchemyAgentStore,
     artifact_store: LocalArtifactStore,

--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -119,6 +119,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "codex-native",
         skills: [],
+        default_workspace: null,
       },
     ]);
     const urls = fetchMock.mock.calls.map((c) => c[0] as string);
@@ -179,6 +180,9 @@ describe("useAvailableAgents", () => {
             name: "databricks_coding_agent",
             description: "A coding agent",
             harness: "codex",
+            // os_env.cwd pass-through (#509): the new-session picker
+            // defaults the workspace field to this value.
+            default_workspace: "/opt/custom",
           },
         ],
         has_more: false,
@@ -207,6 +211,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "claude-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_pi_native",
@@ -215,6 +220,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "pi-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_kiro_native",
@@ -223,6 +229,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "kiro-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_agy_native",
@@ -231,6 +238,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "antigravity-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_opencode_native",
@@ -239,6 +247,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "opencode-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_nessie",
@@ -247,6 +256,7 @@ describe("useAvailableAgents", () => {
         description: "Multi-agent coding orchestrator.",
         harness: "nessie",
         skills: [{ name: "review-pr", description: "Review a pull request" }],
+        default_workspace: null,
       },
       {
         id: "ag_debby",
@@ -255,6 +265,7 @@ describe("useAvailableAgents", () => {
         description: "A two-headed brainstorming partner.",
         harness: "claude-sdk",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_yaml",
@@ -263,6 +274,7 @@ describe("useAvailableAgents", () => {
         description: "A coding agent",
         harness: "codex",
         skills: [],
+        default_workspace: "/opt/custom",
       },
     ]);
   });
@@ -379,6 +391,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "claude-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_doc",
@@ -448,6 +461,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "codex-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_claude",
@@ -456,6 +470,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "claude-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_kiro",
@@ -464,6 +479,7 @@ describe("useAvailableAgents", () => {
         description: null,
         harness: "kiro-native",
         skills: [],
+        default_workspace: null,
       },
       {
         id: "ag_session_kiro",
@@ -739,6 +755,7 @@ describe("prefetchAvailableAgentDetails", () => {
         harness: "claude-sdk",
         sessionId: "conv_3",
         skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
+        default_workspace: null,
       },
     ]);
     expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/conv_3/agent");

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -43,6 +43,13 @@ export interface AvailableAgent {
   // session-discovered agents (custom uploads); absent on catalog agents
   // whose full data is already present from GET /v1/agents.
   sessionId?: string;
+  // The agent's default working directory from spec.os_env.cwd, or
+  // null when the agent declares none. The new-session picker defaults
+  // the workspace field to this when the agent is selected (without
+  // clobbering a user-edited value), so a user need not already know
+  // the agent's required path (#509). Absent on older servers —
+  // treated as null so the host-seeded value is left in place.
+  default_workspace?: string | null;
 }
 
 const DISPLAY_NAMES: Record<string, string> = {
@@ -95,6 +102,7 @@ interface BuiltinAgentWire {
   // older servers, where every catalog row degrades to a protected entry.
   builtin?: boolean;
   created_at?: number | null;
+  default_workspace?: string | null;
 }
 
 interface BuiltinAgentsListWire {
@@ -139,6 +147,7 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     description: a.description ?? null,
     harness: a.harness ?? null,
     skills: a.skills ?? [],
+    default_workspace: a.default_workspace ?? null,
     // Omit rather than set to undefined so toEqual comparisons aren't
     // sensitive to absent-vs-undefined. Logic that reads builtin treats
     // undefined as "protected" (same as true), so omission is safe.
@@ -198,6 +207,7 @@ interface AgentObjectWire {
   description?: string | null;
   harness?: string | null;
   skills?: { name: string; description: string }[];
+  default_workspace?: string | null;
 }
 
 /**
@@ -247,6 +257,7 @@ export async function prefetchAvailableAgentDetails(
               description: json.description ?? null,
               harness: json.harness ?? null,
               skills: json.skills ?? [],
+              default_workspace: json.default_workspace ?? null,
             },
       );
       // If enrichment reveals this agent is a native coding agent (e.g. a

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -12,6 +12,8 @@ import type { Host } from "@/hooks/useHosts";
 import { useHosts } from "@/hooks/useHosts";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import type { HostDirectoryListing } from "@/hooks/useHostFilesystem";
+import type { HostWorktree } from "@/hooks/useHostWorktrees";
 import { NewChatLandingScreen, resetLandingDraft, sanitizeInitialPrompt } from "./NewChatDialog";
 import { writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 
@@ -91,15 +93,19 @@ vi.mock("@/hooks/useAvailableAgents", () => ({
   prefetchAvailableAgentDetails: vi.fn(),
 }));
 // The home listing is only consulted when there's no recent; the recent is
-// always set here, so keep this inert (returns no listing).
+// always set here, so this is inert by default. Cases that open the file
+// browser set a listing so the picker resolves a directory to navigate.
+let hostListing: HostDirectoryListing | undefined;
 vi.mock("@/hooks/useHostFilesystem", () => ({
-  useHostFilesystem: () => ({ data: undefined }),
+  useHostFilesystem: () => ({ data: hostListing, isPlaceholderData: false }),
   // WorkspacePicker reads this on mount when the file browser opens;
   // an idle mutation keeps it inert for these tests.
   useCreateHostDirectory: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
+// No worktrees by default; cases exercising the worktree combobox set one.
+let hostWorktrees: HostWorktree[] | undefined;
 vi.mock("@/hooks/useHostWorktrees", () => ({
-  useHostWorktrees: () => ({ data: undefined }),
+  useHostWorktrees: () => ({ data: hostWorktrees }),
 }));
 // No other sessions in scope — keep the conflict hooks inert so they don't
 // issue their own /health fetch or surface a warning. The warning is covered
@@ -270,6 +276,8 @@ beforeEach(() => {
   localStorage.setItem(RECENT_KEY, JSON.stringify({ host_1: [SEEDED_WORKSPACE] }));
   setHosts([host()]);
   setAgents([agent()]);
+  hostListing = undefined;
+  hostWorktrees = undefined;
 });
 
 afterEach(() => {
@@ -1585,6 +1593,146 @@ describe("NewChatLandingScreen agent cwd default workspace (#509)", () => {
     const body = JSON.parse(init.body as string);
     expect(body.agent_id).toBe("ag_second");
     expect(body.workspace).toBe("/home/path");
+  });
+
+  /** Two custom agents with different configured cwds, first one selected. */
+  function setTwoCwdAgents(): void {
+    setAgents([
+      agent({
+        id: "ag_first",
+        name: "custom_agent",
+        display_name: "Custom",
+        default_workspace: "/opt/custom",
+      }),
+      agent({
+        id: "ag_second",
+        name: "another_custom_agent",
+        display_name: "Another",
+        default_workspace: "/home/path",
+      }),
+    ]);
+  }
+
+  /** Switch agents via the picker (both live in the "Custom agents" submenu). */
+  function switchToSecondAgent(): Promise<void> {
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-custom-agents"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-ag_second"));
+    // The switch is what triggers the cwd default, so wait for it to land
+    // before asserting on the workspace field.
+    return waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Another"),
+    );
+  }
+
+  it("keeps a worktree bound from the branch combobox when the agent changes", async () => {
+    setTwoCwdAgents();
+    hostWorktrees = [
+      {
+        path: "/Users/corey/repo-worktrees/feature-x",
+        branch: "feature/x",
+        is_main: false,
+        detached: false,
+      },
+    ];
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceValue("custom");
+    // Bind to the existing worktree: that writes the workspace through the
+    // branch combobox, not the file browser.
+    openWorktree();
+    fireEvent.focus(screen.getByTestId("new-chat-landing-branch-input"));
+    fireEvent.mouseDown(screen.getByTestId("new-chat-landing-worktree-option"));
+    await waitForWorkspaceValue("feature-x");
+
+    await switchToSecondAgent();
+    // Failure: the new agent's cwd overwrites the worktree directory, silently
+    // dropping the bind (and the branch prefilled from it) the user chose.
+    expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+      "feature-x",
+    );
+
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.workspace).toBe("/Users/corey/repo-worktrees/feature-x");
+    expect(body.git?.existing_worktree).toBe(true);
+  });
+
+  it("still follows the agent cwd after the file browser was opened but nothing picked", async () => {
+    setTwoCwdAgents();
+    hostListing = {
+      entries: [
+        { name: "src", path: "/opt/custom/src", type: "directory", bytes: null, modified_at: 0 },
+      ],
+      truncated: false,
+    };
+
+    renderLanding();
+    await waitForWorkspaceValue("custom");
+    // Open the browser and close it again without navigating anywhere. The
+    // picker reports the directory it opened at, which is not a pick.
+    fireEvent.click(screen.getByTestId("new-chat-landing-workspace-chip"));
+    await screen.findByTestId("workspace-picker");
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    await switchToSecondAgent();
+    // Failure: merely opening the browser pinned the field, so the workspace
+    // stays on the previous agent's cwd instead of following the new one.
+    await waitForWorkspaceValue("path");
+  });
+
+  it("keeps a directory picked in the file browser when the agent changes", async () => {
+    setTwoCwdAgents();
+    hostListing = {
+      entries: [
+        { name: "src", path: "/opt/custom/src", type: "directory", bytes: null, modified_at: 0 },
+      ],
+      truncated: false,
+    };
+
+    renderLanding();
+    await waitForWorkspaceValue("custom");
+    fireEvent.click(screen.getByTestId("new-chat-landing-workspace-chip"));
+    // Navigating into a folder IS a pick — it must survive an agent switch.
+    fireEvent.click(await screen.findByTestId("workspace-picker-entry-src"));
+    await waitForWorkspaceValue("src");
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    await switchToSecondAgent();
+    expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("src");
+  });
+
+  it("keeps a browser-picked directory when the composer is left and reopened", async () => {
+    setTwoCwdAgents();
+    hostListing = {
+      entries: [
+        { name: "src", path: "/opt/custom/src", type: "directory", bytes: null, modified_at: 0 },
+      ],
+      truncated: false,
+    };
+
+    renderLanding();
+    await waitForWorkspaceValue("custom");
+    fireEvent.click(screen.getByTestId("new-chat-landing-workspace-chip"));
+    fireEvent.click(await screen.findByTestId("workspace-picker-entry-src"));
+    await waitForWorkspaceValue("src");
+
+    // Leaving the composer preserves the draft, so returning restores the
+    // fields — including the fact that the directory was the user's pick.
+    cleanup();
+    renderLanding();
+    // Flush the mount effects, the agent-cwd default among them.
+    await act(async () => {});
+    // Failure: the restored pick reads as a default and the agent's cwd
+    // overwrites it the moment the composer reopens.
+    expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("src");
   });
 });
 

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1519,6 +1519,75 @@ describe("NewChatLandingScreen create flow", () => {
   });
 });
 
+describe("NewChatLandingScreen agent cwd default workspace (#509)", () => {
+  // beforeEach always seeds host_1's recent workspace, so these tests prove
+  // the selected agent's os_env.cwd overrides that recent as the default.
+  function waitForWorkspaceValue(basename: string): Promise<void> {
+    return waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(basename),
+    );
+  }
+
+  it("defaults the workspace to the selected agent's cwd and carries it to the create call", async () => {
+    setAgents([agent({ id: "ag_custom", name: "custom_agent", default_workspace: "/opt/custom" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    // The chip shows the agent-cwd basename ("custom"), NOT the seeded
+    // recent ("foo") — the agent's os_env.cwd is the default workspace.
+    await waitForWorkspaceValue("custom");
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.agent_id).toBe("ag_custom");
+    expect(body.workspace).toBe("/opt/custom");
+  });
+
+  it("updates the workspace when switching to an agent with a different cwd", async () => {
+    setAgents([
+      agent({
+        id: "ag_first",
+        name: "custom_agent",
+        display_name: "Custom",
+        default_workspace: "/opt/custom",
+      }),
+      agent({
+        id: "ag_second",
+        name: "another_custom_agent",
+        display_name: "Another",
+        default_workspace: "/home/path",
+      }),
+    ]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceValue("custom");
+    // Switch to the second agent — the workspace must follow its cwd.
+    // Both are custom agents, so they live in the "Custom agents" submenu.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-custom-agents"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-ag_second"));
+    await waitForWorkspaceValue("path");
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.agent_id).toBe("ag_second");
+    expect(body.workspace).toBe("/home/path");
+  });
+});
+
 describe("sanitizeInitialPrompt", () => {
   it.each([
     ["trims surrounding whitespace", "  hello  ", "hello"],

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1814,6 +1814,8 @@ interface LandingDraft {
   sandboxRepoUrl: string;
   sandboxRepoBranch: string;
   workspace: string;
+  /** Whether `workspace` came from the user's own pick, not a default. */
+  workspaceTouched: boolean;
   branchName: string;
   prefilledBranch: string;
   permissionMode: string;
@@ -2140,6 +2142,13 @@ export function NewChatLandingScreen() {
   // Harness-config modal, opened from the composer's gear icon.
   const [configOpen, setConfigOpen] = useState(false);
 
+  // Tracks whether the user has picked the working directory themselves — from
+  // the file browser or the worktree list. Once set, the agent-cwd default
+  // below stops firing so that pick is never clobbered — not by switching
+  // agents, and not by a host switch that re-seeds the field. Restored with the
+  // draft so returning to the composer keeps the pick standing.
+  const workspaceTouchedRef = useRef(landingDraft?.workspaceTouched ?? false);
+
   // Mirror the current draft fields into a ref every render so the unmount
   // cleanup below can snapshot the latest values without re-subscribing.
   // `submittedRef` is flipped once the draft is sent to a create, so the
@@ -2159,6 +2168,7 @@ export function NewChatLandingScreen() {
     sandboxRepoUrl,
     sandboxRepoBranch,
     workspace,
+    workspaceTouched: workspaceTouchedRef.current,
     branchName,
     prefilledBranch,
     permissionMode,
@@ -2310,6 +2320,8 @@ export function NewChatLandingScreen() {
     seededHostRef.current = null;
     worktreeSeededForRef.current = null;
     seededConfigSigRef.current = prefillConfigSig;
+    // A fresh visit: an earlier pick is gone, so re-arm the agent-cwd default.
+    workspaceTouchedRef.current = false;
     setPrefill(initialPrefillState(projectParam));
   }, [projectParam, prefill.project, prefillConfigSig]);
 
@@ -2509,13 +2521,6 @@ export function NewChatLandingScreen() {
     generateBranchName,
   ]);
 
-  // Tracks whether the user has manually picked a working directory from the
-  // file browser. Once set, the agent-cwd default below stops firing so a
-  // manual pick is never clobbered — not by switching agents, and not by a
-  // host switch that re-seeds the field. The intent the user expressed with
-  // that pick is respected for the life of the composer (#509).
-  const workspaceTouchedRef = useRef(false);
-
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
   // The pending custom agent sentinel also wins when set.
@@ -2545,7 +2550,7 @@ export function NewChatLandingScreen() {
   );
   // The selected agent's configured working directory (spec.os_env.cwd), if
   // any. Defaulting the workspace field to it (below) saves the user from
-  // having to already know the agent's required path (#509). Agents without
+  // having to already know the agent's required path. Agents without
   // an os_env.cwd (and older servers that don't expose the field) report
   // null, leaving the host-seeded value in place.
   const defaultWorkspace = selectedAgent?.default_workspace ?? null;
@@ -4522,11 +4527,12 @@ export function NewChatLandingScreen() {
                         initialPath={
                           isNavigablePath(workspaceTrimmed) ? workspaceTrimmed : undefined
                         }
-                        onNavigate={(path) => {
-                          // The user manually chose a directory — pin the
-                          // field so a later agent switch's cwd default
-                          // doesn't clobber it (#509).
-                          workspaceTouchedRef.current = true;
+                        onNavigate={(path, { userInitiated }) => {
+                          // Only a real navigation is a choice — the picker
+                          // also reports the directory it opened at, and
+                          // merely opening the browser must not pin the field
+                          // against the agent-cwd default.
+                          if (userInitiated) workspaceTouchedRef.current = true;
                           setWorkspace(path);
                         }}
                         // Warn when browsing into a directory other live agents
@@ -4659,6 +4665,12 @@ export function NewChatLandingScreen() {
                                       // though blur is about to hide the list.
                                       onMouseDown={(e) => {
                                         e.preventDefault();
+                                        // Binding to a worktree is an explicit
+                                        // directory choice, so pin the field:
+                                        // an agent switch's cwd default would
+                                        // otherwise drop the worktree (and the
+                                        // branch prefilled from it).
+                                        workspaceTouchedRef.current = true;
                                         setWorkspace(w.path);
                                         setBranchInputFocused(false);
                                         setWorktreePopoverOpen(false);

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2509,6 +2509,13 @@ export function NewChatLandingScreen() {
     generateBranchName,
   ]);
 
+  // Tracks whether the user has manually picked a working directory from the
+  // file browser. Once set, the agent-cwd default below stops firing so a
+  // manual pick is never clobbered — not by switching agents, and not by a
+  // host switch that re-seeds the field. The intent the user expressed with
+  // that pick is respected for the life of the composer (#509).
+  const workspaceTouchedRef = useRef(false);
+
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
   // The pending custom agent sentinel also wins when set.
@@ -2536,6 +2543,20 @@ export function NewChatLandingScreen() {
         : agentList.find((a) => a.id === effectiveAgentId),
     [agentList, effectiveAgentId, pendingAgent],
   );
+  // The selected agent's configured working directory (spec.os_env.cwd), if
+  // any. Defaulting the workspace field to it (below) saves the user from
+  // having to already know the agent's required path (#509). Agents without
+  // an os_env.cwd (and older servers that don't expose the field) report
+  // null, leaving the host-seeded value in place.
+  const defaultWorkspace = selectedAgent?.default_workspace ?? null;
+  useEffect(() => {
+    if (workspaceTouchedRef.current) return;
+    // Only an absolute path is acceptable to the backend, so a relative
+    // cwd (e.g. ".") is ignored — the host-seeded value stays.
+    if (defaultWorkspace && isValidWorkspace(defaultWorkspace)) {
+      setWorkspace(defaultWorkspace);
+    }
+  }, [defaultWorkspace]);
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
@@ -4501,7 +4522,13 @@ export function NewChatLandingScreen() {
                         initialPath={
                           isNavigablePath(workspaceTrimmed) ? workspaceTrimmed : undefined
                         }
-                        onNavigate={setWorkspace}
+                        onNavigate={(path) => {
+                          // The user manually chose a directory — pin the
+                          // field so a later agent switch's cwd default
+                          // doesn't clobber it (#509).
+                          workspaceTouchedRef.current = true;
+                          setWorkspace(path);
+                        }}
                         // Warn when browsing into a directory other live agents
                         // occupy. Suppressed only when a NEW isolated worktree
                         // will be created (no shared-dir conflict then). When

--- a/web/src/shell/WorkspacePicker.test.tsx
+++ b/web/src/shell/WorkspacePicker.test.tsx
@@ -381,11 +381,29 @@ describe("WorkspacePicker live selection (onNavigate)", () => {
     const onNavigate = vi.fn();
     render(<WorkspacePicker hostId="host_1" initialPath="/x" onNavigate={onNavigate} />);
     // Mount seeds the value with the directory the picker opened at, so the
-    // common case (open → it's already what you want) needs zero clicks.
-    expect(onNavigate).toHaveBeenCalledWith("/x");
-    // Clicking a folder navigates into it AND reports it as the new value.
+    // common case (open → it's already what you want) needs zero clicks. The
+    // report is flagged as not user-initiated: nobody has picked anything yet,
+    // and a caller that treats a pick as an explicit choice must not count it.
+    expect(onNavigate).toHaveBeenCalledWith("/x", { userInitiated: false });
+    // Clicking a folder navigates into it AND reports it as the new value —
+    // that one IS the user choosing a directory.
     fireEvent.click(screen.getByTestId("workspace-picker-entry-src"));
-    expect(onNavigate).toHaveBeenLastCalledWith("/x/src");
+    expect(onNavigate).toHaveBeenLastCalledWith("/x/src", { userInitiated: true });
+  });
+
+  it("reports a committed path and a home jump as user-initiated", () => {
+    const onNavigate = vi.fn();
+    render(<WorkspacePicker hostId="host_1" initialPath="/x" onNavigate={onNavigate} />);
+    // Typing a path and committing it is a pick, same as clicking a folder.
+    fireEvent.change(screen.getByTestId("workspace-picker-path-input"), {
+      target: { value: "/y" },
+    });
+    fireEvent.keyDown(screen.getByTestId("workspace-picker-path-input"), { key: "Enter" });
+    expect(onNavigate).toHaveBeenLastCalledWith("/y", { userInitiated: true });
+    // Home resolves through the listing rather than the path, so its report
+    // arrives a render later — it still has to count as the user's navigation.
+    fireEvent.click(screen.getByTestId("workspace-picker-home"));
+    expect(onNavigate).toHaveBeenLastCalledWith("/x", { userInitiated: true });
   });
 
   it("hides the Select button when onSelect is not supplied", () => {

--- a/web/src/shell/WorkspacePicker.tsx
+++ b/web/src/shell/WorkspacePicker.tsx
@@ -198,8 +198,13 @@ interface WorkspacePickerProps {
    * caller can track the selection live without an explicit "Select" click.
    * Distinct from ``onSelect`` (which is a one-shot commit + the button):
    * pass ``onNavigate`` for a live-updating picker with no button.
+   *
+   * Also fires once for the directory the picker opens at (``initialPath``
+   * or the resolved home) so a caller starts in sync. ``userInitiated`` is
+   * false for that first report and true for every real navigation, so a
+   * caller that treats a pick as an explicit choice can tell them apart.
    */
-  onNavigate?: (path: string) => void;
+  onNavigate?: (path: string, info: { userInitiated: boolean }) => void;
   /**
    * Called when the user dismisses the picker via the ✕ button.
    * ``undefined`` hides the button (e.g. when the picker is always
@@ -350,10 +355,15 @@ export function WorkspacePicker({
   // it fires only when currentAbsolute actually changes.
   const onNavigateRef = useRef(onNavigate);
   onNavigateRef.current = onNavigate;
+  // Set by navigateTo so the report below can tell a real navigation from the
+  // picker simply resolving the directory it opened at — which happens with no
+  // user input at all and must not read as a deliberate pick.
+  const userNavigatedRef = useRef(false);
   useEffect(() => {
-    if (currentAbsolute.startsWith("/")) {
-      onNavigateRef.current?.(currentAbsolute);
-    }
+    if (!currentAbsolute.startsWith("/")) return;
+    const userInitiated = userNavigatedRef.current;
+    userNavigatedRef.current = false;
+    onNavigateRef.current?.(currentAbsolute, { userInitiated });
   }, [currentAbsolute]);
 
   const parent = parentOf(currentAbsolute);
@@ -383,6 +393,9 @@ export function WorkspacePicker({
     // A click/commit supersedes any in-progress typing; let the
     // mirror effect refill the bar from the new listing.
     userEditedRef.current = false;
+    // Stays set until the report actually goes out, so going home ("" until
+    // the listing resolves it) still reports as user-initiated.
+    userNavigatedRef.current = true;
     setPath(next);
   }
 


### PR DESCRIPTION
## What

Closes #509. Exposes the selected agent's `os_env.cwd` as `default_workspace` on the agent catalog and session-agent responses, so ap-web's new-session workspace picker defaults to the agent's required working directory instead of stranding the user at an arbitrary dir (e.g. `/home/user`) outside the agent's path.

## Server

One additive field, mirrored across both `_to_agent_object` implementations (the builtin-agents route and the sessions route):

- `AgentObject.default_workspace: str | None = None` (`schemas.py`).
- Both routes populate it from `loaded.spec.os_env.cwd` inside the existing spec-load `try/except`, so an unloadable bundle degrades to `None` (the host-seeded value is left in place) rather than breaking the list.

## Frontend (ap-web)

- `useAvailableAgents` threads `default_workspace` through the built-in and session-enrich paths, normalizing absent → `null` (older servers).
- `NewChatLandingScreen` defaults the workspace field to the selected agent's `default_workspace`, gated by `isValidWorkspace` (so a relative cwd like `.` is ignored — the host-seeded value stays). The default follows the agent on switch, but a `workspaceTouchedRef` ensures a manual pick is never clobbered by switching agents or hosts.

Precedence: on initial load the agent cwd overrides the host-seeded recent; once the user manually picks a directory, that intent is respected for the life of the composer (cwd default stops firing). Agents without an `os_env.cwd` (and older servers) report `null`, leaving the host-seeded value untouched.

## Tests

- **Server integration** (`tests/server/integration/test_builtin_agents.py`): `default_workspace` exposure from `os_env.cwd`, plus `None` when no `os_env`. `build_agent_bundle` (`tests/server/helpers.py`) gains an `os_env` param to drive it.
- **ap-web flow** (`NewChatDialog.flow.test.tsx`): cwd wins over the seeded recent; switching agents follows the new cwd.
- **e2e_ui** (`tests/e2e_ui/start_session/test_start_session.py`): workspace defaults from the agent cwd and follows it across an agent switch.

## Checks

- `ruff format` / `ruff check` clean.
- `mypy`: 0 new errors vs base (51 baseline = 51 branch).
- `tsc -b` clean; ap-web vitest green (44 passed in the touched suites).
- Server shard `tests/server/integration/test_builtin_agents.py`: 11 passed, 1 xfailed.
- `pre-commit` all passed.
- CodeRabbit review: ship-it (one Low-Medium note on the manual-pick-then-host-switch edge case — resolved by documenting the "once touched, cwd default doesn't re-fire" contract in the `workspaceTouchedRef` comment rather than adding a half-fix that wouldn't re-arm the effect).

Co-Authored-By: Claude <noreply@anthropic.com>