### PR TITLE
feat(#232): allow choosing the model for a custom agent in the web UI

### DIFF
--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -54,6 +54,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     skills: list[SkillSummary] = []
     terminals: list[str] = []
     harness: str | None = None
+    model: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -91,6 +92,12 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         # Kind for the Add Agent picker (Codex vs Claude). Stays None
         # when the bundle can't be loaded (the except below).
         harness = loaded.spec.executor.harness_kind
+        # Resolved default model for the Add Agent picker (lets the UI
+        # show + override the agent's model, flowed as model_override on
+        # session create). spec.llm is None only when no model is
+        # declared anywhere; the parser syncs executor.model into it.
+        if loaded.spec.llm is not None:
+            model = loaded.spec.llm.model
     except Exception:  # noqa: BLE001 — spec load failure must not break the list
         _logger.debug(
             "Failed to load spec for agent %s; mcp_servers/skills will be empty",
@@ -105,6 +112,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         created_at=agent.created_at,
         updated_at=agent.updated_at,
         harness=harness,
+        model=model,
         mcp_servers=mcp_servers,
         mcp_servers_editable=False,
         skills=skills,

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -349,6 +349,10 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
     # Harness/kind for the UI; None until the spec loads (mirrors the
     # GET /v1/agents catalog so both endpoints report it consistently).
     harness: str | None = None
+    # Resolved default model, same source as the GET /v1/agents catalog.
+    # Session-discovered agents reach the Add Agent picker through this
+    # endpoint, so without it their model input can never pre-fill.
+    model: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -360,6 +364,10 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
                 agent.id, agent.bundle_location, expand_env=agent.session_id is None
             )
             harness = loaded.spec.executor.harness_kind
+            # spec.llm is None only when no model is declared anywhere;
+            # the parser syncs executor.model into it.
+            if loaded.spec.llm is not None:
+                model = loaded.spec.llm.model
             if description is None:
                 description = loaded.spec.description
             # Declared terminal names, in spec order — the Web UI
@@ -411,6 +419,7 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
         created_at=agent.created_at,
         updated_at=agent.updated_at,
         harness=harness,
+        model=model,
         mcp_servers=mcp_servers,
         mcp_servers_editable=(
             agent.session_id is not None and not (harness or "").endswith("-native")

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -234,6 +234,13 @@ class AgentObject(BaseModel):
         bundle cannot be loaded. Lets the Web UI Add Agent picker
         recognise an agent's kind (Codex vs Claude) without
         hardcoding by name slug.
+    :param model: The agent's configured default LLM model identifier
+        (provider-prefixed, e.g. ``"databricks-gpt-5-5"``), resolved
+        from the spec's ``llm.model`` (the parser syncs ``executor.model``
+        into it). ``None`` when the bundle cannot be loaded or no model
+        is declared. Lets the Web UI show / override the agent's model
+        when adding it as a child session (flowed as ``model_override``
+        on session create).
     :param mcp_servers: MCP servers the agent is connected to
         (secret fields omitted). Empty list when the spec
         declares no MCP servers or when the bundle cannot be
@@ -281,6 +288,7 @@ class AgentObject(BaseModel):
     created_at: int
     updated_at: int | None = None
     harness: str | None = None
+    model: str | None = None
     mcp_servers: list[MCPServerSummary] = Field(default_factory=list)
     mcp_servers_editable: bool = False
     policies: list[PolicySummary] = Field(default_factory=list)

--- a/openapi.json
+++ b/openapi.json
@@ -103,6 +103,18 @@
             "title": "Mcp Servers Editable",
             "type": "boolean"
           },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The agent's configured default LLM model identifier (provider-prefixed, e.g. `\"databricks-gpt-5-5\"`), resolved from the spec's `llm.model` (the parser syncs `executor.model` into it). `None` when the bundle cannot be loaded or no model is declared. Lets the Web UI show / override the agent's model when adding it as a child session (flowed as `model_override` on session create).",
+            "title": "Model"
+          },
           "name": {
             "description": "Human-readable agent name, e.g. `\"research-agent\"`.",
             "title": "Name",

--- a/tests/e2e_ui/agents/test_add_subagent_dialog.py
+++ b/tests/e2e_ui/agents/test_add_subagent_dialog.py
@@ -31,8 +31,17 @@ from tests.e2e_ui.conftest import open_right_rail
 _ADD_AGENT_BUTTON = '[data-testid="add-agent-button"]'
 _ADD_AGENT_DIALOG = '[data-testid="add-agent-dialog"]'
 _ADD_AGENT_NAME_INPUT = '[data-testid="add-agent-name-input"]'
+_ADD_AGENT_MODEL_INPUT = '[data-testid="add-agent-model-input"]'
 _ADD_AGENT_SUBMIT = '[data-testid="add-agent-submit"]'
 _SUBAGENT_ROW = '[data-testid="subagent-row"]'
+
+# The hello_world agent declares ``executor.model: gpt-4o-mini`` (see
+# ``tests/e2e_ui/conftest.py`` _TEST_AGENT_YAML), which the spec parser
+# syncs into ``llm.model``. The dialog's Model input must pre-fill with
+# exactly this — proves the agent's declared model traversed
+# GET /v1/agents → AgentObject.model → the picker, not a hardcoded
+# constant.
+_HELLO_WORLD_MODEL = "gpt-4o-mini"
 
 
 def _picker_hello_world_id(base_url: str, session_id: str) -> str:
@@ -64,6 +73,23 @@ def _child_sessions(base_url: str, session_id: str) -> list[dict]:
     resp.raise_for_status()
     body = resp.json()
     return body.get("data", body) if isinstance(body, dict) else body
+
+
+def _session_model_override(base_url: str, session_id: str) -> str | None:
+    """Return the session's ``model_override`` from its snapshot.
+
+    ``GET /v1/sessions/{id}`` carries ``model_override`` on the
+    ``SessionResponse`` (see ``omnigent/server/schemas.py``); this reads
+    it back so the e2e test can prove the dialog's Model input flowed
+    through to the created child session, not just into the request body.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: Session id to read.
+    :returns: The session's ``model_override`` (``None`` when unset).
+    """
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    resp.raise_for_status()
+    return resp.json().get("model_override")
 
 
 def test_add_subagent_from_dialog(
@@ -119,3 +145,65 @@ def test_add_subagent_from_dialog(
     rail = page.get_by_role("complementary", name="Workspace")
     rail.get_by_role("tab", name=re.compile("^Agents")).click()
     expect(rail.locator(_SUBAGENT_ROW)).to_have_count(1, timeout=30_000)
+
+
+def test_add_subagent_dialog_prefills_and_overrides_model(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The dialog pre-fills the agent's declared model and forwards an
+    edit as the child session's ``model_override``.
+
+    The Model input is pre-filled from the picked agent's declared
+    ``llm.model`` (exposed via ``GET /v1/agents`` → ``AgentObject.model``),
+    so a custom agent launches on its own model by default instead of the
+    harness default. Editing the pre-filled value and submitting must
+    flow the edited model through ``POST /v1/sessions`` as
+    ``model_override`` and land on the created child session's snapshot —
+    proof the override reached the server, not just the request body. No
+    LLM turn is involved (the dialog is pure catalog + REST plumbing).
+    """
+    base_url, session_id = seeded_session
+    agent_id = _picker_hello_world_id(base_url, session_id)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Agents")).click()
+
+    add_button = page.locator(_ADD_AGENT_BUTTON)
+    expect(add_button).to_be_attached(timeout=30_000)
+    add_button.dispatch_event("click")
+
+    dialog = page.locator(_ADD_AGENT_DIALOG)
+    expect(dialog).to_be_visible(timeout=15_000)
+
+    # Pick hello_world — its declared model is gpt-4o-mini.
+    dialog.locator(f'[data-testid="agent-card-{agent_id}"]').click()
+
+    # The Model input is pre-filled with the agent's declared model, not
+    # empty — a regression to an empty default would mean the agent's
+    # model never reached the picker.
+    model_input = dialog.locator(_ADD_AGENT_MODEL_INPUT)
+    expect(model_input).to_be_visible()
+    expect(model_input).to_have_value(_HELLO_WORLD_MODEL, timeout=15_000)
+
+    # Name the child and edit the pre-filled model to a sentinel value.
+    dialog.locator(_ADD_AGENT_NAME_INPUT).fill("model-override-sub")
+    # Plain (non-``databricks-``) sentinel, matching the conftest agent:
+    # a databricks- prefix would force gateway auth CI has no creds for.
+    overridden_model = "gpt-4o-mini-override"
+    model_input.fill(overridden_model)
+    dialog.locator(_ADD_AGENT_SUBMIT).click()
+
+    # Land on the freshly-created child session.
+    page.wait_for_url(re.compile(r"/c/(?!" + re.escape(session_id) + r"$)[^/]+$"), timeout=30_000)
+    child_id = page.url.rsplit("/c/", 1)[1]
+    assert child_id != session_id, f"expected to land on a child, still on parent {session_id}"
+
+    # The edited model flowed through POST /v1/sessions as model_override
+    # and is persisted on the child session's snapshot. A None or a
+    # different value means the dialog dropped or mis-routed the input.
+    assert _session_model_override(base_url, child_id) == overridden_model, (
+        f"expected child model_override={overridden_model!r}"
+    )

--- a/tests/e2e_ui/agents/test_add_subagent_dialog.py
+++ b/tests/e2e_ui/agents/test_add_subagent_dialog.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import re
 
 import httpx
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
 
@@ -44,27 +44,47 @@ _SUBAGENT_ROW = '[data-testid="subagent-row"]'
 _HELLO_WORLD_MODEL = "gpt-4o-mini"
 
 
-def _picker_hello_world_id(base_url: str, session_id: str) -> str:
-    """Return the ``hello_world`` agent id the Add-agent picker surfaces.
+def _picker_hello_world_ids(base_url: str, session_id: str) -> list[str]:
+    """Return every agent id the picker may render for ``hello_world``.
 
-    The picker keys each card on the agent id (``agent-card-<id>``). Its hook
-    (``useAvailableAgents``) lets a newer same-named session upload supersede the
-    ``--agent`` template — and this session is already bound to a session-scoped
-    ``hello_world`` (created after the template), so the picker surfaces THAT
-    copy, not the template. Resolve it from the session's bound agent so the card
-    selector matches what the picker renders (rather than guessing the display
-    name, which the SPA prettifies).
+    The picker keys each card on the agent id (``agent-card-<id>``), and two
+    rows compete for the name: the ``--agent`` template in the ``GET
+    /v1/agents`` catalog, and the session-scoped copy this session is bound
+    to. ``useAvailableAgents`` collapses them newest-wins, and which one
+    survives depends on the catalog fetch and the sessions scan resolving in
+    a particular order — so pinning either id alone makes the card selector
+    miss intermittently. Return both and let the caller match whichever
+    rendered, rather than guessing the display name (the SPA prettifies it).
 
     :param base_url: Spawned server base URL.
-    :param session_id: The session whose page hosts the dialog; its bound
-        ``hello_world`` is what the picker shows.
-    :returns: The ``hello_world`` agent id the picker renders.
+    :param session_id: The session whose page hosts the dialog.
+    :returns: Candidate ``hello_world`` agent ids, session-bound copy first.
     """
     resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/agent", timeout=10.0)
     resp.raise_for_status()
     agent = resp.json()
     assert agent.get("name") == "hello_world", f"session not bound to hello_world: {agent}"
-    return str(agent["id"])
+    ids = [str(agent["id"])]
+    catalog = httpx.get(f"{base_url}/v1/agents", timeout=10.0)
+    catalog.raise_for_status()
+    ids += [
+        str(row["id"])
+        for row in catalog.json().get("data", [])
+        if row.get("name") == "hello_world" and str(row["id"]) not in ids
+    ]
+    return ids
+
+
+def _hello_world_card(dialog: Locator, base_url: str, session_id: str) -> Locator:
+    """Locate the ``hello_world`` card the picker actually rendered.
+
+    :param dialog: The open Add-agent dialog.
+    :param base_url: Spawned server base URL.
+    :param session_id: The session whose page hosts the dialog.
+    :returns: Locator for the rendered ``hello_world`` card.
+    """
+    ids = _picker_hello_world_ids(base_url, session_id)
+    return dialog.locator(", ".join(f'[data-testid="agent-card-{i}"]' for i in ids)).first
 
 
 def _child_sessions(base_url: str, session_id: str) -> list[dict]:
@@ -98,7 +118,6 @@ def test_add_subagent_from_dialog(
 ) -> None:
     """Add-agent dialog → pick agent → name → submit → child session is created."""
     base_url, session_id = seeded_session
-    agent_id = _picker_hello_world_id(base_url, session_id)
     page.goto(f"{base_url}/c/{session_id}")
 
     # The Add-agent button lives in the Agents rail panel, so open the rail and
@@ -118,7 +137,7 @@ def test_add_subagent_from_dialog(
     expect(dialog).to_be_visible(timeout=15_000)
 
     # Pick the hello_world agent and give the child a unique, assertable name.
-    dialog.locator(f'[data-testid="agent-card-{agent_id}"]').click()
+    _hello_world_card(dialog, base_url, session_id).click()
     child_name = "rail-spawned-sub"
     name_input = dialog.locator(_ADD_AGENT_NAME_INPUT)
     expect(name_input).to_be_visible()
@@ -164,7 +183,6 @@ def test_add_subagent_dialog_prefills_and_overrides_model(
     LLM turn is involved (the dialog is pure catalog + REST plumbing).
     """
     base_url, session_id = seeded_session
-    agent_id = _picker_hello_world_id(base_url, session_id)
     page.goto(f"{base_url}/c/{session_id}")
 
     open_right_rail(page)
@@ -178,8 +196,10 @@ def test_add_subagent_dialog_prefills_and_overrides_model(
     dialog = page.locator(_ADD_AGENT_DIALOG)
     expect(dialog).to_be_visible(timeout=15_000)
 
-    # Pick hello_world — its declared model is gpt-4o-mini.
-    dialog.locator(f'[data-testid="agent-card-{agent_id}"]').click()
+    # Pick hello_world — its declared model is gpt-4o-mini. Both the catalog
+    # row and the session-scoped copy carry it, so the pre-fill assertion
+    # below holds whichever one the picker collapsed to.
+    _hello_world_card(dialog, base_url, session_id).click()
 
     # The Model input is pre-filled with the agent's declared model, not
     # empty — a regression to an empty default would mean the agent's

--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -182,6 +182,46 @@ async def test_list_builtin_agents_exposes_harness_from_spec(
     assert entry["harness"] == harness
 
 
+async def test_list_builtin_agents_exposes_model_from_spec(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """
+    ``GET /v1/agents`` reports each agent's resolved default ``model``
+    from its spec's ``llm.model``.
+
+    The Web UI Add Agent picker pre-fills this into an editable model
+    field and forwards it as ``model_override`` on session create, so a
+    custom agent with its own declared model is launched on that model
+    by default instead of the harness default. A ``None`` here would
+    mean the bundle failed to load (degrading like ``harness``); a
+    wrong value would mean the route read the wrong spec field. The
+    value mirrors the spec's ``llm.model`` (the parser syncs
+    ``executor.model`` into it), so asserting it equals the declared
+    model proves the load → AgentObject path.
+    """
+    bundle = build_agent_bundle(
+        name="custom-reviewer",
+        executor={"type": "omnigent", "config": {"harness": "codex"}},
+    )
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="b4e1c07d9a3f4e2b8c6d5a09f1e3b7c2",
+        name="custom-reviewer",
+        bundle=bundle,
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    entry = next(a for a in resp.json()["data"] if a["id"] == "b4e1c07d9a3f4e2b8c6d5a09f1e3b7c2")
+    # build_agent_bundle writes llm.model = name, so this proves the
+    # spec's llm.model traversed the load → AgentObject path verbatim.
+    assert entry["model"] == "custom-reviewer"
+
+
 async def test_list_builtin_agents_exposes_declared_terminals_from_spec(
     agent_store: SqlAlchemyAgentStore,
     artifact_store: LocalArtifactStore,

--- a/web/src/components/AgentCard.test.tsx
+++ b/web/src/components/AgentCard.test.tsx
@@ -33,6 +33,7 @@ function agent(overrides: Partial<AvailableAgent> = {}): AvailableAgent {
     display_name: "Some Agent",
     description: null,
     harness: null,
+    model: null,
     skills: [],
     ...overrides,
   };

--- a/web/src/components/AgentHoverCard.test.tsx
+++ b/web/src/components/AgentHoverCard.test.tsx
@@ -12,6 +12,7 @@ function agent(overrides: Partial<AvailableAgent> = {}): AvailableAgent {
     display_name: "Some Agent",
     description: null,
     harness: null,
+    model: null,
     skills: [],
     ...overrides,
   };

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -82,6 +82,7 @@ vi.mock("@/shell/NewChatDialog", () => ({
             display_name: "Claude Code",
             description: null,
             harness: "claude-native",
+            model: null,
             skills: [],
           })
         }
@@ -98,6 +99,7 @@ vi.mock("@/shell/NewChatDialog", () => ({
             display_name: "Polly",
             description: null,
             harness: "claude-sdk",
+            model: null,
             skills: [],
           })
         }
@@ -133,6 +135,7 @@ const AGENTS: AvailableAgent[] = [
     display_name: "Polly",
     description: null,
     harness: "claude-sdk",
+    model: null,
     skills: [],
   },
   {
@@ -141,6 +144,7 @@ const AGENTS: AvailableAgent[] = [
     display_name: "Claude Code",
     description: null,
     harness: "claude-native",
+    model: null,
     skills: [],
   },
 ];

--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -118,6 +118,7 @@ describe("useAvailableAgents", () => {
         display_name: "Codex",
         description: null,
         harness: "codex-native",
+        model: null,
         skills: [],
       },
     ]);
@@ -179,6 +180,7 @@ describe("useAvailableAgents", () => {
             name: "databricks_coding_agent",
             description: "A coding agent",
             harness: "codex",
+            model: "databricks-gpt-5-5",
           },
         ],
         has_more: false,
@@ -206,6 +208,7 @@ describe("useAvailableAgents", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [],
       },
       {
@@ -214,6 +217,7 @@ describe("useAvailableAgents", () => {
         display_name: "Pi",
         description: null,
         harness: "pi-native",
+        model: null,
         skills: [],
       },
       {
@@ -222,6 +226,7 @@ describe("useAvailableAgents", () => {
         display_name: "Kiro",
         description: null,
         harness: "kiro-native",
+        model: null,
         skills: [],
       },
       {
@@ -230,6 +235,7 @@ describe("useAvailableAgents", () => {
         display_name: "Antigravity",
         description: null,
         harness: "antigravity-native",
+        model: null,
         skills: [],
       },
       {
@@ -238,6 +244,7 @@ describe("useAvailableAgents", () => {
         display_name: "OpenCode",
         description: null,
         harness: "opencode-native",
+        model: null,
         skills: [],
       },
       {
@@ -246,6 +253,7 @@ describe("useAvailableAgents", () => {
         display_name: "Nessie",
         description: "Multi-agent coding orchestrator.",
         harness: "nessie",
+        model: null,
         skills: [{ name: "review-pr", description: "Review a pull request" }],
       },
       {
@@ -254,6 +262,7 @@ describe("useAvailableAgents", () => {
         display_name: "Debby",
         description: "A two-headed brainstorming partner.",
         harness: "claude-sdk",
+        model: null,
         skills: [],
       },
       {
@@ -262,6 +271,7 @@ describe("useAvailableAgents", () => {
         display_name: "Databricks_coding_agent",
         description: "A coding agent",
         harness: "codex",
+        model: "databricks-gpt-5-5",
         skills: [],
       },
     ]);
@@ -378,6 +388,7 @@ describe("useAvailableAgents", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [],
       },
       {
@@ -386,6 +397,7 @@ describe("useAvailableAgents", () => {
         display_name: "Doc-writer",
         description: null,
         harness: null,
+        model: null,
         sessionId: "conv_3",
         skills: [],
       },
@@ -447,6 +459,7 @@ describe("useAvailableAgents", () => {
         display_name: "Codex",
         description: null,
         harness: "codex-native",
+        model: null,
         skills: [],
       },
       {
@@ -455,6 +468,7 @@ describe("useAvailableAgents", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [],
       },
       {
@@ -463,6 +477,7 @@ describe("useAvailableAgents", () => {
         display_name: "Kiro",
         description: null,
         harness: "kiro-native",
+        model: null,
         skills: [],
       },
       {
@@ -471,6 +486,7 @@ describe("useAvailableAgents", () => {
         display_name: "Kiro-naitive",
         description: null,
         harness: null,
+        model: null,
         sessionId: "conv_kiro",
         skills: [],
       },
@@ -517,6 +533,7 @@ describe("useAvailableAgents", () => {
         display_name: "Elise_working_agent",
         description: null,
         harness: null,
+        model: null,
         sessionId: "conv_new",
         skills: [],
       },
@@ -526,6 +543,7 @@ describe("useAvailableAgents", () => {
         display_name: "Doc-writer",
         description: null,
         harness: null,
+        model: null,
         sessionId: "conv_doc",
         skills: [],
       },
@@ -696,6 +714,7 @@ describe("useAvailableAgents", () => {
         display_name: "Doc-writer",
         description: null,
         harness: null,
+        model: null,
         sessionId: "conv_3",
         skills: [],
       },
@@ -712,6 +731,7 @@ describe("prefetchAvailableAgentDetails", () => {
       display_name: "Doc-writer",
       description: null,
       harness: null,
+      model: null,
       skills: [],
       sessionId: "conv_3",
     };
@@ -737,6 +757,7 @@ describe("prefetchAvailableAgentDetails", () => {
         display_name: "Doc-writer",
         description: "Documentation specialist",
         harness: "claude-sdk",
+        model: null,
         sessionId: "conv_3",
         skills: [{ name: "humanizer", description: "Remove AI writing patterns" }],
       },
@@ -752,6 +773,7 @@ describe("prefetchAvailableAgentDetails", () => {
       display_name: "Doc-writer",
       description: null,
       harness: "claude-sdk",
+      model: null,
       skills: [],
       sessionId: "conv_3",
     };
@@ -771,6 +793,7 @@ describe("prefetchAvailableAgentDetails", () => {
       display_name: "Claude Code",
       description: null,
       harness: null,
+      model: null,
       skills: [],
     };
     queryClient.setQueryData(["available-agents"], [agent]);
@@ -788,6 +811,7 @@ describe("prefetchAvailableAgentDetails", () => {
       display_name: "Doc-writer",
       description: null,
       harness: null,
+      model: null,
       skills: [],
       sessionId: "conv_3",
     };
@@ -813,6 +837,7 @@ describe("prefetchAvailableAgentDetails", () => {
       display_name: "Kiro",
       description: null,
       harness: "kiro-native",
+      model: null,
       skills: [],
     };
     const kiroShadow = {
@@ -821,6 +846,7 @@ describe("prefetchAvailableAgentDetails", () => {
       display_name: "Kiro-naitive",
       description: null,
       harness: null,
+      model: null,
       skills: [],
       sessionId: "conv_kiro",
     };

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -18,6 +18,11 @@ export interface AvailableAgent {
   // the agent's spec. Lets the picker recognise Codex vs Claude agents
   // by kind rather than by name slug.
   harness: string | null;
+  // Resolved default LLM model from GET /v1/agents (spec's llm.model).
+  // null when the server couldn't load the spec or no model is declared.
+  // Pre-fills the Add Agent model input and is forwarded as
+  // model_override on session create. Absent on older servers.
+  model: string | null;
   // Skills bundled in the agent spec (name + one-line description).
   // Feeds the landing composer's "/" menu before a session exists;
   // host-discovered skills only resolve once a runner is bound, so
@@ -90,6 +95,7 @@ interface BuiltinAgentWire {
   name: string;
   description?: string | null;
   harness?: string | null;
+  model?: string | null;
   skills?: { name: string; description: string }[];
   // True only for server-seeded built-ins (deterministic id). Absent on
   // older servers, where every catalog row degrades to a protected entry.
@@ -138,6 +144,7 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     display_name: displayNameForAgent(a.name, a.harness),
     description: a.description ?? null,
     harness: a.harness ?? null,
+    model: a.model ?? null,
     skills: a.skills ?? [],
     // Omit rather than set to undefined so toEqual comparisons aren't
     // sensitive to absent-vs-undefined. Logic that reads builtin treats
@@ -197,6 +204,7 @@ interface AgentObjectWire {
   name: string;
   description?: string | null;
   harness?: string | null;
+  model?: string | null;
   skills?: { name: string; description: string }[];
 }
 
@@ -212,6 +220,7 @@ function sessionAgentFromScan(scanned: ScannedSessionAgent): AvailableAgent {
     display_name: displayNameForAgent(scanned.agentName),
     description: null,
     harness: null,
+    model: null,
     skills: [],
     sessionId: scanned.sessionId,
     // builtin/created_at intentionally omitted: session-derived agents never
@@ -246,6 +255,7 @@ export async function prefetchAvailableAgentDetails(
               display_name: displayNameForAgent(json.name, json.harness),
               description: json.description ?? null,
               harness: json.harness ?? null,
+              model: json.model ?? null,
               skills: json.skills ?? [],
             },
       );

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -414,6 +414,10 @@ function postEventResponseFromWire(wire: {
  * @param options.subAgentName - Sub-agent name for parent-spec-tree
  *   resolution; null/omitted for user-added agents.
  * @param options.title - Child title, e.g. "ui:claude-native-ui:1".
+ * @param options.modelOverride - Per-session model override (provider-prefixed
+ *   id, e.g. "databricks-gpt-5-5"), pre-filled from the agent's declared
+ *   `llm.model` so a custom agent launches on its own model by default. null
+ *   clears it (harness default). Only sent when provided.
  */
 export async function createSession(
   agentId: string,
@@ -422,6 +426,7 @@ export async function createSession(
     parentSessionId?: string;
     subAgentName?: string | null;
     title?: string;
+    modelOverride?: string | null;
   } = {},
 ): Promise<Session> {
   const body: {
@@ -430,6 +435,7 @@ export async function createSession(
     parent_session_id?: string;
     sub_agent_name?: string | null;
     title?: string;
+    model_override?: string | null;
   } = { agent_id: agentId, initial_items: initialItems };
   if (options.parentSessionId !== undefined) {
     body.parent_session_id = options.parentSessionId;
@@ -439,6 +445,9 @@ export async function createSession(
   }
   if (options.title !== undefined) {
     body.title = options.title;
+  }
+  if (options.modelOverride !== undefined) {
+    body.model_override = options.modelOverride;
   }
   const res = await authenticatedFetch("/v1/sessions", {
     method: "POST",

--- a/web/src/shell/AddAgentDialog.test.tsx
+++ b/web/src/shell/AddAgentDialog.test.tsx
@@ -6,7 +6,11 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { AddAgentDialog } from "./AddAgentDialog";
-import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
+import {
+  useAvailableAgents,
+  prefetchAvailableAgentDetails,
+  type AvailableAgent,
+} from "@/hooks/useAvailableAgents";
 import { createSession } from "@/lib/sessionsApi";
 
 const navigateMock = vi.fn();
@@ -21,6 +25,7 @@ vi.mock("@/hooks/useAvailableAgents", () => ({
 vi.mock("@/lib/sessionsApi", () => ({ createSession: vi.fn() }));
 
 const useAvailableAgentsMock = vi.mocked(useAvailableAgents);
+const prefetchMock = vi.mocked(prefetchAvailableAgentDetails);
 const createSessionMock = vi.mocked(createSession);
 
 const AGENTS: AvailableAgent[] = [
@@ -65,6 +70,8 @@ function renderDialog(parentSessionId = "conv_parent") {
 
 beforeEach(() => {
   useAvailableAgentsMock.mockReset();
+  prefetchMock.mockReset();
+  prefetchMock.mockResolvedValue(undefined);
   createSessionMock.mockReset();
   navigateMock.mockReset();
   mockAgents(AGENTS);
@@ -247,6 +254,68 @@ describe("AddAgentDialog", () => {
       title: "ui:databricks-coding-agent:reviewer",
       modelOverride: null,
     });
+  });
+
+  // A session-discovered row: the sessions scan supplies only id/name, so
+  // its declared model (and description / harness) is null until enriched.
+  const SCANNED_AGENT: AvailableAgent = {
+    id: "ag_scanned",
+    name: "hello_world",
+    display_name: "Hello world",
+    description: null,
+    harness: null,
+    model: null,
+    skills: [],
+    sessionId: "conv_seed",
+  };
+
+  it("enriches only the row focus lands on when the dialog opens", () => {
+    // Enrichment is one GET /v1/sessions/{id}/agent per row, so fetching the
+    // whole list on open bursts on servers with many discovered agents.
+    // Radix moves focus into the dialog, which lands on the first card — that
+    // row enriches, and nothing else does.
+    mockAgents([SCANNED_AGENT, ...AGENTS]);
+    renderDialog();
+    expect(prefetchMock).toHaveBeenCalledTimes(1);
+    expect(prefetchMock.mock.calls[0][0]).toEqual(SCANNED_AGENT);
+  });
+
+  it("enriches a single row on hover and on keyboard focus", () => {
+    mockAgents([SCANNED_AGENT, ...AGENTS]);
+    renderDialog();
+    // Drop the open-time enrichment of the auto-focused row.
+    prefetchMock.mockClear();
+
+    fireEvent.mouseOver(screen.getByTestId("agent-card-ag_codex"));
+    expect(prefetchMock).toHaveBeenCalledTimes(1);
+    expect(prefetchMock.mock.calls[0][0]).toEqual(AGENTS[1]);
+
+    // Tabbing onto a row enriches it too, so keyboard users get the same
+    // pre-fill without a pointer ever touching the card.
+    fireEvent.focusIn(screen.getByTestId("agent-card-ag_claude"));
+    expect(prefetchMock).toHaveBeenCalledTimes(2);
+    expect(prefetchMock.mock.calls[1][0]).toEqual(AGENTS[0]);
+  });
+
+  it("enriches the picked row so a discovered agent's model still pre-fills", () => {
+    // Selection is what the model pre-fill hangs on: the Model input only
+    // appears after a pick, and a session-discovered row carries no model
+    // until this fetch patches the catalog.
+    mockAgents([SCANNED_AGENT]);
+    renderDialog();
+    prefetchMock.mockClear();
+    prefetchMock.mockImplementation((agent) => {
+      mockAgents([
+        { ...(agent as AvailableAgent), harness: "openai-agents", model: "gpt-4o-mini" },
+      ]);
+      return Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTestId("agent-card-ag_scanned"));
+
+    expect(prefetchMock).toHaveBeenCalledTimes(1);
+    expect(prefetchMock.mock.calls[0][0]).toEqual(SCANNED_AGENT);
+    expect(screen.getByTestId("add-agent-model-input")).toHaveValue("gpt-4o-mini");
   });
 
   it("shows an empty-state and a disabled submit when no agents are available", () => {

--- a/web/src/shell/AddAgentDialog.test.tsx
+++ b/web/src/shell/AddAgentDialog.test.tsx
@@ -30,6 +30,7 @@ const AGENTS: AvailableAgent[] = [
     display_name: "Claude Code",
     description: "Claude Code agent",
     harness: "claude-native",
+    model: null,
     skills: [],
   },
   {
@@ -38,6 +39,7 @@ const AGENTS: AvailableAgent[] = [
     display_name: "codex",
     description: null,
     harness: "codex",
+    model: null,
     skills: [],
   },
 ];
@@ -99,6 +101,7 @@ describe("AddAgentDialog", () => {
       parentSessionId: "conv_parent",
       subAgentName: null,
       title: "ui:claude-native-ui:jimmy",
+      modelOverride: null,
     });
     // Rail refreshed for the parent, then navigated into the new child.
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_child"));
@@ -129,6 +132,7 @@ describe("AddAgentDialog", () => {
       parentSessionId: "conv_parent",
       subAgentName: null,
       title: "ui:codex:reviewer",
+      modelOverride: null,
     });
   });
 
@@ -162,6 +166,87 @@ describe("AddAgentDialog", () => {
     const initialItems = createSessionMock.mock.calls[0][1];
     expect(initialItems).not.toEqual([]);
     expect(JSON.stringify(initialItems)).toContain("designs/feature-x.md");
+  });
+
+  it("pre-fills the agent's declared model and forwards it as model_override", async () => {
+    // Agent with a declared llm.model — the dialog must pre-fill the
+    // model input with it and forward the (possibly edited) value as
+    // model_override on session create, so a custom agent launches on
+    // its own model by default instead of the harness default.
+    mockAgents([
+      {
+        id: "ag_custom",
+        name: "databricks-coding-agent",
+        display_name: "Databricks Coding Agent",
+        description: "Custom coding agent",
+        harness: "openai-agents",
+        model: "databricks-gpt-5-5",
+        skills: [],
+      },
+    ]);
+    createSessionMock.mockResolvedValue({
+      id: "conv_child",
+    } as unknown as Awaited<ReturnType<typeof createSession>>);
+
+    renderDialog("conv_parent");
+
+    fireEvent.click(screen.getByTestId("agent-card-ag_custom"));
+    // Pre-filled from the agent's declared default — not empty.
+    const modelInput = screen.getByTestId("add-agent-model-input");
+    expect(modelInput).toHaveValue("databricks-gpt-5-5");
+    fireEvent.change(screen.getByTestId("add-agent-name-input"), {
+      target: { value: "reviewer" },
+    });
+    // The user edits the pre-filled model.
+    fireEvent.change(modelInput, { target: { value: "databricks-gpt-5-4" } });
+    fireEvent.click(screen.getByTestId("add-agent-submit"));
+
+    await waitFor(() => expect(createSessionMock).toHaveBeenCalledTimes(1));
+    // The edited model flows through as model_override (not null).
+    expect(createSessionMock).toHaveBeenCalledWith("ag_custom", [], {
+      parentSessionId: "conv_parent",
+      subAgentName: null,
+      title: "ui:databricks-coding-agent:reviewer",
+      modelOverride: "databricks-gpt-5-4",
+    });
+  });
+
+  it("sends a null model_override when the pre-filled model is cleared", async () => {
+    // Clearing the model input → harness default (model_override: null),
+    // not an empty-string override.
+    mockAgents([
+      {
+        id: "ag_custom",
+        name: "databricks-coding-agent",
+        display_name: "Databricks Coding Agent",
+        description: "Custom coding agent",
+        harness: "openai-agents",
+        model: "databricks-gpt-5-5",
+        skills: [],
+      },
+    ]);
+    createSessionMock.mockResolvedValue({
+      id: "conv_child",
+    } as unknown as Awaited<ReturnType<typeof createSession>>);
+
+    renderDialog("conv_parent");
+
+    fireEvent.click(screen.getByTestId("agent-card-ag_custom"));
+    fireEvent.change(screen.getByTestId("add-agent-name-input"), {
+      target: { value: "reviewer" },
+    });
+    fireEvent.change(screen.getByTestId("add-agent-model-input"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByTestId("add-agent-submit"));
+
+    await waitFor(() => expect(createSessionMock).toHaveBeenCalledTimes(1));
+    expect(createSessionMock).toHaveBeenCalledWith("ag_custom", [], {
+      parentSessionId: "conv_parent",
+      subAgentName: null,
+      title: "ui:databricks-coding-agent:reviewer",
+      modelOverride: null,
+    });
   });
 
   it("shows an empty-state and a disabled submit when no agents are available", () => {

--- a/web/src/shell/AddAgentDialog.tsx
+++ b/web/src/shell/AddAgentDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "@/lib/routing";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { AgentCard } from "@/components/AgentCard";
-import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import { useAvailableAgents, prefetchAvailableAgentDetails } from "@/hooks/useAvailableAgents";
 import { childSessionsQueryKey } from "@/hooks/useChildSessions";
 import { createSession } from "@/lib/sessionsApi";
 
@@ -52,22 +52,30 @@ export function AddAgentDialog({
   const agentList = agents ?? [];
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [name, setName] = useState("");
-  // Pre-filled from the selected agent's declared ``llm.model`` and
-  // forwarded as ``model_override`` on session create. Empty (or an
-  // agent with no declared model) → harness default (no override sent).
-  const [model, setModel] = useState("");
+  // null means "untouched" — the input shows the selected agent's declared
+  // model. Once the user types (including clearing it to ""), their value
+  // wins. Forwarded as ``model_override``; empty → harness default.
+  const [model, setModel] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const selectedAgent = agentList.find((a) => a.id === selectedAgentId) ?? null;
+  const modelValue = model ?? selectedAgent?.model ?? "";
+
+  // Session-discovered rows reach the catalog with only scan data; their
+  // declared model arrives via this enrichment. Without it the picker's
+  // model input stays empty for exactly the agents this dialog surfaces.
+  useEffect(() => {
+    if (!open) return;
+    for (const agent of agentList) {
+      void prefetchAvailableAgentDetails(agent, queryClient);
+    }
+  }, [open, agentList, queryClient]);
 
   function selectAgent(agentId: string): void {
-    const agent = agentList.find((a) => a.id === agentId) ?? null;
     setSelectedAgentId(agentId);
-    // Pre-fill the model input with the agent's declared default so the
-    // user can accept it as-is or edit it; agents without a declared
-    // model start empty (harness default).
-    setModel(agent?.model ?? "");
+    // Back to following the newly picked agent's declared model.
+    setModel(null);
     setError(null);
   }
 
@@ -75,7 +83,7 @@ export function AddAgentDialog({
     if (!next) {
       setSelectedAgentId(null);
       setName("");
-      setModel("");
+      setModel(null);
       setError(null);
       setSubmitting(false);
     }
@@ -89,7 +97,7 @@ export function AddAgentDialog({
       setError("Enter a name for the agent.");
       return;
     }
-    const trimmedModel = model.trim();
+    const trimmedModel = modelValue.trim();
     const title = `${UI_ADDED_TITLE_PREFIX}:${selectedAgent.name}:${trimmed}`;
     setSubmitting(true);
     setError(null);
@@ -186,7 +194,7 @@ export function AddAgentDialog({
                   id="add-agent-model"
                   data-testid="add-agent-model-input"
                   type="text"
-                  value={model}
+                  value={modelValue}
                   onChange={(e) => setModel(e.target.value)}
                   placeholder="Harness default"
                   className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors focus-visible:border-ring"

--- a/web/src/shell/AddAgentDialog.tsx
+++ b/web/src/shell/AddAgentDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "@/lib/routing";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -10,7 +10,11 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { AgentCard } from "@/components/AgentCard";
-import { useAvailableAgents, prefetchAvailableAgentDetails } from "@/hooks/useAvailableAgents";
+import {
+  useAvailableAgents,
+  prefetchAvailableAgentDetails,
+  type AvailableAgent,
+} from "@/hooks/useAvailableAgents";
 import { childSessionsQueryKey } from "@/hooks/useChildSessions";
 import { createSession } from "@/lib/sessionsApi";
 
@@ -63,20 +67,23 @@ export function AddAgentDialog({
   const modelValue = model ?? selectedAgent?.model ?? "";
 
   // Session-discovered rows reach the catalog with only scan data; their
-  // declared model arrives via this enrichment. Without it the picker's
-  // model input stays empty for exactly the agents this dialog surfaces.
-  useEffect(() => {
-    if (!open) return;
-    for (const agent of agentList) {
-      void prefetchAvailableAgentDetails(agent, queryClient);
-    }
-  }, [open, agentList, queryClient]);
+  // declared model (plus description and harness glyph) arrives via this
+  // enrichment. One row at a time, driven by hover / focus / selection, so
+  // opening the dialog doesn't fan out a GET per discovered agent.
+  function enrichAgent(agent: AvailableAgent): void {
+    void prefetchAvailableAgentDetails(agent, queryClient);
+  }
 
   function selectAgent(agentId: string): void {
     setSelectedAgentId(agentId);
     // Back to following the newly picked agent's declared model.
     setModel(null);
     setError(null);
+    // Selection is the path that must enrich: the Model input pre-fills from
+    // the picked agent's declared model, which a session-discovered row only
+    // carries once this fetch lands.
+    const picked = agentList.find((a) => a.id === agentId);
+    if (picked) enrichAgent(picked);
   }
 
   function handleOpenChange(next: boolean): void {
@@ -106,7 +113,8 @@ export function AddAgentDialog({
         parentSessionId,
         subAgentName: null,
         title,
-        // Empty model → null → harness default (no override).
+        // Empty model sends `model_override: null`, which the server reads
+        // the same as an absent field — no override, harness default.
         modelOverride: trimmedModel || null,
       });
       // Refresh the rail so the new child appears immediately, then jump
@@ -145,13 +153,20 @@ export function AddAgentDialog({
               </p>
             ) : (
               agentList.map((agent) => (
-                <AgentCard
+                // Pointer/keyboard landing on a row enriches that row alone,
+                // so its details are ready before the user picks it.
+                <div
                   key={agent.id}
-                  agent={agent}
-                  selected={agent.id === selectedAgentId}
-                  onSelect={() => selectAgent(agent.id)}
-                  hover
-                />
+                  onMouseEnter={() => enrichAgent(agent)}
+                  onFocus={() => enrichAgent(agent)}
+                >
+                  <AgentCard
+                    agent={agent}
+                    selected={agent.id === selectedAgentId}
+                    onSelect={() => selectAgent(agent.id)}
+                    hover
+                  />
+                </div>
               ))
             )}
           </div>

--- a/web/src/shell/AddAgentDialog.tsx
+++ b/web/src/shell/AddAgentDialog.tsx
@@ -52,13 +52,22 @@ export function AddAgentDialog({
   const agentList = agents ?? [];
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [name, setName] = useState("");
+  // Pre-filled from the selected agent's declared ``llm.model`` and
+  // forwarded as ``model_override`` on session create. Empty (or an
+  // agent with no declared model) → harness default (no override sent).
+  const [model, setModel] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const selectedAgent = agentList.find((a) => a.id === selectedAgentId) ?? null;
 
   function selectAgent(agentId: string): void {
+    const agent = agentList.find((a) => a.id === agentId) ?? null;
     setSelectedAgentId(agentId);
+    // Pre-fill the model input with the agent's declared default so the
+    // user can accept it as-is or edit it; agents without a declared
+    // model start empty (harness default).
+    setModel(agent?.model ?? "");
     setError(null);
   }
 
@@ -66,6 +75,7 @@ export function AddAgentDialog({
     if (!next) {
       setSelectedAgentId(null);
       setName("");
+      setModel("");
       setError(null);
       setSubmitting(false);
     }
@@ -79,6 +89,7 @@ export function AddAgentDialog({
       setError("Enter a name for the agent.");
       return;
     }
+    const trimmedModel = model.trim();
     const title = `${UI_ADDED_TITLE_PREFIX}:${selectedAgent.name}:${trimmed}`;
     setSubmitting(true);
     setError(null);
@@ -87,6 +98,8 @@ export function AddAgentDialog({
         parentSessionId,
         subAgentName: null,
         title,
+        // Empty model → null → harness default (no override).
+        modelOverride: trimmedModel || null,
       });
       // Refresh the rail so the new child appears immediately, then jump
       // into it for the first message.
@@ -136,23 +149,51 @@ export function AddAgentDialog({
           </div>
 
           {selectedAgent !== null && (
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor="add-agent-name" className="text-sm font-medium text-muted-foreground">
-                Name
-              </label>
-              {/* Raw input matching NewChatDialog's "Name" field for a
+            <>
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="add-agent-name"
+                  className="text-sm font-medium text-muted-foreground"
+                >
+                  Name
+                </label>
+                {/* Raw input matching NewChatDialog's "Name" field for a
                   consistent look (rounded-md + border-tint focus, no
                   heavy ring). */}
-              <input
-                id="add-agent-name"
-                data-testid="add-agent-name-input"
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Name this agent"
-                className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors focus-visible:border-ring"
-              />
-            </div>
+                <input
+                  id="add-agent-name"
+                  data-testid="add-agent-name-input"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Name this agent"
+                  className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors focus-visible:border-ring"
+                />
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="add-agent-model"
+                  className="text-sm font-medium text-muted-foreground"
+                >
+                  Model
+                </label>
+                {/* Pre-filled from the agent's declared default (llm.model).
+                  Empty → harness default. Raw input matching the Name field
+                  for a consistent look. A richer dropdown picker backed by
+                  a models-list endpoint is a documented follow-up. */}
+                <input
+                  id="add-agent-model"
+                  data-testid="add-agent-model-input"
+                  type="text"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="Harness default"
+                  className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors focus-visible:border-ring"
+                />
+              </div>
+            </>
+
           )}
 
           {error !== null && (

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -151,6 +151,7 @@ function agent(overrides: Partial<AvailableAgent> = {}): AvailableAgent {
     display_name: "Hello World",
     description: null,
     harness: null,
+    model: null,
     skills: [],
     ...overrides,
   };

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -92,6 +92,7 @@ function agent(overrides: Partial<AvailableAgent> = {}): AvailableAgent {
     display_name: "Hello World",
     description: null,
     harness: null,
+    model: null,
     skills: [],
     ...overrides,
   };

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -726,6 +726,7 @@ function setupLandingMocks() {
       display_name: "Claude Code",
       description: null,
       harness: "claude-native",
+      model: null,
       skills: [],
     },
     {
@@ -734,6 +735,7 @@ function setupLandingMocks() {
       display_name: "Codex",
       description: null,
       harness: "codex-native",
+      model: null,
       skills: [],
     },
   ]);
@@ -1020,6 +1022,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Pi",
         description: null,
         harness: "pi-native",
+        model: null,
         skills: [],
       },
       {
@@ -1028,6 +1031,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Kiro",
         description: null,
         harness: "kiro-native",
+        model: null,
         skills: [],
       },
       {
@@ -1036,6 +1040,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Cursor",
         description: null,
         harness: "cursor-native",
+        model: null,
         skills: [],
       },
       {
@@ -1044,6 +1049,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Codex",
         description: null,
         harness: "codex-native",
+        model: null,
         skills: [],
       },
       {
@@ -1052,6 +1058,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [],
       },
       {
@@ -1060,6 +1067,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Polly",
         description: null,
         harness: "claude-sdk",
+        model: null,
         skills: [],
       },
     ]);
@@ -1214,6 +1222,7 @@ describe("NewChatLandingScreen", () => {
         display_name: "Polly",
         description: null,
         harness: "claude-sdk",
+        model: null,
         skills: [],
       },
     ]);
@@ -2450,6 +2459,7 @@ describe("NewChatLandingScreen skills menu", () => {
       display_name: "Skilled Agent",
       description: null,
       harness: "claude-sdk",
+      model: null,
       skills: [
         { name: "review-pr", description: "Review a pull request" },
         { name: "cross-review", description: "Cross-vendor review" },
@@ -2546,6 +2556,7 @@ describe("NewChatLandingScreen skills menu", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [{ name: "review-pr", description: "Review a pull request" }],
       },
     ]);
@@ -2573,6 +2584,7 @@ describe("NewChatLandingScreen skill pills", () => {
       display_name: "Debby",
       description: "Multi-agent debate",
       harness: "claude-sdk",
+      model: null,
       skills: [
         { name: "debate", description: "Have both heads argue it out" },
         { name: "compare", description: "Side-by-side answers from both heads" },
@@ -2605,6 +2617,7 @@ describe("NewChatLandingScreen skill pills", () => {
         display_name: "Skilled Agent",
         description: null,
         harness: "claude-sdk",
+        model: null,
         skills: [{ name: "review-pr", description: "Review a pull request" }],
       },
     ]);
@@ -2623,6 +2636,7 @@ describe("NewChatLandingScreen skill pills", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [],
       },
       debbyAgent(),
@@ -2790,6 +2804,7 @@ describe("NewChatLandingScreen @-file-mention", () => {
         display_name: "SDK Agent",
         description: null,
         harness: "claude-sdk",
+        model: null,
         skills: [],
       },
     ]);
@@ -3026,6 +3041,7 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
         display_name: "OpenCode",
         description: null,
         harness: "opencode-native",
+        model: null,
         skills: [],
       },
     ]);
@@ -3188,6 +3204,7 @@ describe("NewChatLandingScreen agent picker (mobile drill-in)", () => {
         display_name: "Claude Code",
         description: null,
         harness: "claude-native",
+        model: null,
         skills: [],
       },
       {
@@ -3196,6 +3213,7 @@ describe("NewChatLandingScreen agent picker (mobile drill-in)", () => {
         display_name: "My Custom Agent",
         description: null,
         harness: "claude-sdk",
+        model: null,
         skills: [],
       },
     ]);

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2531,6 +2531,7 @@ export function NewChatLandingScreen() {
             display_name: pendingAgent.name,
             description: pendingAgent.description ?? null,
             harness: pendingAgent.harness ?? null,
+            model: pendingAgent.model ?? null,
             skills: [],
           } satisfies AvailableAgent)
         : agentList.find((a) => a.id === effectiveAgentId),


### PR DESCRIPTION
Closes #232.

## What

Expose each built-in agent's resolved default model (`spec.llm.model`) on `GET /v1/agents` (new `AgentObject.model` field), thread it through the ap-web agent catalog, and pre-fill it into an editable **Model** input in the Add Agent dialog. The (possibly edited) value is forwarded as `model_override` on `POST /v1/sessions`, so a custom agent launches on its own declared model by default instead of the harness default. Clearing the input → `null` → harness default (no override).

## Why

Today the Add Agent dialog always launches the child on the harness default model — a custom agent that declares its own `llm.model` (e.g. a Databricks-hosted model) ignores that declaration. The picker already knows the agent's kind (`harness`) for glyph selection; surfacing the model on the same `GET /v1/agents` payload lets the UI show and override it without a new endpoint or a models-list call.

## How
- **Backend:** `AgentObject.model: str | None` in `omnigent/server/schemas.py`; populated in `_to_agent_object` from `loaded.spec.llm.model` (the parser syncs `executor.model` into it; `None` only when the bundle can't load or no model is declared). `openapi.json` regenerated.
- **Frontend:** `useAvailableAgents` threads `model` from both the builtins wire (`GET /v1/agents`) and the enrich wire (`GET /v1/sessions/{id}/agent`); `sessionsApi.createSession` gains a `modelOverride` option → `model_override` body field (server already accepted it on `SessionCreateRequest`); `AddAgentDialog` adds a pre-filled editable Model input mirroring the existing Name input.
- **Smallest mergeable core:** a plain text input (mirrors the dialog's existing Name field). A richer dropdown picker backed by a models-list endpoint is a documented follow-up, not part of this PR.

## Tests
- **Backend:** `tests/server/integration/test_builtin_agents.py` — asserts `GET /v1/agents` exposes the spec's `llm.model`.
- **ap-web vitest:** `AddAgentDialog.test.tsx` (pre-fill, edit→override, clear→null), `useAvailableAgents.test.tsx` (model threaded on both wire paths + null default).
- **e2e_ui:** `tests/e2e_ui/agents/test_add_subagent_dialog.py` — new journey asserts the Model input pre-fills with the agent's declared model and that an edit lands on the created child session's snapshot as `model_override` (no LLM turn; pure catalog + REST plumbing).

## Checklist
- [x] `/check` green: ruff format/check, mypy, pytest shard, `tsc -b`, full ap-web vitest (2846 passed), exfil-scan
- [x] `openapi.json` regenerated (`scripts/dump_openapi.py`); `--check` clean
- [x] e2e_ui test added for the new user-facing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)