### PR TITLE
fix(#547): send valid Cursor SDK model id from Polly model switcher

### DIFF
--- a/ap-web/src/lib/cursorNativeModels.ts
+++ b/ap-web/src/lib/cursorNativeModels.ts
@@ -1,0 +1,77 @@
+/**
+ * Cursor (cursor-sdk) model picker options: the SDK ids the Cursor bridge
+ * accepts, paired with friendly display labels. The Cursor SDK rejects a
+ * display label like ``Composer`` with an invalid_argument error (``Cannot
+ * use this model: Composer. Available models: default, composer-2.5, …``);
+ * the picker sends the SDK ``id`` (e.g. ``composer-2.5``) and shows the
+ * ``label`` (``Composer``), so a user selection never reaches the SDK as a
+ * display label (#547).
+ *
+ * Static snapshot of the known Cursor SDK models. The robust long-term fix is
+ * sourcing the picker options from ``Cursor.models.list()`` (a runner-side
+ * query exposed via the session snapshot, mirroring Codex ``model/list``);
+ * tracked as a #547 follow-up. When a model retires or a new one ships, this
+ * list drifts — refresh it then.
+ *
+ * Lives in a leaf module (no React / store imports) so both the picker UI
+ * (``ChatPage``) and any future store reader can read it without a circular
+ * import — same pattern as {@link claudeNativeModels}.
+ */
+export interface CursorModelOption {
+  /** Cursor SDK model id passed to the bridge (e.g. ``"composer-2.5"``). */
+  id: string;
+  /** Friendly display label shown in the picker (e.g. ``"Composer"``). */
+  label: string;
+}
+
+// Ordered with the natural defaults first (Cursor's ``default`` auto-select,
+// then the Composer flagship), then the frontier models a user would actually
+// switch to, most capable first within each family.
+export const CURSOR_NATIVE_MODELS: readonly CursorModelOption[] = [
+  { id: "default", label: "Default" },
+  { id: "composer-2.5", label: "Composer" },
+  { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+  { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { id: "claude-sonnet-4", label: "Claude Sonnet 4" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  { id: "gpt-5.5", label: "GPT-5.5" },
+  { id: "gpt-5.4", label: "GPT-5.4" },
+  { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+  { id: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
+  { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+  { id: "gpt-5.2", label: "GPT-5.2" },
+  { id: "gpt-5.2-codex", label: "GPT-5.2 Codex" },
+  { id: "gpt-5.1", label: "GPT-5.1" },
+  { id: "gpt-5.1-codex-max", label: "GPT-5.1 Codex Max" },
+  { id: "gpt-5.1-codex-mini", label: "GPT-5.1 Codex Mini" },
+  { id: "gpt-5-mini", label: "GPT-5 Mini" },
+  { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro" },
+  { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
+  { id: "gemini-3-flash", label: "Gemini 3 Flash" },
+  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+] as const;
+
+/**
+ * Is ``model`` something a Cursor (cursor-sdk) session can actually run —
+ * i.e. one of the known Cursor SDK model ids (or a display label this catalog
+ * maps)? Accepts the bare SDK ids ({@link CURSOR_NATIVE_MODELS}) and their
+ * display labels (case-insensitive). Rejects everything else — notably the
+ * Claude / Codex native ids that leak into the cross-harness global picker
+ * selection. Mirrors {@link isClaudeNativeModel}; intended for a future
+ * cursor sticky-model handoff — the store handoff
+ * ({@link nativeModelFamilyForSession}) currently only auto-applies a sticky
+ * model to claude/codex native wrappers, so this guard is not yet on the
+ * production apply path.
+ *
+ * @param model - A model id / display label, or null/undefined.
+ * @returns True only for a Cursor-compatible model.
+ */
+export function isCursorNativeModel(model: string | null | undefined): boolean {
+  if (model == null) return false;
+  const lower = model.toLowerCase();
+  return CURSOR_NATIVE_MODELS.some((m) => m.id === model || m.label.toLowerCase() === lower);
+}

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -86,6 +86,7 @@ import {
 import { getCurrentAuthorId } from "@/lib/identity";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { codexEffortLevelsForModel, findCodexModelOption } from "@/lib/codexNativeModels";
+import { CURSOR_NATIVE_MODELS } from "@/lib/cursorNativeModels";
 import {
   consumePendingInitialPrompt,
   type PendingInitialPrompt,
@@ -752,6 +753,7 @@ export function ChatPage() {
   const codexModelOptions = useChatStore((s) => s.codexModelOptions);
   const selectedModel = useChatStore((s) => s.selectedModel);
   const llmModel = useChatStore((s) => s.llmModel);
+  const sessionHarness = useChatStore((s) => s.sessionHarness);
 
   // Loading + error gates for `/c/:id` hydration.
   if (urlConvId) {
@@ -841,6 +843,7 @@ export function ChatPage() {
   // Once present, the live session snapshot is authoritative.
   const capabilitySource = {
     labels: activeSession ? (activeSession.labels ?? {}) : (activeConv?.labels ?? {}),
+    harness: sessionHarness,
   };
   const modelPickerKind = modelPickerKindForConv(capabilitySource);
   const effortLevels = effortLevelsForConv(
@@ -2689,6 +2692,13 @@ export function formatStatusModelLabel(
   if (codexOption) return codexOption.displayName ?? codexOption.id;
   const known = CLAUDE_NATIVE_MODELS.find((m) => m.id === lower);
   if (known) return known.label;
+  // Cursor: resolve a Cursor SDK id (or a legacy display label) to its
+  // friendly picker label, so the status tray reads "Composer" not
+  // "composer-2.5" (#547).
+  const cursorById = CURSOR_NATIVE_MODELS.find((m) => m.id === raw);
+  if (cursorById) return cursorById.label;
+  const cursorByLabel = CURSOR_NATIVE_MODELS.find((m) => m.label.toLowerCase() === lower);
+  if (cursorByLabel) return cursorByLabel.label;
   return raw;
 }
 
@@ -3938,9 +3948,15 @@ const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
-type NativeModelPickerKind = "claude" | "codex";
+type NativeModelPickerKind = "claude" | "codex" | "cursor";
 
-type LabelSource = { labels?: Record<string, string | null> | null } | null | undefined;
+type LabelSource =
+  | {
+      labels?: Record<string, string | null> | null;
+      harness?: string | null;
+    }
+  | null
+  | undefined;
 
 /**
  * Resolve a structural read-only reason from session labels.
@@ -3991,22 +4007,41 @@ export function effortLevelsForConv(
  * Gated on the wrapper label, not `omnigent.ui === "terminal"`:
  * other terminal-first wrappers may not be Claude/Codex-native (see
  * `TerminalFirstContext.tsx`).
+ *
+ * The Cursor SDK brain harness (a bundle agent like Polly with
+ * ``harness: "cursor"``) is not a native terminal wrapper — it has no
+ * ``omnigent.wrapper`` label — so the cursor model picker is gated on the
+ * session's brain harness instead. The picker sources options from a static
+ * Cursor SDK catalog ({@link CURSOR_NATIVE_MODELS}); the runner honors the
+ * mid-session override via ``HARNESS_CURSOR_MODEL`` (#547).
  */
 export function modelPickerKindForConv(
-  conv: { labels?: Record<string, string | null> | null } | null | undefined,
+  conv:
+    | {
+        labels?: Record<string, string | null> | null;
+        harness?: string | null;
+      }
+    | null
+    | undefined,
 ): NativeModelPickerKind | null {
   switch (conv?.labels?.["omnigent.wrapper"]) {
     case "claude-code-native-ui":
       return "claude";
     case "codex-native-ui":
       return "codex";
-    default:
-      return null;
   }
+  if (conv?.harness === "cursor") return "cursor";
+  return null;
 }
 
 export function shouldShowModelPicker(
-  conv: { labels?: Record<string, string | null> | null } | null | undefined,
+  conv:
+    | {
+        labels?: Record<string, string | null> | null;
+        harness?: string | null;
+      }
+    | null
+    | undefined,
 ): boolean {
   return modelPickerKindForConv(conv) !== null;
 }
@@ -4103,7 +4138,9 @@ function AgentPicker({
       ? CLAUDE_NATIVE_MODELS
       : modelPickerKind === "codex"
         ? codexModelOptions
-        : [];
+        : modelPickerKind === "cursor"
+          ? CURSOR_NATIVE_MODELS
+          : [];
   const isNativeModelPicker = modelPickerKind !== null;
   // Only offer the agent list when there's an actual choice. Inside a
   // session the picker is scoped to the single bound agent (the runner is
@@ -4199,7 +4236,17 @@ function AgentPicker({
                 selectedModel === null &&
                 (modelPickerKind === "codex"
                   ? findCodexModelOption(codexModelOptions, llmModel)?.id === m.id
-                  : isModelImplicitlySelected(m.id, llmModel));
+                  : modelPickerKind === "cursor"
+                    ? // Cursor SDK ids are exact (no tier aliases), so match
+                      // exactly — the loose ``includes`` used for Claude tiers
+                      // would falsely light "gpt-5.1" when "gpt-5.1-codex-mini" is
+                      // bound. Also accept the display label (a legacy override)
+                      // so a session pinned to "Composer" still lights its row.
+                      llmModel === m.id ||
+                      (llmModel != null &&
+                        m.label != null &&
+                        llmModel.toLowerCase() === m.label.toLowerCase())
+                    : isModelImplicitlySelected(m.id, llmModel));
               const isActive = isExplicit || isImplicit;
               return (
                 <DropdownMenuItem

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -2684,6 +2684,7 @@ function ContextRing({ contextWindow, tokensUsed }: { contextWindow: number; tok
 export function formatStatusModelLabel(
   model: string | null,
   codexModelOptions: readonly CodexModelOption[] = [],
+  harness: string | null = null,
 ): string | null {
   const raw = model?.trim();
   if (!raw) return null;
@@ -2694,11 +2695,16 @@ export function formatStatusModelLabel(
   if (known) return known.label;
   // Cursor: resolve a Cursor SDK id (or a legacy display label) to its
   // friendly picker label, so the status tray reads "Composer" not
-  // "composer-2.5" (#547).
-  const cursorById = CURSOR_NATIVE_MODELS.find((m) => m.id === raw);
-  if (cursorById) return cursorById.label;
-  const cursorByLabel = CURSOR_NATIVE_MODELS.find((m) => m.label.toLowerCase() === lower);
-  if (cursorByLabel) return cursorByLabel.label;
+  // "composer-2.5" (#547). Gated on the session harness because the Cursor
+  // catalog shares ids with Codex (e.g. ``gpt-5.5``) — only a cursor session
+  // should relabel them, otherwise a Codex override would misrender as
+  // ``GPT-5.5``.
+  if (harness === "cursor") {
+    const cursorById = CURSOR_NATIVE_MODELS.find((m) => m.id === raw);
+    if (cursorById) return cursorById.label;
+    const cursorByLabel = CURSOR_NATIVE_MODELS.find((m) => m.label.toLowerCase() === lower);
+    if (cursorByLabel) return cursorByLabel.label;
+  }
   return raw;
 }
 
@@ -2719,9 +2725,10 @@ export function formatModelEffortStatusLabel(
   model: string | null,
   effort: string | null,
   codexModelOptions: readonly CodexModelOption[] = [],
+  harness: string | null = null,
 ): string | null {
   const codexOption = model ? findCodexModelOption(codexModelOptions, model.trim()) : null;
-  const modelLabel = formatStatusModelLabel(model, codexModelOptions);
+  const modelLabel = formatStatusModelLabel(model, codexModelOptions, harness);
   const effortLabel = formatStatusEffortLabel(effort, codexOption !== null);
   const parts = [modelLabel, effortLabel].filter((p): p is string => p != null && p.length > 0);
   return parts.length > 0 ? parts.join(" ") : null;
@@ -2752,10 +2759,19 @@ function ComposerStatusLine() {
   // alongside contextWindow — so the branch reads from the same store as
   // the other status-line values rather than a separate fetch.
   const gitBranch = useChatStore((s) => s.gitBranch);
+  // Harness gates the Cursor model-id → label relabel in the status tray
+  // (#547): the Cursor catalog shares ids with Codex (``gpt-5.5``), so only
+  // a cursor session should relabel them.
+  const sessionHarness = useChatStore((s) => s.sessionHarness);
 
   const showBranch = !!conversationId && !!gitBranch;
   const modelEffortLabel = conversationId
-    ? formatModelEffortStatusLabel(selectedModel ?? llmModel, selectedEffort, codexModelOptions)
+    ? formatModelEffortStatusLabel(
+        selectedModel ?? llmModel,
+        selectedEffort,
+        codexModelOptions,
+        sessionHarness,
+      )
     : null;
   const showPlanMode = !!conversationId && codexPlanMode;
   // contextWindow > 0: the SSE path validates it but the snapshot path doesn't, and 0/0 → "NaN%".

--- a/ap-web/src/pages/effortLevels.test.ts
+++ b/ap-web/src/pages/effortLevels.test.ts
@@ -106,6 +106,34 @@ describe("shouldShowModelPicker", () => {
     const conv = { labels: { "omnigent.wrapper": "some-other-wrapper" } };
     expect(shouldShowModelPicker(conv)).toBe(false);
   });
+
+  it("returns true for a Cursor brain-harness session (no native wrapper label)", () => {
+    // WHY: cursor is an SDK brain harness (a bundle agent like Polly), not a
+    // native terminal wrapper — it has no ``omnigent.wrapper`` label. The
+    // picker is gated on the session's ``harness`` instead so the switcher
+    // can send valid Cursor SDK ids rather than display labels (#547).
+    expect(shouldShowModelPicker({ harness: "cursor" })).toBe(true);
+    expect(shouldShowModelPicker({ labels: {}, harness: "cursor" })).toBe(true);
+  });
+
+  it("returns false for a non-cursor brain harness and missing harness", () => {
+    // WHY: other SDK harnesses (claude-sdk, pi, openai-agents) don't expose a
+    // Cursor catalog; fail closed so no non-functional picker pops.
+    expect(shouldShowModelPicker({ harness: "claude-sdk" })).toBe(false);
+    expect(shouldShowModelPicker({ harness: null })).toBe(false);
+    expect(shouldShowModelPicker({ labels: {} })).toBe(false);
+  });
+
+  it("prefers the native wrapper label over the brain harness", () => {
+    // WHY: a claude-native session whose brain harness happens to be cursor
+    // must still show the Claude picker, not the Cursor one.
+    expect(
+      shouldShowModelPicker({
+        labels: { "omnigent.wrapper": "claude-code-native-ui" },
+        harness: "cursor",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("shouldShowEffortPicker", () => {

--- a/ap-web/src/pages/modelPicker.test.ts
+++ b/ap-web/src/pages/modelPicker.test.ts
@@ -6,8 +6,9 @@ import {
   findCodexModelOption,
   isCodexNativeModel,
 } from "@/lib/codexNativeModels";
+import { CURSOR_NATIVE_MODELS, isCursorNativeModel } from "@/lib/cursorNativeModels";
 import type { CodexModelOption } from "@/lib/types";
-import { isModelImplicitlySelected } from "./ChatPage";
+import { formatStatusModelLabel, isModelImplicitlySelected } from "./ChatPage";
 
 const CODEX_MODEL_OPTIONS: CodexModelOption[] = [
   {
@@ -109,5 +110,55 @@ describe("isModelImplicitlySelected", () => {
 
   it("returns false when no model is bound", () => {
     expect(isModelImplicitlySelected("opus", null)).toBe(false);
+  });
+});
+
+describe("CURSOR_NATIVE_MODELS", () => {
+  it("pairs each friendly display label with the SDK id the picker sends", () => {
+    // The core of #547: the picker sends ``id`` (the SDK id the Cursor bridge
+    // accepts) and shows ``label`` (the friendly name). ``Composer`` must map
+    // to ``composer-2.5`` so the SDK never receives the display label.
+    const composer = CURSOR_NATIVE_MODELS.find((m) => m.label === "Composer");
+    expect(composer?.id).toBe("composer-2.5");
+    expect(CURSOR_NATIVE_MODELS.find((m) => m.id === "default")?.label).toBe("Default");
+    // Every option carries a non-empty id + label so the picker never sends a
+    // display label as the model override.
+    for (const m of CURSOR_NATIVE_MODELS) {
+      expect(m.id.length).toBeGreaterThan(0);
+      expect(m.label.length).toBeGreaterThan(0);
+      expect(m.id).not.toBe("Composer"); // the display label never leaks as id
+    }
+  });
+});
+
+describe("isCursorNativeModel", () => {
+  it("accepts the bare Cursor SDK ids and their display labels", () => {
+    expect(isCursorNativeModel("composer-2.5")).toBe(true);
+    expect(isCursorNativeModel("Composer")).toBe(true);
+    expect(isCursorNativeModel("default")).toBe(true);
+    expect(isCursorNativeModel("gpt-5.5")).toBe(true);
+  });
+
+  it("rejects foreign harness ids that leak across the global picker", () => {
+    // WHY: the sticky-model handoff must not push a Claude/Codex id onto a
+    // cursor session (the SDK would reject it).
+    expect(isCursorNativeModel("opus")).toBe(false);
+    expect(isCursorNativeModel("databricks-claude-sonnet-4-6")).toBe(false);
+    expect(isCursorNativeModel(null)).toBe(false);
+  });
+});
+
+describe("formatStatusModelLabel (Cursor)", () => {
+  it("resolves a Cursor SDK id to its friendly label for the status tray", () => {
+    // WHY: the tray should read "Composer", not the raw "composer-2.5" the
+    // runner injects (#547).
+    expect(formatStatusModelLabel("composer-2.5")).toBe("Composer");
+    expect(formatStatusModelLabel("default")).toBe("Default");
+  });
+
+  it("resolves a legacy display-label override to its friendly label", () => {
+    // A session pinned before the picker sent SDK ids may still carry the
+    // display label as its override — show the friendly name, not the raw id.
+    expect(formatStatusModelLabel("Composer")).toBe("Composer");
   });
 });

--- a/ap-web/src/pages/modelPicker.test.ts
+++ b/ap-web/src/pages/modelPicker.test.ts
@@ -151,14 +151,24 @@ describe("isCursorNativeModel", () => {
 describe("formatStatusModelLabel (Cursor)", () => {
   it("resolves a Cursor SDK id to its friendly label for the status tray", () => {
     // WHY: the tray should read "Composer", not the raw "composer-2.5" the
-    // runner injects (#547).
-    expect(formatStatusModelLabel("composer-2.5")).toBe("Composer");
-    expect(formatStatusModelLabel("default")).toBe("Default");
+    // runner injects (#547). The Cursor relabel is gated on the session
+    // harness because the Cursor catalog shares ids with Codex
+    // (``gpt-5.5``) — a non-cursor session must leave them raw.
+    expect(formatStatusModelLabel("composer-2.5", [], "cursor")).toBe("Composer");
+    expect(formatStatusModelLabel("default", [], "cursor")).toBe("Default");
   });
 
   it("resolves a legacy display-label override to its friendly label", () => {
     // A session pinned before the picker sent SDK ids may still carry the
     // display label as its override — show the friendly name, not the raw id.
-    expect(formatStatusModelLabel("Composer")).toBe("Composer");
+    expect(formatStatusModelLabel("Composer", [], "cursor")).toBe("Composer");
+  });
+
+  it("leaves Cursor-catalog ids raw for a non-cursor (e.g. Codex) session", () => {
+    // WHY: ``gpt-5.5`` is a valid Cursor SDK id AND a Codex id — without the
+    // harness gate the status tray would mislabel a Codex override as
+    // ``GPT-5.5``. The harness gate keeps the raw id for non-cursor sessions.
+    expect(formatStatusModelLabel("gpt-5.5", [])).toBe("gpt-5.5");
+    expect(formatStatusModelLabel("gpt-5.5", [], "codex")).toBe("gpt-5.5");
   });
 });

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -76,6 +76,21 @@ _DEFAULT_CURSOR_MODEL = "auto"
 # instead of blocking the SDK's daemon callback thread forever.
 _TOOL_CALL_TIMEOUT_S = 1800.0
 
+# Known Cursor display labels (the friendly names the web switcher / a user
+# might pick or type) mapped to the Cursor SDK model ids the SDK accepts. The
+# SDK rejects a display label like ``Composer`` with an invalid_argument error
+# (``Cannot use this model: Composer. Available models: default, composer-2.5,
+# ...``); normalizing here, before agent creation, means any path that writes a
+# display label into the cursor model override — the web model switcher,
+# ``/model Composer``, or the API — is translated to the SDK id the bridge
+# expects. This is a static snapshot of the labels that don't match their SDK
+# ids; the robust long-term fix is sourcing the picker options from
+# ``Cursor.models.list()`` (see #547 follow-up).
+_CURSOR_DISPLAY_LABEL_TO_SDK_ID: dict[str, str] = {
+    "default": "default",
+    "composer": "composer-2.5",
+}
+
 
 def _resolve_model(model: str | None) -> str:
     """Resolve the cursor model id, dropping ids cursor can't honor.
@@ -84,6 +99,10 @@ def _resolve_model(model: str | None) -> str:
     ``composer-2.5``, ...), so a gateway-routed model id (carried by a spec
     authored for another harness) falls back to cursor's auto-select. ``None``
     likewise resolves to ``auto`` (the SDK requires a model).
+
+    A known display label (e.g. ``Composer``) is normalized to its SDK id
+    (``composer-2.5``) so the SDK doesn't reject it — see
+    :data:`_CURSOR_DISPLAY_LABEL_TO_SDK_ID`.
     """
     if not model or model.startswith(("databricks-", "databricks/")):
         if model:
@@ -97,6 +116,12 @@ def _resolve_model(model: str | None) -> str:
                 _DEFAULT_CURSOR_MODEL,
             )
         return _DEFAULT_CURSOR_MODEL
+    # Normalize a known display label (e.g. "Composer") to its SDK id
+    # ("composer-2.5"). Case-insensitive: the web switcher sends Title-Cased
+    # labels, but a user-typed ``/model composer`` reaches the same id.
+    normalized = _CURSOR_DISPLAY_LABEL_TO_SDK_ID.get(model.lower())
+    if normalized is not None:
+        return normalized
     return model
 
 

--- a/tests/e2e_ui/chat/test_cursor_model_picker.py
+++ b/tests/e2e_ui/chat/test_cursor_model_picker.py
@@ -1,0 +1,135 @@
+"""E2E: the Cursor (cursor-sdk) model switcher sends a valid SDK id, not a
+display label.
+
+Regression coverage for #547: the in-chat model switcher for a Cursor
+brain-harness session (a bundle agent like Polly with ``harness: "cursor"``)
+must send the Cursor SDK model id (e.g. ``composer-2.5``) in the session
+override PATCH, not the friendly display label (``Composer``) the picker
+shows. The Cursor SDK rejects display labels with an invalid_argument error, so
+the picker's ``data-model-id`` (the value written to ``modelOverride``) is the
+SDK id while the row text is the display label.
+
+The override PATCH uses the snake_case wire field ``model_override``
+(matching ``updateSession`` and the ``collaboration_mode`` convention).
+
+The server fixture seeds a normal ``hello_world`` session; this test patches
+the browser's session snapshot into a Cursor brain-harness session (no
+``omnigent.wrapper`` label, ``harness: "cursor"``) so the page boots against
+the real app/server while the picker is gated on the brain harness.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+
+def _patch_session_as_cursor(page: Page, session_id: str) -> list[dict]:
+    """Patch the browser's session snapshot into a Cursor brain-harness session.
+
+    The cursor SDK harness is not a native terminal wrapper, so it carries no
+    ``omnigent.wrapper`` label — the model picker is gated on the session's
+    ``harness`` field instead. This patches ``GET`` / ``PATCH
+    /v1/sessions/{session_id}`` to look like a Polly session running on the
+    Cursor brain harness, and echoes back any ``model_override`` written by
+    the picker so the optimistic state settles.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    :returns: Captured PATCH request bodies.
+    """
+    latest_payload: dict | None = None
+    patch_bodies: list[dict] = []
+
+    def _handle(route: Route) -> None:
+        nonlocal latest_payload
+        request = route.request
+        parsed = urlparse(request.url)
+        if parsed.path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+
+        headers = {"content-type": "application/json"}
+        if request.method == "GET":
+            response = route.fetch()
+            payload = response.json()
+            headers = {**response.headers, **headers}
+        elif request.method == "PATCH":
+            request_body = json.loads(request.post_data or "{}")
+            patch_bodies.append(request_body)
+            payload = dict(latest_payload or {})
+            # updateSession sends snake_case wire fields (``model_override``),
+            # not camelCase — same convention as ``collaboration_mode``.
+            if "model_override" in request_body:
+                payload["model_override"] = request_body["model_override"]
+                payload["llm_model"] = request_body["model_override"]
+        else:
+            route.continue_()
+            return
+
+        # Cursor is an SDK brain harness, NOT a native terminal wrapper: it
+        # must NOT carry a native wrapper label (the picker is harness-gated).
+        labels = dict(payload.get("labels", {}))
+        labels.pop("omnigent.wrapper", None)
+        payload["labels"] = labels
+        payload["harness"] = "cursor"
+        payload["llm_model"] = payload.get("llm_model") or "composer-2.5"
+        latest_payload = dict(payload)
+        route.fulfill(
+            status=200,
+            headers=headers,
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+    return patch_bodies
+
+
+def test_cursor_picker_sends_sdk_id_not_display_label(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Selecting ``Composer`` writes ``composer-2.5`` to the model override.
+
+    The picker row shows the display label ``Composer`` but carries the Cursor
+    SDK id ``composer-2.5`` as its ``data-model-id`` — the value the store
+    writes to ``model_override``. Sending the display label would trip the
+    SDK's ``Cannot use this model: Composer`` rejection (#547).
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser snapshot is patched to a Cursor brain harness.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    patch_bodies = _patch_session_as_cursor(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    trigger = page.get_by_test_id("agent-picker-trigger")
+    expect(trigger).to_be_visible(timeout=15_000)
+    # The Cursor brain harness reads as the identity suffix — "Polly (Cursor)".
+    expect(trigger).to_contain_text("Cursor")
+    trigger.click()
+
+    # The Composer row shows the display label but carries the SDK id.
+    composer_row = page.locator('[data-testid="model-picker-item"][data-model-id="composer-2.5"]')
+    expect(composer_row).to_be_visible()
+    expect(composer_row).to_contain_text("Composer")
+    # The display label must never leak as the model id the picker sends.
+    assert page.locator('[data-testid="model-picker-item"][data-model-id="Composer"]').count() == 0
+
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and urlparse(response.url).path == f"/v1/sessions/{session_id}"
+            and response.status == 200
+        )
+    ):
+        composer_row.click()
+
+    # The core #547 fix: the override PATCH carries the SDK id, not the display
+    # label the user clicked.
+    assert patch_bodies[-1] == {"model_override": "composer-2.5"}

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -174,6 +174,20 @@ def test_resolve_model_drops_databricks_and_defaults_to_auto() -> None:
     assert _resolve_model(None) == "auto"
 
 
+def test_resolve_model_normalizes_known_display_labels() -> None:
+    """A display label the web switcher / ``/model`` might send (e.g. ``Composer``)
+    must resolve to the Cursor SDK id the bridge accepts, not flow through
+    unchanged and trip the SDK's invalid_argument rejection (#547)."""
+    assert _resolve_model("Composer") == "composer-2.5"
+    # Case-insensitive: a user-typed ``/model composer`` reaches the same id.
+    assert _resolve_model("composer") == "composer-2.5"
+    assert _resolve_model("COMPOSER") == "composer-2.5"
+    assert _resolve_model("Default") == "default"
+    # An already-valid SDK id passes through untouched.
+    assert _resolve_model("composer-2.5") == "composer-2.5"
+    assert _resolve_model("gpt-5") == "gpt-5"
+
+
 def test_resolve_model_warns_when_dropping_a_pinned_model(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -449,6 +463,22 @@ async def test_databricks_model_resolved_to_auto(monkeypatch: pytest.MonkeyPatch
     finally:
         await executor.close()
     assert state["create_models"] == ["auto"]
+
+
+async def test_display_label_model_resolved_before_agent_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A display label like ``Composer`` must reach ``AsyncAgent.create`` as the
+    SDK id ``composer-2.5`` — the unnormalized form is what the SDK rejects
+    (#547). Mirrors :func:`test_databricks_model_resolved_to_auto` for the
+    display-label path."""
+    state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    executor = CursorExecutor(model="Composer", api_key="crsr_x")
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+    assert state["create_models"] == ["composer-2.5"]
 
 
 async def test_api_key_threaded_to_create(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

The Polly in-chat model switcher (Cursor harness) showed display labels like `Composer` but the Cursor SDK needs ids like `composer-2.5`. Sending the label tripped `RuntimeError: Cannot use this model: Composer. Available models: default, composer-2.5, …` and the session did not recover cleanly when switching to a valid id afterwards.

Closes #547.

## Why

`omnigent/inner/cursor_executor.py` `_resolve_model` returned non-Databricks model strings unchanged, so the display label the picker sent reached `AsyncAgent.create` verbatim and the SDK rejected it with `invalid_argument`. The picker also had no Cursor-specific catalog — it had nowhere to source the SDK ids from.

## How

- **Backend** (`cursor_executor.py`): `_resolve_model` now normalizes known Cursor display labels (`Composer`/`Default`) to their SDK ids (`composer-2.5`/`default`) before `AsyncAgent.create`, case-insensitively. A static `_CURSOR_DISPLAY_LABEL_TO_SDK_ID` map covers the two labels from the bug report; unknown strings pass through unchanged (preserves databricks→`auto` and valid-id passthrough).
- **Frontend** (`cursorNativeModels.ts` + `ChatPage.tsx`): a static Cursor catalog pairs each SDK id with its display label; the picker is gated on `session.harness === "cursor"` (Cursor is an SDK brain harness, not a native terminal wrapper, so it carries no `omnigent.wrapper` label). The row's `data-model-id` carries the SDK id the picker sends; the row text is the friendly label. The status tray resolves an SDK id back to its label so it reads `Composer`, not `composer-2.5`.

## Scope

Full minimal fix: backend normalization + static UI catalog + Cursor picker + e2e_ui test. The catalog is a **static snapshot** — sourcing picker options from `Cursor.models.list()` (a runner-side query exposed via the session snapshot, mirroring Codex `model/list`) is tracked as a #547 follow-up, as is expanding the backend label map beyond the two bug-report labels (e.g. `GPT-5.5`→`gpt-5.5`).

## Tests

- Backend: `tests/inner/test_cursor_executor.py` — display-label normalization + resolved-before-agent-create.
- ap-web: `modelPicker.test.ts` + `effortLevels.test.ts` — catalog shape, `isCursorNativeModel`, `formatStatusModelLabel` (Cursor), picker gating on `harness === "cursor"`, native-wrapper precedence.
- E2E UI: `tests/e2e_ui/chat/test_cursor_model_picker.py` — selecting `Composer` writes `model_override: "composer-2.5"` to the override PATCH (snake_case wire field), the SDK id never leaks as a display label.

## Checks

- `ruff format` / `ruff check`: clean
- `mypy`: 0 new vs baseline (12 pre-existing in `cursor_executor.py`, unchanged)
- backend `pytest` shard: 34 passed
- ap-web `tsc -b`: exit 0; `prettier`: clean; `vitest` (picker shard): 33 passed
- exfil-scan: passed
- CodeRabbit pre-push review: APPROVE (no critical/high; one medium docstring overclaim on `isCursorNativeModel` — fixed by softening the docstring to not claim it is wired into the sticky-model handoff, which still only auto-applies to claude/codex native wrappers)

Co-Authored-By: Claude <noreply@anthropic.com>