### PR TITLE
fix(cursor-native): honest stderr hint on cold resume

### DIFF
--- a/omnigent/_native_resume_hint.py
+++ b/omnigent/_native_resume_hint.py
@@ -55,3 +55,29 @@ def echo_native_resume_hint(
         server=server,
     )
     click.echo(f"Resume with: {command}", err=True)
+
+
+def echo_native_cold_resume_hint(
+    *,
+    agent_label: str = "Cursor",
+) -> None:
+    """
+    Warn that a cold resume is starting a fresh session, not restoring one.
+
+    Some native wrappers (notably Cursor) cannot reattach to a prior
+    chat once the session terminal has exited: the TUI records no
+    resumable chat id, so ``--resume`` relaunches a *fresh* agent with
+    none of the prior turns. The reattach-to-a-live-terminal path is
+    unaffected; this hint only fires when the terminal is gone and we
+    are cold-starting a new TUI, so the user is not misled into
+    thinking their earlier conversation came back.
+
+    :param agent_label: Human-readable agent name for the message,
+        e.g. ``"Cursor"``.
+    :returns: None.
+    """
+    click.echo(
+        f"Terminal not running — starting a fresh {agent_label} session "
+        "(prior chat not restored).",
+        err=True,
+    )

--- a/omnigent/_native_resume_hint.py
+++ b/omnigent/_native_resume_hint.py
@@ -77,7 +77,7 @@ def echo_native_cold_resume_hint(
     :returns: None.
     """
     click.echo(
-        f"Terminal not running — starting a fresh {agent_label} session "
+        f"Terminal not running - starting a fresh {agent_label} session "
         "(prior chat not restored).",
         err=True,
     )

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -93,7 +93,12 @@ class PreparedCursorTerminal:
         Cursor records no resumable chat id, so this is genuinely a new
         chat - distinct from a brand-new session (``resolved_session_id
         is None``) and from a live reattach. Drives the honest
-        cold-resume stderr hint.
+        cold-resume stderr hint. Note: cursor deliberately treats
+        ``cold_resumed`` and ``reattached`` as mutually exclusive (the
+        cold-resume path leaves ``reattached`` at its ``False`` default)
+        - unlike ``claude_native`` which models them independently. This
+        is safe because cursor never reads ``reattached`` for teardown
+        ownership; do not "fix" the apparent inconsistency.
     """
 
     session_id: str
@@ -361,6 +366,10 @@ async def _prepare_cursor_terminal_via_daemon(
             # Session exists but its terminal has exited. Cursor records no
             # resumable chat id, so the launch below starts a fresh TUI with
             # no prior turns. Flag it so the caller can say so honestly.
+            # Mutually exclusive with the reattach path above: we leave
+            # reattached at False here (unlike claude_native, which treats
+            # cold_resumed/reattached as independent). Safe because cursor
+            # never uses reattached for teardown ownership.
             cold_resumed = True
             if persist_args:
                 _update_startup_progress(startup_progress, "Updating Cursor session...")

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -28,7 +28,7 @@ import click
 import httpx
 import yaml
 
-from omnigent._native_resume_hint import echo_native_resume_hint
+from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import CURSOR_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -82,13 +82,26 @@ class LaunchedCursorTerminal:
 
 @dataclass(frozen=True)
 class PreparedCursorTerminal:
-    """Prepared native Cursor terminal attachment details."""
+    """Prepared native Cursor terminal attachment details.
+
+    :param reattached: ``True`` when an existing, still-running session
+        terminal was reused (the live-reattach path: prior chat is
+        intact).
+    :param cold_resumed: ``True`` when resuming an existing Omnigent
+        session whose terminal had already exited, so a *fresh*
+        ``cursor-agent`` TUI was launched with none of the prior turns.
+        Cursor records no resumable chat id, so this is genuinely a new
+        chat — distinct from a brand-new session (``resolved_session_id
+        is None``) and from a live reattach. Drives the honest
+        cold-resume stderr hint.
+    """
 
     session_id: str
     terminal_id: str
     tmux_socket: Path | None
     tmux_target: str | None
     reattached: bool
+    cold_resumed: bool = False
 
 
 def _configured_cursor_command(env: Mapping[str, str]) -> str:
@@ -265,6 +278,8 @@ def _run_with_remote_server(
                 enabled=auto_open_conversation,
                 warn=lambda message: click.echo(message, err=True),
             )
+            if prepared.cold_resumed:
+                echo_native_cold_resume_hint(agent_label="Cursor")
             await _attach_terminal_resource(prepared)
             if resolved_session_id is None:
                 echo_native_resume_hint(
@@ -301,7 +316,12 @@ async def _prepare_cursor_terminal_via_daemon(
     persist_args = list(cursor_args)
     timeout = httpx.Timeout(30.0, read=120.0)
     async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
-        reattached = session_id is not None
+        # Resuming an existing session can either reattach to a live
+        # terminal (prior chat intact) or — if that terminal has exited —
+        # cold-start a fresh TUI. We only know which after probing for a
+        # running terminal below, so default both flags off here.
+        reattached = False
+        cold_resumed = False
         if session_id is None:
             if session_bundle is None:
                 raise click.ClickException("Creating a Cursor session requires a session bundle.")
@@ -338,6 +358,10 @@ async def _prepare_cursor_terminal_via_daemon(
                     tmux_target=existing_terminal.tmux_target,
                     reattached=True,
                 )
+            # Session exists but its terminal has exited. Cursor records no
+            # resumable chat id, so the launch below starts a fresh TUI with
+            # no prior turns — flag it so the caller can say so honestly.
+            cold_resumed = True
             if persist_args:
                 _update_startup_progress(startup_progress, "Updating Cursor session...")
                 resp = await client.patch(
@@ -375,6 +399,7 @@ async def _prepare_cursor_terminal_via_daemon(
         tmux_socket=terminal.tmux_socket,
         tmux_target=terminal.tmux_target,
         reattached=reattached,
+        cold_resumed=cold_resumed,
     )
 
 

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -91,7 +91,7 @@ class PreparedCursorTerminal:
         session whose terminal had already exited, so a *fresh*
         ``cursor-agent`` TUI was launched with none of the prior turns.
         Cursor records no resumable chat id, so this is genuinely a new
-        chat — distinct from a brand-new session (``resolved_session_id
+        chat - distinct from a brand-new session (``resolved_session_id
         is None``) and from a live reattach. Drives the honest
         cold-resume stderr hint.
     """
@@ -317,7 +317,7 @@ async def _prepare_cursor_terminal_via_daemon(
     timeout = httpx.Timeout(30.0, read=120.0)
     async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout) as client:
         # Resuming an existing session can either reattach to a live
-        # terminal (prior chat intact) or — if that terminal has exited —
+        # terminal (prior chat intact) or, if that terminal has exited,
         # cold-start a fresh TUI. We only know which after probing for a
         # running terminal below, so default both flags off here.
         reattached = False
@@ -360,7 +360,7 @@ async def _prepare_cursor_terminal_via_daemon(
                 )
             # Session exists but its terminal has exited. Cursor records no
             # resumable chat id, so the launch below starts a fresh TUI with
-            # no prior turns — flag it so the caller can say so honestly.
+            # no prior turns. Flag it so the caller can say so honestly.
             cold_resumed = True
             if persist_args:
                 _update_startup_progress(startup_progress, "Updating Cursor session...")

--- a/tests/e2e/test_cursor_native_cli_e2e.py
+++ b/tests/e2e/test_cursor_native_cli_e2e.py
@@ -57,13 +57,16 @@ from __future__ import annotations
 
 import os
 import shutil
+import time
 import uuid
 from pathlib import Path
 
 import httpx
 import pytest
 
+from omnigent.cursor_native_bridge import bridge_dir_for_session_id, kill_session
 from tests.e2e._native_resume_helpers import (
+    PtyHandle,
     cli_env,
     inject_user_message,
     omnigent_console_script,
@@ -102,6 +105,23 @@ _CWD_MARKER_FILE = "CWD_MARKER.txt"
 _CONV_ID_TIMEOUT = 120.0
 _TERMINAL_READY_TIMEOUT = 90.0
 _REPLY_TIMEOUT = 180.0
+_COLD_RESUME_HINT = (
+    "Terminal not running - starting a fresh Cursor session (prior chat not restored)."
+)
+
+
+def _wait_for_output_contains(handle: PtyHandle, needle: str, *, timeout: float) -> str:
+    """Poll a PTY handle until *needle* appears in its decoded output."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        output = handle.output()
+        if needle in output:
+            return output
+        time.sleep(0.2)
+    output = handle.output()
+    raise AssertionError(
+        f"did not see {needle!r} within {timeout}s; output tail:\n{output[-2000:]}"
+    )
 
 
 def test_cursor_native_cli_smoke(
@@ -236,3 +256,96 @@ def test_cursor_native_cli_runs_in_launch_cwd(
                 ) from exc
     finally:
         handle.terminate()
+
+
+def test_cursor_native_cli_resume_warns_when_terminal_was_killed(
+    resume_test_server: str,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Live reattach stays quiet, but cold resume tells the truth.
+
+    This is the e2e guard for the UX bug in ``CURSOR_NATIVE_AUDIT_FIXES.md``
+    item #2. A second ``omnigent cursor --resume <conv>`` while the original
+    tmux pane is still alive should attach to the live terminal and must not
+    print the cold-resume warning. After killing that tmux session, the same
+    resume command necessarily starts a fresh ``cursor-agent`` TUI with no
+    prior Cursor chat, so the CLI must print the honest stderr hint before it
+    attaches.
+
+    :param resume_test_server: Base URL of the allow-list-free test server.
+    :param tmp_path: Per-test temp dir; its ``pwd`` subdir is the launch cwd.
+    :param request: Pytest request - reads ``--profile`` for the test server.
+    """
+    profile = request.config.getoption("--profile")
+    assert profile, "this test requires --profile (e.g. --profile oss) for the test server"
+
+    pwd_dir = tmp_path / "pwd"
+    pwd_dir.mkdir()
+
+    omni = str(omnigent_console_script())
+    base = [omni, "cursor", "--server", resume_test_server]
+    primary = spawn_cli_background(
+        [*base, _FORCE_FLAG],
+        env=cli_env(profile=profile),
+        cwd=str(pwd_dir),
+    )
+    try:
+        conversation_id = wait_for_conversation_id(primary, timeout=_CONV_ID_TIMEOUT)
+        with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+            wait_for_terminal_ready(
+                client,
+                conversation_id=conversation_id,
+                harness="cursor",
+                timeout=_TERMINAL_READY_TIMEOUT,
+            )
+
+        live_resume = spawn_cli_background(
+            [*base, "--resume", conversation_id, _FORCE_FLAG],
+            env=cli_env(profile=profile),
+            cwd=str(pwd_dir),
+        )
+        try:
+            _wait_for_output_contains(
+                live_resume,
+                f"/c/{conversation_id}",
+                timeout=_CONV_ID_TIMEOUT,
+            )
+            # The cold-resume hint is printed immediately after the Web UI line
+            # and before the blocking tmux attach. Wait briefly past that point
+            # before asserting absence, so this catches a misplaced hint on live
+            # reattach rather than racing ahead of it.
+            time.sleep(2.0)
+            live_output = live_resume.output()
+            assert _COLD_RESUME_HINT not in live_output, (
+                "live cursor-native resume incorrectly printed the cold-resume hint; "
+                "it should be a true reattach while the terminal is running."
+            )
+        finally:
+            live_resume.terminate()
+
+        kill_session(bridge_dir_for_session_id(conversation_id), timeout_s=30.0)
+        primary.terminate()
+
+        cold_resume = spawn_cli_background(
+            [*base, "--resume", conversation_id, _FORCE_FLAG],
+            env=cli_env(profile=profile),
+            cwd=str(pwd_dir),
+        )
+        try:
+            _wait_for_output_contains(
+                cold_resume,
+                _COLD_RESUME_HINT,
+                timeout=_CONV_ID_TIMEOUT,
+            )
+            with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+                wait_for_terminal_ready(
+                    client,
+                    conversation_id=conversation_id,
+                    harness="cursor",
+                    timeout=_TERMINAL_READY_TIMEOUT,
+                )
+        finally:
+            cold_resume.terminate()
+    finally:
+        primary.terminate()

--- a/tests/test_cursor_native.py
+++ b/tests/test_cursor_native.py
@@ -118,9 +118,7 @@ async def test_cursor_resume_without_live_terminal_is_marked_as_cold_resume(
     assert prepared.reattached is False
     assert prepared.cold_resumed is True
     assert prepared.terminal_id == "terminal_cursor_main"
-    assert fake.patch_calls == [
-        ("/v1/sessions/conv_cursor", {"terminal_launch_args": ["-f"]})
-    ]
+    assert fake.patch_calls == [("/v1/sessions/conv_cursor", {"terminal_launch_args": ["-f"]})]
     assert fake.post_calls == [
         (
             "/v1/sessions/conv_cursor/resources/terminals",

--- a/tests/test_cursor_native.py
+++ b/tests/test_cursor_native.py
@@ -1,0 +1,141 @@
+"""Tests for cursor-native CLI orchestration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent import cursor_native
+
+
+class _FakeAsyncClient:
+    """Minimal async client for cursor-native daemon orchestration tests."""
+
+    def __init__(self, *, terminal_running: bool) -> None:
+        self.terminal_running = terminal_running
+        self.terminal_gets = 0
+        self.patch_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def get(self, url: str) -> httpx.Response:
+        request = httpx.Request("GET", url)
+        if url == "/v1/sessions/conv_cursor":
+            return httpx.Response(
+                200,
+                json={"labels": {"omnigent.wrapper": "cursor-native-ui"}},
+                request=request,
+            )
+        if url.endswith("/resources/terminals/terminal_cursor_main"):
+            self.terminal_gets += 1
+            if not self.terminal_running and self.terminal_gets == 1:
+                return httpx.Response(404, request=request)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "terminal_cursor_main",
+                    "metadata": {
+                        "running": True,
+                        "tmux_socket": "/tmp/cursor.sock",
+                        "tmux_target": "cursor:0",
+                    },
+                },
+                request=request,
+            )
+        raise AssertionError(f"unexpected GET {url}")
+
+    async def patch(self, url: str, *, json: dict[str, Any]) -> httpx.Response:
+        self.patch_calls.append((url, json))
+        return httpx.Response(200, request=httpx.Request("PATCH", url))
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any] | None = None,
+        **_: object,
+    ) -> httpx.Response:
+        self.post_calls.append((url, json))
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+
+@pytest.mark.asyncio
+async def test_cursor_resume_to_live_terminal_is_marked_as_reattach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resume with a still-running terminal is a true live reattach."""
+
+    fake = _FakeAsyncClient(terminal_running=True)
+    monkeypatch.setattr(cursor_native.httpx, "AsyncClient", lambda **_: fake)
+
+    prepared = await cursor_native._prepare_cursor_terminal_via_daemon(
+        base_url="http://server",
+        headers={},
+        session_id="conv_cursor",
+        session_bundle=None,
+        cursor_args=("-f",),
+        host_id="host_1",
+        workspace="/workspace",
+    )
+
+    assert prepared.reattached is True
+    assert prepared.cold_resumed is False
+    assert prepared.terminal_id == "terminal_cursor_main"
+    assert fake.patch_calls == []
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cursor_resume_without_live_terminal_is_marked_as_cold_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resume whose terminal is gone cold-starts a fresh Cursor TUI."""
+
+    fake = _FakeAsyncClient(terminal_running=False)
+    monkeypatch.setattr(cursor_native.httpx, "AsyncClient", lambda **_: fake)
+    monkeypatch.setattr(cursor_native, "wait_for_host_online", _async_noop)
+    monkeypatch.setattr(cursor_native, "wait_for_runner_online", _async_noop)
+    monkeypatch.setattr(cursor_native, "launch_or_reuse_daemon_runner", _launch_runner)
+    monkeypatch.setattr(cursor_native, "_bind_session_runner", _async_noop)
+
+    prepared = await cursor_native._prepare_cursor_terminal_via_daemon(
+        base_url="http://server",
+        headers={},
+        session_id="conv_cursor",
+        session_bundle=None,
+        cursor_args=("-f",),
+        host_id="host_1",
+        workspace="/workspace",
+    )
+
+    assert prepared.reattached is False
+    assert prepared.cold_resumed is True
+    assert prepared.terminal_id == "terminal_cursor_main"
+    assert fake.patch_calls == [
+        ("/v1/sessions/conv_cursor", {"terminal_launch_args": ["-f"]})
+    ]
+    assert fake.post_calls == [
+        (
+            "/v1/sessions/conv_cursor/resources/terminals",
+            {
+                "terminal": "cursor",
+                "session_key": "main",
+                "ensure_native_terminal": True,
+            },
+        )
+    ]
+
+
+async def _async_noop(*_: object, **__: object) -> None:
+    return None
+
+
+async def _launch_runner(*_: object, **__: object) -> str:
+    return "runner_1"

--- a/tests/test_native_resume_hint.py
+++ b/tests/test_native_resume_hint.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from omnigent._native_resume_hint import format_native_resume_command
+import pytest
+
+from omnigent._native_resume_hint import (
+    echo_native_cold_resume_hint,
+    format_native_resume_command,
+)
 
 
 def test_format_native_resume_command_includes_remote_context() -> None:
@@ -24,3 +29,25 @@ def test_format_native_resume_command_includes_remote_context() -> None:
     )
 
     assert command == ("omnigent claude --server https://example.databricks.com --resume conv_abc")
+
+
+def test_cold_resume_hint_is_honest_on_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    """
+    The cold-resume hint must tell the user, on stderr, that prior turns
+    are gone.
+
+    Cursor cannot reattach to a chat once its terminal exits, so resume
+    cold-starts a fresh TUI. If the hint were silent (or printed an
+    upbeat "resumed!" line), the user would reasonably assume their
+    earlier conversation came back and be misled. The message therefore
+    has to state both facts: the terminal was not running, and the prior
+    chat was not restored. It must go to stderr so it never pollutes the
+    TUI's stdout.
+    """
+    echo_native_cold_resume_hint(agent_label="Cursor")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Terminal not running" in captured.err
+    assert "fresh Cursor session" in captured.err
+    assert "prior chat not restored" in captured.err


### PR DESCRIPTION
## Summary

Addresses `CURSOR_NATIVE_AUDIT_FIXES.md` item #2. Resuming a cursor-native session whose tmux terminal is still alive correctly **reattaches** to the live chat. But once that terminal has exited, resume cold-starts a *fresh* `cursor-agent` TUI with none of the prior turns (Cursor records no resumable chat id, and the TUI's `--resume` silently falls back to the latest chat). Previously this cold start looked identical to a real reattach, misleading users into thinking their earlier conversation came back.

This is a copy-only UX fix (no ACP work — that's the deferred real-restore path).

- `omnigent/cursor_native.py`: distinguish reattach vs cold-start in `_prepare_cursor_terminal_via_daemon`. Added `PreparedCursorTerminal.cold_resumed` (set when an existing Omnigent session's terminal is gone and we relaunch fresh). Previously `reattached` was set to `True` for *all* resumes, including cold ones.
- `omnigent/_native_resume_hint.py`: new `echo_native_cold_resume_hint(...)` that prints, to stderr, `Terminal not running — starting a fresh Cursor session (prior chat not restored).` The hint fires just before the blocking tmux attach so the user sees it on entry.
- Brand-new sessions still get the unchanged `echo_native_resume_hint` after detach.
- Tone matches the other native wrappers (claude/codex/pi).

## Test plan

- [x] `tests/test_native_resume_hint.py` — added `test_cold_resume_hint_is_honest_on_stderr` (asserts the message lands on stderr, not stdout, and states both facts). Existing test still passes.
- [x] `ruff check` clean on changed files.
- [ ] Manual: resume a cursor-native conv after killing its terminal → see the honest hint; resume a live one → no hint (reattach).