### PR TITLE
feat(isaac): add isaac-native terminal-mirror coding agent

### DIFF
--- a/ap-web/src/components/AgentCard.tsx
+++ b/ap-web/src/components/AgentCard.tsx
@@ -26,6 +26,8 @@ function iconForAgent(agent: AvailableAgent): ComponentType<SVGProps<SVGSVGEleme
   if (nativeAgent?.iconKind === "claude") return ClaudeIcon;
   if (nativeAgent?.iconKind === "codex") return CodexIcon;
   if (nativeAgent?.iconKind === "pi") return PiIcon;
+  // Isaac has no branded glyph yet — fall back to the generic bot.
+  if (nativeAgent?.iconKind === "isaac") return BotIcon;
   // A null harness (spec couldn't load) flows through to the bot fallback.
   if (agent.harness?.includes("codex")) return CodexIcon;
   if (agent.harness?.includes("claude")) return ClaudeIcon;

--- a/ap-web/src/lib/nativeCodingAgents.test.ts
+++ b/ap-web/src/lib/nativeCodingAgents.test.ts
@@ -12,6 +12,13 @@ describe("nativeCodingAgentForHarness", () => {
     expect(nativeCodingAgentForHarness("pi-native")?.key).toBe("pi");
   });
 
+  it("resolves the canonical isaac-native harness to the Isaac spec", () => {
+    const spec = nativeCodingAgentForHarness("isaac-native");
+    expect(spec?.key).toBe("isaac");
+    expect(spec?.agentName).toBe("isaac-native-ui");
+    expect(spec?.displayName).toBe("Isaac");
+  });
+
   // The server's harness_kind returns the raw executor.config.harness, so a
   // `native-pi` agent must fold to the same spec — else fork/switch into it
   // would miss the terminal-first wrapper labels and render as chat.

--- a/ap-web/src/lib/nativeCodingAgents.ts
+++ b/ap-web/src/lib/nativeCodingAgents.ts
@@ -4,7 +4,7 @@ export const WRAPPER_LABEL_KEY = "omnigent.wrapper";
 export const UI_MODE_LABEL_KEY = "omnigent.ui";
 export const UI_MODE_TERMINAL_VALUE = "terminal";
 
-export type NativeCodingAgentIconKind = "claude" | "codex" | "pi";
+export type NativeCodingAgentIconKind = "claude" | "codex" | "pi" | "isaac";
 export type NativeCodingAgentCapability = "permissionMode" | "approvalMode";
 
 export interface NativeCodingAgentSpec {
@@ -47,6 +47,15 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "Pi",
     iconKind: "pi",
     sortRank: 30,
+  },
+  {
+    key: "isaac",
+    agentName: "isaac-native-ui",
+    harness: "isaac-native",
+    wrapperLabel: "isaac-native-ui",
+    displayName: "Isaac",
+    iconKind: "isaac",
+    sortRank: 40,
   },
 ] as const satisfies readonly NativeCodingAgentSpec[];
 

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -80,6 +80,7 @@ const BUILTIN_AGENTS = new Set([
   "claude-native-ui", // Claude Code
   "codex-native-ui", // Codex
   "pi-native-ui", // Pi
+  "isaac-native-ui", // Isaac
   "polly",
   "debby",
 ]);

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -20,8 +20,9 @@ export interface ActiveChatOverride {
 export const CLAUDE_NATIVE_DEFAULT_LABEL = "Claude Code";
 export const CODEX_NATIVE_DEFAULT_LABEL = "Codex";
 export const PI_NATIVE_DEFAULT_LABEL = "Pi";
+export const ISAAC_NATIVE_DEFAULT_LABEL = "Isaac";
 
-export type ConversationIconKind = "claude" | "codex" | "pi" | "nessie" | null;
+export type ConversationIconKind = "claude" | "codex" | "pi" | "isaac" | "nessie" | null;
 
 // Display label for a session with no title and no native-wrapper name —
 // shown in the sidebar row and as the browser tab title fallback.

--- a/omnigent/_wrapper_labels.py
+++ b/omnigent/_wrapper_labels.py
@@ -49,3 +49,7 @@ CODEX_NATIVE_WRAPPER_VALUE = "codex-native-ui"
 # Value the ``omnigent pi`` wrapper writes into
 # ``conversations.labels[WRAPPER_LABEL_KEY]``.
 PI_NATIVE_WRAPPER_VALUE = "pi-native-ui"
+
+# Value the ``omnigent isaac`` wrapper writes into
+# ``conversations.labels[WRAPPER_LABEL_KEY]``.
+ISAAC_NATIVE_WRAPPER_VALUE = "isaac-native-ui"

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4199,6 +4199,87 @@ def pi(
     )
 
 
+@cli.command(
+    context_settings={
+        "ignore_unknown_options": True,
+        "allow_extra_args": True,
+    }
+)
+@click.option(
+    "--server",
+    default=None,
+    help=(
+        "Remote omnigent URL. Ensures the host daemon, asks the "
+        "daemon-spawned runner to launch Isaac, and attaches this TTY. "
+        'Pass --server "" to auto-spawn a persistent local server in the '
+        "background and use that instead of a remote one."
+    ),
+)
+@click.option(
+    "-r",
+    "--resume",
+    "resume",
+    is_flag=False,
+    flag_value=_RESUME_PICKER_SENTINEL,
+    default=None,
+    help=(
+        "Resume a prior Omnigent conversation. With a conversation id "
+        "(e.g. ``--resume conv_abc123``) attaches directly; with no value "
+        "opens an interactive picker scoped to isaac-native sessions."
+    ),
+)
+@click.option(
+    "--session",
+    "session_id",
+    metavar="SESSION_ID",
+    default=None,
+    hidden=True,
+    help="Deprecated alias for ``--resume <id>``; kept for one release.",
+)
+@click.argument("isaac_args", nargs=-1, type=click.UNPROCESSED)
+def isaac(
+    server: str | None,
+    resume: str | None,
+    session_id: str | None,
+    isaac_args: tuple[str, ...],
+) -> None:
+    """Launch Isaac TUI in an Omnigent terminal.
+
+    \b
+    Examples:
+      omnigent isaac
+      omnigent isaac --resume conv_abc123
+      omnigent isaac --resume                 # interactive picker
+      omnigent isaac --server https://<app>.databricksapps.com
+    """
+    choice = _split_resume_value(resume)
+    if session_id is not None and (choice.picker or choice.conversation_id is not None):
+        raise click.UsageError(
+            "--session and --resume are mutually exclusive; "
+            "prefer --resume (--session is deprecated).",
+        )
+
+    from omnigent.isaac_native import run_isaac_native
+
+    cfg = _load_effective_config()
+    if server is None:
+        server = cfg.get("server")
+    auto_open_conversation = _resolve_auto_open_conversation_from_config(cfg)
+
+    server = _ensure_backend(server)
+    resolved_session_id = (
+        choice.conversation_id if choice.conversation_id is not None else session_id
+    )
+
+    run_isaac_native(
+        server=server,
+        session_id=resolved_session_id,
+        resume_picker=choice.picker,
+        isaac_args=isaac_args,
+        auto_open_conversation=auto_open_conversation,
+    )
+
+
 def _run_bundled_agent(name: str, run_args: tuple[str, ...]) -> None:
     """Forward a bundled-agent subcommand to ``run`` on its packaged path.
 

--- a/omnigent/harness_aliases.py
+++ b/omnigent/harness_aliases.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 HARNESS_ALIASES: dict[str, str] = {
     "claude": "claude-sdk",
     "native-pi": "pi-native",
+    "native-isaac": "isaac-native",
     # The SDK package / runtime dispatch spelling; specs use "openai-agents".
     "openai-agents-sdk": "openai-agents",
     # User-facing spellings for the Google Antigravity SDK harness; the
@@ -31,6 +32,8 @@ NATIVE_HARNESSES: frozenset[str] = frozenset(
         "native-codex",
         "pi-native",
         "native-pi",
+        "isaac-native",
+        "native-isaac",
     }
 )
 

--- a/omnigent/inner/isaac_native_executor.py
+++ b/omnigent/inner/isaac_native_executor.py
@@ -1,0 +1,62 @@
+"""No-op executor for the ``isaac-native`` terminal mirror.
+
+Unlike the claude/codex/pi native executors, this one forwards nothing. Isaac
+runs in the session terminal and the web UI mirrors that terminal directly:
+browser keystrokes reach Isaac as raw PTY bytes through
+:mod:`omnigent.terminals.ws_bridge`, never through an executor turn. So there is
+no message-injection path, no bridge, and no per-session state — the harness
+subprocess only needs *an* executor to exist so :class:`ExecutorAdapter` can
+build its FastAPI app.
+
+CRITICAL: this executor must read no required spawn env in ``__init__``. The
+pi/codex native executors raise when their bridge-dir env var is unset; copying
+that here would crash every isaac-native harness spawn at construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorEvent,
+    Message,
+    ToolSpec,
+    TurnComplete,
+)
+
+
+class IsaacNativeExecutor(Executor):
+    """Harness-side no-op executor for ``omnigent isaac`` sessions.
+
+    Isaac owns its own terminal I/O; this executor exists only to satisfy the
+    harness contract. Each turn completes immediately with no response.
+    """
+
+    def supports_streaming(self) -> bool:
+        """:returns: ``False`` — output is the mirrored terminal, not turn events."""
+        return False
+
+    def supports_live_message_queue(self) -> bool:
+        """:returns: ``False`` — input reaches Isaac through the terminal PTY."""
+        return False
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        """
+        Complete a turn without doing anything.
+
+        :param messages: Ignored — Isaac receives input via the terminal.
+        :param tools: Ignored — Isaac owns its own tool surface.
+        :param system_prompt: Ignored — Isaac controls its own prompt.
+        :param config: Ignored.
+        :yields: A single :class:`TurnComplete` with no response.
+        """
+        del messages, tools, system_prompt, config
+        yield TurnComplete(response=None)

--- a/omnigent/inner/isaac_native_harness.py
+++ b/omnigent/inner/isaac_native_harness.py
@@ -1,0 +1,28 @@
+"""``harness: isaac-native`` wrap for the native Isaac terminal mirror."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from omnigent.inner.executor import Executor
+from omnigent.inner.isaac_native_executor import IsaacNativeExecutor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+
+def _build_isaac_native_executor() -> Executor:
+    """
+    Construct the native Isaac no-op executor.
+
+    :returns: An :class:`IsaacNativeExecutor`.
+    """
+    return IsaacNativeExecutor()
+
+
+def create_app() -> FastAPI:
+    """
+    Build the ``isaac-native`` harness FastAPI app.
+
+    :returns: The FastAPI app from :class:`ExecutorAdapter`.
+    """
+    adapter = ExecutorAdapter(executor_factory=_build_isaac_native_executor)
+    return adapter.build()

--- a/omnigent/isaac_native.py
+++ b/omnigent/isaac_native.py
@@ -1,0 +1,614 @@
+"""Native Isaac TUI wrapper for the Omnigent CLI.
+
+Unlike the Pi wrapper this is a pure terminal mirror: Isaac talks to its own
+backend, so there is no extension bridge, no provider/credential injection, and
+no forwarding of Web UI messages into the process. The runner hosts the live
+``isaac`` CLI in a tmux pane and the Web UI mirrors that pane; the CLI attaches
+this TTY to the same pane. Resume reattaches the running pane (there is no
+resume of Isaac's own sessions in v1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import click
+import httpx
+import yaml
+
+from omnigent._native_resume_hint import echo_native_resume_hint
+from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
+from omnigent._wrapper_labels import ISAAC_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
+from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
+from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
+from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.host.daemon_launch import (
+    error_text,
+    launch_or_reuse_daemon_runner,
+    wait_for_host_online,
+    wait_for_runner_online,
+)
+from omnigent.native_terminal import (
+    DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_RUNNER_ONLINE_TIMEOUT_S as _DAEMON_RUNNER_ONLINE_TIMEOUT_S,
+)
+from omnigent.native_terminal import (
+    DAEMON_TERMINAL_READY_TIMEOUT_S as _DAEMON_TERMINAL_READY_TIMEOUT_S,
+)
+from omnigent.native_terminal import bind_session_runner as _bind_session_runner
+from omnigent.native_terminal import url_component
+
+_DEFAULT_ISAAC_COMMAND = "isaac"
+_ISAAC_PATH_ENV = "OMNIGENT_ISAAC_COMMAND"
+_AGENT_NAME = "isaac-native-ui"
+_TERMINAL_NAME = "isaac"
+_TERMINAL_SESSION_KEY = "main"
+_SESSION_LABELS = {
+    "omnigent.ui": "terminal",
+    _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
+}
+
+
+@dataclass(frozen=True)
+class NativeIsaacLaunch:
+    """Resolved native Isaac process launch."""
+
+    executable: str
+    argv: list[str]
+
+
+@dataclass(frozen=True)
+class LaunchedIsaacTerminal:
+    """Terminal resource returned by the Omnigent runner launch path."""
+
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+
+
+@dataclass(frozen=True)
+class PreparedIsaacTerminal:
+    """Prepared native Isaac terminal attachment details."""
+
+    session_id: str
+    terminal_id: str
+    tmux_socket: Path | None
+    tmux_target: str | None
+    reattached: bool
+
+
+def _configured_isaac_command(env: Mapping[str, str]) -> str:
+    """Return the configured Isaac executable name/path from *env*."""
+    value = env.get(_ISAAC_PATH_ENV, "").strip()
+    if value:
+        return value
+    return _DEFAULT_ISAAC_COMMAND
+
+
+def resolve_isaac_executable(
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> str:
+    """
+    Resolve the native Isaac executable.
+
+    :param env: Environment mapping to inspect. Defaults to ``os.environ``.
+    :param which: Resolver hook for tests; defaults to ``shutil.which``.
+    :returns: Absolute executable path.
+    :raises click.ClickException: If no Isaac CLI is available.
+    """
+    env = os.environ if env is None else env
+    which = shutil.which if which is None else which
+    command = _configured_isaac_command(env)
+    resolved = which(command)
+    if resolved is None:
+        raise click.ClickException(
+            "Native Isaac requires the 'isaac' CLI on PATH. Install Isaac and add "
+            f"it to PATH. You can also set {_ISAAC_PATH_ENV}=/path/to/isaac."
+        )
+    return resolved
+
+
+def build_isaac_launch(
+    isaac_args: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> NativeIsaacLaunch:
+    """Build the argv for a native Isaac process."""
+    executable = resolve_isaac_executable(env=env, which=which)
+    return NativeIsaacLaunch(executable=executable, argv=[executable, *isaac_args])
+
+
+def run_isaac_native(
+    *,
+    server: str | None,
+    session_id: str | None,
+    isaac_args: tuple[str, ...],
+    resume_picker: bool = False,
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch Isaac TUI in an Omnigent terminal.
+
+    :param server: Resolved Omnigent server URL.
+    :param session_id: Optional existing Omnigent conversation id.
+    :param isaac_args: Raw Isaac CLI args to persist for the runner-owned TUI.
+    :param resume_picker: ``True`` runs the Isaac-native picker.
+    :param auto_open_conversation: When ``True``, open the browser
+        conversation URL after launch.
+    :returns: None after the terminal attach session ends.
+    """
+    _preflight_local_tools()
+    if server is None:
+        raise click.ClickException(
+            "Isaac requires a resolved Omnigent server URL. The CLI should call "
+            "_ensure_backend before run_isaac_native."
+        )
+    with TemporaryDirectory(prefix="omnigent-isaac-native-") as tmpdir:
+        spec_path = _materialize_isaac_agent_spec(Path(tmpdir))
+        _run_with_remote_server(
+            server.rstrip("/"),
+            spec_path,
+            session_id=session_id,
+            resume_picker=resume_picker,
+            isaac_args=isaac_args,
+            auto_open_conversation=auto_open_conversation,
+        )
+
+
+def _materialize_isaac_agent_spec(tmpdir: Path) -> Path:
+    """
+    Write the terminal-first agent spec used by ``omnigent isaac``.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to the generated YAML spec.
+    """
+    yaml_path = tmpdir / "isaac-native-ui.yaml"
+    raw: dict[str, Any] = {
+        "name": _AGENT_NAME,
+        "prompt": (
+            "Isaac is running in the session terminal. The Web UI mirrors that "
+            "terminal directly; Isaac talks to its own backend."
+        ),
+        "executor": {"harness": "isaac-native"},
+        "spawn": True,
+        "os_env": {
+            "type": "caller_process",
+            "cwd": ".",
+            "sandbox": {"type": "none"},
+        },
+        "terminals": {
+            "shell": {
+                "command": "bash",
+                "allow_cwd_override": True,
+                "os_env": {
+                    "type": "caller_process",
+                    "cwd": ".",
+                    "sandbox": {"type": "none"},
+                },
+            },
+        },
+    }
+    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return yaml_path
+
+
+def _run_with_remote_server(
+    base_url: str,
+    spec_path: Path,
+    *,
+    session_id: str | None,
+    resume_picker: bool,
+    isaac_args: tuple[str, ...],
+    auto_open_conversation: bool = False,
+) -> None:
+    """
+    Launch Isaac on an Omnigent server via a daemon-spawned runner.
+
+    :param base_url: Omnigent server base URL.
+    :param spec_path: Generated Isaac wrapper agent spec.
+    :param session_id: Optional existing Omnigent session id.
+    :param resume_picker: When ``True``, run the Isaac-native picker.
+    :param isaac_args: Raw Isaac CLI args.
+    :param auto_open_conversation: Whether to open the web conversation URL.
+    """
+    from omnigent.chat import _bundle_agent, _remote_headers
+    from omnigent.cli import _ensure_host_daemon
+    from omnigent.host.identity import load_or_create_host_identity
+
+    headers = _remote_headers(server_url=base_url)
+    try:
+        resolved_session_id = _resolve_session_id_for_resume(
+            base_url=base_url,
+            headers=headers,
+            session_id=session_id,
+            resume_picker=resume_picker,
+        )
+        if resolved_session_id is None and resume_picker and session_id is None:
+            return
+
+        async def _drive() -> None:
+            with runner_startup_progress(initial_message="Preparing Isaac...") as progress:
+                _update_startup_progress(progress, "Connecting to local daemon...")
+                _ensure_host_daemon(base_url)
+                host_id = load_or_create_host_identity().host_id
+                bundle = None if resolved_session_id is not None else _bundle_agent(spec_path)
+                prepared = await _prepare_isaac_terminal_via_daemon(
+                    base_url=base_url,
+                    headers=headers,
+                    session_id=resolved_session_id,
+                    session_bundle=bundle,
+                    isaac_args=isaac_args,
+                    host_id=host_id,
+                    workspace=str(Path.cwd().resolve()),
+                    startup_progress=progress,
+                )
+            click.echo(f"Web UI: {conversation_url(base_url, prepared.session_id)}", err=True)
+            open_conversation_link_if_enabled(
+                base_url=base_url,
+                conversation_id=prepared.session_id,
+                enabled=auto_open_conversation,
+                warn=lambda message: click.echo(message, err=True),
+            )
+            await _attach_terminal_resource(prepared)
+            if resolved_session_id is None:
+                echo_native_resume_hint(
+                    native_command="isaac",
+                    session_id=prepared.session_id,
+                    server=base_url,
+                )
+
+        asyncio.run(_drive())
+    except httpx.ConnectError as exc:
+        raise click.ClickException(
+            f"Could not reach the omnigent server at {base_url}. "
+            "Confirm the server is running and reachable from here "
+            f"(e.g. `curl {base_url}/health`), and that --server is correct."
+        ) from exc
+
+
+async def _prepare_isaac_terminal_via_daemon(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    session_bundle: bytes | None,
+    isaac_args: tuple[str, ...],
+    host_id: str,
+    workspace: str,
+    startup_progress: RunnerStartupProgress | None = None,
+) -> PreparedIsaacTerminal:
+    """
+    Create or resume an Isaac-native session through a daemon runner.
+
+    :param base_url: Omnigent server base URL.
+    :param headers: HTTP auth headers for Omnigent requests.
+    :param session_id: Existing session id to resume, or ``None``.
+    :param session_bundle: Gzipped Isaac wrapper bundle for fresh sessions.
+    :param isaac_args: User pass-through Isaac args.
+    :param host_id: Local host daemon id.
+    :param workspace: Absolute workspace path for the runner cwd.
+    :param startup_progress: Optional user-visible progress renderer.
+    :returns: Prepared terminal details for attaching.
+    """
+    persist_args = list(isaac_args)
+    timeout = httpx.Timeout(30.0, read=120.0)
+    async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
+        reattached = session_id is not None
+        if session_id is None:
+            if session_bundle is None:
+                raise click.ClickException("Creating an Isaac session requires a session bundle.")
+            _update_startup_progress(startup_progress, "Creating Isaac session...")
+            session_id = await _create_isaac_session(
+                client,
+                session_bundle,
+                terminal_launch_args=persist_args or None,
+            )
+        else:
+            _update_startup_progress(startup_progress, "Loading Isaac session...")
+            payload = await _fetch_isaac_session(client, session_id)
+            labels = payload.get("labels") if isinstance(payload, dict) else None
+            if (
+                not isinstance(labels, dict)
+                or labels.get(_WRAPPER_LABEL_KEY) != _WRAPPER_LABEL_VALUE
+            ):
+                raise click.ClickException(
+                    f"Conversation {session_id!r} is not an isaac-native session."
+                )
+            existing_terminal = await _find_running_isaac_terminal(client, session_id)
+            if existing_terminal is not None:
+                if persist_args:
+                    click.echo(
+                        "Ignoring Isaac launch args for an already-running terminal; "
+                        "restart the session terminal to apply them.",
+                        err=True,
+                    )
+                _update_startup_progress(startup_progress, "Isaac terminal ready.")
+                return PreparedIsaacTerminal(
+                    session_id=session_id,
+                    terminal_id=existing_terminal.terminal_id,
+                    tmux_socket=existing_terminal.tmux_socket,
+                    tmux_target=existing_terminal.tmux_target,
+                    reattached=True,
+                )
+            if persist_args:
+                _update_startup_progress(startup_progress, "Updating Isaac session...")
+                resp = await client.patch(
+                    f"/v1/sessions/{url_component(session_id)}",
+                    json={"terminal_launch_args": persist_args},
+                )
+                if resp.status_code >= 400:
+                    raise click.ClickException(
+                        f"Isaac session launch config update failed "
+                        f"({resp.status_code}): {error_text(resp)}"
+                    )
+
+        await wait_for_host_online(client, host_id, timeout_s=_DAEMON_HOST_ONLINE_TIMEOUT_S)
+        _update_startup_progress(startup_progress, "Starting runner...")
+        runner_id = await launch_or_reuse_daemon_runner(
+            client,
+            host_id=host_id,
+            session_id=session_id,
+            workspace=workspace,
+        )
+        _update_startup_progress(startup_progress, "Waiting for runner...")
+        await wait_for_runner_online(client, runner_id, timeout_s=_DAEMON_RUNNER_ONLINE_TIMEOUT_S)
+        await _bind_session_runner(client, session_id, runner_id)
+        _update_startup_progress(startup_progress, "Starting Isaac terminal...")
+        await _ensure_isaac_terminal_on_runner(client, session_id)
+        terminal = await _wait_for_isaac_terminal_ready(
+            client,
+            session_id,
+            timeout_s=_DAEMON_TERMINAL_READY_TIMEOUT_S,
+        )
+        _update_startup_progress(startup_progress, "Isaac terminal ready.")
+    return PreparedIsaacTerminal(
+        session_id=session_id,
+        terminal_id=terminal.terminal_id,
+        tmux_socket=terminal.tmux_socket,
+        tmux_target=terminal.tmux_target,
+        reattached=reattached,
+    )
+
+
+async def _create_isaac_session(
+    client: httpx.AsyncClient,
+    bundle: bytes,
+    *,
+    terminal_launch_args: list[str] | None = None,
+) -> str:
+    """
+    Create a bundled terminal-first Isaac session.
+
+    :param client: HTTP client pointed at Omnigent.
+    :param bundle: Gzipped agent bundle.
+    :param terminal_launch_args: Pass-through Isaac CLI args to persist.
+    :returns: New Omnigent session id.
+    """
+    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    if terminal_launch_args:
+        metadata["terminal_launch_args"] = terminal_launch_args
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps(metadata)},
+        files={"bundle": ("isaac-native-ui.tar.gz", bundle, "application/gzip")},
+        timeout=120.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Isaac session creation failed ({resp.status_code}): {error_text(resp)}"
+        )
+    body = resp.json()
+    new_session_id = body.get("session_id")
+    if not isinstance(new_session_id, str) or not new_session_id:
+        raise click.ClickException("Isaac session creation response did not include session_id.")
+    return new_session_id
+
+
+async def _fetch_isaac_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+    """Fetch an existing Omnigent session."""
+    resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
+    if resp.status_code == 404:
+        raise click.ClickException(f"Conversation {session_id!r} not found on the server.")
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Failed to fetch conversation {session_id!r} ({resp.status_code}): {error_text(resp)}"
+        )
+    payload = resp.json()
+    if not isinstance(payload, dict):
+        raise click.ClickException("Conversation fetch returned non-object JSON.")
+    return payload
+
+
+async def _ensure_isaac_terminal_on_runner(client: httpx.AsyncClient, session_id: str) -> None:
+    """Ask the bound runner to ensure the Isaac terminal exists."""
+    resp = await client.post(
+        f"/v1/sessions/{url_component(session_id)}/resources/terminals",
+        json={
+            "terminal": _TERMINAL_NAME,
+            "session_key": _TERMINAL_SESSION_KEY,
+            "ensure_native_terminal": True,
+        },
+        timeout=60.0,
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(
+            f"Isaac terminal ensure failed ({resp.status_code}): {error_text(resp)}"
+        )
+
+
+async def _wait_for_isaac_terminal_ready(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    timeout_s: float,
+) -> LaunchedIsaacTerminal:
+    """Wait until the runner exposes the Isaac terminal resource."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        terminal = await _find_running_isaac_terminal(client, session_id)
+        if terminal is not None:
+            return terminal
+        await asyncio.sleep(0.2)
+    raise click.ClickException(
+        f"The runner did not create the Isaac terminal for {session_id!r} within {timeout_s:.0f}s."
+    )
+
+
+async def _find_running_isaac_terminal(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> LaunchedIsaacTerminal | None:
+    """Return the existing running Isaac terminal id if present."""
+    terminal_id = isaac_terminal_resource_id()
+    resp = await client.get(
+        f"/v1/sessions/{url_component(session_id)}"
+        f"/resources/terminals/{url_component(terminal_id)}"
+    )
+    if resp.status_code == 404:
+        return None
+    if resp.status_code >= 400:
+        text = error_text(resp)
+        if resp.status_code in {409, 503} and (
+            "not bound to a runner" in text or "offline" in text
+        ):
+            return None
+        raise click.ClickException(f"Failed to fetch Isaac terminal ({resp.status_code}): {text}")
+    payload = resp.json()
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    if isinstance(metadata, dict) and metadata.get("running") is False:
+        return None
+    return _launched_isaac_terminal_from_payload(payload)
+
+
+def _launched_isaac_terminal_from_payload(payload: object) -> LaunchedIsaacTerminal:
+    """Decode terminal launch metadata returned by the runner."""
+    if not isinstance(payload, dict):
+        raise click.ClickException("Isaac terminal launch returned non-object JSON.")
+    terminal_id = payload.get("id")
+    if not isinstance(terminal_id, str) or not terminal_id:
+        raise click.ClickException("Isaac terminal launch response did not include terminal id.")
+    metadata = payload.get("metadata")
+    tmux_socket: Path | None = None
+    tmux_target: str | None = None
+    if isinstance(metadata, dict):
+        raw_socket = metadata.get("tmux_socket")
+        raw_target = metadata.get("tmux_target")
+        if isinstance(raw_socket, str) and raw_socket:
+            tmux_socket = Path(raw_socket)
+        if isinstance(raw_target, str) and raw_target:
+            tmux_target = raw_target
+    return LaunchedIsaacTerminal(
+        terminal_id=terminal_id,
+        tmux_socket=tmux_socket,
+        tmux_target=tmux_target,
+    )
+
+
+async def _attach_terminal_resource(prepared: PreparedIsaacTerminal) -> None:
+    """Attach the current terminal to the prepared Isaac terminal resource."""
+    direct_tmux_error = _direct_tmux_unavailable_reason(prepared)
+    if direct_tmux_error is not None:
+        raise click.ClickException(
+            f"Runner-owned Isaac terminal requires direct tmux attach, but {direct_tmux_error}"
+        )
+    if prepared.tmux_socket is None or prepared.tmux_target is None:
+        raise click.ClickException("Isaac tmux attach metadata was incomplete.")
+    await _attach_direct_tmux(prepared.tmux_socket, prepared.tmux_target)
+
+
+async def _attach_direct_tmux(socket_path: Path, tmux_target: str) -> None:
+    """Attach the current terminal directly to the runner-owned tmux pane."""
+    env = dict(os.environ)
+    env.pop("TMUX", None)
+    process = await asyncio.create_subprocess_exec(
+        "tmux",
+        "-S",
+        str(socket_path),
+        "-f",
+        os.devnull,
+        "attach",
+        "-t",
+        tmux_target,
+        env=env,
+    )
+    await process.wait()
+
+
+def _direct_tmux_unavailable_reason(prepared: PreparedIsaacTerminal) -> str | None:
+    """Explain why direct tmux attach is unavailable."""
+    if prepared.tmux_socket is None:
+        return "the terminal resource did not include a tmux socket path."
+    if prepared.tmux_target is None:
+        return "the terminal resource did not include a tmux target."
+    if not prepared.tmux_socket.exists():
+        return f"tmux socket {prepared.tmux_socket} is not reachable from this CLI process."
+    if shutil.which("tmux") is None:
+        return "tmux is not available on PATH."
+    return None
+
+
+def _resolve_session_id_for_resume(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str | None,
+    resume_picker: bool,
+) -> str | None:
+    """Translate resume inputs into a concrete Isaac-native session id."""
+    if session_id is not None:
+        return session_id
+    if not resume_picker:
+        return None
+    from omnigent_client import OmnigentClient
+
+    from omnigent.repl._resume_picker import pick_conversation_by_wrapper_label_from_sdk
+
+    async def _drive() -> str | None:
+        async with OmnigentClient(
+            base_url=base_url,
+            headers=headers if headers else None,
+        ) as client:
+            return await pick_conversation_by_wrapper_label_from_sdk(
+                client,
+                wrapper_value=_WRAPPER_LABEL_VALUE,
+                agent_name=_AGENT_NAME,
+            )
+
+    return asyncio.run(_drive())
+
+
+def _update_startup_progress(
+    startup_progress: RunnerStartupProgress | None,
+    message: str,
+) -> None:
+    """Show one concise Isaac startup milestone when a renderer is active."""
+    if startup_progress is not None:
+        startup_progress.update(message)
+
+
+def _preflight_local_tools() -> None:
+    """Verify local executables required by the native Isaac wrapper."""
+    if shutil.which("tmux") is None:
+        raise click.ClickException(
+            "tmux was not found on local PATH. The native Isaac wrapper "
+            "attaches to the runner-owned Isaac tmux terminal."
+        )
+
+
+def isaac_terminal_resource_id() -> str:
+    """Return the deterministic terminal resource id for Isaac."""
+    return terminal_resource_id(_TERMINAL_NAME, _TERMINAL_SESSION_KEY)

--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from omnigent._wrapper_labels import (
     CLAUDE_NATIVE_WRAPPER_VALUE,
     CODEX_NATIVE_WRAPPER_VALUE,
+    ISAAC_NATIVE_WRAPPER_VALUE,
     PI_NATIVE_WRAPPER_VALUE,
     UI_MODE_LABEL_KEY,
     UI_MODE_TERMINAL_VALUE,
@@ -65,10 +66,20 @@ PI_NATIVE_CODING_AGENT = NativeCodingAgent(
     terminal_name="pi",
 )
 
+ISAAC_NATIVE_CODING_AGENT = NativeCodingAgent(
+    key="isaac",
+    display_name="Isaac",
+    agent_name="isaac-native-ui",
+    harness="isaac-native",
+    wrapper_label=ISAAC_NATIVE_WRAPPER_VALUE,
+    terminal_name="isaac",
+)
+
 NATIVE_CODING_AGENTS: tuple[NativeCodingAgent, ...] = (
     CLAUDE_NATIVE_CODING_AGENT,
     CODEX_NATIVE_CODING_AGENT,
     PI_NATIVE_CODING_AGENT,
+    ISAAC_NATIVE_CODING_AGENT,
 )
 
 _BY_AGENT_NAME = {agent.agent_name: agent for agent in NATIVE_CODING_AGENTS}

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -56,6 +56,7 @@ from omnigent.runner.proxy_mcp_manager import ProxyMcpManager
 from omnigent.runner.resource_registry import (
     CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
+    ISAAC_NATIVE_TERMINAL_ROLE,
     OMNIGENT_REPL_TERMINAL_ROLE,
     PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
@@ -545,6 +546,84 @@ async def _pi_native_launch_config(
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class _IsaacNativeLaunchConfig:
+    """
+    Persisted launch config needed for runner-owned Isaac terminal setup.
+
+    :param workspace: Workspace cwd for the Isaac TUI.
+    :param terminal_launch_args: User pass-through Isaac CLI args.
+    """
+
+    workspace: Path
+    terminal_launch_args: list[str] | None
+
+
+def _isaac_session_workspace(session_workspace: str | None) -> Path:
+    """
+    Resolve the cwd for a runner-owned Isaac terminal.
+
+    :param session_workspace: Session ``workspace`` from the server snapshot.
+    :returns: Workspace path for the terminal cwd.
+    """
+    raw = session_workspace or _required_runner_env("OMNIGENT_RUNNER_WORKSPACE")
+    return Path(raw.strip()).expanduser().resolve()
+
+
+async def _isaac_native_launch_config(
+    *,
+    session_id: str,
+    server_client: httpx.AsyncClient | None,
+) -> _IsaacNativeLaunchConfig:
+    """
+    Fetch and validate persisted Isaac launch config for a session.
+
+    :param session_id: Session/conversation id.
+    :param server_client: Runner Omnigent server client.
+    :returns: Parsed launch config.
+    """
+    if server_client is None:
+        raise RuntimeError("server_client is required for runner-owned Isaac terminals.")
+    try:
+        resp = await server_client.get(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            timeout=10.0,
+        )
+    except httpx.HTTPError as exc:
+        raise RuntimeError(f"Could not fetch Isaac launch config for {session_id!r}.") from exc
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Could not fetch Isaac launch config for {session_id!r}: "
+            f"GET /v1/sessions returned {resp.status_code}."
+        )
+    try:
+        snapshot = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Could not fetch Isaac launch config for {session_id!r}: invalid JSON."
+        ) from exc
+    if not isinstance(snapshot, dict):
+        raise RuntimeError(
+            f"Could not fetch Isaac launch config for {session_id!r}: "
+            "snapshot was not a JSON object."
+        )
+    terminal_launch_args = snapshot.get("terminal_launch_args")
+    if terminal_launch_args is not None and not (
+        isinstance(terminal_launch_args, list)
+        and all(isinstance(arg, str) for arg in terminal_launch_args)
+    ):
+        raise RuntimeError(f"Invalid terminal_launch_args for Isaac session {session_id!r}.")
+    session_workspace = snapshot.get("workspace")
+    if session_workspace is not None and (
+        not isinstance(session_workspace, str) or not session_workspace
+    ):
+        raise RuntimeError(f"Invalid workspace for Isaac session {session_id!r}.")
+    return _IsaacNativeLaunchConfig(
+        workspace=_isaac_session_workspace(session_workspace),
+        terminal_launch_args=terminal_launch_args,
+    )
+
+
 async def _codex_native_launch_config(
     *,
     session_id: str,
@@ -719,6 +798,56 @@ def _build_pi_native_args(
     return args
 
 
+def _isaac_args_have_worktree(args: list[str]) -> bool:
+    """
+    Return whether user Isaac args already control worktree selection.
+
+    When the user passes their own worktree-related flag, Omnigent must not
+    inject ``--skip-worktree-selection`` on top — the explicit choice wins.
+
+    :param args: User pass-through Isaac CLI args.
+    :returns: ``True`` when Omnigent should not add ``--skip-worktree-selection``.
+    """
+    worktree_flags = {
+        "--worktree",
+        "--quicktree",
+        "--branch",
+        "--pr",
+        "--ref",
+        "--skip-worktree-selection",
+        "--cloud",
+    }
+    for arg in args:
+        if arg in worktree_flags:
+            return True
+        if arg.startswith(tuple(f"{flag}=" for flag in worktree_flags)):
+            return True
+    return False
+
+
+def _build_isaac_native_args(
+    *,
+    terminal_launch_args: list[str] | None,
+) -> list[str]:
+    """
+    Build Isaac CLI args for a runner-owned native TUI session.
+
+    Isaac runs interactively in the pane (it is a live mirror), so no
+    ``-p``/``--print`` pipe mode is passed. ``--skip-worktree-selection`` is
+    prepended so the pane doesn't hang on Isaac's interactive worktree dialog,
+    unless the user is already driving worktree selection themselves.
+
+    :param terminal_launch_args: User pass-through Isaac args.
+    :returns: Complete Isaac arg vector excluding the executable.
+    """
+    user_args = list(terminal_launch_args or [])
+    args: list[str] = []
+    if not _isaac_args_have_worktree(user_args):
+        args.append("--skip-worktree-selection")
+    args.extend(user_args)
+    return args
+
+
 async def _auto_create_pi_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -825,6 +954,65 @@ async def _auto_create_pi_terminal(
         session_id,
         pi_extension,
     )
+    return terminal_view
+
+
+async def _auto_create_isaac_terminal(
+    session_id: str,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, dict[str, Any]], None],
+    *,
+    server_client: httpx.AsyncClient | None,
+) -> SessionResourceView:
+    """
+    Auto-create an Isaac terminal for an isaac-native session.
+
+    Pure terminal mirror: the runner hosts the live ``isaac`` CLI in a tmux
+    pane and the Web UI mirrors it. There is no extension bridge, no provider
+    injection, and no spawn env — Isaac talks to its own backend.
+
+    :param session_id: Session/conversation identifier.
+    :param resource_registry: Session resource registry for launching the
+        terminal.
+    :param publish_event: Runner session event publisher.
+    :param server_client: Runner Omnigent server client.
+    :returns: Created terminal resource view.
+    """
+    from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
+    from omnigent.isaac_native import resolve_isaac_executable
+
+    launch_config = await _isaac_native_launch_config(
+        session_id=session_id,
+        server_client=server_client,
+    )
+    workspace = str(launch_config.workspace)
+    isaac_command = resolve_isaac_executable()
+    isaac_args = _build_isaac_native_args(
+        terminal_launch_args=launch_config.terminal_launch_args,
+    )
+    terminal_view = await resource_registry.launch_required_terminal(
+        session_id=session_id,
+        terminal_name="isaac",
+        session_key="main",
+        resource_role=ISAAC_NATIVE_TERMINAL_ROLE,
+        spec=TerminalEnvSpec(
+            os_env=OSEnvSpec(type="caller_process", cwd=workspace),
+            command=isaac_command,
+            args=isaac_args,
+            env={},
+            scrollback=100_000,
+            tmux_allow_passthrough=True,
+            tmux_start_on_attach=False,
+        ),
+    )
+    publish_event(
+        session_id,
+        {
+            "type": "session.resource.created",
+            "resource": session_resource_view_to_dict(terminal_view),
+        },
+    )
+    _logger.info("Auto-created isaac terminal for session %s", session_id)
     return terminal_view
 
 
@@ -4336,6 +4524,7 @@ def create_runner_app(
     _session_comment_relays: dict[str, Any] = {}
     _codex_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     _pi_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
+    _isaac_terminal_ensure_locks: dict[str, asyncio.Lock] = {}
     # Per-session lock guarding the claude-native terminal auto-create in
     # ``create_session``. Two ``POST /v1/sessions`` calls can land
     # concurrently on a host-launched runner — ``_on_runner_connect``
@@ -5497,6 +5686,38 @@ def create_runner_app(
                     finally:
                         _publish_terminal_pending(_publish_event, session_id, False)
 
+        if harness_name == "isaac-native":
+            _isaac_ensure_lock = _isaac_terminal_ensure_locks.setdefault(
+                session_id, asyncio.Lock()
+            )
+            async with _isaac_ensure_lock:
+                _tr = resource_registry.terminal_registry
+                _has_isaac_terminal = (
+                    _tr is not None and _tr.get(session_id, "isaac", "main") is not None
+                )
+                if not _has_isaac_terminal:
+                    _publish_terminal_pending(_publish_event, session_id, True)
+                    try:
+                        await _auto_create_isaac_terminal(
+                            session_id,
+                            resource_registry,
+                            _publish_event,
+                            server_client=server_client,
+                        )
+                    except Exception as exc:
+                        _logger.exception(
+                            "Failed to auto-create isaac terminal for %s",
+                            session_id,
+                        )
+                        _publish_native_terminal_start_error(
+                            _publish_event,
+                            session_id,
+                            "Isaac",
+                            exc,
+                        )
+                    finally:
+                        _publish_terminal_pending(_publish_event, session_id, False)
+
         # Auto-bootstrap the Omnigent REPL terminal for non-native
         # (SDK-harness) top-level sessions: host the framework's own TUI
         # (``omnigent attach``) in a tmux pane so the web UI can embed it
@@ -5763,6 +5984,7 @@ def create_runner_app(
         _codex_terminal_ensure_locks.pop(session_id, None)
         _claude_terminal_ensure_locks.pop(session_id, None)
         _pi_terminal_ensure_locks.pop(session_id, None)
+        _isaac_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         _interrupted_sessions.discard(session_id)
 
@@ -6485,7 +6707,7 @@ def create_runner_app(
         # source — fall through and publish. Suppress only once we positively
         # know the harness/edge is terminal-owned.
         harness = _session_harness_name(conv_id)
-        if status != "failed" and harness in {"claude-native", "pi-native"}:
+        if status != "failed" and harness in {"claude-native", "pi-native", "isaac-native"}:
             return
         if status == "idle" and harness == "codex-native":
             return
@@ -10673,6 +10895,40 @@ def create_runner_app(
                 content=session_resource_view_to_dict(terminal_view),
             )
 
+        if (
+            body.get("ensure_native_terminal")
+            and terminal_name == "isaac"
+            and session_key == "main"
+        ):
+            isaac_terminal_id = terminal_resource_id("isaac", "main")
+            ensure_lock = _isaac_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
+            async with ensure_lock:
+                existing = await resource_registry.get_terminal_resource(
+                    session_id, isaac_terminal_id
+                )
+                if existing is not None:
+                    return JSONResponse(
+                        status_code=200,
+                        content=session_resource_view_to_dict(existing),
+                    )
+                try:
+                    terminal_view = await _auto_create_isaac_terminal(
+                        session_id,
+                        resource_registry,
+                        _publish_event,
+                        server_client=server_client,
+                    )
+                except Exception as exc:
+                    _logger.exception(
+                        "Isaac terminal ensure failed for session=%s",
+                        session_id,
+                    )
+                    return _native_terminal_start_error_response(exc, "Isaac")
+            return JSONResponse(
+                status_code=200,
+                content=session_resource_view_to_dict(terminal_view),
+            )
+
         from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
 
         cwd_override = body.get("cwd")
@@ -12147,6 +12403,7 @@ def create_runner_app(
         _codex_terminal_ensure_locks.pop(session_id, None)
         _claude_terminal_ensure_locks.pop(session_id, None)
         _pi_terminal_ensure_locks.pop(session_id, None)
+        _isaac_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         await resource_registry.cleanup_session(session_id)
         return JSONResponse(
@@ -12199,6 +12456,7 @@ def create_runner_app(
         _codex_terminal_ensure_locks.pop(session_id, None)
         _claude_terminal_ensure_locks.pop(session_id, None)
         _pi_terminal_ensure_locks.pop(session_id, None)
+        _isaac_terminal_ensure_locks.pop(session_id, None)
         _repl_terminal_ensure_locks.pop(session_id, None)
         # Close terminals with ``session.resource.deleted`` events BEFORE
         # cleanup_session — cleanup_conversation would silently pop them

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -48,6 +48,7 @@ _DEFAULT_WORKSPACE_ROOT = os.path.join(
 CODEX_NATIVE_TERMINAL_ROLE = "codex-native"
 CLAUDE_NATIVE_TERMINAL_ROLE = "claude-native"
 PI_NATIVE_TERMINAL_ROLE = "pi-native"
+ISAAC_NATIVE_TERMINAL_ROLE = "isaac-native"
 # Role marker for the embedded Omnigent REPL terminal auto-created for
 # runner-hosted SDK sessions (``omnigent attach`` in a tmux pane — the
 # SDK mirror of the native terminals above). The attach WebSocket uses
@@ -934,6 +935,7 @@ class SessionResourceRegistry:
         emit_status = status_publisher is not None and resource_role in {
             CLAUDE_NATIVE_TERMINAL_ROLE,
             PI_NATIVE_TERMINAL_ROLE,
+            ISAAC_NATIVE_TERMINAL_ROLE,
         }
         if activity_publisher is None and not emit_status and exit_publisher is None:
             return

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -49,6 +49,11 @@ _HARNESS_MODULES: dict[str, str] = {
     "pi": "omnigent.inner.pi_harness",
     # Native Pi TUI bridge used by ``omnigent pi``.
     "pi-native": "omnigent.inner.pi_native_harness",
+    # Native Isaac terminal mirror used by ``omnigent isaac``. Isaac is an
+    # external Claude Code wrapper CLI; this harness only mirrors its terminal
+    # (no app-server, forwarder, or message injection), so the executor is a
+    # no-op stub.
+    "isaac-native": "omnigent.inner.isaac_native_harness",
     # Step 4e: openai-agents harness wrap. See
     # omnigent/inner/openai_agents_sdk_harness.py. Registry
     # key is the Omnigent-side spelling (``openai-agents``,

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -22,6 +22,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.native_coding_agents import (
     CLAUDE_NATIVE_CODING_AGENT,
     CODEX_NATIVE_CODING_AGENT,
+    ISAAC_NATIVE_CODING_AGENT,
     PI_NATIVE_CODING_AGENT,
 )
 from omnigent.resources import examples as _examples_resources
@@ -76,6 +77,7 @@ _WEB_UI_GZIP_MINIMUM_SIZE = 1024
 _CLAUDE_NATIVE_AGENT_NAME = CLAUDE_NATIVE_CODING_AGENT.agent_name
 _CODEX_NATIVE_AGENT_NAME = CODEX_NATIVE_CODING_AGENT.agent_name
 _PI_NATIVE_AGENT_NAME = PI_NATIVE_CODING_AGENT.agent_name
+_ISAAC_NATIVE_AGENT_NAME = ISAAC_NATIVE_CODING_AGENT.agent_name
 _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
@@ -350,6 +352,7 @@ def _ensure_default_agents(
     _ensure_default_claude_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_codex_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_pi_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_isaac_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
@@ -551,6 +554,49 @@ def _ensure_default_pi_agent(
         agent_cache,
         name=_PI_NATIVE_AGENT_NAME,
         bundle_bytes=_build_pi_native_bundle(),
+    )
+
+
+def _build_isaac_native_bundle() -> bytes:
+    """
+    Build a gzipped tarball of the isaac-native-ui agent spec.
+
+    :returns: Gzipped tarball bytes suitable for the artifact store.
+    """
+    import tempfile
+
+    from omnigent.isaac_native import _materialize_isaac_agent_spec
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spec_path = _materialize_isaac_agent_spec(Path(tmpdir))
+        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
+        return _tar_gz_dir(bundle_dir)
+
+
+def _ensure_default_isaac_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """
+    Register or refresh the isaac-native-ui agent.
+
+    Called during server lifespan startup so the Web UI can offer Isaac as a
+    built-in native-terminal agent. Content-aware via
+    :func:`_ensure_builtin_agent`: a new wheel with a changed spec refreshes
+    the row in place rather than being ignored.
+
+    :param agent_store: Store for agent metadata.
+    :param artifact_store: Store for agent bundles.
+    :param agent_cache: Cache for loaded agent specs.
+    """
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name=_ISAAC_NATIVE_AGENT_NAME,
+        bundle_bytes=_build_isaac_native_bundle(),
     )
 
 

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -81,6 +81,7 @@ OMNIGENT_HARNESSES = frozenset(
         "codex",
         "codex-native",
         "cursor",
+        "isaac-native",
         "openai-agents",
         "open-responses",
         "pi",

--- a/tests/e2e/test_host_isaac_native_e2e.py
+++ b/tests/e2e/test_host_isaac_native_e2e.py
@@ -1,0 +1,245 @@
+"""End-to-end test for the isaac-native-ui built-in agent.
+
+Verifies the host-spawned Web UI flow for ``isaac-native-ui``: list the
+built-in agents -> find ``isaac-native-ui`` -> connect a host daemon ->
+create a session bound to that agent and host -> assert the runner
+auto-creates the Isaac terminal-mirror resource that the Web UI attaches
+to.
+
+Unlike the claude-native / codex-native e2e tests, Isaac is a pure
+**terminal mirror**: there is no event forwarder, MCP bridge, or message
+injection, so no assistant transcript items are mirrored to the server.
+The durable, server-observable success signal is therefore the
+**terminal resource** itself, not a transcript marker. This also lets the
+test run in CI: the real ``isaac`` CLI is a Databricks-internal ``dbexec``
+wrapper that can't run on a CI runner, so the test points
+``OMNIGENT_ISAAC_COMMAND`` at a small fake ``isaac`` stub (prints a banner,
+then blocks on stdin like an interactive TUI). The stub exercises the real
+dispatch -> auto-create -> tmux-mirror path; it does not exercise Isaac's
+own intelligence.
+
+Run (opt-in via env var)::
+
+    OMNIGENT_E2E_ISAAC_NATIVE=1 \
+    .venv/bin/python -m pytest tests/e2e/test_host_isaac_native_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.entities.session_resources import terminal_resource_id
+from tests.e2e.helpers import POLL_INTERVAL_S
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("OMNIGENT_E2E_ISAAC_NATIVE") != "1",
+    reason=(
+        "isaac-native e2e is opt-in; set OMNIGENT_E2E_ISAAC_NATIVE=1 to run. "
+        "It needs no real `isaac` binary — it stubs the CLI via "
+        "OMNIGENT_ISAAC_COMMAND — so it is safe to run anywhere."
+    ),
+)
+
+# The built-in agent the server auto-registers for the Web UI's "Isaac"
+# option (see server.app._ensure_default_agents).
+_ISAAC_NATIVE_AGENT_NAME = "isaac-native-ui"
+
+
+def _write_fake_isaac(bin_dir: Path) -> Path:
+    """
+    Write a fake ``isaac`` CLI used in place of the real dbexec wrapper.
+
+    The stub prints a recognizable banner and then blocks reading stdin,
+    modeling an interactive TUI that stays alive in the pane. Pointing
+    ``OMNIGENT_ISAAC_COMMAND`` at the absolute stub path makes the runner
+    launch it instead of the real ``isaac`` (which needs dbexec OAuth and
+    can't run in CI).
+
+    :param bin_dir: Directory to write the stub into; created by caller.
+    :returns: Absolute path to the executable stub.
+    """
+    stub = bin_dir / "fake-isaac"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'FAKE_ISAAC_TUI_READY'\n"
+        "# Model an interactive TUI: stay alive holding the pane open.\n"
+        "cat >/dev/null\n"
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return stub
+
+
+def _spawn_host_daemon(
+    *,
+    tmp_path: Path,
+    live_server: str,
+    isaac_command: str,
+) -> subprocess.Popen[bytes]:
+    """
+    Spawn an ``omnigent host`` daemon with the fake ``isaac`` configured.
+
+    :param tmp_path: Per-test temp dir for the daemon log.
+    :param live_server: Test server URL the daemon registers with.
+    :param isaac_command: Absolute path to the fake ``isaac`` stub, wired
+        via ``OMNIGENT_ISAAC_COMMAND`` so the runner launches it.
+    :returns: The spawned daemon subprocess handle.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["OMNIGENT_ISAAC_COMMAND"] = isaac_command
+    daemon_log = tmp_path / "host-daemon.log"
+    with open(daemon_log, "w") as log_fh:
+        return subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "omnigent.host._daemon_entry",
+                "--server",
+                live_server,
+            ],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=log_fh,
+        )
+
+
+def _online_host_id(client: httpx.Client, timeout: float = 30.0) -> str:
+    """
+    Poll ``GET /v1/hosts`` until at least one host is online.
+
+    :param client: HTTP client pointed at the test server.
+    :param timeout: Max seconds to wait.
+    :returns: The online host's ``host_id``.
+    :raises AssertionError: If no host comes online within *timeout*.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get("/v1/hosts")
+        if resp.status_code == 200:
+            online = [h for h in resp.json().get("hosts", []) if h["status"] == "online"]
+            if online:
+                return str(online[0]["host_id"])
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"No host came online within {timeout}s")
+
+
+def _isaac_native_agent_id(client: httpx.Client) -> str:
+    """
+    Return the durable id of the auto-registered ``isaac-native-ui``.
+
+    :param client: HTTP client pointed at the test server.
+    :returns: The ``"ag_..."`` id for ``isaac-native-ui``.
+    :raises AssertionError: If the server did not auto-register it.
+    """
+    resp = client.get("/v1/agents")
+    resp.raise_for_status()
+    for agent in resp.json()["data"]:
+        if agent["name"] == _ISAAC_NATIVE_AGENT_NAME:
+            return str(agent["id"])
+    raise AssertionError(
+        f"{_ISAAC_NATIVE_AGENT_NAME!r} not registered on the server "
+        "(expected from _ensure_default_agents at startup)"
+    )
+
+
+def _poll_for_terminal_resource(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    resource_id: str,
+    timeout: float,
+) -> dict[str, object]:
+    """
+    Poll ``GET /v1/sessions/{id}/resources`` until *resource_id* appears.
+
+    :param client: HTTP client pointed at the test server.
+    :param session_id: Session/conversation id.
+    :param resource_id: Expected terminal resource id, e.g.
+        ``"terminal_isaac_main"``.
+    :param timeout: Max seconds to wait.
+    :returns: The matching terminal resource object.
+    :raises AssertionError: If the resource never appears within *timeout*.
+    """
+    deadline = time.monotonic() + timeout
+    last_seen: list[object] = []
+    while time.monotonic() < deadline:
+        resp = client.get(f"/v1/sessions/{session_id}/resources")
+        if resp.status_code == 200:
+            data = resp.json().get("data", [])
+            last_seen = [r.get("id") for r in data]
+            for resource in data:
+                if resource.get("id") == resource_id and resource.get("type") == "terminal":
+                    return resource
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"Terminal resource {resource_id!r} never appeared for session "
+        f"{session_id} within {timeout}s; saw {last_seen!r}. The "
+        "host-spawned isaac-native auto-create did not register the Isaac "
+        "terminal, so the web UI would have no terminal mirror to attach to."
+    )
+
+
+def test_isaac_native_builtin_session_creates_terminal_mirror(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+) -> None:
+    """
+    Binding an isaac-native-ui session auto-creates the Isaac terminal.
+
+    Happy path for the Isaac integration: the server auto-registers the
+    built-in agent, a host daemon connects, and creating a session bound
+    to that agent + host drives the runner's isaac-native auto-create,
+    which launches the (fake) ``isaac`` TUI in a tmux pane and registers
+    it as the ``terminal_isaac_main`` mirror resource. That resource is
+    exactly what the Web UI attaches to, so its presence is the
+    end-to-end proof the mirror is live.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_isaac = _write_fake_isaac(bin_dir)
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    daemon = _spawn_host_daemon(
+        tmp_path=tmp_path,
+        live_server=live_server,
+        isaac_command=str(fake_isaac),
+    )
+    try:
+        host_id = _online_host_id(http_client, timeout=30.0)
+        agent_id = _isaac_native_agent_id(http_client)
+
+        create = http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "host_id": host_id,
+                "workspace": str(workspace),
+            },
+            timeout=60.0,
+        )
+        create.raise_for_status()
+        session_id = create.json()["id"]
+
+        resource = _poll_for_terminal_resource(
+            http_client,
+            session_id=session_id,
+            resource_id=terminal_resource_id("isaac", "main"),
+            timeout=30.0,
+        )
+        assert resource["type"] == "terminal"
+    finally:
+        daemon.send_signal(signal.SIGTERM)
+        daemon.wait(timeout=5)

--- a/tests/e2e_ui/start_session/test_start_session_isaac.py
+++ b/tests/e2e_ui/start_session/test_start_session_isaac.py
@@ -1,0 +1,228 @@
+"""E2E: starting a new Isaac native session from the home composer ("/").
+
+Mirrors the Pi-native picker coverage in ``test_start_session.py`` for the
+Isaac native terminal-mirror agent this PR adds. Isaac is a Claude Code
+wrapper CLI (``isaac``) that runs as a pure terminal mirror, so the
+user-facing surface is: the new-chat picker offers "Isaac", and selecting
+it + sending POSTs ``/v1/sessions`` with the terminal-first wrapper labels
+that make the runner launch the Isaac TUI and the web UI render the
+Chat/Terminal view.
+
+The async-in-a-fresh-thread shape and the host/agent/create/events stubbing
+are inherited from ``test_start_session.py`` for the reasons documented
+there (the e2e harness's tunneled runner registers no host, so the composer
+needs ``/v1/hosts`` + ``/v1/agents`` faked, and the create POST is captured
+rather than launched).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Stubbed host the composer auto-selects (the tunneled runner registers no host).
+_HOST_ID = "host_e2e"
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own event loop.
+
+    The e2e_ui suite runs many pytest-playwright **sync** tests in the same
+    session; once one has run, pytest-asyncio can't start a loop on the main
+    thread. Running the coroutine from a fresh thread via :func:`asyncio.run`
+    sidesteps that, re-raising any failure on the calling thread.
+
+    :param coro: The coroutine to run to completion.
+    :raises Exception: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    """Poll ``predicate`` on the event loop until true or timeout.
+
+    :param predicate: Zero-arg callable returning truthy when satisfied.
+    :param timeout_s: Max seconds to wait before failing the test.
+    :raises AssertionError: If the predicate never becomes truthy.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _isaac_native_agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: the native Isaac agent.
+
+    ``name: "isaac-native-ui"`` + ``harness: "isaac-native"`` is what the
+    frontend maps (via ``nativeCodingAgents``) to the display label **"Isaac"**
+    and the isaac-native wrapper labels. The wire ``display_name`` is set to the
+    raw ``"isaac-native-ui"`` to prove the picker derives "Isaac" itself rather
+    than echoing the server. Sole agent, so it auto-selects.
+    """
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_isaac_e2e",
+                    "name": "isaac-native-ui",
+                    "display_name": "isaac-native-ui",
+                    "description": "Isaac coding agent",
+                    "harness": "isaac-native",
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+def _hosts_body() -> str:
+    """Stub body for ``GET /v1/hosts``: one online host the composer picks."""
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": "e2e-host",
+                    "owner": "e2e",
+                    "status": "online",
+                }
+            ]
+        }
+    )
+
+
+def test_start_session_isaac_native_picker_and_wrapper_labels(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Native Isaac: the picker shows "Isaac" and create carries terminal labels.
+
+    Covers the user-facing Isaac native-agent flow this PR adds:
+
+    1. **Picker label** — the agent chip renders the harness-derived display
+       label **"Isaac"** (via ``nativeCodingAgents``), NOT the raw agent name
+       ``"isaac-native-ui"`` the server sends.
+    2. **Session-creation wrapper labels** — selecting Isaac and sending POSTs
+       ``/v1/sessions`` with the terminal-first wrapper labels
+       (``omnigent.ui: terminal`` + ``omnigent.wrapper: isaac-native-ui``) that
+       make the runner launch the Isaac TUI and the web UI render the
+       Chat/Terminal view.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_isaac_native_start(base_url, session_id))
+
+
+async def _drive_isaac_native_start(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=_isaac_native_agents_body(),
+                )
+
+            async def handle_events(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                if route.request.method == "POST":
+                    create_bodies.append(route.request.post_data_json)
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_id}),
+                    )
+                else:
+                    await route.continue_()
+
+            # Neutralize agent discovery so the picker shows ONLY the stubbed
+            # built-in Isaac. The landing picker merges /v1/agents with agents
+            # found by scanning the caller's sessions (/v1/sessions?kind=any);
+            # on the shared e2e_ui server, a native fork another test left behind
+            # would otherwise leak in and — ranking ahead of Isaac — auto-select.
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+            # Registered after the bare-sessions route so it wins for kind=any.
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            # Seed a recent working directory so the working-directory chip
+            # auto-fills and Send can enable without touching the file browser.
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # Isaac auto-selects (sole agent). The chip shows the derived label
+            # "Isaac" — and crucially NOT the raw "...native..." agent name.
+            agent_chip = page.get_by_test_id("new-chat-landing-agent-select")
+            await expect(agent_chip).to_contain_text("Isaac")
+            await expect(agent_chip).not_to_contain_text("native")
+
+            await page.get_by_test_id("new-chat-landing-input").fill("explore the repo")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_isaac_e2e", body
+            assert body["host_id"] == _HOST_ID, body
+            assert body["workspace"] == "/work/repo", body
+            # The terminal-first wrapper labels are the contract that drives the
+            # runner-owned Isaac TUI and the web UI's Chat/Terminal view.
+            assert body.get("labels") == {
+                "omnigent.ui": "terminal",
+                "omnigent.wrapper": "isaac-native-ui",
+            }, body
+        finally:
+            await browser.close()

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -45,9 +45,11 @@ from omnigent.runner.app import (
     _agent_os_env_from_spec,
     _auto_create_claude_terminal,
     _auto_create_codex_terminal,
+    _auto_create_isaac_terminal,
     _auto_create_pi_terminal,
     _auto_create_repl_terminal,
     _deliver_subagent_wake_post,
+    _IsaacNativeLaunchConfig,
     _log_terminal_lookup_miss,
     _PiNativeLaunchConfig,
     _publish_native_terminal_start_error,
@@ -61,6 +63,7 @@ from omnigent.runner.mcp_manager import McpSchemasResult
 from omnigent.runner.resource_registry import (
     CLAUDE_NATIVE_TERMINAL_ROLE,
     CODEX_NATIVE_TERMINAL_ROLE,
+    ISAAC_NATIVE_TERMINAL_ROLE,
     OMNIGENT_REPL_TERMINAL_ROLE,
     PI_NATIVE_TERMINAL_ROLE,
     SessionResourceRegistry,
@@ -10514,6 +10517,96 @@ async def test_auto_create_pi_terminal_launches_required_terminal(
     assert captured["session_key"] == "main"
     assert captured["resource_role"] == PI_NATIVE_TERMINAL_ROLE
     assert captured["spec"].command == "pi"
+    # The fresh terminal is surfaced on the live stream for the Terminal toggle.
+    assert any(evt.get("type") == "session.resource.created" for evt in published)
+
+
+@pytest.mark.asyncio
+async def test_auto_create_isaac_terminal_launches_required_terminal_with_skip_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Isaac-native auto-create launches a *required* mirror terminal.
+
+    Isaac is a pure terminal mirror (parity with pi-native): the runtime *is*
+    the terminal process, so the auto-create must use ``launch_required_terminal``
+    and tag the resource with :data:`ISAAC_NATIVE_TERMINAL_ROLE` — that role is
+    what gates the PTY-derived status badge (a mirror has no event forwarder, so
+    the badge is the only working/idle signal). The fake registry exposes ONLY
+    ``launch_required_terminal``, so a stale call site fails here in CI rather
+    than in production.
+
+    Also guards Isaac's one binary-arg rule: ``--skip-worktree-selection`` is
+    prepended (the user passed no worktree flag) so the pane doesn't hang on
+    Isaac's interactive worktree dialog. Neither a real ``isaac`` install nor a
+    host daemon is needed — only the launch lifecycle is under test.
+
+    :param tmp_path: Pytest-provided temporary directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    import omnigent.isaac_native as isaac_native
+
+    # The launch lifecycle — not the binary — is under test; stub the resolver
+    # so CI needs no real ``isaac`` (the dbexec wrapper can't run on a runner).
+    monkeypatch.setattr(isaac_native, "resolve_isaac_executable", lambda: "isaac")
+
+    # Skip the GET /v1/sessions round-trip: hand the flow a ready launch config.
+    async def _fake_launch_config(**_kwargs: Any) -> _IsaacNativeLaunchConfig:
+        return _IsaacNativeLaunchConfig(
+            workspace=tmp_path,
+            terminal_launch_args=None,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.runner.app._isaac_native_launch_config", _fake_launch_config
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        """Records the launch; exposes ONLY the required-terminal launch API."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+        ) -> SessionResourceView:
+            """Record the launch and return a terminal resource view."""
+            captured["terminal_name"] = terminal_name
+            captured["session_key"] = session_key
+            captured["resource_role"] = resource_role
+            captured["spec"] = spec
+            return SessionResourceView(
+                id="terminal_isaac_main",
+                type="terminal",
+                session_id=session_id,
+                name="isaac:main",
+                metadata={"terminal_name": "isaac", "session_key": "main", "running": True},
+            )
+
+    published: list[dict[str, Any]] = []
+
+    await _auto_create_isaac_terminal(
+        "conv_isaac",
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, evt: published.append(evt),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    # Required lifecycle + correct mirror identity (gates the status badge).
+    assert captured["terminal_name"] == "isaac"
+    assert captured["session_key"] == "main"
+    assert captured["resource_role"] == ISAAC_NATIVE_TERMINAL_ROLE
+    assert captured["spec"].command == "isaac"
+    # Worktree dialog is auto-skipped when the user passes no worktree flag.
+    assert "--skip-worktree-selection" in captured["spec"].args
     # The fresh terminal is surfaced on the live stream for the Terminal toggle.
     assert any(evt.get("type") == "session.resource.created" for evt in published)
 

--- a/tests/test_wrapper_labels.py
+++ b/tests/test_wrapper_labels.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from omnigent._wrapper_labels import (
     CLAUDE_NATIVE_WRAPPER_VALUE,
     CODEX_NATIVE_WRAPPER_VALUE,
+    ISAAC_NATIVE_WRAPPER_VALUE,
     PI_NATIVE_WRAPPER_VALUE,
     WRAPPER_LABEL_KEY,
 )
@@ -140,3 +141,21 @@ def test_pi_native_wrapper_constants_match_registry() -> None:
     assert PI_NATIVE_CODING_AGENT.harness == "pi-native"
     assert PI_NATIVE_CODING_AGENT.wrapper_label == PI_NATIVE_WRAPPER_VALUE
     assert PI_NATIVE_CODING_AGENT.terminal_name == "pi"
+
+
+def test_isaac_native_wrapper_constants_match_isaac_native_module() -> None:
+    """``omnigent.isaac_native`` imports the same key/value pair."""
+    from omnigent import isaac_native
+
+    assert isaac_native._WRAPPER_LABEL_KEY == WRAPPER_LABEL_KEY
+    assert isaac_native._WRAPPER_LABEL_VALUE == ISAAC_NATIVE_WRAPPER_VALUE
+
+
+def test_isaac_native_wrapper_constants_match_registry() -> None:
+    """The native coding-agent registry owns the Isaac wrapper metadata."""
+    from omnigent.native_coding_agents import ISAAC_NATIVE_CODING_AGENT
+
+    assert ISAAC_NATIVE_CODING_AGENT.agent_name == "isaac-native-ui"
+    assert ISAAC_NATIVE_CODING_AGENT.harness == "isaac-native"
+    assert ISAAC_NATIVE_CODING_AGENT.wrapper_label == ISAAC_NATIVE_WRAPPER_VALUE
+    assert ISAAC_NATIVE_CODING_AGENT.terminal_name == "isaac"


### PR DESCRIPTION
## What

Adds **Isaac** (the internal `isaac` CLI — itself a Claude Code wrapper) as a fourth native terminal-mirror coding agent alongside Claude/Codex/Pi. Isaac runs in a tmux pane on the host; its terminal is mirrored to the web UI via the existing agent-agnostic PTY↔WebSocket bridge.

**Scope is a pure terminal mirror + session reattach:** no app-server, no event forwarder, no MCP bridge, no message injection, no credential injection (passthrough auth — Isaac uses its own login, matching omnigent's default for Claude Code). The executor is a no-op stub; input flows browser→PTY as raw bytes.

This mirrors the `pi-native` pattern (the simplest native agent) and reuses the existing native-agent registration surface (`_wrapper_labels`, `native_coding_agents`, `harness_aliases`, `runtime/harnesses`, `spec/_omnigent_compat`, `runner` auto-create + dispatch, `server` default-agent seeding, and the ap-web picker entry).

### Status-badge wiring (the one non-obvious bit)
A terminal mirror has no event forwarder, so the session working/idle badge is **100% PTY-derived**. The `isaac-native` terminal role is therefore wired into `resource_registry`'s `emit_status` set **and** the turn-lifecycle suppression set in `runner/app` — miss either and the badge silently never fires.

## Tests

| Layer | Test | Runs in CI? |
|---|---|---|
| Runner unit | `tests/runner/test_app_sessions_native.py::test_auto_create_isaac_terminal_*` — auto-create launches a *required* mirror terminal with the `isaac-native` role + `--skip-worktree-selection`; fake resolver, no binary | ✅ always |
| Wrapper parity | `tests/test_wrapper_labels.py` — isaac wrapper-label constants | ✅ always |
| Frontend unit | `ap-web/src/lib/nativeCodingAgents.test.ts` — `isaac-native` resolves to the Isaac spec | ✅ always |
| Backend e2e | `tests/e2e/test_host_isaac_native_e2e.py` — host session → terminal-mirror happy path, using a **fake `isaac` stub** via `OMNIGENT_ISAAC_COMMAND` (opt-in `OMNIGENT_E2E_ISAAC_NATIVE=1`, like the claude/codex native e2e tests) | opt-in |
| Frontend e2e | `tests/e2e_ui/start_session/test_start_session_isaac.py` — the new-chat picker offers "Isaac" and create POSTs the terminal-first wrapper labels | ✅ in e2e_ui job |

**Why a fake `isaac` stub for the e2e:** the real `isaac` is a Databricks-internal `dbexec` OAuth wrapper that cannot run on a CI runner. The stub (prints a banner, holds the pane) exercises the real dispatch → auto-create → tmux-mirror path; it does not exercise Isaac's own intelligence. This matches how the sibling `claude-native` e2e shims its binary.

**Transparency on local verification:** the always-CI tests (runner unit, wrapper parity, frontend Vitest) pass locally and `tsc`/`ruff` are clean. The two heavyweight e2e suites could not be run green on my local machine (the session-scoped `live_server`/runner-bootstrap fixture doesn't come online locally here, and my Node 26 breaks jsdom `localStorage` in the wider vitest suite) — they are written to the exact sibling patterns, collect cleanly, and are left for CI (Node 22, clean runner) to execute.

## Notes
- DCO signed off.
- This is a focused, standalone change — independent of any other in-flight work.