### PR TITLE
fix(host): tolerate non-JSON daemon-status responses

### DIFF
--- a/omnigent/host/daemon_launch.py
+++ b/omnigent/host/daemon_launch.py
@@ -26,6 +26,31 @@ from omnigent.claude_native_bridge import url_component
 DAEMON_POLL_INTERVAL_S = 0.5
 
 
+def _json_body(resp: httpx.Response) -> dict[str, object]:
+    """Decode a host/runner status response body, tolerating non-JSON.
+
+    The host + runner status endpoints (``GET /v1/hosts/{id}``,
+    ``GET /v1/runners/{id}/status``) are expected to answer JSON. But a
+    server reached over ``--server`` that does not mount the host router
+    (e.g. an API-only deployment, or a misconfigured server) lets these
+    paths fall through to the SPA HTML5-history fallback, which answers
+    ``200 text/html`` with ``index.html``. Calling ``resp.json()`` on that
+    raised an opaque ``json.JSONDecodeError`` that crashed the REPL before
+    it ever became ready. Treat any non-dict / non-JSON 200 body as "no
+    status yet" so the caller keeps polling and ultimately fails with the
+    actionable timeout message instead.
+
+    :param resp: A ``200`` host/runner status response.
+    :returns: The decoded JSON object, or an empty dict when the body is
+        not a JSON object (e.g. the SPA HTML fallback).
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
 async def wait_for_host_online(
     client: httpx.AsyncClient,
     host_id: str,
@@ -58,7 +83,7 @@ async def wait_for_host_online(
         except httpx.TransportError as exc:
             last_error = exc
         else:
-            if resp.status_code == 200 and resp.json().get("status") == "online":
+            if resp.status_code == 200 and _json_body(resp).get("status") == "online":
                 return
         await asyncio.sleep(DAEMON_POLL_INTERVAL_S)
     message = (
@@ -79,7 +104,7 @@ async def runner_is_online(client: httpx.AsyncClient, runner_id: str) -> bool:
     :returns: ``True`` when the status endpoint reports ``online``.
     """
     resp = await client.get(f"/v1/runners/{url_component(runner_id)}/status")
-    return resp.status_code == 200 and bool(resp.json().get("online"))
+    return resp.status_code == 200 and bool(_json_body(resp).get("online"))
 
 
 async def wait_for_runner_online(
@@ -119,7 +144,7 @@ async def wait_for_runner_online(
             last_error = exc
         else:
             if resp.status_code == 200:
-                body = resp.json()
+                body = _json_body(resp)
                 if body.get("online"):
                     return
                 exit_error = body.get("error")
@@ -162,7 +187,7 @@ async def launch_or_reuse_daemon_runner(
     :raises click.ClickException: If the launch request fails.
     """
     snap = await client.get(f"/v1/sessions/{url_component(session_id)}")
-    existing = snap.json().get("runner_id") if snap.status_code == 200 else None
+    existing = _json_body(snap).get("runner_id") if snap.status_code == 200 else None
     if isinstance(existing, str) and existing:
         if await runner_is_online(client, existing):
             return existing

--- a/tests/host/test_daemon_launch.py
+++ b/tests/host/test_daemon_launch.py
@@ -16,7 +16,11 @@ import httpx
 import pytest
 
 from omnigent.host import daemon_launch
-from omnigent.host.daemon_launch import wait_for_host_online, wait_for_runner_online
+from omnigent.host.daemon_launch import (
+    runner_is_online,
+    wait_for_host_online,
+    wait_for_runner_online,
+)
 
 
 class _FlakyThenOnline:
@@ -60,6 +64,66 @@ class _AlwaysRefuses:
         :raises httpx.ConnectError: Always.
         """
         raise httpx.ConnectError("connection refused", request=request)
+
+
+class _HtmlThenOnline:
+    """MockTransport handler that answers the SPA HTML fallback N times, then JSON-online.
+
+    Reproduces a ``--server`` deployment whose host router is not mounted:
+    ``GET /v1/hosts/{id}`` / ``GET /v1/runners/{id}/status`` fall through
+    to the SPA HTML5-history fallback and answer ``200 text/html`` with
+    ``index.html`` until (in this mock) the real status endpoint finally
+    reports online. Before the non-JSON tolerance fix the first HTML body
+    raised ``json.JSONDecodeError`` out of the wait, crashing the REPL
+    before it became ready.
+
+    :param html_polls: Number of initial 200-text/html responses to serve
+        before answering with the JSON ``body``.
+    :param body: JSON body returned once "online".
+    """
+
+    def __init__(self, html_polls: int, body: dict[str, object]) -> None:
+        self.html_polls = html_polls
+        self.body = body
+        self.requests_seen = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """
+        Handle one mock-transport request.
+
+        :param request: The outgoing request the client built.
+        :returns: A ``200 text/html`` SPA-fallback response until the
+            HTML budget is exhausted, then a ``200`` JSON ``body``.
+        """
+        self.requests_seen += 1
+        if self.requests_seen <= self.html_polls:
+            return httpx.Response(
+                200,
+                text="<!doctype html><title>omnigent</title>",
+                headers={"content-type": "text/html"},
+            )
+        return httpx.Response(200, json=self.body)
+
+
+class _AlwaysHtml:
+    """MockTransport handler that always answers the SPA HTML fallback (200 text/html)."""
+
+    def __init__(self) -> None:
+        self.requests_seen = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """
+        Answer with the SPA HTML5-history fallback body.
+
+        :param request: The outgoing request the client built.
+        :returns: A ``200 text/html`` response carrying ``index.html``.
+        """
+        self.requests_seen += 1
+        return httpx.Response(
+            200,
+            text="<!doctype html><title>omnigent</title>",
+            headers={"content-type": "text/html"},
+        )
 
 
 @pytest.fixture
@@ -210,3 +274,73 @@ async def test_wait_for_host_online_deadline_reports_last_connect_error(
     assert "host_abc123" in message
     assert "Last connection error" in message
     assert "connection refused" in message
+
+
+async def test_wait_for_runner_online_tolerates_html_fallback_then_online(
+    fast_poll: None,
+) -> None:
+    """A 200-text/html status body must not crash the runner wait.
+
+    Reproduces the ``--server`` deployment where the status path falls
+    through to the SPA HTML5-history fallback for the first polls, then
+    the runner registers and the endpoint answers JSON ``online: true``.
+    Before the non-JSON tolerance fix the first HTML body raised
+    ``json.JSONDecodeError`` out of the wait; this test failing with a
+    raised ``ValueError`` means that regressed.
+    """
+    handler = _HtmlThenOnline(html_polls=2, body={"online": True})
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://test"
+    ) as client:
+        await wait_for_runner_online(client, "runner_abc123", timeout_s=5.0)
+    # 3 = 2 HTML-fallback polls + the one that observed JSON "online".
+    assert handler.requests_seen == 3
+
+
+async def test_wait_for_runner_online_html_fallback_fails_with_timeout_not_jsonerror(
+    fast_poll: None,
+) -> None:
+    """A status path stuck on the HTML fallback fails with the friendly timeout.
+
+    When the host router is never mounted the status path answers
+    ``200 text/html`` forever. The wait must keep polling and end in
+    ``click.ClickException`` (the actionable timeout) rather than
+    propagating ``json.JSONDecodeError`` on the first poll.
+    """
+    handler = _AlwaysHtml()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://test"
+    ) as client:
+        with pytest.raises(click.ClickException) as excinfo:
+            await wait_for_runner_online(client, "runner_abc123", timeout_s=0.05)
+    assert "runner_abc123" in str(excinfo.value)
+    # >1 proves the HTML body was tolerated as "no status yet" and polling
+    # continued; a raised JSONDecodeError would never reach the asserts.
+    assert handler.requests_seen > 1
+
+
+async def test_runner_is_online_false_on_html_fallback_body() -> None:
+    """``runner_is_online`` reports False (not a crash) on a 200 HTML body.
+
+    The single-shot reuse check must treat a non-JSON 200 as "not online"
+    so ``launch_or_reuse_daemon_runner`` falls back to launching a fresh
+    runner instead of dying on ``resp.json()``.
+    """
+    handler = _AlwaysHtml()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://test"
+    ) as client:
+        assert await runner_is_online(client, "runner_abc123") is False
+
+
+async def test_wait_for_host_online_tolerates_html_fallback_then_online(
+    fast_poll: None,
+) -> None:
+    """Same non-JSON tolerance for the host status endpoint's online wait."""
+    handler = _HtmlThenOnline(html_polls=2, body={"status": "online"})
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://test"
+    ) as client:
+        await wait_for_host_online(client, "host_abc123", timeout_s=5.0)
+    # 3 = 2 HTML-fallback polls + the one that observed JSON "online".
+    assert handler.requests_seen == 3


### PR DESCRIPTION
## Summary

`omnigent run` could crash on startup with an opaque `json.JSONDecodeError` before the REPL ever became ready.

The CLI-side daemon-launch helpers (`omnigent/host/daemon_launch.py`) poll the host + runner status endpoints — `GET /v1/hosts/{id}`, `GET /v1/runners/{id}/status` — and call `resp.json()` on the `200` response. Those paths normally answer JSON, but a server reached over `--server` that does not mount the host router (an API-only deployment, or a misconfigured server) lets them fall through to the SPA HTML5-history fallback, which answers `200 text/html` with `index.html`. `resp.json()` on that body raised `json.JSONDecodeError` straight out of the wait loop, killing the REPL before it printed anything actionable.

This adds a `_json_body(resp)` helper that decodes the status body and treats any non-JSON / non-dict `200` as "no status yet". The wait loops then keep polling and ultimately fail with the existing actionable timeout message (which names the host/runner and the last error) instead of an opaque decode crash. Applied at all 5 status-decode call sites: `wait_for_host_online`, `runner_is_online`, `wait_for_runner_online`, and the `launch_or_reuse_daemon_runner` reuse snapshot.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Adds deterministic unit coverage in `tests/host/test_daemon_launch.py` (the existing home for the daemon-launch polling helpers, alongside the transport-error-tolerance tests). Two new MockTransport handlers — `_HtmlThenOnline` (serves the `200 text/html` SPA fallback N times, then JSON-online) and `_AlwaysHtml` — drive four new tests:

- `test_wait_for_runner_online_tolerates_html_fallback_then_online` — HTML fallback polls are tolerated and the wait succeeds once JSON `online: true` arrives.
- `test_wait_for_runner_online_html_fallback_fails_with_timeout_not_jsonerror` — a path stuck on the HTML fallback ends in the friendly `click.ClickException` timeout, never a raised `JSONDecodeError`.
- `test_runner_is_online_false_on_html_fallback_body` — the single-shot reuse check reports `False` (so the caller launches fresh) instead of crashing.
- `test_wait_for_host_online_tolerates_html_fallback_then_online` — same tolerance for the host status endpoint.

Full file passes 10/10 locally (6 pre-existing + 4 new); each new test fails against the pre-fix code with `JSONDecodeError`, so they pin the regression. No e2e or quarantine-list changes in this PR — the daemon-resume e2e tests remain quarantined under a separate, deeper turn-timeout issue.

This pull request and its description were written by Isaac.
