### PR TITLE
fix(theme): skip redundant theme toggle when system already matches next mode

### DIFF
--- a/ap-web/src/components/theme/ThemeModeMenu.test.tsx
+++ b/ap-web/src/components/theme/ThemeModeMenu.test.tsx
@@ -13,10 +13,11 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 const setTheme = vi.fn();
 let currentTheme: string | undefined;
+let resolvedTheme: string | undefined;
 let embedded: boolean;
 
 vi.mock("next-themes", () => ({
-  useTheme: () => ({ theme: currentTheme, setTheme }),
+  useTheme: () => ({ theme: currentTheme, resolvedTheme, setTheme }),
 }));
 
 vi.mock("@/lib/embedded", () => ({
@@ -35,6 +36,7 @@ function renderMenu() {
 
 beforeEach(() => {
   currentTheme = "system";
+  resolvedTheme = undefined;
   embedded = false;
 });
 
@@ -92,5 +94,21 @@ describe("ThemeModeMenu", () => {
     currentTheme = "sepia";
     renderMenu();
     expect(screen.getByRole("button", { name: "Switch to Dark" })).toBeInTheDocument();
+  });
+
+  it("skips dark when system already resolves to dark", () => {
+    currentTheme = "system";
+    resolvedTheme = "dark";
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Light" }));
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("skips light when system already resolves to light", () => {
+    currentTheme = "system";
+    resolvedTheme = "light";
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Dark" }));
+    expect(setTheme).toHaveBeenCalledWith("dark");
   });
 });

--- a/ap-web/src/components/theme/ThemeModeMenu.tsx
+++ b/ap-web/src/components/theme/ThemeModeMenu.tsx
@@ -31,9 +31,9 @@ export function ThemeModeMenu() {
   // Embedded: the host owns the theme and `embed.tsx` forces light, so a theme
   // switcher would be a no-op. Hide it.
   const isEmbedded = useIsEmbedded();
-  const { theme, setTheme } = useTheme();
+  const { theme, resolvedTheme, setTheme } = useTheme();
   const mode = normalizeThemeMode(theme);
-  const next = nextThemeMode(mode);
+  const next = nextThemeMode(mode, resolvedTheme);
   const NextIcon = themeModeIcons[next];
   const action = `Switch to ${themeModeLabels[next]}`;
 

--- a/ap-web/src/components/theme/themeMode.test.ts
+++ b/ap-web/src/components/theme/themeMode.test.ts
@@ -32,11 +32,20 @@ describe("theme mode helpers", () => {
     expect(normalizeResolvedTheme(undefined)).toBe("light");
   });
 
-  it("cycles system → dark → light → system on each click", () => {
-    // The cycle must visit every mode exactly once before wrapping;
-    // a wrong value here would skip a mode or trap the user in two states.
+  it("cycles system → dark → light → system without resolved theme", () => {
     expect(nextThemeMode("system")).toBe("dark");
     expect(nextThemeMode("dark")).toBe("light");
     expect(nextThemeMode("light")).toBe("system");
+  });
+
+  it("skips redundant transition when resolved theme matches next mode", () => {
+    expect(nextThemeMode("system", "dark")).toBe("light");
+    expect(nextThemeMode("system", "light")).toBe("dark");
+  });
+
+  it("does not skip when resolved theme differs from next mode", () => {
+    expect(nextThemeMode("system", "light")).toBe("dark");
+    expect(nextThemeMode("dark", "dark")).toBe("light");
+    expect(nextThemeMode("light", "light")).toBe("system");
   });
 });

--- a/ap-web/src/components/theme/themeMode.ts
+++ b/ap-web/src/components/theme/themeMode.ts
@@ -54,14 +54,23 @@ export function normalizeResolvedTheme(value: string | undefined): ResolvedTheme
  * click pins dark, the next pins light, and the next returns to
  * following the OS preference.
  *
+ * When the resolved appearance is provided, redundant transitions are
+ * skipped — e.g. "system" already rendering as dark jumps straight to
+ * light instead of offering "Switch to Dark".
+ *
  * @param mode Current selectable theme mode, e.g. `"dark"`.
+ * @param resolvedTheme The actual rendered palette, e.g. `"dark"`.
  * @returns The mode to apply on the next click, e.g. `"light"`.
  */
-export function nextThemeMode(mode: ThemeMode): ThemeMode {
+export function nextThemeMode(mode: ThemeMode, resolvedTheme?: string): ThemeMode {
   const cycle: Record<ThemeMode, ThemeMode> = {
     system: "dark",
     dark: "light",
     light: "system",
   };
-  return cycle[mode];
+  const next = cycle[mode];
+  if (resolvedTheme && next !== "system" && next === resolvedTheme) {
+    return cycle[next];
+  }
+  return next;
 }


### PR DESCRIPTION

<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

  When the theme is set to "system" and the OS preference already resolves to dark,
  the toggle button offered "Switch to Dark", which is a no-op. Now `nextThemeMode` skips
  the redundant transition, so the button shows "Switch to Light" instead (and
  vice versa when system resolves to light).

<img width="572" height="269" alt="Screenshot From 2026-06-17 22-33-52" src="https://github.com/user-attachments/assets/a12a0173-5a46-4338-aaf5-e546855e89a7" />



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->

`npx vitest run src/components/theme/` — 14/14 pass