### PR TITLE
Revert "feat(new-chat): fold Advanced settings into the agent picker as a slide-in sub-page"

### DIFF
--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -477,14 +477,13 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the agent picker (Radix opens on pointerdown), slide into Advanced
-    // settings, and pick a non-default mode. The create call proves the choice
-    // travels as a `--permission-mode <mode>` pair in terminal_launch_args.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    // Open the footer tray's Advanced menu (Radix opens on pointerdown) and
+    // pick a non-default mode. The create call proves the choice travels as
+    // a `--permission-mode <mode>` pair in terminal_launch_args.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-permission-bypassPermissions"));
     // A non-default pick is suffixed onto the pill so the changed mode
-    // stays visible while the radios live in the Advanced settings sub-page.
+    // stays visible while the radios live in the Advanced menu.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
       "Claude Code (Bypass permissions)",
     );
@@ -535,9 +534,8 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the agent picker, step into Advanced settings, and pick "Full access".
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    // Open the footer tray's Advanced menu and pick "Full access".
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-access"));
     // A non-default pick is suffixed onto the pill.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
@@ -577,9 +575,9 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toBeUndefined();
   });
 
-  it("posts harness_override when a brain harness is picked from the Advanced sub-page", async () => {
-    // polly's spec declares claude-sdk; the Advanced settings sub-page offers
-    // the override set.
+  it("posts harness_override when a brain harness is picked from the Advanced menu", async () => {
+    // polly's spec declares claude-sdk; the Advanced menu offers the
+    // override set.
     setAgents([
       agent({ id: "ag_polly", name: "polly", display_name: "Polly", harness: "claude-sdk" }),
     ]);
@@ -590,9 +588,8 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the agent picker, slide into Advanced settings, and pick Pi.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    // Open the footer tray's Advanced menu and pick Pi.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-pi"));
     // The composer pill reflects the pick before any session exists.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Polly (Pi)");
@@ -620,7 +617,7 @@ describe("NewChatLandingScreen create flow", () => {
     renderLanding();
     await waitForWorkspaceSeed();
     // With no explicit pick the pill shows just the agent name — the spec
-    // default is not suffixed (it lives in the Advanced settings sub-page).
+    // default is not suffixed (it lives in the Advanced menu's radios).
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Polly");
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).not.toContain(
       "Claude SDK",
@@ -647,14 +644,10 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Pick Pi, then change mind back to the spec default (Claude SDK). Each
-    // radio pick closes the menu, so reopen and re-enter Advanced settings in
-    // between.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    // Pick Pi, then change mind back to the spec default (Claude SDK).
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-pi"));
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-claude-sdk"));
     typeMessage("go");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -658,15 +658,14 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-connect-host")).toBeTruthy();
   });
 
-  it("shows permission-mode options in the Advanced sub-page only for the claude-native agent", () => {
+  it("shows permission-mode options in the Advanced menu only for the claude-native agent", () => {
     renderLanding();
-    // The radios live behind the agent picker's "Advanced settings" row —
-    // absent until the menu opens.
+    // The radios live behind the footer tray's Advanced chip — absent
+    // until the menu opens.
     expect(screen.queryByTestId("new-chat-landing-permission-plan")).toBeNull();
-    // a1 (Claude Code, claude-native) is the default agent → the picker
-    // surfaces an "Advanced settings" row that slides to the permission radios.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    // a1 (Claude Code, claude-native) is the default agent → the footer
+    // tray surfaces the Advanced chip with the permission-mode radios.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     const planOption = screen.getByTestId("new-chat-landing-permission-plan");
     expect(planOption.textContent).toContain("Plan");
     // The footer line explains the SELECTED mode until a row is hovered —
@@ -676,20 +675,21 @@ describe("NewChatLandingScreen", () => {
     expect(detail.textContent).toContain("Prompts before edits and commands");
     fireEvent.pointerEnter(planOption);
     expect(detail.textContent).toContain("Plans only; makes no edits");
-    // Slide back to the agent list, then switch to Codex (a2: codex-native).
-    // Codex has Advanced settings too, so the picker stays open and its
-    // "Advanced settings" row remains available (now for approval modes).
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-back"));
-    fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
-    expect(screen.queryByTestId("new-chat-landing-advanced-entry")).not.toBeNull();
-  });
-
-  it("shows approval-mode options in the Advanced sub-page for the codex-native agent", () => {
-    renderLanding();
-    // Switch to Codex first; it keeps the menu open (it has Advanced settings).
+    // Switch to Codex (a2: codex-native) — the Advanced chip stays visible
+    // but now shows approval-mode radios instead of permission-mode radios.
+    // Close the Advanced menu first (Escape), then switch agents.
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
-    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
+    expect(screen.queryByTestId("new-chat-landing-advanced-chip")).not.toBeNull();
+  });
+
+  it("shows approval-mode options in the Advanced menu for the codex-native agent", () => {
+    renderLanding();
+    // Switch to Codex first.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
     const fullAccessOption = screen.getByTestId("new-chat-landing-approval-full-access");
     expect(fullAccessOption.textContent).toContain("Full access");
     // The footer line explains the SELECTED mode until a row is hovered.

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -6,8 +6,6 @@ import {
   MonitorCloudIcon,
   CircleHelpIcon,
   ChevronDownIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
   GitBranchIcon,
   ArrowUpIcon,
   FileTextIcon,
@@ -563,8 +561,8 @@ function PermissionModeOptions({
             onPointerEnter={() => setPreviewed(mode.value)}
             // pl only — the kit's pr-8 reserves room for the
             // absolutely-positioned check.
-            // text-sm for legibility in the Advanced menu.
-            className="rounded-sm pl-2 py-1 text-sm"
+            // text-xs matches the other footer-tray menus (host picker).
+            className="rounded-sm pl-2 py-1 text-xs"
           >
             {mode.label}
           </DropdownMenuRadioItem>
@@ -575,7 +573,7 @@ function PermissionModeOptions({
         data-testid="new-chat-landing-permission-detail"
         // One reserved line, not two: reserving the longest blurb's wrapped
         // second line left a permanent blank row under one-line blurbs.
-        className="min-h-5 px-2 pt-0.5 pb-1 text-sm leading-relaxed text-muted-foreground"
+        className="min-h-5 px-2 pt-0.5 pb-1 text-xs leading-relaxed text-muted-foreground"
       >
         {detail}
       </p>
@@ -612,7 +610,7 @@ function ApprovalModeOptions({
             data-testid={`new-chat-landing-approval-${mode.value}`}
             onFocus={() => setPreviewed(mode.value)}
             onPointerEnter={() => setPreviewed(mode.value)}
-            className="rounded-sm pl-2 py-1 text-sm"
+            className="rounded-sm pl-2 py-1 text-xs"
           >
             {mode.label}
           </DropdownMenuRadioItem>
@@ -621,7 +619,7 @@ function ApprovalModeOptions({
       <DropdownMenuSeparator />
       <p
         data-testid="new-chat-landing-approval-detail"
-        className="min-h-5 px-2 pt-0.5 pb-1 text-sm leading-relaxed text-muted-foreground"
+        className="min-h-5 px-2 pt-0.5 pb-1 text-xs leading-relaxed text-muted-foreground"
       >
         {detail}
       </p>
@@ -649,7 +647,7 @@ function BrainHarnessOptions({
 }) {
   return (
     <>
-      <div className="px-2 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground">
+      <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
         Agent Harness
       </div>
       <DropdownMenuRadioGroup value={value} onValueChange={onValueChange}>
@@ -660,8 +658,8 @@ function BrainHarnessOptions({
             data-testid={`new-chat-landing-harness-${id}`}
             // pl only — the kit's pr-8 reserves room for the
             // absolutely-positioned check.
-            // text-sm for legibility in the Advanced menu.
-            className="rounded-sm pl-2 py-1 text-sm"
+            // text-xs matches the other footer-tray menus (host picker).
+            className="rounded-sm pl-2 py-1 text-xs"
           >
             <span className="flex-1">{label}</span>
             {harnessUnconfiguredOnHost(id, host) && (
@@ -677,26 +675,6 @@ function BrainHarnessOptions({
         ))}
       </DropdownMenuRadioGroup>
     </>
-  );
-}
-
-/**
- * True when ``agent`` exposes per-agent knobs in the picker's Advanced
- * settings sub-page: an overridable brain harness (bundle agents like
- * polly / debby), Claude Code's permission mode, or Codex's approval mode.
- *
- * Drives both the "Advanced settings" row's visibility and whether picking
- * the agent keeps the menu open (so the user can step into the sub-page)
- * instead of closing it like a plain agent pick.
- */
-function agentHasAdvancedSettings(
-  agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
-): boolean {
-  const hasOverridableHarness = agent?.harness != null && agent.harness in BRAIN_HARNESS_LABELS;
-  return (
-    hasOverridableHarness ||
-    nativeAgentHasCapability(agent, "permissionMode") ||
-    nativeAgentHasCapability(agent, "approvalMode")
   );
 }
 
@@ -844,15 +822,6 @@ export function NewChatLandingScreen() {
   const [createError, setCreateError] = useState<string | null>(null);
   // "Connect a host" instructions modal, opened from the host dropdown.
   const [connectOpen, setConnectOpen] = useState(false);
-
-  // Agent picker dropdown. Controlled so picking an agent that has Advanced
-  // settings can keep the menu open instead of dismissing it. `agentMenuView`
-  // swaps the popover's contents in place between the agent list and the
-  // selected agent's Advanced settings — one surface, so it works on mobile
-  // (no off-screen flyout). Only the active view is mounted, so the popover
-  // auto-sizes to it and its items are the only ones in the focus order.
-  const [agentMenuOpen, setAgentMenuOpen] = useState(false);
-  const [agentMenuView, setAgentMenuView] = useState<"agents" | "advanced">("agents");
 
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
 
@@ -1104,16 +1073,13 @@ export function NewChatLandingScreen() {
         key={agent.id}
         data-testid={`new-chat-landing-agent-${agent.id}`}
         data-active={agent.id === effectiveAgentId ? "true" : undefined}
-        onSelect={(e) => {
+        onSelect={() => {
           // Switching agents drops the harness override so a
           // pick never leaks across agents.
           if (agent.id !== effectiveAgentId) setPickedHarness(null);
           setPickedAgentId(agent.id);
           // Explicit picks persist; auto-defaults never do.
           writeLastAgentId(agent.id);
-          // Agents with Advanced settings keep the menu open so the user
-          // can step into the sub-view; plain agents close on pick.
-          if (agentHasAdvancedSettings(agent)) e.preventDefault();
         }}
         className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
       >
@@ -1147,15 +1113,6 @@ export function NewChatLandingScreen() {
       </DropdownMenuItem>
     );
   };
-
-  // Never strand the user on an empty Advanced page: if the selected agent
-  // loses its knobs (e.g. the agent list refreshes and it disappears), fall
-  // back to the agent list.
-  useEffect(() => {
-    if (agentMenuView === "advanced" && !agentHasAdvancedSettings(selectedAgent)) {
-      setAgentMenuView("agents");
-    }
-  }, [agentMenuView, selectedAgent]);
 
   function selectHost(hostId: string) {
     // Re-selecting the current host is a no-op. Clearing the workspace here
@@ -1303,8 +1260,8 @@ export function NewChatLandingScreen() {
     // the hero reads better optically.
     <div className="flex flex-1 items-center justify-center" data-testid="new-chat-landing">
       {/* Padding lives inside the 840px cap, so the composer renders at
-          840 − 32 = 808px max; the parent flex centers it on wider screens. */}
-      <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-4 pt-8 pb-16">
+          840 − 80 = 760px max. */}
+      <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-10 pt-8 pb-16">
         <div className="flex flex-col items-center gap-3.5 sm:flex-row">
           <OttoEyes className="h-18 w-auto shrink-0" />
           <h1 className="text-center text-3xl font-medium tracking-[-0.03em] text-foreground sm:text-left">
@@ -1516,14 +1473,7 @@ export function NewChatLandingScreen() {
                   <IntelligentModelControl value={costControlMode} onChange={setCostControlMode} />
                 )}
                 {agentList.length > 0 ? (
-                  <DropdownMenu
-                    open={agentMenuOpen}
-                    onOpenChange={(open) => {
-                      setAgentMenuOpen(open);
-                      // Always reopen on the agent list, never on the Advanced view.
-                      if (!open) setAgentMenuView("agents");
-                    }}
-                  >
+                  <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
                         type="button"
@@ -1538,115 +1488,26 @@ export function NewChatLandingScreen() {
                         <ChevronDownIcon className="size-3.5 opacity-60" />
                       </Button>
                     </DropdownMenuTrigger>
-                    {/* side=bottom documents the intent: a short agent list
-                        that should always drop downward like the other composer
-                        menus. The contents swap in place between the agent list
-                        and the selected agent's Advanced settings — only the
-                        active view is mounted, so the popover sizes to it. */}
+                    {/* side=bottom documents the intent: the menu is a short
+                        agent list (harness / permission settings live in the
+                        footer tray's Advanced menu), so it should always drop
+                        downward like the other composer menus. */}
                     <DropdownMenuContent
                       align="end"
                       side="bottom"
-                      className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
+                      className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
                     >
-                      {agentMenuView === "advanced" ? (
-                        <>
-                          {/* Advanced settings for the selected agent: the
-                              brain-harness override (bundle agents), Claude Code's
-                              permission mode, and Codex's approval mode. */}
-                          <DropdownMenuItem
-                            data-testid="new-chat-landing-advanced-back"
-                            onSelect={(e) => {
-                              // Step back to the list instead of closing the menu.
-                              e.preventDefault();
-                              setAgentMenuView("agents");
-                            }}
-                            className="gap-1.5 rounded-sm px-2 py-1.5 text-sm font-medium"
-                          >
-                            <ChevronLeftIcon className="size-4 shrink-0 opacity-70" />
-                            <span>Back</span>
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          {selectedAgentDefaultHarness != null && (
-                            <BrainHarnessOptions
-                              value={pickedHarness ?? selectedAgentDefaultHarness}
-                              onValueChange={(h) =>
-                                // Picking the spec default clears the override so
-                                // the session tracks the spec.
-                                setPickedHarness(h === selectedAgentDefaultHarness ? null : h)
-                              }
-                              host={harnessWarningHost}
-                            />
-                          )}
-                          {/* Permission mode (Claude Code only) — claude-native
-                            has no overridable harness, so the two sections never
-                            co-render today; the separator covers a future agent
-                            with both. */}
-                          {supportsPermissionMode && (
-                            <>
-                              {selectedAgentDefaultHarness != null && <DropdownMenuSeparator />}
-                              <div className="px-2 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground">
-                                Permission mode
-                              </div>
-                              <PermissionModeOptions
-                                value={permissionMode}
-                                onValueChange={setPermissionMode}
-                              />
-                            </>
-                          )}
-                          {/* Approval mode (Codex only) — codex-native has no
-                            overridable harness, so the two sections never
-                            co-render today; the separator covers a future agent
-                            with both. */}
-                          {supportsApprovalMode && (
-                            <>
-                              {(selectedAgentDefaultHarness != null || supportsPermissionMode) && (
-                                <DropdownMenuSeparator />
-                              )}
-                              <div className="px-2 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground">
-                                Approval mode
-                              </div>
-                              <ApprovalModeOptions
-                                value={approvalMode}
-                                onValueChange={setApprovalMode}
-                              />
-                            </>
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          {/* Built-in agents first, then a divider, then any
-                              custom (user-registered) agents. renderAgentRow is
-                              defined once and reused for both groups. The divider
-                              only renders when BOTH groups are non-empty, so a
-                              deployment with only custom agents (or only built-ins)
-                              never shows a leading/dangling separator. */}
-                          {builtinAgents.map((agent) => renderAgentRow(agent))}
-                          {builtinAgents.length > 0 && customAgents.length > 0 && (
-                            <DropdownMenuSeparator />
-                          )}
-                          {customAgents.map((agent) => renderAgentRow(agent))}
-                          {/* Advanced settings entry — only for the selected agent
-                              that exposes knobs. Swaps to the Advanced view rather
-                              than closing the menu. */}
-                          {agentHasAdvancedSettings(selectedAgent) && (
-                            <>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                data-testid="new-chat-landing-advanced-entry"
-                                onSelect={(e) => {
-                                  e.preventDefault();
-                                  setAgentMenuView("advanced");
-                                }}
-                                className="gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground"
-                              >
-                                <SettingsIcon className="size-4 shrink-0 opacity-70" />
-                                <span className="flex-1">Advanced settings</span>
-                                <ChevronRightIcon className="size-3.5 shrink-0 opacity-60" />
-                              </DropdownMenuItem>
-                            </>
-                          )}
-                        </>
+                      {/* Built-in agents first, then a divider, then any
+                          custom (user-registered) agents. renderAgentRow is
+                          defined once and reused for both groups. The divider
+                          only renders when BOTH groups are non-empty, so a
+                          deployment with only custom agents (or only built-ins)
+                          never shows a leading/dangling separator. */}
+                      {builtinAgents.map((agent) => renderAgentRow(agent))}
+                      {builtinAgents.length > 0 && customAgents.length > 0 && (
+                        <DropdownMenuSeparator />
                       )}
+                      {customAgents.map((agent) => renderAgentRow(agent))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 ) : (
@@ -1961,6 +1822,73 @@ export function NewChatLandingScreen() {
                     </div>
                   </PopoverContent>
                 </Popover>
+              )}
+
+              {/* Advanced settings chip — per-agent knobs that don't warrant
+                their own chip: the brain-harness override (bundle agents),
+                Claude Code's permission mode, and Codex's approval mode.
+                Hidden when the selected agent has none. */}
+              {(selectedAgentDefaultHarness != null ||
+                supportsPermissionMode ||
+                supportsApprovalMode) && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex h-6 items-center gap-1.5 rounded-full px-3 text-13 font-normal text-muted-foreground transition-colors hover:text-foreground"
+                      data-testid="new-chat-landing-advanced-chip"
+                    >
+                      <SettingsIcon className="size-4 shrink-0" />
+                      <span className="truncate">Advanced</span>
+                      <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="start"
+                    className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
+                  >
+                    {selectedAgentDefaultHarness != null && (
+                      <BrainHarnessOptions
+                        value={pickedHarness ?? selectedAgentDefaultHarness}
+                        onValueChange={(h) =>
+                          // Picking the spec default clears the override so the
+                          // session tracks the spec.
+                          setPickedHarness(h === selectedAgentDefaultHarness ? null : h)
+                        }
+                        host={harnessWarningHost}
+                      />
+                    )}
+                    {/* Permission mode (Claude Code only) — claude-native has no
+                      overridable harness, so the two sections never co-render
+                      today; the separator covers a future agent with both. */}
+                    {supportsPermissionMode && (
+                      <>
+                        {selectedAgentDefaultHarness != null && <DropdownMenuSeparator />}
+                        <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
+                          Permission mode
+                        </div>
+                        <PermissionModeOptions
+                          value={permissionMode}
+                          onValueChange={setPermissionMode}
+                        />
+                      </>
+                    )}
+                    {/* Approval mode (Codex only) — codex-native has no
+                      overridable harness, so the two sections never co-render
+                      today; the separator covers a future agent with both. */}
+                    {supportsApprovalMode && (
+                      <>
+                        {(selectedAgentDefaultHarness != null || supportsPermissionMode) && (
+                          <DropdownMenuSeparator />
+                        )}
+                        <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
+                          Approval mode
+                        </div>
+                        <ApprovalModeOptions value={approvalMode} onValueChange={setApprovalMode} />
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
             </div>
           </div>

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -328,10 +328,8 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
                 state="visible", timeout=30_000
             )
             # Claude Code auto-selects (only built-in, ranked first), so the
-            # agent picker's Advanced settings entry — gated on the
-            # Claude-native agent — is present; open the picker and slide in.
-            await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await page.get_by_test_id("new-chat-landing-advanced-entry").click()
+            # Advanced chip — gated on the Claude-native agent — is present.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
             # All six Claude permission modes render as radio rows.
             for mode in ("default", "auto", "acceptEdits", "plan", "dontAsk", "bypassPermissions"):
                 await expect(
@@ -405,11 +403,9 @@ async def _drive_approval_mode(base_url: str, session_id: str) -> None:
             await page.get_by_test_id("new-chat-landing-input").wait_for(
                 state="visible", timeout=30_000
             )
-            # Codex auto-selects (only built-in), so the agent picker's Advanced
-            # settings entry — gated on the Codex-native agent — is present;
-            # open the picker and step in.
-            await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await page.get_by_test_id("new-chat-landing-advanced-entry").click()
+            # Codex auto-selects (only built-in), so the Advanced chip —
+            # gated on the Codex-native agent — is present.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
             # All three Codex approval presets render as radio rows.
             for mode in ("default", "full-access", "read-only"):
                 await expect(
@@ -496,11 +492,9 @@ async def _drive_select_harness(base_url: str, session_id: str) -> None:
             await page.get_by_test_id("new-chat-landing-input").wait_for(
                 state="visible", timeout=30_000
             )
-            # Polly auto-selects (ranked ahead of Debby), so the agent picker's
-            # Advanced settings entry — present because Polly declares a harness
-            # — opens the harness group; open the picker and slide in.
-            await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await page.get_by_test_id("new-chat-landing-advanced-entry").click()
+            # Polly auto-selects (ranked ahead of Debby), so the Advanced chip —
+            # present because Polly declares a harness — opens the harness group.
+            await page.get_by_test_id("new-chat-landing-advanced-chip").click()
             # All four brain harnesses render as radio rows, in registry order.
             for harness in ("claude-sdk", "openai-agents", "codex", "pi"):
                 await expect(
@@ -1024,13 +1018,8 @@ async def _drive_fork_of_fork_dedup(base_url: str, session_id: str) -> None:
             await expect(page.get_by_test_id("new-chat-landing-agent-ag_forkfork")).to_have_count(
                 0
             )
-            # Exactly two AGENT rows: the built-in + the one custom agent — no
-            # duplicate "Claude Code" sneaks in via a leaked clone. Scoped to
-            # the agent rows (the "ag_" id prefix) so the picker's "Advanced
-            # settings" entry — a sibling menuitem for the auto-selected Claude
-            # Code agent — doesn't inflate the count.
-            await expect(
-                page.locator('[data-testid^="new-chat-landing-agent-ag_"]')
-            ).to_have_count(2)
+            # Exactly two options total: the built-in + the one custom agent —
+            # no duplicate "Claude Code" sneaks in via a leaked clone.
+            await expect(page.get_by_role("menuitem")).to_have_count(2)
         finally:
             await browser.close()


### PR DESCRIPTION
Reverts omnigent-ai/omnigent#393

Revert this for now and pend it post 0.2.0 release, since I feel the design causes some friction that users need to click outside again to make the dropdown disappears