### PR TITLE
fix(cursor): enable delta stream so TurnEndedUpdate usage arrives

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -649,9 +649,7 @@ class CursorExecutor(Executor):
                     if isinstance(raw, dict) and raw:
                         turn_usage = _normalize_cursor_usage(raw, model)
 
-            run = await state.agent.send(
-                prompt, options=_SendOptions(on_delta=_capture_delta)
-            )
+            run = await state.agent.send(prompt, options=_SendOptions(on_delta=_capture_delta))
             async for stream_event in run.events():
                 if stream_event.sdk_message is not None:
                     for event in _sdk_message_to_events(stream_event.sdk_message):

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -132,9 +132,22 @@ def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
         "model": model,
     }
     # Carry cache breakdown if the backend reports it.
+    # The Cursor backend sends cacheReadTokens / cacheWriteTokens;
+    # map to the Omnigent-standard cache_read_input_tokens /
+    # cache_creation_input_tokens names.
     for dst, *sources in (
-        ("cache_read_input_tokens", "cacheReadInputTokens", "cache_read_input_tokens"),
-        ("cache_creation_input_tokens", "cacheCreationInputTokens", "cache_creation_input_tokens"),
+        (
+            "cache_read_input_tokens",
+            "cacheReadTokens",
+            "cacheReadInputTokens",
+            "cache_read_input_tokens",
+        ),
+        (
+            "cache_creation_input_tokens",
+            "cacheWriteTokens",
+            "cacheCreationInputTokens",
+            "cache_creation_input_tokens",
+        ),
     ):
         for src in sources:
             val = raw.get(src)
@@ -624,7 +637,21 @@ class CursorExecutor(Executor):
         separate_next_text = False
         turn_usage: dict[str, Any] | None = None
         try:
-            run = await state.agent.send(prompt)
+            # Pass SendOptions with on_delta so the backend sends
+            # interaction updates (including TurnEndedUpdate with usage).
+            # Without enableDeltas the backend omits them entirely.
+            from cursor_sdk import SendOptions as _SendOptions  # lazy: optional dep
+
+            def _capture_delta(update: Any) -> None:  # type: ignore[explicit-any]
+                nonlocal turn_usage
+                if getattr(update, "type", None) == "turn-ended":
+                    raw = getattr(update, "usage", None)
+                    if isinstance(raw, dict) and raw:
+                        turn_usage = _normalize_cursor_usage(raw, model)
+
+            run = await state.agent.send(
+                prompt, options=_SendOptions(on_delta=_capture_delta)
+            )
             async for stream_event in run.events():
                 if stream_event.sdk_message is not None:
                     for event in _sdk_message_to_events(stream_event.sdk_message):

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -92,9 +92,17 @@ def _install_fake_sdk(
             )
 
     class _FakeAgent:
-        async def send(self, prompt: str) -> _FakeRun:
+        async def send(self, prompt: str, **kwargs: Any) -> _FakeRun:
             state["sent"].append(prompt)
-            return _FakeRun(scripts.pop(0))
+            script = scripts.pop(0)
+            # Invoke on_delta for interaction_updates (mirrors real SDK
+            # which dispatches TurnEndedUpdate via on_delta, not events).
+            options = kwargs.get("options")
+            on_delta = getattr(options, "on_delta", None) if options else None
+            if on_delta and "interaction_updates" in script:
+                for iu in script["interaction_updates"]:
+                    on_delta(iu)
+            return _FakeRun(script)
 
         # AsyncAgent exposes close() (a CloseAgent RPC + tool unregister).
         async def close(self) -> None:
@@ -140,11 +148,16 @@ def _install_fake_sdk(
             self.cwd = cwd
             self.custom_tools = custom_tools
 
+    class _FakeSendOptions:
+        def __init__(self, on_delta: Any = None, **_kw: Any) -> None:
+            self.on_delta = on_delta
+
     fake = types.ModuleType("cursor_sdk")
     fake.AsyncClient = _FakeClient  # type: ignore[attr-defined]
     fake.AsyncAgent = _FakeAsyncAgent  # type: ignore[attr-defined]
     fake.CustomTool = _FakeCustomTool  # type: ignore[attr-defined]
     fake.LocalAgentOptions = _FakeLocalAgentOptions  # type: ignore[attr-defined]
+    fake.SendOptions = _FakeSendOptions  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "cursor_sdk", fake)
     return state
 


### PR DESCRIPTION
## Summary
- The Cursor backend only sends `TurnEndedUpdate` (with token usage) when the request includes `enableDeltas: true`, which the SDK sets when `SendOptions(on_delta=...)` is passed to `agent.send()`. Without it, zero `interaction_update` events arrive and cost tracking silently produces nothing.
- Pass `SendOptions(on_delta=_capture_delta)` to capture usage from `TurnEndedUpdate` via the callback
- Add `cacheReadTokens` / `cacheWriteTokens` (the actual field names the Cursor backend sends) to the normalization lookup
- Update test fake to expose `SendOptions` and pipe `interaction_updates` through `on_delta`

**Verified live:** session now shows `usage_by_model: {"auto": {"input_tokens": 18372, "output_tokens": 242, ...}}`

## Test plan
- [x] All 44 existing cursor executor tests pass
- [x] Live-tested with `omnigent run examples/polly/ --harness cursor -p "hi"` — session API returns populated `usage_by_model`

This pull request and its description were written by Isaac.