### PR TITLE
feat(onboarding): auto-detect Claude on Vertex AI via GCP ADC env vars

### DIFF
--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -584,6 +584,24 @@ def detect_providers() -> list[DetectedProvider]:
             )
         )
 
+    # 1b. Claude Code on Vertex AI — the CLI reads three env vars for GCP auth.
+    # Detected separately from plain API keys because Vertex uses GCP ADC
+    # (no Anthropic key), so none of the PROVIDER_ENV_VARS entries cover it.
+    _vertex_truthy = ("1", "true", "yes")
+    if (
+        os.environ.get("CLAUDE_CODE_USE_VERTEX", "").strip().lower() in _vertex_truthy
+        and os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "").strip()
+        and os.environ.get("CLOUD_ML_REGION", "").strip()
+    ):
+        detected.append(
+            DetectedProvider(
+                name="vertex-claude",
+                kind=KEY_KIND,
+                family=ANTHROPIC_FAMILY,
+                source="$CLAUDE_CODE_USE_VERTEX",
+            )
+        )
+
     # 2. Claude CLI login. Like codex (below), existence alone is not enough —
     #    an empty / logged-out ``.credentials.json`` carries no usable login.
     #    On macOS the credential lives in the Keychain rather than the file, so

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -132,6 +132,12 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
             return None
         return build_cli_config_provider_entry("codex", det.model_provider, det.display_name)
 
+    if det.name == "vertex-claude":
+        # Claude Code on Vertex AI — the CLI authenticates via its own env
+        # vars and GCP ADC.  A subscription entry makes the native-claude
+        # resolver skip gateway routing, letting the CLI use Vertex natively.
+        return build_subscription_provider_entry("claude")
+
     if det.family is None:
         # An env key we detect but can't route to a harness (e.g. Gemini).
         return None

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -657,10 +657,25 @@ def test_vertex_claude_detected_with_all_env_vars(
         ("missing-use-vertex", {"ANTHROPIC_VERTEX_PROJECT_ID": "p", "CLOUD_ML_REGION": "r"}),
         ("missing-project-id", {"CLAUDE_CODE_USE_VERTEX": "1", "CLOUD_ML_REGION": "r"}),
         ("missing-region", {"CLAUDE_CODE_USE_VERTEX": "1", "ANTHROPIC_VERTEX_PROJECT_ID": "p"}),
-        ("use-vertex-false", {"CLAUDE_CODE_USE_VERTEX": "0", "ANTHROPIC_VERTEX_PROJECT_ID": "p", "CLOUD_ML_REGION": "r"}),
-        ("use-vertex-blank", {"CLAUDE_CODE_USE_VERTEX": "", "ANTHROPIC_VERTEX_PROJECT_ID": "p", "CLOUD_ML_REGION": "r"}),
+        (
+            "use-vertex-false",
+            {
+                "CLAUDE_CODE_USE_VERTEX": "0",
+                "ANTHROPIC_VERTEX_PROJECT_ID": "p",
+                "CLOUD_ML_REGION": "r",
+            },
+        ),
+        (
+            "use-vertex-blank",
+            {
+                "CLAUDE_CODE_USE_VERTEX": "",
+                "ANTHROPIC_VERTEX_PROJECT_ID": "p",
+                "CLOUD_ML_REGION": "r",
+            },
+        ),
     ],
 )
+
 def test_vertex_claude_not_detected_when_incomplete(
     clean_env, monkeypatch: pytest.MonkeyPatch, label: str, env: dict[str, str]
 ) -> None:

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -25,6 +25,9 @@ _PROVIDER_ENV_VARS = [
     "OPENAI_API_KEY",
     "OPENROUTER_API_KEY",
     "GEMINI_API_KEY",
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLOUD_ML_REGION",
 ]
 
 
@@ -618,3 +621,55 @@ def test_codex_config_other_self_contained_auth_detected(
     )
     detected = detect_providers()
     assert [d.model_provider for d in detected] == ["Custom"]
+
+
+# ── Claude on Vertex AI (GCP ADC) detection ──────────────────────────────────
+
+
+def test_vertex_claude_detected_with_all_env_vars(
+    clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All three Vertex env vars present → vertex-claude is detected.
+
+    Claude Code natively supports Vertex AI via CLAUDE_CODE_USE_VERTEX,
+    ANTHROPIC_VERTEX_PROJECT_ID, and CLOUD_ML_REGION. When all three are
+    set, ambient detection must surface a vertex-claude provider so
+    Omnigent recognises the credential and routes through the CLI's own
+    Vertex auth (GCP ADC).
+    """
+    monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+    monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-gcp-project")
+    monkeypatch.setenv("CLOUD_ML_REGION", "us-east5")
+    detected = detect_providers()
+    assert detected == [
+        DetectedProvider(
+            name="vertex-claude",
+            kind="key",
+            family="anthropic",
+            source="$CLAUDE_CODE_USE_VERTEX",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "label,env",
+    [
+        ("missing-use-vertex", {"ANTHROPIC_VERTEX_PROJECT_ID": "p", "CLOUD_ML_REGION": "r"}),
+        ("missing-project-id", {"CLAUDE_CODE_USE_VERTEX": "1", "CLOUD_ML_REGION": "r"}),
+        ("missing-region", {"CLAUDE_CODE_USE_VERTEX": "1", "ANTHROPIC_VERTEX_PROJECT_ID": "p"}),
+        ("use-vertex-false", {"CLAUDE_CODE_USE_VERTEX": "0", "ANTHROPIC_VERTEX_PROJECT_ID": "p", "CLOUD_ML_REGION": "r"}),
+        ("use-vertex-blank", {"CLAUDE_CODE_USE_VERTEX": "", "ANTHROPIC_VERTEX_PROJECT_ID": "p", "CLOUD_ML_REGION": "r"}),
+    ],
+)
+def test_vertex_claude_not_detected_when_incomplete(
+    clean_env, monkeypatch: pytest.MonkeyPatch, label: str, env: dict[str, str]
+) -> None:
+    """Missing or disabled Vertex env vars → no vertex-claude detection.
+
+    All three vars must be present and CLAUDE_CODE_USE_VERTEX must be
+    truthy. Failure means a partial configuration would surface a bogus
+    provider that fails at run time.
+    """
+    for var, val in env.items():
+        monkeypatch.setenv(var, val)
+    assert detect_providers() == []

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -675,7 +675,6 @@ def test_vertex_claude_detected_with_all_env_vars(
         ),
     ],
 )
-
 def test_vertex_claude_not_detected_when_incomplete(
     clean_env, monkeypatch: pytest.MonkeyPatch, label: str, env: dict[str, str]
 ) -> None:


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

Users with `gcloud auth application-default login` and the three
  Vertex env vars set were seeing "Not logged in" because Omnigent didn't
  know those env vars counted as a credential. Now it does — `omnigent setup`
  auto-detects them and `omnigent claude` just works.

  - Ambient credential detection now recognises the Claude Code Vertex AI
    env var triple (`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`,
    `CLOUD_ML_REGION`) and surfaces a `vertex-claude` provider.
  - The synthesiser maps `vertex-claude` to a `subscription` entry with
    `cli: "claude"`, so the native-claude resolver skips gateway routing and
    lets the CLI authenticate via its own GCP ADC — no API key needed.
  - Adds the ADC auth mode as the default for the `vertex_ai` provider in
    the setup provider definitions.




## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
New tests pass and verified manually via `uv run omnigent config list`. 

<img width="545" height="78" alt="Screenshot From 2026-06-17 23-42-58" src="https://github.com/user-attachments/assets/6ea0f969-92d2-4ebe-b564-dfec89618766" />
