### PR TITLE
fix(pi): redact system prompt from PiExecutor spawn debug log (F92)

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -592,9 +592,15 @@ def _redact_argv_for_log(args: Sequence[str]) -> list[str]:
     """
     Return a copy of ``args`` with sensitive flag values redacted for logging.
 
-    The value following any flag in :data:`_REDACTED_ARGV_FLAGS` (e.g. the full
-    system prompt passed via ``--append-system-prompt``) is replaced with a
-    ``[system prompt N chars]`` placeholder so it never leaks into debug logs.
+    The system prompt value (e.g. passed via ``--append-system-prompt``) is
+    replaced with a ``[system prompt N chars]`` placeholder so it never leaks
+    into debug logs. Two argv forms are handled:
+
+    * the two-token form ``--append-system-prompt <value>`` (what the current
+      spawn code emits), and
+    * the equals-joined form ``--append-system-prompt=<value>`` (not emitted
+      today, but redacted defensively in case a future refactor switches to it).
+
     All other tokens are preserved so the command remains useful for debugging.
     """
     redacted: list[str] = []
@@ -604,9 +610,17 @@ def _redact_argv_for_log(args: Sequence[str]) -> list[str]:
             redacted.append(f"[system prompt {len(arg)} chars]")
             redact_next = False
             continue
-        redacted.append(arg)
         if arg in _REDACTED_ARGV_FLAGS:
+            # Two-token form: redact the following value token.
+            redacted.append(arg)
             redact_next = True
+            continue
+        flag, sep, value = arg.partition("=")
+        if sep and flag in _REDACTED_ARGV_FLAGS:
+            # Equals-joined form: redact the inline value, keep the flag name.
+            redacted.append(f"{flag}=[system prompt {len(value)} chars]")
+            continue
+        redacted.append(arg)
     return redacted
 
 

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -582,6 +582,33 @@ _PI_ENV_ALLOW_EXACT: frozenset[str] = frozenset(
 )
 _STREAM_READ_CHUNK_SIZE = 65536
 
+# CLI flags whose values are sensitive (e.g. the full system prompt) and must
+# not be written to logs verbatim. The value following these flags is replaced
+# with a length-only placeholder.
+_REDACTED_ARGV_FLAGS = frozenset({"--append-system-prompt", "--system-prompt"})
+
+
+def _redact_argv_for_log(args: Sequence[str]) -> list[str]:
+    """
+    Return a copy of ``args`` with sensitive flag values redacted for logging.
+
+    The value following any flag in :data:`_REDACTED_ARGV_FLAGS` (e.g. the full
+    system prompt passed via ``--append-system-prompt``) is replaced with a
+    ``[system prompt N chars]`` placeholder so it never leaks into debug logs.
+    All other tokens are preserved so the command remains useful for debugging.
+    """
+    redacted: list[str] = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            redacted.append(f"[system prompt {len(arg)} chars]")
+            redact_next = False
+            continue
+        redacted.append(arg)
+        if arg in _REDACTED_ARGV_FLAGS:
+            redact_next = True
+    return redacted
+
 
 def _build_models_json(
     host: str,
@@ -812,7 +839,7 @@ class _PiRpcSession:
         if extra_args:
             args.extend(extra_args)
 
-        logger.debug("PiExecutor: spawning %s", " ".join(args))
+        logger.debug("PiExecutor: spawning %s", " ".join(_redact_argv_for_log(args)))
         self.process = await _create_subprocess_exec(
             *args,
             stdin=asyncio.subprocess.PIPE,

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -2692,6 +2692,41 @@ def test_redact_argv_for_log_hides_system_prompt() -> None:
     assert "/tmp/ext.js" in redacted
 
 
+def test_redact_argv_for_log_hides_two_token_system_prompt_flag() -> None:
+    """The two-token ``--system-prompt <value>`` form is redacted too, not just
+    ``--append-system-prompt``."""
+    secret = "REPLACEMENT SYSTEM PROMPT that must never hit the logs"
+    args = ["/fake/pi", "--system-prompt", secret, "--mode", "rpc"]
+
+    redacted = _redact_argv_for_log(args)
+
+    assert secret not in " ".join(redacted)
+    assert f"[system prompt {len(secret)} chars]" in redacted
+    assert "--system-prompt" in redacted
+    assert "--mode" in redacted
+    assert "rpc" in redacted
+
+
+def test_redact_argv_for_log_hides_equals_joined_system_prompt() -> None:
+    """``_redact_argv_for_log`` redacts the equals-joined
+    ``--append-system-prompt=<value>`` / ``--system-prompt=<value>`` forms while
+    keeping the flag name visible."""
+    secret = "SUPER SECRET SYSTEM PROMPT that must never hit the logs"
+    for flag in ("--append-system-prompt", "--system-prompt"):
+        args = ["/fake/pi", "--mode", "rpc", f"{flag}={secret}", "--extension", "/tmp/ext.js"]
+
+        redacted = _redact_argv_for_log(args)
+
+        rendered = " ".join(redacted)
+        assert secret not in rendered
+        assert f"{flag}=[system prompt {len(secret)} chars]" in redacted
+        # Flag name and other tokens stay visible for debugging.
+        assert "--mode" in redacted
+        assert "rpc" in redacted
+        assert "--extension" in redacted
+        assert "/tmp/ext.js" in redacted
+
+
 def test_rpc_start_log_does_not_leak_system_prompt(monkeypatch, caplog) -> None:
     """``_PiRpcSession.start`` must not write the full ``--append-system-prompt``
     value to the debug log; it should be redacted to a length placeholder.

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import os
 import socket
 import unittest
@@ -27,6 +28,7 @@ from omnigent.inner.pi_executor import (
     _generate_extension_js,
     _pi_provider_for_model,
     _PiRpcSession,
+    _redact_argv_for_log,
     _sanitize_schema,
     _ToolServer,
 )
@@ -2657,6 +2659,81 @@ def test_rpc_start_spawns_with_exact_env(monkeypatch) -> None:
 
     # Exactly the executor-built env — nothing merged from os.environ.
     assert captured["env"] == {"PATH": "/usr/bin", "PI_CODING_AGENT_DIR": "/tmp/pi-agent"}
+
+
+def test_redact_argv_for_log_hides_system_prompt() -> None:
+    """``_redact_argv_for_log`` replaces the system-prompt value with a
+    length-only placeholder while leaving every other flag visible."""
+    secret = "SUPER SECRET SYSTEM PROMPT that must never hit the logs"
+    args = [
+        "/fake/pi",
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--model",
+        "databricks/some-model",
+        "--append-system-prompt",
+        secret,
+        "--extension",
+        "/tmp/ext.js",
+    ]
+
+    redacted = _redact_argv_for_log(args)
+
+    rendered = " ".join(redacted)
+    assert secret not in rendered
+    assert f"[system prompt {len(secret)} chars]" in redacted
+    # Other flags stay visible for debugging.
+    assert "--mode" in redacted
+    assert "rpc" in redacted
+    assert "--model" in redacted
+    assert "databricks/some-model" in redacted
+    assert "--extension" in redacted
+    assert "/tmp/ext.js" in redacted
+
+
+def test_rpc_start_log_does_not_leak_system_prompt(monkeypatch, caplog) -> None:
+    """``_PiRpcSession.start`` must not write the full ``--append-system-prompt``
+    value to the debug log; it should be redacted to a length placeholder.
+
+    Guards F92: the old code logged ``" ".join(args)`` verbatim, leaking the
+    entire system prompt into debug logs.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param caplog: Pytest log-capture fixture.
+    """
+    from omnigent.inner import pi_executor as pi_mod
+
+    test_prompt = "TOP-SECRET-SYSTEM-PROMPT-DO-NOT-LOG-12345"
+
+    async def _fake_spawn(*args, **kwargs):
+        return _FakeProcess(stdout_lines=[], stderr_lines=[])
+
+    monkeypatch.setattr(pi_mod, "_create_subprocess_exec", _fake_spawn)
+
+    async def _test():
+        rpc = _PiRpcSession()
+        await rpc.start(
+            "/fake/pi",
+            env={"PATH": "/usr/bin"},
+            model="some-model",
+            system_prompt=test_prompt,
+            extra_args=["--extension", "/tmp/ext.js"],
+        )
+        await rpc.close()
+
+    with caplog.at_level(logging.DEBUG, logger="omnigent.inner.pi_executor"):
+        _run(_test())
+
+    spawn_logs = [r.getMessage() for r in caplog.records if "PiExecutor: spawning" in r.getMessage()]
+    assert spawn_logs, "expected a 'PiExecutor: spawning' debug log line"
+    spawn_line = spawn_logs[0]
+
+    assert test_prompt not in spawn_line
+    assert f"[system prompt {len(test_prompt)} chars]" in spawn_line
+    # Non-sensitive flags remain visible for debugging.
+    assert "--mode" in spawn_line
+    assert "--extension" in spawn_line
 
 
 def test_run_turn_spawn_env_has_no_host_secrets(monkeypatch) -> None:

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -2760,7 +2760,9 @@ def test_rpc_start_log_does_not_leak_system_prompt(monkeypatch, caplog) -> None:
     with caplog.at_level(logging.DEBUG, logger="omnigent.inner.pi_executor"):
         _run(_test())
 
-    spawn_logs = [r.getMessage() for r in caplog.records if "PiExecutor: spawning" in r.getMessage()]
+    spawn_logs = [
+        r.getMessage() for r in caplog.records if "PiExecutor: spawning" in r.getMessage()
+    ]
     assert spawn_logs, "expected a 'PiExecutor: spawning' debug log line"
     spawn_line = spawn_logs[0]
 
@@ -2830,7 +2832,9 @@ def test_run_turn_spawn_log_redacts_system_prompt_end_to_end(monkeypatch, caplog
     assert "--append-system-prompt" in argv
     assert argv[argv.index("--append-system-prompt") + 1] == test_prompt
 
-    spawn_logs = [r.getMessage() for r in caplog.records if "PiExecutor: spawning" in r.getMessage()]
+    spawn_logs = [
+        r.getMessage() for r in caplog.records if "PiExecutor: spawning" in r.getMessage()
+    ]
     assert spawn_logs, "expected a 'PiExecutor: spawning' debug log line"
     spawn_line = spawn_logs[0]
 

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -2736,6 +2736,75 @@ def test_rpc_start_log_does_not_leak_system_prompt(monkeypatch, caplog) -> None:
     assert "--extension" in spawn_line
 
 
+def test_run_turn_spawn_log_redacts_system_prompt_end_to_end(monkeypatch, caplog) -> None:
+    """The normal ``PiExecutor.run_turn`` path must pass the system prompt to
+    Pi without leaking it into the spawn debug log.
+
+    This drives the real executor wiring from ``run_turn`` through
+    ``_ensure_rpc`` and ``_PiRpcSession.start`` with only subprocess creation
+    stubbed, so it catches regressions at the behavior boundary users hit.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param caplog: Pytest log-capture fixture.
+    """
+    from omnigent.inner import pi_executor as pi_mod
+
+    test_prompt = "END-TO-END-SYSTEM-PROMPT-LEAK-SENTINEL-67890"
+    captured: dict[str, list[str]] = {}
+
+    async def _fake_spawn(*args, **kwargs):
+        captured["argv"] = list(args)
+        return _FakeProcess(
+            stdout_lines=[
+                json.dumps({"type": "response", "success": True}),
+                json.dumps(
+                    {
+                        "type": "message_update",
+                        "assistantMessageEvent": {"type": "text_delta", "delta": "hi"},
+                    }
+                ),
+                json.dumps({"type": "agent_end", "messages": []}),
+            ],
+            stderr_lines=[],
+        )
+
+    monkeypatch.setattr(pi_mod, "_create_subprocess_exec", _fake_spawn)
+
+    async def _test():
+        executor = PiExecutor(pi_path="/usr/bin/pi")
+        try:
+            return [
+                e
+                async for e in executor.run_turn(
+                    [{"role": "user", "content": "hello"}],
+                    [],
+                    test_prompt,
+                )
+            ]
+        finally:
+            await executor.close()
+
+    with caplog.at_level(logging.DEBUG, logger="omnigent.inner.pi_executor"):
+        events = _run(_test())
+
+    turn_complete = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(turn_complete) == 1
+    assert turn_complete[0].response == "hi"
+
+    argv = captured["argv"]
+    assert "--append-system-prompt" in argv
+    assert argv[argv.index("--append-system-prompt") + 1] == test_prompt
+
+    spawn_logs = [r.getMessage() for r in caplog.records if "PiExecutor: spawning" in r.getMessage()]
+    assert spawn_logs, "expected a 'PiExecutor: spawning' debug log line"
+    spawn_line = spawn_logs[0]
+
+    assert test_prompt not in spawn_line
+    assert f"[system prompt {len(test_prompt)} chars]" in spawn_line
+    assert "--append-system-prompt" in spawn_line
+    assert "--mode" in spawn_line
+
+
 def test_run_turn_spawn_env_has_no_host_secrets(monkeypatch) -> None:
     """A host secret seeded in ``os.environ`` never reaches the spawned
     Pi process through the full real path (reproduces the leak PoC).


### PR DESCRIPTION
## Summary
- **F92**: `_PiRpcSession.start` logged `" ".join(args)` at debug level, leaking the entire `--append-system-prompt <full prompt>` value into logs.
- Added `_redact_argv_for_log`, which replaces the value following sensitive flags (`--append-system-prompt`, `--system-prompt`) with a length-only placeholder `[system prompt N chars]`, while keeping all other flags visible for debugging.
- The spawn log site now logs the redacted argv without changing the real subprocess argv passed to Pi.

## Test plan
- [x] `test_redact_argv_for_log_hides_system_prompt` — asserts the helper hides the prompt, emits the length placeholder, and preserves other flags/values.
- [x] `test_rpc_start_log_does_not_leak_system_prompt` — drives `_PiRpcSession.start` with a known test prompt and asserts the `PiExecutor: spawning` debug line does not contain it, contains the placeholder, and still shows non-sensitive flags.
- [x] `test_run_turn_spawn_log_redacts_system_prompt_end_to_end` — drives the normal `PiExecutor.run_turn` path through `_ensure_rpc` and `_PiRpcSession.start`, asserting Pi still receives the original prompt in argv while the spawn log only contains the redacted placeholder.
- [x] `uv run --extra dev python -m pytest tests/inner/test_pi_executor.py -k "redact_argv_for_log or log_does_not_leak or run_turn_spawn_log_redacts" -q -p no:xdist -p no:cacheprovider` → 3 passed.
- [x] `uv run --extra dev python -m pytest tests/inner/test_pi_executor.py -q -p no:xdist -p no:cacheprovider` → 116 passed.