### PR TITLE
fix(cost): attribute claude-native cost into the per-model TOKEN USAGE view

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -10,6 +10,7 @@ import logging
 import os
 import tempfile
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -1631,7 +1632,7 @@ async def _forward_session_cost(
     # lower transcript read (e.g. just after a rotation) and suppresses
     # steady-state churn. The two fields advance independently (policy_cost
     # moves mid-turn while display_cost/S is frozen).
-    payload: dict[str, float] = {}
+    payload: dict[str, float | str] = {}
     if display_cost is not None and (
         dedupe.posted_cost is None or display_cost > dedupe.posted_cost
     ):
@@ -1642,6 +1643,17 @@ async def _forward_session_cost(
         payload["policy_cost_usd"] = policy_cost
     if not payload:
         return
+    # Tag a display-cost (S) advance with the active model captured by the
+    # statusLine wrapper (``{"model": "claude-opus-4-8", ...}`` in context.json).
+    # claude-native sends no token counts with its cost, so the server has
+    # nothing to attribute the cost to per-model without this — leaving it out
+    # of the TOKEN USAGE breakdown while the session total still counts it. Sent
+    # only when the display cost moves: that is the value being attributed
+    # (``policy_cost_usd``-only mid-turn posts carry no new display cost).
+    if "cumulative_cost_usd" in payload and isinstance(status_state, dict):
+        model = status_state.get("model")
+        if isinstance(model, str) and model:
+            payload["model"] = model
     try:
         await _post_external_session_usage(
             client,
@@ -3159,7 +3171,7 @@ async def _post_external_session_usage(
     client: httpx.AsyncClient,
     *,
     session_id: str,
-    usage: dict[str, float] | None,
+    usage: Mapping[str, float | str] | None,
     context_window: int | None = None,
 ) -> None:
     """
@@ -3170,7 +3182,9 @@ async def _post_external_session_usage(
 
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
-    :param usage: ``message.usage`` snapshot, or ``None`` to skip.
+    :param usage: ``message.usage`` snapshot, or ``None`` to skip. Values are
+        numeric counters/costs, plus an optional ``model`` string tagging the
+        cost with the active model for per-model attribution.
     :param context_window: Resolved window in tokens, or ``None`` to
         leave the server's persisted value untouched.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2352,7 +2352,11 @@ def _resolve_llm_model(conv: Conversation | None) -> str | None:
             agent.id, agent.bundle_location, expand_env=agent.session_id is None
         )
         return loaded.spec.llm.model if loaded.spec.llm else None
-    except (KeyError, AttributeError, ValueError, ImportError, OSError):
+    except (KeyError, AttributeError, ValueError, ImportError, OSError, RuntimeError):
+        # ``RuntimeError`` covers ``get_agent_cache()`` before the runtime is
+        # initialized: this is a best-effort display resolver (now also called
+        # on native cost-only broadcasts), so an uninitialized runtime must
+        # degrade to "model unknown" — the cost still records, just unattributed.
         return None
 
 
@@ -2832,14 +2836,32 @@ def _persist_native_cumulative_usage(
             + int(current.get("output_tokens", 0))
         )
 
-    # Resolve the model only when tokens are present — both the token-pricing
-    # branch and the per-model attribution below need it, and both are gated on
-    # tokens. Resolving lazily avoids calling ``_resolve_llm_model`` (which
-    # touches the runtime agent cache) on a cost-only broadcast. Computed once
-    # out of the pricing-only branch so attribution works even on an unpriced
-    # turn. The raw harness model id wins; falls back to the agent spec's model.
+    # Resolve the model for per-model attribution on any broadcast that carries
+    # tokens OR a priced cost — both the token-pricing branch and the per-model
+    # attribution below need it. A cost-only broadcast must resolve it too:
+    # claude-native forwards Claude Code's statusLine total (S) with NO token
+    # counts, so gating model resolution on tokens alone dropped that cost from
+    # ``by_model`` entirely — the per-model TOKEN USAGE view undercounted the
+    # session total by every native (sub-)agent's spend, while the flat
+    # ``total_cost_usd`` (and the Session-cost badge) still included it.
+    # Priority mirrors the relay path's ``_accumulate_session_usage``: the
+    # event's ``model`` (the statusLine's active model, forwarded alongside the
+    # cost) wins, then the session's ``model_override`` (the forwarder mirrors
+    # in-pane /model switches there), then the agent spec's static model.
+    # Computed once out of the pricing-only branch so attribution works even on
+    # an unpriced turn. (The agent-cache lookup in ``_resolve_llm_model`` is
+    # memoized, so resolving on cost-only polls is cheap.)
     has_tokens = cin is not None or cout is not None
-    model_name = (data.get("model") or _resolve_llm_model(conv)) if has_tokens else None
+    needs_model = has_tokens or cost is not None
+    model_name = (
+        (
+            data.get("model")
+            or (conv.model_override if conv and conv.model_override else None)
+            or _resolve_llm_model(conv)
+        )
+        if needs_model
+        else None
+    )
     if cost is not None:
         current["total_cost_usd"] = float(cost)
     elif has_tokens:
@@ -2863,8 +2885,9 @@ def _persist_native_cumulative_usage(
     # switch the current model absorbs the cumulative (splitting deferred —
     # keyed on the raw harness model id). Cost mirrors the flat
     # ``total_cost_usd`` so the per-model cost key is present iff priced.
-    # ``model_name`` is only set when tokens are present, so this is skipped
-    # for cost-only broadcasts (nothing to attribute per-model).
+    # ``model_name`` is set on token-bearing AND cost-bearing broadcasts, so a
+    # claude-native cost-only broadcast attributes its cumulative cost here too
+    # (token buckets stay absent — claude-native reports no token counts).
     if isinstance(model_name, str) and model_name:
         bucket = _model_usage_bucket(current, model_name)
         for key in _MODEL_TOKEN_KEYS:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4049,6 +4049,101 @@ async def test_external_session_usage_records_per_model_breakdown(
     assert bucket["total_cost_usd"] == pytest.approx(0.42)
 
 
+async def test_external_session_usage_cost_only_attributes_to_model(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A claude-native COST-ONLY broadcast attributes its cost to ``by_model``.
+
+    claude-native forwards Claude Code's statusLine total (S) with NO token
+    counts, tagging it with the active ``model``. Before this fix the per-model
+    view was gated on tokens, so a cost-only broadcast dropped its cost from
+    ``by_model`` entirely — the TOKEN USAGE panel undercounted the session
+    total by every native (sub-)agent's spend while the flat ``total_cost_usd``
+    still included it. The cost must now land in the model's bucket so the
+    per-model costs reconcile with the flat total (the UI's no-drop invariant).
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_session_usage",
+            "data": {"cumulative_cost_usd": 0.42, "model": "claude-opus-4-8"},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    usage = _read_session_usage(db_uri, session["id"])
+    bucket = usage["by_model"]["claude-opus-4-8"]
+    # Cost attributed to the model; no token counts (claude-native reports none).
+    assert bucket["total_cost_usd"] == pytest.approx(0.42)
+    assert "input_tokens" not in bucket
+    # Per-model cost reconciles with the flat session total — the exact gap
+    # this fix closes ($Session-cost == sum of per-model costs).
+    assert bucket["total_cost_usd"] == pytest.approx(usage["total_cost_usd"])
+
+
+async def test_external_session_usage_cost_only_falls_back_to_model_override(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Cost-only attribution falls back to the session's ``model_override``.
+
+    claude-native's cost broadcast omits ``model`` until the statusLine has
+    captured it, but the forwarder mirrors the in-pane active model to
+    ``model_override`` each poll. The native write path must consult it (as the
+    relay path does) so the cost is still attributed per-model rather than
+    silently dropped from the TOKEN USAGE view.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    # Simulate the forwarder having mirrored the active model to model_override.
+    SqlAlchemyConversationStore(db_uri).update_conversation(
+        session["id"], model_override="claude-sonnet-4-6"
+    )
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_session_usage",
+            "data": {"cumulative_cost_usd": 0.10},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    usage = _read_session_usage(db_uri, session["id"])
+    assert usage["by_model"]["claude-sonnet-4-6"]["total_cost_usd"] == pytest.approx(0.10)
+
+
+async def test_external_session_usage_policy_cost_only_skips_attribution(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A ``policy_cost_usd``-only mid-turn post records no per-model bucket.
+
+    Mid-sub-agent-run the displayed statusLine total is frozen, so the
+    forwarder posts only the advancing enforcement cost (no
+    ``cumulative_cost_usd``, no tokens). There is no DISPLAY cost to attribute,
+    so attribution is skipped — only the priced display cost flows into
+    ``by_model`` (and the badge), keeping the per-model view = the flat
+    ``total_cost_usd`` rather than the higher in-flight gate estimate.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_session_usage", "data": {"policy_cost_usd": 0.50}},
+    )
+    assert resp.status_code == 202, resp.text
+
+    usage = _read_session_usage(db_uri, session["id"])
+    assert "by_model" not in usage
+    assert usage.get("policy_cost_usd") == pytest.approx(0.50)
+
+
 async def test_external_session_usage_event_carries_priced_cost(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5847,3 +5847,79 @@ async def test_fetch_session_snapshot_raises_diagnosable_error_on_html_body() ->
     message = str(excinfo.value)
     assert "conv_abc123" in message
     assert "text/html" in message
+
+
+@pytest.mark.asyncio
+async def test_forward_session_cost_tags_display_advance_with_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A display-cost (S) advance is tagged with the statusLine's active model.
+
+    claude-native sends no token counts with its cost, so the server has
+    nothing to attribute the cost to in the per-model TOKEN USAGE view without
+    a ``model`` tag — it would drop the cost from that view. The forwarder
+    rides the statusLine model (captured in context.json) on the payload
+    whenever the display cost advances. A policy-only mid-turn re-post (S
+    frozen, only the gate estimate C advancing) carries NO model: there is no
+    new display cost to attribute, so tagging it would be meaningless churn.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    parent = tmp_path / "sess.jsonl"
+    parent.write_text("parent", encoding="utf-8")
+
+    status_box = {"value": 0.01}
+    monkeypatch.setattr(
+        forwarder,
+        "read_claude_context_state",
+        lambda _bridge: {"total_cost_usd": status_box["value"], "model": "claude-opus-4-8"},
+    )
+    estimate_box = {"value": 0.65}
+    monkeypatch.setattr(
+        forwarder,
+        "_session_cost_estimate",
+        lambda **_kwargs: estimate_box["value"],
+    )
+    subagent_state = forwarder.SubagentForwardState(
+        subagents={
+            "aaa": forwarder.SubagentEntry(subagent_id="aaa", child_conversation_id="conv_child")
+        }
+    )
+    dedupe = forwarder._ForwardDedupeState()
+    posted: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body.get("type") == "external_session_usage":
+            posted.append(body["data"])
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+
+        async def run() -> None:
+            await forwarder._forward_session_cost(
+                client=client,
+                session_id="conv_parent",
+                bridge_dir=bridge_dir,
+                parent_transcript_path=parent,
+                subagent_state=subagent_state,
+                dedupe=dedupe,
+                cost_cache={},
+            )
+
+        # Display cost advances → the model rides along for per-model attribution.
+        await run()
+        assert posted == [
+            {
+                "cumulative_cost_usd": pytest.approx(0.01),
+                "policy_cost_usd": pytest.approx(0.65),
+                "model": "claude-opus-4-8",
+            }
+        ]
+
+        # Mid-turn: S frozen, only C (policy) advances → policy-only re-post
+        # carries NO model (no new display cost to attribute).
+        estimate_box["value"] = 0.90
+        await run()
+        assert posted[-1] == {"policy_cost_usd": pytest.approx(0.90)}


### PR DESCRIPTION
## Problem

The session **Token usage** panel (sourced from `usage_by_model`) and the **Session cost** badge (sourced from the flat `total_cost_usd`) are both summed over the conversation subtree, and the schema promises the per-model costs sum to the session total (`ModelUsage.total_cost_usd` docstring in `omnigent/server/schemas.py`). They diverge badly for any session containing a **claude-native** (sub-)agent — e.g. Session cost `$25.02` while the only model row shows `$3.34`.

## Root cause

- The **relay** path (`_accumulate_session_usage`) and **codex-native** carry token counts, so `_persist_native_cumulative_usage` resolves a model and attributes the cost into `by_model`.
- **claude-native** instead forwards Claude Code's statusLine total (`S`) as a **cost-only** broadcast with *no token counts*. Model resolution was gated on `has_tokens`, so the model was never resolved and the per-model attribution block was skipped. The cost landed in the flat `total_cost_usd` (and the Session-cost badge) but never in `by_model`, so the per-model panel undercounted the session total by every native agent's spend.

## Fix (source-level, preserves model identity)

- **forwarder** (`_forward_session_cost`): tag the cost payload with the active model captured by the statusLine wrapper (already persisted to `context.json`), sent only when the display cost (`S`) advances.
- **server** (`_persist_native_cumulative_usage`): resolve the model on a *cost-bearing* broadcast too, not just a token-bearing one, with priority `data["model"]` → `conv.model_override` (the forwarder mirrors in-pane `/model` switches there) → agent spec — mirroring the relay path. The existing attribution block then records the cost under the model (token buckets stay absent, as claude-native reports none).

This restores the documented invariant (sum of per-model costs == session total) for native sessions. Widening `_post_external_session_usage`'s `usage` param to a covariant `Mapping` also resolves a pre-existing type error.

## Tests

- cost-only broadcast attributes its cost to the event's model and reconciles with the flat total
- cost-only falls back to `model_override` when the event omits `model`
- a `policy_cost_usd`-only mid-turn post skips attribution
- the forwarder tags a display-cost advance with the model and omits it on policy-only re-posts

All new + existing cost/usage/by_model tests pass; mypy on the touched files goes 65 → 64 errors (zero new; one pre-existing invariance error fixed).