### PR TITLE
perf(conversation-store): maintain next_position counter to drop per-append MAX(position) aggregate

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -361,6 +361,13 @@ class SqlConversation(Base):
     # AgentSpec instead of the parent's. Replaces task.agent_name
     # from the removed task store. None for top-level sessions.
     sub_agent_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Monotonic allocator for the next item position in this conversation.
+    # append() reads and advances this instead of scanning
+    # MAX(SqlConversationItem.position) on every write, making position
+    # assignment O(1) and collision-free under the conversation lock. New rows
+    # start at 0 (column default); NULL marks a row created before this column
+    # existed, which append() backfills via a one-time scan on its next write.
+    next_position: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
     external_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     # JSON-serialized mutable per-conversation key/value store
     # used by policy callables to accumulate state across turns.

--- a/omnigent/db/migrations/versions/n1a2b3c4d5e6_add_next_position_to_conversations.py
+++ b/omnigent/db/migrations/versions/n1a2b3c4d5e6_add_next_position_to_conversations.py
@@ -1,0 +1,45 @@
+"""add next_position to conversations
+
+Revision ID: n1a2b3c4d5e6
+Revises: m1a2b3c4d5e6
+Create Date: 2026-06-18 00:00:00.000000
+
+Adds the maintained item-position allocator to the conversations table:
+
+- ``next_position``: nullable Integer — the next 0-based position to assign
+  to an appended conversation item. ``append()`` reads and advances this
+  counter instead of scanning ``MAX(conversation_items.position)`` on every
+  write, which keeps position assignment O(1) and collision-free under the
+  conversation lock.
+
+The column is added nullable with NO server default, so every pre-existing
+conversation reads ``NULL``. ``append()`` treats ``NULL`` as "not yet
+populated": it falls back to a one-time ``MAX(position)`` scan and then
+persists the advanced counter on the conversation row, so the very next
+append on that conversation is scan-free. New rows created through the ORM
+start at ``0`` via the model-level column default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "n1a2b3c4d5e6"
+down_revision: str | None = "m1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.add_column(
+            sa.Column("next_position", sa.Integer(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_column("next_position")

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -495,9 +495,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         row to escalate the transaction to ``RESERVED``. SQLite
         starts transactions as ``DEFERRED`` (read-only) by
         default — concurrent ``append()`` calls would otherwise
-        both run the ``select(max(position))`` query without
-        holding any write lock, both compute the same ``max_pos``,
-        and both try to INSERT at ``max_pos + 1`` → UNIQUE
+        both read the same ``next_position`` counter (or, for a
+        pre-counter conversation, the same ``max(position)``) without
+        holding any write lock, both allocate the same position, and
+        both try to INSERT it → UNIQUE
         constraint failure on
         ``ix_conversation_items_conversation_id_position``.
         Reproduced 2026-04-30 in the user's 20-shell scenario:
@@ -508,8 +509,9 @@ class SqlAlchemyConversationStore(ConversationStore):
         escalates this transaction to ``RESERVED`` immediately,
         so a second concurrent transaction blocks on
         ``busy_timeout`` (20s, set in :func:`make_managed_session_maker`)
-        rather than racing the SELECT, and re-reads ``max_pos``
-        with the up-to-date state once the holder commits.
+        rather than racing the read, and re-reads the up-to-date
+        ``next_position`` counter (or, for a pre-counter conversation,
+        ``max(position)``) once the holder commits.
 
         :param session: The active SQLAlchemy session.
         :param conversation_id: The conversation to lock,
@@ -1377,15 +1379,34 @@ class SqlAlchemyConversationStore(ConversationStore):
             if conv_row is not None:
                 conv_row.updated_at = now
 
-            # coalesce to -1 so the first appended item gets position 0.
-            max_pos = session.execute(
-                select(func.coalesce(func.max(SqlConversationItem.position), -1)).where(
-                    SqlConversationItem.conversation_id == conversation_id
+            # Allocate item positions from the conversation's maintained
+            # next_position counter instead of running a MAX(position) aggregate
+            # on every append. Reading + advancing the counter under
+            # _lock_conversation keeps allocation O(1), drops a query per write,
+            # and stays collision-free. The aggregate is an index lookup on this
+            # schema (ix_conversation_items_conversation_id_position), but a
+            # maintained counter avoids the per-append round-trip regardless and
+            # scales to backends where that same allocation is a full scan.
+            #
+            # Backwards compatibility: conversations created before this counter
+            # existed have next_position = NULL; fall back to a one-time
+            # MAX(position) scan (coalesce to -1 so the first item gets 0), then
+            # persist the counter below so every later append is scan-free.
+            if conv_row is not None and conv_row.next_position is not None:
+                next_pos = conv_row.next_position
+            else:
+                next_pos = (
+                    session.execute(
+                        select(func.coalesce(func.max(SqlConversationItem.position), -1)).where(
+                            SqlConversationItem.conversation_id == conversation_id
+                        )
+                    ).scalar_one()
+                    + 1
                 )
-            ).scalar_one()
 
             for item in items:
-                max_pos += 1
+                position = next_pos
+                next_pos += 1
                 data_dict = item.data.model_dump(exclude_none=True)
                 # Strip NUL bytes before they reach a Postgres text
                 # column, which rejects them outright. Tool output can
@@ -1400,7 +1421,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     response_id=item.response_id,
                     created_at=now,
                     status="completed",  # items are final on append
-                    position=max_pos,
+                    position=position,
                     type=item.type,
                     data=data,
                     search_text=search,
@@ -1419,6 +1440,11 @@ class SqlAlchemyConversationStore(ConversationStore):
                         created_by=item.created_by,
                     )
                 )
+
+            # Persist the advanced counter so the next append reads it instead
+            # of scanning; this also lazily backfills a pre-counter conversation.
+            if conv_row is not None:
+                conv_row.next_position = next_pos
 
         return persisted
 
@@ -2263,6 +2289,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                     new_conv.id,
                     src_item.search_text or "",
                 )
+
+            # The clone copied len(source_items) items at dense positions
+            # 0..N-1, so its position allocator starts at N. Seed it from the
+            # snapshot (not the source row's counter) so the fork is correct
+            # even when the source predates the counter.
+            new_conv.next_position = len(source_items)
 
             # Bind the cloned agent to the forked session atomically.
             if agent_id is not None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -718,6 +718,14 @@ def test_concurrent_appends_do_not_collide_on_position(
         f"persisted twice or list_items returned duplicates."
     )
 
+    # Positions are contiguous 0..N-1. The UNIQUE index catches *reused*
+    # positions (IntegrityError, asserted above), but a counter that
+    # over-advances — or an append silently skipped — leaves a *gap* with no
+    # error. list_items hides position, so assert on the raw column directly.
+    assert _stored_positions(conversation_store, conv.id) == list(range(expected_count)), (
+        "concurrent appends must allocate a gap-free 0..N-1 position sequence"
+    )
+
 
 def test_heavy_batch_racing_steering_append_does_not_collide(
     conversation_store: SqlAlchemyConversationStore,
@@ -856,6 +864,14 @@ def test_heavy_batch_racing_steering_append_does_not_collide(
     assert len(item_ids) == 80, (
         f"expected 80 distinct item IDs; got {len(item_ids)}. "
         f"Duplicate IDs would mean an item was persisted twice."
+    )
+
+    # Gap-free 0..79 across both threads: the heavy batch advances the
+    # next_position counter by 3 and the steering append by 1, so a counter
+    # that mis-advances under this asymmetric race would skip or reuse a
+    # position without tripping the UNIQUE index. Assert the raw column.
+    assert _stored_positions(conversation_store, conv.id) == list(range(80)), (
+        "heavy-batch + steering appends must allocate a gap-free 0..79 sequence"
     )
 
 
@@ -3964,3 +3980,199 @@ def test_list_conversations_by_host_id_empty(
     conversation_store.create_conversation()
     result = conversation_store.list_conversations_by_host_id("host_nonexistent")
     assert result == []
+
+
+# ── next_position counter (write-path MAX(position) scan removal) ──────
+
+
+def _user_message(text: str, response_id: str = "resp_pos") -> NewConversationItem:
+    """A minimal user message item for position-counter tests."""
+    return NewConversationItem(
+        type="message",
+        response_id=response_id,
+        data=MessageData(role="user", content=[{"type": "input_text", "text": text}]),
+    )
+
+
+def _stored_next_position(
+    conversation_store: SqlAlchemyConversationStore, conversation_id: str
+) -> int | None:
+    """Read the raw ``conversations.next_position`` counter for assertions."""
+    from omnigent.db.db_models import SqlConversation
+
+    with conversation_store._session() as session:
+        row = session.get(SqlConversation, conversation_id)
+        assert row is not None
+        return row.next_position
+
+
+def _stored_positions(
+    conversation_store: SqlAlchemyConversationStore, conversation_id: str
+) -> list[int]:
+    """Raw item positions for a conversation, ascending — the source of
+    truth ``list_items`` (which hides ``position``) cannot assert on."""
+    from sqlalchemy import select
+
+    from omnigent.db.db_models import SqlConversationItem
+
+    with conversation_store._session() as session:
+        return sorted(
+            session.execute(
+                select(SqlConversationItem.position).where(
+                    SqlConversationItem.conversation_id == conversation_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+def test_new_conversation_seeds_next_position_zero(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A freshly created conversation starts its position allocator at 0, so
+    the first append reads the counter rather than scanning MAX(position)."""
+    conv = conversation_store.create_conversation()
+    assert _stored_next_position(conversation_store, conv.id) == 0
+
+
+@pytest.mark.parametrize("batch_sizes", [[1], [1, 1, 1], [3], [2, 1, 4]])
+def test_append_allocates_dense_positions_and_advances_counter(
+    conversation_store: SqlAlchemyConversationStore,
+    batch_sizes: list[int],
+) -> None:
+    """append() assigns contiguous positions from next_position and advances
+    the counter by the batch size, so the stored counter always equals the
+    total items appended — across single- and multi-item batches.
+
+    Real store, real SQLite; asserts on the raw position column and counter,
+    no mocks.
+    """
+    conv = conversation_store.create_conversation()
+    total = 0
+    for batch in batch_sizes:
+        conversation_store.append(conv.id, [_user_message(f"m{total + i}") for i in range(batch)])
+        total += batch
+        assert _stored_positions(conversation_store, conv.id) == list(range(total))
+        # The counter points one past the last item — the next position to hand out.
+        assert _stored_next_position(conversation_store, conv.id) == total
+
+
+def test_append_reads_counter_not_max_scan(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """append() allocates from the maintained counter, not a MAX(position)
+    scan: advancing the counter past the real max makes the next item land at
+    the counter value, which a scan-based implementation could never produce.
+    """
+    from omnigent.db.db_models import SqlConversation
+
+    conv = conversation_store.create_conversation()
+    conversation_store.append(conv.id, [_user_message("a"), _user_message("b")])
+    # Real max position is 1; jump the counter ahead to 100.
+    with conversation_store._session() as session:
+        session.get(SqlConversation, conv.id).next_position = 100
+
+    conversation_store.append(conv.id, [_user_message("c")])
+
+    # Position 100 (counter), not 2 (max + 1) — proves the scan path is unused.
+    assert _stored_positions(conversation_store, conv.id) == [0, 1, 100]
+    assert _stored_next_position(conversation_store, conv.id) == 101
+
+
+@pytest.mark.parametrize("preexisting", [0, 1, 3])
+def test_append_falls_back_to_scan_when_counter_null(
+    conversation_store: SqlAlchemyConversationStore,
+    preexisting: int,
+) -> None:
+    """A conversation written before the counter existed has
+    next_position = NULL. The next append falls back to a one-time
+    MAX(position) scan to place items correctly, then persists the advanced
+    counter so subsequent appends are scan-free.
+    """
+    from omnigent.db.db_models import SqlConversation
+
+    conv = conversation_store.create_conversation()
+    if preexisting:
+        conversation_store.append(conv.id, [_user_message(f"pre{i}") for i in range(preexisting)])
+    # Simulate a pre-counter row: clear the maintained counter.
+    with conversation_store._session() as session:
+        session.get(SqlConversation, conv.id).next_position = None
+    assert _stored_next_position(conversation_store, conv.id) is None
+
+    conversation_store.append(conv.id, [_user_message("new")])
+
+    # The fallback scan placed the new item right after the existing max...
+    assert _stored_positions(conversation_store, conv.id) == list(range(preexisting + 1))
+    # ...and the counter is now backfilled, so the next append won't scan.
+    assert _stored_next_position(conversation_store, conv.id) == preexisting + 1
+
+
+def test_fork_seeds_next_position_from_copied_items(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """A full fork seeds the clone's allocator from the number of copied items,
+    so the clone's first append is scan-free and collision-free."""
+    agent_store.create(agent_id="ag_fork_pos", name="fork-pos", bundle_location="ag_fork_pos/h")
+    source = conversation_store.create_conversation(agent_id="ag_fork_pos")
+    conversation_store.append(
+        source.id, [_user_message(f"s{i}", response_id="resp_1") for i in range(3)]
+    )
+
+    fork = conversation_store.fork_conversation(source.id, title="fork")
+
+    # 3 items copied (dense positions 0..2) → allocator starts at 3.
+    assert _stored_next_position(conversation_store, fork.id) == 3
+    conversation_store.append(fork.id, [_user_message("after")])
+    assert _stored_positions(conversation_store, fork.id) == [0, 1, 2, 3]
+
+
+def test_truncated_fork_seeds_next_position_from_copied_items(
+    conversation_store: SqlAlchemyConversationStore,
+    agent_store: SqlAlchemyAgentStore,
+) -> None:
+    """A truncated fork seeds the allocator from the count of the *copied*
+    items, not the source length, so the shorter clone stays collision-free."""
+    agent_store.create(
+        agent_id="ag_fork_trunc", name="fork-trunc", bundle_location="ag_fork_trunc/h"
+    )
+    source = conversation_store.create_conversation(agent_id="ag_fork_trunc")
+    conversation_store.append(
+        source.id,
+        [_user_message("a", "resp_1"), _user_message("b", "resp_1")],
+    )
+    conversation_store.append(
+        source.id,
+        [_user_message("c", "resp_2"), _user_message("d", "resp_2")],
+    )
+
+    fork = conversation_store.fork_conversation(source.id, up_to_response_id="resp_1")
+
+    # Only resp_1's 2 items are copied → allocator starts at 2.
+    assert _stored_positions(conversation_store, fork.id) == [0, 1]
+    assert _stored_next_position(conversation_store, fork.id) == 2
+    conversation_store.append(fork.id, [_user_message("after")])
+    assert _stored_positions(conversation_store, fork.id) == [0, 1, 2]
+
+
+def test_append_many_batches_stay_contiguous(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """End-to-end: many sequential appends produce a contiguous, gap-free
+    position sequence and a counter equal to the item count — the invariant
+    the maintained allocator must preserve across a long session (the
+    scan-per-write pattern this replaces grew with that length)."""
+    conv = conversation_store.create_conversation()
+    total = 0
+    for turn in range(25):
+        conversation_store.append(
+            conv.id,
+            [_user_message(f"t{turn}-{i}", response_id=f"resp_{turn}") for i in range(3)],
+        )
+        total += 3
+
+    assert _stored_positions(conversation_store, conv.id) == list(range(total))
+    assert _stored_next_position(conversation_store, conv.id) == total
+    listed = conversation_store.list_items(conv.id, limit=total)
+    assert len(listed.data) == total


### PR DESCRIPTION
## Related issue

N/A — performance/robustness cleanup of the conversation store's item-position
allocation; no tracking issue.

## Summary

`append()` assigned each item's position by running
`SELECT coalesce(max(position), -1)` over `conversation_items` on every call.
This PR maintains a `next_position` counter on the `conversations` row instead:

- `append()` reads and advances the counter under the existing
  `_lock_conversation` serialization — O(1) allocation, one fewer query per
  write, collision-free.
- New nullable `conversations.next_position` column (Alembic migration
  `n1a2b3c4d5e6`), with a model-level default of `0` for new rows.
- Backwards compatible: rows created before the column read `NULL`; `append()`
  falls back to a one-time `MAX(position)` scan and then persists the counter,
  so the next append is aggregate-free.
- `fork_conversation` seeds the clone's counter from the number of copied
  (re-densified) items, so the first append on a fork is collision-free
  (covers full and truncated forks).

The `MAX` aggregate is an index lookup on the SQL backends (there is a unique
index on `(conversation_id, position)`), so here this is primarily a
round-trip/allocation cleanup; the maintained counter also scales cleanly to
backends where that same position allocation would be a full scan.

### ELI5

Instead of asking "what's the highest position number so far?" on every save —
which means looking through the conversation each time — each conversation now
keeps a small "next number to use" sticky note. Saving reads the note, uses the
number, and bumps it; no looking around. Old conversations without a note get
one written the first time they save.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added to `tests/stores/test_conversation_store.py` (real
`SqlAlchemyConversationStore` over a real per-test SQLite DB built through the
production Alembic migration chain — no mocks):

- counter allocation + advance across batch shapes (`[1]`, `[1,1,1]`, `[3]`,
  `[2,1,4]`), asserting dense positions and `next_position == total`;
- counter-is-source-of-truth: advance the counter past the real max, then the
  next item lands at the counter value (a scan-based impl could never produce
  that);
- `NULL`-counter fallback for 0 / 1 / 3 pre-existing items — verifies the
  one-time `MAX(position)` scan places items correctly and then backfills the
  counter;
- full and truncated `fork_conversation` seeding, each with a collision-free
  post-fork append;
- a long-session contiguity check (25 batches) that positions stay gap-free.

Commands (via `uv run --extra dev`):
- `pytest tests/stores/test_conversation_store.py` → **142 passed**
- `pytest tests/stores/` → **395 passed** (sibling stores share the migrated schema)
- `ruff check` (changed files) → clean; `ruff format` applied

No separate process/browser E2E was added: this is a store-internal change with
no API/UI surface, and it is already exercised end-to-end through the store's
public API (`append` / `fork_conversation` / `list_items`) against a real
database and the real migration chain. The migration is validated implicitly —
the fixture runs `alembic upgrade head` per test, which would fail on a
branched/duplicate head.

This pull request and its description were written by Isaac.
