### PR TITLE
feat(filesystem): render image files in the workspace viewer

### DIFF
--- a/ap-web/src/shell/CodeViewer.test.tsx
+++ b/ap-web/src/shell/CodeViewer.test.tsx
@@ -31,6 +31,21 @@ function makeFileQuery(content: string, truncated = false): ReturnType<typeof us
   } as unknown as ReturnType<typeof useFileContent>;
 }
 
+// A real (1×1, transparent) PNG, base64-encoded — i.e. exactly what the server
+// returns for a binary file (encoding="base64", content_type="image/png").
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+function makeImageQuery(contentType: string, truncated = false): ReturnType<typeof useFileContent> {
+  return {
+    data: { content: PNG_BASE64, encoding: "base64", content_type: contentType, truncated },
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+  } as unknown as ReturnType<typeof useFileContent>;
+}
+
 const noopRef = { current: null };
 
 function renderViewer(
@@ -238,5 +253,70 @@ describe("CodeViewer HTML preview sandbox", () => {
     expect(sandbox).not.toContain("allow-same-origin");
     // #777: every link opens in a new tab via the injected base tag.
     expect(iframe!.getAttribute("srcdoc")).toContain('<base target="_blank">');
+  });
+});
+
+describe("CodeViewer image rendering", () => {
+  // jsdom implements neither URL.createObjectURL nor revokeObjectURL; ImageViewer
+  // calls both, so stub them and capture the blob it encodes.
+  let createdBlob: Blob | null;
+
+  beforeEach(() => {
+    createdBlob = null;
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn((blob: Blob) => {
+        createdBlob = blob;
+        return "blob:mock-object-url";
+      }),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderImage(contentType: string, path = "logo.png", truncated = false) {
+    return render(
+      <CodeViewer
+        conversationId="conv_1"
+        path={path}
+        fileQuery={makeImageQuery(contentType, truncated)}
+        comments={[]}
+        activeSelection={null}
+        onSetActiveSelection={() => {}}
+        panelOpen={true}
+        searchOpen={false}
+        setSearchOpen={() => {}}
+        searchInputRef={noopRef}
+        viewMode="source"
+      />,
+    );
+  }
+
+  it("renders a binary PNG as a blob-backed <img>, not source or placeholder", async () => {
+    renderImage("image/png", "assets/logo.png");
+
+    // alt is the basename; the src is the stubbed object URL — i.e. the image is
+    // shown through a blob, never the base64 placeholder or Monaco/Shiki source.
+    const img = (await screen.findByAltText("logo.png")) as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe("blob:mock-object-url");
+    expect(screen.queryByTestId("monaco-editor-stub")).toBeNull();
+    expect(screen.queryByText(/binary file/i)).toBeNull();
+
+    // The blob handed to createObjectURL carries the server's MIME type and the
+    // decoded PNG bytes (base64 round-trips through fileContentToBlob's atob path).
+    expect(createdBlob?.type).toBe("image/png");
+    expect(createdBlob?.size).toBe(atob(PNG_BASE64).length);
+  });
+
+  it("shows the truncated banner when a binary image was truncated", () => {
+    renderImage("image/png", "logo.png", true);
+    expect(screen.getByText(/too large to load fully/)).toBeDefined();
+  });
+
+  it("routes by content_type over extension (image MIME on a .txt name)", async () => {
+    renderImage("image/png", "data.txt");
+    expect(await screen.findByAltText("data.txt")).toBeDefined();
   });
 });

--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -33,7 +33,11 @@ import { highlightCode } from "@/components/ai-elements/code-block";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { type Comment } from "@/hooks/useComments";
-import { useFileContent } from "@/hooks/useFileContent";
+import {
+  type FileContentResponse,
+  fileContentToBlob,
+  useFileContent,
+} from "@/hooks/useFileContent";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { cn } from "@/lib/utils";
 import { MarkdownRichTextViewer } from "./MarkdownRichTextViewer";
@@ -45,6 +49,7 @@ import {
   getSelectionOffsets,
   indexToLine,
   isBinaryPath,
+  isImageFile,
   lineOverlapsSelection,
   prepareHtmlPreviewDoc,
 } from "./codeViewerHelpers";
@@ -70,6 +75,66 @@ function MarkdownPreview({ content }: { content: string }) {
   return (
     <div className="px-6 py-4 overflow-auto h-full prose dark:prose-invert prose-sm max-w-none">
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ImageViewer — render an image file via a blob URL
+// ---------------------------------------------------------------------------
+
+// A subtle checkerboard so transparent regions of PNG/WebP/SVG are visible
+// against either light or dark backgrounds.
+const CHECKERBOARD_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "linear-gradient(45deg, rgba(128,128,128,0.15) 25%, transparent 25%)," +
+    "linear-gradient(-45deg, rgba(128,128,128,0.15) 25%, transparent 25%)," +
+    "linear-gradient(45deg, transparent 75%, rgba(128,128,128,0.15) 75%)," +
+    "linear-gradient(-45deg, transparent 75%, rgba(128,128,128,0.15) 75%)",
+  backgroundSize: "16px 16px",
+  backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0",
+};
+
+function ImageViewer({ data, path }: { data: FileContentResponse; path: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [errored, setErrored] = useState(false);
+
+  // Create the object URL in an effect and revoke it on cleanup so the blob is
+  // released when the file changes or the viewer unmounts (avoids a leak).
+  useEffect(() => {
+    setErrored(false);
+    const objectUrl = URL.createObjectURL(fileContentToBlob(data));
+    setUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [data]);
+
+  const filename = path.split("/").pop() ?? path;
+
+  const body = errored ? (
+    <div className="flex items-center justify-center p-8 text-muted-foreground text-sm">
+      {data.truncated
+        ? "Image is too large to preview (truncated by the server)."
+        : "Unable to render image."}
+    </div>
+  ) : (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+      {url && (
+        <img
+          src={url}
+          alt={filename}
+          onError={() => setErrored(true)}
+          className="max-h-full max-w-full object-contain"
+          style={CHECKERBOARD_STYLE}
+        />
+      )}
+    </div>
+  );
+
+  if (!data.truncated) return body;
+  return (
+    <div className="flex h-full flex-col">
+      <TruncatedBanner />
+      {body}
     </div>
   );
 }
@@ -362,6 +427,9 @@ export function CodeViewer({
         {fileQuery.error instanceof Error ? fileQuery.error.message : String(fileQuery.error)}
       </div>
     );
+  }
+  if (fileQuery.data && isImageFile(path, fileQuery.data.content_type)) {
+    return <ImageViewer data={fileQuery.data} path={path} />;
   }
   if (fileQuery.data?.encoding === "base64" || isBinaryPath(path)) {
     return (

--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -102,6 +102,14 @@ function ImageViewer({ data, path }: { data: FileContentResponse; path: string }
   // Create the object URL in an effect and revoke it on cleanup so the blob is
   // released when the file changes or the viewer unmounts (avoids a leak).
   useEffect(() => {
+    // A truncated image is a partial (corrupt) byte stream — mounting it would
+    // flash a broken-image icon before onError fires. Skip the blob and go
+    // straight to the error/banner UI.
+    if (data.truncated) {
+      setUrl(null);
+      setErrored(true);
+      return;
+    }
     setErrored(false);
     const objectUrl = URL.createObjectURL(fileContentToBlob(data));
     setUrl(objectUrl);

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -81,6 +81,7 @@ import {
   MONACO_SPLIT_BREAKPOINT,
   type SaveStatus,
   detectLang,
+  isImageFile,
   openHtmlArtifactInNewTab,
 } from "./codeViewerHelpers";
 import { CommentsPanel, type ActiveSelection } from "./CommentsPanel";
@@ -574,8 +575,13 @@ function FileViewerBody({
   // View mode toggle — preview is the default for md/html, source for everything else.
   const lang = detectLang(path);
   const isPreviewable = lang === "markdown" || lang === "html";
+  // Images render through CodeViewer's <ImageViewer> regardless of view mode;
+  // they have no source/diff representation, so diff is suppressed for them
+  // (Monaco would otherwise render the base64 payload as garbage text).
+  const isImage = isImageFile(path, fileQuery.data?.content_type);
   // Show Δ button only when the file appears in the session's changed-files list.
-  const isDiffAvailable = changedFiles.data?.data.some((f) => f.path === path) ?? false;
+  const isDiffAvailable =
+    !isImage && (changedFiles.data?.data.some((f) => f.path === path) ?? false);
   const isDeletedFile =
     changedFiles.data?.data.some((f) => f.path === path && f.status === "deleted") ?? false;
 

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   getSelectionOffsets,
   indexToLine,
   isBinaryPath,
+  isImageFile,
   lineOverlapsSelection,
   openHtmlArtifactInNewTab,
   prepareHtmlPreviewDoc,
@@ -108,6 +109,55 @@ describe("isBinaryPath", () => {
 
   it("treats extension-less paths as non-binary", () => {
     expect(isBinaryPath("Dockerfile")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isImageFile — image-preview detection (MIME-first, extension fallback)
+// ---------------------------------------------------------------------------
+
+describe("isImageFile", () => {
+  it.each([
+    "logo.png",
+    "photo.jpg",
+    "scan.jpeg",
+    "anim.gif",
+    "icon.ico",
+    "hero.webp",
+    "next.avif",
+    "diagram.svg",
+  ])("classifies %s as an image by extension", (path) => {
+    expect(isImageFile(path)).toBe(true);
+  });
+
+  it.each(["app.py", "archive.zip", "clip.mp4", "font.woff2", "notes.txt"])(
+    "classifies %s as non-image by extension",
+    (path) => {
+      expect(isImageFile(path)).toBe(false);
+    },
+  );
+
+  it("is case-insensitive on the extension", () => {
+    expect(isImageFile("LOGO.PNG")).toBe(true);
+  });
+
+  it("treats a content type as authoritative over the extension", () => {
+    // A misleading/extension-less name still previews when the server says image.
+    expect(isImageFile("blob", "image/png")).toBe(true);
+    expect(isImageFile("data.txt", "image/jpeg")).toBe(true);
+    // ...and an image extension is overridden by a non-image content type.
+    expect(isImageFile("logo.png", "text/plain")).toBe(false);
+    expect(isImageFile("photo.jpg", "application/octet-stream")).toBe(false);
+  });
+
+  it("falls back to the extension when content type is null/undefined", () => {
+    expect(isImageFile("logo.png", null)).toBe(true);
+    expect(isImageFile("logo.png", undefined)).toBe(true);
+    expect(isImageFile("notes.txt", null)).toBe(false);
+  });
+
+  it("treats extension-less paths with no content type as non-image", () => {
+    expect(isImageFile("Dockerfile")).toBe(false);
   });
 });
 

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -96,6 +96,35 @@ export function isBinaryPath(path: string): boolean {
   return BINARY_EXTENSIONS.has(ext);
 }
 
+// Image formats the browser can render directly via an <img> tag. SVG is
+// included but is only ever rendered through a blob URL (never inlined into
+// the DOM), so scripts embedded in it cannot execute.
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "bmp",
+  "ico",
+  "webp",
+  "avif",
+  "svg",
+]);
+
+/**
+ * Return true if `path` should be previewed as an image.
+ *
+ * MIME-first: when the server supplies a `content_type` it is authoritative
+ * (handles files with missing or misleading extensions). Falls back to the
+ * file extension when no content type is available (e.g. `guess_type`
+ * returned null).
+ */
+export function isImageFile(path: string, contentType?: string | null): boolean {
+  if (contentType) return contentType.startsWith("image/");
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
 export function detectLang(path: string): BundledLanguage | "text" {
   const ext = path.split(".").pop()?.toLowerCase() ?? "";
   const map: Record<string, BundledLanguage> = {

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+import base64
 import contextlib
 import json
 import os
@@ -743,6 +744,7 @@ class CallerProcessOSEnvironment(OSEnvironment):
         path: str,
         offset: int = 1,
         limit: int | None = None,
+        max_binary_bytes: int | None = None,
     ) -> OpResult:
         if offset < 1:
             return {"error": "offset must be >= 1"}
@@ -755,6 +757,7 @@ class CallerProcessOSEnvironment(OSEnvironment):
                 "path": path,
                 "offset": offset,
                 "limit": limit,
+                "max_binary_bytes": max_binary_bytes,
             },
         )
         return cast(OpResult, result)
@@ -891,10 +894,13 @@ def _handle_helper_request(
             return {"error": str(exc)}
         offset_raw = request.get("offset", 1)
         offset = offset_raw if isinstance(offset_raw, int) else 1
+        max_binary_raw = request.get("max_binary_bytes")
+        max_binary_bytes = max_binary_raw if isinstance(max_binary_raw, int) else None
         return _read_impl(
             path,
             offset,
             request.get("limit"),
+            max_binary_bytes=max_binary_bytes,
         )
 
     if op == "write":
@@ -1014,18 +1020,44 @@ def _assert_write_allowed(policy: SandboxPolicy, path: Path) -> None:
     raise PermissionError(f"Write access to '{path}' is blocked by sandbox.")
 
 
-def _read_impl(path: Path, offset: int, limit: JsonValue) -> OpResult:
+def _read_impl(
+    path: Path,
+    offset: int,
+    limit: JsonValue,
+    max_binary_bytes: int | None = None,
+) -> OpResult:
     """
-    Read lines from a text file.
+    Read a file as UTF-8 text, or as base64-encoded bytes when it is binary.
+
+    The file is read as raw bytes and a strict UTF-8 decode is attempted.
+    Files that decode cleanly are returned as text with the usual
+    line-oriented ``offset``/``limit`` windowing. Files that do *not* decode
+    (images, archives, fonts, …) cannot be line-windowed, so they are capped
+    by *bytes* instead.
+
+    For binary files the behaviour depends on ``max_binary_bytes``:
+
+    * ``None`` (the default, used by the agent ``sys_os_read`` tool) — the
+      base64 payload is **not** inlined. A model cannot decode base64, and a
+      multi-MB blob would saturate the context window, so only a descriptor
+      (``total_bytes`` + a ``note``) is returned.
+    * a positive int (used by the filesystem service that feeds the web
+      viewer / downloads) — up to that many raw bytes are base64-encoded and
+      returned, with ``truncated`` set when the file was larger.
 
     :param path: Absolute path of the file to read.
-    :param offset: 1-based line number to start reading from.
+    :param offset: 1-based line number to start reading from (text only).
     :param limit: Maximum number of lines to return, or ``None`` for no
         limit (return all lines from *offset* to end of file).  Callers
         that want the default agent-tool cap should pass
-        :data:`_DEFAULT_READ_LIMIT` explicitly.
-    :returns: An :class:`OpResult` dict with ``path``, ``content``,
-        ``offset``, ``limit``, ``returned_lines``, and ``total_lines``.
+        :data:`_DEFAULT_READ_LIMIT` explicitly.  Ignored for binary files.
+    :param max_binary_bytes: Byte cap for binary files (see above). ``None``
+        returns a descriptor only.
+    :returns: For text, an :class:`OpResult` with ``encoding="utf-8"``,
+        ``content``, ``offset``, ``limit``, ``returned_lines``, and
+        ``total_lines``.  For binary, ``encoding="base64"``, ``total_bytes``,
+        ``truncated`` and either ``content`` (the base64 string, byte-capped
+        callers) or a ``note`` (descriptor-only callers).
     """
     if offset < 1:
         return {"error": "offset must be >= 1"}
@@ -1033,7 +1065,36 @@ def _read_impl(path: Path, offset: int, limit: JsonValue) -> OpResult:
         if not isinstance(limit, int) or limit < 1:
             return {"error": "limit must be >= 1"}
 
-    text = path.read_text(encoding="utf-8", errors="replace")
+    raw = path.read_bytes()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        # Binary file: base64 cannot be line-windowed, so cap by bytes.
+        total = len(raw)
+        if max_binary_bytes is None:
+            # Agent tool path: return a descriptor only — inlining base64 the
+            # model cannot use would waste (and risk saturating) the context.
+            return {
+                "path": str(path),
+                "encoding": "base64",
+                "content": "",
+                "total_bytes": total,
+                "truncated": total > 0,
+                "note": (
+                    f"Binary file not inlined ({total} bytes). "
+                    "View or download it via the file viewer."
+                ),
+            }
+        payload = raw[:max_binary_bytes]
+        return {
+            "path": str(path),
+            "content": base64.b64encode(payload).decode("ascii"),
+            "encoding": "base64",
+            "total_bytes": total,
+            "returned_bytes": len(payload),
+            "truncated": len(payload) < total,
+        }
+
     lines = text.splitlines(keepends=True)
     start = offset - 1
     effective_limit = len(lines) if limit is None else limit
@@ -1042,6 +1103,7 @@ def _read_impl(path: Path, offset: int, limit: JsonValue) -> OpResult:
     return {
         "path": str(path),
         "content": content,
+        "encoding": "utf-8",
         "offset": offset,
         "limit": effective_limit,
         "returned_lines": max(0, resolved_limit - start),

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1064,6 +1064,8 @@ def _read_impl(
     if limit is not None:
         if not isinstance(limit, int) or limit < 1:
             return {"error": "limit must be >= 1"}
+    if max_binary_bytes is not None and max_binary_bytes < 1:
+        return {"error": "max_binary_bytes must be >= 1"}
 
     raw = path.read_bytes()
     try:
@@ -1079,7 +1081,8 @@ def _read_impl(
                 "encoding": "base64",
                 "content": "",
                 "total_bytes": total,
-                "truncated": total > 0,
+                # Not truncated — the content was deliberately not inlined.
+                "truncated": False,
                 "note": (
                     f"Binary file not inlined ({total} bytes). "
                     "View or download it via the file viewer."

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import codecs
 import contextlib
 import json
 import os
@@ -1020,6 +1021,74 @@ def _assert_write_allowed(policy: SandboxPolicy, path: Path) -> None:
     raise PermissionError(f"Write access to '{path}' is blocked by sandbox.")
 
 
+# Bytes sampled to classify a file as text vs binary. A NUL byte or an invalid
+# UTF-8 sequence in this prefix marks the file binary (the same prefix-sniff
+# heuristic git uses), so a multi-MB binary is never read in full just to find
+# out it is not text.
+_BINARY_SNIFF_BYTES = 8192
+
+
+def _is_binary_file(path: Path) -> bool:
+    """Classify *path* as binary by inspecting only its first chunk.
+
+    Reads at most :data:`_BINARY_SNIFF_BYTES` and reports binary when those
+    bytes are not valid UTF-8. An incremental decoder is used with
+    ``final=False`` so a multi-byte character straddling the chunk boundary is
+    treated as *incomplete* (text), not invalid (binary).
+
+    :param path: Absolute path of the file to classify.
+    :returns: ``True`` if the prefix is not decodable as UTF-8.
+    """
+    with path.open("rb") as fh:
+        prefix = fh.read(_BINARY_SNIFF_BYTES)
+    try:
+        codecs.getincrementaldecoder("utf-8")("strict").decode(prefix, final=False)
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def _read_binary_impl(path: Path, max_binary_bytes: int | None) -> OpResult:
+    """Read a binary file as base64, bounded by *max_binary_bytes*.
+
+    Only ``stat`` (for the total size) and at most *max_binary_bytes* are read
+    from disk, so a large file neither saturates memory nor inflates IPC.
+
+    :param path: Absolute path of the binary file.
+    :param max_binary_bytes: Byte cap. ``None`` returns a descriptor only (the
+        agent ``sys_os_read`` path); a positive int inlines up to that many
+        base64-encoded bytes (the filesystem-service path).
+    :returns: An :class:`OpResult` with ``encoding="base64"`` (see
+        :func:`_read_impl`).
+    """
+    total = path.stat().st_size
+    if max_binary_bytes is None:
+        # Agent tool path: return a descriptor only — inlining base64 the
+        # model cannot use would waste (and risk saturating) the context.
+        return {
+            "path": str(path),
+            "encoding": "base64",
+            "content": "",
+            "total_bytes": total,
+            # Not truncated — the content was deliberately not inlined.
+            "truncated": False,
+            "note": (
+                f"Binary file not inlined ({total} bytes). "
+                "View or download it via the file viewer."
+            ),
+        }
+    with path.open("rb") as fh:
+        payload = fh.read(max_binary_bytes)
+    return {
+        "path": str(path),
+        "content": base64.b64encode(payload).decode("ascii"),
+        "encoding": "base64",
+        "total_bytes": total,
+        "returned_bytes": len(payload),
+        "truncated": len(payload) < total,
+    }
+
+
 def _read_impl(
     path: Path,
     offset: int,
@@ -1029,11 +1098,11 @@ def _read_impl(
     """
     Read a file as UTF-8 text, or as base64-encoded bytes when it is binary.
 
-    The file is read as raw bytes and a strict UTF-8 decode is attempted.
-    Files that decode cleanly are returned as text with the usual
-    line-oriented ``offset``/``limit`` windowing. Files that do *not* decode
-    (images, archives, fonts, …) cannot be line-windowed, so they are capped
-    by *bytes* instead.
+    The file's first chunk is sniffed for UTF-8 validity (see
+    :func:`_is_binary_file`). Files that look like text are read and returned
+    with the usual line-oriented ``offset``/``limit`` windowing. Files that do
+    *not* (images, archives, fonts, …) cannot be line-windowed, so they are
+    capped by *bytes* instead, reading at most ``max_binary_bytes`` from disk.
 
     For binary files the behaviour depends on ``max_binary_bytes``:
 
@@ -1067,36 +1136,16 @@ def _read_impl(
     if max_binary_bytes is not None and max_binary_bytes < 1:
         return {"error": "max_binary_bytes must be >= 1"}
 
-    raw = path.read_bytes()
+    if _is_binary_file(path):
+        return _read_binary_impl(path, max_binary_bytes)
+
     try:
-        text = raw.decode("utf-8")
+        text = path.read_text(encoding="utf-8", errors="strict")
     except UnicodeDecodeError:
-        # Binary file: base64 cannot be line-windowed, so cap by bytes.
-        total = len(raw)
-        if max_binary_bytes is None:
-            # Agent tool path: return a descriptor only — inlining base64 the
-            # model cannot use would waste (and risk saturating) the context.
-            return {
-                "path": str(path),
-                "encoding": "base64",
-                "content": "",
-                "total_bytes": total,
-                # Not truncated — the content was deliberately not inlined.
-                "truncated": False,
-                "note": (
-                    f"Binary file not inlined ({total} bytes). "
-                    "View or download it via the file viewer."
-                ),
-            }
-        payload = raw[:max_binary_bytes]
-        return {
-            "path": str(path),
-            "content": base64.b64encode(payload).decode("ascii"),
-            "encoding": "base64",
-            "total_bytes": total,
-            "returned_bytes": len(payload),
-            "truncated": len(payload) < total,
-        }
+        # The sniffed prefix decoded cleanly but bytes further in did not (a
+        # file that is text up front and binary later). Fall back to the binary
+        # path so we never return garbled text.
+        return _read_binary_impl(path, max_binary_bytes)
 
     lines = text.splitlines(keepends=True)
     start = offset - 1

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -1032,15 +1032,20 @@ def _is_binary_file(path: Path) -> bool:
     """Classify *path* as binary by inspecting only its first chunk.
 
     Reads at most :data:`_BINARY_SNIFF_BYTES` and reports binary when those
-    bytes are not valid UTF-8. An incremental decoder is used with
-    ``final=False`` so a multi-byte character straddling the chunk boundary is
-    treated as *incomplete* (text), not invalid (binary).
+    bytes contain a NUL or are not valid UTF-8. The NUL check matters because
+    ``\x00`` *is* valid UTF-8, so a UTF-16/NUL-laden file would otherwise be
+    misread as text; checking for it explicitly matches git's heuristic. An
+    incremental decoder is used with ``final=False`` so a multi-byte character
+    straddling the chunk boundary is treated as *incomplete* (text), not
+    invalid (binary).
 
     :param path: Absolute path of the file to classify.
-    :returns: ``True`` if the prefix is not decodable as UTF-8.
+    :returns: ``True`` if the prefix contains a NUL or is not decodable UTF-8.
     """
     with path.open("rb") as fh:
         prefix = fh.read(_BINARY_SNIFF_BYTES)
+    if b"\x00" in prefix:
+        return True
     try:
         codecs.getincrementaldecoder("utf-8")("strict").decode(prefix, final=False)
     except UnicodeDecodeError:

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -553,7 +553,12 @@ class CallerProcessFilesystem:
 
         byte_truncated = len(data) > byte_cap
         if byte_truncated:
-            data = data[:byte_cap]
+            # Truncate on a valid UTF-8 boundary: a naive ``data[:byte_cap]``
+            # can split a multi-byte codepoint, leaving invalid UTF-8 that
+            # raises ``UnicodeDecodeError`` (500) when the API response path
+            # later decodes it. Dropping the partial trailing codepoint keeps
+            # ``data`` decodable.
+            data = data[:byte_cap].decode("utf-8", "ignore").encode("utf-8")
 
         # Also flag truncation when the line cap was hit.
         returned_lines = result.get("returned_lines")

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -11,6 +11,7 @@ filesystem service.
 
 from __future__ import annotations
 
+import base64
 import os
 import re
 import stat
@@ -521,18 +522,35 @@ class CallerProcessFilesystem:
         if not validated:
             raise InvalidPath("Cannot read the environment root")
 
+        byte_cap = max_bytes or _MAX_READ_BYTES
+
         result = await _run_os_env_async(
             self._os_env.read,
             validated,
             limit=limit,
+            # Inline binary content up to the byte cap so it can be served to
+            # the viewer / download. (The agent read path omits this and gets a
+            # descriptor only — see ``_read_impl``.)
+            max_binary_bytes=byte_cap,
         )
         if "error" in result:
             raise FilesystemPathNotFound(f"Path {path!r} not found")
 
+        # Binary files come back base64-encoded with encoding="base64", already
+        # capped to ``byte_cap`` by the helper, which also reports truncation.
+        if result.get("encoding") == "base64":
+            data = base64.b64decode(result.get("content", ""))
+            return FileContent(
+                path=path,
+                data=data,
+                bytes=len(data),
+                encoding=None,
+                truncated=bool(result.get("truncated")),
+            )
+
         content_str = result.get("content", "")
         data = content_str.encode("utf-8")
 
-        byte_cap = max_bytes or _MAX_READ_BYTES
         byte_truncated = len(data) > byte_cap
         if byte_truncated:
             data = data[:byte_cap]

--- a/tests/e2e_ui/files/test_image_rendering.py
+++ b/tests/e2e_ui/files/test_image_rendering.py
@@ -1,0 +1,106 @@
+"""E2E: image files render through the FileViewer's <ImageViewer>.
+
+A file the server classifies as an image (via ``mimetypes.guess_type`` →
+``content_type``) must render as an ``<img>`` fed by a blob URL, not as
+syntax-highlighted source or the binary placeholder.
+
+We use an SVG fixture rather than a raster image because the filesystem PUT
+endpoint can only seed text (``str.encode(encoding)`` — base64 is not a text
+codec), and SVG is valid UTF-8 that round-trips through that path. It also
+exercises the security-relevant case: SVG is rendered only through a blob URL
+(``<img src=blob:...>``), never inlined into the DOM, so any embedded script
+cannot execute. Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_IMAGE_FILE_PATH = "diagram.svg"
+
+# A minimal but valid SVG with explicit dimensions so the rendered <img> has a
+# non-zero natural size once the browser decodes it.
+_SVG_CONTENT = """\
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <rect width="120" height="80" fill="#4f46e5"/>
+  <circle cx="60" cy="40" r="24" fill="#ffffff"/>
+</svg>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_image_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed the SVG file and yield (base_url, session_id, path).
+
+    :param seeded_session: Runner-bound (base_url, session_id) pair.
+    :returns: ``(base_url, session_id, file_path)`` for the test body.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_IMAGE_FILE_PATH}"
+    )
+    resp = httpx.put(
+        file_url,
+        json={"content": _SVG_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, _IMAGE_FILE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_image_file_renders_as_img(
+    page: Page,
+    seeded_image_session: tuple[str, str, str],
+) -> None:
+    """An image file renders as a blob-backed <img>, not source or placeholder."""
+    base_url, session_id, _file_path = seeded_image_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    file_button = page.get_by_role("button", name=re.compile(rf"^{re.escape(_IMAGE_FILE_PATH)}\b"))
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    # Two FileViewer instances mount with the same test id (mobile push-panel,
+    # md:hidden, and the desktop rail). Match the visible one directly.
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    # The image renders as an <img> tagged with the filename as its alt text.
+    img = file_viewer.locator(f'img[alt="{_IMAGE_FILE_PATH}"]')
+    expect(img).to_be_visible(timeout=10_000)
+
+    # The blob actually decoded as an image — i.e. the onError fallback did NOT
+    # fire. A loaded <img> reports complete=true and naturalWidth>0.
+    page.wait_for_function(
+        "(el) => el.complete && el.naturalWidth > 0",
+        arg=img.element_handle(),
+        timeout=10_000,
+    )
+
+    # It rendered through the blob URL, never as inline SVG markup nor as the
+    # binary placeholder / source text.
+    expect(img).to_have_attribute("src", re.compile(r"^blob:"))
+    expect(file_viewer.get_by_text("Unable to render image")).to_have_count(0)
+    expect(file_viewer.locator("[contenteditable='true']")).to_have_count(0)

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -226,3 +226,22 @@ def test_read_impl_multibyte_char_straddling_sniff_boundary_is_text(tmp_path: Pa
 
     assert result["encoding"] == "utf-8"
     assert result["content"] == text
+
+
+def test_read_impl_nul_byte_file_classified_binary(tmp_path: Path) -> None:
+    """A NUL byte marks a file binary even though ``\\x00`` is valid UTF-8.
+
+    UTF-16/NUL-laden files decode cleanly as UTF-8, so without an explicit NUL
+    check they'd be misread as text and line-windowed into garbage.
+
+    :returns: None.
+    """
+    # UTF-16-LE-style ASCII: every byte is valid UTF-8, but the interleaved
+    # NULs make this binary.
+    f = tmp_path / "utf16.bin"
+    f.write_bytes(b"H\x00e\x00l\x00l\x00o\x00")
+
+    result = _read_impl(f, offset=1, limit=2_000)
+
+    assert result["encoding"] == "base64"
+    assert result["total_bytes"] == 10

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from omnigent.inner.os_env import build_helper_env
+import base64
+from pathlib import Path
+
+from omnigent.inner.os_env import _read_impl, build_helper_env
 from omnigent.inner.sandbox import SandboxPolicy
 from omnigent.runner.identity import RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR
 
@@ -81,3 +84,62 @@ def test_build_helper_env_active_drops_binding_token() -> None:
     assert RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR not in env
     assert "bug-binding-token-secret" not in env.values()
     assert env["PATH"] == "/usr/bin"  # PATH is in the default allowlist
+
+
+# ---------------------------------------------------------------------------
+# _read_impl — binary file handling
+# ---------------------------------------------------------------------------
+
+_BINARY = b"\x89PNG\r\n\x1a\n\x00\x01\x02\xff"
+
+
+def test_read_impl_binary_descriptor_for_agent(tmp_path: Path) -> None:
+    """With no byte cap (agent ``sys_os_read`` path) binary is not inlined.
+
+    The base64 payload would be useless to the model and could saturate the
+    context window, so only a descriptor is returned.
+
+    :returns: None.
+    """
+    f = tmp_path / "logo.png"
+    f.write_bytes(_BINARY)
+
+    result = _read_impl(f, offset=1, limit=2_000)
+
+    assert result["encoding"] == "base64"
+    assert result["content"] == ""
+    assert result["total_bytes"] == len(_BINARY)
+    assert result["truncated"] is True
+    assert "note" in result
+
+
+def test_read_impl_binary_inlined_within_cap(tmp_path: Path) -> None:
+    """A byte cap larger than the file inlines the whole payload, untruncated.
+
+    :returns: None.
+    """
+    f = tmp_path / "logo.png"
+    f.write_bytes(_BINARY)
+
+    result = _read_impl(f, offset=1, limit=2_000, max_binary_bytes=10 * 1024 * 1024)
+
+    assert result["encoding"] == "base64"
+    assert base64.b64decode(result["content"]) == _BINARY
+    assert result["total_bytes"] == len(_BINARY)
+    assert result["truncated"] is False
+
+
+def test_read_impl_binary_truncated_at_cap(tmp_path: Path) -> None:
+    """A byte cap smaller than the file truncates and flags it.
+
+    :returns: None.
+    """
+    f = tmp_path / "logo.png"
+    f.write_bytes(_BINARY)
+
+    result = _read_impl(f, offset=1, limit=2_000, max_binary_bytes=4)
+
+    assert base64.b64decode(result["content"]) == _BINARY[:4]
+    assert result["returned_bytes"] == 4
+    assert result["total_bytes"] == len(_BINARY)
+    assert result["truncated"] is True

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import tracemalloc
 from pathlib import Path
 
 from omnigent.inner.os_env import _read_impl, build_helper_env
@@ -144,3 +145,84 @@ def test_read_impl_binary_truncated_at_cap(tmp_path: Path) -> None:
     assert result["returned_bytes"] == 4
     assert result["total_bytes"] == len(_BINARY)
     assert result["truncated"] is True
+
+
+def _make_large_binary(path: Path, size: int) -> None:
+    """Write a sparse file with a binary prefix and a logical size of *size*.
+
+    The 8 KB binary prefix forces the prefix-sniff to classify it binary; the
+    ``truncate`` extends the (sparse) file to *size* without writing the bytes,
+    so the test stays cheap while exercising a large logical file.
+
+    :returns: None.
+    """
+    with path.open("wb") as fh:
+        fh.write(b"\xff\xfe\x00\x01" * 2_048)  # 8 KB of non-UTF-8 bytes
+        fh.truncate(size)
+
+
+def test_read_impl_binary_descriptor_does_not_read_whole_file(tmp_path: Path) -> None:
+    """The descriptor path is O(1): it stats the size, never reading content.
+
+    Regression guard for inlining the whole file (``path.read_bytes()``) just
+    to compute ``total_bytes`` — which would OOM on large workspace blobs.
+
+    :returns: None.
+    """
+    size = 256 * 1024 * 1024  # 256 MB logical, only ~8 KB on disk
+    f = tmp_path / "big.bin"
+    _make_large_binary(f, size)
+
+    tracemalloc.start()
+    try:
+        result = _read_impl(f, offset=1, limit=2_000)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert result["total_bytes"] == size
+    assert result["content"] == ""
+    # A full read would have allocated ~256 MB; bounded reads stay tiny.
+    assert peak < 10 * 1024 * 1024
+
+
+def test_read_impl_binary_cap_reads_only_the_cap(tmp_path: Path) -> None:
+    """The byte-capped path reads at most ``max_binary_bytes``, not the file.
+
+    :returns: None.
+    """
+    size = 256 * 1024 * 1024
+    f = tmp_path / "big.bin"
+    _make_large_binary(f, size)
+
+    tracemalloc.start()
+    try:
+        result = _read_impl(f, offset=1, limit=2_000, max_binary_bytes=16)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert result["returned_bytes"] == 16
+    assert result["total_bytes"] == size
+    assert result["truncated"] is True
+    assert peak < 10 * 1024 * 1024
+
+
+def test_read_impl_multibyte_char_straddling_sniff_boundary_is_text(tmp_path: Path) -> None:
+    """A multi-byte char split across the 8 KB sniff boundary stays text.
+
+    The incremental decoder must treat the truncated trailing sequence as
+    *incomplete*, not invalid — otherwise valid UTF-8 would be misread as
+    binary purely because of where the prefix happened to be cut.
+
+    :returns: None.
+    """
+    # 8 KB sniff window cuts the 3-byte '€' (0xE2 0x82 0xAC) at byte 8191.
+    text = "a" * 8_190 + "€" + "tail\n"
+    f = tmp_path / "wide.txt"
+    f.write_text(text, encoding="utf-8")
+
+    result = _read_impl(f, offset=1, limit=2_000)
+
+    assert result["encoding"] == "utf-8"
+    assert result["content"] == text

--- a/tests/inner/test_os_env.py
+++ b/tests/inner/test_os_env.py
@@ -109,7 +109,8 @@ def test_read_impl_binary_descriptor_for_agent(tmp_path: Path) -> None:
     assert result["encoding"] == "base64"
     assert result["content"] == ""
     assert result["total_bytes"] == len(_BINARY)
-    assert result["truncated"] is True
+    # Not truncated — the payload was deliberately omitted, not cut short.
+    assert result["truncated"] is False
     assert "note" in result
 
 

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -205,7 +205,8 @@ async def test_read_text_byte_cap_truncates_on_utf8_boundary(
     ``UnicodeDecodeError`` (500) when the response path later decodes them.
     The read path must truncate on a valid boundary instead.
     """
-    # "é" is 2 bytes (0xC3 0xA9) in UTF-8; a 1-byte cap lands mid-codepoint.
+    # "é" is 2 bytes (0xC3 0xA9) in UTF-8; on "aé" a 2-byte cap keeps the "a"
+    # and lands mid-codepoint inside "é".
     (workspace / "accents.txt").write_text("aé")
 
     os_env = create_os_environment(

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -29,6 +29,9 @@ def workspace(tmp_path: Path) -> Path:
     (ws / "hello.txt").write_text("hello world")
     (ws / "src").mkdir()
     (ws / "src" / "main.py").write_text("print('hi')")
+    # A binary file (PNG signature + a NUL) that is not valid UTF-8, used to
+    # exercise the base64 binary-read path.
+    (ws / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x01\x02\xff")
     return ws
 
 
@@ -165,6 +168,29 @@ async def test_read_file_content(
     assert body["content"] == "hello world"
     assert body["encoding"] == "utf-8"
     assert body["bytes"] == 11
+
+
+@pytest.mark.asyncio
+async def test_read_binary_file_content(
+    client: httpx.AsyncClient,
+) -> None:
+    """A non-UTF-8 file is returned whole as base64, not truncated text."""
+    import base64
+
+    raw = b"\x89PNG\r\n\x1a\n\x00\x01\x02\xff"
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/logo.png"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["encoding"] == "base64"
+    assert body["content_type"] == "image/png"
+    # The base64 payload round-trips to the exact original bytes — no
+    # UTF-8 replacement-char corruption.
+    assert base64.b64decode(body["content"]) == raw
+    assert body["bytes"] == len(raw)
+    assert body["truncated"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -17,6 +17,7 @@ from omnigent.entities.environment_filesystem import FilesystemPathNotFound
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.os_env import create_os_environment
 from omnigent.runner import create_runner_app
+from omnigent.runner.environment_filesystem import CallerProcessFilesystem
 from omnigent.runner.resource_registry import SessionResourceRegistry
 from tests.runner.helpers import NullServerClient
 
@@ -191,6 +192,32 @@ async def test_read_binary_file_content(
     assert base64.b64decode(body["content"]) == raw
     assert body["bytes"] == len(raw)
     assert body["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_text_byte_cap_truncates_on_utf8_boundary(
+    workspace: Path,
+) -> None:
+    """A byte cap that lands mid-codepoint still yields decodable UTF-8.
+
+    Slicing the raw UTF-8 byte string at an arbitrary cap can split a
+    multi-byte codepoint, leaving invalid bytes that raise
+    ``UnicodeDecodeError`` (500) when the response path later decodes them.
+    The read path must truncate on a valid boundary instead.
+    """
+    # "é" is 2 bytes (0xC3 0xA9) in UTF-8; a 1-byte cap lands mid-codepoint.
+    (workspace / "accents.txt").write_text("aé")
+
+    os_env = create_os_environment(
+        OSEnvSpec(type="caller_process", cwd=str(workspace), sandbox=OSEnvSandboxSpec(type="none"))
+    )
+    assert os_env is not None
+    fs = CallerProcessFilesystem(os_env)
+
+    content = await fs.read("accents.txt", max_bytes=2)
+    assert content.truncated is True
+    # The partial trailing codepoint is dropped, leaving decodable bytes.
+    assert content.data.decode("utf-8") == "a"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Workspace files that are images now render as **images** in the FileViewer, instead of as garbled source text or a "binary file" placeholder.

## Why

The filesystem read path decoded everything as UTF-8 (`errors="replace"`), so an image opened in the viewer showed replacement-char garbage. This adds a proper binary read path and an image renderer.

## Changes

**Backend (`omnigent/inner/os_env.py`, `omnigent/runner/environment_filesystem.py`)**
- `_read_impl` reads raw bytes and attempts a strict UTF-8 decode. Files that decode cleanly keep the existing line-windowed text behavior; files that don't are returned base64-encoded.
- Binary reads are **byte-capped**, not line-capped:
  - The agent `sys_os_read` path (no cap) returns a **descriptor only** (`total_bytes` + a note) — a base64 blob the model can't decode would otherwise waste / saturate the context window.
  - The filesystem service passes an explicit cap (10 MiB) to get the actual bytes for the viewer/download, capping *before* base64-encoding and IPC transfer, and trusts the helper's `truncated` flag.

**Frontend (`ap-web/src/shell/*`)**
- `isImageFile` — MIME-first (server `content_type` is authoritative), extension fallback.
- New `ImageViewer` renders via a blob URL. SVG is included but only ever rendered through `<img src=blob:…>`, never inlined into the DOM, so embedded scripts can't execute.
- FileViewer suppresses the diff button for images (no source/diff representation).

## Tests

- `_read_impl` binary handling (descriptor / within-cap / truncated) — `tests/inner/test_os_env.py`
- server-side binary read base64 round-trip — `tests/runner/test_environment_filesystem.py`
- `isImageFile` matrix — `ap-web/src/shell/codeViewerHelpers.test.ts`
- CodeViewer image render with a real base64 PNG — `ap-web/src/shell/CodeViewer.test.tsx`
- e2e_ui SVG render through the live stack — `tests/e2e_ui/files/test_image_rendering.py`

Verified locally: `npm test` (2861 passed), `npm run build` (type-check + build clean), `npm run lint`, pre-commit, and the relevant `pytest` + e2e_ui tests all pass.

> Note: a real-PNG browser e2e isn't possible yet because the filesystem write path (PUT) is text-only, so binary fixtures can't be seeded into the runner workspace. The PNG render branch is covered by the component test instead. Adding base64 write support (to close the read/write asymmetry) is a possible follow-up.