### PR TITLE
test(cursor): add cursor-native e2e + e2e_ui render-parity tests

### DIFF
--- a/tests/e2e/test_cursor_native_cli_e2e.py
+++ b/tests/e2e/test_cursor_native_cli_e2e.py
@@ -1,0 +1,238 @@
+"""End-to-end tests: ``omnigent cursor`` drives the native Cursor TUI.
+
+The cursor-native sibling of ``test_codex_native_cli_cwd_e2e`` /
+``test_codex_native_cli_resume_e2e``. ``cursor-native`` is a *terminal-first*
+harness: ``omnigent cursor`` launches the official ``cursor-agent`` TUI in a
+runner-owned tmux pane, and each web-UI turn is injected into that pane
+(bracketed paste + Enter) by
+:class:`omnigent.inner.cursor_native_executor.CursorNativeExecutor`. The TUI's
+own conversation store is tailed by
+:mod:`omnigent.cursor_native_forwarder`, which mirrors ``cursor-agent``'s
+replies back onto the Omnigent conversation as assistant items.
+
+These tests drive the full stack the way a user does — spawn ``omnigent
+cursor``, then talk to the session **through the server** (``POST
+/v1/sessions/{id}/events``, the web-UI path) — and assert on the persisted
+assistant items:
+
+* **smoke** — inject a prompt that makes ``cursor-agent`` emit a unique marker
+  word, and confirm the marker comes back as an assistant item. This exercises
+  CLI parse -> daemon runner spawn -> cursor terminal launch -> tmux injection
+  -> ``cursor-agent`` turn -> forwarder mirror -> conversation store.
+* **cwd** — drop a marker file in the launch cwd and ask ``cursor-agent`` to
+  read it. The file exists only in the launch directory (never in the runner's
+  spec-bundle dir), so a correct answer proves both that the TUI launched in
+  the launch cwd *and* that its built-in Read tool ran.
+
+Unlike the SDK ``cursor`` harness (``test_per_harness_cursor``), cursor-native
+authenticates from the **ambient ``cursor-agent login``** under ``$HOME/.cursor``
+— there is no ``CURSOR_API_KEY``. The TUI is launched with ``-f`` (Cursor's
+force/trust flag) so it neither blocks on the per-directory "Workspace Trust"
+prompt nor on per-tool approval prompts — either of which would hang the pane.
+
+Environment requirements (why this is opt-in, not pure-CI)
+----------------------------------------------------------
+* **Opt-in only**: set ``OMNIGENT_E2E_CURSOR_NATIVE=1`` to run. Like the other
+  native-TUI e2e tests, cursor-native needs an interactive ``cursor-agent
+  login`` anchored to the real ``$HOME`` and a ``tmux`` binary; the
+  ``cursor-agent`` binary may be present on CI but unauthenticated, which would
+  hang the TUI. The env-var gate keeps it out of CI; a developer with a
+  logged-in Cursor opts in. ``tmux`` and ``cursor-agent`` on ``PATH`` are also
+  required (checked below).
+* Run it like the codex-native CLI tests::
+
+    OMNIGENT_E2E_CURSOR_NATIVE=1 \
+    .venv/bin/python -m pytest tests/e2e/test_cursor_native_cli_e2e.py \
+        --profile oss \
+        --llm-api-key "$(databricks auth token -p oss \
+            | python -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')" \
+        -v
+
+  The ``--profile`` / ``--llm-api-key`` only satisfy the test server's startup
+  (``resume_test_server``); the ``cursor-agent`` turn itself authenticates via
+  the ambient Cursor login, not the Databricks gateway.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tests.e2e._native_resume_helpers import (
+    cli_env,
+    inject_user_message,
+    omnigent_console_script,
+    poll_for_assistant_marker,
+    spawn_cli_background,
+    wait_for_conversation_id,
+    wait_for_terminal_ready,
+)
+
+# ``resume_test_server`` is provided by tests/e2e/conftest.py (the allow-list-
+# free server the CLI wrapper's self-spawned host daemon can register against).
+
+# Opt-in only — see module docstring. Binary presence is not a sufficient gate
+# (present-but-unauthenticated hangs the TUI), so require the explicit env var,
+# plus the two binaries the terminal-first harness needs on PATH.
+pytestmark = pytest.mark.skipif(
+    os.environ.get("OMNIGENT_E2E_CURSOR_NATIVE") != "1"
+    or shutil.which("cursor-agent") is None
+    or shutil.which("tmux") is None,
+    reason=(
+        "cursor-native CLI e2e needs an interactive `cursor-agent login` and a "
+        "`tmux` binary; set OMNIGENT_E2E_CURSOR_NATIVE=1 (and have `cursor-agent` "
+        "installed + logged in and `tmux` on PATH) to run"
+    ),
+)
+
+# Cursor's force/trust flag, passed as a raw cursor-agent arg. Clears the
+# per-directory "Workspace Trust" gate and per-tool approval prompts so the TUI
+# never blocks the tmux pane waiting on a y/n the test can't answer.
+_FORCE_FLAG = "-f"
+
+_CWD_MARKER_FILE = "CWD_MARKER.txt"
+
+# cursor-agent cold-starts the TUI and round-trips to Cursor's backend; mirror
+# the headroom the codex-native CLI tests allow on a contended host.
+_CONV_ID_TIMEOUT = 120.0
+_TERMINAL_READY_TIMEOUT = 90.0
+_REPLY_TIMEOUT = 180.0
+
+
+def test_cursor_native_cli_smoke(
+    resume_test_server: str,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """A cursor-native turn driven through the server returns the model's reply.
+
+    Spawns a backgrounded ``omnigent cursor`` session, waits for its terminal
+    to register, injects (via ``/events`` — the web-UI path) a prompt asking
+    ``cursor-agent`` to emit a unique marker word, and asserts the marker comes
+    back as an assistant item. The marker is a fresh per-run nonce so a match
+    cannot be coincidental and a parallel run cannot leak it.
+
+    This is the end-to-end smoke gate for the cursor-native harness: it covers
+    the whole path from CLI parse through tmux injection to the forwarder
+    mirroring ``cursor-agent``'s reply onto the conversation store.
+
+    :param resume_test_server: Base URL of the allow-list-free test server.
+    :param tmp_path: Per-test temp dir; its ``pwd`` subdir is the launch cwd.
+    :param request: Pytest request — reads ``--profile`` for the test server.
+    """
+    profile = request.config.getoption("--profile")
+    assert profile, "this test requires --profile (e.g. --profile oss) for the test server"
+
+    pwd_dir = tmp_path / "pwd"
+    pwd_dir.mkdir()
+    marker = f"CURSOR_{uuid.uuid4().hex[:8].upper()}"
+
+    omni = str(omnigent_console_script())
+    handle = spawn_cli_background(
+        [omni, "cursor", "--server", resume_test_server, _FORCE_FLAG],
+        env=cli_env(profile=profile),
+        cwd=str(pwd_dir),
+    )
+    try:
+        conversation_id = wait_for_conversation_id(handle, timeout=_CONV_ID_TIMEOUT)
+        with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+            wait_for_terminal_ready(
+                client,
+                conversation_id=conversation_id,
+                harness="cursor",
+                timeout=_TERMINAL_READY_TIMEOUT,
+            )
+            inject_user_message(
+                client,
+                conversation_id=conversation_id,
+                text=f"Reply with ONLY this exact word and nothing else: {marker}",
+            )
+            try:
+                poll_for_assistant_marker(
+                    client,
+                    conversation_id=conversation_id,
+                    marker=marker,
+                    timeout=_REPLY_TIMEOUT,
+                )
+            except AssertionError as exc:
+                raise AssertionError(
+                    f"`omnigent cursor` did not return marker {marker!r}. The "
+                    "cursor-native path regressed somewhere between tmux injection, "
+                    "the cursor-agent turn, and the forwarder mirroring the reply "
+                    f"onto the conversation.\n\nCLI output tail:\n{handle.output()[-2000:]}"
+                ) from exc
+    finally:
+        handle.terminate()
+
+
+def test_cursor_native_cli_runs_in_launch_cwd(
+    resume_test_server: str,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """``omnigent cursor`` launches ``cursor-agent`` in the directory it was run from.
+
+    Spawns a backgrounded ``omnigent cursor`` whose process cwd is a temp
+    directory containing a marker file, then injects (via the server, the
+    web-UI path) a request to read that file. The marker exists only in the
+    launch cwd (never in the runner's spec-bundle dir), so it can come back
+    only if the wrapper launched the TUI in the launch directory *and*
+    ``cursor-agent``'s built-in Read tool ran (the ``-f`` flag auto-approves
+    it). The cursor-native sibling of ``test_codex_native_cli_runs_in_launch_cwd``.
+
+    :param resume_test_server: Base URL of the allow-list-free test server.
+    :param tmp_path: Per-test temp dir; its ``pwd`` subdir is the launch cwd.
+    :param request: Pytest request — reads ``--profile`` for the test server.
+    """
+    profile = request.config.getoption("--profile")
+    assert profile, "this test requires --profile (e.g. --profile oss) for the test server"
+
+    pwd_dir = tmp_path / "pwd"
+    pwd_dir.mkdir()
+    marker = f"PWD_{uuid.uuid4().hex[:6].upper()}"
+    (pwd_dir / _CWD_MARKER_FILE).write_text(marker + "\n")
+
+    omni = str(omnigent_console_script())
+    handle = spawn_cli_background(
+        [omni, "cursor", "--server", resume_test_server, _FORCE_FLAG],
+        env=cli_env(profile=profile),
+        cwd=str(pwd_dir),
+    )
+    try:
+        conversation_id = wait_for_conversation_id(handle, timeout=_CONV_ID_TIMEOUT)
+        with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+            wait_for_terminal_ready(
+                client,
+                conversation_id=conversation_id,
+                harness="cursor",
+                timeout=_TERMINAL_READY_TIMEOUT,
+            )
+            inject_user_message(
+                client,
+                conversation_id=conversation_id,
+                text=(
+                    f"Read the file {_CWD_MARKER_FILE} in your current directory "
+                    "and reply with its exact contents and nothing else."
+                ),
+            )
+            try:
+                poll_for_assistant_marker(
+                    client,
+                    conversation_id=conversation_id,
+                    marker=marker,
+                    timeout=_REPLY_TIMEOUT,
+                )
+            except AssertionError as exc:
+                raise AssertionError(
+                    f"`omnigent cursor` did not return marker {marker!r} from "
+                    f"{_CWD_MARKER_FILE} — it did not run cursor-agent in its launch "
+                    "cwd (the wrapper-path cwd resolution regressed, likely the "
+                    f"spec-bundle dir).\n\nCLI output tail:\n{handle.output()[-2000:]}"
+                ) from exc
+    finally:
+        handle.terminate()

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1871,3 +1871,141 @@ def native_codex_session(
             except subprocess.TimeoutExpired:
                 respawned.kill()
                 respawned.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# ``native_cursor_session`` is the sibling native-CLI fixture for the
+# ``cursor-native`` ("Cursor") wrapper: it spins up a real Cursor wrapper
+# session — the same terminal-first spec ``omnigent cursor`` ships — and yields
+# ``(base_url, session_id)``. The runner auto-launches ``cursor-agent`` in the
+# session terminal on bind (``_auto_create_cursor_terminal`` in
+# ``omnigent/runner/app.py``), exactly like the claude/codex fixtures.
+#
+# Two things differ from claude/codex, both stemming from cursor-agent owning
+# its own auth/approval:
+#
+# * **Auth has NO Databricks-gateway path.** cursor-agent talks only to
+#   Cursor's backend, so it does not derive auth from the runner's gateway
+#   credentials the way Claude Code / Codex do. It authenticates from the
+#   ambient ``cursor-agent login`` (``$HOME/.cursor``, inherited by the runner)
+#   or an ambient ``CURSOR_API_KEY``. The render-parity test is therefore gated
+#   to skip when neither the binary nor a usable login is present (CI does not
+#   provision a Cursor account by default), so it stays green there while
+#   running for real wherever Cursor is logged in.
+# * **``-f`` (force/trust) is passed as a launch arg.** cursor-agent blocks on a
+#   per-directory "Workspace Trust" prompt and per-tool approval prompts; in a
+#   runner-owned tmux pane there is no one to answer them, so the TUI would
+#   hang. ``-f`` (Cursor's force/yolo flag) clears both. It is threaded through
+#   ``terminal_launch_args`` exactly as the plan-mode claude fixture threads
+#   ``--permission-mode``.
+# ---------------------------------------------------------------------------
+
+
+def _create_native_cursor_session(base_url: str, runner_id: str) -> str:
+    """Register the ``cursor-native`` wrapper agent and bind its session.
+
+    Reuses the exact terminal-first spec ``omnigent cursor`` ships
+    (:func:`omnigent.cursor_native._materialize_cursor_agent_spec`) so the
+    fixture never drifts from production, and stamps the same wrapper /
+    terminal-first labels (``omnigent.wrapper`` + ``omnigent.ui = terminal``)
+    the CLI writes. The spec carries no ``spec_version``, so it is bundled
+    under a ``*.yaml`` arcname to route through the omnigent compat translator
+    (which preserves ``executor.harness`` + ``terminals:``); a ``config.yaml``
+    arcname would hit the strict parser and reject it.
+
+    Binding the session to the runner triggers the runner's cursor-native
+    auto-bootstrap (:func:`omnigent.runner.app._auto_create_cursor_terminal`):
+    it launches ``cursor-agent`` in the session terminal — with the ``-f``
+    force/trust arg threaded via ``terminal_launch_args`` so the unattended
+    tmux pane never blocks on Cursor's workspace-trust / per-tool prompts — and
+    starts the forwarder that mirrors the TUI transcript back as conversation
+    items.
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: The token-bound runner id to bind.
+    :returns: The new session/conversation id.
+    """
+    import json as _json
+    import tempfile
+
+    from omnigent._wrapper_labels import (
+        CURSOR_NATIVE_WRAPPER_VALUE,
+        UI_MODE_LABEL_KEY,
+        UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY,
+    )
+    from omnigent.cursor_native import _materialize_cursor_agent_spec
+
+    with tempfile.TemporaryDirectory() as _tmp:
+        spec_path = _materialize_cursor_agent_spec(Path(_tmp))
+        yaml_text = spec_path.read_text()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        # Non-config.yaml arcname → omnigent compat translator (the spec has
+        # no spec_version), matching the terminal_session fixture.
+        info = tarfile.TarInfo("cursor-native-ui.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    labels = {
+        UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY: CURSOR_NATIVE_WRAPPER_VALUE,
+    }
+    # Pin a real workspace on THIS session (like the codex fixture): the
+    # forwarder keys cursor's chat store by ``md5(cwd)``, so the TUI needs a
+    # concrete launch cwd. The repo root is a valid dir on the runner's
+    # filesystem. ``-f`` trusts that dir + auto-approves tools so the
+    # unattended pane never hangs on an approval prompt.
+    metadata = {
+        "labels": labels,
+        "workspace": str(_REPO_ROOT),
+        "terminal_launch_args": ["-f"],
+    }
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": _json.dumps(metadata)},
+        files={"bundle": ("cursor-native-ui.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+@pytest.fixture
+def native_cursor_session(
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session on the real ``cursor-native`` ("Cursor") wrapper.
+
+    The runner auto-launches ``cursor-agent`` in the session terminal on bind
+    (ambient ``cursor-agent login`` / ``CURSOR_API_KEY`` auth + ``-f`` trust
+    handled runner-side), so the SPA's Terminal view attaches to a live Cursor
+    TUI and its Chat view renders the same canonical transcript. Drives the
+    native cursor render-parity suite.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    session_id = _create_native_cursor_session(live_server, runner_id)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            # Escalate to SIGKILL if the runner ignores SIGTERM, so a wedged
+            # process can't raise in teardown and leak / fail unrelated tests
+            # (matching terminal_session / seeded_session_pair).
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)

--- a/tests/e2e_ui/messages/test_native_cursor_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_cursor_render_parity.py
@@ -1,0 +1,289 @@
+r"""UI journey: a native Cursor session renders parity with its TUI.
+
+The native ``cursor-native`` ("Cursor") wrapper is terminal-first: a real
+``cursor-agent`` CLI runs in the session terminal, the SPA's **Terminal** view
+attaches to that live TUI over a WebSocket, and the SPA's **Chat** view renders
+the SAME canonical transcript (``GET /v1/sessions/{id}/items``) the TUI prints.
+A native forwarder (:mod:`omnigent.cursor_native_forwarder`) tails
+``cursor-agent``'s own chat store and mirrors the transcript back OUT as
+conversation items; web-composer messages are injected INTO the TUI's tmux pane
+by :class:`omnigent.inner.cursor_native_executor.CursorNativeExecutor`. This
+suite asserts that round-trips both ways and renders exactly once — the same
+three properties the codex/claude native forwarders are pinned against
+(:mod:`tests.e2e_ui.messages.test_native_codex_render_parity`):
+
+1. **Render parity with the TUI.** Composer turns are sent through the web SPA;
+   each per-turn user marker and assistant token the SPA shows in a bubble must
+   also appear in the canonical transcript, in the same order, exactly once.
+
+2. **A TUI-originated message surfaces in the web UI.** A turn is typed directly
+   into the Cursor TUI (the embedded xterm in the Terminal view) — never through
+   the composer. The forwarder must mirror it back out as a user item +
+   assistant reply, so switching to Chat shows both as bubbles.
+
+3. **No duplicate rendering.** Every marker/token — composer- and TUI-originated
+   alike — must land in EXACTLY ONE bubble and one transcript entry.
+
+How this differs from the claude/codex render-parity suites
+-----------------------------------------------------------
+Claude Code and Codex derive their model auth from the runner's own Databricks
+gateway credentials (CI exchanges Databricks OAuth before pytest), so those
+suites run unconditionally in CI. ``cursor-agent`` has **no Databricks-gateway
+path** — it talks only to Cursor's backend and authenticates from the ambient
+``cursor-agent login`` (``$HOME/.cursor``) or an ambient ``CURSOR_API_KEY``.
+Because CI does not provision a Cursor account by default, this suite is **gated
+to skip** when ``cursor-agent`` is absent or no usable Cursor login is present
+(see :func:`_cursor_unavailable_reason`); it runs for real wherever Cursor is
+logged in (a dev box, or a CI job that installs ``cursor-agent`` and provides a
+``CURSOR_API_KEY`` secret). The ``native_cursor_session`` fixture launches the
+TUI with ``-f`` so the unattended tmux pane never blocks on Cursor's
+workspace-trust / per-tool approval prompts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# Reuse the custom-agent suite's helpers — both surfaces render from the same
+# canonical transcript, so parity / dedup / ordering are asserted identically.
+from .test_message_render_parity import (
+    _ASSISTANT,
+    _USER,
+    _WORKING,
+    _assert_no_duplicate_render,
+    _assert_transcript_parity,
+    _ensure_chat_view,
+    _send,
+    _turn_prompt,
+)
+
+_log = logging.getLogger(__name__)
+
+_TERMINAL_VIEW = '[data-testid="terminal-view"]'
+# xterm.js routes all keystrokes through a hidden helper <textarea>; focusing it
+# and typing is how a user (and Playwright) drives the embedded TUI.
+_XTERM_INPUT = ".xterm-helper-textarea"
+
+# A native Cursor turn is a full agent loop (real LLM, possible tool use),
+# so it is far slower than a single custom-agent LLM call.
+_NATIVE_TURN_TIMEOUT_MS = 180_000
+# cursor-agent boots in the terminal on bind; the auto-launch + first-run
+# trust pre-accept + WS attach can take a while on a cold runner.
+_TERMINAL_READY_TIMEOUT_MS = 120_000
+
+# Two composer turns (the IN direction) + one TUI turn (the OUT direction).
+_COMPOSER_TURNS = 2
+
+
+def _cursor_unavailable_reason() -> str | None:
+    """Return a skip reason when the cursor-native prerequisites are absent.
+
+    cursor-native needs (1) the ``cursor-agent`` binary on PATH and (2) a usable
+    Cursor login — either an ambient ``CURSOR_API_KEY`` or a prior
+    ``cursor-agent login`` whose state lives under ``$HOME/.cursor``. Either
+    missing is a clean **skip** (CI does not provision a Cursor account), so the
+    e2e-ui shards stay green while the suite runs for real wherever Cursor is
+    logged in.
+
+    :returns: A human-readable skip reason, or ``None`` when both prerequisites
+        are present.
+    """
+    if shutil.which("cursor-agent") is None:
+        return "cursor-native render-parity needs the `cursor-agent` binary on PATH."
+    if shutil.which("tmux") is None:
+        return "cursor-native render-parity needs `tmux` on PATH (runner-owned TUI pane)."
+    has_api_key = bool(os.environ.get("CURSOR_API_KEY"))
+    has_login = (Path.home() / ".cursor").is_dir()
+    if not (has_api_key or has_login):
+        return (
+            "cursor-native render-parity needs a Cursor login: export CURSOR_API_KEY "
+            "or run `cursor-agent login` (state under $HOME/.cursor). Skipped (not "
+            "failed) because CI does not provision a Cursor account by default."
+        )
+    return None
+
+
+pytestmark = pytest.mark.skipif(
+    _cursor_unavailable_reason() is not None,
+    reason=_cursor_unavailable_reason() or "",
+)
+
+
+def _open_terminal_view(page: Page) -> None:
+    """Switch a terminal-first session to its Terminal (TUI) view.
+
+    :param page: The Playwright page, on the session's chat surface.
+    """
+    view_mode = page.get_by_role("group", name="View mode")
+    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
+    terminal_button = view_mode.get_by_role("button", name="Terminal")
+    expect(terminal_button).to_be_visible(timeout=30_000)
+    terminal_button.click()
+
+
+def _wait_terminal_connected(page: Page) -> None:
+    """Wait until the embedded xterm has attached to the live Cursor TUI.
+
+    :param page: The Playwright page, on the Terminal view.
+    """
+    terminal = page.locator(_TERMINAL_VIEW).last
+    expect(terminal).to_have_attribute(
+        "data-state", "connected", timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+
+
+def _type_into_tui(page: Page, text: str) -> None:
+    """Type *text* into the embedded Cursor TUI and submit with Enter.
+
+    Drives the real TUI exactly as a user would: focus the xterm input,
+    type the prompt, press Enter. This is the OUT direction — the message
+    originates in the terminal, not the web composer.
+
+    :param page: The Playwright page, on the connected Terminal view.
+    :param text: The single-line prompt to type into the TUI.
+    """
+    # Scope to the active terminal-view (not page-level) so the lookup can't
+    # focus a stray textarea from another terminal widget — matches the shell
+    # E2E test pattern.
+    xterm_input = page.locator(_TERMINAL_VIEW).last.locator(_XTERM_INPUT)
+    expect(xterm_input).to_be_attached(timeout=30_000)
+    xterm_input.focus()
+    # Type at a human-ish cadence: the TUI composer can drop or reorder
+    # characters injected faster than it repaints.
+    page.keyboard.type(text, delay=15)
+    # Let cursor-agent's composer fully register the typed text before Enter.
+    # Unlike Codex's, it debounces input, so an Enter pressed in the same tick
+    # as the last character can fire before the text is committed — the
+    # composer then submits empty / stale and the turn is never sent. A short
+    # settle pause makes the submission reliable.
+    page.wait_for_timeout(1500)
+    page.keyboard.press("Enter")
+
+
+def _wait_marker_in_transcript(
+    base_url: str, session_id: str, marker: str, *, timeout_ms: int
+) -> None:
+    """Poll the canonical transcript until *marker* appears in any item.
+
+    Used after typing into the TUI to confirm the Enter submission actually
+    reached ``cursor-agent`` (the forwarder only mirrors the turn once Cursor
+    has accepted and stored it). This MUST complete before the test leaves the
+    Terminal view: switching views tears down the embedded xterm's WebSocket,
+    and cursor-agent's composer commits a submission slightly slower than
+    Codex's — switching too early can drop the in-flight Enter keystroke before
+    it reaches the tmux pane, so the turn is never sent. Waiting on the
+    transcript (not a fixed sleep) keeps this deterministic.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The cursor-native session/conversation id.
+    :param marker: The literal token to wait for (the per-turn user marker).
+    :param timeout_ms: Max wait in milliseconds.
+    """
+    deadline = time.monotonic() + timeout_ms / 1000.0
+    while time.monotonic() < deadline:
+        resp = httpx.get(
+            f"{base_url}/v1/sessions/{session_id}/items",
+            params={"limit": 100, "order": "asc"},
+            timeout=10.0,
+        )
+        if resp.status_code == 200 and any(
+            marker in str(item.get("content")) for item in resp.json().get("data", [])
+        ):
+            return
+        time.sleep(2.0)
+    raise AssertionError(
+        f"marker {marker!r} never reached the transcript within {timeout_ms}ms — "
+        f"the TUI-typed turn was not submitted/forwarded for {session_id}."
+    )
+
+
+@pytest.mark.timeout(900)
+def test_native_cursor_message_render_parity(
+    page: Page,
+    native_cursor_session: tuple[str, str],
+) -> None:
+    """Native Cursor renders parity with its TUI, both ways, with no dupes.
+
+    Covers all three properties on a single (expensive to spin up) native
+    session: composer parity (IN), a TUI-originated turn surfacing in the web UI
+    (OUT), and no duplicate rendering across every turn. Mirrors
+    ``test_native_codex_message_render_parity``.
+    """
+    base_url, session_id = native_cursor_session
+    _log.info("native-cursor session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The Terminal view proves cursor-agent actually booted in the session
+    # terminal (the runner's cursor-native auto-launch) before we send anything.
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _log.info("Cursor TUI attached (terminal-view connected)")
+
+    user_markers: list[str] = []
+    assistant_tokens: list[str] = []
+
+    def _new_turn(index: int) -> tuple[str, str]:
+        nonce = uuid.uuid4().hex[:8]
+        user_marker = f"usr-{index}-{nonce}"
+        assistant_token = f"ast-{index}-{nonce}"
+        user_markers.append(user_marker)
+        assistant_tokens.append(assistant_token)
+        return user_marker, assistant_token
+
+    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
+    _ensure_chat_view(page)
+    for index in range(1, _COMPOSER_TURNS + 1):
+        user_marker, assistant_token = _new_turn(index)
+        _log.info(
+            "composer turn %d: sending (marker=%s token=%s)", index, user_marker, assistant_token
+        )
+        _send(page, _turn_prompt(index, user_marker, assistant_token))
+        # The echoed token in an assistant bubble = this turn produced its reply.
+        expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
+            timeout=_NATIVE_TURN_TIMEOUT_MS
+        )
+        # Fully settle (working shimmer gone) before the next send, so any
+        # transient native live-preview has collapsed into the committed bubble.
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+        expect(page.locator(_USER)).to_have_count(index, timeout=30_000)
+        _log.info("composer turn %d: settled", index)
+
+    # --- Property 2 & 3: a TUI-originated turn (OUT) surfaces in the web UI. ---
+    tui_index = _COMPOSER_TURNS + 1
+    tui_marker, tui_token = _new_turn(tui_index)
+    _open_terminal_view(page)
+    _wait_terminal_connected(page)
+    _log.info(
+        "TUI turn %d: typing into xterm (marker=%s token=%s)", tui_index, tui_marker, tui_token
+    )
+    _type_into_tui(page, _turn_prompt(tui_index, tui_marker, tui_token))
+    # Stay on the Terminal view until the forwarder has mirrored this turn —
+    # leaving it tears down the xterm WS and can drop the just-pressed Enter
+    # before cursor-agent's (slower-than-Codex) composer commits it.
+    _wait_marker_in_transcript(base_url, session_id, tui_token, timeout_ms=_NATIVE_TURN_TIMEOUT_MS)
+
+    # Back in Chat, the forwarder must have mirrored the TUI turn OUT as a user
+    # item + assistant reply — both render as bubbles, exactly once.
+    _ensure_chat_view(page)
+    expect(page.locator(_ASSISTANT, has_text=tui_token).first).to_be_visible(
+        timeout=_NATIVE_TURN_TIMEOUT_MS
+    )
+    expect(page.locator(_USER, has_text=tui_marker).first).to_be_visible(timeout=30_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(page.locator(_USER)).to_have_count(len(user_markers), timeout=30_000)
+    _log.info("TUI turn %d: surfaced in web UI (user + assistant bubbles present)", tui_index)
+
+    # --- Assert all three properties over every turn. ---
+    _assert_no_duplicate_render(page, user_markers, assistant_tokens)
+    _assert_transcript_parity(base_url, session_id, user_markers, assistant_tokens)
+    _log.info("all turns verified: render parity + no-duplicate-render + transcript parity")


### PR DESCRIPTION
## What

Adds end-to-end coverage for the **cursor-native** (terminal-first) harness introduced in #551, mirroring the existing claude/codex native suites.

### CLI e2e — `tests/e2e/test_cursor_native_cli_e2e.py`
- **smoke**: drive `omnigent cursor` as a subprocess, inject a turn through the server (the web-UI `/events` path), assert the marker comes back as an assistant item — covers CLI parse → daemon runner → cursor terminal launch → tmux injection → `cursor-agent` turn → forwarder mirror → conversation store.
- **launch-cwd**: `cursor-agent` reads a file that exists only in the launch cwd (proves cwd resolution + the built-in Read tool ran). Sibling of `test_codex_native_cli_runs_in_launch_cwd`.

### UI render-parity e2e — `tests/e2e_ui/messages/test_native_cursor_render_parity.py` (+ `native_cursor_session` fixture)
Mirrors `test_native_codex_render_parity.py`: composer parity (IN), a TUI-typed turn surfacing in the web UI (OUT), and no-duplicate-render — the three properties the codex/claude forwarders are pinned against.

## Gating / CI

Both are gated to **skip** (not fail) unless `cursor-agent` + `tmux` are on `PATH` **and** a Cursor login is present (`CURSOR_API_KEY` or `cursor-agent login` under `$HOME/.cursor`), so CI shards stay green.

Unlike claude/codex — which CI runs live by repointing their `base_url` at the Databricks AI Gateway and reusing the gateway OAuth token — **cursor-agent has no gateway path**: it speaks Cursor's proprietary `aiserver.v1` Connect-RPC/Protobuf protocol against `api2.cursor.sh` with a Cursor account credential (`crsr_…`). So it cannot reuse the AI Gateway key CI already has. Running it live in CI would require a `CURSOR_API_KEY` repo secret + a `cursor-agent` install step (follow-up).

The fixture launches the TUI with `-f` so the unattended tmux pane never blocks on Cursor's workspace-trust / per-tool approval prompts.

## Notes
Two cursor-only TUI-driving fixes vs codex (both deterministic, found via live debugging): a settle-pause before Enter (cursor's composer debounces input) and staying on the Terminal view until the forwarder mirrors the turn (switching tears down the xterm WebSocket before the Enter commits).

## Testing
Verified locally with `cursor-agent` logged in: both CLI tests pass; the render-parity test passes stably (~44s, multiple runs).