### PR TITLE
fix(pi): never crash _ToolServer response path on non-JSON-serializable tool results (F03)

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -124,6 +124,32 @@ JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dic
 # ---------------------------------------------------------------------------
 
 
+def _safe_dumps(response: dict[str, Any], req_id: str | None) -> str:  # type: ignore[explicit-any]
+    """Serialize a tool-server response, never raising on bad payloads.
+
+    Tool callbacks may return values ``json.dumps`` can't encode (a
+    ``datetime``, ``set``, ``bytes``, custom object, ...). Encoding happens
+    on the response path *outside* :meth:`_ToolServer._execute`'s try, so an
+    unguarded ``json.dumps`` would propagate and the connection would close
+    with zero bytes written — leaving the JS ``callTool`` promise pending and
+    hanging the entire Pi turn. Mirrors codex's ``_result_text`` guard: on a
+    serialization failure, fall back to an ``{"error": ...}`` envelope so the
+    client always receives a valid frame.
+
+    :param response: The response dict to serialize.
+    :param req_id: The originating request id, echoed back on the error
+        envelope so the client correlates the failure with its call.
+    :returns: A compact JSON string (no trailing newline).
+    """
+    try:
+        return json.dumps(response, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        return json.dumps(
+            {"id": req_id, "error": f"unserializable tool result: {exc}"},
+            separators=(",", ":"),
+        )
+
+
 class _ToolServer:
     """Async TCP server that handles tool-call requests from the Pi extension.
 
@@ -213,7 +239,14 @@ class _ToolServer:
                 else:
                     response = await self._execute(raw_tool_name, tool_args)
                     response["id"] = raw_req_id
-                out = json.dumps(response, separators=(",", ":")) + "\n"
+                # Serialize defensively: a tool result may carry a value
+                # ``json.dumps`` can't encode (e.g. ``datetime``/``set``).
+                # If it raises here — outside ``_execute``'s try — the frame
+                # is never written and the JS ``callTool`` promise hangs the
+                # whole turn (no ``data``/``error`` event). Always emit a JSON
+                # frame: a serializable error envelope when the response can't
+                # be encoded, mirroring codex's ``_result_text`` guard.
+                out = _safe_dumps(response, raw_req_id) + "\n"
                 writer.write(out.encode("utf-8"))
                 await writer.drain()
         except (asyncio.CancelledError, ConnectionError):
@@ -371,7 +404,17 @@ const TOKEN = {token_json};
 
 /** Send a tool call request over TCP and return the result. */
 function callTool(toolName, args) {{
-  return new Promise((resolve, reject) => {{
+  return new Promise((resolve) => {{
+    // Idempotent settle: a tool call must resolve exactly once. Route every
+    // resolve through finish() so a late "close" after a real "data" response
+    // can't clobber the result, and a bare close with no data still resolves
+    // (rather than hanging Pi's agent loop forever).
+    let settled = false;
+    const finish = (v) => {{ if (!settled) {{ settled = true; resolve(v); }} }};
+    const errorResult = (text) => ({{
+      content: [{{ type: "text", text: JSON.stringify({{ error: text }}) }}],
+      isError: true
+    }});
     const client = net.createConnection({{ port: PORT, host: "127.0.0.1" }}, () => {{
       const id = Math.random().toString(36).slice(2);
       const req = JSON.stringify({{ id, token: TOKEN, tool: toolName, args }}) + "\\n";
@@ -384,39 +427,33 @@ function callTool(toolName, args) {{
             const resp = JSON.parse(buf.slice(0, nl));
             client.end();
             if (resp.error) {{
-              resolve({{
-                content: [{{ type: "text", text: JSON.stringify({{ error: resp.error }}) }}],
-                isError: true
-              }});
+              finish(errorResult(resp.error));
             }} else {{
               const text = typeof resp.result === "string"
                 ? resp.result
                 : JSON.stringify(resp.result);
               const isError = resp.result && (resp.result.error || resp.result.blocked);
-              resolve({{ content: [{{ type: "text", text }}], isError: !!isError }});
+              finish({{ content: [{{ type: "text", text }}], isError: !!isError }});
             }}
           }} catch (e) {{
             client.end();
-            resolve({{
-              content: [{{ type: "text", text: JSON.stringify({{ error: e.message }}) }}],
-              isError: true
-            }});
+            finish(errorResult(e.message));
           }}
         }}
       }});
       client.on("error", (err) => {{
-        resolve({{
-          content: [{{ type: "text", text: JSON.stringify({{ error: err.message }}) }}],
-          isError: true
-        }});
+        finish(errorResult(err.message));
+      }});
+      // A clean FIN with no bytes (e.g. the server failed to serialize the
+      // result and closed) emits neither "data" nor "error"; without this
+      // the promise would hang forever. finish() is a no-op if already settled.
+      client.on("close", () => {{
+        finish(errorResult("tool server closed connection without a response"));
       }});
       client.write(req);
     }});
     client.on("error", (err) => {{
-      resolve({{
-        content: [{{ type: "text", text: JSON.stringify({{ error: err.message }}) }}],
-        isError: true
-      }});
+      finish(errorResult(err.message));
     }});
   }});
 }}

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -144,8 +144,13 @@ def _safe_dumps(response: dict[str, Any], req_id: str | None) -> str:  # type: i
     try:
         return json.dumps(response, separators=(",", ":"))
     except (TypeError, ValueError) as exc:
+        # Stringify ``req_id`` so the fallback envelope itself can never raise
+        # on a non-serializable id (the caller passes a ``str`` today, but the
+        # guard must hold for any future caller). ``None`` stays ``None`` so the
+        # client still sees a null id rather than the literal "None".
+        safe_id: str | None = req_id if req_id is None or isinstance(req_id, str) else str(req_id)
         return json.dumps(
-            {"id": req_id, "error": f"unserializable tool result: {exc}"},
+            {"id": safe_id, "error": f"unserializable tool result: {exc}"},
             separators=(",", ":"),
         )
 

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -5,6 +5,7 @@ import json
 import os
 import socket
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -600,6 +601,50 @@ class TestToolServer(unittest.TestCase):
             response = json.loads(response_line)
             self.assertEqual(response["id"], "req3")
             self.assertIn("No tool executor", response["error"])
+
+            writer.close()
+            await server.stop()
+
+        _run(_test())
+
+    def test_non_json_serializable_result_returns_error_frame(self):
+        """A tool result ``json.dumps`` can't encode yields an error frame.
+
+        Regression for F03: serialization happens on the response path
+        *outside* ``_execute``'s try, so a tool returning a ``datetime`` (or
+        ``set``) used to raise ``TypeError`` there, close the socket with zero
+        bytes, and hang the JS ``callTool`` promise — wedging the whole turn.
+        The handler must instead always write a valid frame: here an
+        ``{"error": ...}`` envelope, correlated by ``id``, delivered well
+        within the timeout (proving it did not hang).
+        """
+
+        async def _test():
+            server = _ToolServer()
+            await server.start()
+
+            async def executor(name, args):
+                # A dict carrying values json.dumps rejects by default.
+                return {"when": datetime(2026, 6, 18, 12, 0, 0), "tags": {1, 2, 3}}
+
+            server._tool_executor = executor
+
+            reader, writer = await asyncio.open_connection("127.0.0.1", server.port)
+            request = (
+                json.dumps({"id": "req6", "token": server.token, "tool": "exotic", "args": {}})
+                + "\n"
+            )
+            writer.write(request.encode())
+            await writer.drain()
+
+            # The key assertion is that a frame arrives at all (no hang): a
+            # short timeout would fire if the response path crashed/closed.
+            response_line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+            self.assertTrue(response_line, "tool server closed without writing a frame (hang)")
+            response = json.loads(response_line)
+            self.assertEqual(response["id"], "req6")
+            self.assertIn("unserializable tool result", response["error"])
+            self.assertNotIn("result", response)
 
             writer.close()
             await server.stop()

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -31,6 +31,7 @@ from omnigent.inner.pi_executor import (
     _generate_extension_js,
     _pi_provider_for_model,
     _PiRpcSession,
+    _safe_dumps,
     _sanitize_schema,
     _ToolServer,
 )
@@ -736,6 +737,21 @@ class TestToolServer(unittest.TestCase):
             await server.stop()
 
         _run(_test())
+
+    def test_safe_dumps_with_non_serializable_req_id_does_not_raise(self):
+        """``_safe_dumps`` never raises, even on a non-serializable ``req_id``.
+
+        The fallback envelope serializes ``req_id`` too, so a future caller
+        passing an id ``json.dumps`` can't encode (here a ``datetime``) must
+        still yield a valid frame rather than re-raising the very crash the
+        guard exists to prevent. The id is stringified in that envelope.
+        """
+        bad_id = datetime(2026, 6, 18, 12, 0, 0)
+        out = _safe_dumps({"id": bad_id, "result": {"k": "v"}}, bad_id)  # type: ignore[arg-type]
+        payload = json.loads(out)
+        self.assertEqual(payload["id"], str(bad_id))
+        self.assertIn("unserializable tool result", payload["error"])
+        self.assertNotIn("result", payload)
 
     def test_generated_bridge_returns_error_for_unserializable_tool_result(self):
         """End-to-end: Node bridge + Python server return an error result.

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -3,7 +3,10 @@
 import asyncio
 import json
 import os
+import shutil
 import socket
+import tempfile
+import textwrap
 import unittest
 from datetime import datetime
 from pathlib import Path
@@ -516,6 +519,89 @@ class TestToolServer(unittest.TestCase):
         finally:
             probe.close()
 
+    async def _run_generated_bridge_tool(
+        self,
+        *,
+        port: int,
+        token: str,
+        timeout: float = 5.0,
+    ) -> dict:
+        """Run the generated JS extension under Node and execute one tool.
+
+        This is intentionally cross-runtime: Python starts the real loopback
+        server, while Node loads the generated Pi extension, captures the
+        registered tool, and calls its ``execute`` method. It exercises the
+        same JSONL/TCP boundary Pi uses without needing a live Pi process.
+        """
+        node_path = shutil.which("node")
+        if node_path is None:
+            self.skipTest("node is required for generated Pi bridge e2e tests")
+
+        schema = [
+            {
+                "name": "exotic",
+                "description": "exercise generated bridge",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            extension_path = tmp_path / "omnigent_tools.js"
+            runner_path = tmp_path / "run_bridge.js"
+            extension_path.write_text(_generate_extension_js(port, schema, token))
+            runner_path.write_text(
+                textwrap.dedent(
+                    """
+                    const extension = require(process.argv[2]);
+                    let registered;
+                    const fakePi = {
+                      on() {},
+                      registerTool(tool) { registered = tool; },
+                    };
+
+                    (async () => {
+                      extension(fakePi);
+                      if (!registered) {
+                        throw new Error("tool was not registered");
+                      }
+                      const result = await registered.execute(
+                        "call-1",
+                        { input: "hello" },
+                        undefined,
+                        undefined,
+                        {}
+                      );
+                      process.stdout.write(JSON.stringify(result));
+                    })().catch((err) => {
+                      process.stderr.write(err && err.stack ? err.stack : String(err));
+                      process.exit(1);
+                    });
+                    """
+                )
+            )
+
+            proc = await asyncio.create_subprocess_exec(
+                node_path,
+                str(runner_path),
+                str(extension_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                stdout, stderr = await proc.communicate()
+                stderr_text = stderr.decode("utf-8", errors="replace")
+                self.fail(f"generated Pi bridge did not resolve within {timeout}s: {stderr_text}")
+            self.assertEqual(
+                proc.returncode,
+                0,
+                stderr.decode("utf-8", errors="replace"),
+            )
+            return json.loads(stdout.decode("utf-8"))
+
     def test_start_and_stop(self):
         async def _test():
             server = _ToolServer()
@@ -648,6 +734,69 @@ class TestToolServer(unittest.TestCase):
 
             writer.close()
             await server.stop()
+
+        _run(_test())
+
+    def test_generated_bridge_returns_error_for_unserializable_tool_result(self):
+        """End-to-end: Node bridge + Python server return an error result.
+
+        The previous unit test proves the TCP server writes an error frame.
+        This test follows the actual Pi bridge path too: generated JS running
+        in Node receives that frame and returns a Pi tool result with
+        ``isError=true`` instead of hanging or throwing.
+        """
+
+        async def _test():
+            server = _ToolServer()
+            await server.start()
+
+            async def executor(name, args):
+                return {"when": datetime(2026, 6, 18, 12, 0, 0), "tags": {1, 2, 3}}
+
+            server._tool_executor = executor
+            try:
+                result = await self._run_generated_bridge_tool(
+                    port=server.port,
+                    token=server.token,
+                )
+            finally:
+                await server.stop()
+
+            self.assertTrue(result["isError"])
+            self.assertEqual(result["content"][0]["type"], "text")
+            payload = json.loads(result["content"][0]["text"])
+            self.assertIn("unserializable tool result", payload["error"])
+
+        _run(_test())
+
+    def test_generated_bridge_resolves_on_bare_socket_close(self):
+        """End-to-end: a zero-byte close resolves the generated JS callTool.
+
+        This exercises the defense-in-depth close handler. If the generated
+        bridge only resolved on ``data`` or ``error`` events, the Node process
+        would hang here until ``wait_for`` timed out.
+        """
+
+        async def _test():
+            async def close_without_response(reader, writer):
+                await reader.readline()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_server(close_without_response, "127.0.0.1", 0)
+            port = server.sockets[0].getsockname()[1]
+            try:
+                result = await self._run_generated_bridge_tool(
+                    port=port,
+                    token="close-token",
+                )
+            finally:
+                server.close()
+                await server.wait_closed()
+
+            self.assertTrue(result["isError"])
+            payload = json.loads(result["content"][0]["text"])
+            self.assertIn("closed connection without a response", payload["error"])
 
         _run(_test())
 


### PR DESCRIPTION
## Summary
Fixes **F03** from `SDK_INTEGRATION_BUG_AUDIT.md`: `_ToolServer._handle_client` crashed the response path (and hung the Pi tool call) when a tool result was not JSON-serializable.

`_ToolServer._execute` wraps only the tool callback, so a result carrying a value `json.dumps` can't encode (e.g. a `datetime`, `set`, or `bytes`) raised `TypeError` at the serialization site in `_handle_client` — outside both `_execute`'s try and the handler's `except (CancelledError, ConnectionError)`. The exception propagated, `finally` closed the socket with zero bytes written, and the JS `callTool` promise (which only resolves on `data`/`error`, never `close`) hung forever — wedging the entire Pi turn until the 120s `read_line` timeout surfaced a misleading `"Pi process ended without response."`.

## Changes
- **Primary (Python):** New `_safe_dumps` helper mirrors codex's `_result_text` guard — `json.dumps` can no longer raise on the response path. On a serialization failure it returns an `{"id": ..., "error": "unserializable tool result: ..."}` envelope instead of a bare socket close, so the client always receives a valid frame.
- **Defense-in-depth (JS):** The generated `callTool` extension now routes every resolution through an idempotent `finish()` settle guard and resolves on socket `close` with an error result, so a bare zero-byte close can never hang the agent loop (and a late close after a real `data` response can't clobber the result).
- **Unit coverage:** A direct TCP server test asserts a tool returning a `datetime` + `set` yields a correlated error frame within the timeout.
- **E2E-style bridge coverage:** Node-backed tests run the generated Pi extension against (1) the real Python `_ToolServer` non-serializable-result path and (2) a zero-byte-close TCP server, proving the generated JS bridge returns `isError: true` instead of hanging.

## Test plan
- [x] `uv run --extra dev python -m pytest tests/inner/test_pi_executor.py -q -k "generated_bridge or non_json_serializable"` — 3 passed
- [x] `uv run --extra dev python -m pytest tests/inner/test_pi_executor.py -q` — 116 passed
- [x] `uv run --extra dev ruff check omnigent/inner/pi_executor.py tests/inner/test_pi_executor.py` — passed