### PR TITLE
fix: thread ApiKeyAuth.base_url to claude-sdk harness

### DIFF
--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1027,6 +1027,8 @@ def _build_claude_sdk_spawn_env(
             env["HARNESS_CLAUDE_SDK_API_KEY_HELPER"] = (
                 f"printf %s {shlex.quote(auth_from_spec.api_key)}"
             )
+            if auth_from_spec.base_url:
+                env["HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"] = auth_from_spec.base_url
             profile = None
         else:
             # Legacy path: executor.config["profile"] or executor.profile.


### PR DESCRIPTION
## Summary
Add 2 lines to `_build_claude_sdk_spawn_env` to set `HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL` from `ApiKeyAuth.base_url`, matching the existing pattern in `_build_openai_agents_sdk_spawn_env`.

### Before
```
executor:
  auth:
    type: api_key
    api_key: mock-key
    base_url: http://mock:9999/v1   # ← IGNORED for claude-sdk
```

### After
```
executor:
  auth:
    type: api_key
    api_key: mock-key
    base_url: http://mock:9999/v1   # ← now sets HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL
```

The env var flows through the harness (`claude_sdk_harness.py:281`) to `ANTHROPIC_BASE_URL` in the executor, which the `claude` CLI uses.

### Why
Enables mock LLM testing for claude-sdk harness agents via `register_inline_agent(harness="claude-sdk", mock_llm_base_url=...)`. The mock server already has a `/v1/messages` endpoint (Anthropic SSE format, PR #597).

## Test plan
- [x] All 6 integration tests pass
- [x] Pre-commit passes
- [ ] CI passes

This pull request and its description were written by Isaac.