### PR TITLE
feat(cursor): evaluate PHASE_TOOL_CALL policy for native tools

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import json
 import logging
 import os
@@ -273,7 +274,11 @@ def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore
             is_bridged = False
         call_id = getattr(message, "call_id", None)
         if status == "running":
-            events.append(ToolCallRequest(name=name, args=args, metadata={"call_id": call_id, "is_bridged": is_bridged}))
+            events.append(
+                ToolCallRequest(
+                    name=name, args=args, metadata={"call_id": call_id, "is_bridged": is_bridged}
+                )
+            )
         elif status in ("completed", "error"):
             result = getattr(message, "result", None)
             classification = classify_tool_result(result)
@@ -649,14 +654,12 @@ class CursorExecutor(Executor):
                                 if gate["block"]:
                                     # Cancel the run to prevent further
                                     # native tool use.
-                                    try:
+                                    with contextlib.suppress(Exception):
                                         await run.cancel()
-                                    except Exception:  # noqa: BLE001
-                                        pass
                                     yield event  # emit so observers see what was attempted
-                                    yield ExecutorError(
-                                        message=f"Native tool {event.name!r} denied by policy: {gate['reason']}"
-                                    )
+                                    reason = gate["reason"]
+                                    msg = f"Native tool {event.name!r} denied by policy: {reason}"
+                                    yield ExecutorError(message=msg)
                                     return
                         elif isinstance(event, ToolCallComplete):
                             separate_next_text = True

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -9,6 +9,14 @@ assistant text → :class:`TextChunk`, thinking → :class:`ReasoningChunk`,
 tool calls → :class:`ToolCallRequest` / :class:`ToolCallComplete`, completing
 on the run's terminal :class:`cursor_sdk.RunResult`.
 
+Policy enforcement covers three phases: PHASE_LLM_REQUEST (pre-send),
+PHASE_LLM_RESPONSE (post-response), and PHASE_TOOL_CALL (native tools).
+Cursor's native tools execute inside the Cursor process so they cannot be
+pre-blocked, but when a non-bridged tool call is observed the executor
+evaluates PHASE_TOOL_CALL and cancels the run on DENY.  Bridged Omnigent
+tools (MCP-wrapped) are already gated server-side via the dispatch bridge
+and are skipped to avoid double evaluation.
+
 Crucially, Omnigent's spec-declared tools (``sys_session_send`` et al.) are
 bridged into Cursor **in-process** via the SDK's ``custom_tools``: each
 :class:`~omnigent.inner.executor.ToolSpec` becomes a ``cursor_sdk.CustomTool``
@@ -260,9 +268,12 @@ def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore
             name = str(args.get("toolName") or name)
             inner = args.get("args")
             args = inner if isinstance(inner, dict) else {}
+            is_bridged = True
+        else:
+            is_bridged = False
         call_id = getattr(message, "call_id", None)
         if status == "running":
-            events.append(ToolCallRequest(name=name, args=args, metadata={"call_id": call_id}))
+            events.append(ToolCallRequest(name=name, args=args, metadata={"call_id": call_id, "is_bridged": is_bridged}))
         elif status in ("completed", "error"):
             result = getattr(message, "result", None)
             classification = classify_tool_result(result)
@@ -277,7 +288,7 @@ def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore
                     status=tool_status,
                     result=result,
                     error=error,
-                    metadata={"call_id": call_id},
+                    metadata={"call_id": call_id, "is_bridged": is_bridged},
                 )
             )
         return events
@@ -377,9 +388,10 @@ class CursorExecutor(Executor):
         # Installed by the runtime adapter; routes a bridged-tool call back into
         # Omnigent's session (policy gating, sub-agent dispatch, logging).
         self._tool_executor: ToolExecutor | None = None
-        # Installed by the runtime adapter; evaluates PHASE_LLM_REQUEST /
-        # PHASE_LLM_RESPONSE policies (the same round-trip pi / claude-sdk use).
-        # ``None`` on single-process / pre-turn paths (then policy is a no-op).
+        # Installed by the runtime adapter; evaluates PHASE_LLM_REQUEST,
+        # PHASE_LLM_RESPONSE, and PHASE_TOOL_CALL policies (the same round-trip
+        # pi / claude-sdk use). ``None`` on single-process / pre-turn paths
+        # (then policy is a no-op).
         self._policy_evaluator: Callable[[str, dict[str, Any]], Awaitable[Any]] | None = None
 
     def supports_streaming(self) -> bool:
@@ -408,6 +420,24 @@ class CursorExecutor(Executor):
             if isinstance(meta, dict) and meta.get("session_id"):
                 return str(meta["session_id"])
         return "__default__"
+
+    # -- native-tool policy gate --------------------------------------------
+
+    async def _evaluate_native_tool_policy(
+        self, name: str, args: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Evaluate PHASE_TOOL_CALL policy for a Cursor native tool.
+
+        Returns ``{"block": bool, "reason": str}``.
+        """
+        evaluator = self._policy_evaluator
+        if evaluator is None:
+            return {"block": False, "reason": ""}
+        verdict = await evaluator("PHASE_TOOL_CALL", {"name": name, "arguments": args})
+        action = getattr(verdict, "action", None)
+        if action == "POLICY_ACTION_DENY":
+            return {"block": True, "reason": getattr(verdict, "reason", "") or "blocked by policy"}
+        return {"block": False, "reason": ""}
 
     # -- custom-tool bridge -------------------------------------------------
 
@@ -609,6 +639,25 @@ class CursorExecutor(Executor):
                         elif isinstance(event, ToolCallRequest):
                             tool_calls += 1
                             separate_next_text = True
+                            # Evaluate PHASE_TOOL_CALL for native tools.
+                            # Bridged tools are already gated by the
+                            # dispatch bridge — skip to avoid double eval.
+                            if not event.metadata.get("is_bridged") and policy_eval is not None:
+                                gate = await self._evaluate_native_tool_policy(
+                                    event.name, event.args if isinstance(event.args, dict) else {}
+                                )
+                                if gate["block"]:
+                                    # Cancel the run to prevent further
+                                    # native tool use.
+                                    try:
+                                        await run.cancel()
+                                    except Exception:  # noqa: BLE001
+                                        pass
+                                    yield event  # emit so observers see what was attempted
+                                    yield ExecutorError(
+                                        message=f"Native tool {event.name!r} denied by policy: {gate['reason']}"
+                                    )
+                                    return
                         elif isinstance(event, ToolCallComplete):
                             separate_next_text = True
                         yield event

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -879,7 +879,9 @@ def test_sdk_message_to_events_marks_native_tool_not_bridged() -> None:
     assert events[0].metadata["is_bridged"] is False
 
     # Completed status too.
-    done = _sdk_message_to_events(_tool("bash", "t1", "completed", args={"cmd": "ls"}, result="ok"))
+    done = _sdk_message_to_events(
+        _tool("bash", "t1", "completed", args={"cmd": "ls"}, result="ok")
+    )
     assert isinstance(done[0], ToolCallComplete)
     assert done[0].metadata["is_bridged"] is False
 
@@ -950,6 +952,12 @@ async def test_run_turn_native_tool_denied_by_policy(monkeypatch: pytest.MonkeyP
     assert "denied by policy" in errors[0].message
     assert "bash" in errors[0].message
 
+    # ToolCallRequest appears before ExecutorError, and nothing follows the error.
+    req_idx = next(i for i, e in enumerate(events) if isinstance(e, ToolCallRequest))
+    err_idx = next(i for i, e in enumerate(events) if isinstance(e, ExecutorError))
+    assert req_idx < err_idx
+    assert err_idx == len(events) - 1  # error is the last event
+
     # No TurnComplete — the turn was aborted.
     assert not any(isinstance(e, TurnComplete) for e in events)
 
@@ -998,6 +1006,10 @@ async def test_run_turn_bridged_tool_skips_tool_call_policy(
         events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
     finally:
         await executor.close()
+
+    # Verify the bridged tool call was actually observed (not silently dropped).
+    reqs = [e for e in events if isinstance(e, ToolCallRequest)]
+    assert len(reqs) == 1 and reqs[0].name == "sys_session_send"
 
     # The turn completes normally — the bridged tool was NOT policy-gated here.
     assert any(isinstance(e, TurnComplete) for e in events)

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -82,6 +82,9 @@ def _install_fake_sdk(
             for iu in self._script.get("interaction_updates", []):
                 yield SimpleNamespace(sdk_message=None, interaction_update=iu)
 
+        async def cancel(self) -> None:
+            pass  # no-op for tests
+
         async def wait(self) -> Any:
             return SimpleNamespace(
                 status=self._script.get("status", "finished"),
@@ -262,7 +265,7 @@ def test_sdk_message_to_events_unwraps_envelope_on_completion_and_error() -> Non
     done = _sdk_message_to_events(_envelope("completed", [{"type": "text", "text": "ok"}]))
     assert isinstance(done[0], ToolCallComplete)
     assert done[0].name == "sys_session_send"  # unwrapped, not "mcp"
-    assert done[0].metadata == {"call_id": "c1"}
+    assert done[0].metadata == {"call_id": "c1", "is_bridged": True}
 
     err = _sdk_message_to_events(_envelope("error", "boom"))
     assert isinstance(err[0], ToolCallComplete)
@@ -861,3 +864,168 @@ def test_normalize_cursor_usage_zero_tokens_preserved() -> None:
     assert result["input_tokens"] == 0
     assert result["output_tokens"] == 0
     assert result["total_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# PHASE_TOOL_CALL policy for native tools
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_message_to_events_marks_native_tool_not_bridged() -> None:
+    """A plain (non-MCP-wrapped) tool call has ``is_bridged=False`` in metadata."""
+    events = _sdk_message_to_events(_tool("bash", "t1", "running", args={"cmd": "ls"}))
+    assert len(events) == 1
+    assert isinstance(events[0], ToolCallRequest)
+    assert events[0].metadata["is_bridged"] is False
+
+    # Completed status too.
+    done = _sdk_message_to_events(_tool("bash", "t1", "completed", args={"cmd": "ls"}, result="ok"))
+    assert isinstance(done[0], ToolCallComplete)
+    assert done[0].metadata["is_bridged"] is False
+
+
+def test_sdk_message_to_events_marks_mcp_tool_bridged() -> None:
+    """An MCP-wrapped tool call has ``is_bridged=True`` in metadata."""
+    envelope = SimpleNamespace(
+        type="tool_call",
+        name="mcp",
+        call_id="c1",
+        status="running",
+        args={
+            "providerIdentifier": "custom-user-tools",
+            "toolName": "sys_session_send",
+            "args": {"session": "s1"},
+        },
+        result=None,
+    )
+    events = _sdk_message_to_events(envelope)
+    assert isinstance(events[0], ToolCallRequest)
+    assert events[0].metadata["is_bridged"] is True
+
+    # Completed too.
+    envelope_done = SimpleNamespace(
+        type="tool_call",
+        name="mcp",
+        call_id="c1",
+        status="completed",
+        args={
+            "providerIdentifier": "custom-user-tools",
+            "toolName": "sys_session_send",
+            "args": {"session": "s1"},
+        },
+        result="ok",
+    )
+    done = _sdk_message_to_events(envelope_done)
+    assert isinstance(done[0], ToolCallComplete)
+    assert done[0].metadata["is_bridged"] is True
+
+
+async def test_run_turn_native_tool_denied_by_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A native tool call triggers PHASE_TOOL_CALL. On DENY the run emits
+    ToolCallRequest then ExecutorError and the turn ends."""
+    script = {
+        "messages": [
+            _assistant("Let me run that."),
+            _tool("bash", "t1", "running", args={"cmd": "rm -rf /"}),
+        ],
+        "status": "finished",
+        "result": "",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x")
+    executor._policy_evaluator = _policy("PHASE_TOOL_CALL")
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    # The ToolCallRequest is emitted so observers see what was attempted.
+    reqs = [e for e in events if isinstance(e, ToolCallRequest)]
+    assert len(reqs) == 1
+    assert reqs[0].name == "bash"
+
+    # Then an ExecutorError with the denial reason.
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert "denied by policy" in errors[0].message
+    assert "bash" in errors[0].message
+
+    # No TurnComplete — the turn was aborted.
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_bridged_tool_skips_tool_call_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bridged (MCP-wrapped) tool does NOT trigger PHASE_TOOL_CALL — it's
+    already gated server-side via the dispatch bridge."""
+    # Build an MCP-envelope tool call (bridged).
+    mcp_running = SimpleNamespace(
+        type="tool_call",
+        name="mcp",
+        call_id="c1",
+        status="running",
+        args={
+            "providerIdentifier": "custom-user-tools",
+            "toolName": "sys_session_send",
+            "args": {"session": "s1", "message": "go"},
+        },
+        result=None,
+    )
+    mcp_done = SimpleNamespace(
+        type="tool_call",
+        name="mcp",
+        call_id="c1",
+        status="completed",
+        args={
+            "providerIdentifier": "custom-user-tools",
+            "toolName": "sys_session_send",
+            "args": {"session": "s1", "message": "go"},
+        },
+        result="ok",
+    )
+    script = {
+        "messages": [_assistant("Dispatching."), mcp_running, mcp_done, _assistant("Done.")],
+        "status": "finished",
+        "result": "Done.",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+
+    # Wire a policy that denies PHASE_TOOL_CALL — if it fires, the turn would abort.
+    executor = CursorExecutor(api_key="crsr_x")
+    executor._policy_evaluator = _policy("PHASE_TOOL_CALL")
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    # The turn completes normally — the bridged tool was NOT policy-gated here.
+    assert any(isinstance(e, TurnComplete) for e in events)
+    assert not any(isinstance(e, ExecutorError) for e in events)
+
+
+async def test_run_turn_native_tool_allowed_by_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When PHASE_TOOL_CALL returns ALLOW, the turn proceeds normally."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "echo hi"}),
+            _tool("bash", "t1", "completed", result="hi"),
+            _assistant("Done."),
+        ],
+        "status": "finished",
+        "result": "Done.",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x")
+    executor._policy_evaluator = _policy(None)  # never denies
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    assert any(isinstance(e, TurnComplete) for e in events)
+    assert not any(isinstance(e, ExecutorError) for e in events)
+    # The tool call went through.
+    reqs = [e for e in events if isinstance(e, ToolCallRequest)]
+    assert len(reqs) == 1 and reqs[0].name == "bash"


### PR DESCRIPTION
## Summary
- Cursor's native tools (bash, file editing, etc.) previously bypassed all `PHASE_TOOL_CALL` policies. Now when a non-bridged tool call is observed in the stream, the executor evaluates `PHASE_TOOL_CALL` and cancels the run on DENY
- Added `is_bridged` flag to `ToolCallRequest`/`ToolCallComplete` metadata to distinguish MCP-wrapped (already server-side gated) tools from native cursor tools
- Bridged tools are skipped to avoid double evaluation since they're already gated via the dispatch bridge

**Caveat:** Cursor native tools execute inside the Cursor process, so we cannot pre-block them — by the time we see `status="running"`, the tool has already started. However, we cancel the run on DENY to prevent further tool use in the turn.

## Test plan
- [x] `test_sdk_message_to_events_marks_native_tool_not_bridged` — native tools get `is_bridged=False`
- [x] `test_sdk_message_to_events_marks_mcp_tool_bridged` — MCP-wrapped tools get `is_bridged=True`
- [x] `test_run_turn_native_tool_denied_by_policy` — DENY cancels run, emits ToolCallRequest + ExecutorError, no TurnComplete
- [x] `test_run_turn_bridged_tool_skips_tool_call_policy` — bridged tool with DENY policy completes normally (not double-gated)
- [x] `test_run_turn_native_tool_allowed_by_policy` — ALLOW lets turn proceed normally
- [x] All 44 existing tests pass

This pull request and its description were written by Isaac.