### PR TITLE
feat(cursor): enforce PHASE_TOOL_CALL via preToolUse hook for all native tools

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -356,6 +356,21 @@ def _encode_tool_result(result: Any) -> Any:  # type: ignore[explicit-any]
 # ---------------------------------------------------------------------------
 
 
+def _get_conversation_id() -> str | None:
+    """Extract the ``--conversation-id`` value from the CLI args.
+
+    The harness subprocess is launched by :mod:`process_manager` with
+    ``--conversation-id conv_<hex>`` on the command line. This is the
+    canonical server-side conversation ID (with ``conv_`` prefix) that
+    the policy evaluation endpoint expects.
+    """
+    argv = sys.argv
+    for i, arg in enumerate(argv):
+        if arg == "--conversation-id" and i + 1 < len(argv):
+            return argv[i + 1]
+    return None
+
+
 def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, session_id: str) -> Path:
     """Write ``.cursor/hooks.json`` to the workspace for preToolUse policy enforcement.
 
@@ -569,7 +584,6 @@ class CursorExecutor(Executor):
         state: _CursorSessionState,
         model: str,
         tools: list[ToolSpec],
-        session_key: str,
     ) -> None:
         """Launch the local bridge and create the SDK agent if not already live.
 
@@ -582,9 +596,6 @@ class CursorExecutor(Executor):
         PHASE_TOOL_CALL policies are enforced on ALL Cursor native tools --
         including those that execute silently without emitting ``tool_call``
         SDK messages.
-
-        :param session_key: The conversation/session ID, baked into the hooks
-            command so the hook script can call the server's policy endpoint.
         """
         if state.agent is not None:
             return
@@ -602,10 +613,14 @@ class CursorExecutor(Executor):
         # Write .cursor/hooks.json for preToolUse policy enforcement.
         # RUNNER_SERVER_URL is inherited by the harness subprocess via
         # _build_harness_spawn_env (process_manager.py).
+        # The conversation_id comes from the --conversation-id CLI arg
+        # passed by the process_manager — NOT from the executor's
+        # session_key (which is an internal UUID without the conv_ prefix).
         server_url = os.environ.get("RUNNER_SERVER_URL", "")
-        if server_url and session_key != "__default__":
+        conv_id = _get_conversation_id()
+        if server_url and conv_id:
             hook_script = str(Path(__file__).with_name("cursor_policy_hook.py"))
-            state.hooks_file = _write_cursor_hooks(cwd, hook_script, server_url, session_key)
+            state.hooks_file = _write_cursor_hooks(cwd, hook_script, server_url, conv_id)
 
         client = await AsyncClient.launch_bridge(workspace=cwd)
         try:
@@ -659,7 +674,7 @@ class CursorExecutor(Executor):
         state.tools_fingerprint = tools_fp
 
         try:
-            await self._ensure_session(state, model, tools, session_key)
+            await self._ensure_session(state, model, tools)
         except Exception as exc:  # noqa: BLE001 — surfaced as ExecutorError (CancelledError propagates)
             await self.close_session(session_key)
             yield ExecutorError(message=f"Failed to start cursor-sdk agent: {exc}")

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -372,11 +372,11 @@ def _get_conversation_id() -> str | None:
 
 
 def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, session_id: str) -> Path:
-    """Write ``.cursor/hooks.json`` to the workspace for preToolUse policy enforcement.
+    """Write ``.cursor/hooks.json`` and a wrapper shell script for preToolUse policy enforcement.
 
-    The hook command bakes the server URL and session ID as inline env vars so
-    the standalone hook script can reach the Omnigent server without any shared
-    state or bridge-directory protocol.
+    The Cursor SDK hook executor runs the command directly (not via a shell),
+    so inline ``env VAR=val`` doesn't work.  Instead we write a tiny shell
+    wrapper that exports the env vars and execs the Python hook script.
 
     :param cwd: Workspace root directory.
     :param hook_script_path: Absolute path to ``cursor_policy_hook.py``.
@@ -387,14 +387,19 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
     hooks_dir = Path(cwd) / ".cursor"
     hooks_dir.mkdir(parents=True, exist_ok=True)
     hooks_file = hooks_dir / "hooks.json"
-    # Bake env vars into the command so the hook script can read them without
-    # relying on the bridge subprocess's inherited environment.
-    command = (
-        f"env _OMNIGENT_SERVER_URL={server_url} "
-        f"_OMNIGENT_SESSION_ID={session_id} "
-        f"{sys.executable} {hook_script_path}"
+
+    # Write a wrapper script that sets env vars and execs the hook.
+    wrapper = hooks_dir / "omnigent-hook.sh"
+    wrapper.write_text(
+        f"#!/bin/sh\n"
+        f"export _OMNIGENT_SERVER_URL='{server_url}'\n"
+        f"export _OMNIGENT_SESSION_ID='{session_id}'\n"
+        f"exec '{sys.executable}' '{hook_script_path}'\n"
     )
+    wrapper.chmod(0o755)
+    command = str(wrapper)
     config = {
+        "version": 1,
         "hooks": {
             "preToolUse": [
                 {
@@ -608,7 +613,7 @@ class CursorExecutor(Executor):
             ) from exc
 
         loop = asyncio.get_running_loop()
-        cwd = self._cwd or os.getcwd()
+        cwd = os.path.abspath(self._cwd or os.getcwd())
 
         # Write .cursor/hooks.json for preToolUse policy enforcement.
         # RUNNER_SERVER_URL is inherited by the harness subprocess via
@@ -822,10 +827,13 @@ class CursorExecutor(Executor):
         if state.client is not None:
             await _safe_close(state.client)
             state.client = None
-        # Best-effort cleanup of the hooks.json we wrote at session startup.
+        # Best-effort cleanup of hooks.json and the wrapper script.
         if state.hooks_file is not None:
             try:
                 state.hooks_file.unlink(missing_ok=True)
+                # Also remove the wrapper shell script alongside hooks.json.
+                wrapper = state.hooks_file.parent / "omnigent-hook.sh"
+                wrapper.unlink(missing_ok=True)
             except OSError:
                 pass
             state.hooks_file = None

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -46,8 +46,9 @@ import contextlib
 import json
 import logging
 import os
+import sys
 from collections.abc import AsyncIterator, Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -355,6 +356,43 @@ def _encode_tool_result(result: Any) -> Any:  # type: ignore[explicit-any]
 # ---------------------------------------------------------------------------
 
 
+def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, session_id: str) -> Path:
+    """Write ``.cursor/hooks.json`` to the workspace for preToolUse policy enforcement.
+
+    The hook command bakes the server URL and session ID as inline env vars so
+    the standalone hook script can reach the Omnigent server without any shared
+    state or bridge-directory protocol.
+
+    :param cwd: Workspace root directory.
+    :param hook_script_path: Absolute path to ``cursor_policy_hook.py``.
+    :param server_url: Omnigent server URL, e.g. ``"http://127.0.0.1:6767"``.
+    :param session_id: Conversation / session ID for policy evaluation.
+    :returns: The path to the written ``hooks.json`` file.
+    """
+    hooks_dir = Path(cwd) / ".cursor"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hooks_file = hooks_dir / "hooks.json"
+    # Bake env vars into the command so the hook script can read them without
+    # relying on the bridge subprocess's inherited environment.
+    command = (
+        f"env _OMNIGENT_SERVER_URL={server_url} "
+        f"_OMNIGENT_SESSION_ID={session_id} "
+        f"{sys.executable} {hook_script_path}"
+    )
+    config = {
+        "hooks": {
+            "preToolUse": [
+                {
+                    "command": command,
+                    "timeout": 30,
+                }
+            ]
+        }
+    }
+    hooks_file.write_text(json.dumps(config, indent=2))
+    return hooks_file
+
+
 @dataclass
 class _CursorSessionState:
     """Per-Omnigent-conversation SDK session state."""
@@ -365,6 +403,7 @@ class _CursorSessionState:
     model: str | None = None
     tools_fingerprint: str | None = None
     has_sent_prompt: bool = False
+    hooks_file: Path | None = field(default=None, repr=False)
 
 
 class CursorExecutor(Executor):
@@ -526,13 +565,26 @@ class CursorExecutor(Executor):
     # -- session lifecycle --------------------------------------------------
 
     async def _ensure_session(
-        self, state: _CursorSessionState, model: str, tools: list[ToolSpec]
+        self,
+        state: _CursorSessionState,
+        model: str,
+        tools: list[ToolSpec],
+        session_key: str,
     ) -> None:
         """Launch the local bridge and create the SDK agent if not already live.
 
         On any bring-up failure the partially-created client is closed before
         propagating, so a bad ``CURSOR_API_KEY`` / launch error can't orphan a
         bridge subprocess.
+
+        Before agent creation, writes ``.cursor/hooks.json`` to the workspace
+        with a ``preToolUse`` hook pointing at :mod:`cursor_policy_hook` so
+        PHASE_TOOL_CALL policies are enforced on ALL Cursor native tools --
+        including those that execute silently without emitting ``tool_call``
+        SDK messages.
+
+        :param session_key: The conversation/session ID, baked into the hooks
+            command so the hook script can call the server's policy endpoint.
         """
         if state.agent is not None:
             return
@@ -546,12 +598,25 @@ class CursorExecutor(Executor):
 
         loop = asyncio.get_running_loop()
         cwd = self._cwd or os.getcwd()
+
+        # Write .cursor/hooks.json for preToolUse policy enforcement.
+        # RUNNER_SERVER_URL is inherited by the harness subprocess via
+        # _build_harness_spawn_env (process_manager.py).
+        server_url = os.environ.get("RUNNER_SERVER_URL", "")
+        if server_url and session_key != "__default__":
+            hook_script = str(Path(__file__).with_name("cursor_policy_hook.py"))
+            state.hooks_file = _write_cursor_hooks(cwd, hook_script, server_url, session_key)
+
         client = await AsyncClient.launch_bridge(workspace=cwd)
         try:
-            local = LocalAgentOptions(
-                cwd=cwd,
-                custom_tools=self._make_custom_tools(tools, loop) or None,
-            )
+            local_kwargs: dict[str, Any] = {
+                "cwd": cwd,
+                "custom_tools": self._make_custom_tools(tools, loop) or None,
+            }
+            # Tell the SDK to read project-level settings (including hooks.json).
+            if state.hooks_file is not None:
+                local_kwargs["setting_sources"] = ["project"]
+            local = LocalAgentOptions(**local_kwargs)
             agent = await AsyncAgent.create(
                 client=client,
                 model=model,
@@ -594,7 +659,7 @@ class CursorExecutor(Executor):
         state.tools_fingerprint = tools_fp
 
         try:
-            await self._ensure_session(state, model, tools)
+            await self._ensure_session(state, model, tools, session_key)
         except Exception as exc:  # noqa: BLE001 — surfaced as ExecutorError (CancelledError propagates)
             await self.close_session(session_key)
             yield ExecutorError(message=f"Failed to start cursor-sdk agent: {exc}")
@@ -742,6 +807,13 @@ class CursorExecutor(Executor):
         if state.client is not None:
             await _safe_close(state.client)
             state.client = None
+        # Best-effort cleanup of the hooks.json we wrote at session startup.
+        if state.hooks_file is not None:
+            try:
+                state.hooks_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+            state.hooks_file = None
 
     async def close_session(self, session_key: str) -> None:
         state = self._session_states.pop(session_key, None)

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -407,7 +407,7 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
                     "timeout": 30,
                 }
             ]
-        }
+        },
     }
     hooks_file.write_text(json.dumps(config, indent=2))
     return hooks_file

--- a/omnigent/inner/cursor_policy_hook.py
+++ b/omnigent/inner/cursor_policy_hook.py
@@ -1,0 +1,100 @@
+"""Cursor preToolUse hook script for Omnigent policy enforcement.
+
+Standalone script -- no omnigent imports.  Runs as a subprocess of the
+Cursor SDK bridge process, not the harness.
+
+Reads tool-call info from stdin (Cursor hook protocol), evaluates
+PHASE_TOOL_CALL policy via the Omnigent server, and returns the
+verdict on stdout.
+
+Environment variables (baked into the hooks.json command by the
+CursorExecutor at session startup):
+
+    _OMNIGENT_SERVER_URL  : Base URL of the Omnigent server
+                            (e.g. ``http://127.0.0.1:6767``).
+    _OMNIGENT_SESSION_ID  : Session / conversation ID for policy
+                            evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> None:
+    server_url = os.environ.get("_OMNIGENT_SERVER_URL", "")
+    session_id = os.environ.get("_OMNIGENT_SESSION_ID", "")
+
+    if not server_url or not session_id:
+        # No server wired -- fail open (allow).
+        json.dump({"permission": "allow"}, sys.stdout)
+        return
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError, ValueError):
+        json.dump({"permission": "allow"}, sys.stdout)
+        return
+
+    tool_name = payload.get("tool_name") or payload.get("toolName") or "unknown"
+    tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
+
+    # Build the evaluation request matching the server's EvaluationRequest
+    # schema.
+    eval_body = json.dumps(
+        {
+            "event": {
+                "type": "PHASE_TOOL_CALL",
+                "target": "",
+                "data": {
+                    "name": tool_name,
+                    "arguments": tool_input if isinstance(tool_input, dict) else {},
+                },
+                "context": {},
+            },
+        }
+    ).encode()
+
+    url = f"{server_url.rstrip('/')}/v1/sessions/{session_id}/policies/evaluate"
+
+    try:
+        req = urllib.request.Request(
+            url,
+            data=eval_body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=25) as resp:
+            result = json.loads(resp.read())
+    except Exception:  # noqa: BLE001 -- fail open on any error
+        # Network error / timeout / server down -- fail open.
+        json.dump({"permission": "allow"}, sys.stdout)
+        return
+
+    action = result.get("result", "POLICY_ACTION_ALLOW")
+    reason = result.get("reason", "")
+
+    if action == "POLICY_ACTION_DENY":
+        out: dict[str, str] = {"permission": "deny"}
+        if reason:
+            out["agent_message"] = f"Tool '{tool_name}' denied by Omnigent policy: {reason}"
+        json.dump(out, sys.stdout)
+    elif action == "POLICY_ACTION_ASK":
+        # ASK means the server already resolved approval (it parks the
+        # HTTP request until the human decides).  If we get ASK here it
+        # means the server couldn't resolve it -- fail closed.
+        out = {"permission": "deny"}
+        if reason:
+            out["agent_message"] = f"Tool '{tool_name}' requires approval: {reason}"
+        json.dump(out, sys.stdout)
+    else:
+        # ALLOW or UNSPECIFIED
+        json.dump({"permission": "allow"}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -114,7 +114,10 @@ def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
     if not isinstance(data, dict):
         return _ALLOW
     tool = data.get("name", "")
-    if tool in _SYS_OS_TOOLS or tool in _NATIVE_OS_TOOLS or tool in _CURSOR_NATIVE_OS_TOOLS or tool in _PI_NATIVE_OS_TOOLS:
+    _all_os_tools = (
+        _SYS_OS_TOOLS | _NATIVE_OS_TOOLS | _CURSOR_NATIVE_OS_TOOLS | _PI_NATIVE_OS_TOOLS
+    )
+    if tool in _all_os_tools:
         args = data.get("arguments", {})
         # Build a short preview of what the tool is doing.
         if tool in ("sys_os_shell", "Bash", "bash", "Shell"):

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -23,6 +23,12 @@ _SYS_OS_TOOLS = frozenset({"sys_os_read", "sys_os_write", "sys_os_edit", "sys_os
 # inside the CLI subprocess.
 _NATIVE_OS_TOOLS = frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
 
+# Cursor SDK native tool names surfaced via the preToolUse hook
+# (see ``omnigent.inner.cursor_policy_hook``). Cursor uses ``Shell``
+# for its terminal tool (not ``Bash``). ``Read`` / ``Write`` / ``Edit``
+# are already in ``_NATIVE_OS_TOOLS`` above.
+_CURSOR_NATIVE_OS_TOOLS = frozenset({"Shell"})
+
 # Pi native tool names (lowercase), surfaced via the pi ``tool_call``
 # extension hook (see ``omnigent.inner.pi_executor._gate_native_tool``).
 # Pi runs these in-process and routes them through the same TOOL_CALL
@@ -79,7 +85,7 @@ def max_tool_calls_per_session(limit: int = 100) -> PolicyCallable:
 def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
     """ASK for user approval before any file or shell tool call.
 
-    Covers four tool-name families:
+    Covers five tool-name families:
 
     - **Omnigent built-in OS tools** (``sys_os_read``,
       ``sys_os_write``, ``sys_os_edit``, ``sys_os_shell``).
@@ -88,6 +94,9 @@ def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
       ``PreToolUse`` hook contract.
     - **Codex native tools** — uses the same ``PreToolUse`` hook
       contract with the same tool names (e.g. ``Bash``).
+    - **Cursor SDK native tools** (``Shell``) — surfaced via the
+      ``preToolUse`` hook (see ``cursor_policy_hook.py``). Cursor
+      uses ``Shell`` instead of ``Bash`` for its terminal tool.
     - **Pi native tools** (``read``, ``bash``, ``write``, ``edit``)
       — surfaced via the pi ``tool_call`` extension hook. Lowercase
       and distinct from the Claude/Codex casing.
@@ -105,10 +114,10 @@ def ask_on_os_tools(event: PolicyEvent) -> PolicyResponse:
     if not isinstance(data, dict):
         return _ALLOW
     tool = data.get("name", "")
-    if tool in _SYS_OS_TOOLS or tool in _NATIVE_OS_TOOLS or tool in _PI_NATIVE_OS_TOOLS:
+    if tool in _SYS_OS_TOOLS or tool in _NATIVE_OS_TOOLS or tool in _CURSOR_NATIVE_OS_TOOLS or tool in _PI_NATIVE_OS_TOOLS:
         args = data.get("arguments", {})
         # Build a short preview of what the tool is doing.
-        if tool in ("sys_os_shell", "Bash", "bash"):
+        if tool in ("sys_os_shell", "Bash", "bash", "Shell"):
             preview = args.get("command", "") if isinstance(args, dict) else ""
         elif tool in ("Grep", "Glob"):
             preview = args.get("pattern", "") if isinstance(args, dict) else ""

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1069,6 +1069,7 @@ async def test_ensure_session_writes_hooks_json(
     correct preToolUse config pointing at the hook script."""
     _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    monkeypatch.setattr("sys.argv", ["runner", "--conversation-id", "conv_test123"])
     cwd = str(tmp_path)
     executor = CursorExecutor(api_key="crsr_x", cwd=cwd)
     _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
@@ -1084,7 +1085,7 @@ async def test_ensure_session_writes_hooks_json(
     assert hooks[0]["timeout"] == 30
     cmd = hooks[0]["command"]
     assert "_OMNIGENT_SERVER_URL=http://127.0.0.1:6767" in cmd
-    assert "_OMNIGENT_SESSION_ID=conv1" in cmd
+    assert "_OMNIGENT_SESSION_ID=conv_test123" in cmd
     assert "cursor_policy_hook.py" in cmd
 
     await executor.close()
@@ -1118,6 +1119,7 @@ async def test_hooks_json_cleaned_up_on_close(
         [{"messages": [_assistant("ok")], "result": "ok"}],
     )
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    monkeypatch.setattr("sys.argv", ["runner", "--conversation-id", "conv_cleanup"])
     cwd = str(tmp_path)
     executor = CursorExecutor(api_key="crsr_x", cwd=cwd)
     _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1084,11 +1084,21 @@ async def test_ensure_session_writes_hooks_json(
     assert len(hooks) == 1
     assert hooks[0]["timeout"] == 30
     cmd = hooks[0]["command"]
-    assert "_OMNIGENT_SERVER_URL=http://127.0.0.1:6767" in cmd
-    assert "_OMNIGENT_SESSION_ID=conv_test123" in cmd
-    assert "cursor_policy_hook.py" in cmd
+    # The command points to the wrapper shell script, not the Python hook directly.
+    assert "omnigent-hook.sh" in cmd
+
+    # Verify the wrapper script exists and contains the env vars + exec.
+    wrapper = tmp_path / ".cursor" / "omnigent-hook.sh"
+    assert wrapper.exists()
+    wrapper_text = wrapper.read_text()
+    assert "_OMNIGENT_SERVER_URL='http://127.0.0.1:6767'" in wrapper_text
+    assert "_OMNIGENT_SESSION_ID='conv_test123'" in wrapper_text
+    assert "cursor_policy_hook.py" in wrapper_text
 
     await executor.close()
+    # Both files are cleaned up on close.
+    assert not hooks_file.exists()
+    assert not wrapper.exists()
 
 
 async def test_hooks_json_not_written_without_server_url(
@@ -1125,10 +1135,13 @@ async def test_hooks_json_cleaned_up_on_close(
     _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
 
     hooks_file = tmp_path / ".cursor" / "hooks.json"
+    wrapper = tmp_path / ".cursor" / "omnigent-hook.sh"
     assert hooks_file.exists()
+    assert wrapper.exists()
 
     await executor.close()
     assert not hooks_file.exists()
+    assert not wrapper.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1054,3 +1054,221 @@ async def test_run_turn_native_tool_allowed_by_policy(monkeypatch: pytest.Monkey
     # The tool call went through.
     reqs = [e for e in events if isinstance(e, ToolCallRequest)]
     assert len(reqs) == 1 and reqs[0].name == "bash"
+
+
+# ---------------------------------------------------------------------------
+# preToolUse hook: .cursor/hooks.json writing and cleanup
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_session_writes_hooks_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """After _ensure_session, .cursor/hooks.json exists in the workspace with the
+    correct preToolUse config pointing at the hook script."""
+    _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    cwd = str(tmp_path)
+    executor = CursorExecutor(api_key="crsr_x", cwd=cwd)
+    _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+
+    # Assert BEFORE close (close cleans up the file).
+    hooks_file = tmp_path / ".cursor" / "hooks.json"
+    assert hooks_file.exists()
+    config = json.loads(hooks_file.read_text())
+    assert "hooks" in config
+    assert "preToolUse" in config["hooks"]
+    hooks = config["hooks"]["preToolUse"]
+    assert len(hooks) == 1
+    assert hooks[0]["timeout"] == 30
+    cmd = hooks[0]["command"]
+    assert "_OMNIGENT_SERVER_URL=http://127.0.0.1:6767" in cmd
+    assert "_OMNIGENT_SESSION_ID=conv1" in cmd
+    assert "cursor_policy_hook.py" in cmd
+
+    await executor.close()
+
+
+async def test_hooks_json_not_written_without_server_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Without RUNNER_SERVER_URL in env, no hooks.json is written."""
+    _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    monkeypatch.delenv("RUNNER_SERVER_URL", raising=False)
+    cwd = str(tmp_path)
+    executor = CursorExecutor(api_key="crsr_x", cwd=cwd)
+    try:
+        _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    hooks_file = tmp_path / ".cursor" / "hooks.json"
+    assert not hooks_file.exists()
+
+
+async def test_hooks_json_cleaned_up_on_close(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """hooks.json is removed when the session is closed."""
+    _install_fake_sdk(
+        monkeypatch,
+        [{"messages": [_assistant("ok")], "result": "ok"}],
+    )
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
+    cwd = str(tmp_path)
+    executor = CursorExecutor(api_key="crsr_x", cwd=cwd)
+    _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+
+    hooks_file = tmp_path / ".cursor" / "hooks.json"
+    assert hooks_file.exists()
+
+    await executor.close()
+    assert not hooks_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# cursor_policy_hook.py unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_policy_hook_allow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hook script returns allow when the server responds with ALLOW."""
+    import io
+    from unittest.mock import patch
+
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+    stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+    server_response = json.dumps({"result": "POLICY_ACTION_ALLOW", "reason": ""}).encode()
+
+    from omnigent.inner import cursor_policy_hook
+
+    fake_resp = io.BytesIO(server_response)
+    fake_resp.read = fake_resp.read  # type: ignore[assignment]
+    fake_resp.__enter__ = lambda s: s  # type: ignore[attr-defined]
+    fake_resp.__exit__ = lambda s, *a: None  # type: ignore[attr-defined]
+
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout),
+        patch("urllib.request.urlopen", return_value=fake_resp),
+    ):
+        cursor_policy_hook.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["permission"] == "allow"
+
+
+def test_cursor_policy_hook_deny(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hook script returns deny when the server responds with DENY."""
+    import io
+    from unittest.mock import patch
+
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+    stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}})
+    server_response = json.dumps(
+        {"result": "POLICY_ACTION_DENY", "reason": "dangerous command"}
+    ).encode()
+
+    from omnigent.inner import cursor_policy_hook
+
+    fake_resp = io.BytesIO(server_response)
+    fake_resp.__enter__ = lambda s: s  # type: ignore[attr-defined]
+    fake_resp.__exit__ = lambda s, *a: None  # type: ignore[attr-defined]
+
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout),
+        patch("urllib.request.urlopen", return_value=fake_resp),
+    ):
+        cursor_policy_hook.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["permission"] == "deny"
+    assert "dangerous command" in result["agent_message"]
+    assert "Bash" in result["agent_message"]
+
+
+def test_cursor_policy_hook_network_error_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On network error, the hook script fails open (allows)."""
+    import io
+    from unittest.mock import patch
+
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+    stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+
+    from omnigent.inner import cursor_policy_hook
+
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout),
+        patch("urllib.request.urlopen", side_effect=OSError("connection refused")),
+    ):
+        cursor_policy_hook.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["permission"] == "allow"
+
+
+def test_cursor_policy_hook_no_env_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without server URL / session ID env vars, the hook allows."""
+    import io
+    from unittest.mock import patch
+
+    monkeypatch.delenv("_OMNIGENT_SERVER_URL", raising=False)
+    monkeypatch.delenv("_OMNIGENT_SESSION_ID", raising=False)
+
+    from omnigent.inner import cursor_policy_hook
+
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO("{}")),
+        patch.object(sys, "stdout", stdout),
+    ):
+        cursor_policy_hook.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["permission"] == "allow"
+
+
+def test_cursor_policy_hook_ask_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ASK verdict (unresolved approval) fails closed with deny."""
+    import io
+    from unittest.mock import patch
+
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+    stdin_data = json.dumps({"tool_name": "Write", "tool_input": {}})
+    server_response = json.dumps(
+        {"result": "POLICY_ACTION_ASK", "reason": "needs approval"}
+    ).encode()
+
+    from omnigent.inner import cursor_policy_hook
+
+    fake_resp = io.BytesIO(server_response)
+    fake_resp.__enter__ = lambda s: s  # type: ignore[attr-defined]
+    fake_resp.__exit__ = lambda s, *a: None  # type: ignore[attr-defined]
+
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout),
+        patch("urllib.request.urlopen", return_value=fake_resp),
+    ):
+        cursor_policy_hook.main()
+
+    result = json.loads(stdout.getvalue())
+    assert result["permission"] == "deny"
+    assert "requires approval" in result["agent_message"]


### PR DESCRIPTION
## Summary
- Cursor native tools can execute **silently** (results embedded in assistant text, no `tool_call` SDK message), bypassing the stream-based policy gate from #643
- Write `.cursor/hooks.json` at session startup with a `preToolUse` hook pointing at a standalone policy hook script
- The hook script reads tool call info from stdin, POSTs to the Omnigent server's `/v1/sessions/{id}/policies/evaluate`, and returns `allow`/`deny` on stdout — **before** the tool executes
- Uses `setting_sources=["project"]` in `LocalAgentOptions` so the Cursor SDK reads project-level hooks
- Server URL (`RUNNER_SERVER_URL`) and session ID are baked as inline env vars in the hook command
- Hooks.json is cleaned up on session close
- Hook script is standalone (no omnigent imports) — uses only stdlib `urllib.request`
- Fails open on network errors; fails closed on unresolved ASK

## New file
- `omnigent/inner/cursor_policy_hook.py` — standalone preToolUse hook script

## Test plan
- [x] `test_ensure_session_writes_hooks_json` — hooks.json written with correct structure
- [x] `test_hooks_json_not_written_without_server_url` — no hooks.json when RUNNER_SERVER_URL absent
- [x] `test_hooks_json_cleaned_up_on_close` — file removed on session teardown
- [x] `test_cursor_policy_hook_allow` — ALLOW verdict → `{"permission": "allow"}`
- [x] `test_cursor_policy_hook_deny` — DENY verdict → `{"permission": "deny", "agent_message": "..."}`
- [x] `test_cursor_policy_hook_network_error_fails_open` — network error → allow
- [x] `test_cursor_policy_hook_ask_fails_closed` — ASK verdict → deny
- [x] `test_cursor_policy_hook_no_env_fails_open` — missing env vars → allow
- [x] All 52 tests pass

This pull request and its description were written by Isaac.