### PR TITLE
fix(comments): normalize single-user author so Edit/Delete show in local dev

### DIFF
--- a/omnigent/server/routes/comments.py
+++ b/omnigent/server/routes/comments.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel, model_validator
 from omnigent.entities import Comment
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.auth import LEVEL_EDIT, LEVEL_READ, AuthProvider
-from omnigent.server.routes._auth_helpers import get_user_id, require_access
+from omnigent.server.routes._auth_helpers import (
+    attribution_user,
+    get_user_id,
+    require_access,
+)
 from omnigent.stores import ConversationStore
 from omnigent.stores.comment_store import CommentStore
 from omnigent.stores.permission_store import PermissionStore
@@ -211,7 +215,12 @@ def create_comments_router(
             start_index=body.start_index,
             end_index=body.end_index,
             anchor_content=body.anchor_content,
-            created_by=user_id,
+            # Map the single-user "local" sentinel to None (matching the
+            # sessions/messages write paths) so single-user comments record
+            # no author and stay editable/deletable by any editor — both the
+            # author-only server gate (``_require_comment_author``) and the
+            # client's Edit/Delete affordances key off ``created_by is None``.
+            created_by=attribution_user(user_id),
         )
         return asdict(comment)
 

--- a/tests/e2e_ui/comments/test_comment_actions.py
+++ b/tests/e2e_ui/comments/test_comment_actions.py
@@ -21,14 +21,23 @@ every file type):
      in a fresh browser context lands on the file with the exact comment
      auto-selected (panel open, card highlighted).
 
-The per-card Edit/Delete affordances are author-gated: they render only when
-the viewer authored the comment. The e2e server runs in header mode with a
-single-user fallback, so a header-less POST records ``created_by = "local"``,
-which the client treats as "no author" — hiding Edit/Delete. The edit/delete
-tests therefore drive the browser AS a real identity (``X-Forwarded-Email``)
-and seed the comment authored by that same identity (see
-``editor_commented_session``); the other tests, which don't depend on author
-gating, use the cheaper header-less ``commented_session``.
+The per-card Edit/Delete affordances are author-gated, with a deliberate
+single-user carve-out:
+
+  * Multi-user: they render only when the viewer authored the comment
+    (``created_by === currentAuthorId``). The author-gated tests drive the
+    browser AS a real identity (``X-Forwarded-Email``) and seed the comment
+    authored by that same identity (see ``editor_commented_session``).
+  * Single-user (the default local-dev experience): the e2e server runs in
+    header mode with a single-user fallback, so a header-less POST records
+    ``created_by = None`` (the server maps the ``"local"`` sentinel to None
+    via ``attribution_user``). The client treats a null author as "owned by
+    any editor", so Edit/Delete render without any identity header — see
+    ``test_single_user_comment_is_editable_and_deletable``, which guards the
+    plain local-dev path that header-driven tests would otherwise mask.
+
+The tests that don't depend on author gating (show-more, address-all,
+copy-link) use the cheaper header-less ``commented_session``.
 """
 
 from __future__ import annotations
@@ -79,14 +88,12 @@ _LONG_BODY = "\n".join(
 _LEVEL_EDIT = 2
 
 # A real (non-``local``) identity used by the author-gated edit/delete tests.
-# The per-card Edit/Delete affordances only render when the viewer authored the
-# comment (``created_by === currentAuthorId``). The e2e server runs in header
-# mode with single-user fallback, so a header-less POST records
-# ``created_by = "local"``, which the client treats as "no author"
-# (``getCurrentAuthorId()`` returns null for the ``local`` sentinel) — hiding
-# Edit/Delete. To exercise those affordances we drive the browser AS this user
-# (X-Forwarded-Email) and seed the comment authored by the same user, so the
-# stored ``created_by`` matches the viewer.
+# In multi-user mode the per-card Edit/Delete affordances only render when the
+# viewer authored the comment (``created_by === currentAuthorId``). To exercise
+# that path we drive the browser AS this user (X-Forwarded-Email) and seed the
+# comment authored by the same user, so the stored ``created_by`` matches the
+# viewer. (The single-user path — header-less, ``created_by = None`` — is
+# covered separately by ``test_single_user_comment_is_editable_and_deletable``.)
 _EDITOR = "editor@ui.test"
 
 
@@ -117,8 +124,9 @@ def _seed_comment(
     When ``author`` is given it is sent as ``X-Forwarded-Email`` so the server
     records that identity as ``created_by`` (required for the author-gated
     Edit/Delete affordances to render for a browser driven as the same user).
-    With no ``author`` the server's single-user fallback records
-    ``created_by = "local"``.
+    With no ``author`` the server's single-user fallback maps the ``"local"``
+    sentinel to ``created_by = None`` (via ``attribution_user``), which the
+    client treats as "owned by any editor".
 
     :param base_url: Live server origin.
     :param session_id: Session to attach the comment to.
@@ -336,6 +344,62 @@ def test_delete_comment(
         ctx.close()
 
     # REST confirms the comment is gone.
+    comments_resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={_FILE_PATH}",
+        timeout=10.0,
+    )
+    comments_resp.raise_for_status()
+    assert comments_resp.json() == [], "comment should be deleted server-side"
+
+
+def test_single_user_comment_is_editable_and_deletable(
+    page: Page,
+    commented_session: tuple[str, str, str],
+) -> None:
+    """In single-user mode, a header-less comment shows Edit/Delete to any editor.
+
+    This guards the default local-dev experience: there is no identity header,
+    so the server records ``created_by = None`` (the ``"local"`` sentinel mapped
+    via ``attribution_user``). The client treats a null author as "owned by any
+    editor", so the per-card Edit and Delete affordances must render and work
+    using the plain ``page`` fixture — no ``X-Forwarded-Email`` context.
+
+    Regression guard: when the comments route stored the raw ``"local"``
+    sentinel instead of ``None``, ``getCurrentAuthorId()`` (null for ``local``)
+    never matched ``created_by``, so Edit/Delete silently vanished in local dev
+    even though the author-gated tests (driven as a real identity) still passed.
+    """
+    base_url, session_id, _comment_id = commented_session
+
+    # The server contract this test guards: a header-less POST records no
+    # author. (Before the fix it stored the raw ``"local"`` sentinel here.)
+    seeded = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/comments?path={_FILE_PATH}",
+        timeout=10.0,
+    )
+    seeded.raise_for_status()
+    assert seeded.json()[0]["created_by"] is None, seeded.json()
+
+    file_viewer = _open_comments_panel(page, base_url, session_id)
+    expect(file_viewer).to_contain_text(_SHORT_BODY)
+
+    # Edit renders for the header-less viewer and persists.
+    file_viewer.get_by_role("button", name="Edit").click()
+    edit_textarea = file_viewer.locator("textarea")
+    expect(edit_textarea).to_have_value(_SHORT_BODY)
+    edited_body = "Edited in single-user mode (e2e)."
+    edit_textarea.fill(edited_body)
+    file_viewer.get_by_role("button", name="Save", exact=True).click()
+    expect(file_viewer).to_contain_text(edited_body)
+    expect(file_viewer).not_to_contain_text(_SHORT_BODY)
+
+    # Delete also renders and removes the comment.
+    file_viewer.get_by_role("button", name="Delete").click()
+    expect(file_viewer).not_to_contain_text(edited_body)
+    expect(file_viewer).to_contain_text("No open comments.")
+
+    # REST confirms the comment is gone, and the seeded comment carried no
+    # author (created_by None) — the single-user contract this test guards.
     comments_resp = httpx.get(
         f"{base_url}/v1/sessions/{session_id}/comments?path={_FILE_PATH}",
         timeout=10.0,


### PR DESCRIPTION
## Problem

In local development, the per-comment **Edit** and **Delete** options stopped appearing on the commenter's own comments.

Root cause: the `add_comment` route stored the raw user id. In single-user/local mode `get_user_id` returns the `"local"` sentinel, so comments were saved with `created_by="local"` instead of `None`. The client treats `"local"` as null (`getCurrentAuthorId()` returns null for the sentinel), so `canModify` in `CommentsPanel.tsx` never matched and the Edit/Delete affordances silently vanished.

This diverged from the sessions/messages write paths, which already normalize the sentinel via `attribution_user()`.

## Fix

Route `created_by` through `attribution_user()` in `add_comment`, mapping the `"local"` sentinel to `None`. With `created_by=None`, both the author-only server gate (`_require_comment_author`) and the client's Edit/Delete affordances treat the comment as editable by any editor — matching the intent already documented in the existing code.

## Test

Added `test_single_user_comment_is_editable_and_deletable` to `tests/e2e_ui/comments/test_comment_actions.py`, covering the default local-dev path that the existing author-gated tests masked (they drove the browser as a real identity). It asserts via REST that a header-less comment records `created_by=None` (the direct regression guard — fails on the old `"local"` behavior) and that Edit/Delete render and work with no identity header. Also corrected now-stale docstrings describing the old behavior.

## Verification

All 6 tests in `test_comment_actions.py` pass locally (Playwright + spawned server), including the existing author-gated multi-user edit/delete tests.