### PR TITLE
fix(sandbox): harden OpenShell launcher: background contract, channel cleanup, observability

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -257,6 +257,30 @@ class SandboxLauncher(ABC):
             command exits non-zero.
         """
 
+    def run_background(
+        self, sandbox_id: str, command: str, *, log_path: str = "/tmp/omnigent-host.log"
+    ) -> RemoteCommandResult:
+        """
+        Start *command* as a detached background process in the sandbox.
+
+        The default wraps the command in ``setsid nohup … & echo launched``
+        so it survives the exec session ending. Providers where backgrounded
+        processes are reaped on exec return (e.g. OpenShell) override this
+        to hold the exec stream open instead.
+
+        :param sandbox_id: Target sandbox.
+        :param command: Shell command to background, e.g.
+            ``"ENV=val omnigent host --server https://…"``.
+        :param log_path: Where stdout/stderr of the backgrounded process
+            are redirected inside the sandbox.
+        :returns: A synthetic result with ``stdout="launched\\n"`` on success.
+        :raises click.ClickException: If the launch command fails.
+        """
+        return self.run(
+            sandbox_id,
+            f"setsid nohup {command} > {log_path} 2>&1 < /dev/null & echo launched",
+        )
+
     def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
         """
         Copy a local file into the sandbox.

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -37,6 +37,7 @@ Notes that shape this launcher:
 
 from __future__ import annotations
 
+import logging
 import os
 import shlex
 from collections.abc import Callable, Sequence
@@ -57,6 +58,8 @@ if TYPE_CHECKING:
 
     from openshell import ExecResult
 
+_logger = logging.getLogger(__name__)
+
 HOST_IMAGE_ENV_VAR: str = "OMNIGENT_OPENSHELL_HOST_IMAGE"
 """Environment variable overriding :data:`DEFAULT_HOST_IMAGE` for
 OpenShell sandboxes."""
@@ -76,7 +79,7 @@ _EXEC_TIMEOUT_S = 300
 # ceiling. The pidfile records the in-sandbox pid so Ctrl-C can kill the
 # remote process (cancelling the local stream doesn't stop it).
 _FOREGROUND_TIMEOUT_S = 7 * 24 * 3600
-_FOREGROUND_PIDFILE = "/tmp/oa-openshell-foreground.pid"
+_FOREGROUND_PIDFILE_TEMPLATE = "/tmp/oa-openshell-foreground-{sandbox_id}.pid"
 
 # OpenShell runs the agent as the non-root ``sandbox`` user (its image
 # contract; see deploy/docker/Dockerfile), whose home is ``/home/sandbox``.
@@ -232,12 +235,13 @@ class _OpenShellClient:
                 ):
                     pass
             except Exception:
-                # Fire-and-forget daemon pump: exec_stream raises (gRPC
-                # cancellation / SandboxError) when the in-sandbox host exits
-                # or the sandbox is deleted — the expected end of this thread,
-                # with no caller left to surface it to.
-                pass
+                _logger.debug(
+                    "exec_background stream ended for sandbox %s",
+                    name,
+                    exc_info=True,
+                )
 
+        self._bg_threads = [t for t in self._bg_threads if t.is_alive()]
         thread = threading.Thread(target=_pump, name=f"openshell-host-{name}", daemon=True)
         thread.start()
         self._bg_threads.append(thread)
@@ -265,6 +269,9 @@ class _OpenShellClient:
                 f"Failed to delete OpenShell sandbox '{name}': {exc}"
             ) from exc
         except SandboxError as exc:
+            if "not found" in str(exc).lower():
+                self._ids.pop(name, None)
+                return
             raise click.ClickException(
                 f"Failed to delete OpenShell sandbox '{name}': {exc}"
             ) from exc
@@ -356,25 +363,6 @@ class OpenShellSandboxLauncher(SandboxLauncher):
 
     def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
         """Run ``bash -lc <command>`` in the sandbox and capture its output."""
-        # The server's managed-host launch detaches the in-sandbox host with a
-        # ``setsid nohup omnigent host … & echo launched`` idiom and expects it
-        # to keep running after this call returns. On OpenShell a backgrounded
-        # exec process is killed the moment the exec returns, so run it instead
-        # as a foreground command on a held-open stream (exec_background); the
-        # host then survives to dial back and register.
-        stripped = command.rstrip()
-        if stripped.endswith("& echo launched") and "omnigent host" in stripped:
-            # Drop the detach scaffolding (``setsid nohup … & echo launched``):
-            # the command must run in the FOREGROUND of the held-open stream,
-            # or OpenShell reaps it the instant the exec returns. The output
-            # redirect (``> … 2>&1 < /dev/null``) is kept so the stream stays
-            # quiet while the host runs for the session's lifetime.
-            foreground = stripped[: -len("& echo launched")].rstrip()
-            foreground = foreground.replace("setsid nohup ", "")
-            self._openshell().exec_background(
-                sandbox_id, ["bash", "-lc", foreground], timeout=_FOREGROUND_TIMEOUT_S
-            )
-            return RemoteCommandResult(returncode=0, stdout="launched\n", stderr="")
         result = self._openshell().execute(sandbox_id, ["bash", "-lc", command])
         if result.stdout:
             click.echo(result.stdout, nl=False)
@@ -388,6 +376,22 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         return RemoteCommandResult(
             returncode=result.exit_code, stdout=result.stdout, stderr=result.stderr
         )
+
+    def run_background(
+        self, sandbox_id: str, command: str, *, log_path: str = "/tmp/omnigent-host.log"
+    ) -> RemoteCommandResult:
+        """Hold *command* on a long-lived exec stream instead of detaching.
+
+        OpenShell kills an exec's processes when the RPC returns, so the
+        base class's ``setsid nohup`` detach pattern doesn't work. Instead
+        the command runs in the foreground of an ``exec_stream`` drained on
+        a daemon thread — the stream stays open for the process's lifetime.
+        """
+        bg_command = f"{command} > {log_path} 2>&1 < /dev/null"
+        self._openshell().exec_background(
+            sandbox_id, ["bash", "-lc", bg_command], timeout=_FOREGROUND_TIMEOUT_S
+        )
+        return RemoteCommandResult(returncode=0, stdout="launched\n", stderr="")
 
     def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
         """Copy a local file into the sandbox by piping its bytes to ``cat``."""
@@ -413,10 +417,11 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         Ctrl-C kills the remote process and re-raises ``KeyboardInterrupt``.
         """
         client = self._openshell()
+        pidfile = _FOREGROUND_PIDFILE_TEMPLATE.format(sandbox_id=sandbox_id)
         # `exec` keeps the recorded pid across the shell swap, so a Ctrl-C
         # can kill the remote process — cancelling the local gRPC stream
         # stops our reads but doesn't stop the remote command.
-        remote = f"echo $$ > {shlex.quote(_FOREGROUND_PIDFILE)} && exec {command}"
+        remote = f"echo $$ > {shlex.quote(pidfile)} && exec {command}"
         try:
             return client.run_foreground(
                 sandbox_id, ["bash", "-lc", remote], timeout=_FOREGROUND_TIMEOUT_S
@@ -428,7 +433,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
                 [
                     "bash",
                     "-lc",
-                    f"kill $(cat {shlex.quote(_FOREGROUND_PIDFILE)}) 2>/dev/null || true",
+                    f"kill $(cat {shlex.quote(pidfile)}) 2>/dev/null || true",
                 ],
             )
             raise
@@ -445,6 +450,15 @@ class OpenShellSandboxLauncher(SandboxLauncher):
             if self._client is not None:
                 self._client.close()
                 self._client = None
+
+    def close(self) -> None:
+        """Release the underlying gRPC channel, if one was opened."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __del__(self) -> None:
+        self.close()
 
     def _openshell(self) -> _OpenShellClient:
         if self._client is None:
@@ -465,7 +479,7 @@ class OpenShellSandboxLauncher(SandboxLauncher):
             value = os.environ.get(name)
             if value is None:
                 raise click.ClickException(
-                    f"sandbox env passthrough names '{name}' but it is not set "
+                    f"sandbox env passthrough lists '{name}' but it is not set "
                     "in the server's environment — set it (or remove it from "
                     f"sandbox.openshell.env / {SANDBOX_ENV_PASSTHROUGH_ENV_VAR})."
                 )

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1473,15 +1473,10 @@ def _start_host_in_sandbox(
             (HOST_NAME_ENV_VAR, host_name),
         )
     )
-    launcher.run(
+    launcher.run_background(
         sandbox_id,
-        # setsid + nohup + redirects detach the host from the exec
-        # session: the exec's bash exits immediately (the trailing echo
-        # gives it a clean foreground completion) while the host keeps
-        # running for the sandbox's lifetime.
-        f"{env_prefix} setsid nohup omnigent host "
-        f"--server {shlex.quote(server_url)} "
-        f"> {_HOST_LOG_PATH} 2>&1 < /dev/null & echo launched",
+        f"{env_prefix} omnigent host --server {shlex.quote(server_url)}",
+        log_path=_HOST_LOG_PATH,
     )
     return workspace
 

--- a/tests/onboarding/sandboxes/test_openshell.py
+++ b/tests/onboarding/sandboxes/test_openshell.py
@@ -57,9 +57,13 @@ class _FakeOpenShellAPI:
     closed: bool = False
     exec_result: _FakeExecResult = field(default_factory=_FakeExecResult)
     created_name: str = "petname-test"
+    background_calls: list[tuple[str, list[str]]] = field(default_factory=list)
     foreground_calls: list[tuple[str, list[str]]] = field(default_factory=list)
     foreground_exit_code: int = 0
     foreground_raises: BaseException | None = None
+
+    def exec_background(self, name: str, command: list[str], *, timeout: int) -> None:
+        self.background_calls.append((name, list(command)))
 
     def create_sandbox(self, *, image: str, env: dict[str, str]) -> str:
         self.create_kwargs.append({"image": image, "env": env})
@@ -211,6 +215,26 @@ def test_run_no_check_allows_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.stderr == "boom\n"
 
 
+def test_run_background_uses_exec_background(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run_background`` routes through ``exec_background`` instead of detaching."""
+    fake = _FakeOpenShellAPI()
+    launcher = OpenShellSandboxLauncher()
+    monkeypatch.setattr(launcher, "_openshell", lambda: fake)
+
+    result = launcher.run_background(
+        "sb-1", "ENV=val omnigent host --server https://s", log_path="/tmp/host.log"
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "launched\n"
+    [(name, command)] = fake.background_calls
+    assert name == "sb-1"
+    assert command[:2] == ["bash", "-lc"]
+    assert "omnigent host --server https://s" in command[2]
+    assert "> /tmp/host.log 2>&1 < /dev/null" in command[2]
+    assert fake.exec_calls == []
+
+
 def test_put_uploads_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``put`` streams the file's bytes to ``cat`` over the exec channel."""
     fake = _FakeOpenShellAPI()
@@ -318,6 +342,7 @@ class _SDKState:
 
     connect_error: bool = False
     delete_not_found: bool = False
+    delete_not_found_via_sandbox_error: bool = False
     created_spec: Any = None
     waited: tuple[str, int | None] | None = None
     got: list[str] = field(default_factory=list)
@@ -414,6 +439,8 @@ def sdk(monkeypatch: pytest.MonkeyPatch) -> _SDKState:
             state.deleted.append(name)
             if state.delete_not_found:
                 raise _NotFound(_StatusCode.NOT_FOUND)
+            if state.delete_not_found_via_sandbox_error:
+                raise _SandboxError("sandbox not found")
 
         def close(self) -> None:
             state.closed = True
@@ -508,6 +535,16 @@ def test_client_execute_pins_sandbox_home(sdk: _SDKState) -> None:
 def test_client_delete_ignores_not_found(sdk: _SDKState) -> None:
     """Deleting a missing sandbox is treated as success (idempotent)."""
     sdk.delete_not_found = True
+    client = _OpenShellClient()
+
+    client.delete_sandbox("gone-sandbox")
+
+    assert sdk.deleted == ["gone-sandbox"]
+
+
+def test_client_delete_ignores_sandbox_error_not_found(sdk: _SDKState) -> None:
+    """Deleting via SandboxError with 'not found' is treated as success."""
+    sdk.delete_not_found_via_sandbox_error = True
     client = _OpenShellClient()
 
     client.delete_sandbox("gone-sandbox")


### PR DESCRIPTION


<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

Hardens the OpenShell sandbox launcher with eight improvements found during review:

  - Extract run_background() into the base class so managed-host background launch is a clean override instead of fragile
  string-matching inside run(). OpenShell overrides it to hold an exec stream open; other providers get the existing
  setsid nohup detach as the default.
  - Add close() / __del__ on the launcher so the gRPC channel is released even when terminate() is never called (e.g. a
  failed provision).
  - Add debug logging to exec_background's daemon thread — previously swallowed all exceptions silently, making
  background host failures invisible.
  - Prune dead threads from _bg_threads before appending new ones so the list doesn't grow unboundedly.
  - Handle SandboxError not-found in delete_sandbox — previously only grpc.RpcError NOT_FOUND was treated as idempotent;
  a future SDK wrapping it into SandboxError would raise.
  - Embed sandbox_id in the foreground pidfile path to prevent collision if multiple foreground execs ever run
  concurrently.
  - Fix error message grammar in _resolve_sandbox_env.


## Type of change

  - [ ] Bug fix
  - [x] Feature
  - [x] Refactor / chore
  - [ ] Docs
  - [ ] Test / CI
  - [ ] Breaking change


## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

  - [x] Unit tests added / updated
  - [ ] Integration tests added / updated
  - [ ] E2E tests added / updated
  - [ ] Manual verification completed
  - [x] Existing tests cover this change
  - [ ] Not applicable


## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
pytest tests/onboarding/sandboxes/test_openshell.py — 27 tests, all pass. 