### PR TITLE
fix(cursor): strip whitespace on env-detected CURSOR_API_KEY (F103)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8200,7 +8200,12 @@ def _set_cursor_api_key() -> str | None:
     )
     from omnigent.onboarding.interactive import prompt_text
 
-    detected = os.environ.get("CURSOR_API_KEY")
+    # Strip surrounding whitespace before validating/forwarding so a key
+    # exported with a trailing newline (a common ``export $(…)`` mishap)
+    # validates and resolves cleanly — matching the pasted-key branch's
+    # ``.strip()`` below and the strip in ``resolve_secret``'s ``env:`` branch.
+    raw_detected = os.environ.get("CURSOR_API_KEY")
+    detected = raw_detected.strip() if raw_detected else None
     if detected and click.confirm(
         "Detected CURSOR_API_KEY in the environment — use it?", default=True
     ):

--- a/omnigent/onboarding/cursor_auth.py
+++ b/omnigent/onboarding/cursor_auth.py
@@ -164,6 +164,16 @@ def resolve_cursor_api_key(config: dict[str, object] | None = None) -> str | Non
     spawn-env builder and the setup readout — can fall back to an inherited
     ``CURSOR_API_KEY`` instead of crashing a run.
 
+    An empty / all-whitespace resolved value also reads as ``None``: the
+    shared ``resolve_secret`` ``env:`` branch only raises on an *unset*
+    variable, so a configured ``env:CURSOR_API_KEY`` pointing at an empty
+    (``CURSOR_API_KEY=""``) or whitespace-only var resolves to ``""``. Folding
+    that to ``None`` here keeps :func:`cursor_api_key_configured` and the
+    spawn-env builder in agreement — both treat such a value as unset rather
+    than reporting "key set" for a credential the runtime won't forward.
+    (``keychain:`` values are stripped at store time, so only the ``env:``
+    path needs this runtime guard; we apply it uniformly for simplicity.)
+
     :param config: A pre-loaded config mapping; ``None`` loads the global
         config.
     :returns: The plaintext Cursor API key, or ``None`` when none is
@@ -173,9 +183,10 @@ def resolve_cursor_api_key(config: dict[str, object] | None = None) -> str | Non
     if ref is None:
         return None
     try:
-        return resolve_secret(ref)
+        resolved = resolve_secret(ref)
     except OmnigentError:
         return None
+    return resolved if resolved.strip() else None
 
 
 def cursor_api_key_configured(config: dict[str, object] | None = None) -> bool:

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -414,7 +414,10 @@ def resolve_secret(ref: str) -> str:
                 f"'env:{var}'. Set the variable in the environment.",
                 code=ErrorCode.INVALID_INPUT,
             )
-        return value
+        # Strip surrounding whitespace: a key exported with a stray trailing
+        # newline (e.g. ``export KEY=$(cat file)``) must not be forwarded
+        # verbatim to a harness/SDK, where the padding fails auth.
+        return value.strip()
     # Bare inline reference, e.g. "$ANTHROPIC_API_KEY" or a literal value.
     expanded = os.path.expandvars(ref)
     check_unresolved_env_vars(ref, expanded)

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1476,10 +1476,12 @@ def _build_cursor_spawn_env(
         from omnigent.onboarding.cursor_auth import resolve_cursor_api_key
 
         stored_key = resolve_cursor_api_key()
-        if stored_key is not None:
+        if stored_key:
             env["HARNESS_CURSOR_API_KEY"] = stored_key
-        elif os.environ.get("CURSOR_API_KEY"):
-            env["HARNESS_CURSOR_API_KEY"] = os.environ["CURSOR_API_KEY"]
+        else:
+            ambient_key = os.environ.get("CURSOR_API_KEY")
+            if ambient_key and ambient_key.strip():
+                env["HARNESS_CURSOR_API_KEY"] = ambient_key.strip()
     # Always set so the wrap doesn't fall back to ``"all"`` and override an
     # explicit ``skills: none`` from the spec (parity with the peer builders).
     env["HARNESS_CURSOR_SKILLS_FILTER"] = json.dumps(spec.skills_filter)

--- a/tests/e2e/omnigent/test_per_harness_cursor.py
+++ b/tests/e2e/omnigent/test_per_harness_cursor.py
@@ -11,7 +11,9 @@ over a local bridge (``agent.send`` → streamed ``run.messages()``) →
 **Prerequisites (skipped when absent):**
 - The ``cursor-sdk`` package installed (a baseline dependency).
 - ``CURSOR_API_KEY`` set — the SDK requires an API key and does NOT reuse a
-  ``cursor-agent login``.
+  ``cursor-agent login``. The subprocess receives this key with surrounding
+  newlines to prove the CLI/spawn-env path strips env-detected keys before
+  forwarding them to the cursor SDK (F103).
 
 Unlike the other per-harness e2e tests, the Cursor SDK talks only to Cursor's
 own backend — there is no Databricks-gateway path, so this test does NOT use
@@ -63,7 +65,8 @@ def test_per_harness_cursor_one_shot(
     """
     if importlib.util.find_spec("cursor_sdk") is None:
         pytest.skip("cursor prerequisite missing: the 'cursor-sdk' package is not installed.")
-    if not os.environ.get("CURSOR_API_KEY"):
+    cursor_api_key = os.environ.get("CURSOR_API_KEY", "").strip()
+    if not cursor_api_key:
         pytest.skip(
             "cursor prerequisite missing: CURSOR_API_KEY is not set. The Cursor SDK "
             "requires an API key (it does not reuse a 'cursor-agent login'), so this "
@@ -72,7 +75,11 @@ def test_per_harness_cursor_one_shot(
 
     yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
 
-    # The SDK reads CURSOR_API_KEY from the environment, so pass os.environ through.
+    env = dict(os.environ)
+    # Regression coverage for F103: this live gate runs the real
+    # CLI -> spawn-env -> cursor-harness path, so pad the key in the same shape
+    # that previously reached the SDK verbatim and failed auth.
+    env["CURSOR_API_KEY"] = f"\n{cursor_api_key}\n"
     result = subprocess.run(
         [
             str(omnigent_python),
@@ -87,7 +94,7 @@ def test_per_harness_cursor_one_shot(
             "--no-log",
             "--no-session",
         ],
-        env=dict(os.environ),
+        env=env,
         cwd=str(omnigent_repo_root),
         capture_output=True,
         text=True,

--- a/tests/onboarding/test_cursor_auth.py
+++ b/tests/onboarding/test_cursor_auth.py
@@ -79,6 +79,24 @@ def test_env_ref_resolves(_isolate: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert cursor_api_key_configured() is True
 
 
+def test_env_ref_strips_surrounding_whitespace(
+    _isolate: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A whitespace-padded ``env:`` key validates and resolves cleanly (F103).
+
+    A ``CURSOR_API_KEY`` exported with a stray leading/trailing newline (a
+    common ``export $(…)`` mishap) must strip before the ``crsr_`` prefix
+    check and before forwarding to the SDK — else the padding fails the
+    ``looks_like`` validation and reaches the harness verbatim.
+    """
+    monkeypatch.setenv("CURSOR_API_KEY", "\ncrsr_test\n")
+    _write_config(_isolate, {"cursor": {"api_key_ref": "env:CURSOR_API_KEY"}})
+    resolved = resolve_cursor_api_key()
+    assert resolved == "crsr_test"
+    assert looks_like_cursor_api_key(resolved)
+    assert cursor_api_key_configured() is True
+
+
 def test_inline_api_key_field_accepted(_isolate: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A hand-edited inline ``api_key: $VAR`` is honored as a fallback shape."""
     monkeypatch.setenv("INLINE_CURSOR", "crsr_inline")

--- a/tests/onboarding/test_cursor_auth.py
+++ b/tests/onboarding/test_cursor_auth.py
@@ -97,6 +97,33 @@ def test_env_ref_strips_surrounding_whitespace(
     assert cursor_api_key_configured() is True
 
 
+def test_empty_env_ref_reads_as_unconfigured(
+    _isolate: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configured ``env:`` ref pointing at an EMPTY var reads as not-configured.
+
+    The shared ``resolve_secret`` ``env:`` branch only raises on an *unset*
+    variable, so an exported-but-empty ``CURSOR_API_KEY=""`` (or all-whitespace)
+    resolves to ``""``. The cursor layer must fold that to ``None`` so the setup
+    readout (``cursor_api_key_configured``) and the spawn-env builder agree —
+    both treat it as unset rather than claiming a key the runtime won't forward.
+    """
+    monkeypatch.setenv("CURSOR_API_KEY", "")
+    _write_config(_isolate, {"cursor": {"api_key_ref": "env:CURSOR_API_KEY"}})
+    assert resolve_cursor_api_key() is None
+    assert cursor_api_key_configured() is False
+
+
+def test_whitespace_only_env_ref_reads_as_unconfigured(
+    _isolate: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configured ``env:`` ref pointing at an all-whitespace var is not-configured."""
+    monkeypatch.setenv("CURSOR_API_KEY", "   \n\t  ")
+    _write_config(_isolate, {"cursor": {"api_key_ref": "env:CURSOR_API_KEY"}})
+    assert resolve_cursor_api_key() is None
+    assert cursor_api_key_configured() is False
+
+
 def test_inline_api_key_field_accepted(_isolate: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A hand-edited inline ``api_key: $VAR`` is honored as a fallback shape."""
     monkeypatch.setenv("INLINE_CURSOR", "crsr_inline")

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -220,9 +220,7 @@ def test_databricks_auth_does_not_adopt_stored_cursor_key(
     assert "HARNESS_CURSOR_API_KEY" not in env
 
 
-def test_empty_stored_env_key_is_omitted(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_empty_stored_env_key_is_omitted(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A configured ``env:CURSOR_API_KEY`` ref pointing at an EMPTY var is omitted.
 
     ``resolve_secret``'s ``env:`` branch only raises on an *unset* variable, so

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -102,6 +102,15 @@ def test_ambient_cursor_api_key_used_when_no_spec_auth(monkeypatch: pytest.Monke
     assert env["HARNESS_CURSOR_API_KEY"] == "crsr_ambient"
 
 
+def test_ambient_cursor_api_key_stripped_before_forwarding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A padded ambient ``CURSOR_API_KEY`` is cleaned before reaching the SDK."""
+    monkeypatch.setenv("CURSOR_API_KEY", "\ncrsr_ambient\n")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_CURSOR_API_KEY"] == "crsr_ambient"
+
+
 def test_spec_api_key_wins_over_ambient(monkeypatch: pytest.MonkeyPatch) -> None:
     """An explicit spec api-key auth takes precedence over an ambient key."""
     monkeypatch.setenv("CURSOR_API_KEY", "crsr_ambient")
@@ -150,6 +159,16 @@ def test_stored_cursor_key_used_when_spec_has_no_auth(
     """A CURSOR_API_KEY registered via ``omnigent setup`` flows when the spec
     declares no auth — so a user need not export it in every shell."""
     monkeypatch.setenv("CURSOR_KEY_SRC", "crsr_stored_123")
+    _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert env["HARNESS_CURSOR_API_KEY"] == "crsr_stored_123"
+
+
+def test_stored_env_cursor_key_stripped_before_forwarding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A padded ``env:`` cursor key resolves cleanly before SDK forwarding."""
+    monkeypatch.setenv("CURSOR_KEY_SRC", "\ncrsr_stored_123\n")
     _write_cursor_config(tmp_path, "env:CURSOR_KEY_SRC")
     env = _build_cursor_spawn_env(_make_spec(auth=None))
     assert env["HARNESS_CURSOR_API_KEY"] == "crsr_stored_123"

--- a/tests/runtime/test_cursor_spawn_env.py
+++ b/tests/runtime/test_cursor_spawn_env.py
@@ -220,6 +220,34 @@ def test_databricks_auth_does_not_adopt_stored_cursor_key(
     assert "HARNESS_CURSOR_API_KEY" not in env
 
 
+def test_empty_stored_env_key_is_omitted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured ``env:CURSOR_API_KEY`` ref pointing at an EMPTY var is omitted.
+
+    ``resolve_secret``'s ``env:`` branch only raises on an *unset* variable, so
+    an exported-but-empty ``CURSOR_API_KEY=""`` resolves to ``""`` — which the
+    cursor layer folds to ``None``. The builder must therefore write no
+    ``HARNESS_CURSOR_API_KEY`` (the ambient fallback reads the same empty var
+    and is also skipped), agreeing with ``cursor_api_key_configured() is False``
+    rather than forwarding a blank credential.
+    """
+    monkeypatch.setenv("CURSOR_API_KEY", "")
+    _write_cursor_config(tmp_path, "env:CURSOR_API_KEY")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert "HARNESS_CURSOR_API_KEY" not in env
+
+
+def test_whitespace_only_stored_env_key_is_omitted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A configured ``env:`` ref pointing at an all-whitespace var is omitted."""
+    monkeypatch.setenv("CURSOR_API_KEY", "   \n\t  ")
+    _write_cursor_config(tmp_path, "env:CURSOR_API_KEY")
+    env = _build_cursor_spawn_env(_make_spec(auth=None))
+    assert "HARNESS_CURSOR_API_KEY" not in env
+
+
 def test_unresolvable_stored_key_is_omitted(tmp_path: Path) -> None:
     """A dangling stored reference resolves softly to no env var.
 


### PR DESCRIPTION
## Summary
- Fixes **F103**: env-detected `CURSOR_API_KEY` values are stripped before `looks_like_cursor_api_key` validation and before they are forwarded to the cursor SDK as `HARNESS_CURSOR_API_KEY`.
- Strips the `omnigent setup` detected-env branch, the shared `resolve_secret("env:...")` branch used by configured cursor refs, and the runtime ambient `CURSOR_API_KEY` fallback in `_build_cursor_spawn_env`.
- Treats empty/whitespace-only resolved stored cursor keys as absent so they are not forwarded as blank harness credentials.

## Test plan
- [x] Added onboarding resolver coverage: `CURSOR_API_KEY="\ncrsr_test\n"` resolves to `"crsr_test"` and passes `looks_like_cursor_api_key`.
- [x] Added runtime spawn-env coverage for both configured `env:` refs and ambient `CURSOR_API_KEY`, asserting `HARNESS_CURSOR_API_KEY` is stripped before forwarding.
- [x] Strengthened the live cursor e2e gate so, when `cursor-sdk` and a real `CURSOR_API_KEY` are available, it deliberately launches `omnigent run --harness cursor` with a newline-padded key and validates the full CLI -> spawn-env -> cursor-harness path.
- [x] `uv run --extra dev python -m pytest tests/onboarding/test_cursor_auth.py tests/onboarding/test_provider_config.py tests/runtime/test_cursor_spawn_env.py tests/e2e/omnigent/test_per_harness_cursor.py -q -p no:xdist` — 67 passed, 1 skipped (live cursor e2e skipped locally because prerequisites are unavailable), 1 warning.