### PR TITLE
Fix stale D6 fan-out docstring pointer

### DIFF
--- a/tests/frontends/sdk/test_build_tool_handler_concurrency.py
+++ b/tests/frontends/sdk/test_build_tool_handler_concurrency.py
@@ -17,9 +17,9 @@ concurrently via ``asyncio.gather`` and asserts that the
 total wall-clock is close to the single-body duration, not
 N-times it. Fast (~sleep duration) and deterministic.
 
-The ``@tool`` path's parallel E2E
-(``tests/e2e/test_d6_parallel_fan_out_e2e.py``) exercises
-the same property with a real LLM.
+The re-homed D6 parallel fan-out coverage
+(``tests/integration/test_d6_parallel_fan_out_round_trip.py``) exercises
+the sessions-layer fan-out round trip.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Update the build-tool handler concurrency test docstring to point at the re-homed D6 parallel fan-out integration coverage.
- Remove the stale reference to the deleted e2e path and align the wording with sessions-layer coverage.

## Verification
- `rg -n "tests/e2e/test_d6_parallel_fan_out_e2e.py|test_d6_parallel_fan_out_e2e.py|tests/e2e/test_sys_terminal_e2e.py" tests/frontends/sdk/test_build_tool_handler_concurrency.py` found no stale references.
- `ls tests/integration/test_d6_parallel_fan_out_round_trip.py` confirmed the replacement file exists.
- `ruff check tests/frontends/sdk/test_build_tool_handler_concurrency.py` passed.