### PR TITLE
fix(security): preserve ASK-time data snapshot in runner policy verdict

### DIFF
--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -294,13 +294,12 @@ class RunnerToolPolicyGate:
                     data=composed_data,
                 )
         if pending_ask is not None:
-            # Attach any data accumulated after the ASK verdict.
-            return PolicyVerdict(
-                action="ask",
-                policy_name=pending_ask.policy_name,
-                reason=pending_ask.reason,
-                data=composed_data,
-            )
+            # Return the verdict captured at ASK time — its data field is the
+            # snapshot of composed_data at the moment the ASK fired, which is
+            # what the ASK policy intended to show the user (e.g. redacted
+            # args). Rebuilding with the post-loop composed_data would let a
+            # subsequent ALLOW policy silently overwrite that redaction.
+            return pending_ask
         if composed_data is not None:
             return PolicyVerdict(action="allow", data=composed_data)
         return _ALLOW

--- a/tests/runner/test_runner_policy.py
+++ b/tests/runner/test_runner_policy.py
@@ -111,3 +111,57 @@ async def test_success_deny_verdict_passed_through() -> None:
     verdict = await _run(server, "PHASE_TOOL_CALL")
     assert verdict["action"] == "POLICY_ACTION_DENY", verdict
     assert verdict["reason"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_policies — ASK data snapshot
+# ---------------------------------------------------------------------------
+
+
+async def test_ask_verdict_carries_data_from_ask_policy_not_later_allow() -> None:
+    """ASK verdict data must be the snapshot at ASK time, not overwritten by a later ALLOW.
+
+    An ASK policy may return transformed/redacted data (e.g. PII-scrubbed args)
+    for the approval prompt. A subsequent ALLOW policy that returns its own data
+    must not overwrite that snapshot — doing so would defeat the redaction and
+    show the user unredacted args.
+    """
+    from omnigent.policies import FunctionPolicy
+    from omnigent.policies.types import PolicyResult
+    from omnigent.runner.policy import Phase, RunnerToolPolicyGate, _GatedPolicy
+    from omnigent.spec.types import FunctionPolicySpec, PolicyAction
+
+    redacted = {"name": "tool", "arguments": {"query": "<REDACTED>"}}
+    original = {"name": "tool", "arguments": {"query": "secret search term"}}
+
+    def ask_with_redacted(ctx: object, cfg: object) -> PolicyResult:
+        return PolicyResult(action=PolicyAction.ASK, reason="approve?", data=redacted)
+
+    def allow_with_original(ctx: object, cfg: object) -> PolicyResult:
+        return PolicyResult(action=PolicyAction.ALLOW, data=original)
+
+    spec_ask = FunctionPolicySpec(name="redactor", on=None)
+    spec_allow = FunctionPolicySpec(name="logger", on=None)
+
+    gate = RunnerToolPolicyGate(
+        [
+            _GatedPolicy(
+                name="redactor",
+                policy=FunctionPolicy(spec=spec_ask, callable_obj=ask_with_redacted),
+                phases=frozenset([Phase.TOOL_CALL]),
+            ),
+            _GatedPolicy(
+                name="logger",
+                policy=FunctionPolicy(spec=spec_allow, callable_obj=allow_with_original),
+                phases=frozenset([Phase.TOOL_CALL]),
+            ),
+        ]
+    )
+
+    verdict = await gate.evaluate_tool_call("tool", {"query": "secret search term"})
+
+    assert verdict.action == "ask"
+    assert verdict.data is redacted, (
+        "ASK verdict must carry the redacted data from the ASK policy, "
+        f"not the post-loop data from the ALLOW policy; got {verdict.data!r}"
+    )


### PR DESCRIPTION
## Summary

- **Bug**: `RunnerToolPolicyGate._evaluate_policies()` captured the ASK verdict's `data` field from `composed_data` at ASK-fire time, but then continued iterating. A later `ALLOW` policy returning its own `data` would update `composed_data`, and the original code rebuilt the ASK `PolicyVerdict` using the post-loop value — silently overwriting the ASK policy's redacted payload.
- **Impact**: Any pipeline where an ASK policy returns PII-scrubbed or otherwise transformed tool arguments, followed by an ALLOW policy returning the original args, would show the user the unredacted arguments in the approval prompt — defeating the point of the ASK redaction.
- **Fix**: Snapshot the full `PolicyVerdict` (including `data`) into `pending_ask` the moment the ASK fires, then `return pending_ask` directly without rebuilding. No post-loop mutation can reach it.

## Test plan

- [ ] New test `test_ask_verdict_carries_data_from_ask_policy_not_later_allow` in `tests/runner/test_runner_policy.py`: chains a redacting ASK policy with a subsequent ALLOW policy that returns original data; asserts verdict `data is redacted`.
- [ ] All 8 existing `test_runner_policy` tests still pass.
- [ ] `ruff check` and `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)