### PR TITLE
feat(chat): reveal "Jump to top" pill on scroll-up

### DIFF
--- a/ap-web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/ap-web/src/pages/ChatPage.historyLoad.test.tsx
@@ -155,6 +155,7 @@ describe("JumpToTopButton", () => {
   afterEach(() => {
     cleanup();
     useChatStore.setState({ loadMoreHistory: originalLoadMoreHistory, hasMoreHistory: false });
+    vi.useRealTimers();
   });
 
   // Query by the aria-label attribute rather than role/accessible-name: when
@@ -222,6 +223,51 @@ describe("JumpToTopButton", () => {
     // Leaving the conversation hides it again.
     act(() => {
       fireEvent.mouseLeave(container);
+    });
+    expect(pill().className).toContain("pointer-events-none");
+  });
+
+  it("reveals when the user scrolls up, then auto-hides after the linger timeout", () => {
+    vi.useFakeTimers();
+    const { container, scroll, scroller } = makeScroller({
+      scrollTop: 500,
+      scrollHeight: 1000,
+      clientHeight: 400,
+    });
+    const metrics = scroll as unknown as { scrollTop: number };
+
+    render(<JumpToTopButton containerEl={container} scroller={scroller} hasMoreHistory={true} />);
+    // Mount reads the initial position; no scroll yet, so the pill stays hidden.
+    expect(pill().className).toContain("pointer-events-none");
+
+    // Scroll up (scrollTop decreases): the pill reveals without any hover.
+    act(() => {
+      metrics.scrollTop = 300;
+      fireEvent.scroll(scroll);
+    });
+    expect(pill().className).toContain("pointer-events-auto");
+
+    // After the linger window with no further upward scroll, it fades back out.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(pill().className).toContain("pointer-events-none");
+  });
+
+  it("does not reveal on a downward scroll", () => {
+    const { container, scroll, scroller } = makeScroller({
+      scrollTop: 300,
+      scrollHeight: 1000,
+      clientHeight: 400,
+    });
+    const metrics = scroll as unknown as { scrollTop: number };
+
+    render(<JumpToTopButton containerEl={container} scroller={scroller} hasMoreHistory={true} />);
+
+    // Scrolling down (scrollTop increases) must not surface the pill.
+    act(() => {
+      metrics.scrollTop = 600;
+      fireEvent.scroll(scroll);
     });
     expect(pill().className).toContain("pointer-events-none");
   });

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -1771,6 +1771,12 @@ export function JumpToTopButton({
   const [atTop, setAtTop] = useState(true);
   const [hovering, setHovering] = useState(false);
   const [jumping, setJumping] = useState(false);
+  // Reveal the pill while the user is scrolling up, then fade it back out once
+  // they pause — so it's reachable without having to find the top hover band.
+  const [scrolledUp, setScrolledUp] = useState(false);
+
+  // How long the pill lingers after the last upward scroll before fading out.
+  const SCROLL_REVEAL_MS = 2000;
 
   // Pixels below the conversation's top edge that count as "hovering the top".
   // Comfortably clears the pill (anchored at the fade border, ~50px) so moving
@@ -1795,23 +1801,38 @@ export function JumpToTopButton({
     };
   }, [containerEl]);
 
-  // Track whether the loaded window is scrolled to its very top.
+  // Track whether the loaded window is scrolled to its very top, and reveal the
+  // pill whenever the user scrolls up (auto-hiding after they pause).
   const scrollEl = scroller?.el ?? null;
   useEffect(() => {
     if (!scrollEl) return;
+    let lastTop = scrollEl.scrollTop;
+    let hideTimer: ReturnType<typeof setTimeout> | undefined;
     const onScroll = () => {
-      const next = scrollEl.scrollTop <= 1;
+      const top = scrollEl.scrollTop;
+      const next = top <= 1;
       setAtTop((prev) => (prev === next ? prev : next));
+      // Upward scroll (and not already pinned to the top): show the pill and
+      // (re)arm the idle timer that fades it out once scrolling settles.
+      if (top < lastTop - 1 && top > 1) {
+        setScrolledUp(true);
+        clearTimeout(hideTimer);
+        hideTimer = setTimeout(() => setScrolledUp(false), SCROLL_REVEAL_MS);
+      }
+      lastTop = top;
     };
     onScroll();
     scrollEl.addEventListener("scroll", onScroll, { passive: true });
-    return () => scrollEl.removeEventListener("scroll", onScroll);
+    return () => {
+      clearTimeout(hideTimer);
+      scrollEl.removeEventListener("scroll", onScroll);
+    };
   }, [scrollEl]);
 
   // Somewhere to go: older pages exist, or we're scrolled down within the
   // loaded window. At the very first message there's nothing to jump to.
   const canJump = hasMoreHistory || !atTop;
-  const visible = jumping || (hovering && canJump);
+  const visible = jumping || ((hovering || scrolledUp) && canJump);
 
   const jumpToTop = useCallback(async () => {
     if (!scroller) return;

--- a/tests/e2e_ui/chat/test_jump_to_top.py
+++ b/tests/e2e_ui/chat/test_jump_to_top.py
@@ -45,6 +45,11 @@ _TAG_SCROLLER = """
 }
 """
 _SCROLL_TOP = "document.querySelector('[data-pw-scroller]').scrollTop"
+# True while the pill is revealed and clickable (opacity-100 / pointer-events-auto).
+_PILL_INTERACTIVE = (
+    "document.querySelector(\"button[aria-label='Jump to the first message']\")"
+    ".className.includes('pointer-events-auto')"
+)
 
 
 def _send_turn(page: Page, text: str, turn: int) -> None:
@@ -98,3 +103,49 @@ def test_jump_to_top_returns_to_first_message(
     # scroll position has settled at (or within a pixel of) the top.
     expect(page.locator(_USER).first).to_be_in_viewport(timeout=30_000)
     page.wait_for_function(f"{_SCROLL_TOP} <= 2", timeout=30_000)
+
+
+def test_jump_to_top_reveals_on_scroll_up_then_auto_hides(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Scrolling up surfaces the pill (no hover needed); pausing fades it out."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    page.set_viewport_size(_VIEWPORT)
+
+    for turn, prompt in enumerate(("Say hello.", "Say hello again.", "Say hello once more."), 1):
+        _send_turn(page, prompt, turn)
+
+    # Scroll to the bottom: the pill is hidden there.
+    scroll_top = page.evaluate(_TAG_SCROLLER)
+    assert scroll_top > 50, (
+        f"conversation did not overflow enough to scroll (scrollTop={scroll_top})"
+    )
+    assert page.evaluate(_PILL_INTERACTIVE) is False
+
+    # Park the cursor near the BOTTOM of the conversation — clear of the 140px
+    # top hover band — so the reveal (and, crucially, the auto-hide) is driven by
+    # the scroll alone, never a lingering hover. The viewport is only 320px tall,
+    # so the conversation's *center* still falls inside the band; the bottom edge
+    # does not.
+    box = page.locator("[data-pw-scroller]").bounding_box()
+    assert box is not None
+    page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] - 5)
+
+    # Scroll up to roughly the middle. Setting scrollTop dispatches a real
+    # 'scroll' event — the same signal a wheel/drag emits, and exactly how
+    # _TAG_SCROLLER above scrolls — so this drives the component's scroll
+    # direction detection deterministically, without depending on wheel-delta
+    # mapping. Staying near the middle keeps us clear of the very top, where the
+    # at-top state deliberately suppresses the scroll reveal.
+    mid = page.evaluate(
+        "() => { const el = document.querySelector('[data-pw-scroller]');"
+        " el.scrollTop = Math.floor(el.scrollHeight / 2); return el.scrollTop; }"
+    )
+    assert mid > 1, f"scroll-up did not land clear of the top (scrollTop={mid})"
+
+    # The pill reveals on the upward scroll…
+    page.wait_for_function(_PILL_INTERACTIVE, timeout=10_000)
+    # …then fades back out once scrolling settles (SCROLL_REVEAL_MS = 2000ms).
+    page.wait_for_function(f"!({_PILL_INTERACTIVE})", timeout=10_000)


### PR DESCRIPTION
## What

The **Jump to top** pill on the chat page previously surfaced only when the cursor hovered the top ~140px band of the conversation. This makes it hard to discover and reach.

Now an **upward scroll** also reveals the pill, and it fades back out ~2s after scrolling settles (`SCROLL_REVEAL_MS = 2000`). The existing top-hover behavior is unchanged; the new reveal is OR-ed in and still respects `canJump` (older history exists or not already pinned to the top).

## How

In `JumpToTopButton` (`ap-web/src/pages/ChatPage.tsx`):
- New `scrolledUp` state.
- The scroll handler now detects upward scroll (`top < lastTop - 1 && top > 1`), sets `scrolledUp`, and arms an idle timer that clears it once scrolling settles. Timer is reset on each upward scroll and cleaned up on unmount.
- Visibility is now `jumping || ((hovering || scrolledUp) && canJump)`.

## Tests

- **Unit** (`ChatPage.historyLoad.test.tsx`): reveal on scroll-up + auto-hide after the linger timeout; no reveal on a downward scroll.
- **E2E** (`tests/e2e_ui/chat/test_jump_to_top.py`): scrolling up surfaces the pill (cursor parked clear of the hover band), then it auto-hides.

### Verification (run locally)
- `npm test` — 2841 passed
- `npm run build` — clean
- `tests/e2e_ui/chat/test_jump_to_top.py` — 2 passed (live LLM + Chromium)