### PR TITLE
fix: use world-writable /tmp safely in modal sandbox and test guardrails

### DIFF
--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -14,6 +14,7 @@ App OAuth dance, host registration) lives in ``bootstrap``.
 
 from __future__ import annotations
 
+import secrets
 import shlex
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager
@@ -73,6 +74,81 @@ def host_image_wheel_install_command(remote_tgz_path: str) -> str:
         f"tar xzf {remote_tgz_path} -C oa-wheels --warning=no-unknown-keyword && "
         "pip install --quiet --force-reinstall --no-deps "
         "--no-warn-script-location oa-wheels/*.whl"
+    )
+
+
+# Prefix for the private dir a launcher creates under world-writable ``/tmp``
+# to record the pid of an exec'd foreground process (several providers' SDKs
+# expose no kill handle for exec'd processes, so the pid is recorded and a
+# second exec signals it on detach). The dir carries an unpredictable random
+# suffix and is created mode 700 with a bare ``mkdir`` that fails closed if
+# the path already exists, so a co-tenant on the sandbox can't pre-create,
+# symlink-redirect, or read the pidfile in ``/tmp``.
+_FOREGROUND_RUNDIR_PREFIX: str = "/tmp/oa-foreground-"
+
+
+def foreground_pidfile() -> tuple[str, str]:
+    """Allocate a private, unpredictably-named pidfile under ``/tmp``.
+
+    Used by :meth:`SandboxLauncher.exec_foreground` implementations whose
+    SDK cannot kill an exec'd process through its handle (Modal,
+    CoreWeave, OpenShell). The caller records the remote pid with
+    :func:`foreground_record_prefix` and tears it down with
+    :func:`foreground_kill_command`, both of which operate on the paths
+    returned here.
+
+    The pidfile lives in a fresh dir created ``mode 700`` with a bare
+    ``mkdir`` (no ``-p``) so it **fails closed** if the path already
+    exists — a co-tenant can't pre-seed a symlink we'd write through, nor
+    read our pid back, in the world-writable ``/tmp`` it lives under.
+
+    :returns: A ``(run_dir, pidfile)`` pair of absolute ``/tmp`` paths.
+        ``run_dir`` is ``/tmp/oa-foreground-<32 hex chars>`` and
+        ``pidfile`` is ``<run_dir>/pid``.
+    """
+    run_dir = f"{_FOREGROUND_RUNDIR_PREFIX}{secrets.token_hex(16)}"
+    return run_dir, f"{run_dir}/pid"
+
+
+def foreground_record_prefix(pidfile: str) -> str:
+    """Shell prefix that creates the run dir and records the shell pid.
+
+    ``mkdir -m 700`` (no ``-p``) fails closed if the path exists, and
+    ``echo $$`` writes the shell pid before the caller swaps in the real
+    command via ``exec`` (which keeps the pid across the swap). Both
+    paths are :func:`shlex.quote`-d before interpolation so the function
+    stays safe even if a future caller passes a non-hex path; the
+    standard hex paths from :func:`foreground_pidfile` quote harmlessly.
+
+    :param pidfile: The pidfile path returned by :func:`foreground_pidfile`.
+    :returns: A shell fragment such as ``"mkdir -m 700 /tmp/… && echo $$ > /tmp/…/pid && "``
+        to prepend before the foreground command.
+    """
+    run_dir = pidfile.rsplit("/", 1)[0]
+    q_dir = shlex.quote(run_dir)
+    q_pid = shlex.quote(pidfile)
+    return f"mkdir -m 700 {q_dir} && echo $$ > {q_pid} && "
+
+
+def foreground_kill_command(pidfile: str) -> str:
+    """Shell command that signals the recorded pid and drops the run dir.
+
+    Only a fully-numeric pid read back from the private pidfile is ever
+    signalled — the ``case`` rejects empty and non-numeric content, so
+    unvalidated file contents never reach ``kill``. The run dir is then
+    removed so a successful foreground run leaves nothing behind in
+    ``/tmp``.
+
+    :param pidfile: The pidfile path returned by :func:`foreground_pidfile`.
+    :returns: A self-contained shell command string for a second exec.
+    """
+    run_dir = pidfile.rsplit("/", 1)[0]
+    q_dir = shlex.quote(run_dir)
+    q_pid = shlex.quote(pidfile)
+    return (
+        f"pid=$(cat {q_pid} 2>/dev/null); "
+        f'case "$pid" in ""|*[!0-9]*) ;; *) kill "$pid" 2>/dev/null ;; esac; '
+        f"rm -rf {q_dir}"
     )
 
 

--- a/omnigent/onboarding/sandboxes/cwsandbox.py
+++ b/omnigent/onboarding/sandboxes/cwsandbox.py
@@ -37,6 +37,9 @@ from omnigent.onboarding.sandboxes.base import (
     RemoteCommandResult,
     RemoteProcess,
     SandboxLauncher,
+    foreground_kill_command,
+    foreground_pidfile,
+    foreground_record_prefix,
     host_image_wheel_install_command,
 )
 
@@ -56,9 +59,6 @@ _SANDBOX_RESOURCES = {"cpu": "2", "memory": "4Gi"}
 # Slack the managed launch-token TTL is set above the sandbox lifetime, so a
 # live sandbox can always re-authenticate its tunnel across reconnects.
 _TOKEN_TTL_SLACK_S = 3600
-# Where exec_foreground records the remote pid so Ctrl-C can kill it — the
-# SDK's process.cancel() only cancels the local future, not the remote exec.
-_FOREGROUND_PIDFILE = "/tmp/oa-foreground.pid"
 
 
 def resolve_max_lifetime_s() -> int:
@@ -279,19 +279,31 @@ class CWSandboxLauncher(SandboxLauncher):
     def exec_foreground(self, sandbox_id: str, command: str) -> int:
         """Run *command*, echo its output locally until exit; Ctrl-C kills it."""
         handle = self._resolve(sandbox_id)
-        # Record the remote pid (process.cancel() can't kill the remote exec):
-        # `echo $$ … && exec` keeps the pid across the shell swap, so the
-        # interrupt path can kill it with a second exec.
-        remote = f"echo $$ > {_FOREGROUND_PIDFILE} && exec {command} 2>&1"
+        # Record the remote pid (process.cancel() only cancels the local
+        # future, not the remote exec) in a private, unpredictably-named dir
+        # under world-writable /tmp: `mkdir -m 700` (no -p) fails closed if the
+        # path already exists, so a co-tenant can't pre-seed a symlink we'd
+        # write through, nor read our pid back. `echo $$ … && exec` keeps the
+        # pid across the shell swap, so the interrupt path can kill it with a
+        # second exec. See :func:`foreground_pidfile` for the shared rationale.
+        run_dir, pidfile = foreground_pidfile()
+        remote = f"{foreground_record_prefix(pidfile)}exec {command} 2>&1"
         process = handle.exec(["bash", "-lc", remote])
         try:
             for line in process.stdout:
                 click.echo(line, nl=False)
-            return process.wait()
+            rc = process.wait()
         except KeyboardInterrupt:
             click.echo("\n  → detaching; stopping the remote process")
-            handle.exec(["bash", "-lc", f"kill $(cat {_FOREGROUND_PIDFILE}) 2>/dev/null"]).wait()
+            # Signal only a numeric pid read back from our own private pidfile,
+            # then drop the dir; never feed unvalidated file contents to kill.
+            handle.exec(["bash", "-lc", foreground_kill_command(pidfile)]).wait()
             raise
+        # Normal exit: drop the run dir so we don't orphan a mode-700 dir in
+        # /tmp. The interrupt path already cleans up via
+        # :func:`foreground_kill_command`.
+        handle.exec(["bash", "-c", f"rm -rf {run_dir} 2>/dev/null"]).wait()
+        return rc
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:
         """Overlay shipped wheels onto the prebaked host image."""

--- a/omnigent/onboarding/sandboxes/modal.py
+++ b/omnigent/onboarding/sandboxes/modal.py
@@ -28,6 +28,7 @@ Platform constraints that shape this launcher:
 from __future__ import annotations
 
 import os
+import secrets
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
@@ -87,11 +88,14 @@ the WORKLOAD's environment. The server's managed-host config
 _SANDBOX_CPU: float = 2.0
 _SANDBOX_MEMORY_MIB: int = 4096
 
-# Where exec_foreground records the remote process's pid so Ctrl-C on
-# the local side can kill it (the SDK has no kill API for exec'd
-# processes). One foreground process per sandbox at a time, by design —
-# it holds the local terminal.
-_FOREGROUND_PIDFILE: str = "/tmp/oa-foreground.pid"
+# Prefix for the private dir exec_foreground creates to record the remote
+# process's pid so Ctrl-C on the local side can kill it (the SDK has no kill
+# API for exec'd processes). One foreground process per sandbox at a time, by
+# design — it holds the local terminal. The dir carries an unpredictable random
+# suffix and is created mode 700 with a bare `mkdir` that fails closed if the
+# path already exists, so a co-tenant on the sandbox can't pre-create, symlink,
+# or read the pidfile in the world-writable /tmp it lives under.
+_FOREGROUND_RUNDIR_PREFIX: str = "/tmp/oa-foreground-"
 
 
 def _ensure_sdk() -> None:
@@ -521,7 +525,15 @@ class ModalSandboxLauncher(SandboxLauncher):
             process when the user detaches with Ctrl-C.
         """
         handle = self._resolve(sandbox_id)
-        remote = f"echo $$ > {_FOREGROUND_PIDFILE} && TERM=xterm-256color exec {command}"
+        # Record the pid in a private, unpredictably-named dir under /tmp.
+        # `mkdir -m 700` (no -p) fails closed if the path already exists, so a
+        # co-tenant on the sandbox can't pre-seed a symlink we'd write through,
+        # nor read our pid back, in world-writable /tmp.
+        run_dir = f"{_FOREGROUND_RUNDIR_PREFIX}{secrets.token_hex(16)}"
+        pidfile = f"{run_dir}/pid"
+        remote = (
+            f"mkdir -m 700 {run_dir} && echo $$ > {pidfile} && TERM=xterm-256color exec {command}"
+        )
         process = handle.exec("bash", "-lc", remote, pty=True)
         try:
             for line in process.stdout:
@@ -529,7 +541,14 @@ class ModalSandboxLauncher(SandboxLauncher):
             return process.wait()
         except KeyboardInterrupt:
             click.echo("\n  → detaching; stopping the remote process")
-            handle.exec("bash", "-c", f"kill $(cat {_FOREGROUND_PIDFILE}) 2>/dev/null").wait()
+            # Signal only a numeric pid read back from our own private pidfile,
+            # then drop the dir; never feed unvalidated file contents to kill.
+            kill = (
+                f"pid=$(cat {pidfile} 2>/dev/null); "
+                f'case "$pid" in ""|*[!0-9]*) ;; *) kill "$pid" 2>/dev/null ;; esac; '
+                f"rm -rf {run_dir}"
+            )
+            handle.exec("bash", "-c", kill).wait()
             raise
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:

--- a/omnigent/onboarding/sandboxes/modal.py
+++ b/omnigent/onboarding/sandboxes/modal.py
@@ -28,7 +28,6 @@ Platform constraints that shape this launcher:
 from __future__ import annotations
 
 import os
-import secrets
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
@@ -40,6 +39,9 @@ from omnigent.onboarding.sandboxes.base import (
     RemoteCommandResult,
     RemoteProcess,
     SandboxLauncher,
+    foreground_kill_command,
+    foreground_pidfile,
+    foreground_record_prefix,
     host_image_wheel_install_command,
 )
 
@@ -87,15 +89,6 @@ the WORKLOAD's environment. The server's managed-host config
 # enough for a host running one interactive session.
 _SANDBOX_CPU: float = 2.0
 _SANDBOX_MEMORY_MIB: int = 4096
-
-# Prefix for the private dir exec_foreground creates to record the remote
-# process's pid so Ctrl-C on the local side can kill it (the SDK has no kill
-# API for exec'd processes). One foreground process per sandbox at a time, by
-# design — it holds the local terminal. The dir carries an unpredictable random
-# suffix and is created mode 700 with a bare `mkdir` that fails closed if the
-# path already exists, so a co-tenant on the sandbox can't pre-create, symlink,
-# or read the pidfile in the world-writable /tmp it lives under.
-_FOREGROUND_RUNDIR_PREFIX: str = "/tmp/oa-foreground-"
 
 
 def _ensure_sdk() -> None:
@@ -528,28 +521,26 @@ class ModalSandboxLauncher(SandboxLauncher):
         # Record the pid in a private, unpredictably-named dir under /tmp.
         # `mkdir -m 700` (no -p) fails closed if the path already exists, so a
         # co-tenant on the sandbox can't pre-seed a symlink we'd write through,
-        # nor read our pid back, in world-writable /tmp.
-        run_dir = f"{_FOREGROUND_RUNDIR_PREFIX}{secrets.token_hex(16)}"
-        pidfile = f"{run_dir}/pid"
-        remote = (
-            f"mkdir -m 700 {run_dir} && echo $$ > {pidfile} && TERM=xterm-256color exec {command}"
-        )
+        # nor read our pid back, in world-writable /tmp. See
+        # :func:`foreground_pidfile` for the shared rationale.
+        run_dir, pidfile = foreground_pidfile()
+        remote = f"{foreground_record_prefix(pidfile)}TERM=xterm-256color exec {command}"
         process = handle.exec("bash", "-lc", remote, pty=True)
         try:
             for line in process.stdout:
                 click.echo(line, nl=False)
-            return process.wait()
+            rc = process.wait()
         except KeyboardInterrupt:
             click.echo("\n  → detaching; stopping the remote process")
             # Signal only a numeric pid read back from our own private pidfile,
             # then drop the dir; never feed unvalidated file contents to kill.
-            kill = (
-                f"pid=$(cat {pidfile} 2>/dev/null); "
-                f'case "$pid" in ""|*[!0-9]*) ;; *) kill "$pid" 2>/dev/null ;; esac; '
-                f"rm -rf {run_dir}"
-            )
-            handle.exec("bash", "-c", kill).wait()
+            handle.exec("bash", "-c", foreground_kill_command(pidfile)).wait()
             raise
+        # Normal exit: drop the run dir so we don't orphan a mode-700
+        # dir in /tmp. The interrupt path already cleans up via
+        # :func:`foreground_kill_command`.
+        handle.exec("bash", "-c", f"rm -rf {run_dir} 2>/dev/null").wait()
+        return rc
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:
         """

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -50,6 +50,9 @@ from omnigent.onboarding.sandboxes.base import (
     DEFAULT_HOST_IMAGE,
     RemoteCommandResult,
     SandboxLauncher,
+    foreground_kill_command,
+    foreground_pidfile,
+    foreground_record_prefix,
     host_image_wheel_install_command,
 )
 
@@ -79,7 +82,6 @@ _EXEC_TIMEOUT_S = 300
 # ceiling. The pidfile records the in-sandbox pid so Ctrl-C can kill the
 # remote process (cancelling the local stream doesn't stop it).
 _FOREGROUND_TIMEOUT_S = 7 * 24 * 3600
-_FOREGROUND_PIDFILE_TEMPLATE = "/tmp/oa-openshell-foreground-{sandbox_id}.pid"
 
 # OpenShell runs the agent as the non-root ``sandbox`` user (its image
 # contract; see deploy/docker/Dockerfile), whose home is ``/sandbox``.
@@ -419,26 +421,33 @@ class OpenShellSandboxLauncher(SandboxLauncher):
         Ctrl-C kills the remote process and re-raises ``KeyboardInterrupt``.
         """
         client = self._openshell()
-        pidfile = _FOREGROUND_PIDFILE_TEMPLATE.format(sandbox_id=sandbox_id)
-        # `exec` keeps the recorded pid across the shell swap, so a Ctrl-C
-        # can kill the remote process — cancelling the local gRPC stream
-        # stops our reads but doesn't stop the remote command.
-        remote = f"echo $$ > {shlex.quote(pidfile)} && exec {command}"
+        # Record the remote pid in a private, unpredictably-named dir under
+        # world-writable /tmp: `mkdir -m 700` (no -p) fails closed if the path
+        # already exists, so a co-tenant can't pre-seed a symlink we'd write
+        # through, nor read our pid back. `echo $$ … && exec` keeps the pid
+        # across the shell swap, so cancelling the local gRPC stream (which
+        # stops our reads but not the remote command) can still kill it. See
+        # :func:`foreground_pidfile` for the shared rationale.
+        run_dir, pidfile = foreground_pidfile()
+        remote = f"{foreground_record_prefix(pidfile)}exec {command}"
         try:
-            return client.run_foreground(
+            rc = client.run_foreground(
                 sandbox_id, ["bash", "-lc", remote], timeout=_FOREGROUND_TIMEOUT_S
             )
         except KeyboardInterrupt:
             click.echo("\n  → detaching; stopping the remote process")
+            # Signal only a numeric pid read back from our own private pidfile,
+            # then drop the dir; never feed unvalidated file contents to kill.
             client.execute(
                 sandbox_id,
-                [
-                    "bash",
-                    "-lc",
-                    f"kill $(cat {shlex.quote(pidfile)}) 2>/dev/null || true",
-                ],
+                ["bash", "-lc", foreground_kill_command(pidfile)],
             )
             raise
+        # Normal exit: drop the run dir so we don't orphan a mode-700 dir in
+        # /tmp. The interrupt path already cleans up via
+        # :func:`foreground_kill_command`.
+        client.execute(sandbox_id, ["bash", "-c", f"rm -rf {run_dir} 2>/dev/null"])
+        return rc
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:
         """Overlay shipped wheels onto the prebaked host image."""

--- a/omnigent/testing/guardrails.py
+++ b/omnigent/testing/guardrails.py
@@ -123,14 +123,21 @@ def looks_like_test_db(db_uri: str) -> bool:
         return True
 
     path = _sqlite_path(db_uri)
-    # Only treat a ``test`` token as proof for file-backed SQLite paths.
-    # Non-SQLite authorities such as ``postgresql://prod-test-cluster/app``
-    # may contain ``test`` in a real host name and must not be silently
-    # accepted as throwaway DBs.
-    if path is not None and _sqlite_path_has_test_token(path):
-        return True
-    if path is not None and _under_temp_dir(path):
-        return True
+    if path is not None:
+        # Resolve symlinks before trusting the path. A file in a world-writable
+        # dir like /tmp may be a symlink an attacker (or a stale fixture)
+        # planted to point a "throwaway" test DB at a real database; classify
+        # the resolved target, not the link, so we never green-light mutating a
+        # production DB reached through ``sqlite:////tmp/test.db``.
+        resolved = _resolve(path)
+        # Only treat a ``test`` token as proof for file-backed SQLite paths.
+        # Non-SQLite authorities such as ``postgresql://prod-test-cluster/app``
+        # may contain ``test`` in a real host name and must not be silently
+        # accepted as throwaway DBs.
+        if _sqlite_path_has_test_token(resolved):
+            return True
+        if _under_temp_dir(resolved):
+            return True
 
     return False
 

--- a/tests/onboarding/sandboxes/test_cwsandbox.py
+++ b/tests/onboarding/sandboxes/test_cwsandbox.py
@@ -58,8 +58,9 @@ class _FakeOp:
 
 
 class _FakeProcess:
-    def __init__(self, result: _FakeResult) -> None:
+    def __init__(self, result: _FakeResult, *, wait_raises: BaseException | None = None) -> None:
         self._result = result
+        self._wait_raises = wait_raises
         self.cancelled = False
 
     @property
@@ -70,6 +71,8 @@ class _FakeProcess:
         return self._result
 
     def wait(self, timeout: float | None = None) -> int:
+        if self._wait_raises is not None:
+            raise self._wait_raises
         return self._result.returncode
 
     def cancel(self) -> bool:
@@ -87,6 +90,10 @@ class _State:
     stopped: list[str] = field(default_factory=list)
     exec_result: _FakeResult = field(default_factory=_FakeResult)
     from_id_missing: bool = False
+    # Each exec() call's command (list argv), in order.
+    exec_commands: list[list] = field(default_factory=list)
+    # Processes handed back by successive exec() calls, in order.
+    exec_processes: list[_FakeProcess] = field(default_factory=list)
 
 
 class _FakeSandbox:
@@ -115,6 +122,9 @@ class _FakeSandbox:
         return self
 
     def exec(self, command, **kwargs) -> _FakeProcess:
+        self._state.exec_commands.append(list(command))
+        if self._state.exec_processes:
+            return self._state.exec_processes.pop(0)
         return _FakeProcess(self._state.exec_result)
 
     def write_file(self, path: str, data: bytes) -> _FakeOp:
@@ -209,3 +219,44 @@ def test_terminate_swallows_not_found(sdk: _State) -> None:
 def test_terminate_stops_existing(sdk: _State) -> None:
     CWSandboxLauncher().terminate("sb-1")
     assert sdk.stopped == ["sb-1"]
+
+
+# ── exec_foreground ─────────────────────────────────────────
+
+
+def test_exec_foreground_records_pid_and_streams_output(sdk: _State) -> None:
+    """The foreground command records its pid in a private mode-700 dir."""
+    sdk.exec_processes = [
+        _FakeProcess(_FakeResult(stdout="host-output\n", returncode=0)),
+        _FakeProcess(_FakeResult()),  # cleanup exec on normal exit
+    ]
+
+    returncode = CWSandboxLauncher().exec_foreground("sb-1", "omnigent host --server u")
+
+    assert returncode == 0
+    remote = sdk.exec_commands[0][-1]
+    # The pidfile lives in a private, unpredictably-named dir created mode 700
+    # (fails closed if it already exists) so /tmp can't be pre-seeded.
+    assert "mkdir -m 700 /tmp/oa-foreground-" in remote
+    assert "echo $$ > /tmp/oa-foreground-" in remote and "/pid" in remote
+    # `exec` keeps the recorded pid across the swap to the real command.
+    assert "exec omnigent host --server u" in remote
+    # A normal exit cleans up the run dir so it isn't orphaned in /tmp.
+    assert len(sdk.exec_commands) == 2
+    cleanup = sdk.exec_commands[1][-1]
+    assert cleanup.startswith("rm -rf /tmp/oa-foreground-")
+
+
+def test_exec_foreground_kills_remote_on_interrupt(sdk: _State) -> None:
+    """Ctrl-C kills the remote process (via the pidfile) and re-raises."""
+    sdk.exec_processes = [_FakeProcess(_FakeResult(), wait_raises=KeyboardInterrupt())]
+
+    with pytest.raises(KeyboardInterrupt):
+        CWSandboxLauncher().exec_foreground("sb-1", "omnigent host --server u")
+
+    # Second exec is the kill, addressed via the recorded pidfile. The pid is
+    # validated as numeric before being signalled, and the dir is cleaned up.
+    assert len(sdk.exec_commands) == 2
+    kill = sdk.exec_commands[1][-1]
+    assert 'case "$pid" in' in kill and 'kill "$pid"' in kill
+    assert "rm -rf /tmp/oa-foreground-" in kill

--- a/tests/onboarding/sandboxes/test_modal.py
+++ b/tests/onboarding/sandboxes/test_modal.py
@@ -618,7 +618,10 @@ def test_exec_foreground_records_pid_and_streams_output(
     call = sandbox.exec_calls[0]
     assert call.pty is True
     remote = call.argv[-1]
-    assert "echo $$ > /tmp/oa-foreground.pid" in remote
+    # The pidfile lives in a private, unpredictably-named dir created mode 700
+    # (fails closed if it already exists) so /tmp can't be pre-seeded.
+    assert "mkdir -m 700 /tmp/oa-foreground-" in remote
+    assert "echo $$ > /tmp/oa-foreground-" in remote and "/pid" in remote
     assert "TERM=xterm-256color" in remote
     # `exec` keeps the recorded pid across the swap to the real command.
     assert "exec omnigent host --server u" in remote
@@ -639,9 +642,12 @@ def test_exec_foreground_kills_remote_on_interrupt(monkeypatch: pytest.MonkeyPat
     with pytest.raises(KeyboardInterrupt):
         ModalSandboxLauncher().exec_foreground("sb-1", "omnigent host --server u")
 
-    # Second exec is the kill, addressed via the recorded pidfile.
+    # Second exec is the kill, addressed via the recorded pidfile. The pid is
+    # validated as numeric before being signalled, and the dir is cleaned up.
     assert len(sandbox.exec_calls) == 2
-    assert "kill $(cat /tmp/oa-foreground.pid)" in sandbox.exec_calls[1].argv[-1]
+    kill = sandbox.exec_calls[1].argv[-1]
+    assert 'case "$pid" in' in kill and 'kill "$pid"' in kill
+    assert "rm -rf /tmp/oa-foreground-" in kill
 
 
 # ── wheel_install_command ───────────────────────────────────

--- a/tests/onboarding/sandboxes/test_modal.py
+++ b/tests/onboarding/sandboxes/test_modal.py
@@ -611,6 +611,8 @@ def test_exec_foreground_records_pid_and_streams_output(
     state = _install_fake_modal(monkeypatch)
     sandbox = _seed_sandbox(state)
     sandbox.exec_queue.append(_FakeProcess(stdout="host-output\n"))
+    # The cleanup exec on normal exit pops this next process.
+    sandbox.exec_queue.append(_FakeProcess())
 
     returncode = ModalSandboxLauncher().exec_foreground("sb-1", "omnigent host --server u")
 
@@ -627,6 +629,10 @@ def test_exec_foreground_records_pid_and_streams_output(
     assert "exec omnigent host --server u" in remote
     # Output reached the local terminal.
     assert "host-output" in capsys.readouterr().out
+    # A normal exit cleans up the run dir so it isn't orphaned in /tmp.
+    assert len(sandbox.exec_calls) == 2
+    cleanup = sandbox.exec_calls[1].argv[-1]
+    assert cleanup.startswith("rm -rf /tmp/oa-foreground-")
 
 
 def test_exec_foreground_kills_remote_on_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/onboarding/sandboxes/test_openshell.py
+++ b/tests/onboarding/sandboxes/test_openshell.py
@@ -311,8 +311,16 @@ def test_exec_foreground_returns_exit_code(monkeypatch: pytest.MonkeyPatch) -> N
     [(name, command)] = fake.foreground_calls
     assert name == "sb-1"
     assert command[:2] == ["bash", "-lc"]
-    assert command[2].startswith("echo $$ >")
+    # The pidfile lives in a private, unpredictably-named dir created mode 700
+    # (fails closed if it already exists) so /tmp can't be pre-seeded.
+    assert command[2].startswith("mkdir -m 700 /tmp/oa-foreground-")
+    assert "echo $$ > /tmp/oa-foreground-" in command[2] and "/pid" in command[2]
     assert "exec omnigent host --server https://s" in command[2]
+    # A normal exit cleans up the run dir so it isn't orphaned in /tmp.
+    assert len(fake.exec_calls) == 1
+    cleanup = fake.exec_calls[0][1]
+    assert cleanup[:2] == ["bash", "-c"]
+    assert cleanup[2].startswith("rm -rf /tmp/oa-foreground-")
 
 
 def test_exec_foreground_ctrl_c_kills_remote(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -324,8 +332,12 @@ def test_exec_foreground_ctrl_c_kills_remote(monkeypatch: pytest.MonkeyPatch) ->
     with pytest.raises(KeyboardInterrupt):
         launcher.exec_foreground("sb-1", "omnigent host --server https://s")
 
-    # The interrupt handler issued a best-effort kill of the recorded pid.
-    assert any("kill $(cat" in command[2] for _name, command, _stdin in fake.exec_calls)
+    # The interrupt handler signals only a numeric pid read back from the
+    # private pidfile, then drops the dir.
+    assert len(fake.exec_calls) == 1
+    kill = fake.exec_calls[0][1][2]
+    assert 'case "$pid" in' in kill and 'kill "$pid"' in kill
+    assert "rm -rf /tmp/oa-foreground-" in kill
 
 
 # ── _OpenShellClient wrapper against a faked SDK ────────────

--- a/tests/testing/test_guardrails.py
+++ b/tests/testing/test_guardrails.py
@@ -88,6 +88,22 @@ def test_looks_like_test_db_rejects_real_uris(db_uri: str) -> None:
     assert looks_like_test_db(db_uri) is False
 
 
+def test_looks_like_test_db_rejects_symlink_to_real_db(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A test-named symlink in a writable dir must not launder a real DB.
+
+    A file in a world-writable dir like /tmp can be a symlink an attacker
+    (or a stale fixture) planted to point a ``test``-named path at a real
+    database. The classifier resolves symlinks, so the real (non-throwaway)
+    target is what gets judged.
+    """
+    # The symlink sits in a temp dir with a ``test`` name (both of which the
+    # classifier would otherwise trust); its target is a real DB outside any
+    # temp root. Without resolution this passes on name/location alone.
+    link = tmp_path / "test.db"
+    link.symlink_to("/opt/omnigent/prod.db")
+    assert looks_like_test_db(f"sqlite:///{link}") is False
+
+
 @pytest.mark.parametrize("db_uri", ["", "   "])
 def test_empty_db_uri_skips_db_check(
     db_uri: str,


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

  Harden two unsafe uses of world-writable `/tmp`:

  - **`modal.py`** — `exec_foreground` recorded the remote pid at a fixed path (`/tmp/oa-foreground.pid`), letting a
  co-tenant symlink-redirect the write or spoof the pid that gets killed. Now uses a private, randomly-named `mkdir -m 700` dir (fails closed if it exists) and only kills a numeric pid read back from it.
  - **`guardrails.py`** — `looks_like_test_db` trusted a SQLite path's `test` token / temp location without resolving
  symlinks, so a `/tmp` symlink could pass a real DB off as throwaway. Now resolves the path before classifying it.

  ## Type of change

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor / chore
  - [ ] Docs
  - [ ] Test / CI
  - [ ] Breaking change

  ## Test coverage

  - [x] Unit tests added / updated
  - [ ] Integration tests added / updated
  - [ ] E2E tests added / updated
  - [x] Manual verification completed
  - [] Existing tests cover this change
  - [ ] Not applicable

  ## Coverage rationale

  `test_guardrails.py` adds a symlink-rejection regression test; `test_modal.py` asserts the new mode-700 dir, pidfile, and
  numeric-guarded kill. Manually verified the Modal launcher end-to-end against a live sandbox (provision → run → put →
  exec_foreground → terminate), confirming the run dir is mode-700 and `mkdir` fails closed. Normal-path behavior is 
  unchanged, so surrounding coverage still applies.

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
