### PR TITLE
test: migrate switch-agent and fork-switch e2e tests to mock LLM

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -776,6 +776,18 @@ def _resolve_gateway_env(
         corresponding base URL or auth command.
     """
     host = host_override.rstrip("/") if host_override else None
+    if host is None and base_url_override is not None and auth_command_override is not None:
+        # Generic-provider gateway: explicit base_url + auth command,
+        # no Databricks host or profile required (e.g. ApiKeyAuth with
+        # a mock LLM server URL).
+        return {
+            "ANTHROPIC_BASE_URL": base_url_override,
+            "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": str(
+                auth_refresh_interval_ms or _GATEWAY_AUTH_REFRESH_MS
+            ),
+            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+            _CLAUDE_API_KEY_HELPER_ENV_KEY: auth_command_override,
+        }
     if host is None:
         try:
             from .databricks_executor import _read_databrickscfg

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1024,27 +1024,35 @@ def _build_claude_sdk_spawn_env(
             # _extra_env so it reaches settings.apiKeyHelper at turn time.
             # shlex.quote ensures the key is shell-safe even when it contains
             # special characters.
-            env["HARNESS_CLAUDE_SDK_API_KEY_HELPER"] = (
-                f"printf %s {shlex.quote(auth_from_spec.api_key)}"
-            )
+            _key_cmd = f"printf %s {shlex.quote(auth_from_spec.api_key)}"
+            env["HARNESS_CLAUDE_SDK_API_KEY_HELPER"] = _key_cmd
             if auth_from_spec.base_url:
                 env["HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"] = auth_from_spec.base_url
+                # The gateway auth command is required by
+                # _resolve_gateway_env when no Databricks profile is
+                # present.  Reuse the same printf command so the
+                # executor resolves ANTHROPIC_BASE_URL correctly.
+                env["HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND"] = _key_cmd
             profile = None
         else:
             # Legacy path: executor.config["profile"] or executor.profile.
             # DEPRECATED: use executor.auth: {type: databricks, profile: …} instead.
             profile = spec.executor.config.get("profile") or spec.executor.profile or None
 
-        # Enable Databricks routing when an explicit profile is set OR
-        # the model starts with ``databricks-``
-        # (mirrors the legacy :func:`should_use_databricks_for_claude` heuristic).
-        # Without the model-prefix check, ``databricks-*`` models run with no
-        # profile configured hit ``api.anthropic.com`` and get a confusing
-        # "model not found" error.
-        use_databricks = bool(profile) or (
-            model is not None and model.startswith(("databricks-", "databricks/"))
+        # Enable gateway routing when:
+        # 1. An explicit Databricks profile is set, OR
+        # 2. The model starts with ``databricks-``, OR
+        # 3. An ApiKeyAuth with a custom ``base_url`` is declared (e.g.
+        #    pointing at a mock LLM server).
+        # Without the gateway flag the executor ignores
+        # ``HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL`` and falls through to
+        # ``api.anthropic.com``.
+        use_gateway = (
+            bool(profile)
+            or (model is not None and model.startswith(("databricks-", "databricks/")))
+            or (isinstance(auth_from_spec, ApiKeyAuth) and bool(auth_from_spec.base_url))
         )
-        if use_databricks:
+        if use_gateway:
             env["HARNESS_CLAUDE_SDK_GATEWAY"] = "true"
             if profile:
                 env["HARNESS_CLAUDE_SDK_DATABRICKS_PROFILE"] = str(profile)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -479,6 +479,7 @@ def live_server(
         tmp_path_factory.mktemp("e2e_builtin_agents"),
         databricks_workspace_host=databricks_workspace_host,
         profile=request.config.getoption("--profile") or None,
+        mock_llm_server_url=mock_llm_server_url if using_mock_llm else None,
     )
     env = {
         **os.environ,
@@ -927,6 +928,7 @@ def _materialize_builtin_sdk_chat_spec(
     *,
     databricks_workspace_host: str | None,
     profile: str | None,
+    mock_llm_server_url: str | None = None,
 ) -> Path:
     """
     Write a profile-aware copy of ``sdk-chat-builtin.yaml`` to seed as a built-in.
@@ -945,6 +947,11 @@ def _materialize_builtin_sdk_chat_spec(
     tests look up, and no ``os_env`` is added (the os_env-reset test relies
     on the target declaring none).
 
+    In mock mode (``mock_llm_server_url`` set), injects an ``auth`` block
+    so the claude-sdk executor routes ``ANTHROPIC_BASE_URL`` at the mock
+    server. The Anthropic SDK appends ``/v1/messages`` to the base URL, so
+    the base URL must NOT include ``/v1``.
+
     :param dest_dir: Directory to write the materialized spec into, e.g. a
         ``tmp_path_factory.mktemp(...)`` dir.
     :param databricks_workspace_host: Workspace host URL, or ``None`` when
@@ -952,11 +959,22 @@ def _materialize_builtin_sdk_chat_spec(
     :param profile: The ``--profile`` value to stamp onto the executor,
         e.g. ``"default"``; ignored when *databricks_workspace_host* is
         ``None``.
+    :param mock_llm_server_url: Mock LLM server base URL, e.g.
+        ``"http://127.0.0.1:12345"``. When set, the built-in's executor
+        gets an ``auth`` block pointing at this URL (without ``/v1``).
     :returns: Path to the written ``sdk-chat-builtin.yaml``.
     """
     config = yaml.safe_load(_SDK_CHAT_BUILTIN_SPEC.read_text())
     if databricks_workspace_host is not None:
         _rewrite_yaml_models(config, profile, spread_key=_SDK_CHAT_BUILTIN_SPEC.stem)
+    if mock_llm_server_url is not None:
+        # The Anthropic SDK appends /v1/messages to base_url, so do NOT
+        # include /v1 here — the mock server serves POST /v1/messages.
+        config.setdefault("executor", {})["auth"] = {
+            "type": "api_key",
+            "api_key": "mock-key",
+            "base_url": mock_llm_server_url,
+        }
     dest = dest_dir / _SDK_CHAT_BUILTIN_SPEC.name
     dest.write_text(yaml.safe_dump(config, sort_keys=False))
     return dest

--- a/tests/e2e/test_sessions_fork_e2e.py
+++ b/tests/e2e/test_sessions_fork_e2e.py
@@ -29,7 +29,6 @@ import uuid
 from typing import Any
 
 import httpx
-import pytest
 
 from tests.e2e.conftest import (
     configure_mock_llm,
@@ -368,14 +367,21 @@ def test_fork_with_agent_switch_carries_history(
     claude_coder_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """
     Forking with ``agent_id`` binds the TARGET agent and keeps history.
 
-    Forks a claude-coder-seeded session into the seeded
+    Forks a source-agent-seeded session into the seeded
     ``sdk-chat-builtin`` built-in (same provider family — the
     history-preserving switch the Web UI's picker offers). SDK targets
     replay the copied transcript as context.
+
+    In mock mode the source agent is an inline ``openai-agents`` agent
+    pointed at the mock LLM server, and the ``sdk-chat-builtin`` built-in
+    is wired to the mock server via ``executor.auth.base_url`` (seeded in
+    ``conftest._materialize_builtin_sdk_chat_spec``). The mock server
+    keys responses by model name so each agent gets its own queue.
 
     **What breaks if wrong:**
 
@@ -385,13 +391,41 @@ def test_fork_with_agent_switch_carries_history(
       from the fork's items / the agent can't recall it.
     """
     if using_mock_llm:
-        pytest.skip(
-            "fork-with-agent-switch requires a built-in claude-sdk agent "
-            "as target; the mock LLM cannot drive the claude-sdk harness"
+        uid = uuid.uuid4().hex[:6]
+        source_model = f"mock-fork-switch-src-{uid}"
+        source_agent = register_inline_agent(
+            http_client,
+            name=f"fork-switch-src-{uid}",
+            harness="openai-agents",
+            model=source_model,
+            profile="",
+            prompt="You are a terse assistant.",
+            mock_llm_base_url=f"{mock_llm_server_url}/v1",
         )
+        # Target: the sdk-chat-builtin built-in uses model
+        # "claude-sonnet-4-20250514" — key the mock queue on that.
+        target_model = "claude-sonnet-4-20250514"
+        reset_mock_llm(mock_llm_server_url)
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "OK"}],
+            key=source_model,
+        )
+        # The claude-sdk harness replays the forked transcript as context
+        # when binding the switched fork, which sends an initial
+        # /v1/messages request before the user's recall turn. Queue two
+        # responses: a throwaway for the replay and the codeword for the
+        # actual recall.
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "OK"}, {"text": _CODEWORD_1}],
+            key=target_model,
+        )
+    else:
+        source_agent = claude_coder_agent
 
     source_id = create_runner_bound_session(
-        http_client, agent_name=claude_coder_agent, runner_id=live_runner_id
+        http_client, agent_name=source_agent, runner_id=live_runner_id
     )
     response_id = send_user_message_to_session(
         http_client,

--- a/tests/e2e/test_switch_agent_e2e.py
+++ b/tests/e2e/test_switch_agent_e2e.py
@@ -24,10 +24,10 @@ import time
 import uuid
 
 import httpx
-import pytest
 import yaml
 
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
     poll_session_until_terminal,
     register_inline_agent,
@@ -70,10 +70,11 @@ def test_switch_agent_in_place_carries_history(
     claude_coder_agent: str,
     live_runner_id: str,
     using_mock_llm: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """A switched agent recalls a code word planted before the switch.
 
-    Plants a marker on a claude-sdk session, switches the session IN PLACE to
+    Plants a marker on a source session, switches the session IN PLACE to
     the ``sdk-chat-builtin`` agent, then asks the new agent to recall it. The
     new agent can only answer from the replayed Omnigent transcript — a
     regression (history not carried, or the runner kept serving the old
@@ -81,27 +82,60 @@ def test_switch_agent_in_place_carries_history(
     bound agent actually changed, proving this is an in-place switch and not a
     fork.
 
-    Requires a real LLM: the switch endpoint only binds built-in agents, and
-    the ``sdk-chat-builtin`` built-in uses ``claude-sdk`` which authenticates
-    via the Claude CLI's OAuth session (not mockable through ``OPENAI_BASE_URL``).
+    In mock mode the source agent is an inline ``openai-agents`` agent
+    pointed at the mock LLM server, and the ``sdk-chat-builtin`` built-in
+    is wired to the mock server via ``executor.auth.base_url`` (seeded in
+    ``conftest._materialize_builtin_sdk_chat_spec``). The mock server
+    keys responses by model name so each agent gets its own queue.
 
     :param http_client: HTTP client pointed at the live server.
-    :param claude_coder_agent: The uploaded claude-sdk source agent name.
+    :param claude_coder_agent: The uploaded claude-sdk source agent name
+        (used only in real-LLM mode).
     :param live_runner_id: The server fixture's runner id.
     :param using_mock_llm: Whether mock LLM is active.
+    :param mock_llm_server_url: Mock LLM server URL.
     :returns: None.
     """
-    if using_mock_llm:
-        pytest.skip(
-            "switch-agent only binds built-in agents; sdk-chat-builtin uses "
-            "claude-sdk which requires a real LLM (not mockable via OPENAI_BASE_URL)"
-        )
-
     marker = f"SWITCHWORD_{uuid.uuid4().hex[:6].upper()}"
 
-    # 1. Source session (claude-sdk) on the server's runner; plant a word.
+    if using_mock_llm:
+        # Source: inline openai-agents agent with its own mock queue.
+        uid = uuid.uuid4().hex[:6]
+        source_model = f"mock-switch-src-{uid}"
+        source_agent = register_inline_agent(
+            http_client,
+            name=f"switch-src-{uid}",
+            harness="openai-agents",
+            model=source_model,
+            profile="",
+            prompt="You are a terse assistant.",
+            mock_llm_base_url=f"{mock_llm_server_url}/v1",
+        )
+        # Target: the sdk-chat-builtin built-in uses model
+        # "claude-sonnet-4-20250514" — key the mock queue on that.
+        target_model = "claude-sonnet-4-20250514"
+        reset_mock_llm(mock_llm_server_url)
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "ACK"}],
+            key=source_model,
+        )
+        # The claude-sdk harness replays the prior transcript as context
+        # when binding a switched session, which sends an initial
+        # /v1/messages request before the user's recall turn. Queue two
+        # responses: a throwaway for the replay and the marker for the
+        # actual recall.
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": "OK"}, {"text": marker}],
+            key=target_model,
+        )
+    else:
+        source_agent = claude_coder_agent
+
+    # 1. Source session on the server's runner; plant a word.
     session_id = create_runner_bound_session(
-        http_client, agent_name=claude_coder_agent, runner_id=live_runner_id
+        http_client, agent_name=source_agent, runner_id=live_runner_id
     )
     original_agent_id = _bound_agent(http_client, session_id)["id"]
     rid_1 = send_user_message_to_session(


### PR DESCRIPTION
## Summary
- Remove the `using_mock_llm: pytest.skip(...)` guards from `test_switch_agent_in_place_carries_history` and `test_fork_with_agent_switch_carries_history`, enabling them to run against the mock LLM server
- In mock mode, register an inline `openai-agents` source agent and wire the built-in `sdk-chat-builtin` target to the mock server via `executor.auth.base_url` (seeded in `conftest._materialize_builtin_sdk_chat_spec`)
- Fix `_resolve_gateway_env` to handle the generic-provider path where `base_url_override` + `auth_command_override` are set without any Databricks host/profile
- Fix the workflow layer to set `HARNESS_CLAUDE_SDK_GATEWAY=true` and `HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND` when `ApiKeyAuth` has a `base_url`, so the executor activates gateway transport and threads `ANTHROPIC_BASE_URL` to the CLI subprocess

## Test plan
- [x] `test_switch_agent_in_place_carries_history` passes in mock mode
- [x] `test_fork_with_agent_switch_carries_history` passes in mock mode
- [x] All 6 tests across both files pass (existing tests unaffected)
- [x] Pre-commit hooks pass on all changed files

This pull request and its description were written by Isaac.