### PR TITLE
test(repl): un-quarantine 4 stale-green REPL tests

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -190,12 +190,6 @@ skips:
   # timeout lets the rest of the shard complete). Same bulk-first,
   # triage-later approach as PRs #475/#482/#554/#606.
 
-  - id: tests/e2e/omnigent/test_run_omnigent_rate_limit_approval.py::test_run_omnigent_rate_limit_approval_round_trip
-    reason: "Shard 3 bulk: pexpect timeout waiting for 'approval required'; hung the whole pytest process under single-worker thread-timeout."
-    issue: 532
-    cluster: repl-pexpect-cli
-    mode: skip
-
   - id: tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_oneshot
     reason: "Shard 3 bulk: coding supervisor one-shot. Triage under #532."
     issue: 532
@@ -321,18 +315,6 @@ skips:
     cluster: repl-pexpect-cli
     mode: skip
 
-  - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_full_session_lifecycle
-    reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
-    issue: 532
-    cluster: repl-pexpect-cli
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_local_mode_launches_runner_subprocess
-    reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
-    issue: 532
-    cluster: repl-pexpect-cli
-    mode: skip
-
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_recover_after_runner_death
     reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
     issue: 532
@@ -341,12 +323,6 @@ skips:
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_resume_reuses_daemon_runner
     reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
-    issue: 532
-    cluster: repl-pexpect-cli
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_interactive_enters_repl
-    reason: "Nightly bulk: run_omnigent CLI cluster."
     issue: 532
     cluster: repl-pexpect-cli
     mode: skip
@@ -543,11 +519,6 @@ skips:
     issue: 0
     cluster: steering-cancel-compaction-state
     mode: skip
-  - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_reasoning_effort_threads_through
-    reason: "Force-merge backlog (standalone). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
-    issue: 0
-    cluster: repl-pexpect-cli
-    mode: skip
   - id: tests/e2e/test_filesystem_changed_files_e2e.py::test_filesystem_changes_appear_after_agent_write
     reason: "Force-merge backlog (standalone). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."
     issue: 0
@@ -620,4 +591,10 @@ skips:
     reason: "openai-agents empty-output/crash resurfaced on the gateway (#2707)."
     issue: 2707
     cluster: openai-agents-empty-output
+    mode: skip
+
+  - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_local_mode_launches_runner_subprocess
+    reason: "CI-only failure: 'No runner subprocess found under <pid>' — the test asserts the runner is a direct child in the process tree, which holds locally (macOS) but not in CI's Linux container/daemon process model. Passes 0/30 in CI flake-stress while its 4 session-lifecycle siblings pass. Needs a CI-robust runner-detection fix (likely tied to the daemon-reuse lifecycle work)."
+    issue: 532
+    cluster: repl-pexpect-cli
     mode: skip


### PR DESCRIPTION
## Summary

Un-quarantines 4 REPL e2e tests swept into the "Nightly bulk" / force-merge quarantines that now pass — the shared pexpect harness (`tests/e2e/omnigent/_pexpect_harness.py`: theme-picker bypass, input-readiness wait, turn-complete, per-HOME daemon cleanup) has matured and the openai-agents base_url routing bug is fixed (#629 + #645):

- `test_repl_session_lifecycle.py::test_repl_full_session_lifecycle`
- `test_repl_session_lifecycle.py::test_repl_reasoning_effort_threads_through`
- `test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_interactive_enters_repl`
- `test_run_omnigent_rate_limit_approval.py::test_run_omnigent_rate_limit_approval_round_trip`

**Not** un-quarantined: `test_repl_local_mode_launches_runner_subprocess` — it passes locally (macOS) but fails 0/30 in CI flake-stress with `AssertionError: No runner subprocess found under <pid>` (it asserts the runner is a direct process-tree child, which doesn't hold in CI's container/daemon model). Its `known_failures` reason is updated to record that; it stays quarantined pending a CI-robust runner-detection fix. The other still-quarantined repl-pexpect tests (daemon-resume empty-response, timeouts, snapshot drift) are separate, in-progress.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Quarantine-list-only change. The 4 un-quarantined tests passed **30/30** in CI flake-stress (run 27750934594) on the three affected files; `local_mode` was the sole failure there and is kept quarantined. No code or test-body changes.

This pull request and its description were written by Isaac.
