### PR TITLE
ci: regen workflows commit as omnigent-ci[bot]

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -155,11 +155,11 @@ jobs:
       # to GITHUB_TOKEN and a maintainer must re-push to run CI).
       - name: Mint App token
         id: app-token
-        if: vars.OSS_REGEN_APP_ID != ''
+        if: vars.OMNIGENT_BOT_APP_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.OSS_REGEN_APP_ID }}
-          private-key: ${{ secrets.OSS_REGEN_APP_KEY }}
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
 
       # ${{ }} values pass via env: as "$VAR" to avoid injection (HEAD_REF is a
       # user-influenced branch name). The push token authenticates inline (scoped
@@ -171,8 +171,8 @@ jobs:
           PUSH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "omnigent-ci[bot]"
+          git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
           # --porcelain (not git diff) so first-time UNTRACKED lockfiles count too.
           if [ -z "$(git status --porcelain -- uv.lock ap-web/package-lock.json)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -87,11 +87,11 @@ jobs:
       # own CI. Skipped when the App isn't configured (falls back to GITHUB_TOKEN).
       - name: Mint App token
         id: app-token
-        if: vars.OSS_REGEN_APP_ID != ''
+        if: vars.OMNIGENT_BOT_APP_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ vars.OSS_REGEN_APP_ID }}
-          private-key: ${{ secrets.OSS_REGEN_APP_KEY }}
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
 
       # Persist the validated lockfiles via a PR (not a direct push to main, so
       # it works under branch protection). App token so `gh pr create` isn't
@@ -103,8 +103,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "omnigent-ci[bot]"
+          git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
           # --porcelain (not git diff) so first-regen UNTRACKED lockfiles count too.
           if [ -z "$(git status --porcelain -- uv.lock ap-web/package-lock.json)" ]; then
             echo "Lockfiles already current — nothing to PR."


### PR DESCRIPTION
## Summary
- Updated `.github/workflows/oss-regenerate-and-smoke.yml` lines 90, 93-94, and 106-107 to use `OMNIGENT_BOT_APP_*` and commit as `omnigent-ci[bot]`.
- Updated `.github/workflows/oss-regen-on-comment.yml` lines 158, 161-162, and 174-175 to use `OMNIGENT_BOT_APP_*` and commit as `omnigent-ci[bot]`.

## Validation
- `grep -n "OSS_REGEN_APP" .github/workflows/oss-regenerate-and-smoke.yml .github/workflows/oss-regen-on-comment.yml` returns nothing.
- `pre-commit run check-yaml --files .github/workflows/oss-regenerate-and-smoke.yml .github/workflows/oss-regen-on-comment.yml` passed.

## Out of scope
- `OSS_REGEN_APP_*` does not appear in any other workflow under `.github/workflows`.