### PR TITLE
fix(security): use normpath + backslash rejection in worktree_guard

### DIFF
--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -9,6 +9,7 @@ The evaluators run runner-side at tool dispatch
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 from collections.abc import Callable
@@ -560,7 +561,16 @@ def worktree_guard(
         path = args.get("path") or args.get("file_path")
         if not isinstance(path, str):
             return _ALLOW
-        if path.startswith(("/", "~")) or ".." in path.split("/"):
+        # Backslashes are not valid in POSIX paths and could confuse
+        # downstream processing into treating them as separators, slipping a
+        # ``..\\`` past the split-on-'/' traversal check.
+        if "\\" in path:
+            return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
+        # normpath collapses ``..``/``.``/repeated slashes and pushes every
+        # upward traversal to the front, so a single startswith catches every
+        # escape form (e.g. "a/../../escape" → "../../escape").
+        normalized = os.path.normpath(path)
+        if normalized.startswith(("/", "~", "..")):
             return _decision("DENY", f"{deny_reason} (outside {allowed_root}/: {path!r})")
         return _ALLOW
 

--- a/tests/inner/nessie/test_policies.py
+++ b/tests/inner/nessie/test_policies.py
@@ -372,10 +372,15 @@ def test_headless_subagent_purpose_guard_ignores_non_session_tools() -> None:
     [
         ("src/app.py", "ALLOW"),
         ("web/src/store/chatStore.ts", "ALLOW"),
+        # normpath collapses safe ..-then-back traversals — these stay in tree.
+        ("subdir/../file.py", "ALLOW"),
         ("/etc/passwd", "DENY"),
         ("~/.bashrc", "DENY"),
         ("../outside.py", "DENY"),
         ("a/../../escape.py", "DENY"),
+        # Backslash embedded in a component was bypassing the split-on-'/' check.
+        ("subdir/..\\escape", "DENY"),
+        ("..\\etc\\passwd", "DENY"),
     ],
 )
 def test_worktree_guard_blocks_escapes(path: str, expected: str) -> None:


### PR DESCRIPTION
## Summary

- `worktree_guard` checked for path traversal by splitting on `'/'` and looking for an exact `'..'` token — a path like `subdir/..\\escape` splits to `['subdir', '..\\escape']`, so no token equals `'..'` and the guard was bypassed.
- Replace with two checks: (1) reject any backslash (not valid in POSIX paths, could confuse downstream tools into treating it as a separator), and (2) run `os.path.normpath` to canonicalize the path and check that the result doesn't start with `'/'`, `'~'`, or `'..'` — after normpath all upward traversals are pushed to the front, so a single `startswith` catches every form.

**Before:**
```python
if path.startswith(("/", "~")) or ".." in path.split("/"):
```
**After:**
```python
if "\\" in path:
    return _decision("DENY", ...)
normalized = os.path.normpath(path)
if normalized.startswith(("/", "~", "..")):
    return _decision("DENY", ...)
```

Closes #1 in dalamgir/omnigent.

## Type of change
- [x] Bug fix

## Test coverage
- [x] Unit tests added / updated

## Coverage rationale
Added two parametrize cases to `test_worktree_guard_blocks_escapes`: `subdir/..\\escape` and `..\\etc\\passwd` (both must DENY). Also added `subdir/../file.py` (must ALLOW — normpath collapses a safe round-trip traversal that stays inside the tree). All 86 unit tests pass.