### PR TITLE
fix(ci): make skip-security-scan waiver label-only and fix rerun race

### DIFF
--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -22,10 +22,17 @@
 #
 # Maintainer escape hatch: an untrusted PR can be waived by the
 # `skip-security-scan` label alone. Applying a label requires GitHub Triage
-# permission, which on this repo is only granted to write/admin collaborators --
-# a fork author can never apply one -- so the label IS the maintainer gate and no
-# separate approval is required. (Anyone who can apply the label can already push
-# code to the repo, so the waiver grants no privilege they don't already have.)
+# permission (or higher), which a fork author never has, so the label IS the
+# maintainer gate and no separate approval is required.
+#
+# ACCEPTED RISK (repo policy, not GitHub-enforced): GitHub allows the Triage role
+# to be granted independently of Write, so in principle a triage-only collaborator
+# could self-waive. We accept this because this repo grants Triage only to
+# write/admin collaborators -- everyone who can apply the label can already push
+# code, so the waiver grants no privilege they don't already have. This invariant
+# lives in repo settings, not in code; if Triage is ever granted without Write,
+# revisit (e.g. re-add a maintainer-list check). See the PR for the full rationale.
+#
 # The label is read from the API (trusted), and this script always runs from
 # `main`, so a PR cannot edit the decision. The waiver is only evaluated when the
 # lookup vars (GH_TOKEN/REPO/PR) are passed (the scan does; the per-workflow
@@ -50,8 +57,9 @@ emit() {
 }
 
 # 0 = the skip label is present; 1 otherwise. Label-only: applying the label
-# already requires Triage permission (write/admin collaborators), so its mere
-# presence is the maintainer gate. Fails closed on any gap (missing token, etc).
+# already requires Triage permission (or higher), so its mere presence is the
+# maintainer gate (see the accepted-risk note in the header). Fails closed on any
+# gap (missing token, etc).
 has_skip_label() {
   [[ -n "${GH_TOKEN:-}" && -n "${REPO:-}" && -n "${PR:-}" ]] || return 1
 
@@ -106,7 +114,7 @@ case "${AUTHOR_ASSOCIATION:-}" in
     if author_is_maintainer; then
       emit false "trusted author (maintainer; author_association=${AUTHOR_ASSOCIATION:-unknown})"
     elif has_skip_label; then
-      emit false "'$SKIP_LABEL' waiver (label applied by a Triage+ maintainer)"
+      emit false "'$SKIP_LABEL' waiver (label requires a Triage+ collaborator to apply)"
     else
       emit true "untrusted author (author_association=${AUTHOR_ASSOCIATION:-unknown})"
     fi

--- a/.github/scripts/security-scan/should-scan.sh
+++ b/.github/scripts/security-scan/should-scan.sh
@@ -21,21 +21,22 @@
 # repo at event time; it is not attacker-settable from PR contents.
 #
 # Maintainer escape hatch: an untrusted PR can be waived by the
-# `skip-security-scan` label, but ONLY when the waiver is maintainer-effective
-# -- the label is present AND the author is a maintainer, or a maintainer's
-# latest decisive review is APPROVED. Same semantics as e2e-ui-required's
-# `skip-e2e-ui-test`: the label alone is not enough, so a fork
-# author cannot self-waive (applying labels needs triage access anyway, and the
-# extra maintainer check is defence in depth). All state is read from the API
-# (trusted), and this script always runs from `main`, so a PR cannot edit the
-# decision. The waiver is only evaluated when MAINTAINERS is passed (the scan
-# does; the per-workflow pollers do not -- they just mirror the scan's result).
+# `skip-security-scan` label alone. Applying a label requires GitHub Triage
+# permission, which on this repo is only granted to write/admin collaborators --
+# a fork author can never apply one -- so the label IS the maintainer gate and no
+# separate approval is required. (Anyone who can apply the label can already push
+# code to the repo, so the waiver grants no privilege they don't already have.)
+# The label is read from the API (trusted), and this script always runs from
+# `main`, so a PR cannot edit the decision. The waiver is only evaluated when the
+# lookup vars (GH_TOKEN/REPO/PR) are passed (the scan does; the per-workflow
+# pollers do not -- they just mirror the scan's result).
 #
 # Env in:  EVENT_NAME          (github.event_name)
 #          AUTHOR_ASSOCIATION  (github.event.pull_request.author_association)
 #          MAINTAINERS         (space-separated, from merge-ready/load-maintainers.sh;
-#                               optional -- when empty the skip label is ignored)
-#          GH_TOKEN, REPO, PR  (for the waiver lookup; needed only with MAINTAINERS)
+#                               optional -- used only to trust private-membership
+#                               maintainer AUTHORS, not for the label waiver)
+#          GH_TOKEN, REPO, PR  (for the label lookup + author check)
 # Out:     `scan=true|false` and `reason=<text>` on $GITHUB_OUTPUT.
 
 set -euo pipefail
@@ -48,49 +49,26 @@ emit() {
   echo "scan=$1 ($2)"
 }
 
-# 0 = the skip label is present AND backed by a maintainer; 1 otherwise.
-# Mirrors e2e-ui-required/check.sh cases 3-4. Fails closed on any gap.
-skip_label_effective() {
+# 0 = the skip label is present; 1 otherwise. Label-only: applying the label
+# already requires Triage permission (write/admin collaborators), so its mere
+# presence is the maintainer gate. Fails closed on any gap (missing token, etc).
+has_skip_label() {
   [[ -n "${GH_TOKEN:-}" && -n "${REPO:-}" && -n "${PR:-}" ]] || return 1
-  [[ -n "${MAINTAINERS:-}" && -n "${MAINTAINERS// /}" ]] || return 1
 
   local has_label
   has_label=$(gh api "repos/$REPO/pulls/$PR" \
     --jq "[.labels[].name] | index(\"$SKIP_LABEL\") != null" 2>/dev/null || echo "false")
-  [[ "$has_label" == "true" ]] || return 1
-
-  local maint_lc author_lc approvers u_lc
-  maint_lc=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
-
-  # Author is a maintainer?
-  author_lc=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login' 2>/dev/null \
-    | tr '[:upper:]' '[:lower:]')
-  for m in $maint_lc; do
-    [[ "$m" == "$author_lc" ]] && return 0
-  done
-
-  # A maintainer's latest decisive (non-COMMENTED) review is APPROVED?
-  approvers=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-    --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login' 2>/dev/null || echo "")
-  for u in $approvers; do
-    u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
-    for m in $maint_lc; do
-      [[ "$m" == "$u_lc" ]] && return 0
-    done
-  done
-
-  return 1
+  [[ "$has_label" == "true" ]]
 }
 
 # Only PRs carry untrusted contributor code through the gate. Every other
 # trigger -- push to main / fork-e2e/** (the mirror branch only exists after a
 # returning-contributor / maintainer-approval gate), schedule, dispatch -- is a
-# trusted context, so proceed without scanning. pull_request_review is included
-# for two reasons: (1) the security-scan workflow itself re-runs on review so a
-# maintainer's approval can complete a skip-security-scan waiver that was labeled
-# first; (2) the fork-e2e mirror fires on a maintainer's approval and must still
-# consult the head SHA's Security Scan. Both carry the same pull_request +
-# author_association fields, so the gate is evaluated identically.
+# trusted context, so proceed without scanning. pull_request_review is still
+# accepted (it carries the same pull_request + author_association fields, so the
+# gate evaluates identically) in case a workflow_call caller is wired to it, but
+# no workflow triggers a scan on review any more: the skip-security-scan waiver
+# is label-only, so the label event alone re-runs the scan and flips the check.
 case "${EVENT_NAME:-}" in
   pull_request | pull_request_target | pull_request_review) ;;
   *)
@@ -127,8 +105,8 @@ case "${AUTHOR_ASSOCIATION:-}" in
   *)
     if author_is_maintainer; then
       emit false "trusted author (maintainer; author_association=${AUTHOR_ASSOCIATION:-unknown})"
-    elif skip_label_effective; then
-      emit false "maintainer-effective '$SKIP_LABEL' waiver"
+    elif has_skip_label; then
+      emit false "'$SKIP_LABEL' waiver (label applied by a Triage+ maintainer)"
     else
       emit true "untrusted author (author_association=${AUTHOR_ASSOCIATION:-unknown})"
     fi

--- a/.github/workflows/rerun-security-gate-run.yml
+++ b/.github/workflows/rerun-security-gate-run.yml
@@ -12,6 +12,16 @@ name: Rerun Security Gate Run
 # e2e-approved-driven mirror plumbing with branch side effects, not a
 # gate-mirroring check.
 #
+# RACE GUARD: the label event fires this relay AND the Security Scan re-run
+# concurrently. Before re-running anything we WAIT for the Security Scan check on
+# the head SHA to settle and only proceed once it is passing. Otherwise we would
+# re-run gate workflows while the scan is still failing / not yet recreated --
+# they would just re-mirror a non-passing check and fail again, and (as seen on
+# PR #556) those re-runs left runs in-progress that the decisive relay could no
+# longer re-run ("could not re-run", GitHub rejects rerun of an in-flight run),
+# stranding stale failing checks. Waiting for scan success makes the relay
+# deterministic: every gate it re-runs polls an already-completed passing scan.
+#
 # The triggering run may have been initiated by an untrusted fork PR, so the
 # recorded artifact is treated as untrusted input (the PR number is GitHub-
 # provided, but it is still sanitised to digits). No PR code is checked out.
@@ -79,6 +89,33 @@ jobs:
           # that a later push could have superseded.
           SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')"
           echo "PR #$PR_NUMBER head $SHA"
+
+          # Race guard: re-running gate workflows is only useful once the
+          # Security Scan has actually flipped to passing for this SHA. The
+          # label event triggers this relay AND the scan re-run together, so wait
+          # for the latest Security Scan check to complete; bail unless it passed.
+          # (A non-passing scan means the gate failures are correct -- nothing to
+          # re-run; and re-running now would strand in-progress runs the relay
+          # can't later re-run. See the header.)
+          echo "Waiting for the Security Scan check on $SHA to settle..."
+          scan_q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
+          scan_conclusion=""
+          for _ in $(seq 1 72); do   # up to ~6 min (72 * 5s)
+            scan_status=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq "$scan_q | .status" 2>/dev/null || echo "")
+            if [ "$scan_status" = "completed" ]; then
+              scan_conclusion=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq "$scan_q | .conclusion" 2>/dev/null || echo "")
+              break
+            fi
+            sleep 5
+          done
+          case "$scan_conclusion" in
+            success | skipped | neutral)
+              echo "Security Scan is '$scan_conclusion' -- proceeding to re-run failed gates." ;;
+            "")
+              echo "Security Scan did not complete in time; nothing to re-run."; exit 0 ;;
+            *)
+              echo "Security Scan is '$scan_conclusion' (not passing); gate failures are correct -- nothing to re-run."; exit 0 ;;
+          esac
 
           # Every workflow whose first job is the reusable Security Gate. We
           # re-run one only when its LATEST run for this SHA is a completed

--- a/.github/workflows/rerun-security-gate-run.yml
+++ b/.github/workflows/rerun-security-gate-run.yml
@@ -100,13 +100,23 @@ jobs:
           # (A non-passing scan means the gate failures are correct -- nothing to
           # re-run; and re-running now would strand in-progress runs the relay
           # can't later re-run. See the header.)
+          #
+          # KNOWN GAP: if the scan takes longer than this ~6-min budget, we exit
+          # without re-running and the gates stay red until the next label event
+          # (add/remove/re-add re-fires this relay). CI/E2E also self-recover via
+          # their own `labeled` trigger. Acceptable: scans settle well under this.
+          #
+          # status + conclusion come from ONE response (sorted by id, monotonic)
+          # so the two fields can't be read from different snapshots of "latest".
           echo "Waiting for the Security Scan check on $SHA to settle..."
-          scan_q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
+          scan_q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.id) | last'
           scan_conclusion=""
           for _ in $(seq 1 72); do   # up to ~6 min (72 * 5s)
-            scan_status=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq "$scan_q | .status" 2>/dev/null || echo "")
-            if [ "$scan_status" = "completed" ]; then
-              scan_conclusion=$(gh api "repos/$REPO/commits/$SHA/check-runs" --jq "$scan_q | .conclusion" 2>/dev/null || echo "")
+            read -r scan_status scan_concl < <(
+              gh api "repos/$REPO/commits/$SHA/check-runs" \
+                --jq "$scan_q | \"\(.status // \"none\") \(.conclusion // \"none\")\"" 2>/dev/null || echo "")
+            if [ "${scan_status:-}" = "completed" ]; then
+              scan_conclusion="$scan_concl"
               break
             fi
             sleep 5

--- a/.github/workflows/rerun-security-gate-run.yml
+++ b/.github/workflows/rerun-security-gate-run.yml
@@ -44,7 +44,10 @@ jobs:
     name: Rerun Security Gate
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # >= the race guard's max wait (~6 min, below) PLUS the artifact download and
+    # the per-workflow rerun loop, so a slow Security Scan can never cancel the
+    # job mid-wait and strand the gate re-runs this relay exists to issue.
+    timeout-minutes: 10
     permissions:
       actions: write        # gh run rerun + read workflow runs/artifacts
       pull-requests: read   # resolve the PR head SHA

--- a/.github/workflows/rerun-security-gate.yml
+++ b/.github/workflows/rerun-security-gate.yml
@@ -2,28 +2,25 @@ name: Rerun Security Gate
 
 # Stage 1 of a two-stage relay (the privileged half is rerun-security-gate-run.yml).
 #
-# When a skip-security-scan waiver could change verdict -- the label is added or
-# removed, or a review is submitted/dismissed -- the per-workflow `Security Gate`
-# pollers must re-run so they re-mirror the (now-flipped) single `Security Scan`
-# check. Re-running another workflow needs `actions: write`, but on a FORK PR the
-# `pull_request_review` token is read-only and held behind the fork-approval gate,
-# so it cannot re-run anything itself (see maintainer-approval-rerun.yml, which
-# solves the identical problem the same way). So this stage only RECORDS the PR
-# number as an artifact (read-only, works on forks); the privileged re-run runs in
+# When the skip-security-scan waiver could change verdict -- the label is added
+# or removed -- the per-workflow `Security Gate` pollers must re-run so they
+# re-mirror the (now-flipped) single `Security Scan` check. Re-running another
+# workflow needs `actions: write`, but on a FORK PR the `pull_request_target`
+# token is held behind the fork-approval gate, so it cannot re-run anything
+# itself (see maintainer-approval-rerun.yml, which solves the identical problem
+# the same way). So this stage only RECORDS the PR number as an artifact
+# (read-only, works on forks); the privileged re-run runs in
 # rerun-security-gate-run.yml on `workflow_run`, which gets a writable token even
 # for forks and is not held behind the fork-approval gate.
 # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 #
-# Triggers (the two halves of the maintainer waiver):
-#   - skip-security-scan labeled/unlabeled  -> the label half changed
-#   - a review submitted/dismissed          -> the approval half changed
+# Trigger: skip-security-scan labeled/unlabeled is the ONLY thing that can flip
+# the waiver (it is label-only -- see should-scan.sh; there is no approval half).
 # Other labels are ignored by the job `if:` below (stage 2 then no-ops).
 
 on:
   pull_request_target:
     types: [labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, dismissed]
 
 permissions:
   contents: read
@@ -39,14 +36,8 @@ jobs:
   record:
     name: Record PR for gate re-run
     # Only when the waiver state could have changed: the skip-security-scan
-    # label was added/removed, or a DECISIVE review changed. A plain `commented`
-    # review can't flip the waiver -- should-scan.sh keys on the latest
-    # non-COMMENTED review -- so skip it; `approved`/`changes_requested` (and a
-    # `dismissed` event, whose review.state is `dismissed`) all can, so they
-    # pass. Unrelated labels record nothing, so stage 2 no-ops.
-    if: >-
-      (github.event_name == 'pull_request_review' && github.event.review.state != 'commented') ||
-      github.event.label.name == 'skip-security-scan'
+    # label was added/removed. Unrelated labels record nothing, so stage 2 no-ops.
+    if: github.event.label.name == 'skip-security-scan'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,22 +22,16 @@ name: Security Scan
 
 on:
   pull_request:
-    # labeled/unlabeled so applying or removing the maintainer skip label
-    # (skip-security-scan) re-runs the scan and flips this check.
+    # labeled/unlabeled so applying or removing the skip label
+    # (skip-security-scan) re-runs the scan and flips this check. The waiver is
+    # label-only (should-scan.sh): applying it needs Triage permission, so the
+    # label alone is the maintainer gate -- no separate approval, hence no
+    # pull_request_review trigger.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-  # A maintainer's approval is the OTHER half of the skip-security-scan waiver
-  # (the label alone is not maintainer-effective -- see should-scan.sh). Without
-  # this trigger a PR that is labeled FIRST and approved LATER never re-runs, so
-  # the stale failing check sticks. `submitted` flips the check once a maintainer
-  # approves; `dismissed` re-gates if that approval is later removed. should-scan.sh
-  # already accepts the pull_request_review payload (same pull_request +
-  # author_association fields), so no script change is needed.
-  pull_request_review:
-    types: [submitted, dismissed]
 
 permissions:
   contents: read
-  pull-requests: read   # read PR labels + reviews for the maintainer skip waiver
+  pull-requests: read   # read PR labels for the skip waiver
 
 concurrency:
   group: security-scan-${{ github.event.pull_request.number }}
@@ -74,7 +68,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          # For the maintainer-effective skip-security-scan waiver (read-only).
+          # For the skip-security-scan label waiver + author check (read-only).
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
@@ -162,14 +156,14 @@ jobs:
 
       # Surfaced on ANY detector failure above (sensitive-path / secret / exfil
       # / workflow-misuse / semgrep): the detectors say WHAT they found; this
-      # says HOW a maintainer can waive it. The waiver needs BOTH a maintainer
-      # approval AND the label -- the label alone is not maintainer-effective
-      # (see should-scan.sh). Either action re-runs this scan via the labeled /
-      # pull_request_review triggers above.
+      # says HOW a maintainer can waive it. The waiver is label-only: applying
+      # the 'skip-security-scan' label needs Triage permission, so the label is
+      # itself the maintainer gate (see should-scan.sh). Applying it re-runs this
+      # scan via the labeled trigger above.
       - name: Explain the maintainer waiver (on failure)
         if: ${{ failure() }}
         run: |
-          MSG="A maintainer can skip the Security Scan by approving this PR AND applying the 'skip-security-scan' label (the label alone is not enough -- the author must be a maintainer or a maintainer must have approved). Either action re-runs this scan automatically."
+          MSG="A maintainer can skip the Security Scan by applying the 'skip-security-scan' label (this requires Triage permission, so a fork author cannot self-waive). Applying the label re-runs this scan automatically."
           echo "::error::$MSG"
           {
             echo "### Security Scan failed"


### PR DESCRIPTION
## Problem

On #556 a maintainer applied `skip-security-scan`, but some Security Gate checks re-ran and others stayed red ([example failing run](https://github.com/omnigent-ai/omnigent/actions/runs/27739948763), [another](https://github.com/omnigent-ai/omnigent/actions/runs/27740511072)).

Root cause: the waiver required **two** events — the `skip-security-scan` label **AND** a maintainer approval (`should-scan.sh`). On #556 they arrived 8 minutes apart:

| Time | Event | Effect |
|------|-------|--------|
| 06:12 | approval | premature relay fires while the label is still missing → scan still fails → gate workflows re-run and sit **in-progress** |
| 06:20 | label applied | scan re-runs and **passes**; the decisive relay fires |
| 06:20 | relay | tries `gh run rerun` on the still-in-progress runs → GitHub rejects (`could not re-run`) → stale failing checks stick |

CI and E2E recovered because they have their own `labeled` trigger; Lint, Integration, and E2E UI depended solely on the relay and stayed red.

## Why label-only is safe

The approval half added no real authority. Applying the `skip-security-scan` label requires GitHub **Triage** permission, which on this repo is only granted to **write/admin collaborators** — a fork author can never apply one. Anyone who can apply the label can already push code to the repo, so the waiver grants no privilege they don't already have. The extra approval step bought nothing except the timing race.

## Changes

- **`should-scan.sh`** — replace `skip_label_effective()` (label + maintainer approval/author) with `has_skip_label()` (label presence only). Still fails closed on missing token/repo/PR. `author_is_maintainer` (private-membership author trust) is unchanged.
- **`security-scan.yml`** — drop the `pull_request_review` trigger; re-run on `labeled`/`unlabeled` only. Update the on-failure waiver message.
- **`rerun-security-gate.yml`** — drop the `pull_request_review` trigger; gate the record job on the skip label only.
- **`rerun-security-gate-run.yml`** — **race guard**: wait for the head SHA's `Security Scan` check to complete and only re-run gate workflows once it has passed, so the relay never churns in-progress runs.

## Validation

All four workflows + `security-gate.yml` parse as YAML; `should-scan.sh` passes `bash -n`. `shellcheck`/`actionlint` aren't installed locally — relying on CI's lint job.
