### PR TITLE
fix(openai-agents): honor ambient OPENAI_BASE_URL on spec api_key path

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -438,10 +438,22 @@ def _get_openai_async_client(
     # Checked before profile and env-var lookups so the spec is self-contained.
     # base_url_override is populated from HARNESS_OPENAI_AGENTS_GATEWAY_BASE_URL
     # when the spec also declares executor.auth.base_url.
+    #
+    # Fall back to the ambient OPENAI_BASE_URL when no override reached us.
+    # The api_key is frequently a gateway credential (e.g. a Databricks AI
+    # Gateway PAT detected from OPENAI_API_KEY), and the companion base_url
+    # can be dropped anywhere on the daemon → runner → harness propagation
+    # chain (the spec auth bake omits it when OPENAI_BASE_URL is absent at
+    # materialization time; a reused local daemon may predate the env var).
+    # Without this fallback, a missing base_url silently routes the gateway
+    # token to api.openai.com and every request 401s; honoring the ambient
+    # OPENAI_BASE_URL the runner inherits keeps the gateway target present on
+    # every turn even when the override is lost. base_url=None still defaults
+    # to api.openai.com for a genuine OpenAI key with no gateway configured.
     if api_key and api_key.strip():
         return AsyncOpenAI(
             api_key=api_key,
-            base_url=base_url_override or None,
+            base_url=base_url_override or os.environ.get("OPENAI_BASE_URL") or None,
             **retry_kwargs,
         )
 

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -1625,6 +1625,102 @@ def test_get_openai_client_host_override_requires_auth_command(monkeypatch):
         )
 
 
+def test_get_openai_client_api_key_falls_back_to_env_base_url(monkeypatch):
+    """A spec-level api_key with NO override honors ambient ``OPENAI_BASE_URL``.
+
+    Regression for the residual gateway 401 (continuation-turn daemon
+    spawns): the api_key is frequently a gateway credential (e.g. a
+    Databricks AI Gateway PAT detected from ``OPENAI_API_KEY``), and the
+    companion base_url can be dropped on the daemon → runner → harness
+    propagation chain (the spec-auth bake omits it when ``OPENAI_BASE_URL``
+    is absent at materialization time; a reused local daemon may predate the
+    env var). Without the ambient fallback, the gateway PAT is sent to
+    ``api.openai.com`` and 401s. The runner inherits ``OPENAI_BASE_URL``, so
+    honoring it here keeps the gateway target present on every turn.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example.com/ai-gateway/openai/v1")
+
+    captured: dict[str, Any] = {}
+
+    class _StubAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    import openai as _openai_mod
+
+    with patch.object(_openai_mod, "AsyncOpenAI", _StubAsyncOpenAI, create=True):
+        _get_openai_async_client(api_key="dapi-gateway-token", base_url_override=None)
+
+    assert captured["api_key"] == "dapi-gateway-token"
+    assert captured["base_url"] == "https://gateway.example.com/ai-gateway/openai/v1", (
+        "A spec-level api_key with no base_url override must fall back to the "
+        "ambient OPENAI_BASE_URL the runner inherits; routing to api.openai.com "
+        "(base_url=None) sends a gateway PAT to OpenAI and 401s."
+    )
+
+
+def test_get_openai_client_api_key_override_wins_over_env_base_url(monkeypatch):
+    """An explicit base_url override wins over the ambient ``OPENAI_BASE_URL``.
+
+    The baked ``executor.auth.base_url`` (threaded via
+    ``HARNESS_OPENAI_AGENTS_GATEWAY_BASE_URL``) is the authoritative
+    per-spec target and must not be shadowed by a differing env var.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://wrong-env.example.com/v1")
+
+    captured: dict[str, Any] = {}
+
+    class _StubAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    import openai as _openai_mod
+
+    with patch.object(_openai_mod, "AsyncOpenAI", _StubAsyncOpenAI, create=True):
+        _get_openai_async_client(
+            api_key="dapi-gateway-token",
+            base_url_override="https://spec-gateway.example.com/openai/v1",
+        )
+
+    assert captured["base_url"] == "https://spec-gateway.example.com/openai/v1"
+
+
+def test_get_openai_client_api_key_no_env_defaults_to_openai(monkeypatch):
+    """A genuine OpenAI key with no gateway anywhere still defaults to OpenAI.
+
+    With no override and no ambient ``OPENAI_BASE_URL``, ``base_url`` stays
+    ``None`` so the AsyncOpenAI client targets ``api.openai.com`` — the
+    correct behavior for a real ``sk-...`` key.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    from omnigent.inner.openai_agents_sdk_executor import _get_openai_async_client
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    class _StubAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    import openai as _openai_mod
+
+    with patch.object(_openai_mod, "AsyncOpenAI", _StubAsyncOpenAI, create=True):
+        _get_openai_async_client(api_key="sk-real-openai-key", base_url_override=None)
+
+    assert captured["api_key"] == "sk-real-openai-key"
+    assert captured["base_url"] is None
+
+
 def test_get_openai_client_no_profile_honors_env_vars(monkeypatch):
     """Without an explicit profile, the env-var branch still works.
 


### PR DESCRIPTION
## Summary

Follow-up to #629. The openai-agents executor's spec-`api_key` branch (`omnigent/inner/openai_agents_sdk_executor.py::_get_openai_async_client`) returned `AsyncOpenAI(api_key=…, base_url=base_url_override or None)` and **never consulted the ambient `OPENAI_BASE_URL`**. So when a spec carries a baked `executor.auth` api_key that is actually a Databricks gateway PAT (from an ambient `OPENAI_API_KEY` detection) but the baked `base_url` is missing, the client defaults to `api.openai.com` and the PAT 401s.

The baked `base_url` goes missing in two ways: `chat._inject_openai_env_auth_if_needed` only bakes it `if base_url:` (omitted when `OPENAI_BASE_URL` is absent at materialization), and the local daemon is reused on `server_config_signature()` = `{auth, version}` which excludes `OPENAI_BASE_URL` — so a daemon spawned earlier without the env var is reused (the intermittent "~4%" race behind the residual `approve_always` / multi-turn REPL 401s).

Fix (one line): `base_url=base_url_override or os.environ.get("OPENAI_BASE_URL") or None` — the baked override stays authoritative when present, otherwise honor the `OPENAI_BASE_URL` the runner/harness already inherits, so the gateway target is present on every turn regardless of where base_url was dropped. A genuine `sk-…` key with no gateway anywhere still gets `base_url=None` → `api.openai.com` (unchanged).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

- 3 unit tests on `_get_openai_async_client` in `tests/inner/test_openai_agents_sdk_executor.py`: api_key + ambient `OPENAI_BASE_URL` → client base_url is the gateway (fails pre-fix, passes post-fix); explicit override wins over a differing env var; no override + no env → base_url stays `None` (real OpenAI key). 68 tests pass in that file; regression suites (harness, provider-spawn-env, detected) green.
- Unblocks the residual ~4% `approve_always` / multi-turn 401 on the openai-agents REPL approval e2e tests (confirmed via flake-stress on `tests/e2e/test_repl_approval_e2e.py`).

This pull request and its description were written by Isaac.
