### PR TITLE
chore(ci): run duplicate-PRs sweep every 4 hours instead of daily

### DIFF
--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -3,14 +3,14 @@ name: Duplicate PRs
 # Closes duplicate community PRs that reference the same issue: when more than
 # one open PR (created in the last 14 days) closes the same issue, the oldest is
 # kept and the newer ones are closed, labeled `duplicate`, and commented on.
-# Maintainer-authored PRs are never touched. Runs on a daily schedule (and on
-# demand) rather than per-PR, so a freshly opened PR is only flagged once a real
+# Maintainer-authored PRs are never touched. Runs every 4 hours (and on demand)
+# rather than per-PR, so a freshly opened PR is only flagged once a real
 # duplicate exists. Never checks out or runs PR code -- it reads PR metadata via
 # the API using only the default-branch script. See duplicate-prs.js.
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */4 * * *"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## Related issue

N/A — operational tuning of the duplicate-PRs workflow (#605).

## Summary

Changes the `Duplicate PRs` sweep from daily to **every 4 hours** (`cron: "0 0 * * *"` → `"0 */4 * * *"`), and updates the header comment to match.

A daily cron leaves a duplicate PR open for up to 24h before it's closed, which works against the goal of sparing reviewers. Every 4 hours caps that delay at ~4h — responsive enough to save review time, but not so aggressive that it closes a PR minutes after a maintainer might have reacted. Only 6 runs/day.

Safe to run more often:
- **Idempotent** — closed PRs drop out of the `is:open` search and labeled ones drop out of grouping, so re-running produces no duplicate comments or re-closes.
- **Cheap** — each run is a handful of GraphQL searches (~1 point each) against the 5,000/hr budget.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Configuration-only change to the workflow's cron schedule and a header comment — no executable logic is touched, so there is nothing for a unit test to exercise. The detection/closing logic and its tests are unchanged.
