### PR TITLE
fix(#552): render Markdown task-list items as checkboxes

### DIFF
--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -509,6 +509,28 @@
   cursor: pointer;
 }
 
+/* GFM task lists (`* [ ]` / `* [x]`) — remark-gfm tags the list with
+ * `contains-task-list` and each task item with `task-list-item`, emitting a
+ * disabled <input type=checkbox> whose `checked` attribute mirrors the marker.
+ * Streamdown's default <ul> always applies `list-disc`, which sits a disc
+ * bullet beside every checkbox and makes the list read as plain bullets
+ * (#552). Drop the inherited disc marker for task items only (plain `* foo`
+ * items lack `task-list-item` and keep their disc) and lay the checkbox out
+ * inline with the text, letting the native checkbox reflect the checked
+ * state. Inline (not flex) keeps mixed inline content — `* [x] a **bold** c` —
+ * flowing as one text run; flex + gap would split the strong/text into
+ * separate flex items and run the words together. */
+ul.contains-task-list > li.task-list-item {
+  list-style: none;
+  padding-left: 0;
+}
+ul.contains-task-list > li.task-list-item > input[type="checkbox"] {
+  margin: 0 0.375rem 0 0;
+  vertical-align: middle;
+  accent-color: var(--primary);
+  cursor: default;
+}
+
 /* Flatten Streamdown's loud heading ramp (text-3xl..xl) to em sizes proportional to body. */
 [data-streamdown="heading-1"] {
   font-size: 1.4em;

--- a/ap-web/src/pages/ChatPage.taskList.test.tsx
+++ b/ap-web/src/pages/ChatPage.taskList.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Bubble } from "@/lib/renderItems";
+import { FileViewerContext } from "@/shell/FileViewerContext";
+import { BubbleView } from "./ChatPage";
+
+// Task-list markdown (`* [ ]` / `* [x]`) flows through the same Streamdown
+// renderer as the rest of the chat (FilePathAwareMessageResponse). These
+// tests pin the GFM task-list wiring that #552 fixed: remark-gfm emits a
+// disabled <input type=checkbox> per item whose `checked` mirrors the marker,
+// and tags the <ul> with `contains-task-list` / <li> with `task-list-item` so
+// the index.css overrides can drop the disc bullet and lay the checkbox
+// beside the text. If the wiring regresses (e.g. remark-gfm dropped from the
+// default remark plugins), the checkboxes vanish and these assertions fail.
+
+afterEach(cleanup);
+
+const FILE_VIEWER_NOOP = {
+  openFile: () => {},
+  isChangedPath: () => false,
+  conversationId: undefined,
+  workspaceRoot: null,
+  workspaceHome: null,
+};
+
+function assistantBubble(text: string): Extract<Bubble, { kind: "assistant" }> {
+  return {
+    kind: "assistant",
+    responseId: "codex_turn_123",
+    stableId: "msg_1",
+    lifecycle: "completed",
+    error: null,
+    items: [{ kind: "text", itemId: "msg_1", text, final: true }],
+  };
+}
+
+function userBubble(text: string): Extract<Bubble, { kind: "user" }> {
+  return {
+    kind: "user" as const,
+    itemId: "u1",
+    content: [{ type: "input_text" as const, text }],
+  };
+}
+
+function renderBubble(bubble: Bubble) {
+  return render(
+    <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+      <BubbleView bubble={bubble} />
+    </FileViewerContext.Provider>,
+  );
+}
+
+describe("Task-list markdown rendering", () => {
+  it("renders `* [ ]` / `* [x]` items as disabled checkboxes reflecting state", () => {
+    const { container } = renderBubble(assistantBubble("* [ ] Incomplete\n* [x] Complete"));
+
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    expect(checkboxes).toHaveLength(2);
+    // Both checkboxes are disabled (read-only render of agent output).
+    expect(checkboxes[0]!.hasAttribute("disabled")).toBe(true);
+    expect(checkboxes[1]!.hasAttribute("disabled")).toBe(true);
+    // State mirrors the marker: `[ ]` -> unchecked, `[x]` -> checked.
+    expect(checkboxes[0]!.hasAttribute("checked")).toBe(false);
+    expect(checkboxes[1]!.hasAttribute("checked")).toBe(true);
+  });
+
+  it("tags the list so the CSS overrides apply (contains-task-list / task-list-item)", () => {
+    const { container } = renderBubble(assistantBubble("* [ ] Incomplete\n* [x] Complete"));
+
+    const ul = container.querySelector("ul");
+    expect(ul).not.toBeNull();
+    expect(ul!.classList.contains("contains-task-list")).toBe(true);
+
+    const items = container.querySelectorAll("li.task-list-item");
+    expect(items).toHaveLength(2);
+  });
+
+  it("renders the item text beside the checkbox, not the literal `[ ]` markers", () => {
+    const { container } = renderBubble(assistantBubble("* [ ] Incomplete\n* [x] Complete"));
+
+    // The bracket markers must be consumed by the parser, not shown as text.
+    expect(container.textContent).toContain("Incomplete");
+    expect(container.textContent).toContain("Complete");
+    expect(container.textContent).not.toContain("[ ]");
+    expect(container.textContent).not.toContain("[x]");
+  });
+
+  it("leaves plain bullets as plain bullets (no checkbox, no task-list-item class)", () => {
+    const { container } = renderBubble(assistantBubble("- plain bullet"));
+
+    expect(container.querySelectorAll('input[type="checkbox"]')).toHaveLength(0);
+    const li = container.querySelector("li");
+    expect(li).not.toBeNull();
+    expect(li!.classList.contains("task-list-item")).toBe(false);
+  });
+
+  it("works in the user bubble path (remark-breaks extends, not replaces, remark-gfm)", () => {
+    const { container } = renderBubble(userBubble("* [ ] todo\n* [x] done"));
+
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]!.hasAttribute("checked")).toBe(false);
+    expect(checkboxes[1]!.hasAttribute("checked")).toBe(true);
+    expect(container.querySelector("ul.contains-task-list")).not.toBeNull();
+  });
+});

--- a/tests/e2e_ui/chat/test_markdown_task_list.py
+++ b/tests/e2e_ui/chat/test_markdown_task_list.py
@@ -1,0 +1,96 @@
+"""E2E: GFM task-list markdown renders as checkboxes reflecting checked state.
+
+Regression guard for #552. The chat markdown renderer (Streamdown +
+remark-gfm) emits a disabled ``<input type=checkbox>`` per ``* [ ]`` /
+``* [x]`` item whose ``checked`` attribute mirrors the marker, and
+tags the ``<ul>`` with ``contains-task-list`` / the ``<li>`` with
+``task-list-item`` so the ``index.css`` overrides can drop the disc
+bullet (Streamdown's default ``list-disc`` would otherwise sit a bullet
+beside every checkbox) and lay the checkbox beside the text.
+
+A deterministic assistant message is seeded via the
+``external_assistant_message`` event (no LLM run) containing one
+unchecked task, one checked task, and a plain bullet. The test asserts:
+
+  - two disabled checkboxes render, in the order/states written;
+  - the list carries ``contains-task-list`` and the task items carry
+    ``task-list-item`` (so the CSS overrides apply);
+  - the literal ``[ ]`` / ``[x]`` markers are consumed, not shown;
+  - a plain bullet gets no checkbox and no ``task-list-item`` class.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_AGENT_NAME = "tasklist_demo"
+
+# One unchecked task, one checked task, then a plain bullet. The plain
+# bullet lives in the SAME list as the tasks (remark-gfm tags the <ul>
+# ``contains-task-list`` whenever any item is a task) — this proves the
+# CSS targets the ``task-list-item`` items only, leaving plain bullets
+# with their disc.
+_TASK_LIST_TEXT = "Here is my plan:\n\n* [ ] Incomplete\n* [x] Complete\n* plain bullet\n"
+
+
+@pytest.fixture
+def tasklist_session(seeded_session: tuple[str, str]) -> tuple[str, str]:
+    """Bind the seeded session and append a task-list assistant bubble.
+
+    Uses ``external_assistant_message`` so the markdown is rendered through
+    the real Streamdown pipeline without an LLM turn.
+
+    :param seeded_session: ``(base_url, session_id)`` from the conftest.
+    :returns: ``(base_url, session_id)`` with a seeded assistant reply.
+    """
+    base_url, session_id = seeded_session
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": _TASK_LIST_TEXT},
+        },
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return base_url, session_id
+
+
+def test_chat_renders_task_list_as_checkboxes(
+    page: Page,
+    tasklist_session: tuple[str, str],
+) -> None:
+    """`* [ ]`/`* [x]` render as state-reflecting checkboxes; plain bullets don't."""
+    base_url, session_id = tasklist_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The task-list <ul> is tagged so the index.css overrides apply. Locating
+    # on the class (not bare `ul`) avoids matching any prior plain list.
+    task_ul = page.locator("ul.contains-task-list").first
+    expect(task_ul).to_be_visible(timeout=30_000)
+
+    # Two disabled checkboxes, ordered as written: unchecked then checked.
+    checkboxes = task_ul.locator('input[type="checkbox"]')
+    expect(checkboxes).to_have_count(2)
+    expect(checkboxes.nth(0)).to_have_attribute("disabled", "")
+    expect(checkboxes.nth(1)).to_have_attribute("disabled", "")
+    expect(checkboxes.nth(0)).not_to_have_attribute("checked", "")
+    expect(checkboxes.nth(1)).to_have_attribute("checked", "")
+
+    # The two task items carry `task-list-item` (the CSS hook that drops the
+    # disc bullet and lays the checkbox beside the text).
+    expect(task_ul.locator("li.task-list-item")).to_have_count(2)
+
+    # The bracket markers must be consumed by the parser, not rendered as text.
+    # Scoped to the task <ul> (not <body>) so future UI chrome that happens to
+    # render a bracketed string can't flake this assertion.
+    expect(task_ul).not_to_contain_text("[ ]")
+    expect(task_ul).not_to_contain_text("[x]")
+
+    # The plain bullet sits in the same contains-task-list <ul> but is NOT a
+    # task item: no checkbox and no task-list-item class, so it keeps its disc.
+    plain_li = task_ul.locator("li:not(.task-list-item)").first
+    expect(plain_li).to_contain_text("plain bullet")
+    expect(plain_li.locator('input[type="checkbox"]')).to_have_count(0)


### PR DESCRIPTION
## Summary

Fixes #552. GFM task-list syntax (`* [ ]` / `* [x]`) in chat messages rendered as plain bullets with no checkbox — it "doesn't show the completed task or pending." This PR makes checked/unchecked task items render as real checkboxes reflecting their state, matching GitHub.

## Root cause

The chat markdown renderer (Streamdown, a drop-in for react-markdown) already runs `remark-gfm` — it's in Streamdown's `defaultRemarkPlugins`, and the chat path in `BlockRenderer.tsx` extends (not replaces) those defaults. remark-gfm already emits a disabled `<input type=checkbox>` per task item (whose `checked` attribute mirrors the marker) and tags the `<ul>`/`<li>` with `contains-task-list`/`task-list-item`. So the checkboxes were already in the DOM — the bug was purely visual: Streamdown's `MemoUl` hardcodes Tailwind `list-disc`, putting a disc bullet beside every checkbox so the list read as plain bullets.

No plugin/wiring change was needed.

## Fix (CSS-only)

`ap-web/src/index.css` — drop the inherited disc marker for `li.task-list-item` only and lay the checkbox inline with the text:

- `li.task-list-item { list-style: none; padding-left: 0 }` removes the disc for task items. Plain `* foo` items lack `task-list-item`, so they keep their disc bullet.
- `li.task-list-item > input[type="checkbox"]` gets a right margin, `vertical-align: middle`, `accent-color: var(--primary)`, and `cursor: default` (read-only). The native checkbox reflects the checked state from the source marker.

Inline layout (not flex) is deliberate: a task item can carry mixed inline content (`* [x] a **bold** c`). With `display: flex` + `gap`, the `<strong>` and surrounding text nodes become separate flex items and the words run together (flex collapses the whitespace between them). Inline keeps them flowing as one text run, matching GitHub.

The rules are unlayered, so they win over Tailwind v4's layered `list-disc` utility regardless of specificity.

## Type of change

- [ ] Bug fix
- [x] Feature (UI rendering behavior change)
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

### Added tests

- `ap-web/src/pages/ChatPage.taskList.test.tsx` (vitest, 5 cases) — `* [ ]`/`* [x]` render as disabled checkboxes with `checked` mirroring the marker; `contains-task-list`/`task-list-item` classes present (so the CSS overrides apply); literal `[ ]`/`[x]` markers consumed; plain bullets get no checkbox and no `task-list-item`; user-bubble path (remark-breaks extends, not replaces, remark-gfm).
- `tests/e2e_ui/chat/test_markdown_task_list.py` (Playwright) — seeds an `external_assistant_message` containing a mixed task list (one unchecked, one checked, one plain bullet) via the conftest `seeded_session` fixture (no LLM run), opens it in a real browser, and asserts the rendered `ul.contains-task-list`, the two disabled checkboxes with correct checked state, the `li.task-list-item` count, that the bracket markers are consumed, and that the plain bullet keeps no checkbox. Satisfies the `E2E UI Required` gate for UI changes.

## Commands run

- `npx prettier --check` (changed files) — pass
- `npx tsc -b` — pass
- `npx vitest run src/pages/ChatPage.taskList.test.tsx src/pages/ChatPage.userBubble.test.tsx` — 12/12 pass
- `uvx ruff format` + `uvx ruff check` (changed file) — pass
- `uv run --extra dev mypy tests/e2e_ui/chat/test_markdown_task_list.py` — no issues
- `uv run --extra dev pytest tests/e2e_ui/chat/test_markdown_task_list.py` — 1 passed (real built SPA + spawned server)
- `uv run --extra dev pre-commit run --files <changed>` — all pass
- CodeRabbit `coderabbit:code-reviewer` review — APPROVE (no blocking findings; both low-severity suggestions addressed: switched flex→inline to avoid breaking mixed inline content, and scoped the e2e `not_to_contain_text` assertions to the task `<ul>`)

Closes #552.

Co-Authored-By: Claude <noreply@anthropic.com>