### PR TITLE
feat(ap-web): add bulk actions for selected sessions in sidebar

### DIFF
--- a/ap-web/src/hooks/useConversations.test.ts
+++ b/ap-web/src/hooks/useConversations.test.ts
@@ -11,6 +11,9 @@ import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
 import {
   deleteConversation,
   renameConversation,
+  useBulkArchiveConversations,
+  useBulkDeleteConversations,
+  useBulkStopSessions,
   useConversations,
   useRenameConversation,
   useStopAndDeleteConversation,
@@ -484,5 +487,175 @@ describe("useStopSession invalidation", () => {
     // state. Dropping this invalidation reintroduces the bug where the
     // header lagged (Stop lingering).
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["session", "conv_x"] });
+  });
+});
+
+describe("useBulkArchiveConversations", () => {
+  function renderBulkArchiveHook() {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useBulkArchiveConversations(), { wrapper });
+    return { queryClient, invalidateSpy, rendered };
+  }
+
+  it("PATCHes each session and invalidates the list on success", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          id: "conv_a",
+          object: "conversation",
+          title: "A",
+          created_at: 0,
+          updated_at: 10,
+          labels: {},
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          id: "conv_b",
+          object: "conversation",
+          title: "B",
+          created_at: 0,
+          updated_at: 11,
+          labels: {},
+        }),
+      );
+
+    const { invalidateSpy, rendered } = renderBulkArchiveHook();
+    rendered.result.current.mutate({ ids: ["conv_a", "conv_b"], archived: true });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [, init] of fetchMock.mock.calls as [string, RequestInit][]) {
+      expect(init.method).toBe("PATCH");
+      expect(JSON.parse(init.body as string)).toEqual({ archived: true });
+    }
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+  });
+
+  it("throws with failed ids when some archives fail", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          id: "conv_a",
+          object: "conversation",
+          title: "A",
+          created_at: 0,
+          updated_at: 10,
+          labels: {},
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+
+    const { rendered } = renderBulkArchiveHook();
+    rendered.result.current.mutate({ ids: ["conv_a", "conv_b"], archived: true });
+    await waitFor(() => expect(rendered.result.current.isError).toBe(true));
+
+    expect((rendered.result.current.error as any).failed).toEqual(["conv_b"]);
+  });
+});
+
+describe("useBulkDeleteConversations", () => {
+  function renderBulkDeleteHook() {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([
+        conversation({ id: "conv_a" }),
+        conversation({ id: "conv_b" }),
+        conversation({ id: "conv_keep" }),
+      ]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useBulkDeleteConversations(), { wrapper });
+    return { queryClient, rendered };
+  }
+
+  it("stops and deletes each session, then removes them from cache", async () => {
+    // For each id: stop (POST) then delete (DELETE) = 4 calls for 2 ids.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ queued: false })) // stop conv_a
+      .mockResolvedValueOnce(mockResponse({ deleted: true })) // delete conv_a
+      .mockResolvedValueOnce(mockResponse({ queued: false })) // stop conv_b
+      .mockResolvedValueOnce(mockResponse({ deleted: true })); // delete conv_b
+
+    const { queryClient, rendered } = renderBulkDeleteHook();
+    rendered.result.current.mutate(["conv_a", "conv_b"]);
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_keep"]);
+  });
+
+  it("evicts succeeded ids from cache even when some deletes fail", async () => {
+    // conv_a succeeds (stop+delete), conv_b fails on delete.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ queued: false })) // stop conv_a
+      .mockResolvedValueOnce(mockResponse({ deleted: true })) // delete conv_a
+      .mockResolvedValueOnce(mockResponse({ queued: false })) // stop conv_b
+      .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 })); // delete conv_b fails
+
+    const { queryClient, rendered } = renderBulkDeleteHook();
+    rendered.result.current.mutate(["conv_a", "conv_b"]);
+    await waitFor(() => expect(rendered.result.current.isError).toBe(true));
+
+    // conv_a was successfully deleted and should be evicted; conv_b stays.
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    const ids = data!.pages[0].data.map((c) => c.id);
+    expect(ids).not.toContain("conv_a");
+    expect(ids).toContain("conv_b");
+    expect(ids).toContain("conv_keep");
+  });
+});
+
+describe("useBulkStopSessions", () => {
+  function renderBulkStopHook() {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const rendered = renderHook(() => useBulkStopSessions(), { wrapper });
+    return { invalidateSpy, rendered };
+  }
+
+  it("POSTs stop_session for each id and invalidates the list", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ queued: false }))
+      .mockResolvedValueOnce(mockResponse({ queued: false }));
+
+    const { invalidateSpy, rendered } = renderBulkStopHook();
+    rendered.result.current.mutate(["conv_a", "conv_b"]);
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [url, init] of fetchMock.mock.calls as [string, RequestInit][]) {
+      expect(url).toMatch(/\/v1\/sessions\/conv_[ab]\/events$/);
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({ type: "stop_session", data: {} });
+    }
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+  });
+
+  it("throws with failed ids when some stops fail", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ queued: false }))
+      .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 503 }));
+
+    const { rendered } = renderBulkStopHook();
+    rendered.result.current.mutate(["conv_a", "conv_b"]);
+    await waitFor(() => expect(rendered.result.current.isError).toBe(true));
+
+    const err = rendered.result.current.error as any;
+    expect(err.succeeded).toEqual(["conv_a"]);
+    expect(err.failed).toEqual(["conv_b"]);
   });
 });

--- a/ap-web/src/hooks/useConversations.ts
+++ b/ap-web/src/hooks/useConversations.ts
@@ -445,13 +445,15 @@ export function useBulkArchiveConversations() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ ids, archived }: { ids: string[]; archived: boolean }) => {
-      const results = await Promise.allSettled(
-        ids.map((id) => archiveConversation(id, archived)),
-      );
+      const results = await Promise.allSettled(ids.map((id) => archiveConversation(id, archived)));
       const failed: string[] = [];
       for (let i = 0; i < results.length; i++) {
         if (results[i].status === "rejected") failed.push(ids[i]);
-        else markConversationSeen(ids[i], (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at);
+        else
+          markConversationSeen(
+            ids[i],
+            (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at,
+          );
       }
       if (failed.length > 0) throw { failed, total: ids.length };
       return results

--- a/ap-web/src/hooks/useConversations.ts
+++ b/ap-web/src/hooks/useConversations.ts
@@ -434,6 +434,124 @@ export function useStopSession() {
 }
 
 /**
+ * Archive multiple conversations in parallel via `PATCH /v1/sessions/{id}`.
+ *
+ * Each session is archived independently — individual failures don't
+ * block the rest. The conversations list is invalidated once on
+ * completion so the sidebar refreshes. Returns an array of session IDs
+ * that failed.
+ */
+export function useBulkArchiveConversations() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ ids, archived }: { ids: string[]; archived: boolean }) => {
+      const results = await Promise.allSettled(
+        ids.map((id) => archiveConversation(id, archived)),
+      );
+      const failed: string[] = [];
+      for (let i = 0; i < results.length; i++) {
+        if (results[i].status === "rejected") failed.push(ids[i]);
+        else markConversationSeen(ids[i], (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at);
+      }
+      if (failed.length > 0) throw { failed, total: ids.length };
+      return results
+        .filter((r): r is PromiseFulfilledResult<Conversation> => r.status === "fulfilled")
+        .map((r) => r.value);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+  });
+}
+
+/**
+ * Delete multiple conversations in parallel (stop + delete each).
+ *
+ * Each session is stopped (best-effort) then deleted independently.
+ * The conversations list cache is patched to remove successful
+ * deletions. Returns an array of session IDs that failed.
+ */
+export function useBulkDeleteConversations() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: string[]) => {
+      const results = await Promise.allSettled(
+        ids.map(async (id) => {
+          try {
+            await stopSession(id);
+          } catch {
+            // Best-effort stop
+          }
+          await deleteConversation(id);
+        }),
+      );
+      const succeeded: string[] = [];
+      const failed: string[] = [];
+      for (let i = 0; i < results.length; i++) {
+        if (results[i].status === "fulfilled") succeeded.push(ids[i]);
+        else failed.push(ids[i]);
+      }
+      if (failed.length > 0) throw { failed, succeeded, total: ids.length };
+      return { succeeded, failed };
+    },
+    onSuccess: (_data, ids) => {
+      const idSet = new Set(ids);
+      for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+        queryKey: ["conversations"],
+      })) {
+        const { data: next, removed } = removeIdsFromPages(data, idSet);
+        if (removed) queryClient.setQueryData(key, next);
+      }
+      for (const id of ids) {
+        queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
+        queryClient.removeQueries({ queryKey: ["session", id] });
+      }
+    },
+    onError: (err: any) => {
+      if (err?.succeeded) {
+        const idSet = new Set(err.succeeded as string[]);
+        for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+          queryKey: ["conversations"],
+        })) {
+          const { data: next, removed } = removeIdsFromPages(data, idSet);
+          if (removed) queryClient.setQueryData(key, next);
+        }
+        for (const id of err.succeeded) {
+          queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
+          queryClient.removeQueries({ queryKey: ["session", id] });
+        }
+      }
+    },
+  });
+}
+
+/**
+ * Stop multiple live sessions in parallel.
+ *
+ * Each session is stopped independently — individual failures don't
+ * block the rest. Returns arrays of succeeded/failed IDs.
+ */
+export function useBulkStopSessions() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: string[]) => {
+      const results = await Promise.allSettled(ids.map((id) => stopSession(id)));
+      const succeeded: string[] = [];
+      const failed: string[] = [];
+      for (let i = 0; i < results.length; i++) {
+        if (results[i].status === "fulfilled") succeeded.push(ids[i]);
+        else failed.push(ids[i]);
+      }
+      if (failed.length > 0) throw { failed, succeeded, total: ids.length };
+      return { succeeded, failed };
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    },
+  });
+}
+
+/**
  * Fetch pinned sessions that aren't present in the loaded paginated
  * data. Returns the backfilled conversations so the caller can merge
  * them into the list before grouping.

--- a/ap-web/src/shell/Sidebar.archive.test.tsx
+++ b/ap-web/src/shell/Sidebar.archive.test.tsx
@@ -34,6 +34,9 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => mocks.archive,
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
 }));
 

--- a/ap-web/src/shell/Sidebar.delete.test.tsx
+++ b/ap-web/src/shell/Sidebar.delete.test.tsx
@@ -33,6 +33,9 @@ vi.mock("@/hooks/useConversations", () => ({
   // stubs keep the row from crashing on mount.
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
 }));
 

--- a/ap-web/src/shell/Sidebar.rowActions.test.tsx
+++ b/ap-web/src/shell/Sidebar.rowActions.test.tsx
@@ -31,6 +31,9 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => mocks.rename,
   useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
 }));
 

--- a/ap-web/src/shell/Sidebar.stop.test.tsx
+++ b/ap-web/src/shell/Sidebar.stop.test.tsx
@@ -32,6 +32,9 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
 }));
 

--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -16,6 +16,9 @@ import type { Conversation } from "@/hooks/useConversations";
 vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
   useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
   usePinnedConversationBackfill: () => [],

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1517,8 +1517,7 @@ function BulkActionBar({
   );
 
   const allSelectedSameArchiveGroup =
-    ownedSelected.length > 0 &&
-    (archivedSelected.length === 0 || nonArchivedSelected.length === 0);
+    ownedSelected.length > 0 && (archivedSelected.length === 0 || nonArchivedSelected.length === 0);
 
   const count = selectedIds.size;
   const allSelected = count > 0 && count === allConversations.length;

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -403,7 +403,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
             selectAll((conversationsQuery.data?.pages ?? []).flatMap((page) => page.data))
           }
           onDeselectAll={deselectAll}
-          onClear={exitSelectionMode}
+          onClear={deselectAll}
         />
       )}
 
@@ -1598,6 +1598,7 @@ function BulkActionBar({
               variant="ghost"
               size="sm"
               className="h-6 px-2 text-xs"
+              disabled={count === 0}
               onClick={onClear}
             >
               Clear
@@ -1720,6 +1721,10 @@ function BulkActionBar({
               be undone.
             </DialogDescription>
           </DialogHeader>
+          <p className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-xs text-muted-foreground">
+            <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
+            Branches are not cleaned up. Use single-session delete for branch surgery.
+          </p>
           <DialogFooter className="border-t-0 bg-transparent">
             <Button
               type="button"

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -52,7 +52,6 @@ import {
   useArchiveConversation,
   useBulkArchiveConversations,
   useBulkDeleteConversations,
-  useBulkStopSessions,
   useConversations,
   usePinnedConversationBackfill,
   useRenameConversation,
@@ -1484,7 +1483,6 @@ function BulkActionBar({
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
   const bulkArchive = useBulkArchiveConversations();
   const bulkDelete = useBulkDeleteConversations();
-  const bulkStop = useBulkStopSessions();
 
   const selectedConversations = useMemo(
     () => allConversations.filter((c) => selectedIds.has(c.id)),
@@ -1494,16 +1492,6 @@ function BulkActionBar({
   const ownedSelected = useMemo(
     () => selectedConversations.filter((c) => isOwnedByViewer(c)),
     [selectedConversations],
-  );
-
-  const stoppableSelected = useMemo(
-    () =>
-      ownedSelected.filter(
-        (c) =>
-          isSessionStoppable({ labels: c.labels, hostId: c.host_id, runnerId: c.runner_id }) &&
-          c.status === "running",
-      ),
-    [ownedSelected],
   );
 
   const archivedSelected = useMemo(
@@ -1521,7 +1509,7 @@ function BulkActionBar({
 
   const count = selectedIds.size;
   const allSelected = count > 0 && count === allConversations.length;
-  const isBusy = bulkArchive.isPending || bulkDelete.isPending || bulkStop.isPending;
+  const isBusy = bulkArchive.isPending || bulkDelete.isPending;
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
@@ -1562,18 +1550,6 @@ function BulkActionBar({
         if (activeId && err?.succeeded?.includes(activeId)) navigate("/", { replace: true });
       },
     });
-  }
-
-  function handleStop() {
-    if (stoppableSelected.length === 0) return;
-    bulkStop.mutate(
-      stoppableSelected.map((c) => c.id),
-      {
-        onSuccess: () => {
-          onDeselectAll();
-        },
-      },
-    );
   }
 
   return (
@@ -1654,29 +1630,6 @@ function BulkActionBar({
                 <TooltipContent>Unarchive {archivedSelected.length} session(s)</TooltipContent>
               </Tooltip>
             )}
-            {stoppableSelected.length > 0 && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-7 gap-1.5 text-xs text-destructive"
-                    disabled={isBusy}
-                    onClick={handleStop}
-                    data-testid="bulk-stop"
-                  >
-                    {bulkStop.isPending ? (
-                      <Loader2Icon className="size-3 animate-spin" />
-                    ) : (
-                      <CircleStopIcon className="size-3" />
-                    )}
-                    Stop
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Stop {stoppableSelected.length} session(s)</TooltipContent>
-              </Tooltip>
-            )}
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -1705,7 +1658,7 @@ function BulkActionBar({
           </div>
         )}
 
-        {(bulkArchive.isError || bulkDelete.isError || bulkStop.isError) && (
+        {(bulkArchive.isError || bulkDelete.isError) && (
           <p className="text-xs text-destructive" role="alert">
             Some actions failed. Retry or dismiss.
           </p>

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -412,9 +412,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
       {selectionMode && (
         <BulkActionBar
           selectedIds={selectedIds}
-          allConversations={
-            (conversationsQuery.data?.pages ?? []).flatMap((page) => page.data)
-          }
+          allConversations={(conversationsQuery.data?.pages ?? []).flatMap((page) => page.data)}
           onSelectAll={() =>
             selectAll((conversationsQuery.data?.pages ?? []).flatMap((page) => page.data))
           }
@@ -922,7 +920,8 @@ function ConversationRow({
         className={cn(
           "relative flex w-full flex-col gap-0.5 rounded-md py-2 text-left text-sm hover:bg-muted",
           selectionMode ? "pl-9 pr-4" : "px-4",
-          !selectionMode && (sessionState?.kind === "awaiting" ? "pr-44 md:pr-28" : "pr-28 md:pr-16"),
+          !selectionMode &&
+            (sessionState?.kind === "awaiting" ? "pr-44 md:pr-28" : "pr-28 md:pr-16"),
           isActive && !selectionMode && "bg-muted font-semibold",
           selectionMode && isSelected && "bg-primary/5",
         )}
@@ -990,183 +989,193 @@ function ConversationRow({
           {relativeTime(conversation.updated_at * 1000)}
         </span>
       ) : null}
-      {!selectionMode && <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
-        data-testid="quick-pin-conversation"
-        className={cn(
-          "-translate-y-1/2 absolute top-1/2 right-9 transition-opacity",
-          "md:opacity-0 md:group-hover:opacity-100",
-          "md:group-has-[:focus-visible]:opacity-100 md:group-has-[[aria-expanded=true]]:opacity-100",
-        )}
-        onClick={(e) => {
-          // Keep the toggle click off the surrounding Link (no navigation).
-          e.preventDefault();
-          e.stopPropagation();
-          onTogglePinned(conversation.id);
-        }}
-      >
-        {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
-      </Button>}
-      {!selectionMode && <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Conversation actions"
-            data-testid="conversation-actions"
-            // Absolute-positioned trigger. On mobile (no hover state)
-            // it's always visible. On desktop it stays hidden until
-            // hover / keyboard focus, with `aria-expanded` keeping it
-            // surfaced while the menu is open so the trigger doesn't
-            // vanish under the cursor.
-            className={cn(
-              "-translate-y-1/2 absolute top-1/2 right-1 transition-opacity",
-              "md:opacity-0 md:group-hover:opacity-100 md:group-has-[:focus-visible]:opacity-100",
-              "md:aria-expanded:opacity-100",
-            )}
-            onClick={(e) => {
-              // Keep the trigger click from bubbling into the Link.
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
-            <MoreHorizontalIcon className="size-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-36">
-          {isOwner ? (
-            <DropdownMenuItem data-testid="archive-conversation" onSelect={runArchive}>
-              {isArchived ? (
-                <ArchiveRestoreIcon className="size-3.5" />
-              ) : (
-                <ArchiveIcon className="size-3.5" />
+      {!selectionMode && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
+          data-testid="quick-pin-conversation"
+          className={cn(
+            "-translate-y-1/2 absolute top-1/2 right-9 transition-opacity",
+            "md:opacity-0 md:group-hover:opacity-100",
+            "md:group-has-[:focus-visible]:opacity-100 md:group-has-[[aria-expanded=true]]:opacity-100",
+          )}
+          onClick={(e) => {
+            // Keep the toggle click off the surrounding Link (no navigation).
+            e.preventDefault();
+            e.stopPropagation();
+            onTogglePinned(conversation.id);
+          }}
+        >
+          {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
+        </Button>
+      )}
+      {!selectionMode && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Conversation actions"
+              data-testid="conversation-actions"
+              // Absolute-positioned trigger. On mobile (no hover state)
+              // it's always visible. On desktop it stays hidden until
+              // hover / keyboard focus, with `aria-expanded` keeping it
+              // surfaced while the menu is open so the trigger doesn't
+              // vanish under the cursor.
+              className={cn(
+                "-translate-y-1/2 absolute top-1/2 right-1 transition-opacity",
+                "md:opacity-0 md:group-hover:opacity-100 md:group-has-[:focus-visible]:opacity-100",
+                "md:aria-expanded:opacity-100",
               )}
-              {isArchived ? "Unarchive" : "Archive"}
-            </DropdownMenuItem>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <DropdownMenuItem data-testid="archive-conversation" disabled>
-                    {isArchived ? (
-                      <ArchiveRestoreIcon className="size-3.5" />
-                    ) : (
-                      <ArchiveIcon className="size-3.5" />
-                    )}
-                    {isArchived ? "Unarchive" : "Archive"}
-                  </DropdownMenuItem>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                Only the session owner can {isArchived ? "unarchive" : "archive"} this session
-              </TooltipContent>
-            </Tooltip>
-          )}
-          {canManage ? (
-            <DropdownMenuItem data-testid="share-conversation" onSelect={() => setShareOpen(true)}>
-              <ShareIcon className="size-3.5" />
-              Share
-            </DropdownMenuItem>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <DropdownMenuItem data-testid="share-conversation" disabled>
-                    <ShareIcon className="size-3.5" />
-                    Share
-                  </DropdownMenuItem>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                You need manage permissions to share this session
-              </TooltipContent>
-            </Tooltip>
-          )}
-          {canEdit ? (
-            <DropdownMenuItem data-testid="rename-conversation" onSelect={() => setIsEditing(true)}>
-              <PencilIcon className="size-3.5" />
-              Rename
-            </DropdownMenuItem>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <DropdownMenuItem data-testid="rename-conversation" disabled>
-                    <PencilIcon className="size-3.5" />
-                    Rename
-                  </DropdownMenuItem>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                You need edit permissions to rename this session
-              </TooltipContent>
-            </Tooltip>
-          )}
-          {/* Stop session — only on stoppable sessions whose runner isn't
-              already known-offline (canStop). Owner-gated like Delete:
-              non-owners see it disabled with an explanatory tooltip. */}
-          {canStop &&
-            (isOwner ? (
-              <DropdownMenuItem
-                data-testid="stop-conversation"
-                variant="destructive"
-                onSelect={() => {
-                  // Clear any prior failure so a stale "couldn't stop"
-                  // message doesn't greet the next attempt. Must happen
-                  // here: Radix only fires the Dialog's onOpenChange for
-                  // Radix-initiated changes, not this programmatic open.
-                  stopSession.reset();
-                  setStopOpen(true);
-                }}
-              >
-                <CircleStopIcon className="size-3.5" />
-                Stop session
+              onClick={(e) => {
+                // Keep the trigger click from bubbling into the Link.
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <MoreHorizontalIcon className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-36">
+            {isOwner ? (
+              <DropdownMenuItem data-testid="archive-conversation" onSelect={runArchive}>
+                {isArchived ? (
+                  <ArchiveRestoreIcon className="size-3.5" />
+                ) : (
+                  <ArchiveIcon className="size-3.5" />
+                )}
+                {isArchived ? "Unarchive" : "Archive"}
               </DropdownMenuItem>
             ) : (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div>
-                    <DropdownMenuItem data-testid="stop-conversation" disabled>
-                      <CircleStopIcon className="size-3.5" />
-                      Stop session
+                    <DropdownMenuItem data-testid="archive-conversation" disabled>
+                      {isArchived ? (
+                        <ArchiveRestoreIcon className="size-3.5" />
+                      ) : (
+                        <ArchiveIcon className="size-3.5" />
+                      )}
+                      {isArchived ? "Unarchive" : "Archive"}
                     </DropdownMenuItem>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent side="left">
-                  Only the session owner can stop this session
+                  Only the session owner can {isArchived ? "unarchive" : "archive"} this session
                 </TooltipContent>
               </Tooltip>
-            ))}
-          {isOwner ? (
-            <DropdownMenuItem
-              data-testid="delete-conversation"
-              variant="destructive"
-              onSelect={() => setDeleteOpen(true)}
-            >
-              <Trash2Icon className="size-3.5" />
-              Delete
-            </DropdownMenuItem>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <DropdownMenuItem data-testid="delete-conversation" disabled>
-                    <Trash2Icon className="size-3.5" />
-                    Delete
-                  </DropdownMenuItem>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                Only the session owner can delete this session
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>}
+            )}
+            {canManage ? (
+              <DropdownMenuItem
+                data-testid="share-conversation"
+                onSelect={() => setShareOpen(true)}
+              >
+                <ShareIcon className="size-3.5" />
+                Share
+              </DropdownMenuItem>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <DropdownMenuItem data-testid="share-conversation" disabled>
+                      <ShareIcon className="size-3.5" />
+                      Share
+                    </DropdownMenuItem>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  You need manage permissions to share this session
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {canEdit ? (
+              <DropdownMenuItem
+                data-testid="rename-conversation"
+                onSelect={() => setIsEditing(true)}
+              >
+                <PencilIcon className="size-3.5" />
+                Rename
+              </DropdownMenuItem>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <DropdownMenuItem data-testid="rename-conversation" disabled>
+                      <PencilIcon className="size-3.5" />
+                      Rename
+                    </DropdownMenuItem>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  You need edit permissions to rename this session
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {/* Stop session — only on stoppable sessions whose runner isn't
+              already known-offline (canStop). Owner-gated like Delete:
+              non-owners see it disabled with an explanatory tooltip. */}
+            {canStop &&
+              (isOwner ? (
+                <DropdownMenuItem
+                  data-testid="stop-conversation"
+                  variant="destructive"
+                  onSelect={() => {
+                    // Clear any prior failure so a stale "couldn't stop"
+                    // message doesn't greet the next attempt. Must happen
+                    // here: Radix only fires the Dialog's onOpenChange for
+                    // Radix-initiated changes, not this programmatic open.
+                    stopSession.reset();
+                    setStopOpen(true);
+                  }}
+                >
+                  <CircleStopIcon className="size-3.5" />
+                  Stop session
+                </DropdownMenuItem>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <DropdownMenuItem data-testid="stop-conversation" disabled>
+                        <CircleStopIcon className="size-3.5" />
+                        Stop session
+                      </DropdownMenuItem>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="left">
+                    Only the session owner can stop this session
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            {isOwner ? (
+              <DropdownMenuItem
+                data-testid="delete-conversation"
+                variant="destructive"
+                onSelect={() => setDeleteOpen(true)}
+              >
+                <Trash2Icon className="size-3.5" />
+                Delete
+              </DropdownMenuItem>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <DropdownMenuItem data-testid="delete-conversation" disabled>
+                      <Trash2Icon className="size-3.5" />
+                      Delete
+                    </DropdownMenuItem>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  Only the session owner can delete this session
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
       <PermissionsModal sessionId={conversation.id} open={shareOpen} onOpenChange={setShareOpen} />
       <Dialog
         open={deleteOpen}

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   CircleStopIcon,
   GitBranchIcon,
   InboxIcon,
+  ListChecksIcon,
   Loader2Icon,
   MoreHorizontalIcon,
   PanelRightOpenIcon,
@@ -25,6 +26,8 @@ import {
   PinOffIcon,
   SearchIcon,
   ShareIcon,
+  SquareIcon,
+  SquareCheckBigIcon,
   Trash2Icon,
   XIcon,
 } from "lucide-react";
@@ -47,6 +50,9 @@ import {
 import {
   type Conversation,
   useArchiveConversation,
+  useBulkArchiveConversations,
+  useBulkDeleteConversations,
+  useBulkStopSessions,
   useConversations,
   usePinnedConversationBackfill,
   useRenameConversation,
@@ -132,6 +138,30 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [pinnedConversationIds, setPinnedConversationIds] = useState(readPinnedConversationIds);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback((conversations: Conversation[]) => {
+    setSelectedIds(new Set(conversations.map((c) => c.id)));
+  }, []);
+
+  const deselectAll = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  }, []);
 
   // Debounce search input so we don't fire a server request on every
   // keystroke. 300 ms is fast enough to feel responsive.
@@ -325,16 +355,39 @@ export function Sidebar({ open, onClose }: SidebarProps) {
             )}
           </Link>
         </Button>
-        <div className="relative mt-3">
-          <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 size-3.5 text-muted-foreground" />
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            aria-label="Search sessions"
-            placeholder="Search sessions"
-            className="min-h-8 w-full rounded-full border border-input pr-3 pl-8 text-sm transition placeholder:text-muted-foreground focus-visible:outline-1"
-          />
+        <div className="relative mt-3 flex items-center gap-1.5">
+          <div className="relative flex-1">
+            <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 size-3.5 text-muted-foreground" />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search sessions"
+              placeholder="Search sessions"
+              className="min-h-8 w-full rounded-full border border-input pr-3 pl-8 text-sm transition placeholder:text-muted-foreground focus-visible:outline-1"
+            />
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant={selectionMode ? "secondary" : "ghost"}
+                size="icon-sm"
+                aria-label={selectionMode ? "Exit selection mode" : "Select sessions"}
+                data-testid="toggle-selection-mode"
+                className="shrink-0 rounded-full"
+                onClick={() => {
+                  if (selectionMode) exitSelectionMode();
+                  else setSelectionMode(true);
+                }}
+              >
+                <ListChecksIcon className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {selectionMode ? "Exit selection" : "Select sessions"}
+            </TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -342,7 +395,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           scrollbars, the list's scrollbar appearing/disappearing (e.g. while
           a Radix menu locks scrolling) resizes every row — titles gain/lose
           a character. Reserving the gutter keeps row width constant. */}
-      <nav className="flex-1 overflow-y-auto px-3 pb-3 [scrollbar-gutter:stable]">
+      <nav className="relative flex-1 overflow-y-auto px-3 pb-3 [scrollbar-gutter:stable]">
         <ConversationList
           conversationsQuery={conversationsQuery}
           onRowClick={onNavClick}
@@ -350,8 +403,25 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           pinnedConversationIds={pinnedConversationIds}
           onPinnedConversationIdsChange={setPinnedConversationIds}
           onTogglePinned={togglePinnedConversation}
+          selectionMode={selectionMode}
+          selectedIds={selectedIds}
+          onToggleSelected={toggleSelected}
         />
       </nav>
+
+      {selectionMode && (
+        <BulkActionBar
+          selectedIds={selectedIds}
+          allConversations={
+            (conversationsQuery.data?.pages ?? []).flatMap((page) => page.data)
+          }
+          onSelectAll={() =>
+            selectAll((conversationsQuery.data?.pages ?? []).flatMap((page) => page.data))
+          }
+          onDeselectAll={deselectAll}
+          onDone={exitSelectionMode}
+        />
+      )}
 
       {/* Account footer. Sibling *after* the flex-1 nav so it pins to the
           bottom of the sidebar column. Renders nothing (no border, no
@@ -369,6 +439,9 @@ interface ConversationListProps {
   pinnedConversationIds: string[];
   onPinnedConversationIdsChange: (ids: string[]) => void;
   onTogglePinned: (conversationId: string) => void;
+  selectionMode: boolean;
+  selectedIds: Set<string>;
+  onToggleSelected: (conversationId: string) => void;
 }
 
 // permission_level null (no ACL row / legacy) or >= 4 both mean owner.
@@ -383,6 +456,9 @@ function ConversationList({
   pinnedConversationIds,
   onPinnedConversationIdsChange,
   onTogglePinned,
+  selectionMode,
+  selectedIds,
+  onToggleSelected,
 }: ConversationListProps) {
   // All loaded conversations from the single paginated list (for pinned
   // backfill, normalization, and the flat session list).
@@ -517,6 +593,9 @@ function ConversationList({
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={onToggleSelected}
             />
           )}
           {sections.sessions.length > 0 && (
@@ -528,6 +607,9 @@ function ConversationList({
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={onToggleSelected}
             />
           )}
           {sections.shared.length > 0 && (
@@ -539,12 +621,11 @@ function ConversationList({
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={onToggleSelected}
             />
           )}
-          {/* Archived sessions, grouped at the very bottom (below "Shared
-              with me"). Collapsible + persisted like the other sections; this
-              is also the surface that makes the per-row "Unarchive" action
-              reachable again. */}
           {sections.archived.length > 0 && (
             <ConversationSection
               title="Archived"
@@ -554,6 +635,9 @@ function ConversationList({
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={onToggleSelected}
             />
           )}
           {/* Pagination extends the Recent list, so the button hides with
@@ -591,25 +675,26 @@ function ConversationSection({
   onToggleCollapsed,
   onRowClick,
   onTogglePinned,
+  selectionMode,
+  selectedIds,
+  onToggleSelected,
 }: {
-  // Section header, e.g. "Recent". Untitled sections render as a bare
-  // list and cannot collapse (there is no header to click).
   title?: string;
   conversations: Conversation[];
   pinnedConversationIds: string[];
-  /** Titles currently collapsed; an untitled section can't collapse. */
   collapsedSections: string[];
   onToggleCollapsed: (sectionTitle: string) => void;
   onRowClick: (e: MouseEvent<HTMLAnchorElement>) => void;
   onTogglePinned: (conversationId: string) => void;
+  selectionMode: boolean;
+  selectedIds: Set<string>;
+  onToggleSelected: (conversationId: string) => void;
 }) {
   const collapsed = title != null && collapsedSections.includes(title);
   return (
     <section>
       {title && (
         <h2>
-          {/* Full-width header button = a comfortable touch target on the
-              mobile drawer, where a chevron-sized hit area would be fiddly. */}
           <button
             type="button"
             aria-expanded={!collapsed}
@@ -617,9 +702,6 @@ function ConversationSection({
             className="group flex w-full items-center gap-1 rounded-md px-2 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
           >
             {title}
-            {/* Chevron trails the label (Codex/Cursor-style). Hidden until
-                hover when expanded; always visible when collapsed so the
-                hidden content stays discoverable. */}
             <ChevronRightIcon
               className={cn(
                 "size-3.5 shrink-0 transition-transform",
@@ -638,6 +720,9 @@ function ConversationSection({
               isPinned={pinnedConversationIds.includes(conv.id)}
               onClick={onRowClick}
               onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              isSelected={selectedIds.has(conv.id)}
+              onToggleSelected={onToggleSelected}
             />
           ))}
         </ul>
@@ -651,11 +736,17 @@ function ConversationRow({
   isPinned,
   onClick,
   onTogglePinned,
+  selectionMode,
+  isSelected,
+  onToggleSelected,
 }: {
   conversation: Conversation;
   isPinned: boolean;
   onClick: (e: MouseEvent<HTMLAnchorElement>) => void;
   onTogglePinned: (conversationId: string) => void;
+  selectionMode: boolean;
+  isSelected: boolean;
+  onToggleSelected: (conversationId: string) => void;
 }) {
   // `useParams` reads from the active matched route. On `/`, the param is
   // undefined; on `/c/:conversationId`, it carries the active id.
@@ -827,35 +918,40 @@ function ConversationRow({
   return (
     <li className="group relative">
       <Link
-        to={`/c/${conversation.id}`}
+        to={selectionMode ? "#" : `/c/${conversation.id}`}
         className={cn(
-          // Right padding reserves room for the trailing controls so long
-          // titles truncate before colliding with them. On desktop the time
-          // marker shares a slot with the hover controls (pin + kebab,
-          // swapped in on hover), so reserve room for both (pr-16). On
-          // mobile there's no hover, so the marker, pin, and kebab are all
-          // visible side by side — reserve pr-28 to clear the marker that
-          // sits left of them. The wide "Needs response" tag replaces the
-          // timestamp in that slot, so reserve extra room for it
-          // (pr-44 / md:pr-28). flex-col stacks the name row over the
-          // git-branch subtitle row.
-          "relative flex w-full flex-col gap-0.5 rounded-md px-4 py-2 text-left text-sm hover:bg-muted",
-          sessionState?.kind === "awaiting" ? "pr-44 md:pr-28" : "pr-28 md:pr-16",
-          isActive && "bg-muted font-semibold",
+          "relative flex w-full flex-col gap-0.5 rounded-md py-2 text-left text-sm hover:bg-muted",
+          selectionMode ? "pl-9 pr-4" : "px-4",
+          !selectionMode && (sessionState?.kind === "awaiting" ? "pr-44 md:pr-28" : "pr-28 md:pr-16"),
+          isActive && !selectionMode && "bg-muted font-semibold",
+          selectionMode && isSelected && "bg-primary/5",
         )}
-        onClick={onClick}
-        // Double-click renames inline (a quick alternative to the kebab's
-        // Rename item). The first click of the gesture still selects/navigates
-        // the row natively; the dblclick then swaps in the edit field. Gated on
-        // edit permission so a viewer-only row stays read-only. preventDefault
-        // suppresses the browser's double-click text selection on the title.
+        onClick={(e) => {
+          if (selectionMode) {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleSelected(conversation.id);
+            return;
+          }
+          onClick(e);
+        }}
         onDoubleClick={(e) => {
+          if (selectionMode) return;
           if (!canEdit) return;
           e.preventDefault();
           setIsEditing(true);
         }}
         title={conversation.title ?? conversation.id}
       >
+        {selectionMode && (
+          <span className="-translate-y-1/2 absolute top-1/2 left-2.5 flex items-center">
+            {isSelected ? (
+              <SquareCheckBigIcon className="size-4 text-primary" />
+            ) : (
+              <SquareIcon className="size-4 text-muted-foreground" />
+            )}
+          </span>
+        )}
         {/* Row 1: the session name. Status markers (working, needs-approval,
             unseen) render in the trailing time-marker slot below, replacing
             the timestamp — not inline here. Leading icons (agent type, pin,
@@ -878,21 +974,14 @@ function ConversationRow({
           </span>
         )}
       </Link>
-      {/* Time-marker slot. On desktop it shares the controls' slot (right-2)
-          and fades out on hover/focus so the pin + kebab can take over in
-          place. On mobile there is no hover, so it sits to the left of the
-          always-visible pin + kebab (right-[4.5rem]) and stays put — they
-          read side by side. When the session has a state badge (working dot,
-          "Needs response", unseen dot), the badge takes this slot INSTEAD of
-          the timestamp — the row shows one trailing marker, never both. */}
-      {sessionState !== null ? (
+      {!selectionMode && sessionState !== null ? (
         // pointer-events-none keeps clicks falling through to the row, so
         // the badge's hover tooltip is intentionally inert here; screen
         // readers still get the badge's own role="img" aria-label.
         <span className={TIME_MARKER_SLOT_CLASS}>
           <SessionStateBadge state={sessionState} />
         </span>
-      ) : (
+      ) : !selectionMode ? (
         <span
           className={cn(TIME_MARKER_SLOT_CLASS, "text-xs tabular-nums text-muted-foreground")}
           aria-label={absoluteTime(conversation.updated_at * 1000)}
@@ -900,13 +989,8 @@ function ConversationRow({
         >
           {relativeTime(conversation.updated_at * 1000)}
         </span>
-      )}
-      {/* Quick pin/unpin — the sole pin affordance now (removed from the
-          kebab menu). Sits just left of the kebab. On mobile (no hover) it's
-          always visible alongside the kebab; on desktop it reveals on
-          hover/focus, and stays surfaced while the kebab menu is open so it
-          doesn't vanish when the row's controls are otherwise visible. */}
-      <Button
+      ) : null}
+      {!selectionMode && <Button
         type="button"
         variant="ghost"
         size="icon-sm"
@@ -925,8 +1009,8 @@ function ConversationRow({
         }}
       >
         {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
-      </Button>
-      <DropdownMenu>
+      </Button>}
+      {!selectionMode && <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"
@@ -1082,7 +1166,7 @@ function ConversationRow({
             </Tooltip>
           )}
         </DropdownMenuContent>
-      </DropdownMenu>
+      </DropdownMenu>}
       <PermissionsModal sessionId={conversation.id} open={shareOpen} onOpenChange={setShareOpen} />
       <Dialog
         open={deleteOpen}
@@ -1371,6 +1455,280 @@ function ConversationEditRow({ initialTitle, onCommit, onCancel }: ConversationE
         <XIcon className="size-3.5" />
       </Button>
     </div>
+  );
+}
+
+function BulkActionBar({
+  selectedIds,
+  allConversations,
+  onSelectAll,
+  onDeselectAll,
+  onDone,
+}: {
+  selectedIds: Set<string>;
+  allConversations: Conversation[];
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onDone: () => void;
+}) {
+  const navigate = useNavigate();
+  const { conversationId: activeId } = useParams<{ conversationId: string }>();
+  const bulkArchive = useBulkArchiveConversations();
+  const bulkDelete = useBulkDeleteConversations();
+  const bulkStop = useBulkStopSessions();
+
+  const selectedConversations = useMemo(
+    () => allConversations.filter((c) => selectedIds.has(c.id)),
+    [allConversations, selectedIds],
+  );
+
+  const ownedSelected = useMemo(
+    () => selectedConversations.filter((c) => isOwnedByViewer(c)),
+    [selectedConversations],
+  );
+
+  const stoppableSelected = useMemo(
+    () =>
+      ownedSelected.filter(
+        (c) =>
+          isSessionStoppable({ labels: c.labels, hostId: c.host_id, runnerId: c.runner_id }) &&
+          c.status === "running",
+      ),
+    [ownedSelected],
+  );
+
+  const archivedSelected = useMemo(
+    () => ownedSelected.filter((c) => c.archived === true),
+    [ownedSelected],
+  );
+
+  const nonArchivedSelected = useMemo(
+    () => ownedSelected.filter((c) => c.archived !== true),
+    [ownedSelected],
+  );
+
+  const count = selectedIds.size;
+  const allSelected = count > 0 && count === allConversations.length;
+  const isBusy = bulkArchive.isPending || bulkDelete.isPending || bulkStop.isPending;
+
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  function handleArchive() {
+    if (nonArchivedSelected.length === 0) return;
+    bulkArchive.mutate(
+      { ids: nonArchivedSelected.map((c) => c.id), archived: true },
+      {
+        onSuccess: () => {
+          onDeselectAll();
+        },
+      },
+    );
+  }
+
+  function handleUnarchive() {
+    if (archivedSelected.length === 0) return;
+    bulkArchive.mutate(
+      { ids: archivedSelected.map((c) => c.id), archived: false },
+      {
+        onSuccess: () => {
+          onDeselectAll();
+        },
+      },
+    );
+  }
+
+  function handleDelete() {
+    const ids = ownedSelected.map((c) => c.id);
+    if (ids.length === 0) return;
+    setConfirmDeleteOpen(false);
+    bulkDelete.mutate(ids, {
+      onSuccess: () => {
+        if (activeId && ids.includes(activeId)) navigate("/", { replace: true });
+        onDeselectAll();
+      },
+      onError: (err: any) => {
+        if (activeId && err?.succeeded?.includes(activeId)) navigate("/", { replace: true });
+      },
+    });
+  }
+
+  function handleStop() {
+    if (stoppableSelected.length === 0) return;
+    bulkStop.mutate(
+      stoppableSelected.map((c) => c.id),
+      {
+        onSuccess: () => {
+          onDeselectAll();
+        },
+      },
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-2 border-t border-border bg-card px-3 py-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-muted-foreground">
+            {count === 0 ? "None selected" : `${count} selected`}
+          </span>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={allSelected ? onDeselectAll : onSelectAll}
+            >
+              {allSelected ? "Deselect all" : "Select all"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={onDone}
+            >
+              Done
+            </Button>
+          </div>
+        </div>
+
+        {count > 0 && (
+          <div className="flex items-center gap-1.5">
+            {nonArchivedSelected.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5 text-xs"
+                    disabled={isBusy}
+                    onClick={handleArchive}
+                    data-testid="bulk-archive"
+                  >
+                    {bulkArchive.isPending ? (
+                      <Loader2Icon className="size-3 animate-spin" />
+                    ) : (
+                      <ArchiveIcon className="size-3" />
+                    )}
+                    Archive
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Archive {nonArchivedSelected.length} session(s)</TooltipContent>
+              </Tooltip>
+            )}
+            {archivedSelected.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5 text-xs"
+                    disabled={isBusy}
+                    onClick={handleUnarchive}
+                    data-testid="bulk-unarchive"
+                  >
+                    {bulkArchive.isPending ? (
+                      <Loader2Icon className="size-3 animate-spin" />
+                    ) : (
+                      <ArchiveRestoreIcon className="size-3" />
+                    )}
+                    Unarchive
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Unarchive {archivedSelected.length} session(s)</TooltipContent>
+              </Tooltip>
+            )}
+            {stoppableSelected.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5 text-xs text-destructive"
+                    disabled={isBusy}
+                    onClick={handleStop}
+                    data-testid="bulk-stop"
+                  >
+                    {bulkStop.isPending ? (
+                      <Loader2Icon className="size-3 animate-spin" />
+                    ) : (
+                      <CircleStopIcon className="size-3" />
+                    )}
+                    Stop
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Stop {stoppableSelected.length} session(s)</TooltipContent>
+              </Tooltip>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1.5 text-xs text-destructive"
+                  disabled={isBusy || ownedSelected.length === 0}
+                  onClick={() => setConfirmDeleteOpen(true)}
+                  data-testid="bulk-delete"
+                >
+                  {bulkDelete.isPending ? (
+                    <Loader2Icon className="size-3 animate-spin" />
+                  ) : (
+                    <Trash2Icon className="size-3" />
+                  )}
+                  Delete
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {ownedSelected.length > 0
+                  ? `Delete ${ownedSelected.length} session(s)`
+                  : "No owned sessions selected"}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+
+        {(bulkArchive.isError || bulkDelete.isError || bulkStop.isError) && (
+          <p className="text-xs text-destructive" role="alert">
+            Some actions failed. Retry or dismiss.
+          </p>
+        )}
+      </div>
+
+      <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {ownedSelected.length} session(s)?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete the selected sessions and all their history. This cannot
+              be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="border-t-0 bg-transparent">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={bulkDelete.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={bulkDelete.isPending}
+            >
+              Delete {ownedSelected.length} session(s)
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -395,6 +395,18 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           scrollbars, the list's scrollbar appearing/disappearing (e.g. while
           a Radix menu locks scrolling) resizes every row — titles gain/lose
           a character. Reserving the gutter keeps row width constant. */}
+      {selectionMode && (
+        <BulkActionBar
+          selectedIds={selectedIds}
+          allConversations={(conversationsQuery.data?.pages ?? []).flatMap((page) => page.data)}
+          onSelectAll={() =>
+            selectAll((conversationsQuery.data?.pages ?? []).flatMap((page) => page.data))
+          }
+          onDeselectAll={deselectAll}
+          onClear={exitSelectionMode}
+        />
+      )}
+
       <nav className="relative flex-1 overflow-y-auto px-3 pb-3 [scrollbar-gutter:stable]">
         <ConversationList
           conversationsQuery={conversationsQuery}
@@ -408,18 +420,6 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           onToggleSelected={toggleSelected}
         />
       </nav>
-
-      {selectionMode && (
-        <BulkActionBar
-          selectedIds={selectedIds}
-          allConversations={(conversationsQuery.data?.pages ?? []).flatMap((page) => page.data)}
-          onSelectAll={() =>
-            selectAll((conversationsQuery.data?.pages ?? []).flatMap((page) => page.data))
-          }
-          onDeselectAll={deselectAll}
-          onDone={exitSelectionMode}
-        />
-      )}
 
       {/* Account footer. Sibling *after* the flex-1 nav so it pins to the
           bottom of the sidebar column. Renders nothing (no border, no
@@ -1472,13 +1472,13 @@ function BulkActionBar({
   allConversations,
   onSelectAll,
   onDeselectAll,
-  onDone,
+  onClear,
 }: {
   selectedIds: Set<string>;
   allConversations: Conversation[];
   onSelectAll: () => void;
   onDeselectAll: () => void;
-  onDone: () => void;
+  onClear: () => void;
 }) {
   const navigate = useNavigate();
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
@@ -1515,6 +1515,10 @@ function BulkActionBar({
     () => ownedSelected.filter((c) => c.archived !== true),
     [ownedSelected],
   );
+
+  const allSelectedSameArchiveGroup =
+    ownedSelected.length > 0 &&
+    (archivedSelected.length === 0 || nonArchivedSelected.length === 0);
 
   const count = selectedIds.size;
   const allSelected = count > 0 && count === allConversations.length;
@@ -1575,7 +1579,7 @@ function BulkActionBar({
 
   return (
     <>
-      <div className="flex flex-col gap-2 border-t border-border bg-card px-3 py-2">
+      <div className="flex flex-col gap-2 border-b border-border bg-card px-3 py-2">
         <div className="flex items-center justify-between">
           <span className="text-xs font-medium text-muted-foreground">
             {count === 0 ? "None selected" : `${count} selected`}
@@ -1595,16 +1599,16 @@ function BulkActionBar({
               variant="ghost"
               size="sm"
               className="h-6 px-2 text-xs"
-              onClick={onDone}
+              onClick={onClear}
             >
-              Done
+              Clear
             </Button>
           </div>
         </div>
 
         {count > 0 && (
           <div className="flex items-center gap-1.5">
-            {nonArchivedSelected.length > 0 && (
+            {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
@@ -1627,7 +1631,7 @@ function BulkActionBar({
                 <TooltipContent>Archive {nonArchivedSelected.length} session(s)</TooltipContent>
               </Tooltip>
             )}
-            {archivedSelected.length > 0 && (
+            {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button

--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -5,7 +5,7 @@ button next to the search box. Once active, each conversation row renders
 a checkbox (``SquareCheckBigIcon`` / ``SquareIcon``); clicking the row
 toggles selection instead of navigating. A ``BulkActionBar`` appears at
 the bottom of the sidebar with Archive, Unarchive, Stop, Delete, Select
-all / Deselect all, and Clear controls.
+all / Deselect all, and Clear (deselect) controls.
 
 These tests drive the full round-trip: enter selection mode → select
 sessions → perform a bulk action → verify the server-side effect is
@@ -47,7 +47,8 @@ def test_selection_mode_toggle(
     - Rows show checkbox icons in selection mode.
     - Clicking a row in selection mode toggles its selection (no navigation).
     - The BulkActionBar shows the selection count.
-    - Exiting selection mode (Clear button) hides the bar and checkboxes.
+    - Clicking Clear deselects all but stays in selection mode.
+    - Exiting selection mode (toggle button) hides the bar and checkboxes.
 
     :param page: Playwright page fixture (fresh context per test).
     :param seeded_session: ``(base_url, session_id)`` for a pre-created
@@ -82,8 +83,15 @@ def test_selection_mode_toggle(
     # BulkActionBar shows "1 selected".
     expect(page.get_by_text("1 selected")).to_be_visible()
 
-    # Click Clear to exit selection mode.
+    # Click Clear to deselect all (stays in selection mode).
     page.get_by_role("button", name="Clear").click()
+    expect(page.get_by_text("None selected")).to_be_visible()
+
+    # Still in selection mode — checkbox icons remain visible (unchecked).
+    expect(row.locator("svg.lucide-square")).to_be_visible()
+
+    # Exit selection mode via the toggle button.
+    toggle.click()
     expect(toggle).to_have_attribute("aria-label", "Select sessions")
 
     # Checkbox icons should be gone.
@@ -91,7 +99,7 @@ def test_selection_mode_toggle(
     expect(row.locator("svg.lucide-square-check-big")).to_have_count(0)
 
     # BulkActionBar text should be gone.
-    expect(page.get_by_text("1 selected")).to_have_count(0)
+    expect(page.get_by_text("None selected")).to_have_count(0)
 
 
 def test_bulk_archive_moves_session_to_archived(

--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -71,13 +71,14 @@ def test_selection_mode_toggle(
     expect(toggle).to_have_attribute("aria-label", "Exit selection mode")
 
     # The row should now show a checkbox icon (unchecked square).
-    checkbox_unchecked = row.locator("svg.lucide-square")
+    row_link = row.locator(f'a[href="/c/{session_id}"]')
+    checkbox_unchecked = row_link.locator("svg.lucide-square")
     expect(checkbox_unchecked).to_be_visible()
 
     # Click the row to select it — should NOT navigate away.
-    row.locator("a").click()
+    row_link.click()
     # The checked icon appears instead of the unchecked one.
-    checkbox_checked = row.locator("svg.lucide-square-check-big")
+    checkbox_checked = row_link.locator("svg.lucide-square-check-big")
     expect(checkbox_checked).to_be_visible()
 
     # BulkActionBar shows "1 selected".
@@ -88,15 +89,15 @@ def test_selection_mode_toggle(
     expect(page.get_by_text("None selected")).to_be_visible()
 
     # Still in selection mode — checkbox icons remain visible (unchecked).
-    expect(row.locator("svg.lucide-square")).to_be_visible()
+    expect(row_link.locator("svg.lucide-square")).to_be_visible()
 
     # Exit selection mode via the toggle button.
     toggle.click()
     expect(toggle).to_have_attribute("aria-label", "Select sessions")
 
     # Checkbox icons should be gone.
-    expect(row.locator("svg.lucide-square")).to_have_count(0)
-    expect(row.locator("svg.lucide-square-check-big")).to_have_count(0)
+    expect(row_link.locator("svg.lucide-square")).to_have_count(0)
+    expect(row_link.locator("svg.lucide-square-check-big")).to_have_count(0)
 
     # BulkActionBar text should be gone.
     expect(page.get_by_text("None selected")).to_have_count(0)
@@ -127,7 +128,7 @@ def test_bulk_archive_moves_session_to_archived(
 
     # Enter selection mode and select the row.
     page.get_by_test_id("toggle-selection-mode").click()
-    row.locator("a").click()
+    row.locator(f'a[href="/c/{session_id}"]').click()
     expect(page.get_by_text("1 selected")).to_be_visible()
 
     # Click Archive.
@@ -184,7 +185,7 @@ def test_bulk_delete_removes_sessions(
 
     # Enter selection mode and select the row.
     page.get_by_test_id("toggle-selection-mode").click()
-    row.locator("a").click()
+    row.locator(f'a[href="/c/{session_id}"]').click()
     expect(page.get_by_text("1 selected")).to_be_visible()
 
     # Click Delete — should open confirmation dialog.

--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -21,9 +21,9 @@ import httpx
 from playwright.sync_api import Locator, Page, expect
 
 
-def _row(page: Page, session_id: str) -> Locator:
-    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
-    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+def _row_link(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row link for *session_id* by its href."""
+    return page.locator(f'a[href="/c/{session_id}"]')
 
 
 def _set_title(base_url: str, session_id: str, title: str) -> None:
@@ -60,7 +60,7 @@ def test_selection_mode_toggle(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row(page, session_id)
+    row = _row_link(page, session_id)
     expect(row).to_be_visible()
 
     toggle = page.get_by_test_id("toggle-selection-mode")
@@ -71,15 +71,12 @@ def test_selection_mode_toggle(
     expect(toggle).to_have_attribute("aria-label", "Exit selection mode")
 
     # The row should now show a checkbox icon (unchecked square).
-    row_link = row.locator(f'a[href="/c/{session_id}"]')
-    checkbox_unchecked = row_link.locator("svg.lucide-square")
-    expect(checkbox_unchecked).to_be_visible()
+    expect(row.locator("svg.lucide-square")).to_be_visible()
 
     # Click the row to select it — should NOT navigate away.
-    row_link.click()
+    row.click()
     # The checked icon appears instead of the unchecked one.
-    checkbox_checked = row_link.locator("svg.lucide-square-check-big")
-    expect(checkbox_checked).to_be_visible()
+    expect(row.locator("svg.lucide-square-check-big")).to_be_visible()
 
     # BulkActionBar shows "1 selected".
     expect(page.get_by_text("1 selected")).to_be_visible()
@@ -89,15 +86,15 @@ def test_selection_mode_toggle(
     expect(page.get_by_text("None selected")).to_be_visible()
 
     # Still in selection mode — checkbox icons remain visible (unchecked).
-    expect(row_link.locator("svg.lucide-square")).to_be_visible()
+    expect(row.locator("svg.lucide-square")).to_be_visible()
 
     # Exit selection mode via the toggle button.
     toggle.click()
     expect(toggle).to_have_attribute("aria-label", "Select sessions")
 
     # Checkbox icons should be gone.
-    expect(row_link.locator("svg.lucide-square")).to_have_count(0)
-    expect(row_link.locator("svg.lucide-square-check-big")).to_have_count(0)
+    expect(row.locator("svg.lucide-square")).to_have_count(0)
+    expect(row.locator("svg.lucide-square-check-big")).to_have_count(0)
 
     # BulkActionBar text should be gone.
     expect(page.get_by_text("None selected")).to_have_count(0)
@@ -123,12 +120,12 @@ def test_bulk_archive_moves_session_to_archived(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row(page, session_id)
+    row = _row_link(page, session_id)
     expect(row).to_be_visible()
 
     # Enter selection mode and select the row.
     page.get_by_test_id("toggle-selection-mode").click()
-    row.locator(f'a[href="/c/{session_id}"]').click()
+    row.click()
     expect(page.get_by_text("1 selected")).to_be_visible()
 
     # Click Archive.
@@ -180,12 +177,12 @@ def test_bulk_delete_removes_sessions(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row(page, session_id)
+    row = _row_link(page, session_id)
     expect(row).to_be_visible()
 
     # Enter selection mode and select the row.
     page.get_by_test_id("toggle-selection-mode").click()
-    row.locator(f'a[href="/c/{session_id}"]').click()
+    row.click()
     expect(page.get_by_text("1 selected")).to_be_visible()
 
     # Click Delete — should open confirmation dialog.
@@ -236,7 +233,7 @@ def test_select_all_and_deselect_all(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row(page, session_id)
+    row = _row_link(page, session_id)
     expect(row).to_be_visible()
 
     # Enter selection mode.

--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -5,7 +5,7 @@ button next to the search box. Once active, each conversation row renders
 a checkbox (``SquareCheckBigIcon`` / ``SquareIcon``); clicking the row
 toggles selection instead of navigating. A ``BulkActionBar`` appears at
 the bottom of the sidebar with Archive, Unarchive, Stop, Delete, Select
-all / Deselect all, and Done controls.
+all / Deselect all, and Clear controls.
 
 These tests drive the full round-trip: enter selection mode → select
 sessions → perform a bulk action → verify the server-side effect is
@@ -47,7 +47,7 @@ def test_selection_mode_toggle(
     - Rows show checkbox icons in selection mode.
     - Clicking a row in selection mode toggles its selection (no navigation).
     - The BulkActionBar shows the selection count.
-    - Exiting selection mode (Done button) hides the bar and checkboxes.
+    - Exiting selection mode (Clear button) hides the bar and checkboxes.
 
     :param page: Playwright page fixture (fresh context per test).
     :param seeded_session: ``(base_url, session_id)`` for a pre-created
@@ -82,8 +82,8 @@ def test_selection_mode_toggle(
     # BulkActionBar shows "1 selected".
     expect(page.get_by_text("1 selected")).to_be_visible()
 
-    # Click Done to exit selection mode.
-    page.get_by_role("button", name="Done").click()
+    # Click Clear to exit selection mode.
+    page.get_by_role("button", name="Clear").click()
     expect(toggle).to_have_attribute("aria-label", "Select sessions")
 
     # Checkbox icons should be gone.

--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -1,0 +1,249 @@
+"""Browser e2e for bulk session actions in the sidebar.
+
+Selection mode is toggled via the ``data-testid="toggle-selection-mode"``
+button next to the search box. Once active, each conversation row renders
+a checkbox (``SquareCheckBigIcon`` / ``SquareIcon``); clicking the row
+toggles selection instead of navigating. A ``BulkActionBar`` appears at
+the bottom of the sidebar with Archive, Unarchive, Stop, Delete, Select
+all / Deselect all, and Done controls.
+
+These tests drive the full round-trip: enter selection mode → select
+sessions → perform a bulk action → verify the server-side effect is
+durable (not just a client-cache splice).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Give a session a title via ``PATCH /v1/sessions/{id}``."""
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def test_selection_mode_toggle(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Entering selection mode shows checkboxes; exiting hides them and clears selection.
+
+    Verifies:
+    - The toggle button enters selection mode (aria-label flips).
+    - Rows show checkbox icons in selection mode.
+    - Clicking a row in selection mode toggles its selection (no navigation).
+    - The BulkActionBar shows the selection count.
+    - Exiting selection mode (Done button) hides the bar and checkboxes.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-bulk-toggle-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    toggle = page.get_by_test_id("toggle-selection-mode")
+    expect(toggle).to_have_attribute("aria-label", "Select sessions")
+
+    # Enter selection mode.
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-label", "Exit selection mode")
+
+    # The row should now show a checkbox icon (unchecked square).
+    checkbox_unchecked = row.locator("svg.lucide-square")
+    expect(checkbox_unchecked).to_be_visible()
+
+    # Click the row to select it — should NOT navigate away.
+    row.locator("a").click()
+    # The checked icon appears instead of the unchecked one.
+    checkbox_checked = row.locator("svg.lucide-square-check-big")
+    expect(checkbox_checked).to_be_visible()
+
+    # BulkActionBar shows "1 selected".
+    expect(page.get_by_text("1 selected")).to_be_visible()
+
+    # Click Done to exit selection mode.
+    page.get_by_role("button", name="Done").click()
+    expect(toggle).to_have_attribute("aria-label", "Select sessions")
+
+    # Checkbox icons should be gone.
+    expect(row.locator("svg.lucide-square")).to_have_count(0)
+    expect(row.locator("svg.lucide-square-check-big")).to_have_count(0)
+
+    # BulkActionBar text should be gone.
+    expect(page.get_by_text("1 selected")).to_have_count(0)
+
+
+def test_bulk_archive_moves_session_to_archived(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Bulk-archiving a selected session flips its ``archived`` flag on the server.
+
+    Verifies:
+    - Selecting a session and clicking Archive removes it from the non-archived view.
+    - The server-side ``archived`` flag is durably set (not just a cache splice).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-bulk-archive-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Enter selection mode and select the row.
+    page.get_by_test_id("toggle-selection-mode").click()
+    row.locator("a").click()
+    expect(page.get_by_text("1 selected")).to_be_visible()
+
+    # Click Archive.
+    archive_btn = page.get_by_test_id("bulk-archive")
+    expect(archive_btn).to_be_visible()
+    archive_btn.click()
+
+    # The selection clears on success (the bar shows "None selected" or
+    # exits selection mode). The row may still be visible if "Show archived"
+    # is toggled, but the server flag must be set.
+    # Poll the server to verify the archived flag is durably true.
+    deadline = time.monotonic() + 15.0
+    archived = False
+    while time.monotonic() < deadline:
+        resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+        if resp.status_code == 200 and resp.json().get("archived") is True:
+            archived = True
+            break
+        time.sleep(0.5)
+    assert archived, "session should be archived on the server after bulk archive"
+
+    # Clean up: unarchive the session so it doesn't interfere with other tests.
+    httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"archived": False},
+        timeout=10.0,
+    ).raise_for_status()
+
+
+def test_bulk_delete_removes_sessions(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Bulk-deleting a selected session removes it from the sidebar and the store.
+
+    Verifies:
+    - Selecting a session and clicking Delete opens a confirmation dialog.
+    - Confirming the dialog fires the delete chain.
+    - The row drops out of the sidebar.
+    - The session is gone from the server (``GET /v1/sessions/{id}`` → 404).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-bulk-delete-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Enter selection mode and select the row.
+    page.get_by_test_id("toggle-selection-mode").click()
+    row.locator("a").click()
+    expect(page.get_by_text("1 selected")).to_be_visible()
+
+    # Click Delete — should open confirmation dialog.
+    delete_btn = page.get_by_test_id("bulk-delete")
+    expect(delete_btn).to_be_visible()
+    delete_btn.click()
+
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+    expect(dialog).to_contain_text("Delete 1 session(s)?")
+
+    # Confirm the delete.
+    dialog.get_by_role("button", name="Delete 1 session(s)").click()
+
+    # The row drops out of the sidebar.
+    expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+    # And the deletion is durable on the server.
+    deadline = time.monotonic() + 15.0
+    last_status = None
+    while time.monotonic() < deadline:
+        last_status = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0).status_code
+        if last_status == 404:
+            break
+        time.sleep(0.25)
+    assert last_status == 404, (
+        f"deleted session should be gone from the store (404), got {last_status}"
+    )
+
+
+def test_select_all_and_deselect_all(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Select all / Deselect all buttons toggle all visible sessions.
+
+    Verifies:
+    - "Select all" checks every visible row (selection count matches).
+    - "Deselect all" unchecks everything (count drops to "None selected").
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-bulk-selectall-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+
+    # Enter selection mode.
+    page.get_by_test_id("toggle-selection-mode").click()
+
+    # Initially none selected.
+    expect(page.get_by_text("None selected")).to_be_visible()
+
+    # Click "Select all".
+    page.get_by_role("button", name="Select all").click()
+    # At least 1 session should be selected (the seeded one).
+    expect(page.get_by_text("None selected")).to_have_count(0)
+    # The button text flips to "Deselect all" when all are selected.
+    deselect_btn = page.get_by_role("button", name="Deselect all")
+    expect(deselect_btn).to_be_visible()
+
+    # Click "Deselect all".
+    deselect_btn.click()
+    expect(page.get_by_text("None selected")).to_be_visible()

--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -21,9 +21,20 @@ import httpx
 from playwright.sync_api import Locator, Page, expect
 
 
-def _row_link(page: Page, session_id: str) -> Locator:
-    """Locate the sidebar row link for *session_id* by its href."""
-    return page.locator(f'a[href="/c/{session_id}"]')
+def _row_link(page: Page, title: str) -> Locator:
+    """Locate the sidebar row link by its unique *title* attribute.
+
+    Keying on the title (which is ``conversation.title`` and stays stable
+    in both normal and selection mode) is required rather than the href:
+    in selection mode every row's ``Link`` ``to`` becomes ``"#"``, which
+    react-router resolves against the active ``/c/{id}`` route, so *all*
+    rows collapse to the same href. An ``a[href="/c/{id}"]`` locator is
+    therefore non-unique the moment the sidebar holds more than one
+    session (e.g. leftover fork/clone sessions on the shared CI server),
+    triggering a Playwright strict-mode violation. The per-test title is
+    unique, so it identifies exactly one row.
+    """
+    return page.locator(f'a[title="{title}"]')
 
 
 def _set_title(base_url: str, session_id: str, title: str) -> None:
@@ -60,7 +71,7 @@ def test_selection_mode_toggle(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row_link(page, session_id)
+    row = _row_link(page, title)
     expect(row).to_be_visible()
 
     toggle = page.get_by_test_id("toggle-selection-mode")
@@ -120,7 +131,7 @@ def test_bulk_archive_moves_session_to_archived(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row_link(page, session_id)
+    row = _row_link(page, title)
     expect(row).to_be_visible()
 
     # Enter selection mode and select the row.
@@ -177,7 +188,7 @@ def test_bulk_delete_removes_sessions(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row_link(page, session_id)
+    row = _row_link(page, title)
     expect(row).to_be_visible()
 
     # Enter selection mode and select the row.
@@ -198,7 +209,7 @@ def test_bulk_delete_removes_sessions(
     dialog.get_by_role("button", name="Delete 1 session(s)").click()
 
     # The row drops out of the sidebar.
-    expect(page.locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+    expect(_row_link(page, title)).to_have_count(0)
 
     # And the deletion is durable on the server.
     deadline = time.monotonic() + 15.0
@@ -233,7 +244,7 @@ def test_select_all_and_deselect_all(
 
     page.goto(f"{base_url}/c/{session_id}")
 
-    row = _row_link(page, session_id)
+    row = _row_link(page, title)
     expect(row).to_be_visible()
 
     # Enter selection mode.


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes # N/A

## Summary

- Add selection mode to the sidebar session list, toggled via a checklist icon next to the search bar
- In selection mode, rows show checkboxes and clicking toggles selection instead of navigating
- A bulk action bar appears at the bottom with Archive, Unarchive, Stop, and Delete actions (owner-gated)
- Bulk mutations (`useBulkArchiveConversations`, `useBulkDeleteConversations`, `useBulkStopSessions`) use `Promise.allSettled` for partial-failure resilience

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added e2e test and verified manually.

<img width="458" height="822" alt="image" src="https://github.com/user-attachments/assets/b42a3b1d-aa36-473d-884d-ebeb7fd3c542" />
