### PR TITLE
ci(merge-ready): pin gate scripts to main, never the PR head

### DIFF
--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -106,13 +106,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          # Trusted gate scripts from main, never the PR head: on the
-          # pull_request (automerge) event the default ref is
-          # refs/pull/N/merge and on check_suite it is the suite head SHA,
-          # so an unpinned checkout would source the PR's own required.sh /
-          # evaluate-checks.sh -- a stale REQUIRED list (e.g. predating E2E)
-          # or an edited gate would then decide the merge. Pin to main.
-          ref: main
+          ref: main             # trusted gate scripts; never the PR head
           sparse-checkout: .github/scripts/merge-ready
           persist-credentials: false
 

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -106,6 +106,13 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          # Trusted gate scripts from main, never the PR head: on the
+          # pull_request (automerge) event the default ref is
+          # refs/pull/N/merge and on check_suite it is the suite head SHA,
+          # so an unpinned checkout would source the PR's own required.sh /
+          # evaluate-checks.sh -- a stale REQUIRED list (e.g. predating E2E)
+          # or an edited gate would then decide the merge. Pin to main.
+          ref: main
           sparse-checkout: .github/scripts/merge-ready
           persist-credentials: false
 


### PR DESCRIPTION
## Problem

The `Check out scripts` step in `merge-ready.yml` has **no `ref:` pinned**, so the gate scripts it sources depend on the trigger event:

| Trigger | default checkout ref | scripts sourced |
|---|---|---|
| `pull_request` (automerge) | `refs/pull/N/merge` | **PR's branch** |
| `check_suite` (fork-e2e/**) | suite head SHA | **PR head (fork)** |
| `workflow_run` / `issue_comment` / `workflow_dispatch` | main tip | main ✅ |

Verified on a live `pull_request`-triggered run — the checkout log shows it fetching `refs/pull/635/merge` and sparse-checking-out `.github/scripts/merge-ready` from the **PR's** tree, not main.

`required.sh` is a generated file ("replaced wholesale on every sync"), so a PR branched **before E2E was added to `REQUIRED`** carries a stale list. Labeling such a PR `automerge` makes Merge Ready evaluate the gate from the PR's old `required.sh` and **merge it without E2E required** — exactly the "merged without E2E running" symptom.

It's also a **privilege escalation**: a same-repo PR runs with the job's `contents: write` + auto-merge permissions, so it could edit its own `required.sh` / `evaluate-checks.sh` to weaken the gate and self-merge.

## Fix

Pin the checkout to `ref: main` so Merge Ready always evaluates with main's gate logic regardless of which event triggered it. This matches the established pattern in `fork-e2e-mirror.yml` (`ref: main  # trusted; never the PR head`).

## Validation

- `yaml.safe_load` parses.
- One-line change (plus an explanatory comment); no logic touched.

## Note

This does not affect the intentional admin escape hatch (`enforce_admins=false` — a repo admin can still "merge without waiting for requirements"); that path is separate from the gate scripts.