### PR TITLE
feat(ci): flag maintainer duplicate PRs instead of auto-closing

### DIFF
--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -1,8 +1,12 @@
 // Close duplicate community PRs that reference (close) the same issue.
 // Only considers open PRs created in the last 14 days. For each issue with
 // more than one such PR, the oldest PR is kept and the newer ones are closed,
-// labeled `duplicate`, and commented on. Maintainer-authored PRs are ignored.
-// Ported from mlflow/mlflow's .github/workflows/duplicate-prs.js.
+// labeled `duplicate`, and commented on. Maintainer PRs are included in
+// detection (so a maintainer's PR can be the kept "keeper") but are never
+// auto-closed: a maintainer duplicate instead gets a softer heads-up comment
+// and the `duplicate` label (no close). Originally ported from mlflow/mlflow's
+// .github/workflows/duplicate-prs.js, with the maintainer skip narrowed from
+// detection to closing only.
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DAYS_TO_CONSIDER = 14;
@@ -10,6 +14,11 @@ const DUPLICATE_LABEL = "duplicate";
 
 const duplicateMessage = (author, issueNumber, keeperPR) =>
   `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). Closing as a duplicate.`;
+
+// Maintainer duplicates are flagged but not auto-closed -- a softer, no-action
+// heads-up so the maintainer can decide what to do.
+const maintainerDuplicateMessage = (author, issueNumber, keeperPR) =>
+  `@${author} This PR may be a duplicate -- it references the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). It won't be auto-closed since it's a maintainer PR; please close it manually if it is indeed a duplicate.`;
 
 // GraphQL query to fetch open PRs created in the search window.
 const QUERY = `
@@ -39,17 +48,22 @@ const QUERY = `
   }
 `;
 
-const shouldProcessPR = (pr) => {
-  // Only process community PRs (skip maintainer / collaborator PRs).
-  const memberAssociations = ["MEMBER", "OWNER", "COLLABORATOR"];
-  if (memberAssociations.includes(pr.authorAssociation)) {
-    return false;
-  }
-  // Skip PRs already labeled as duplicate.
+const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
+
+// Maintainer PRs participate in detection (so they can be the kept "keeper"
+// that makes a community duplicate closeable) but are never themselves closed.
+const isMaintainerPR = (pr) => MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation);
+
+// Whether a PR should be considered at all when grouping by issue. Already
+// labeled-duplicate PRs are skipped (already handled); everything else --
+// community and maintainer alike -- is considered.
+const shouldConsiderPR = (pr) => {
   const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
-  if (labels.includes(DUPLICATE_LABEL)) return false;
-  return true;
+  return !labels.includes(DUPLICATE_LABEL);
 };
+
+// Whether a duplicate PR is eligible to be auto-closed: only community PRs.
+const canClosePR = (pr) => !isMaintainerPR(pr);
 
 const getIssueReferences = (pr) => {
   const references = pr.closingIssuesReferences?.nodes || [];
@@ -86,15 +100,16 @@ module.exports = async ({ context, github }) => {
 
     console.log(`Found ${allPRs.length} open PRs from the last ${DAYS_TO_CONSIDER} days`);
 
-    // Filter to community PRs only.
-    const communityPRs = allPRs.filter(shouldProcessPR);
-    console.log(`${communityPRs.length} are community PRs`);
+    // Consider every open PR (community and maintainer) that isn't already
+    // labeled a duplicate -- a maintainer PR can still be the kept "keeper".
+    const consideredPRs = allPRs.filter(shouldConsiderPR);
+    console.log(`${consideredPRs.length} PRs are eligible for grouping`);
 
     // Group PRs by the single issue they reference.
     // Skip PRs that reference multiple issues (ambiguous intent).
     const prsByIssue = new Map();
 
-    for (const pr of communityPRs) {
+    for (const pr of consideredPRs) {
       const issueRefs = getIssueReferences(pr);
 
       if (issueRefs.length === 0) {
@@ -122,6 +137,7 @@ module.exports = async ({ context, github }) => {
 
     // Process each issue that has multiple PRs.
     let closedCount = 0;
+    let flaggedCount = 0;
     for (const [issueNumber, prs] of prsByIssue.entries()) {
       if (prs.length <= 1) {
         // Only one PR for this issue, no duplicates.
@@ -142,11 +158,40 @@ module.exports = async ({ context, github }) => {
       console.log(`  Keeping PR #${keeper.number} (oldest, created ${keeper.createdAt})`);
 
       for (const pr of duplicates) {
+        // pr.author is null for deleted/ghost accounts; fall back gracefully.
+        const author = pr.author?.login ?? "contributor";
+
+        // Maintainer duplicates are flagged but never auto-closed: post a
+        // heads-up comment, then label so the next run doesn't re-flag them
+        // (the label excludes the PR from grouping via shouldConsiderPR).
+        // Comment before labeling so a label failure re-posts rather than
+        // silently swallowing the heads-up.
+        if (!canClosePR(pr)) {
+          console.log(`  Flagging PR #${pr.number} as a possible duplicate (maintainer PR -- not auto-closed)`);
+
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: pr.number,
+            body: maintainerDuplicateMessage(author, issueNumber, keeper.number),
+          });
+
+          await github.rest.issues.addLabels({
+            owner,
+            repo,
+            issue_number: pr.number,
+            labels: [DUPLICATE_LABEL],
+          });
+
+          flaggedCount++;
+          continue;
+        }
+
         console.log(`  Closing PR #${pr.number} as duplicate (created ${pr.createdAt})`);
 
         // Close first so a failure here leaves the PR open and unlabeled,
         // letting the next run retry. If we labeled first and then failed
-        // to close, shouldProcessPR would skip the PR forever.
+        // to close, shouldConsiderPR would skip the PR forever.
         await github.rest.pulls.update({
           owner,
           repo,
@@ -161,8 +206,6 @@ module.exports = async ({ context, github }) => {
           labels: [DUPLICATE_LABEL],
         });
 
-        // pr.author is null for deleted/ghost accounts; fall back gracefully.
-        const author = pr.author?.login ?? "contributor";
         await github.rest.issues.createComment({
           owner,
           repo,
@@ -174,7 +217,7 @@ module.exports = async ({ context, github }) => {
       }
     }
 
-    console.log(`Closed ${closedCount} duplicate PRs.`);
+    console.log(`Closed ${closedCount} duplicate PRs; flagged ${flaggedCount} maintainer PRs.`);
   } catch (error) {
     if (error.status === 429 || error.message?.includes("rate limit")) {
       console.log(`Rate limit hit. Exiting gracefully.`);

--- a/.github/workflows/duplicate-prs.test.js
+++ b/.github/workflows/duplicate-prs.test.js
@@ -90,13 +90,48 @@ function assert(name, cond, detail) {
   ]);
   assert("distinct issues -> no closures", r.closed.length === 0, JSON.stringify(r));
 
-  // 4. Maintainer (MEMBER) duplicate is ignored; community duplicate closed.
+  // 4a. Maintainer PR (older) is the keeper -> newer community duplicate closes.
   r = await run([
     pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9], assoc: "MEMBER" }),
     pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9] }),
   ]);
-  assert("maintainer PR excluded -> only its lone community PR remains, no closures",
-    r.closed.length === 0, JSON.stringify(r));
+  assert("maintainer keeper -> newer community duplicate is closed",
+    JSON.stringify(r.closed) === JSON.stringify([2]), JSON.stringify(r));
+
+  // 4b. Community PR (older) keeper, maintainer PR (newer) duplicate -> the
+  //     maintainer PR is flagged (heads-up comment + label) but never closed.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9] }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9], assoc: "MEMBER" }),
+  ]);
+  assert("maintainer duplicate is flagged, not closed",
+    r.closed.length === 0 &&
+    JSON.stringify(r.labeled) === JSON.stringify([2]) &&
+    r.commented.length === 1 &&
+    r.commented[0].issue_number === 2 &&
+    r.commented[0].body.includes("won't be auto-closed"),
+    JSON.stringify(r));
+
+  // 4c. Two maintainer PRs on one issue -> neither is closed; the newer one is
+  //     flagged with the heads-up comment.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9], assoc: "OWNER" }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9], assoc: "COLLABORATOR" }),
+  ]);
+  assert("two maintainer PRs -> none closed, newer flagged",
+    r.closed.length === 0 &&
+    JSON.stringify(r.labeled) === JSON.stringify([2]) &&
+    r.commented.length === 1 && r.commented[0].issue_number === 2,
+    JSON.stringify(r));
+
+  // 4d. Mixed group: maintainer keeper + two community duplicates -> both close.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9], assoc: "MEMBER" }),
+    pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [9] }),
+    pr({ number: 3, createdAt: "2026-06-03T00:00:00Z", issues: [9] }),
+  ]);
+  assert("maintainer keeper + 2 community dupes -> both community closed",
+    JSON.stringify(r.closed) === JSON.stringify([2, 3]), JSON.stringify(r));
 
   // 5. Already-labeled duplicate is skipped (filtered before grouping).
   r = await run([


### PR DESCRIPTION
## Related issue

N/A — follow-up to the merged duplicate-PRs workflow (#605).

## Summary

Refines the duplicate-PR automation so maintainer PRs participate in detection without being auto-closed:

- **Detection includes all PRs.** Previously maintainer PRs were dropped before grouping, so a maintainer's PR couldn't be the kept "keeper" and a newer community duplicate of it survived. Now every open PR is grouped by issue; the oldest is the keeper.
- **Only community PRs are auto-closed.** A maintainer PR is never closed by the workflow.
- **Maintainer duplicates are flagged, not closed.** When the newer duplicate is itself a maintainer PR, it gets a softer heads-up comment ("this may be a duplicate … won't be auto-closed since it's a maintainer PR; please close it manually if it is") plus the `duplicate` label (for idempotency, so daily runs don't re-comment), but it stays open.

Behavior matrix (older vs. newer PR on the same issue):

| Older | Newer | Result |
|---|---|---|
| maintainer | community | community duplicate **closed** |
| community | maintainer | maintainer duplicate **flagged** (comment + label), kept open |
| community | community | newer **closed** (unchanged) |
| maintainer | maintainer | newer **flagged**, both kept open |

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Extended `.github/workflows/duplicate-prs.test.js` (offline, mocked GitHub client, no network) to cover the four maintainer arrangements above plus the existing community/ambiguity/no-reference cases — 10 cases total. Ran `node .github/workflows/duplicate-prs.test.js` locally: all 10 PASS. The `duplicate-prs.test.yml` CI job re-runs them on this PR since the script changed.
