### PR TITLE
docs: fix SDK README paths

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -9,14 +9,13 @@ sdks/
   python-client/           # Headless HTTP/SSE client
     pyproject.toml
     omnigent_client/    # import omnigent_client
-  frontend/                # Terminal UI layer (Rich + prompt_toolkit)
+  ui/                      # Terminal UI layer (Rich + prompt_toolkit)
     pyproject.toml
     omnigent_ui_sdk/    # import omnigent_ui_sdk
       terminal/
 ```
 
-Claude Code skills for SDK development live in the top-level `skills/`
-directory (e.g. `skills/repl-sdk/`).
+Claude Code skills for SDK development live under `.claude/skills/`.
 
 ## `omnigent_client` — the headless client
 
@@ -96,7 +95,7 @@ Provides:
 ### Install
 
 ```bash
-pip install -e sdks/frontend
+pip install -e sdks/ui
 ```
 
 (Pulls in `omnigent-client` as a dependency.)
@@ -166,10 +165,3 @@ stream = pipe(
 The built-in REPL at `omnigent/repl/` demonstrates all features:
 streaming, tool calls, reasoning, slash commands, conversation
 switching, elapsed timer. See `omnigent/repl/_repl.py`.
-
-## Design Documents
-
-- `designs/CLIENT_AND_REPL.md` — client library + REPL design
-- `designs/STREAM_RENDERER.md` — block stream design
-- `designs/FRONTEND_SDK_LAYERS.md` — three-layer architecture
-- `designs/FRONTEND_SDK_V2.md` — blocks with context, transforms


### PR DESCRIPTION
## Summary

- Fix `sdks/README.md` to reference the current `sdks/ui` package path instead of the removed `sdks/frontend` path.
- Point SDK development skills at the actual `.claude/skills/` directory and remove stale design-doc links that no longer exist in the repo.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Docs-only change. Verified with:

- `rg -n "sdks/frontend|frontend/|skills/repl-sdk|CLIENT_AND_REPL|STREAM_RENDERER|FRONTEND_SDK" sdks/README.md || true`
- `git diff --check`
- `npx --yes prettier@3.6.2 --check sdks/README.md`
