### PR TITLE
feat(ci): auto-close duplicate PRs referencing the same issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,22 @@
 <!--
 For AI-written descriptions:
-- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
+- Follow this template (Related issue, Summary, Type of change, Test coverage, Coverage rationale).
 - Keep it concise; reviewers skim long descriptions.
 - For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
 - Leave every checkbox in place. The PR Template check fails if required sections
   or checkbox rows are removed.
 -->
+
+## Related issue
+
+<!--
+Link the issue this PR addresses with a closing keyword so GitHub auto-links it
+(and closes it on merge): e.g. `Closes #123`. One issue per PR -- if another open
+PR already closes the same issue, the newer one is auto-closed as a duplicate.
+Use `N/A` for chores/docs with no associated issue.
+-->
+
+Closes #
 
 ## Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,10 @@ For AI-written descriptions:
 
 <!--
 Link the issue this PR addresses with a closing keyword so GitHub auto-links it
-(and closes it on merge): e.g. `Closes #123`. One issue per PR -- if another open
-PR already closes the same issue, the newer one is auto-closed as a duplicate.
-Use `N/A` for chores/docs with no associated issue.
+(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
+still-open community PR already closes the same issue, the newer one may be
+auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
+chores/docs with no associated issue.
 -->
 
 Closes #

--- a/.github/workflows/duplicate-prs-test.yml
+++ b/.github/workflows/duplicate-prs-test.yml
@@ -1,0 +1,31 @@
+name: Duplicate PRs Test
+
+# Offline unit test for the duplicate-PR-closing logic: runs
+# duplicate-prs.test.js (mocked GitHub client, no network). Triggers only when
+# the script or its test change. Runs on `pull_request` (PR head checkout) so it
+# tests the PR's own version. No secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/duplicate-prs.js
+      - .github/workflows/duplicate-prs.test.js
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: duplicate-prs-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run duplicate-PR unit test
+        run: node .github/workflows/duplicate-prs.test.js

--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -130,8 +130,12 @@ module.exports = async ({ context, github }) => {
 
       console.log(`Issue #${issueNumber} has ${prs.length} PRs`);
 
-      // Sort PRs by creation date (oldest first).
-      prs.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+      // Sort PRs by creation date (oldest first). Break ties on PR number
+      // (lower = opened earlier) so "keep the oldest" is deterministic when two
+      // PRs share a createdAt timestamp.
+      prs.sort(
+        (a, b) => new Date(a.createdAt) - new Date(b.createdAt) || a.number - b.number
+      );
 
       // Keep the oldest PR, close the rest as duplicates.
       const [keeper, ...duplicates] = prs;
@@ -157,11 +161,13 @@ module.exports = async ({ context, github }) => {
           labels: [DUPLICATE_LABEL],
         });
 
+        // pr.author is null for deleted/ghost accounts; fall back gracefully.
+        const author = pr.author?.login ?? "contributor";
         await github.rest.issues.createComment({
           owner,
           repo,
           issue_number: pr.number,
-          body: duplicateMessage(pr.author.login, issueNumber, keeper.number),
+          body: duplicateMessage(author, issueNumber, keeper.number),
         });
 
         closedCount++;

--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -1,0 +1,179 @@
+// Close duplicate community PRs that reference (close) the same issue.
+// Only considers open PRs created in the last 14 days. For each issue with
+// more than one such PR, the oldest PR is kept and the newer ones are closed,
+// labeled `duplicate`, and commented on. Maintainer-authored PRs are ignored.
+// Ported from mlflow/mlflow's .github/workflows/duplicate-prs.js.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DAYS_TO_CONSIDER = 14;
+const DUPLICATE_LABEL = "duplicate";
+
+const duplicateMessage = (author, issueNumber, keeperPR) =>
+  `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). Closing as a duplicate.`;
+
+// GraphQL query to fetch open PRs created in the search window.
+const QUERY = `
+  query($cursor: String, $searchQuery: String!) {
+    rateLimit { remaining resetAt }
+    search(query: $searchQuery, type: ISSUE, first: 50, after: $cursor) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        ... on PullRequest {
+          number
+          createdAt
+          url
+          author { login }
+          authorAssociation
+          labels(first: 20) { nodes { name } }
+          closingIssuesReferences(first: 10) {
+            nodes {
+              number
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const shouldProcessPR = (pr) => {
+  // Only process community PRs (skip maintainer / collaborator PRs).
+  const memberAssociations = ["MEMBER", "OWNER", "COLLABORATOR"];
+  if (memberAssociations.includes(pr.authorAssociation)) {
+    return false;
+  }
+  // Skip PRs already labeled as duplicate.
+  const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
+  if (labels.includes(DUPLICATE_LABEL)) return false;
+  return true;
+};
+
+const getIssueReferences = (pr) => {
+  const references = pr.closingIssuesReferences?.nodes || [];
+  return references.map((node) => node.number);
+};
+
+module.exports = async ({ context, github }) => {
+  const { owner, repo } = context.repo;
+
+  try {
+    // Calculate the start of the search window.
+    const cutoff = new Date(Date.now() - DAYS_TO_CONSIDER * MS_PER_DAY);
+    const dateString = cutoff.toISOString().slice(0, 10);
+    const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${dateString}`;
+
+    console.log(`Searching for PRs: ${searchQuery}`);
+
+    let cursor = null;
+    let hasNextPage = true;
+    const allPRs = [];
+
+    // Fetch all open PRs from the search window.
+    while (hasNextPage) {
+      const response = await github.graphql(QUERY, { cursor, searchQuery });
+      const { remaining, resetAt } = response.rateLimit;
+      console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+
+      const { nodes, pageInfo } = response.search;
+      hasNextPage = pageInfo.hasNextPage;
+      cursor = pageInfo.endCursor;
+
+      allPRs.push(...nodes);
+    }
+
+    console.log(`Found ${allPRs.length} open PRs from the last ${DAYS_TO_CONSIDER} days`);
+
+    // Filter to community PRs only.
+    const communityPRs = allPRs.filter(shouldProcessPR);
+    console.log(`${communityPRs.length} are community PRs`);
+
+    // Group PRs by the single issue they reference.
+    // Skip PRs that reference multiple issues (ambiguous intent).
+    const prsByIssue = new Map();
+
+    for (const pr of communityPRs) {
+      const issueRefs = getIssueReferences(pr);
+
+      if (issueRefs.length === 0) {
+        // PR doesn't reference any issue, skip it.
+        continue;
+      }
+
+      if (issueRefs.length > 1) {
+        // PR references multiple issues, skip it (ambiguous).
+        console.log(
+          `Skipping PR #${pr.number}: references multiple issues (${issueRefs.join(", ")})`
+        );
+        continue;
+      }
+
+      // PR references exactly one issue.
+      const issueNumber = issueRefs[0];
+      if (!prsByIssue.has(issueNumber)) {
+        prsByIssue.set(issueNumber, []);
+      }
+      prsByIssue.get(issueNumber).push(pr);
+    }
+
+    console.log(`Found ${prsByIssue.size} issues with associated PRs`);
+
+    // Process each issue that has multiple PRs.
+    let closedCount = 0;
+    for (const [issueNumber, prs] of prsByIssue.entries()) {
+      if (prs.length <= 1) {
+        // Only one PR for this issue, no duplicates.
+        continue;
+      }
+
+      console.log(`Issue #${issueNumber} has ${prs.length} PRs`);
+
+      // Sort PRs by creation date (oldest first).
+      prs.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+
+      // Keep the oldest PR, close the rest as duplicates.
+      const [keeper, ...duplicates] = prs;
+      console.log(`  Keeping PR #${keeper.number} (oldest, created ${keeper.createdAt})`);
+
+      for (const pr of duplicates) {
+        console.log(`  Closing PR #${pr.number} as duplicate (created ${pr.createdAt})`);
+
+        // Close first so a failure here leaves the PR open and unlabeled,
+        // letting the next run retry. If we labeled first and then failed
+        // to close, shouldProcessPR would skip the PR forever.
+        await github.rest.pulls.update({
+          owner,
+          repo,
+          pull_number: pr.number,
+          state: "closed",
+        });
+
+        await github.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: pr.number,
+          labels: [DUPLICATE_LABEL],
+        });
+
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: pr.number,
+          body: duplicateMessage(pr.author.login, issueNumber, keeper.number),
+        });
+
+        closedCount++;
+      }
+    }
+
+    console.log(`Closed ${closedCount} duplicate PRs.`);
+  } catch (error) {
+    if (error.status === 429 || error.message?.includes("rate limit")) {
+      console.log(`Rate limit hit. Exiting gracefully.`);
+      return;
+    }
+    throw error;
+  }
+};

--- a/.github/workflows/duplicate-prs.test.js
+++ b/.github/workflows/duplicate-prs.test.js
@@ -1,0 +1,121 @@
+// Local unit test for duplicate-prs.js -- mocks the GitHub client and runs the
+// real decision logic. No network. The script paginates a GraphQL search and
+// then closes/labels/comments the newer PRs for each over-subscribed issue.
+
+const path = require("path");
+const script = require(path.resolve(".github/workflows/duplicate-prs.js"));
+
+// Build a PR node shaped like the GraphQL response. `issues` is the list of
+// closing-issue references; `assoc` is the authorAssociation; `labels` is the
+// label name list.
+function pr({ number, createdAt, author = "ext", assoc = "CONTRIBUTOR", issues = [], labels = [] }) {
+  return {
+    number,
+    createdAt,
+    url: `https://example/pr/${number}`,
+    author: { login: author },
+    authorAssociation: assoc,
+    labels: { nodes: labels.map((name) => ({ name })) },
+    closingIssuesReferences: { nodes: issues.map((n) => ({ number: n })) },
+  };
+}
+
+// Run the script against a set of PR nodes; returns the side effects.
+async function run(nodes) {
+  const closed = [];
+  const labeled = [];
+  const commented = [];
+  let calls = 0;
+  const github = {
+    // Single page: first call returns the nodes, then stop.
+    graphql: async () => {
+      const done = calls++ > 0;
+      return {
+        rateLimit: { remaining: 4999, resetAt: "n/a" },
+        search: {
+          pageInfo: { hasNextPage: !done, endCursor: "c" },
+          nodes: done ? [] : nodes,
+        },
+      };
+    },
+    rest: {
+      pulls: {
+        update: async ({ pull_number, state }) => closed.push({ pull_number, state }),
+      },
+      issues: {
+        addLabels: async ({ issue_number, labels }) => labeled.push({ issue_number, labels }),
+        createComment: async ({ issue_number, body }) => commented.push({ issue_number, body }),
+      },
+    },
+  };
+  const context = { repo: { owner: "omnigent-ai", repo: "omnigent" } };
+  await script({ context, github });
+  return {
+    closed: closed.map((c) => c.pull_number).sort((a, b) => a - b),
+    labeled: labeled.map((l) => l.issue_number).sort((a, b) => a - b),
+    commented,
+  };
+}
+
+function assert(name, cond, detail) {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+}
+
+(async () => {
+  // 1. Two community PRs on the same issue: keep oldest (#1), close newer (#2).
+  let r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [100] }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [100] }),
+  ]);
+  assert("closes the newer duplicate, keeps the oldest",
+    JSON.stringify(r.closed) === JSON.stringify([2]) &&
+    JSON.stringify(r.labeled) === JSON.stringify([2]) &&
+    r.commented.length === 1 && r.commented[0].body.includes("#1"),
+    JSON.stringify(r));
+
+  // 2. Three PRs on one issue: keep oldest, close the other two.
+  r = await run([
+    pr({ number: 5, createdAt: "2026-06-03T00:00:00Z", issues: [7] }),
+    pr({ number: 3, createdAt: "2026-06-01T00:00:00Z", issues: [7] }),
+    pr({ number: 4, createdAt: "2026-06-02T00:00:00Z", issues: [7] }),
+  ]);
+  assert("keeps oldest of three, closes the other two",
+    JSON.stringify(r.closed) === JSON.stringify([4, 5]), JSON.stringify(r));
+
+  // 3. Single PR per issue: nothing closed.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [1] }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [2] }),
+  ]);
+  assert("distinct issues -> no closures", r.closed.length === 0, JSON.stringify(r));
+
+  // 4. Maintainer (MEMBER) duplicate is ignored; community duplicate closed.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9], assoc: "MEMBER" }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9] }),
+  ]);
+  assert("maintainer PR excluded -> only its lone community PR remains, no closures",
+    r.closed.length === 0, JSON.stringify(r));
+
+  // 5. Already-labeled duplicate is skipped (filtered before grouping).
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9] }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9], labels: ["duplicate"] }),
+  ]);
+  assert("already-labeled duplicate is skipped", r.closed.length === 0, JSON.stringify(r));
+
+  // 6. PR referencing multiple issues is ambiguous -> skipped.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9] }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9, 10] }),
+  ]);
+  assert("multi-issue PR is skipped, no duplicate group forms", r.closed.length === 0, JSON.stringify(r));
+
+  // 7. PR with no issue reference is ignored.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9] }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [] }),
+  ]);
+  assert("PR with no issue reference is ignored", r.closed.length === 0, JSON.stringify(r));
+})();

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -1,0 +1,42 @@
+name: Duplicate PRs
+
+# Closes duplicate community PRs that reference the same issue: when more than
+# one open PR (created in the last 14 days) closes the same issue, the oldest is
+# kept and the newer ones are closed, labeled `duplicate`, and commented on.
+# Maintainer-authored PRs are never touched. Runs on a daily schedule (and on
+# demand) rather than per-PR, so a freshly opened PR is only flagged once a real
+# duplicate exists. Never checks out or runs PR code -- it reads PR metadata via
+# the API using only the default-branch script. See duplicate-prs.js.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  duplicate-prs:
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      # Trusted default branch only (.github sparse). Never the PR head, so no
+      # PR-authored code runs.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/duplicate-prs.js");
+            await script({ context, github });

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -24,14 +24,19 @@ jobs:
     if: github.repository == 'omnigent-ai/omnigent'
     runs-on: ubuntu-latest
     permissions:
+      # Job-level permissions REPLACE the workflow-level block (they don't
+      # merge), so contents:read must be restated here for actions/checkout.
+      contents: read
       issues: write
       pull-requests: write
     timeout-minutes: 10
     steps:
-      # Trusted default branch only (.github sparse). Never the PR head, so no
-      # PR-authored code runs.
+      # Trusted default branch only (.github sparse). Pin the ref explicitly so
+      # manual workflow_dispatch runs can't execute a script from another
+      # branch. Never the PR head, so no PR-authored code runs.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0


### PR DESCRIPTION
## Related issue

N/A — CI tooling addition; requested directly.

## Summary

- Adds a daily **Duplicate PRs** workflow (`duplicate-prs.yml` + `duplicate-prs.js`, ported from `mlflow/mlflow`) that finds open community PRs created in the last 14 days, groups them by the single issue each one closes (`closingIssuesReferences`), and for any issue with more than one PR keeps the oldest while closing the rest — labeling them `duplicate` and leaving a comment. Maintainer-authored and already-labeled PRs are skipped. Closes before labeling so a mid-run failure stays retryable.
- Runs on a schedule (not per-PR) so a freshly opened PR is only flagged once a real duplicate exists. Never checks out or runs PR code — sparse-checkout of `.github` on the default branch only.
- Adds a `## Related issue` section to the PR template with a `Closes #` closing keyword so the link that feeds GitHub's `closingIssuesReferences` is consistently present. Optional and ungated (not added to the validator's required headings), matching mlflow.
- Adds an offline, mocked-client unit test (`duplicate-prs.test.js`) and a path-triggered test workflow (`duplicate-prs-test.yml`), following the existing `auto-assign-reviewer` convention.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `.github/workflows/duplicate-prs.test.js`, an offline test with a mocked GitHub client (no network) covering: closing the newer duplicate, three-PR grouping, distinct issues (no-op), maintainer exclusion, already-labeled skip, multi-issue ambiguity skip, and no-reference skip. Ran locally with `node .github/workflows/duplicate-prs.test.js` — all 7 cases PASS. The workflow itself reads PR metadata via the API and runs no PR code, so behavior is fully exercised by the unit test.
