### PR TITLE
fix(ci): strip sub-agent preamble from Polly review comments

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -328,6 +328,17 @@ jobs:
             | tee /tmp/polly_output.txt \
             || { echo "::warning::Polly review exited non-zero"; cat polly-stderr.log; }
 
+          # Strip coordination preamble that sub-agents sometimes leak
+          # (e.g. "I've dispatched the codex reviewer…").  Keep from the
+          # first markdown heading or horizontal rule onward.
+          python3 -c "
+          import re, pathlib
+          raw = pathlib.Path('/tmp/polly_output.txt').read_text()
+          m = re.search(r'^(#{1,3} |---)', raw, re.MULTILINE)
+          if m:
+              pathlib.Path('/tmp/polly_output.txt').write_text(raw[m.start():])
+          "
+
           # Use a collision-resistant random delimiter so model output
           # containing "REVIEW_EOF" cannot truncate the output.
           delim="REVIEW_$(openssl rand -hex 8)"

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -303,7 +303,9 @@ jobs:
           IMPORTANT: Your output will be posted directly as a PR comment. Output
           ONLY the final structured review — no coordination messages, no status
           updates about dispatching sub-agents, no "waiting for results" narration.
-          Start your response with the review content itself.
+          Begin your response with the exact marker <!-- POLLY_REVIEW_START -->
+          on its own line, then the review content. Nothing before the marker
+          will be shown.
           """
           pathlib.Path("/tmp/review_prompt.txt").write_text(prompt)
           PYEOF
@@ -328,15 +330,21 @@ jobs:
             | tee /tmp/polly_output.txt \
             || { echo "::warning::Polly review exited non-zero"; cat polly-stderr.log; }
 
-          # Strip coordination preamble that sub-agents sometimes leak
-          # (e.g. "I've dispatched the codex reviewer…").  Keep from the
-          # first markdown heading or horizontal rule onward.
+          # Strip any sub-agent coordination preamble that leaks before
+          # the actual review.  Primary: look for the sentinel we asked the
+          # model to emit.  Fallback: first markdown heading or standalone
+          # horizontal rule.
           python3 -c "
           import re, pathlib
           raw = pathlib.Path('/tmp/polly_output.txt').read_text()
-          m = re.search(r'^(#{1,3} |---)', raw, re.MULTILINE)
-          if m:
-              pathlib.Path('/tmp/polly_output.txt').write_text(raw[m.start():])
+          sentinel = '<!-- POLLY_REVIEW_START -->'
+          idx = raw.find(sentinel)
+          if idx >= 0:
+              cleaned = raw[idx + len(sentinel):].lstrip('\n')
+          else:
+              m = re.search(r'^(#{1,6} |---\s*$)', raw, re.MULTILINE)
+              cleaned = raw[m.start():] if m else raw
+          pathlib.Path('/tmp/polly_output.txt').write_text(cleaned)
           "
 
           # Use a collision-resistant random delimiter so model output


### PR DESCRIPTION
## Summary
- Polly review comments sometimes include verbose coordination preamble leaked by sub-agents (e.g. "I've dispatched the codex reviewer. Waiting for its structured report…")
- Adds a post-processing step that strips everything before the first markdown heading or `---` rule in the Polly output before posting the PR comment

## Test plan
- [ ] Trigger `/review` on a PR and verify the comment starts cleanly with the review content (no preamble)
- [ ] Verify normal reviews (without preamble) are unaffected

This pull request and its description were written by Isaac.