### PR TITLE
fix(policies): emit terminal event on INPUT-phase DENY so omnigent run doesn't wedge

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -192,6 +192,7 @@ from omnigent.server.routes._host_worktree import CreatedWorktree
 from omnigent.server.schemas import (
     AgentObject,
     ChildSessionSummary,
+    CompletedEvent,
     ConversationDeleted,
     CreatedSessionResponse,
     ElicitationRequestEvent,
@@ -207,6 +208,7 @@ from omnigent.server.schemas import (
     PaginatedList,
     PermissionObject,
     PolicySummary,
+    ResponseObject,
     SandboxStatus,
     ServerStreamEvent,
     SessionAgentChangedEvent,
@@ -9349,6 +9351,43 @@ def _publish_policy_deny(session_id: str, reason: str) -> None:
     )
 
 
+def _publish_input_deny_terminal(session_id: str, conv: Conversation, reason: str) -> None:
+    """
+    Publish a terminal ``response.completed`` for an INPUT-phase DENY.
+
+    The short-circuit never forwards to a runner, so no runner-relayed
+    terminal ``response.*`` event is emitted. SSE consumers that drive a
+    turn off the live-tail (the headless ``-p`` client,
+    :class:`omnigent_client.SessionsChat.send`) iterate until a
+    turn-terminal event arrives and would otherwise block forever. The
+    output carries the same sentinel text so the terminal-snapshot fallback
+    also surfaces the deny.
+
+    :param session_id: Session/conversation identifier.
+    :param conv: Conversation whose agent/model name tags the response.
+    :param reason: Human-readable deny reason from the policy verdict.
+    """
+    sentinel = f"{_DENY_SENTINEL_PREFIX}{reason}]"
+    response = ResponseObject(
+        id=f"deny_{secrets.token_hex(8)}",
+        status="completed",
+        model=conv.agent_id or "policy",
+        created_at=int(time.time()),
+        completed_at=int(time.time()),
+        output=[
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": sentinel}],
+            }
+        ],
+    )
+    session_stream.publish(
+        session_id,
+        CompletedEvent(type="response.completed", response=response).model_dump(exclude_none=True),
+    )
+
+
 async def _persist_policy_deny_sentinel(
     session_id: str,
     conv: Conversation,
@@ -16084,6 +16123,9 @@ def create_sessions_router(
                     conversation_store,
                     agent_store,
                 )
+                # Terminal response.completed before idle so live-tail
+                # consumers (the headless ``-p`` client) unblock.
+                _publish_input_deny_terminal(session_id, conv, reason)
                 _publish_status(session_id, "idle")
                 # Return the same shape the client expects from POST
                 # /events so postEvent doesn't throw on an unexpected
@@ -16111,6 +16153,8 @@ def create_sessions_router(
                     conversation_store,
                     agent_store,
                 )
+                # Terminal response.completed before idle (see message branch).
+                _publish_input_deny_terminal(session_id, conv, reason)
                 _publish_status(session_id, "idle")
                 return {"queued": False, "denied": True, "reason": reason}
         elif (

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -95,12 +95,6 @@ skips:
     cluster: terminal-d6
     mode: skip
 
-  - id: tests/e2e/omnigent/test_run_omnigent_policy_enforcement.py::test_policy_denies_input_containing_sentinel[openai-agents]
-    reason: "Shard 0 bulk: policy-enforcement family, same cluster as test_policy_denies_tool_call_by_name[codex] (#476)."
-    issue: 476
-    cluster: policy-guardrails
-    mode: skip
-
   - id: tests/e2e/test_async_tools_e2e.py::test_async_tool_real_llm_e2e
     reason: "Shard 0 bulk: async tool real-LLM assertion failure. Triage under #532."
     issue: 532
@@ -152,18 +146,6 @@ skips:
     cluster: runner-wedge-subprocess-fanout
     mode: skip
 
-  - id: tests/e2e/omnigent/test_run_omnigent_policy_enforcement.py::test_policy_denies_input_containing_sentinel[claude-sdk]
-    reason: "Shard 1 bulk: policy-enforcement cluster (#476)."
-    issue: 476
-    cluster: policy-guardrails
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_run_omnigent_policy_enforcement.py::test_policy_denies_input_containing_sentinel[codex]
-    reason: "Shard 1 bulk: policy-enforcement cluster (#476)."
-    issue: 476
-    cluster: policy-guardrails
-    mode: skip
-
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[claude-sdk]
     reason: "Shard 1 bulk: no-AGENT harness round-trip claude-sdk."
     issue: 532
@@ -175,8 +157,6 @@ skips:
     issue: 532
     cluster: repl-pexpect-cli
     mode: skip
-
-
 
   - id: tests/e2e/test_client_tool_sse_status_e2e.py::test_client_side_tool_inline_sse_carries_action_required
     reason: "Shard 1 bulk: SSE action_required signaling. Triage under #532."
@@ -611,24 +591,6 @@ skips:
   # regression broke the whole module — fork, interrupt, reasoning
   # effort, runner-state, repl-adapter, title-seeding all flipped
   # red together).
-  # Cluster: policy / canada classifier. Related to existing #483
-  # (prompt-policy sub-executor routing), but the regression now
-  # spans more harness parametrizations than #483 originally listed.
-  - id: tests/e2e/omnigent/test_yaml_policies.py::test_yaml_policies_blocks_canada_input[claude-sdk]
-    reason: "Force-merge backlog (canada-policy cluster, related to #483). First observed failing at ab620102 (2026-05-23T00:33:55Z, E2E)."
-    issue: 483
-    cluster: policy-guardrails
-    mode: skip
-  - id: tests/e2e/omnigent/test_yaml_policies.py::test_yaml_policies_blocks_canada_input[codex]
-    reason: "Force-merge backlog (canada-policy cluster, related to #483). First observed failing at 2fe283bf (2026-05-23T00:08:54Z, E2E)."
-    issue: 483
-    cluster: policy-guardrails
-    mode: skip
-  - id: tests/e2e/omnigent/test_yaml_policies.py::test_yaml_policies_blocks_canada_input[openai-agents]
-    reason: "Force-merge backlog (canada-policy cluster, related to #483). First observed failing at 801c389c (2026-05-23T00:35:30Z, E2E)."
-    issue: 483
-    cluster: policy-guardrails
-    mode: skip
   # Cluster: claude_coder sandbox enforcement. All 5 tests in
   # test_claude_coder_sandbox.py flipped together — suggests the
   # sandbox enforcement path or its fixture regressed.


### PR DESCRIPTION
## Summary

One-shot `omnigent run` hung forever (zero output, leaked server + runner) whenever a policy returned **DENY at the INPUT/request phase**. The INPUT-DENY short-circuit in `POST /v1/sessions/{id}/events` (`omnigent/server/routes/sessions.py`) published `running → output_text.delta → idle` but **never a terminal `response.*` event**, so the client turn loop (`chat.py` / `SessionsChat.send`) blocked forever tailing the long-lived session stream. ALLOW and tool_call-phase DENY emit a real terminal event from the runner, which is why only INPUT-DENY wedged.

Fix (+44 lines, `sessions.py` only): `_publish_input_deny_terminal` emits a synthetic terminal `response.completed` event (carrying the deny sentinel) in both INPUT-DENY branches, right before the final idle status so ordering matches a normal turn. The sentinel is still persisted to history by the existing path; this only adds the missing live-stream terminal signal. Unquarantines the 6 entries this unblocks: `test_policy_denies_input_containing_sentinel[*]` (#476) and `test_yaml_policies_blocks_canada_input[*]` (#483) — both were the same INPUT-DENY wedge via different policy types.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable


Stress run: https://github.com/omnigent-ai/omnigent/actions/runs/27733429659

## Coverage rationale

The fix is covered by the 6 e2e tests it un-quarantines plus existing unit/integration suites; no new tests were needed since the behavior already had quarantined e2e coverage that now passes.

- Live (oss / `databricks-gpt-5-4-mini`, hard timeouts): `test_policy_denies_input_containing_sentinel` and `test_yaml_policies_blocks_canada_input` INPUT-DENY now exit 0 with `[Denied by policy: ...]` on codex + openai-agents (both previously wedged past 90s); ALLOW + tool_call-DENY unchanged (no regression).
- `uv run --extra dev python -m pytest tests/runner/test_runner_policy.py tests/runtime/policies tests/server/routes/test_sessions_policy.py tests/server/integration/test_sessions_policy_evaluate_read_only.py` — all pass.
- `claude-sdk` shares this server code path (not runnable locally — `claude` is a shell alias in this env).

