### PR TITLE
fix(#206): pin the pending choice box to the bottom of the conversation

### DIFF
--- a/ap-web/src/components/blocks/BlockRenderer.tsx
+++ b/ap-web/src/components/blocks/BlockRenderer.tsx
@@ -14,7 +14,7 @@
 // spinners.
 
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 import type React from "react";
 import { defaultRemarkPlugins } from "streamdown";
 import remarkBreaks from "remark-breaks";
@@ -36,6 +36,26 @@ import { SlashCommandCard } from "./SlashCommandCard";
 import { TerminalCommandCard } from "./TerminalCommandCard";
 import { ErrorBanner, PolicyDeniedBanner, RetryIndicator } from "./StatusBlocks";
 import { ToolCard, ToolGroupSummary } from "./ToolCard";
+
+/**
+ * React context carrying the ``elicitationId`` of the choice/elicitation card
+ * currently pinned just above the composer (see ``PinnedElicitationBar`` in
+ * ``ChatPage``), or ``null`` when none is pending.
+ *
+ * While a selection is pending, the active choice box is rendered in a pinned
+ * slot above the composer so it stays in view as the conversation grows (issue
+ * #206). To avoid a duplicate interactive card, the inline copy is suppressed
+ * — but only the ONE card that the pinned slot mirrors (matched by
+ * ``elicitationId``); any other pending elicitations (e.g. a concurrent
+ * sub-agent prompt) keep rendering inline. Once the user resolves the prompt,
+ * ``status`` flips to ``"responded"`` so this suppression no longer applies and
+ * the responded summary card returns to its inline place in the scroll
+ * history.
+ *
+ * Default ``null`` keeps ``BlockRenderer`` self-contained when rendered outside
+ * the chat surface (no pinned slot), e.g. in isolated unit tests.
+ */
+export const PinnedElicitationIdContext = createContext<string | null>(null);
 
 /**
  * Inline-`code` renderer that turns workspace file paths (e.g.
@@ -283,6 +303,10 @@ interface BlockRendererProps {
 
 export function BlockRenderer({ items, sessionStatus }: BlockRendererProps) {
   const rendered: ReactNode[] = [];
+  // Read once here (not inside renderItem) so the rules of hooks hold:
+  // renderItem is called in a loop and would otherwise call useContext a
+  // variable number of times per render.
+  const pinnedElicitationId = useContext(PinnedElicitationIdContext);
   const isAgentActive = sessionStatus === "running" || sessionStatus === "waiting";
   const streamingRunStart = isAgentActive ? findStreamingRunStart(items) : -1;
   // Reasoning is "currently streaming" iff the agent is live AND this
@@ -320,20 +344,22 @@ export function BlockRenderer({ items, sessionStatus }: BlockRendererProps) {
             <ToolGroupSummary tools={grouped} count={run.length} />
             {standalone.length > 0 && (
               <div className="mt-1 ml-2 space-y-1 border-l pl-3 py-1 peer-data-[state=open]:mt-0">
-                {standalone.map((tool, idx) => renderItem(tool, runStart + idx, false))}
+                {standalone.map((tool, idx) =>
+                  renderItem(tool, runStart + idx, false, pinnedElicitationId),
+                )}
               </div>
             )}
           </div>,
         );
       } else {
         for (const tool of standalone) {
-          rendered.push(renderItem(tool, runStart, false));
+          rendered.push(renderItem(tool, runStart, false, pinnedElicitationId));
         }
       }
       continue;
     }
 
-    rendered.push(renderItem(item, i, i === reasoningStreamingIdx));
+    rendered.push(renderItem(item, i, i === reasoningStreamingIdx, pinnedElicitationId));
   }
 
   return <>{rendered}</>;
@@ -391,7 +417,12 @@ function isInProgressTool(item: RenderItem): boolean {
   return item.kind === "tool" && item.state === "input-available";
 }
 
-function renderItem(item: RenderItem, index: number, isReasoningStreaming: boolean): ReactNode {
+function renderItem(
+  item: RenderItem,
+  index: number,
+  isReasoningStreaming: boolean,
+  pinnedElicitationId: string | null,
+): ReactNode {
   const key = keyFor(item, index);
   switch (item.kind) {
     case "text":
@@ -467,6 +498,14 @@ function renderItem(item: RenderItem, index: number, isReasoningStreaming: boole
         />
       );
     case "elicitation":
+      // The pending card that the pinned slot above the composer mirrors is
+      // suppressed inline so the actionable prompt lives in one place (issue #206).
+      // Resolved cards (status === "responded") always render inline as the
+      // historical record; any other pending card (a different elicitationId)
+      // renders inline too — only the mirrored one is hoisted.
+      if (item.status === "pending" && pinnedElicitationId === item.elicitationId) {
+        return null;
+      }
       return (
         <ApprovalCard
           key={key}

--- a/ap-web/src/pages/ChatPage.pinnedElicitation.test.tsx
+++ b/ap-web/src/pages/ChatPage.pinnedElicitation.test.tsx
@@ -1,0 +1,181 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BlockRenderer, PinnedElicitationIdContext } from "@/components/blocks/BlockRenderer";
+import type { Bubble, RenderItem } from "@/lib/renderItems";
+import { PinnedElicitationBar, selectPendingElicitation } from "./ChatPage";
+
+// Issue #206: while a choice/elicitation is pending, the actionable card is
+// pinned just above the composer (PinnedElicitationBar) and the inline copy
+// in the transcript is suppressed (BlockRenderer + PinnedElicitationIdContext)
+// so the prompt lives in exactly one place — where the user's attention lands.
+
+type ElicitationItem = Extract<RenderItem, { kind: "elicitation" }>;
+
+function pendingElicitation(elicitationId = "elic_1"): ElicitationItem {
+  return {
+    kind: "elicitation",
+    itemId: `item_${elicitationId}`,
+    elicitationId,
+    message: "Approve the git push?",
+    phase: "pre-tool",
+    policyName: "blast_radius",
+    contentPreview: "",
+    requestedSchema: {},
+    status: "pending",
+    response: null,
+  };
+}
+
+function respondedElicitation(elicitationId = "elic_1"): ElicitationItem {
+  return {
+    ...pendingElicitation(elicitationId),
+    status: "responded",
+    response: { action: "accept", content: undefined },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PinnedElicitationBar", () => {
+  it("renders the pending card in the pinned slot above the composer", () => {
+    // WHY: the actionable prompt must be visible at the bottom of the
+    // conversation, not buried mid-transcript — the pinned slot is the fix.
+    render(<PinnedElicitationBar elicitation={pendingElicitation()} />);
+    expect(screen.getByTestId("pinned-elicitation")).toBeInTheDocument();
+    const card = screen.getByTestId("approval-card");
+    expect(card).toHaveAttribute("data-state", "pending");
+    expect(within(card).getByText("Approval required")).toBeInTheDocument();
+    expect(within(card).getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByText(/Pinned · decision required/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when no elicitation is pending", () => {
+    // WHY: once the user resolves the prompt (or there never was one), the
+    // pinned slot must vanish so the composer isn't pushed down by an empty
+    // frame and the responded summary card returns to its inline place.
+    const { container } = render(<PinnedElicitationBar elicitation={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("BlockRenderer inline suppression (issue #206)", () => {
+  // BlockRenderer is exported; PinnedElicitationIdContext is the value ChatPage
+  // threads in so the inline copy of the mirrored pending card is dropped.
+
+  it("suppresses the inline pending card when its elicitationId is pinned", () => {
+    // WHY: the pinned slot already owns this card; rendering it inline too
+    // would duplicate the actionable prompt and split the user's focus.
+    const elicitation = pendingElicitation("elic_pin");
+    render(
+      <PinnedElicitationIdContext.Provider value={elicitation.elicitationId}>
+        <BlockRenderer items={[elicitation]} sessionStatus="idle" />
+      </PinnedElicitationIdContext.Provider>,
+    );
+    expect(screen.queryByTestId("approval-card")).toBeNull();
+  });
+
+  it("renders the inline pending card when no elicitation is pinned", () => {
+    // WHY: outside the chat (or before a pin exists), BlockRenderer must keep
+    // rendering elicitations inline so the card is never lost entirely.
+    render(
+      <PinnedElicitationIdContext.Provider value={null}>
+        <BlockRenderer items={[pendingElicitation()]} sessionStatus="idle" />
+      </PinnedElicitationIdContext.Provider>,
+    );
+    expect(screen.getByTestId("approval-card")).toHaveAttribute("data-state", "pending");
+  });
+
+  it("renders a concurrent pending card inline even while a different one is pinned", () => {
+    // WHY: only the ONE mirrored card is hoisted; a different pending prompt
+    // (e.g. a sub-agent's) still renders inline so it isn't hidden.
+    render(
+      <PinnedElicitationIdContext.Provider value="elic_pinned">
+        <BlockRenderer items={[pendingElicitation("elic_other")]} sessionStatus="idle" />
+      </PinnedElicitationIdContext.Provider>,
+    );
+    expect(screen.getByTestId("approval-card")).toHaveAttribute("data-state", "pending");
+  });
+
+  it("always renders a resolved card inline even when its elicitationId is pinned", () => {
+    // WHY: a resolved card is the historical record — it must return inline
+    // once the user has decided, not stay suppressed by a stale pin value.
+    render(
+      <PinnedElicitationIdContext.Provider value="elic_1">
+        <BlockRenderer items={[respondedElicitation("elic_1")]} sessionStatus="idle" />
+      </PinnedElicitationIdContext.Provider>,
+    );
+    expect(screen.getByTestId("approval-card")).toHaveAttribute("data-state", "responded");
+  });
+});
+
+type AssistantBubble = Extract<Bubble, { kind: "assistant" }>;
+
+function assistantWith(items: RenderItem[], responseId: string): AssistantBubble {
+  return {
+    kind: "assistant",
+    responseId,
+    stableId: responseId,
+    lifecycle: "completed",
+    error: null,
+    items,
+  };
+}
+
+describe("selectPendingElicitation (issue #206 priority)", () => {
+  // The selector is the pure back-to-front walk that picks which pending card
+  // to pin. Only the LATEST pending elicitation is pinned; older pending cards
+  // stay inline. Exercised here at the selector level (no React tree) so the
+  // "two pending, latest wins" contract has a direct unit check.
+
+  it("returns null when no elicitation is pending", () => {
+    expect(selectPendingElicitation([assistantWith([respondedElicitation()], "r1")])).toBeNull();
+    expect(selectPendingElicitation([])).toBeNull();
+  });
+
+  it("picks the single pending elicitation", () => {
+    const elicitation = pendingElicitation();
+    expect(selectPendingElicitation([assistantWith([elicitation], "r1")])).toBe(elicitation);
+  });
+
+  it("pins the latest pending elicitation when several are pending", () => {
+    // WHY: a new prompt supersedes an older unresolved one — the user's next
+    // selection resolves the most recent decision. The older card stays inline.
+    const older = pendingElicitation("elic_old");
+    const newer = pendingElicitation("elic_new");
+    const selected = selectPendingElicitation([
+      assistantWith([older], "r1"),
+      assistantWith([newer], "r2"),
+    ]);
+    expect(selected?.elicitationId).toBe("elic_new");
+  });
+
+  it("ignores responded elicitations even if they appear later in the transcript", () => {
+    // WHY: a resolved card is history, not an actionable prompt — a pending
+    // card earlier in the transcript must still win over a responded one that
+    // lands after it.
+    const pending = pendingElicitation("elic_pending");
+    const responded = respondedElicitation("elic_done");
+    const selected = selectPendingElicitation([
+      assistantWith([pending], "r1"),
+      assistantWith([responded], "r2"),
+    ]);
+    expect(selected?.elicitationId).toBe("elic_pending");
+  });
+
+  it("skips non-assistant bubbles", () => {
+    // WHY: user bubbles and other kinds never carry elicitations; the walk
+    // must not blow up or pick up items from them.
+    const elicitation = pendingElicitation();
+    const selected = selectPendingElicitation([
+      {
+        kind: "user",
+        itemId: "u1",
+        content: [{ type: "input_text", text: "hi" }],
+      },
+      assistantWith([elicitation], "r1"),
+    ]);
+    expect(selected).toBe(elicitation);
+  });
+});

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -27,6 +27,7 @@ import {
   Loader2Icon,
   MessageSquareIcon,
   PaperclipIcon,
+  PinIcon,
   SquareIcon,
   TerminalIcon,
   WifiOffIcon,
@@ -51,7 +52,12 @@ import {
   MessageContent,
 } from "@/components/ai-elements/message";
 import { Shimmer } from "@/components/ai-elements/shimmer";
-import { BlockRenderer, FilePathAwareMessageResponse } from "@/components/blocks/BlockRenderer";
+import {
+  BlockRenderer,
+  FilePathAwareMessageResponse,
+  PinnedElicitationIdContext,
+} from "@/components/blocks/BlockRenderer";
+import { ApprovalCard } from "@/components/blocks/ApprovalCard";
 import { CompactionMarker } from "@/components/blocks/StatusBlocks";
 import { SystemMessageView } from "@/components/blocks/SystemMessage";
 import { parseSystemMessage } from "@/lib/systemMessage";
@@ -378,6 +384,29 @@ function saveDraftsToStorage(drafts: Map<string, { text: string; files: File[] }
 const sessionDrafts = loadDraftsFromStorage();
 
 /**
+ * The most recent still-pending elicitation across the transcript, or null.
+ *
+ * Walks the bubbles back-to-front (latest-first) so the newest pending prompt
+ * wins — the one a new selection would resolve. Used to pin the actionable
+ * choice card just above the composer (issue #206) instead of letting it scroll
+ * out of view mid-conversation. Pure + exported so the selection logic is
+ * unit-testable without rendering the component tree.
+ */
+export function selectPendingElicitation(
+  bubbles: Bubble[],
+): Extract<RenderItem, { kind: "elicitation" }> | null {
+  for (let i = bubbles.length - 1; i >= 0; i -= 1) {
+    const bubble = bubbles[i]!;
+    if (bubble.kind !== "assistant") continue;
+    for (let j = bubble.items.length - 1; j >= 0; j -= 1) {
+      const item = bubble.items[j]!;
+      if (item.kind === "elicitation" && item.status === "pending") return item;
+    }
+  }
+  return null;
+}
+
+/**
  * Single component that drives the chat surface. Streaming + history
  * state lives in `useChatStore` (a Zustand store at module scope), so
  * this component is reactive but not stateful — it observes the store
@@ -538,6 +567,14 @@ export function ChatPage() {
       buildPendingBubbles(pendingUserMessages, getCurrentAuthorId()),
     );
   }, [blocks, activeResponse, interruptedResponseIds, pendingUserMessages]);
+
+  // The most recent still-pending elicitation card across the transcript.
+  // While pending it is pinned just above the composer (issue #206) instead of
+  // rendering inline, so a decision prompt never scrolls up and out of view.
+  // Cleared once the user resolves it; the responded summary card then returns
+  // to its inline place in the scroll history. Walks back-to-front so the
+  // latest pending prompt wins (the one a new selection would resolve).
+  const pendingElicitation = useMemo(() => selectPendingElicitation(bubbles), [bubbles]);
 
   // Picker selection. ChatPage stays mounted across `/` to `/c/:id`,
   // so the pick survives sidebar clicks; resets on full page reload.
@@ -879,6 +916,7 @@ export function ChatPage() {
       onSend={onSend}
       onSendSlashCommand={onSendSlashCommand}
       onStop={onStop}
+      pendingElicitation={pendingElicitation}
       onShowReconnectHelp={() => {
         // Route the banner to the SAME dialog typing a message would: an
         // unbound coding clone opens the directory picker (bind + launch),
@@ -1138,6 +1176,13 @@ interface MainAgentSurfaceProps {
    * ``subAgentComposerLabel``.
    */
   subAgentLabel: string | null;
+  /**
+   * The most recent still-pending elicitation (choice/approval prompt), or
+   * ``null`` when none is pending. While non-null it is pinned just above the
+   * composer (issue #206) and its inline copy is suppressed via
+   * {@link PinnedElicitationIdContext} so only one interactive card exists.
+   */
+  pendingElicitation: Extract<RenderItem, { kind: "elicitation" }> | null;
 }
 
 /**
@@ -1202,6 +1247,7 @@ function MainAgentSurface({
   costRoutingVerdict,
   costRoutingEligible,
   subAgentLabel,
+  pendingElicitation,
 }: MainAgentSurfaceProps) {
   const terminalFirst = useTerminalFirst();
   // Mirrors ChatPage's `sandboxLaunching`: while the managed-sandbox
@@ -1330,108 +1376,117 @@ function MainAgentSurface({
 
   return (
     <>
-      {/* Wrapper div gives us a ref to scope the SelectionPopup to the
-          conversation area without requiring Conversation to forward refs. */}
-      <div ref={setConversationEl} className="relative flex min-h-0 flex-1 overflow-hidden">
-        {/* chat-scroll-fade masks the viewport's top edge so scrolling
+      <PinnedElicitationIdContext.Provider value={pendingElicitation?.elicitationId ?? null}>
+        {/* Wrapper div gives us a ref to scope the SelectionPopup to the
+            conversation area without requiring Conversation to forward refs. */}
+        <div ref={setConversationEl} className="relative flex min-h-0 flex-1 overflow-hidden">
+          {/* chat-scroll-fade masks the viewport's top edge so scrolling
             content dissolves into the canvas before reaching the
             ChatHeader overlay's controls (geometry in index.css). */}
-        <Conversation className="chat-scroll-fade flex-1">
-          {/* gap-4 overrides ConversationContent's default gap-8 so consecutive agent turns read as one thread. */}
-          <ConversationContent className={cn("mx-auto w-full gap-4 pt-20 pb-6", CHAT_COLUMN_WIDTH)}>
-            {/* Scroll helpers — must live inside StickToBottom to access context. */}
-            <ScrollToBottomOnSend nonce={sendScrollNonce} />
-            <ConversationScrollRefBridge onScroller={setScroller} />
-            <HistoryAutoLoader
-              hasMoreHistory={hasMoreHistory}
-              loadingMoreHistory={loadingMoreHistory}
-            />
-            {bubbles.length === 0 && !showWorkingIndicator ? (
-              // Cold launch: a centered spinner instead of the "ready to
-              // type" empty state (the create-then-send path uses the
-              // "row" variant). Two launch shapes land here: a
-              // terminal-first spin-up (gate on isTerminalFirst too —
-              // terminalStartingUp is set for non-terminal-first sessions
-              // as well) and a managed-sandbox launch, whose stage text
-              // renders in the same spot for ANY session type.
-              (terminalFirst?.isTerminalFirst && terminalFirst.terminalStartingUp) ||
-              sandboxLaunching ? (
-                <RunnerStartingIndicator variant="hero" />
+          <Conversation className="chat-scroll-fade flex-1">
+            {/* gap-4 overrides ConversationContent's default gap-8 so consecutive agent turns read as one thread. */}
+            <ConversationContent
+              className={cn("mx-auto w-full gap-4 pt-20 pb-6", CHAT_COLUMN_WIDTH)}
+            >
+              {/* Scroll helpers — must live inside StickToBottom to access context. */}
+              <ScrollToBottomOnSend nonce={sendScrollNonce} />
+              <ConversationScrollRefBridge onScroller={setScroller} />
+              <HistoryAutoLoader
+                hasMoreHistory={hasMoreHistory}
+                loadingMoreHistory={loadingMoreHistory}
+              />
+              {bubbles.length === 0 && !showWorkingIndicator ? (
+                // Cold launch: a centered spinner instead of the "ready to
+                // type" empty state (the create-then-send path uses the
+                // "row" variant). Two launch shapes land here: a
+                // terminal-first spin-up (gate on isTerminalFirst too —
+                // terminalStartingUp is set for non-terminal-first sessions
+                // as well) and a managed-sandbox launch, whose stage text
+                // renders in the same spot for ANY session type.
+                (terminalFirst?.isTerminalFirst && terminalFirst.terminalStartingUp) ||
+                sandboxLaunching ? (
+                  <RunnerStartingIndicator variant="hero" />
+                ) : (
+                  <ConversationEmptyState>
+                    <div className="space-y-1.5">
+                      <h3 className="text-2xl font-medium tracking-[-0.02em]">
+                        What should we work on?
+                      </h3>
+                      <p className="text-muted-foreground text-base">
+                        {agentsError
+                          ? `Failed to load agents: ${agentsError instanceof Error ? agentsError.message : String(agentsError)}`
+                          : "Send a message to get started."}
+                      </p>
+                    </div>
+                  </ConversationEmptyState>
+                )
               ) : (
-                <ConversationEmptyState>
-                  <div className="space-y-1.5">
-                    <h3 className="text-2xl font-medium tracking-[-0.02em]">
-                      What should we work on?
-                    </h3>
-                    <p className="text-muted-foreground text-base">
-                      {agentsError
-                        ? `Failed to load agents: ${agentsError instanceof Error ? agentsError.message : String(agentsError)}`
-                        : "Send a message to get started."}
-                    </p>
-                  </div>
-                </ConversationEmptyState>
-              )
-            ) : (
-              <>
-                {bubbles.map((bubble) => (
-                  <BubbleView key={bubbleKey(bubble)} bubble={bubble} />
-                ))}
-                {/* Working… shimmer between send and first rendered block.
+                <>
+                  {bubbles.map((bubble) => (
+                    <BubbleView key={bubbleKey(bubble)} bubble={bubble} />
+                  ))}
+                  {/* Working… shimmer between send and first rendered block.
                     Suppressed when the last bubble is a compaction spinner —
                     that bubble already owns the "in-progress" slot. aria-hidden:
                     the pinned pill owns the single aria-live region (see WorkingStatusPin). */}
-                {showWorkingIndicator && (
-                  <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
-                    <MessageContent>
-                      {/* py-0.5 = headroom for the bob: MessageContent is overflow-hidden
+                  {showWorkingIndicator && (
+                    <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
+                      <MessageContent>
+                        {/* py-0.5 = headroom for the bob: MessageContent is overflow-hidden
                           and would clip otto's head at the top of the bounce. */}
-                      <div className="flex items-center gap-1.5 py-0.5">
-                        <OttoIcon className="otto-working h-4 w-auto shrink-0" />
-                        <Shimmer className="text-xs font-mono" duration={1.5}>
-                          Working…
-                        </Shimmer>
-                      </div>
-                    </MessageContent>
-                  </Message>
-                )}
-                {/* Terminal-first spin-up cue beneath the just-sent first
+                        <div className="flex items-center gap-1.5 py-0.5">
+                          <OttoIcon className="otto-working h-4 w-auto shrink-0" />
+                          <Shimmer className="text-xs font-mono" duration={1.5}>
+                            Working…
+                          </Shimmer>
+                        </div>
+                      </MessageContent>
+                    </Message>
+                  )}
+                  {/* Terminal-first spin-up cue beneath the just-sent first
                     message: the prompt bubble renders immediately (no
                     runner-online send gate), but `showWorkingIndicator` stays
                     suppressed while the runner is offline, so without this the
                     user's message sits with no sign anything is happening.
                     Self-gates to null off the spin-up window; rendered only
                     when not already showing Working… so the two never stack. */}
-                {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
-              </>
-            )}
-          </ConversationContent>
-          <ConversationScrollButton />
-          {/* Outside ConversationContent so it's pinned to the viewport, not the scroll. See WorkingStatusPin.
+                  {!showWorkingIndicator && <RunnerStartingIndicator variant="row" />}
+                </>
+              )}
+            </ConversationContent>
+            <ConversationScrollButton />
+            {/* Outside ConversationContent so it's pinned to the viewport, not the scroll. See WorkingStatusPin.
               Suppressed in a sub-agent session: the composer's "Chatting with sub-agent …" tray owns this slot. */}
-          <WorkingStatusPin show={showWorkingIndicator} suppress={subAgentLabel != null} />
-          <UserMessageNavConnected
-            goPrev={nav.goPrev}
-            goNext={nav.goNext}
-            canPrev={nav.canPrev}
-            canNext={nav.canNext}
-            hidden={userMessageIds.length === 0}
-          />
-        </Conversation>
-        {/* Hover the top edge to reveal a pill that loads all older history and
+            <WorkingStatusPin show={showWorkingIndicator} suppress={subAgentLabel != null} />
+            <UserMessageNavConnected
+              goPrev={nav.goPrev}
+              goNext={nav.goNext}
+              canPrev={nav.canPrev}
+              canNext={nav.canNext}
+              hidden={userMessageIds.length === 0}
+            />
+          </Conversation>
+          {/* Hover the top edge to reveal a pill that loads all older history and
             scrolls to the first message. Rendered here (a wrapper sibling of
             Conversation) rather than inside it so it escapes the chat-scroll-fade
             mask and can sit right at the fade border. */}
-        <JumpToTopButton
-          containerEl={containerEl}
-          scroller={scroller}
-          hasMoreHistory={hasMoreHistory}
-        />
-      </div>
+          <JumpToTopButton
+            containerEl={containerEl}
+            scroller={scroller}
+            hasMoreHistory={hasMoreHistory}
+          />
+        </div>
+      </PinnedElicitationIdContext.Provider>
       {/* Floating reply button — scoped to the conversation container. */}
       <SelectionPopup
         containerRef={conversationRef}
         onReply={(text) => setReplyQuotes((prev) => [...prev, text])}
       />
+
+      {/* Pending choice/approval prompt pinned just above the composer so it
+          stays visible as the conversation scrolls (issue #206). Suppressed
+          inline via PinnedElicitationIdContext above. */}
+      <PinnedElicitationBar elicitation={pendingElicitation} />
 
       <Composer
         disabled={disabled}
@@ -1580,6 +1635,56 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * The pending choice/elicitation card pinned just above the composer (issue #206).
+ *
+ * While a selection is pending, the actionable prompt is anchored at the
+ * bottom of the conversation — where attention naturally lands — instead of
+ * scrolling up and out of view with the explanatory output. The inline copy
+ * is suppressed via {@link PinnedElicitationIdContext} so only ONE interactive
+ * card exists; once the user resolves the prompt, this bar disappears (the
+ * elicitation is no longer pending) and the responded summary card returns to
+ * its inline place in the scroll history.
+ *
+ * Rendered as a flex sibling between the conversation wrapper and the Composer,
+ * so it occupies its natural height right above the input area (it does not
+ * scroll with the conversation). Centered to the chat column width to match
+ * the inline card and the composer.
+ */
+export function PinnedElicitationBar({
+  elicitation,
+}: {
+  elicitation: Extract<RenderItem, { kind: "elicitation" }> | null;
+}) {
+  if (!elicitation) return null;
+  return (
+    <div
+      data-testid="pinned-elicitation"
+      className={cn("mx-auto w-full px-6 pt-2", CHAT_COLUMN_WIDTH)}
+    >
+      <div className="mb-1.5 flex items-center gap-1.5 text-muted-foreground text-xs">
+        <PinIcon className="size-3.5" />
+        <span>Pinned · decision required</span>
+      </div>
+      <ApprovalCard
+        elicitationId={elicitation.elicitationId}
+        message={elicitation.message}
+        phase={elicitation.phase}
+        policyName={elicitation.policyName}
+        contentPreview={elicitation.contentPreview}
+        requestedSchema={elicitation.requestedSchema}
+        url={elicitation.url}
+        status={elicitation.status}
+        response={elicitation.response}
+        askUserQuestion={elicitation.askUserQuestion}
+        exitPlanMode={elicitation.exitPlanMode}
+        codexCommand={elicitation.codexCommand}
+        allowAllEdits={elicitation.allowAllEdits}
+      />
     </div>
   );
 }

--- a/tests/e2e_ui/approvals/test_pinned_elicitation.py
+++ b/tests/e2e_ui/approvals/test_pinned_elicitation.py
@@ -1,0 +1,104 @@
+"""E2E: a pending choice/approval prompt pins to the bottom of the conversation.
+
+Issue #206: when Omnigent presents a choice/selection box it rendered inline
+mid-conversation and scrolled out of view as the conversation grew, so users
+missed that a decision was pending and the turn silently blocked. The fix
+pins the ACTIVE/pending card just above the composer (``PinnedElicitationBar``
+in ``ap-web/src/pages/ChatPage.tsx``) and suppresses its inline copy via
+``PinnedElicitationIdContext`` (``BlockRenderer.tsx``) so the actionable
+prompt lives in exactly one place — where attention lands. Once resolved,
+the bar disappears and the responded summary card returns to its inline place
+in the scroll history.
+
+This drives the full loop on the openai-agents harness via the
+``approval_session`` fixture (a ``blast_radius`` guardrail that gates pushes):
+send a turn that makes the agent attempt a gated ``git push``, wait for the
+pending card, assert it is pinned (and the inline copy is suppressed), then
+Approve and assert the responded card returns inline. Real LLM in the loop →
+nightly + a generous timeout, matching the other agent-driven UI suites.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_APPROVAL_CARD = '[data-testid="approval-card"]'
+_PINNED_SLOT = '[data-testid="pinned-elicitation"]'
+# A pending card that lives INSIDE the pinned slot (descendant combinator).
+_PINNED_PENDING = f'{_PINNED_SLOT} [data-testid="approval-card"][data-state="pending"]'
+
+# The agent must boot, take a turn, and emit the gated tool call before the
+# card appears — cold-start can be slow, so allow well past the streaming
+# default but under the test's 600s ceiling.
+_AGENT_TURN_TIMEOUT_MS = 120_000
+
+
+def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
+    """Return the session snapshot's pending elicitation events (owner view)."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("pending_elicitations") or []
+
+
+def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.25) -> None:
+    """Poll *predicate* until truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise AssertionError("condition not met within timeout")
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(600)
+def test_pending_choice_box_pins_above_composer(
+    page: Page,
+    approval_session: tuple[str, str],
+) -> None:
+    """Gated tool call → pending card pinned above composer → Approve → inline."""
+    base_url, session_id = approval_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Run the command now.")
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    # The agent calls the gated push; the policy ASK surfaces a pending card.
+    # Issue #206: that card must render inside the pinned slot above the
+    # composer, not inline in the scroll history.
+    pinned_card = page.locator(_PINNED_PENDING).first
+    expect(pinned_card).to_be_visible(timeout=_AGENT_TURN_TIMEOUT_MS)
+    expect(pinned_card.get_by_text("Approval required")).to_be_visible()
+    # The server is genuinely parked on this prompt, not just an optimistic UI.
+    assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
+
+    # The pinned slot itself is visible and labels the hoisted prompt.
+    expect(page.locator(_PINNED_SLOT)).to_be_visible()
+    expect(
+        page.locator(_PINNED_SLOT).get_by_text(re.compile(r"Pinned · decision required"))
+    ).to_be_visible()
+
+    # The inline copy is suppressed: there is exactly ONE pending approval card
+    # in the DOM, and it is the one inside the pinned slot. Without the
+    # PinnedElicitationIdContext suppression there would be two (pinned + inline).
+    expect(page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')).to_have_count(1)
+
+    # Resolve the prompt. The pinned card's Approve button is the one in view.
+    pinned_card.get_by_role("button", name="Approve").click()
+
+    # Once resolved, the pinned slot vanishes (no pending elicitation to pin)
+    # and the responded summary card returns to its INLINE place in the
+    # transcript — i.e. it is NOT a descendant of the pinned slot.
+    expect(page.locator(_PINNED_SLOT)).to_have_count(0)
+    responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
+    expect(responded).to_be_visible(timeout=30_000)
+    expect(responded.get_by_text("Approved", exact=False).first).to_be_visible()
+    _wait_for(lambda: not _pending_elicitations(base_url, session_id))


### PR DESCRIPTION
## Summary

Fixes #206.

When Omnigent presents a choice/selection (elicitation) box, it rendered inline
mid-conversation and scrolled out of view as the conversation grew — so users
missed that a decision was pending and the turn silently blocked. This pins the
**active/pending** choice box just above the composer so it stays visible while a
selection is pending; once resolved, it returns to its inline place in the
scroll history.

## Approach

- While an elicitation is `pending`, the actionable card is hoisted into a new
  `PinnedElicitationBar` rendered as a flex sibling between the conversation and
  the `Composer` — so it occupies its natural height right above the input area
  and does **not** scroll with the conversation.
- The inline copy of that **one** card is suppressed via a new
  `PinnedElicitationIdContext` so the prompt lives in exactly one place (no
  duplicate interactive cards). The context is read once at the top of
  `BlockRenderer` (rules-of-hooks safe) and threaded as a parameter to
  `renderItem`.
- Only the mirrored pending card is suppressed inline. A **different** concurrent
  pending card (e.g. a sub-agent's) still renders inline, and **resolved** cards
  (`status === "responded"`) always render inline as the historical record — so
  once the user decides, the pinned bar disappears and the summary card returns
  to its inline place.
- `ChatPage` computes the pending elicitation by walking the transcript
  back-to-front (latest-first) and pinning the first pending one it finds.

## Files

- `ap-web/src/components/blocks/BlockRenderer.tsx` — adds
  `PinnedElicitationIdContext`; threads `pinnedElicitationId` through
  `renderItem`; suppresses the mirrored pending card inline.
- `ap-web/src/pages/ChatPage.tsx` — adds `pendingElicitation` memo, wraps the
  conversation in the context provider, renders `PinnedElicitationBar` above
  the composer, and defines `PinnedElicitationBar` (exported for tests).

## Tests

- `ap-web/src/pages/ChatPage.pinnedElicitation.test.tsx` (vitest, 6 cases):
  pinned slot renders the pending card; renders nothing when nothing pending;
  inline suppression when the elicitationId matches; inline render when no pin
  / a different pin; a concurrent pending card still renders inline; a resolved
  card always renders inline even when its id is pinned.
- `tests/e2e_ui/approvals/test_pinned_elicitation.py` (nightly Playwright):
  drives the real `approval_session` (gated `git push`), asserts the pending
  card lives inside `[data-testid="pinned-elicitation"]`, that there is exactly
  one pending card in the DOM (inline suppressed), then Approves and asserts the
  pinned slot vanishes and the responded card returns inline.

## Gate

- `ap-web` `tsc -b`, `vitest`, `prettier --check`, `oxlint` (added lines clean),
  and repo `pre-commit` all pass locally. The new e2e_ui test is
  `@pytest.mark.nightly` (real LLM, matching the sibling approval tests) and
  collects cleanly; it runs in the nightly pass, not the PR gate.

Co-Authored-By: Claude <noreply@anthropic.com>