### PR TITLE
fix(fork): don't promise native fork history for cursor/pi-native

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8884,11 +8884,11 @@ def _same_provider_family(a: Agent, b: Agent) -> bool:
 def _agent_is_native(agent: Agent) -> bool:
     """Return whether an agent runs a native CLI harness.
 
-    Loads the agent's spec to read its ``harness_kind``. A native target
-    (claude-native / codex-native) is the only case where a fork needs the
-    transcript-rebuild carry path — SDK targets replay the Omnigent
-    transcript as context on their own. Returns ``False`` when the bundle
-    can't be loaded (treated as non-native).
+    Loads the agent's spec to read its ``harness_kind``. Native targets run
+    a vendor TUI in a terminal (claude-native / codex-native / pi-native /
+    cursor-native). This is broader than "can replay fork history"; use
+    ``_agent_carries_native_fork_history`` for that narrower gate. Returns
+    ``False`` when the bundle can't be loaded (treated as non-native).
 
     :param agent: The agent whose harness to classify.
     :returns: ``True`` for a native CLI harness, else ``False``.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8906,6 +8906,33 @@ def _agent_is_native(agent: Agent) -> bool:
     return is_native_harness(spec.executor.harness_kind)
 
 
+def _agent_carries_native_fork_history(agent: Agent) -> bool:
+    """Return whether *agent*'s native harness can replay fork history.
+
+    Only claude-native / codex-native record a resumable native session and
+    can rebuild a fork's transcript from the copied Omnigent items. cursor-
+    native and pi-native are native CLIs but cannot carry chat history into a
+    fork (no resumable external_session_id and their TUIs can't import a
+    transcript), so stamping ``carry_history_into_native`` for them would be a
+    false promise — the fork launches fresh regardless. Returns ``False`` when
+    the bundle can't be loaded (treated as non-carrying).
+
+    :param agent: The agent whose harness to classify.
+    :returns: ``True`` only for fork-history-capable native harnesses.
+    """
+    from omnigent.harness_aliases import canonicalize_harness
+
+    try:
+        spec = (
+            get_agent_cache()
+            .load(agent.id, agent.bundle_location, expand_env=agent.session_id is None)
+            .spec
+        )
+    except Exception:  # noqa: BLE001 — unloadable bundle → treat as non-carrying
+        return False
+    return canonicalize_harness(spec.executor.harness_kind) in {"claude-native", "codex-native"}
+
+
 def _native_coding_agent_for_agent(agent: Agent) -> NativeCodingAgent | None:
     """
     Return native coding-agent metadata for an agent's harness.
@@ -13582,7 +13609,12 @@ def create_sessions_router(
         # items (the converters consume Omnigent's normalized item shape, so
         # the source harness doesn't matter). SDK targets replay the
         # transcript as context regardless, so the marker is inert for them.
-        carry_history_into_native = await asyncio.to_thread(_agent_is_native, base_agent)
+        # Only claude/codex native can replay fork history; cursor/pi native
+        # can't (no resumable session, TUI can't import a transcript), so don't
+        # stamp a carry-history promise they'd silently break with a fresh launch.
+        carry_history_into_native = await asyncio.to_thread(
+            _agent_carries_native_fork_history, base_agent
+        )
         # The source's native session id is only resumable by a target in the
         # SAME provider family — a Claude target can't clone a Codex rollout.
         # Cross-family, the store must skip the fork-source directive so the
@@ -13770,7 +13802,12 @@ def create_sessions_router(
         copy_model_settings = await asyncio.to_thread(
             _same_provider_family, current_agent, target_agent
         )
-        carry_history_into_native = await asyncio.to_thread(_agent_is_native, target_agent)
+        # Only claude/codex native can replay fork history; cursor/pi native
+        # can't (no resumable session, TUI can't import a transcript), so don't
+        # stamp a carry-history promise they'd silently break with a fresh launch.
+        carry_history_into_native = await asyncio.to_thread(
+            _agent_carries_native_fork_history, target_agent
+        )
         presentation_labels = await asyncio.to_thread(_presentation_labels_for_agent, target_agent)
 
         # Resolve the built-in the session is leaving so the UI can offer a

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -8886,7 +8886,8 @@ def _agent_is_native(agent: Agent) -> bool:
 
     Loads the agent's spec to read its ``harness_kind``. Native targets run
     a vendor TUI in a terminal (claude-native / codex-native / pi-native /
-    cursor-native). This is broader than "can replay fork history"; use
+    cursor-native). This is broader than "can replay fork history" — only
+    claude/codex native carry the transcript-rebuild path; use
     ``_agent_carries_native_fork_history`` for that narrower gate. Returns
     ``False`` when the bundle can't be loaded (treated as non-native).
 
@@ -8904,6 +8905,16 @@ def _agent_is_native(agent: Agent) -> bool:
     except Exception:  # noqa: BLE001 — unloadable bundle → treat as non-native
         return False
     return is_native_harness(spec.executor.harness_kind)
+
+
+# Native harnesses that record a resumable session and can rebuild a fork's
+# transcript from copied Omnigent items. Both spellings are listed because
+# canonicalize_harness passes the reversed native ids through unchanged (only
+# "native-pi" is aliased) — same reasoning as model_override._CLAUDE_FAMILY_HARNESSES.
+# cursor/pi native are intentionally absent: they can't replay fork history.
+_FORK_HISTORY_NATIVE_HARNESSES: frozenset[str] = frozenset(
+    {"claude-native", "native-claude", "codex-native", "native-codex"}
+)
 
 
 def _agent_carries_native_fork_history(agent: Agent) -> bool:
@@ -8930,7 +8941,7 @@ def _agent_carries_native_fork_history(agent: Agent) -> bool:
         )
     except Exception:  # noqa: BLE001 — unloadable bundle → treat as non-carrying
         return False
-    return canonicalize_harness(spec.executor.harness_kind) in {"claude-native", "codex-native"}
+    return canonicalize_harness(spec.executor.harness_kind) in _FORK_HISTORY_NATIVE_HARNESSES
 
 
 def _native_coding_agent_for_agent(agent: Agent) -> NativeCodingAgent | None:

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1088,8 +1088,8 @@ class ConversationStore(ABC):
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript (clone the source's
             native transcript, or build from the copied Omnigent items) instead
-            of starting fresh. Set by the route whenever the fork binds a
-            native target, regardless of the source's provider family.
+            of starting fresh. Set by the route only for native targets whose
+            harness can replay fork history.
         :param resume_source_native_session: When ``True`` (default), a
             full fork of a source with a native session stamps
             :data:`FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY` so the runner

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2159,8 +2159,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param carry_history_into_native: When ``True``, stamp
             :data:`FORK_CARRY_HISTORY_LABEL_KEY` on the fork so a native
             target harness rebuilds its transcript instead of starting
-            fresh. Set by the route whenever the fork binds a native
-            target, regardless of the source's provider family.
+            fresh. Set by the route only for native targets whose harness can
+            replay fork history.
         :param resume_source_native_session: When ``True`` (default), a
             full fork of a source with a native session stamps
             :data:`FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY` so the runner

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -14,9 +14,10 @@ Each case asserts what the server+UI can guarantee WITHOUT a host or a real
 native CLI: the fork is created on the TARGET agent, the copied transcript
 renders, and the fork's labels route the runner correctly —
 
-  - native targets stamp ``omnigent.fork.carry_history`` (the runner must
-    rebuild the native transcript; absent → the clone would launch fresh
-    and lose history) and the TARGET ``omnigent.wrapper`` (so the clone
+  - native targets that can replay fork history stamp
+    ``omnigent.fork.carry_history`` (the runner must rebuild the native
+    transcript; absent → the clone would launch fresh and lose history) and
+    every native target stamps the TARGET ``omnigent.wrapper`` (so the clone
     opens in the right UI mode, not the source's chat mode);
   - the SDK target stamps neither (an SDK target replays the transcript as
     context, and plain chat has no wrapper).
@@ -81,11 +82,9 @@ def _agent_id_by_name(base_url: str, name: str) -> str:
         # SDK → Codex: SAME-family native target. Same carry-history rebuild
         # path; the wrapper flips to the codex-native terminal UI.
         pytest.param("codex-native-ui", "codex-native-ui", True, id="sdk-to-codex"),
-        # SDK → Pi: native, but multi-family (its harness family is null), so
-        # the picker would drop it unless gated on isNativeHarness too. This is
-        # the case #230 fixes — the option must be offerable, and the fork must
-        # flip to the Pi terminal UI with carry-history stamped.
-        pytest.param("pi-native-ui", "pi-native-ui", True, id="sdk-to-pi"),
+        # SDK → Pi: native, but it cannot replay fork history, so the fork
+        # must flip to the Pi terminal UI without carry-history stamped.
+        pytest.param("pi-native-ui", "pi-native-ui", False, id="sdk-to-pi"),
     ],
 )
 def test_fork_switch_agent_carries_history(
@@ -104,7 +103,8 @@ def test_fork_switch_agent_carries_history(
     :param expected_wrapper: TARGET ``omnigent.wrapper`` value, or ``None``
         when the target runs as plain chat (SDK).
     :param expect_carry_history: Whether the fork must stamp the
-        carry-history label (true only for native targets).
+        carry-history label (true only for native targets that can replay
+        fork history, currently claude/codex native).
     """
     base_url, session_id = seeded_session
     target_agent_id = _agent_id_by_name(base_url, target_name)
@@ -171,17 +171,19 @@ def test_fork_switch_agent_carries_history(
     )
     if expect_carry_history:
         assert labels.get(_CARRY_HISTORY_LABEL_KEY) == "1", (
-            f"native-target fork must stamp carry-history, got {labels!r}"
-        )
-        assert labels.get(_WRAPPER_LABEL_KEY) == expected_wrapper, (
-            f"native-target fork must present as {expected_wrapper!r}, got {labels!r}"
+            f"history-capable native target must stamp carry-history, got {labels!r}"
         )
     else:
         assert _CARRY_HISTORY_LABEL_KEY not in labels, (
-            f"SDK-target fork must not stamp carry-history, got {labels!r}"
+            f"target must not stamp carry-history, got {labels!r}"
         )
+    if expected_wrapper is None:
         assert _WRAPPER_LABEL_KEY not in labels, (
             f"SDK-target fork must stay in chat mode (no wrapper), got {labels!r}"
+        )
+    else:
+        assert labels.get(_WRAPPER_LABEL_KEY) == expected_wrapper, (
+            f"native-target fork must present as {expected_wrapper!r}, got {labels!r}"
         )
 
 

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -770,6 +770,25 @@ async def test_fork_switch_404_unknown_target() -> None:
             False,
             {"omnigent.ui": "terminal", "omnigent.wrapper": "codex-native-ui"},
         ),
+        # cursor/pi targets are native terminal-first harnesses, but they
+        # cannot replay fork history (no resumable native session and no TUI
+        # transcript import), so do not stamp carry_history_into_native.
+        (
+            "claude_sdk",
+            "cursor-native",
+            False,
+            False,
+            False,
+            {"omnigent.ui": "terminal", "omnigent.wrapper": "cursor-native-ui"},
+        ),
+        (
+            "claude_sdk",
+            "pi-native",
+            False,
+            False,
+            False,
+            {"omnigent.ui": "terminal", "omnigent.wrapper": "pi-native-ui"},
+        ),
         # native → SDK, same family: model carries, but an SDK target
         # replays the transcript itself so no native-rebuild marker is set.
         # The clone drops terminal-first mode (chat) — the bug this fixes.
@@ -801,13 +820,13 @@ async def test_fork_switch_model_and_carry_gating(
     """The switch gates model copy + native carry + UI mode on the target.
 
     A model id is provider-bound, so ``copy_model_settings`` must be True
-    only within a family. ``carry_history_into_native`` must be True for
-    ANY native target — same-family rebuilds via clone-or-items, cross-
-    family via items only — while SDK targets replay history themselves so
-    they never set it. ``resume_source_native_session`` must be False on a
-    cross-family switch so the store skips the fork-source directive (the
-    source's native transcript is the wrong format; a clone attempt would
-    fail and launch fresh). ``presentation_labels`` must reflect the TARGET
+    only within a family. ``carry_history_into_native`` must be True only for
+    native targets that can replay fork history (claude/codex); cursor/pi
+    targets are terminal-first but launch fresh, and SDK targets replay
+    history themselves so they never set it. ``resume_source_native_session``
+    must be False on a cross-family switch so the store skips the fork-source
+    directive (the source's native transcript is the wrong format; a clone
+    attempt would fail and launch fresh). ``presentation_labels`` must reflect the TARGET
     harness so the clone's UI mode is right — an SDK target drops
     terminal-first mode (``{}``), a native target sets it; copying the
     source's would leave an SDK clone of a native session with a stale
@@ -840,7 +859,7 @@ async def test_fork_switch_model_and_carry_gating(
     )
     assert fork_call["carry_history_into_native"] is expect_carry, (
         f"{source_harness}->{target_harness}: carry_history_into_native should "
-        f"be {expect_carry} (native rebuild for any native target; never for SDK)."
+        f"be {expect_carry} (only native harnesses with replayable fork history)."
     )
     assert fork_call["resume_source_native_session"] is expect_resume_source, (
         f"{source_harness}->{target_harness}: resume_source_native_session should "

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -890,3 +890,37 @@ async def test_fork_no_switch_native_source_carries_history(
         "A same-agent fork must not recompute presentation labels (None); "
         "the copied source labels are already correct."
     )
+
+
+@pytest.mark.parametrize("harness", ["cursor-native", "pi-native"])
+@pytest.mark.asyncio
+async def test_fork_cursor_native_does_not_carry_history(
+    monkeypatch: pytest.MonkeyPatch,
+    harness: str,
+) -> None:
+    """A fork of a cursor/pi native source must NOT mark native carry.
+
+    Unlike claude/codex native, the cursor and pi harnesses record no
+    resumable native session and their TUIs can't import a transcript, so
+    ``carry_history_into_native`` must be False — stamping it would be a
+    false promise the runner can't keep (the fork launches fresh anyway).
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(
+        conversations={"conv_src": conv},
+        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+    )
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_agent_cache",
+        lambda: _StubAgentCache({"ag_test": harness}),
+    )
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post("/v1/sessions/conv_src/fork", json={})
+
+    assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+    fork_call = conv_store.fork_calls[0]
+    assert fork_call["carry_history_into_native"] is False, (
+        f"A {harness} fork must not mark native carry — that harness can't "
+        "replay fork history, so the directive would be a false promise."
+    )

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -943,3 +943,50 @@ async def test_fork_cursor_native_does_not_carry_history(
         f"A {harness} fork must not mark native carry — that harness can't "
         "replay fork history, so the directive would be a false promise."
     )
+
+
+@pytest.mark.parametrize(
+    "harness,expect_carry",
+    [
+        # Reversed native spellings ("native-claude" / "native-codex") are
+        # valid harness ids that canonicalize_harness passes through unchanged,
+        # so the carry gate must recognize them just like their canonical
+        # spellings — otherwise an identically-behaving agent silently loses
+        # fork history. cursor/pi (either spelling) still must NOT carry.
+        ("native-claude", True),
+        ("native-codex", True),
+        ("native-cursor", False),
+        ("native-pi", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_fork_reversed_native_spelling_carry_gating(
+    monkeypatch: pytest.MonkeyPatch,
+    harness: str,
+    expect_carry: bool,
+) -> None:
+    """The carry gate honors reversed native spellings like the canonical ones.
+
+    ``canonicalize_harness`` only aliases ``native-pi``; the other reversed
+    spellings pass through unchanged, so the predicate must list both forms
+    explicitly. claude/codex carry fork history; cursor/pi never do.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(
+        conversations={"conv_src": conv},
+        items_by_conv={"conv_src": [_make_item("msg_1", "Hi")]},
+    )
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_agent_cache",
+        lambda: _StubAgentCache({"ag_test": harness}),
+    )
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post("/v1/sessions/conv_src/fork", json={})
+
+    assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+    fork_call = conv_store.fork_calls[0]
+    assert fork_call["carry_history_into_native"] is expect_carry, (
+        f"A {harness} fork should set carry_history_into_native={expect_carry}: "
+        "reversed native spellings must be treated like their canonical form."
+    )

--- a/tests/server/routes/test_sessions_switch_agent.py
+++ b/tests/server/routes/test_sessions_switch_agent.py
@@ -180,6 +180,38 @@ class _AgentCacheStub:
         return object()
 
 
+class _LoadedAgentStub:
+    """Loaded-agent stub exposing ``spec.executor.harness_kind``."""
+
+    def __init__(self, harness_kind: str) -> None:
+        class _Executor:
+            def __init__(self, hk: str) -> None:
+                self.harness_kind = hk
+
+        class _Spec:
+            def __init__(self, hk: str) -> None:
+                self.executor = _Executor(hk)
+
+        self.spec = _Spec(harness_kind)
+
+
+class _HarnessAgentCacheStub:
+    """Agent cache stub mapping agent id to harness kind."""
+
+    def __init__(self, harness_by_id: dict[str, str]) -> None:
+        self._harness_by_id = harness_by_id
+
+    def load(
+        self,
+        agent_id: str,
+        bundle_location: str,
+        *,
+        expand_env: bool = False,
+    ) -> _LoadedAgentStub:
+        del bundle_location, expand_env
+        return _LoadedAgentStub(self._harness_by_id[agent_id])
+
+
 # ── Helpers ──────────────────────────────────────────────────────
 
 
@@ -287,6 +319,8 @@ _CURRENT = _agent("ag_session_scoped", "claude (switch src)", "bundle/claude-sdk
 _BUILTIN_ORIGIN = _agent("ag_builtin_origin", "claude", "bundle/claude-sdk", None)
 _BUILTIN_CLAUDE = _agent("ag_builtin_claude", "claude-native-ui", "bundle/claude-native", None)
 _BUILTIN_CODEX = _agent("ag_builtin_codex", "codex-native-ui", "bundle/codex", None)
+_BUILTIN_CURSOR = _agent("ag_builtin_cursor", "cursor-native-ui", "bundle/cursor", None)
+_BUILTIN_PI = _agent("ag_builtin_pi", "pi-native-ui", "bundle/pi", None)
 
 
 # ── Tests ────────────────────────────────────────────────────────
@@ -378,6 +412,58 @@ async def test_switch_cross_family_resets_model_but_carries_history(
     # rebuilds the transcript from Omnigent items. False here would mean
     # the cross-family gate regressed and the session resumes blank.
     assert call["carry_history_into_native"] is True
+
+
+@pytest.mark.parametrize(
+    "target_agent,target_harness,expected_labels",
+    [
+        (
+            _BUILTIN_CURSOR,
+            "cursor-native",
+            {"omnigent.ui": "terminal", "omnigent.wrapper": "cursor-native-ui"},
+        ),
+        (
+            _BUILTIN_PI,
+            "pi-native",
+            {"omnigent.ui": "terminal", "omnigent.wrapper": "pi-native-ui"},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_switch_cursor_pi_native_targets_do_not_carry_history(
+    monkeypatch: pytest.MonkeyPatch,
+    target_agent: Agent,
+    target_harness: str,
+    expected_labels: dict[str, str],
+) -> None:
+    """Switching into cursor/pi native keeps terminal UI but does not carry history."""
+    conv_store = _ConversationStore(conversations={"conv_src": _conv()})
+    agent_store = _AgentStore(
+        {
+            "ag_session_scoped": _CURRENT,
+            target_agent.id: target_agent,
+            "ag_builtin_origin": _BUILTIN_ORIGIN,
+        }
+    )
+    monkeypatch.setattr(
+        sessions_mod,
+        "get_agent_cache",
+        lambda: _HarnessAgentCacheStub(
+            {"ag_session_scoped": "claude_sdk", target_agent.id: target_harness}
+        ),
+    )
+    client = TestClient(_build_app(conv_store, agent_store))
+
+    resp = client.post("/v1/sessions/conv_src/switch-agent", json={"agent_id": target_agent.id})
+
+    assert resp.status_code == 200, resp.text
+    call = conv_store.switch_calls[0]
+    assert call["copy_model_settings"] is False
+    assert call["carry_history_into_native"] is False, (
+        f"{target_harness} cannot replay fork history; switching to it must not "
+        "stamp carry_history_into_native."
+    )
+    assert call["presentation_labels"] == expected_labels
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_switch_agent.py
+++ b/tests/server/routes/test_sessions_switch_agent.py
@@ -263,7 +263,9 @@ def _patch_family_helpers(
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :param same_family: Value ``_same_provider_family`` returns.
-    :param native: Value ``_agent_is_native`` returns.
+    :param native: Value ``_agent_is_native`` /
+        ``_agent_carries_native_fork_history`` return (these switch tests
+        target claude/codex native, which both classify and carry history).
     :param labels: Value ``_presentation_labels_for_agent`` returns.
     :param raise_on_load: Whether the bundle precheck should fail.
     """
@@ -272,6 +274,7 @@ def _patch_family_helpers(
     )
     monkeypatch.setattr(sessions_mod, "_same_provider_family", lambda a, b: same_family)
     monkeypatch.setattr(sessions_mod, "_agent_is_native", lambda a: native)
+    monkeypatch.setattr(sessions_mod, "_agent_carries_native_fork_history", lambda a: native)
     monkeypatch.setattr(sessions_mod, "_presentation_labels_for_agent", lambda a: labels)
 
 


### PR DESCRIPTION
## Summary
- `cursor-native` and `pi-native` are native CLI harnesses but **cannot** replay fork chat history — they record no resumable `external_session_id` and their TUIs can't import a transcript. The fork and switch-agent routes previously stamped `carry_history_into_native = _agent_is_native(agent)`, which is `True` for them, making a promise the runner can't keep (the fork launches fresh).
- Add `_agent_carries_native_fork_history(agent)`, which returns `True` only for harnesses that can actually replay fork history (`claude-native` / `codex-native`), and use it at both gate sites in `omnigent/server/routes/sessions.py`. Comments at each site document why cursor/pi are excluded.
- Strengthen route and browser E2E coverage so cursor/pi native targets stay terminal-first but do **not** stamp carry-history. Update stale store/test docs that described carry-history as applying to every native target.

## Changes
- `omnigent/server/routes/sessions.py`: new `_agent_carries_native_fork_history` predicate; both `carry_history_into_native` assignments now use it.
- `tests/server/routes/test_sessions_fork.py`: same-agent cursor/pi fork negative test, plus fork-switch rows for cursor/pi native targets.
- `tests/server/routes/test_sessions_switch_agent.py`: switch-agent route tests exercising the real predicate for cursor/pi native targets.
- `tests/e2e_ui/fork_session/test_fork_switch_agent.py`: browser E2E now expects Pi to keep terminal wrapper without carry-history.
- Store docstrings now clarify that the flag is only set for native harnesses that can replay fork history.

## Test plan
- [x] `uv run --extra dev ruff check omnigent/server/routes/sessions.py omnigent/stores/conversation_store/__init__.py omnigent/stores/conversation_store/sqlalchemy_store.py tests/server/routes/test_sessions_fork.py tests/server/routes/test_sessions_switch_agent.py tests/e2e_ui/fork_session/test_fork_switch_agent.py`
- [x] `uv run --extra dev pytest tests/server/routes/test_sessions_fork.py tests/server/routes/test_sessions_switch_agent.py tests/runner/test_app_sessions_native.py tests/e2e/test_sessions_fork_e2e.py tests/e2e/test_switch_agent_native_e2e.py -q -p no:cacheprovider` — 213 passed, 4 skipped (native opt-in)
- [x] `uv run --extra dev pytest tests/e2e_ui/fork_session/test_fork_switch_agent.py -q -p no:cacheprovider` — 5 passed