### PR TITLE
fix(ci): pass --repo to gh run rerun in the security-gate relay

### DIFF
--- a/.github/workflows/rerun-security-gate-run.yml
+++ b/.github/workflows/rerun-security-gate-run.yml
@@ -170,7 +170,13 @@ jobs:
             )
             if [ "${gate_failed:-0}" -gt 0 ]; then
               echo "• $wf: Security Gate failed in run $id -- re-running"
-              gh run rerun "$id" || echo "::warning::$wf: could not re-run $id"
+              # `--repo` is REQUIRED: unlike the `gh api "repos/$REPO/..."` calls
+              # above (repo is in the URL path), `gh run rerun` resolves the repo
+              # from -R / GH_REPO / the local git remote. This job has no checkout,
+              # so without -R it dies client-side ("failed to determine base repo:
+              # ... not a git repository") and never reaches GitHub -- the silent
+              # failure that stranded Lint/Integration/E2E UI on #556 and #644.
+              gh run rerun "$id" --repo "$REPO" || echo "::warning::$wf: could not re-run $id"
             else
               echo "• $wf: run $id failed but not at the Security Gate -- skipping"
             fi


### PR DESCRIPTION
## Problem

On both #556 and #644, applying `skip-security-scan` left **Lint / Integration / E2E UI** (and `ap-web Tests` / `Polly AI Review`) stuck red, even though the Security Scan re-ran and passed. The relay's log showed it *trying* to re-run them, then warning `could not re-run`.

## Root cause

The actual `gh` error in the relay logs (identical on #556 and #644) is **client-side** — it never reached GitHub:

```
failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[warning]Lint: could not re-run 27749939967
```

`gh run rerun` resolves its target repo from, in order: a `-R`/`--repo` flag, the `GH_REPO` env var, or the **local git remote**. The relay job (`rerun-security-gate-run.yml`):
- has **no `actions/checkout`** (so there's no `.git` to read a remote from), and
- sets only `REPO`, **not** `GH_REPO`, and passes **no `-R`**.

So `gh run rerun "$id"` fell through to the git-remote path and failed locally with "not a git repository" — before contacting GitHub. The error was swallowed by `|| echo "::warning::..."`, so the relay *looked* like it ran but re-ran nothing.

The script's other calls (`gh api "repos/$REPO/..."`) work fine because the repo is embedded in the URL path — only `gh run rerun` needs repo resolution, and that's the one call that lacked it.

This is **deterministic**, not a transient/race condition: the relay's `gh run rerun` has never actually worked. CI and E2E recovered anyway because they self-trigger on the `labeled` event, independent of the relay; the workflows without a `labeled` trigger had no fallback.

## Fix

```diff
- gh run rerun "$id" || echo "::warning::$wf: could not re-run $id"
+ gh run rerun "$id" --repo "$REPO" || echo "::warning::$wf: could not re-run $id"
```

`$REPO` (= `github.repository`) is the **base repo**, which is exactly where these run ids resolve — a fork PR's `pull_request` checks execute base-side, and the relay already discovers the run ids via `gh api "repos/$REPO/actions/runs?..."`, so the rerun targets the same repo by construction.

One line; the relay's design (selective re-run of only gate-failed runs, race guard waiting for the scan to pass) is otherwise correct and unchanged.

## Validation

YAML parses. The exact client-side error was confirmed in the logs of both the #556 and #644 relay runs.
