### PR TITLE
feat(cursor): implement cost/usage tracking for cursor harness

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -102,11 +102,20 @@ def _resolve_model(model: str | None) -> str:
     return model
 
 
+def _first_of(d: dict[str, Any], *keys: str, default: int = 0) -> int:
+    """Return the value of the first key present (and not None) in *d*."""
+    for k in keys:
+        v = d.get(k)
+        if v is not None:
+            return int(v)
+    return default
+
+
 def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
     """Map Cursor SDK usage fields to the standard Omnigent usage dict."""
-    in_tok = raw.get("inputTokens") or raw.get("input_tokens") or 0
-    out_tok = raw.get("outputTokens") or raw.get("output_tokens") or 0
-    total = raw.get("totalTokens") or raw.get("total_tokens") or (in_tok + out_tok)
+    in_tok = _first_of(raw, "inputTokens", "input_tokens")
+    out_tok = _first_of(raw, "outputTokens", "output_tokens")
+    total = _first_of(raw, "totalTokens", "total_tokens", default=in_tok + out_tok)
     usage: dict[str, Any] = {
         "input_tokens": in_tok,
         "output_tokens": out_tok,
@@ -114,15 +123,15 @@ def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
         "model": model,
     }
     # Carry cache breakdown if the backend reports it.
-    for src, dst in (
-        ("cacheReadInputTokens", "cache_read_input_tokens"),
-        ("cache_read_input_tokens", "cache_read_input_tokens"),
-        ("cacheCreationInputTokens", "cache_creation_input_tokens"),
-        ("cache_creation_input_tokens", "cache_creation_input_tokens"),
+    for dst, *sources in (
+        ("cache_read_input_tokens", "cacheReadInputTokens", "cache_read_input_tokens"),
+        ("cache_creation_input_tokens", "cacheCreationInputTokens", "cache_creation_input_tokens"),
     ):
-        val = raw.get(src)
-        if val:
-            usage[dst] = val
+        for src in sources:
+            val = raw.get(src)
+            if val is not None:
+                usage[dst] = val
+                break
     return usage
 
 

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -4,7 +4,7 @@ Drives Cursor via :mod:`cursor_sdk` over a local bridge — one persistent
 ``AsyncAgent`` per Omnigent conversation, created on a
 :meth:`cursor_sdk.AsyncClient.launch_bridge` client and reused turn to turn.
 Each ``run_turn`` issues one ``agent.send`` and translates the streamed
-``run.messages()`` (``SDKMessage`` objects) into ExecutorEvents:
+``run.events()`` (``RunStreamEvent`` objects) into ExecutorEvents:
 assistant text → :class:`TextChunk`, thinking → :class:`ReasoningChunk`,
 tool calls → :class:`ToolCallRequest` / :class:`ToolCallComplete`, completing
 on the run's terminal :class:`cursor_sdk.RunResult`.
@@ -41,6 +41,8 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeAlias
+
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 
 from .datamodel import OSEnvSpec
 from .executor import (
@@ -98,6 +100,30 @@ def _resolve_model(model: str | None) -> str:
             )
         return _DEFAULT_CURSOR_MODEL
     return model
+
+
+def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
+    """Map Cursor SDK usage fields to the standard Omnigent usage dict."""
+    in_tok = raw.get("inputTokens") or raw.get("input_tokens") or 0
+    out_tok = raw.get("outputTokens") or raw.get("output_tokens") or 0
+    total = raw.get("totalTokens") or raw.get("total_tokens") or (in_tok + out_tok)
+    usage: dict[str, Any] = {
+        "input_tokens": in_tok,
+        "output_tokens": out_tok,
+        "total_tokens": total,
+        "model": model,
+    }
+    # Carry cache breakdown if the backend reports it.
+    for src, dst in (
+        ("cacheReadInputTokens", "cache_read_input_tokens"),
+        ("cache_read_input_tokens", "cache_read_input_tokens"),
+        ("cacheCreationInputTokens", "cache_creation_input_tokens"),
+        ("cache_creation_input_tokens", "cache_creation_input_tokens"),
+    ):
+        val = raw.get(src)
+        if val:
+            usage[dst] = val
+    return usage
 
 
 def _tools_fingerprint(tools: list[ToolSpec]) -> str:
@@ -552,29 +578,37 @@ class CursorExecutor(Executor):
         # Streamed deltas of a single response (no tool between) still
         # concatenate seamlessly, so this never splits one sentence.
         separate_next_text = False
+        turn_usage: dict[str, Any] | None = None
         try:
             run = await state.agent.send(prompt)
-            async for message in run.messages():
-                for event in _sdk_message_to_events(message):
-                    if isinstance(event, TextChunk):
-                        if separate_next_text and response_text and event.text:
-                            # Guarantee a blank-line (paragraph) boundary between
-                            # pre- and post-tool narration, regardless of any single
-                            # trailing/leading newline the two blocks already carry
-                            # (a lone space or "\n" must still become a blank line).
-                            trailing = len(response_text) - len(response_text.rstrip("\n"))
-                            leading = len(event.text) - len(event.text.lstrip("\n"))
-                            if trailing + leading < 2:
-                                pad = "\n" * (2 - trailing - leading)
-                                event = TextChunk(text=pad + event.text)
-                        separate_next_text = False
-                        response_text += event.text
-                    elif isinstance(event, ToolCallRequest):
-                        tool_calls += 1
-                        separate_next_text = True
-                    elif isinstance(event, ToolCallComplete):
-                        separate_next_text = True
-                    yield event
+            async for stream_event in run.events():
+                if stream_event.sdk_message is not None:
+                    for event in _sdk_message_to_events(stream_event.sdk_message):
+                        if isinstance(event, TextChunk):
+                            if separate_next_text and response_text and event.text:
+                                # Guarantee a blank-line (paragraph) boundary between
+                                # pre- and post-tool narration, regardless of any single
+                                # trailing/leading newline the two blocks already carry
+                                # (a lone space or "\n" must still become a blank line).
+                                trailing = len(response_text) - len(response_text.rstrip("\n"))
+                                leading = len(event.text) - len(event.text.lstrip("\n"))
+                                if trailing + leading < 2:
+                                    pad = "\n" * (2 - trailing - leading)
+                                    event = TextChunk(text=pad + event.text)
+                            separate_next_text = False
+                            response_text += event.text
+                        elif isinstance(event, ToolCallRequest):
+                            tool_calls += 1
+                            separate_next_text = True
+                        elif isinstance(event, ToolCallComplete):
+                            separate_next_text = True
+                        yield event
+                # Capture usage from TurnEndedUpdate interaction updates.
+                iu = stream_event.interaction_update
+                if iu is not None and getattr(iu, "type", None) == "turn-ended":
+                    raw_usage = getattr(iu, "usage", None)
+                    if isinstance(raw_usage, dict) and raw_usage:
+                        turn_usage = _normalize_cursor_usage(raw_usage, model)
             result = await run.wait()
         except asyncio.CancelledError:
             raise
@@ -611,8 +645,9 @@ class CursorExecutor(Executor):
                 yield ExecutorError(message=f"LLM response denied by policy: {reason}")
                 return
 
-        # The SDK RunResult carries no token counts, so the turn is left unpriced.
-        yield TurnComplete(response=final, usage=None)
+        if turn_usage:
+            _notify_usage_from_dict(model=model, usage=turn_usage)
+        yield TurnComplete(response=final, usage=turn_usage)
 
     async def _close_state(self, state: _CursorSessionState) -> None:
         if state.agent is not None:

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -76,10 +76,6 @@ def _install_fake_sdk(
         def __init__(self, script: dict[str, Any]) -> None:
             self._script = script
 
-        async def messages(self) -> Any:
-            for message in self._script.get("messages", []):
-                yield message
-
         async def events(self) -> Any:
             for message in self._script.get("messages", []):
                 yield SimpleNamespace(sdk_message=message, interaction_update=None)
@@ -850,3 +846,18 @@ async def test_run_turn_usage_none_when_no_turn_ended_update(
     assert len(completes) == 1
     assert completes[0].usage is None
     assert notified == []  # not called when there is no usage
+
+
+def test_normalize_cursor_usage_camel_takes_priority_over_snake() -> None:
+    raw = {"inputTokens": 100, "input_tokens": 999, "outputTokens": 50, "output_tokens": 888}
+    result = _normalize_cursor_usage(raw, "auto")
+    assert result["input_tokens"] == 100
+    assert result["output_tokens"] == 50
+
+
+def test_normalize_cursor_usage_zero_tokens_preserved() -> None:
+    raw = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
+    result = _normalize_cursor_usage(raw, "auto")
+    assert result["input_tokens"] == 0
+    assert result["output_tokens"] == 0
+    assert result["total_tokens"] == 0

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -23,6 +23,7 @@ import pytest
 from omnigent.inner.cursor_executor import (
     CursorExecutor,
     _build_cursor_prompt,
+    _normalize_cursor_usage,
     _resolve_model,
     _sdk_message_to_events,
 )
@@ -78,6 +79,12 @@ def _install_fake_sdk(
         async def messages(self) -> Any:
             for message in self._script.get("messages", []):
                 yield message
+
+        async def events(self) -> Any:
+            for message in self._script.get("messages", []):
+                yield SimpleNamespace(sdk_message=message, interaction_update=None)
+            for iu in self._script.get("interaction_updates", []):
+                yield SimpleNamespace(sdk_message=None, interaction_update=iu)
 
         async def wait(self) -> Any:
             return SimpleNamespace(
@@ -732,3 +739,114 @@ def test_build_cursor_prompt_serializes_single_user_history() -> None:
     prompt = _build_cursor_prompt(messages, is_first_turn=True, system_prompt="SYS")
     assert "Conversation so far:" in prompt
     assert "earlier context" in prompt and "follow up" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Usage / cost tracking
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_cursor_usage_camel_case() -> None:
+    raw = {"inputTokens": 100, "outputTokens": 50, "totalTokens": 150}
+    result = _normalize_cursor_usage(raw, "cursor-fast")
+    assert result == {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "total_tokens": 150,
+        "model": "cursor-fast",
+    }
+
+
+def test_normalize_cursor_usage_snake_case() -> None:
+    raw = {"input_tokens": 200, "output_tokens": 80}
+    result = _normalize_cursor_usage(raw, "auto")
+    assert result["input_tokens"] == 200
+    assert result["output_tokens"] == 80
+    assert result["total_tokens"] == 280  # computed from in + out
+
+
+def test_normalize_cursor_usage_includes_cache_fields() -> None:
+    raw = {
+        "inputTokens": 500,
+        "outputTokens": 100,
+        "totalTokens": 600,
+        "cacheReadInputTokens": 300,
+        "cacheCreationInputTokens": 50,
+    }
+    result = _normalize_cursor_usage(raw, "auto")
+    assert result["cache_read_input_tokens"] == 300
+    assert result["cache_creation_input_tokens"] == 50
+
+
+async def test_run_turn_captures_usage_from_turn_ended_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a TurnEndedUpdate with usage appears in the event stream, the
+    TurnComplete event carries the normalized usage dict and
+    _notify_usage_from_dict is called."""
+    turn_ended = SimpleNamespace(
+        type="turn-ended",
+        usage={"inputTokens": 1000, "outputTokens": 200, "totalTokens": 1200},
+    )
+    script = {
+        "messages": [_assistant("Hello")],
+        "interaction_updates": [turn_ended],
+        "status": "finished",
+        "result": "Hello",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+
+    notified: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "omnigent.inner.cursor_executor._notify_usage_from_dict",
+        lambda *, model, usage: notified.append({"model": model, "usage": usage}),
+    )
+
+    executor = CursorExecutor(api_key="crsr_x")
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    usage = completes[0].usage
+    assert usage is not None
+    assert usage["input_tokens"] == 1000
+    assert usage["output_tokens"] == 200
+    assert usage["total_tokens"] == 1200
+    assert usage["model"] == "auto"
+
+    # _notify_usage_from_dict was called with the same data.
+    assert len(notified) == 1
+    assert notified[0]["model"] == "auto"
+    assert notified[0]["usage"] == usage
+
+
+async def test_run_turn_usage_none_when_no_turn_ended_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a TurnEndedUpdate, usage stays None (backward-compatible)."""
+    script = {
+        "messages": [_assistant("Hi")],
+        "status": "finished",
+        "result": "Hi",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+
+    notified: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "omnigent.inner.cursor_executor._notify_usage_from_dict",
+        lambda *, model, usage: notified.append({"model": model, "usage": usage}),
+    )
+
+    executor = CursorExecutor(api_key="crsr_x")
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    assert completes[0].usage is None
+    assert notified == []  # not called when there is no usage


### PR DESCRIPTION
## Summary
- Switch cursor executor from `run.messages()` to `run.events()` to capture `TurnEndedUpdate` interaction updates that carry token usage data
- Add `_normalize_cursor_usage` helper to map Cursor SDK usage fields (camelCase/snake_case) to the standard Omnigent usage dict
- Pipe usage through `_notify_usage_from_dict` (telemetry) and `TurnComplete` (SSE response), matching the pattern used by all other harnesses

## Test plan
- [x] Unit tests for `_normalize_cursor_usage` (camelCase, snake_case, cache fields)
- [x] End-to-end test: `TurnEndedUpdate` with usage → `TurnComplete` carries normalized usage and `_notify_usage_from_dict` is called
- [x] Backward-compat test: no `TurnEndedUpdate` → usage stays `None`, no notify call
- [x] All 37 existing cursor executor tests still pass

This pull request and its description were written by Isaac.