### PR TITLE
test: make mock-LLM integration tests correct-by-default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ markers = [
     "llm_flaky(reruns=2, reruns_delay=1): rerun a nondeterministic real-LLM test on failure, rotating to a different model each attempt (tests/_model_pools.py). Never apply to heavy e2e tests that can hit the CI --timeout=180 cap (rerun + loadscope can crash the shard).",
     "in_process_sessions: run a server integration test with the legacy in-process sessions path instead of sessions-native runner dispatch.",
     "nightly: runs only in the scheduled/dispatch pass of its suite; PR and push runs exclude it via -m 'not nightly'. Remove the marker to promote a burned-in test to the PR gate.",
+    "mock_only: tests/integration test that only works in mock-LLM mode (no --llm-api-key). Skipped by tests/integration/conftest.py when a real --llm-api-key is supplied (the real-LLM Integration jobs). Use for tests whose mock LLM is scripted with a fixed tool-call sequence — a real LLM cannot reproduce the scripted markers.",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -56,3 +56,36 @@ its own session-scoped live server, same as `tests/e2e/`).
   markers (`uuid` hex), never just "some text came back".
 - New harness? Add a nightly.yml matrix leg and extend
   `_SUPPORTED_HARNESSES` in `conftest.py`.
+
+## Mock-LLM mode (also runs in the default suite)
+
+When invoked with NO `--llm-api-key`, this directory's `--integration`
+gate is lifted (`conftest.py::pytest_collection_modifyitems`) and the
+tests run against the always-on mock LLM server instead of a real
+gateway. `using_mock_llm` is True and `_is_mock_mode(config)` is the
+signal. The same files run in TWO CI job families: `Pytest
+(integration-mock)` (mock) and `Integration (claude-sdk|codex|
+openai-agents)` (real LLM, passes `--llm-api-key`).
+
+Two rules keep the two modes correct:
+
+- **`mock_only` marker** — tests whose mock LLM is scripted with a
+  fixed tool-call sequence (e.g. the scripted server→client round-trip
+  tests) CANNOT run against a real LLM: it would 401 on the mock base
+  URL and could never reproduce the scripted call_ids/markers. Mark
+  those modules `pytestmark = pytest.mark.mock_only`; the central gate
+  in `conftest.py` skips them when a real `--llm-api-key` is supplied.
+  Do NOT mark dual-mode journeys (`test_smoke` / `test_multi_turn` /
+  `test_sharing` / `test_client_tools`) — they use the `default` queue
+  and are designed to run in both modes.
+  - A `if mock_llm_server_url is None: pytest.skip(...)` guard inside a
+    test body is DEAD CODE: the `mock_llm_server_url` fixture is "always
+    started regardless of --llm-api-key", so it never yields `None` and
+    the skip never fires. Use the `mock_only` marker, not that guard.
+- **Central queue reset** — `conftest.py` has an autouse,
+  function-scoped `_reset_mock_llm_between_tests` fixture that clears the
+  shared (session-scoped) mock server queues before and after every
+  test. The mock server falls back to a default response when a queue is
+  exhausted or keyed for another agent, so without this reset a scripted
+  test leaks responses into its siblings. Do NOT add a per-file reset
+  fixture — the central one covers the whole directory.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,7 @@ of this package.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 import httpx
@@ -38,6 +39,7 @@ from tests.e2e.conftest import (  # noqa: F401  (re-exported pytest fixtures)
     llm_api_key,
     mock_llm_server_url,
     register_inline_agent,
+    reset_mock_llm,
     using_mock_llm,
 )
 from tests.integration.model_selection import resolve_default_model
@@ -82,9 +84,57 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         for item in items:
             item.add_marker(marker)
         return
+    # Gate ``mock_only`` tests out of the real-LLM Integration jobs. The
+    # only correct signal for "mock mode" is the absence of a real
+    # ``--llm-api-key`` (``_is_mock_mode`` / the ``using_mock_llm``
+    # fixture). The ``mock_llm_server_url`` fixture is "always started
+    # regardless of --llm-api-key" so a ``mock_llm_server_url is None``
+    # guard inside a test is dead code that never skips. Scripted
+    # tool-call tests (fixed mock queue) cannot run against a real LLM,
+    # which would 401 on the mock base URL or fail the scripted-marker
+    # assertions; skip them centrally here instead.
+    if not _is_mock_mode(config):
+        skip_mock_only = pytest.mark.skip(
+            reason="mock_only test: requires mock-LLM mode (no --llm-api-key)"
+        )
+        for item in items:
+            if item.get_closest_marker("mock_only") is not None:
+                item.add_marker(skip_mock_only)
     if config.getoption("--harness") == "codex":
         for item in items:
             item.add_marker(pytest.mark.flaky(reruns=2, reruns_delay=5))
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _reset_mock_llm_between_tests(
+    mock_llm_server_url: str | None,  # noqa: F811
+) -> Iterator[None]:
+    """Clear the shared mock-LLM queues before and after every test.
+
+    The ``mock_llm_server_url`` fixture is session-scoped: the mock
+    server's keyed response queues, captured requests, and gates
+    persist across every test in a shard. ``_ResponseQueue.next()``
+    silently returns a default ``"Mock LLM response"`` when exhausted
+    and ``resolve_queue`` falls back to the ``"default"`` queue on a key
+    miss, so a queue left non-empty (or keyed for another agent) by one
+    test leaks scripted responses into its siblings — the recurring
+    cause of ``test_smoke`` / ``test_multi_turn`` / ``test_sharing``
+    breaking when run alongside the scripted round-trip tests.
+
+    Resetting before *and* after each test makes every integration test
+    start from a clean queue without a per-file opt-in fixture.
+    ``reset_mock_llm`` is a no-op when the URL is ``None`` (real-LLM
+    mode never starts the server fixture lazily) and the server is
+    always up in mock mode, so calling it unconditionally is safe in
+    both modes.
+
+    :param mock_llm_server_url: Mock server URL, or ``None`` in real mode.
+    """
+    reset_mock_llm(mock_llm_server_url)
+    try:
+        yield
+    finally:
+        reset_mock_llm(mock_llm_server_url)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_d6_async_cancel_round_trip.py
+++ b/tests/integration/test_d6_async_cancel_round_trip.py
@@ -54,6 +54,16 @@ import pytest
 from tests.e2e.conftest import configure_mock_llm, send_user_message_to_session
 from tests.integration.conftest import JourneySession
 
+# The mock LLM is scripted with a fixed tool-call sequence, so these
+# tests cannot run against a real LLM (it would 401 on the mock base URL
+# and could never reproduce the scripted call_ids/markers). The central
+# gate in ``tests/integration/conftest.py`` skips ``mock_only`` tests
+# when a real ``--llm-api-key`` is supplied (the real-LLM Integration
+# jobs). This replaces the dead ``if mock_llm_server_url is None: skip``
+# guards: that fixture is always started regardless of --llm-api-key, so
+# the guard never fired in any job.
+pytestmark = pytest.mark.mock_only
+
 _COMPUTE_TOOL: dict[str, Any] = {
     "type": "function",
     "function": {
@@ -141,9 +151,6 @@ def test_client_tool_round_trip(
     full server->client round-trip the SSE-parser unit tests
     never reach.
     """
-    if mock_llm_server_url is None:
-        pytest.skip("requires the mock LLM server (mock mode)")
-
     marker = f"D6-ROUND-TRIP-{uuid.uuid4().hex[:8]}"
     call_id = f"call_{uuid.uuid4().hex[:8]}"
     sid = journey_session.session_id
@@ -268,9 +275,6 @@ def test_direct_cancel_parks_then_interrupts_cleanly(
     sessions surface the runner synthesizes the idle terminal +
     history instead, and that synthesized shape is what clients see.
     """
-    if mock_llm_server_url is None:
-        pytest.skip("requires the mock LLM server (mock mode)")
-
     call_id = f"call_{uuid.uuid4().hex[:8]}"
     sid = journey_session.session_id
 


### PR DESCRIPTION
## Summary

Makes mock-LLM integration tests (`tests/integration/`) **correct-by-default**, fixing two systemic bugs that have broken multiple PRs. No production code changes.

- **Bug B — mock-only tests ran against the real LLM and failed (401/404).** The old per-test guard `if mock_llm_server_url is None: pytest.skip(...)` was **dead code**: the `mock_llm_server_url` fixture is started unconditionally and is *never* `None` (`tests/e2e/conftest.py`), so it never skipped in any job. In the `Integration (claude-sdk|codex|openai-agents)` jobs (`--llm-api-key` present → `_is_mock_mode` False) the scripted tests hit the real gateway and failed. **Fix:** a centralized `mock_only` marker + a `pytest_collection_modifyitems` gate in `tests/integration/conftest.py` that skips marked tests when `not _is_mock_mode(config)` — the correct `using_mock_llm` signal.
- **Bug A — shared mock-LLM state contaminated sibling tests.** The session-scoped mock server silently falls back to a `default` "Mock LLM response" queue, so unconsumed/leftover scripted responses leaked to later tests in the shard. Only one test file opted into a reset fixture. **Fix:** a centralized `@pytest.fixture(autouse=True, scope="function")` reset in `tests/integration/conftest.py` that calls `reset_mock_llm` before & after every integration test (no-op when the URL is `None`).

ELI5: the old "am I in mock mode?" check always answered "yes" so it never protected anything, and tests left their toy phone off the hook for the next test to pick up. This adds one real check and hangs up the phone after every call — in one place, so no test author has to remember.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Infra/harness change; verified by running the affected suite in both modes and a contamination repro:

- **Mock mode, full shard:** `uv run pytest tests/integration -v` → all pass, nothing newly skipped.
- **Real-LLM gate (no real key needed):** `uv run pytest tests/integration -v --llm-api-key dummy --integration --harness openai-agents` → the `mock_only` tests **SKIP**; the dual-mode tests (`test_smoke`/`test_multi_turn`/`test_sharing`/`test_client_tools`) are **not** skipped by the marker (they fail only on the dummy key's 404, which is expected — they are meant to run against a real gateway). 0 collection errors.
- **Contamination, mixed order, 3×:** `uv run pytest tests/integration/test_d6_async_cancel_round_trip.py tests/integration/test_smoke.py tests/integration/test_multi_turn.py tests/integration/test_sharing.py -p no:randomly -v` → all pass each run, proving the central autouse reset works even after removing `test_d6_async_cancel_round_trip.py`'s former per-file reset.
- `ruff check` + `ruff format --check` clean.

**Scope notes:** `mock_llm_server.py` is intentionally **unchanged** — making the mock queue "fail loud" on an exhausted/unmatched keyed queue is a deliberate follow-up (wider blast radius). Marker applied to `test_d6_async_cancel_round_trip.py` only on `main`; the in-flight re-home PRs (#592, #594) adopt `pytestmark = pytest.mark.mock_only` and drop their dead `mock_llm_server_url is None` guards + per-file reset fixtures on rebase (documented in `tests/integration/AGENTS.md`).
