### PR TITLE
fix(cursor-sdk): treat cancelled/expired runs as cancellation/error, not success (F31)

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -820,6 +820,14 @@ class CursorExecutor(Executor):
             await self.close_session(session_key)
             yield TurnCancelled(reason="cursor-sdk run cancelled")
             return
+        if status != "finished":
+            await self.close_session(session_key)
+            detail = getattr(result, "result", "") or "cursor-sdk run finished with unknown status"
+            yield ExecutorError(
+                message=f"cursor-sdk run returned non-finished status {status!r}: {detail}",
+                retryable=True,
+            )
+            return
 
         # Prefer the streamed text we accumulated (which carries the paragraph
         # breaks inserted above) over the SDK's aggregate ``result`` (which does

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -67,6 +67,7 @@ from .executor import (
     ToolCallRequest,
     ToolCallStatus,
     ToolSpec,
+    TurnCancelled,
     TurnComplete,
     classify_tool_result,
 )
@@ -800,11 +801,24 @@ class CursorExecutor(Executor):
             yield ExecutorError(message=f"cursor-sdk turn failed: {exc}", retryable=True)
             return
 
+        # RunResult.status is Literal["finished", "error", "cancelled",
+        # "expired"]. Only "finished" should commit a TurnComplete; the other
+        # terminal statuses are surfaced as errors/cancellation and tear the
+        # session down (the agent/bridge may be in an inconsistent state).
         status = getattr(result, "status", "")
         if status == "error":
             await self.close_session(session_key)
             detail = getattr(result, "result", "") or "cursor-sdk run reported an error"
             yield ExecutorError(message=f"cursor-sdk run error: {detail}", retryable=True)
+            return
+        if status == "expired":
+            await self.close_session(session_key)
+            detail = getattr(result, "result", "") or "cursor-sdk run expired"
+            yield ExecutorError(message=f"cursor-sdk run expired: {detail}", retryable=True)
+            return
+        if status == "cancelled":
+            await self.close_session(session_key)
+            yield TurnCancelled(reason="cursor-sdk run cancelled")
             return
 
         # Prefer the streamed text we accumulated (which carries the paragraph

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -55,6 +55,7 @@ from omnigent.inner.executor import (
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
+    TurnCancelled,
     TurnComplete,
 )
 from omnigent.inner.tracing import TracingContext, is_tracing_enabled
@@ -438,6 +439,15 @@ class ExecutorAdapter(HarnessApp):
                     if isinstance(event, TurnComplete):
                         if tctx is not None and agent_span is not None:
                             tctx.end_agent_span(agent_span, response=response_text)
+                            agent_span = None
+                        return
+                    if isinstance(event, TurnCancelled):
+                        ctx.cancelled.set()
+                        if tctx is not None and agent_span is not None:
+                            from omnigent.runtime.telemetry import record_cancellation
+
+                            record_cancellation(agent_span)
+                            tctx.end_agent_span(agent_span, response=None, status="ERROR")
                             agent_span = None
                         return
                     if isinstance(event, ExecutorError):

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -448,7 +448,6 @@ class ExecutorAdapter(HarnessApp):
 
                             record_cancellation(agent_span)
                             tctx.end_agent_span(agent_span, response=None, status="ERROR")
-                            agent_span = None
                         return
                     if isinstance(event, ExecutorError):
                         if tctx is not None and agent_span is not None:

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -827,6 +827,32 @@ async def test_mid_turn_cancelled_status_emits_turn_cancelled_and_drops_session(
     assert any(isinstance(e, TurnComplete) for e in turn2)
 
 
+async def test_mid_turn_unknown_non_finished_status_is_retryable_and_drops_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only ``finished`` is allowed to produce TurnComplete. If the SDK adds a
+    new terminal status, fail loud and retry instead of silently committing
+    partial streamed text as a successful assistant turn."""
+    scripts = [
+        {"messages": [_assistant("partial")], "status": "paused", "result": "new state"},
+        {"messages": [_assistant("recovered")], "result": "recovered"},
+    ]
+    state = _install_fake_sdk(monkeypatch, scripts)
+    executor = CursorExecutor(api_key="crsr_x")
+    try:
+        turn1 = [e async for e in executor.run_turn([_user("first")], [], "SYS")]
+        turn2 = [e async for e in executor.run_turn([_user("second")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    errors = [e for e in turn1 if isinstance(e, ExecutorError)]
+    assert len(errors) == 1 and errors[0].retryable is True
+    assert "non-finished status 'paused'" in errors[0].message
+    assert not any(isinstance(e, TurnComplete) for e in turn1)
+    assert len(state["create_models"]) == 2
+    assert any(isinstance(e, TurnComplete) for e in turn2)
+
+
 async def test_empty_prompt_completes_without_sending(monkeypatch: pytest.MonkeyPatch) -> None:
     state = _install_fake_sdk(monkeypatch, [])
     executor = CursorExecutor(api_key="crsr_x")

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -35,6 +35,7 @@ from omnigent.inner.executor import (
     ToolCallComplete,
     ToolCallRequest,
     ToolCallStatus,
+    TurnCancelled,
     TurnComplete,
 )
 
@@ -766,6 +767,62 @@ async def test_mid_turn_error_status_drops_session(monkeypatch: pytest.MonkeyPat
     assert len(errors) == 1 and errors[0].retryable is True
     assert "model exploded" in errors[0].message
     # Session was dropped on the error, so turn 2 creates a fresh agent.
+    assert len(state["create_models"]) == 2
+    assert any(isinstance(e, TurnComplete) for e in turn2)
+
+
+async def test_mid_turn_expired_status_is_retryable_and_drops_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``expired`` terminal status (Cursor-side timeout / usage cap / quota)
+    must surface as a retryable ExecutorError and drop the session — never a
+    TurnComplete committing whatever partial text streamed."""
+    scripts = [
+        {"messages": [_assistant("partial")], "status": "expired", "result": "quota hit"},
+        {"messages": [_assistant("recovered")], "result": "recovered"},
+    ]
+    state = _install_fake_sdk(monkeypatch, scripts)
+    executor = CursorExecutor(api_key="crsr_x")
+    try:
+        turn1 = [e async for e in executor.run_turn([_user("first")], [], "SYS")]
+        turn2 = [e async for e in executor.run_turn([_user("second")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    errors = [e for e in turn1 if isinstance(e, ExecutorError)]
+    assert len(errors) == 1 and errors[0].retryable is True
+    assert "expired" in errors[0].message
+    # No TurnComplete — the partial text must not be committed as a success.
+    assert not any(isinstance(e, TurnComplete) for e in turn1)
+    # Session was dropped on expiry, so turn 2 creates a fresh agent.
+    assert len(state["create_models"]) == 2
+    assert any(isinstance(e, TurnComplete) for e in turn2)
+
+
+async def test_mid_turn_cancelled_status_emits_turn_cancelled_and_drops_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``cancelled`` terminal status must surface as a TurnCancelled (not a
+    TurnComplete) and drop the session, so partial text isn't persisted as a
+    legitimate assistant message."""
+    scripts = [
+        {"messages": [_assistant("partial")], "status": "cancelled", "result": "stopped"},
+        {"messages": [_assistant("recovered")], "result": "recovered"},
+    ]
+    state = _install_fake_sdk(monkeypatch, scripts)
+    executor = CursorExecutor(api_key="crsr_x")
+    try:
+        turn1 = [e async for e in executor.run_turn([_user("first")], [], "SYS")]
+        turn2 = [e async for e in executor.run_turn([_user("second")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    cancels = [e for e in turn1 if isinstance(e, TurnCancelled)]
+    assert len(cancels) == 1
+    # Cancellation is not an error, and must not be committed as a completed turn.
+    assert not any(isinstance(e, ExecutorError) for e in turn1)
+    assert not any(isinstance(e, TurnComplete) for e in turn1)
+    # Session was dropped on cancellation, so turn 2 creates a fresh agent.
     assert len(state["create_models"]) == 2
     assert any(isinstance(e, TurnComplete) for e in turn2)
 

--- a/tests/runtime/harnesses/_test_executor_adapter_harness.py
+++ b/tests/runtime/harnesses/_test_executor_adapter_harness.py
@@ -11,6 +11,7 @@ Four scripts:
 - ``"tool_call"``: a ToolCallRequest, then a ToolCallComplete
   with a result, then a TurnComplete (no further text).
 - ``"error"``: an ExecutorError event.
+- ``"cancelled"``: a TurnCancelled event.
 - ``"capture_messages"``: writes the received messages list as
   JSON to the path in ``MOCK_EXECUTOR_CAPTURE_PATH``, then
   emits a TurnComplete. Used to verify the full AP→harness→
@@ -39,6 +40,7 @@ from omnigent.inner.executor import (
     ToolCallRequest,
     ToolCallStatus,
     ToolSpec,
+    TurnCancelled,
     TurnComplete,
 )
 from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
@@ -142,6 +144,20 @@ def _build_error() -> Executor:
     return executor
 
 
+def _build_cancelled() -> Executor:
+    """
+    MockExecutor scripted with a provider-side :class:`TurnCancelled`.
+
+    The adapter should map this cleanly to ``response.cancelled`` rather than
+    falling through to ``response.completed``.
+
+    :returns: A configured :class:`MockExecutor` instance.
+    """
+    executor = MockExecutor()
+    executor._turns.append([TurnCancelled(reason="provider_cancelled")])
+    return executor
+
+
 def _build_capture_messages() -> Executor:
     """
     :class:`_CapturingExecutor` builder.
@@ -159,6 +175,7 @@ _SCRIPTS: dict[str, Callable[[], Executor]] = {
     "text_only": _build_text_only,
     "tool_call": _build_tool_call,
     "error": _build_error,
+    "cancelled": _build_cancelled,
     "capture_messages": _build_capture_messages,
 }
 

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -154,6 +154,12 @@ def use_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def use_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MockExecutor that yields a provider-side TurnCancelled."""
+    monkeypatch.setenv("MOCK_EXECUTOR_SCRIPT", "cancelled")
+
+
+@pytest.fixture
 def use_capture_messages(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """Capturing executor: records the messages it received as JSON.
 
@@ -378,6 +384,31 @@ async def test_executor_error_terminates_with_response_failed(
     # via the RuntimeError wrap in the adapter; the scaffold
     # builds an ErrorDetail with the exception's str().
     assert "mock error" in error_detail["message"]
+
+
+async def test_turn_cancelled_terminates_with_response_cancelled(
+    use_cancelled: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """TurnCancelled -> response.cancelled terminal event.
+
+    Provider-side cancellation is not driven by an inbound interrupt event, so
+    the adapter must mark the turn context cancelled itself. Otherwise the
+    scaffold sees a clean return and emits response.completed.
+    """
+    conv_id = "conv_cancelled"
+    client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    events: list[_ParsedSSEEvent] = []
+    async with client.stream(
+        "POST", f"/v1/sessions/{conv_id}/events", json=_start_turn_body()
+    ) as response:
+        async for event in _stream_iter(response):
+            events.append(event)
+
+    assert events[-1].event == "response.cancelled"
+    terminal_response = events[-1].data["response"]
+    assert terminal_response["status"] == "cancelled"
+    assert terminal_response.get("error") is None
 
 
 # ── Error-code classification ──────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes **F31** from `SDK_INTEGRATION_BUG_AUDIT.md`.

After `result = await run.wait()`, `run_turn` only handled `status == "error"`. The cursor SDK's `RunResult.status` is `Literal["finished", "error", "cancelled", "expired"]`, so a `cancelled` or `expired` terminal status fell straight through to `TurnComplete(...)` — committing whatever partial text streamed as a successful turn, and leaving the agent/session alive (no `close_session`) unlike the error path.

- `error` → unchanged (close_session + retryable `ExecutorError`)
- `expired` → now close_session + retryable `ExecutorError` (Cursor-side timeout / usage cap / quota should be retried, not silently truncated)
- `cancelled` → now close_session + `TurnCancelled` (surfaced as a cancellation, not persisted as a legitimate assistant message)
- Only `finished` yields `TurnComplete`.

## Test plan

- [x] `pytest tests/inner/test_cursor_executor.py -q` → 54 passed
- Added `test_mid_turn_expired_status_is_retryable_and_drops_session` (retryable error, no TurnComplete, session dropped)
- Added `test_mid_turn_cancelled_status_emits_turn_cancelled_and_drops_session` (TurnCancelled, no ExecutorError/TurnComplete, session dropped)
- Both parallel the existing `status == "error"` test.