### PR TITLE
chore(cursor-native): drop unread REQUEST_SESSION_ID guard env

### DIFF
--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -23,8 +23,6 @@ from typing import Any
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_CURSOR_NATIVE_BRIDGE_DIR"
-#: Env var carrying the requesting Omnigent session id into the harness.
-REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CURSOR_NATIVE_REQUEST_SESSION_ID"
 
 _BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "cursor-native"
 _TMUX_FILE = "tmux.json"
@@ -62,7 +60,6 @@ def build_cursor_native_spawn_env(session_id: str) -> dict[str, str]:
     _ensure_dir(bridge_dir)
     return {
         BRIDGE_DIR_ENV_VAR: str(bridge_dir),
-        REQUEST_SESSION_ID_ENV_VAR: session_id,
     }
 
 

--- a/tests/inner/test_cursor_native_executor.py
+++ b/tests/inner/test_cursor_native_executor.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from omnigent.cursor_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
-    REQUEST_SESSION_ID_ENV_VAR,
     _paste_payload_bytes,
     bridge_dir_for_session_id,
     build_cursor_native_spawn_env,
@@ -95,10 +94,13 @@ class TestBridge:
         assert a1 != b
         assert "cursor-native" in str(a1)
 
-    def test_spawn_env_carries_bridge_dir_and_session(self) -> None:
+    def test_spawn_env_carries_bridge_dir(self) -> None:
         env = build_cursor_native_spawn_env("conv_xyz")
         assert env[BRIDGE_DIR_ENV_VAR] == str(bridge_dir_for_session_id("conv_xyz"))
-        assert env[REQUEST_SESSION_ID_ENV_VAR] == "conv_xyz"
+        # The cursor bridge has no active-session concept (unlike claude/pi), so
+        # no request-session-id guard env is emitted — only the bridge dir.
+        assert "HARNESS_CURSOR_NATIVE_REQUEST_SESSION_ID" not in env
+        assert list(env) == [BRIDGE_DIR_ENV_VAR]
 
     def test_tmux_target_round_trip(self, tmp_path: Path) -> None:
         write_tmux_target(tmp_path, socket_path=Path("/tmp/x/tmux.sock"), tmux_target="main")

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -26,7 +26,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
-from omnigent import claude_native_bridge, codex_native_bridge
+from omnigent import claude_native_bridge, codex_native_bridge, cursor_native_bridge
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
     bridge_dir_for_bridge_id,
@@ -1099,6 +1099,59 @@ async def test_create_session_threads_resolved_bundle_dir_to_codex_spawn_env(
     assert env is not None
     assert env["HARNESS_CODEX_BUNDLE_DIR"] == str(bundle_dir)
     assert env["HARNESS_CODEX_SKILLS_FILTER"] == '["codex_e2e_xyz_greet_a3f9c2"]'
+
+
+@pytest.mark.asyncio
+async def test_create_session_threads_cursor_bridge_dir_without_dead_guard_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cursor-native session pre-spawn emits only the bridge dir env.
+
+    This locks the runner boundary, not just the bridge helper: the
+    session-creation route must pass a cursor-native bridge dir into the
+    harness process manager, while omitting the unread request-session-id
+    guard env. Inject/stop/interrupt paths use the bridge dir and tmux target;
+    none consume an active-session guard.
+    """
+    monkeypatch.setattr(cursor_native_bridge, "_BRIDGE_ROOT", tmp_path / "cursor-bridge")
+    spec = AgentSpec(
+        spec_version=1,
+        name="cursor-native-agent",
+        executor=ExecutorSpec(
+            config={"harness": "cursor-native", "model": "cursor-default"},
+        ),
+    )
+    harness_client = _ScriptedHarnessClient([])
+    pm = _FakeProcessManager(harness_client)
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": "conv_cursor", "agent_id": "ag_cursor"},
+        )
+
+    assert resp.status_code == 201
+    assert pm.get_client_calls
+    conversation_id, harness, env = pm.get_client_calls[-1]
+    assert conversation_id == "conv_cursor"
+    assert harness == "cursor-native"
+    assert env == {
+        cursor_native_bridge.BRIDGE_DIR_ENV_VAR: str(
+            cursor_native_bridge.bridge_dir_for_session_id("conv_cursor")
+        )
+    }
+    assert "HARNESS_CURSOR_NATIVE_REQUEST_SESSION_ID" not in env
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Resolves item #4 ("dead guard") from `CURSOR_NATIVE_AUDIT_FIXES.md`.

`build_cursor_native_spawn_env` set `HARNESS_CURSOR_NATIVE_REQUEST_SESSION_ID`, but nothing in the cursor-native harness reads it. In `claude_native_executor` / `pi_native_executor` the analogous env var feeds a `_session_is_active` check that gates injection after a `/clear` creates a new active session. Cursor has **no active-session concept** — `cursor_native_bridge` has no `read_active_session_id` equivalent and the TUI records no resumable chat id — so there is nothing to gate on.

Per the task, I picked the smaller option (**Option A**): remove the dead env var rather than build out active-session tracking that would only exist to satisfy an unused guard.

Changes:
- Drop the `REQUEST_SESSION_ID_ENV_VAR` constant and stop emitting it from `build_cursor_native_spawn_env` (now returns only the bridge dir).
- Update `tests/inner/test_cursor_native_executor.py`: the spawn-env helper test now asserts the guard env is absent and that only `BRIDGE_DIR_ENV_VAR` is emitted.
- Add `tests/runner/test_app_sessions_native.py::test_create_session_threads_cursor_bridge_dir_without_dead_guard_env`, which exercises the session-creation route and asserts the actual env handed to the harness process manager contains only the cursor-native bridge dir.

No behavior change to the inject / stop / interrupt paths — none of them ever read this env var. claude/pi-native are untouched.

## Test plan

- [x] `uv run --extra dev python -m pytest tests/inner/test_cursor_native_executor.py tests/runner/test_app_sessions_native.py::test_create_session_threads_cursor_bridge_dir_without_dead_guard_env -q` — 18 passed
- [x] `uv run --extra dev ruff check omnigent/cursor_native_bridge.py tests/inner/test_cursor_native_executor.py tests/runner/test_app_sessions_native.py` — passed
- [x] `uv run --extra dev python -m pytest tests/e2e/test_cursor_native_cli_e2e.py -q` — 2 skipped here because `OMNIGENT_E2E_CURSOR_NATIVE=1` / logged-in `cursor-agent` opt-in gate is not enabled
- [x] Confirmed no production consumers of `HARNESS_CURSOR_NATIVE_REQUEST_SESSION_ID` / the removed constant (grep across repo)