### PR TITLE
chore: add stale issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
-          days-before-stale: 30
+          days-before-stale: 14
           days-before-close: 14
           stale-issue-label: stale
           stale-issue-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 30
           days-before-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
-          days-before-stale: 14
+          days-before-stale: 30
           days-before-close: 14
           stale-issue-label: stale
           stale-issue-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days with no
+            activity.
+          exempt-issue-labels: pinned,security,bug
+          stale-pr-message: ""
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/designs/issue-triage-proposal.md
+++ b/designs/issue-triage-proposal.md
@@ -62,7 +62,7 @@ Triggered on every new issue. The bot classifies, deduplicates, resolves what it
 | **`needs-info`**, reporter responds | Bot removes `needs-info`, re-adds `needs-triage`, bot re-triages | No |
 | **`needs-info`**, no response 14d | Marked `stale` → closed after 7 more days | No |
 | **`good-first-issue`** | Contributor claims via comment, starts working | No (until PR review) |
-| **Stale** (14d no activity) | Marked `stale` → closed after 14 more days | No |
+| **Stale** (30d no activity) | Marked `stale` → closed after 14 more days | No |
 | **`P0-critical` or `P1-high`** | Stays open, exempt from stale bot | **Yes - escalated** |
 | **`P2-medium` bug** with repro | Stays open for contributor pickup or maintainer prioritization | **Maybe** |
 | **Bot uncertain** | Leaves `needs-triage`, doesn't apply priority | **Yes - escalated** |
@@ -127,7 +127,7 @@ Duplicates get a 3-day grace period. Reporter can react 👎 to prevent closure.
 
 ### Decision: Stale lifecycle with exemptions
 
-14 days → stale, 14 more days → close. P0/P1, GFI, and help-wanted issues are exempt.
+30 days → stale, 14 more days → close. P0/P1, GFI, and help-wanted issues are exempt.
 
 **Why:** Prevents issue rot without losing important work. The exemption list ensures high-priority bugs and contributor-ready issues stay open. Anyone can reopen a stale-closed issue.
 

--- a/designs/issue-triage-proposal.md
+++ b/designs/issue-triage-proposal.md
@@ -62,7 +62,7 @@ Triggered on every new issue. The bot classifies, deduplicates, resolves what it
 | **`needs-info`**, reporter responds | Bot removes `needs-info`, re-adds `needs-triage`, bot re-triages | No |
 | **`needs-info`**, no response 14d | Marked `stale` → closed after 7 more days | No |
 | **`good-first-issue`** | Contributor claims via comment, starts working | No (until PR review) |
-| **Stale** (30d no activity) | Marked `stale` → closed after 14 more days | No |
+| **Stale** (14d no activity) | Marked `stale` → closed after 14 more days | No |
 | **`P0-critical` or `P1-high`** | Stays open, exempt from stale bot | **Yes - escalated** |
 | **`P2-medium` bug** with repro | Stays open for contributor pickup or maintainer prioritization | **Maybe** |
 | **Bot uncertain** | Leaves `needs-triage`, doesn't apply priority | **Yes - escalated** |
@@ -127,7 +127,7 @@ Duplicates get a 3-day grace period. Reporter can react 👎 to prevent closure.
 
 ### Decision: Stale lifecycle with exemptions
 
-30 days → stale, 14 more days → close. P0/P1, GFI, and help-wanted issues are exempt.
+14 days → stale, 14 more days → close. P0/P1, GFI, and help-wanted issues are exempt.
 
 **Why:** Prevents issue rot without losing important work. The exemption list ensures high-priority bugs and contributor-ready issues stay open. Anyone can reopen a stale-closed issue.
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that labels issues as `stale` after 14 days of inactivity and auto-closes them after another 14 days
- Uses commit-pinned `actions/stale` (v9) for supply-chain safety
- Exempts issues labeled `pinned`, `security`, or `bug`
- Does not affect PRs

## Test plan
- [ ] Verify workflow syntax is valid via Actions tab
- [ ] Optionally trigger manually via `workflow_dispatch` to confirm it runs

This pull request and its description were written by Isaac.