### PR TITLE
fix(antigravity): stamp model on usage dict for cost pricing

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -544,6 +544,11 @@ class AntigravityExecutor(Executor):
             yield TurnCancelled(reason="user_cancelled", phase="model")
             return
         usage = self._extract_usage(state.last_usage)
+        # Stamp the resolved model onto the usage dict so the scaffold can
+        # price the turn via the MLflow catalog (same pattern as the
+        # claude-sdk and openai-agents-sdk executors).
+        if usage is not None:
+            usage["model"] = model
         # Notify in-process usage subscribers (and the auto-recorder) before the
         # terminal event, matching the peer SDK executors so antigravity turns
         # are not invisible to usage observers. No-op for an empty usage dict.

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -350,12 +350,14 @@ async def test_streaming_maps_text_reasoning_and_usage(monkeypatch: pytest.Monke
     assert len(completes) == 1
     # Final text is the accumulation of the streamed deltas.
     assert completes[0].response == "Hello world"
-    # Usage maps the SDK's UsageMetadata field names onto Omnigent's keys.
+    # Usage maps the SDK's UsageMetadata field names onto Omnigent's keys and
+    # stamps the resolved model so the scaffold can price the turn.
     assert completes[0].usage == {
         "input_tokens": 11,
         "output_tokens": 7,
         "total_tokens": 18,
         "cache_read_input_tokens": 2,
+        "model": "gemini-3-pro",
     }
 
 


### PR DESCRIPTION
## Summary
- The antigravity executor's `_extract_usage()` did not include the `"model"` key in the usage dict, so the scaffold created `Usage(model=None)` and the cost pricing pipeline (`compute_llm_cost` via `fetch_model_pricing`) could not resolve Gemini pricing from the MLflow catalog — `total_cost_usd` stayed at 0 for all antigravity turns.
- Stamps `usage["model"] = model` after extraction, matching the pattern used by the claude-sdk (`claude_sdk_executor.py:2428`) and openai-agents-sdk (`openai_agents_sdk_executor.py:1736`) executors.
- The `gemini-` prefix is already mapped to the `google` provider in `_MODEL_PREFIX_TO_PROVIDER`, so pricing resolution works once the model name reaches the scaffold.

## Test plan
- [x] Updated existing `test_streaming_maps_text_reasoning_and_usage` to assert `"model"` key in usage dict
- [x] All 32 antigravity executor tests pass
- [x] All 13 antigravity harness tests pass

This pull request and its description were written by Isaac.