### PR TITLE
fix(pi): kill the whole Pi process tree on session close (F08, F07)

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -990,34 +990,44 @@ class _PiRpcSession:
         self._read_task = None
         self._stderr_task = None
         if self.process is not None:
-            pid = self.process.pid
-            if os.name == "posix" and pid is not None:
-                # Signal the whole process group (pgid == child pid, created
-                # via start_new_session at spawn) so the launcher, pi node CLI,
-                # and any descendants it spawned are torn down — not just the
-                # direct child.  Mirrors codex_executor._terminate_process_tree.
-                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
-                    os.killpg(pid, signal.SIGTERM)
-            else:
-                with contextlib.suppress(ProcessLookupError, Exception):
-                    self.process.terminate()
-            try:
-                await asyncio.wait_for(self.process.wait(), timeout=2.0)
-            except (asyncio.TimeoutError, ProcessLookupError, RuntimeError):
-                # RuntimeError can happen when the subprocess was created on a
-                # different event loop (e.g. test fixtures that call close() in
-                # a fresh loop).  Fall back to a SIGKILL of the group.
+            if self.process.returncode is None:
+                pid = self.process.pid
+                group_signal_sent = False
                 if os.name == "posix" and pid is not None:
-                    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
-                        os.killpg(pid, signal.SIGKILL)
-                else:
-                    with contextlib.suppress(ProcessLookupError):
-                        self.process.kill()
-                # Reap the killed child so its returncode is set and no zombie
-                # lingers under non-default child watchers (F07).  Guarded so a
-                # wrong-event-loop RuntimeError cannot abort the rest of close().
-                with contextlib.suppress(Exception):
-                    await self.process.wait()
+                    try:
+                        # Signal the whole process group (pgid == child pid,
+                        # created via start_new_session at spawn) so the
+                        # launcher, pi node CLI, and any descendants it spawned
+                        # are torn down, not just the direct child. Mirrors
+                        # codex_executor._terminate_process_tree.
+                        os.killpg(pid, signal.SIGTERM)
+                        group_signal_sent = True
+                    except (ProcessLookupError, PermissionError, OSError):
+                        pass
+                if not group_signal_sent:
+                    with contextlib.suppress(ProcessLookupError, Exception):
+                        self.process.terminate()
+                try:
+                    await asyncio.wait_for(self.process.wait(), timeout=2.0)
+                except (asyncio.TimeoutError, ProcessLookupError, RuntimeError):
+                    # RuntimeError can happen when the subprocess was created on a
+                    # different event loop (e.g. test fixtures that call close() in
+                    # a fresh loop).  Fall back to a SIGKILL of the group.
+                    group_kill_sent = False
+                    if os.name == "posix" and pid is not None:
+                        try:
+                            os.killpg(pid, signal.SIGKILL)
+                            group_kill_sent = True
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+                    if not group_kill_sent:
+                        with contextlib.suppress(ProcessLookupError):
+                            self.process.kill()
+                    # Reap the killed child so its returncode is set and no zombie
+                    # lingers under non-default child watchers (F07). Guarded so a
+                    # wrong-event-loop RuntimeError cannot abort the rest of close().
+                    with contextlib.suppress(Exception):
+                        await self.process.wait()
             close_subprocess_transport(self.process)
             self.process = None
         if self._tmp_dir is not None:

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -1003,6 +1003,9 @@ class _PiRpcSession:
                         os.killpg(pid, signal.SIGTERM)
                         group_signal_sent = True
                     except (ProcessLookupError, PermissionError, OSError):
+                        # Best-effort: the group may already be gone or unsignalable.
+                        # group_signal_sent stays False, so the fallback below
+                        # terminates the direct child instead — non-fatal.
                         pass
                 if not group_signal_sent:
                     with contextlib.suppress(ProcessLookupError, Exception):
@@ -1019,6 +1022,9 @@ class _PiRpcSession:
                             os.killpg(pid, signal.SIGKILL)
                             group_kill_sent = True
                         except (ProcessLookupError, PermissionError, OSError):
+                            # Best-effort: the group may already be gone or
+                            # unsignalable. group_kill_sent stays False, so the
+                            # fallback below kills the direct child — non-fatal.
                             pass
                     if not group_kill_sent:
                         with contextlib.suppress(ProcessLookupError):

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -39,6 +39,7 @@ import os
 import pathlib
 import secrets
 import shutil
+import signal
 import subprocess
 import tempfile
 from asyncio import Queue, Task
@@ -903,6 +904,12 @@ class _PiRpcSession:
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
             env=env,
+            # New session/process group (pgid == child pid) so teardown can
+            # os.killpg the whole tree.  The spawned child is frequently the
+            # sandbox launcher wrapping the pi node CLI, which itself spawns
+            # MCP servers / shell tools; signalling only the direct child
+            # would orphan that subtree.  Mirrors codex_executor's spawn.
+            start_new_session=(os.name == "posix"),
         )
         self._read_task = asyncio.create_task(self._reader())
         self._stderr_task = asyncio.create_task(self._stderr_reader())
@@ -983,16 +990,34 @@ class _PiRpcSession:
         self._read_task = None
         self._stderr_task = None
         if self.process is not None:
-            with contextlib.suppress(ProcessLookupError):
-                self.process.terminate()
+            pid = self.process.pid
+            if os.name == "posix" and pid is not None:
+                # Signal the whole process group (pgid == child pid, created
+                # via start_new_session at spawn) so the launcher, pi node CLI,
+                # and any descendants it spawned are torn down — not just the
+                # direct child.  Mirrors codex_executor._terminate_process_tree.
+                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                    os.killpg(pid, signal.SIGTERM)
+            else:
+                with contextlib.suppress(ProcessLookupError, Exception):
+                    self.process.terminate()
             try:
                 await asyncio.wait_for(self.process.wait(), timeout=2.0)
             except (asyncio.TimeoutError, ProcessLookupError, RuntimeError):
                 # RuntimeError can happen when the subprocess was created on a
                 # different event loop (e.g. test fixtures that call close() in
-                # a fresh loop).  Fall back to synchronous kill.
-                with contextlib.suppress(ProcessLookupError):
-                    self.process.kill()
+                # a fresh loop).  Fall back to a SIGKILL of the group.
+                if os.name == "posix" and pid is not None:
+                    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                        os.killpg(pid, signal.SIGKILL)
+                else:
+                    with contextlib.suppress(ProcessLookupError):
+                        self.process.kill()
+                # Reap the killed child so its returncode is set and no zombie
+                # lingers under non-default child watchers (F07).  Guarded so a
+                # wrong-event-loop RuntimeError cannot abort the rest of close().
+                with contextlib.suppress(Exception):
+                    await self.process.wait()
             close_subprocess_transport(self.process)
             self.process = None
         if self._tmp_dir is not None:

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -5,7 +5,9 @@ import json
 import logging
 import os
 import shutil
+import signal
 import socket
+import sys
 import tempfile
 import textwrap
 import unittest
@@ -13,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import psutil
 import pytest
 
 from omnigent.inner.databricks_executor import DatabricksCredentials
@@ -48,6 +51,25 @@ def _run(coro):
     finally:
         loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
+
+
+async def _wait_until(predicate, *, timeout: float = 3.0, interval: float = 0.02) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError("timed out waiting for condition")
+        await asyncio.sleep(interval)
+
+
+def _pid_is_running(pid: int) -> bool:
+    try:
+        status = psutil.Process(pid).status()
+    except psutil.NoSuchProcess:
+        return False
+    except psutil.AccessDenied:
+        return True
+    return status != psutil.STATUS_ZOMBIE
 
 
 # ---------------------------------------------------------------------------
@@ -1172,6 +1194,77 @@ class TestPiRpcSession(unittest.TestCase):
             self.assertIsNone(rpc.process)
 
         _run(_test())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group teardown is POSIX-only")
+def test_rpc_close_terminates_real_process_group_descendants(tmp_path: Path) -> None:
+    """Close a real launcher -> child tree and assert the child receives SIGTERM.
+
+    This covers the F08 failure mode more directly than mocks: without
+    start_new_session + killpg, close() only terminates the launcher and the
+    grandchild keeps running without writing the SIGTERM marker.
+    """
+
+    grandchild_pid_file = tmp_path / "grandchild.pid"
+    grandchild_term_file = tmp_path / "grandchild.sigterm"
+    child_code = f"""
+import os
+import signal
+import time
+
+pid_file = {str(grandchild_pid_file)!r}
+term_file = {str(grandchild_term_file)!r}
+
+def on_term(signum, frame):
+    with open(term_file, "w", encoding="utf-8") as fh:
+        fh.write("sigterm")
+    raise SystemExit(0)
+
+signal.signal(signal.SIGTERM, on_term)
+with open(pid_file, "w", encoding="utf-8") as fh:
+    fh.write(str(os.getpid()))
+while True:
+    time.sleep(1)
+"""
+    launcher = tmp_path / "fake_pi_launcher.py"
+    launcher.write_text(
+        f"""#!{sys.executable}
+import subprocess
+import sys
+import time
+
+subprocess.Popen([sys.executable, "-c", {child_code!r}])
+while True:
+    time.sleep(1)
+""",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+
+    async def _test() -> None:
+        rpc = _PiRpcSession()
+        grandchild_pid: int | None = None
+        try:
+            await rpc.start(str(launcher), env=os.environ.copy(), cwd=str(tmp_path))
+            await _wait_until(grandchild_pid_file.exists)
+            grandchild_pid = int(grandchild_pid_file.read_text(encoding="utf-8"))
+
+            assert rpc.process is not None
+            assert os.getpgid(rpc.process.pid) == rpc.process.pid
+            assert os.getpgid(grandchild_pid) == rpc.process.pid
+
+            await rpc.close()
+            await _wait_until(grandchild_term_file.exists)
+            await _wait_until(
+                lambda: grandchild_pid is not None and not _pid_is_running(grandchild_pid)
+            )
+        finally:
+            if rpc.process is not None:
+                await rpc.close()
+            if grandchild_pid is not None and _pid_is_running(grandchild_pid):
+                os.kill(grandchild_pid, signal.SIGKILL)
+
+    _run(_test())
 
 
 # ---------------------------------------------------------------------------
@@ -2849,10 +2942,11 @@ def test_rpc_start_spawns_with_exact_env(monkeypatch) -> None:
     from omnigent.inner import pi_executor as pi_mod
 
     monkeypatch.setenv("FAKE_HOST_SECRET", "PWNED")
-    captured: dict[str, dict[str, str]] = {}
+    captured: dict[str, object] = {}
 
     async def _fake_spawn(*args, **kwargs):
         captured["env"] = kwargs["env"]
+        captured["start_new_session"] = kwargs["start_new_session"]
         return _FakeProcess(stdout_lines=[], stderr_lines=[])
 
     monkeypatch.setattr(pi_mod, "_create_subprocess_exec", _fake_spawn)
@@ -2869,6 +2963,7 @@ def test_rpc_start_spawns_with_exact_env(monkeypatch) -> None:
 
     # Exactly the executor-built env — nothing merged from os.environ.
     assert captured["env"] == {"PATH": "/usr/bin", "PI_CODING_AGENT_DIR": "/tmp/pi-agent"}
+    assert captured["start_new_session"] == (os.name == "posix")
 
 
 def test_redact_argv_for_log_hides_system_prompt() -> None:


### PR DESCRIPTION
## Summary

Fixes **F08** (high) and **F07** (low) from `SDK_INTEGRATION_BUG_AUDIT.md`.

- **F08 — orphaned Pi/node tree on close.** `_PiRpcSession.start()` spawned Pi via `_create_subprocess_exec` with no `start_new_session`/process-group isolation, and `close()` only `terminate()`/`kill()`'d the single direct child PID. The spawned child is frequently the sandbox launcher wrapping the `pi` node CLI, which itself spawns MCP servers / shell tools — so on every close/interrupt the real pi tree was orphaned (reparented to init), leaking CPU/memory/FDs per abandoned turn. Now mirrors `codex_executor`: spawn with `start_new_session=(os.name == "posix")` and tear down with `os.killpg(SIGTERM → SIGKILL)` against the group, falling back to direct `terminate()`/`kill()` off-posix.
- **F07 — zombie after kill.** After the SIGKILL fallback, `close()` never reaped the child, so it could linger as a zombie under non-default child watchers. Added a guarded `await self.process.wait()` after the kill (mirrors codex ~1225-1229). The `await` is wrapped in `contextlib.suppress(Exception)` so a wrong-event-loop `RuntimeError` (test fixtures) can't abort the rest of `close()`.

Added `import signal` for the new `os.killpg` calls.

## Test plan

- [x] `pytest tests/inner/test_pi_executor.py -q` → 113 passed
- [x] `ruff check omnigent/inner/pi_executor.py` → clean
- [x] No new mypy errors introduced (existing `explicit-any` errors are pre-existing and unrelated to these lines)