### PR TITLE
harden(cursor-native): validate bridge-dir ancestors (no symlinks/foreign owners)

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -36,7 +36,6 @@ import queue
 import re
 import secrets
 import shlex
-import stat
 import sys
 import tempfile
 import threading
@@ -52,6 +51,8 @@ from typing import TYPE_CHECKING, Any
 from urllib import error, request
 
 from omnigent.claude_native_message_display_hook import MESSAGE_DELTAS_FILE
+from omnigent.native_bridge_security import absolute_syntactic_path as _absolute_syntactic_path
+from omnigent.native_bridge_security import ensure_secure_dir as _ensure_secure_dir_under
 
 if TYPE_CHECKING:
     from omnigent.llms.context_window import ModelPricing
@@ -163,21 +164,6 @@ _TERMINAL_FAILURE_TAIL_LINES = 12
 _TERMINAL_FAILURE_TAIL_CHARS = 800
 
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
-
-
-def _absolute_syntactic_path(path: Path) -> Path:
-    """
-    Return an absolute path without following symlinks.
-
-    Security validation needs to inspect symlinked ancestors with
-    ``lstat``. ``Path.resolve`` would follow an existing symlink before
-    that inspection, so this helper only expands ``~`` and normalizes
-    ``.`` / ``..`` components.
-
-    :param path: Path to normalize, e.g. ``Path("~/.omnigent/x")``.
-    :returns: Absolute path with syntactic normalization applied.
-    """
-    return Path(os.path.abspath(os.fspath(path.expanduser())))
 
 
 def _trusted_parent_for_bridge_dir(target: Path) -> Path:
@@ -597,33 +583,7 @@ def _ensure_secure_dir(target: Path) -> None:
     """
     target = _absolute_syntactic_path(target)
     trusted_parent = _trusted_parent_for_bridge_dir(target)
-    ancestors: list[Path] = []
-    cur = target
-    while cur != trusted_parent and cur != cur.parent:
-        ancestors.append(cur)
-        cur = cur.parent
-    if cur != trusted_parent:
-        raise RuntimeError(f"bridge dir {target!s} is not under trusted parent {trusted_parent!s}")
-    ancestors.reverse()
-    my_uid = os.getuid()
-    for ancestor in ancestors:
-        try:
-            os.mkdir(ancestor, mode=0o700)
-            continue
-        except FileExistsError:
-            pass
-        st = os.lstat(ancestor)
-        if stat.S_ISLNK(st.st_mode):
-            raise RuntimeError(f"refusing to use bridge ancestor {ancestor!s}: is a symlink")
-        if not stat.S_ISDIR(st.st_mode):
-            raise RuntimeError(f"refusing to use bridge ancestor {ancestor!s}: not a directory")
-        if st.st_uid != my_uid:
-            raise RuntimeError(
-                f"refusing to use bridge ancestor {ancestor!s}: owned by uid "
-                f"{st.st_uid}, not current user ({my_uid})"
-            )
-        if (st.st_mode & 0o077) != 0:
-            os.chmod(ancestor, 0o700)
+    _ensure_secure_dir_under(target, trusted_parent=trusted_parent)
 
 
 def bridge_dir_for_bridge_id(bridge_id: str) -> Path:

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -21,10 +21,20 @@ import time
 from pathlib import Path
 from typing import Any
 
+from omnigent.native_bridge_security import ensure_secure_dir as _ensure_secure_dir_under
+
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_CURSOR_NATIVE_BRIDGE_DIR"
 
-_BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "cursor-native"
+# Root for the per-process cursor bridge tree. Namespaced by uid so other
+# Unix users on the same host cannot read the tmux target or pre-create the
+# parent as a symlink to redirect the bridge tree. The trusted parent
+# (``$TMPDIR``/``/tmp``) is shared; everything under ``_BRIDGE_ROOT_PARENT``
+# must be owned by the current uid and not be a symlink — see
+# :func:`_ensure_secure_dir`.
+_TRUSTED_PARENT = Path(os.environ.get("TMPDIR", "/tmp"))
+_BRIDGE_ROOT_PARENT = _TRUSTED_PARENT / f"omnigent-{os.getuid()}"
+_BRIDGE_ROOT = _BRIDGE_ROOT_PARENT / "cursor-native"
 _TMUX_FILE = "tmux.json"
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 10.0
@@ -47,17 +57,23 @@ def bridge_dir_for_session_id(session_id: str) -> Path:
     return _BRIDGE_ROOT / digest
 
 
-def _ensure_dir(path: Path) -> None:
-    """Create *path* (and parents) with owner-only permissions."""
-    path.mkdir(parents=True, exist_ok=True)
-    with contextlib.suppress(OSError):
-        os.chmod(path, 0o700)
+def _ensure_secure_dir(target: Path) -> None:
+    """Create or validate *target* as an owner-only directory chain.
+
+    Walks ancestors from the shared trusted parent (``$TMPDIR``/``/tmp``)
+    down to *target*, rejecting symlinks and foreign-owned ancestors and
+    enforcing ``0o700`` — the cursor analog of
+    :func:`omnigent.claude_native_bridge._ensure_secure_dir`. A plain
+    ``mkdir(parents=True)`` would silently follow a pre-created symlinked
+    ancestor and redirect the bridge tree (which records the tmux target).
+    """
+    _ensure_secure_dir_under(target, trusted_parent=_TRUSTED_PARENT)
 
 
 def build_cursor_native_spawn_env(session_id: str) -> dict[str, str]:
     """Build the ``HARNESS_CURSOR_NATIVE_*`` env the harness executor reads."""
     bridge_dir = bridge_dir_for_session_id(session_id)
-    _ensure_dir(bridge_dir)
+    _ensure_secure_dir(bridge_dir)
     return {
         BRIDGE_DIR_ENV_VAR: str(bridge_dir),
     }
@@ -71,7 +87,7 @@ def write_tmux_target(
     pid: int | None = None,
 ) -> None:
     """Advertise the tmux socket + target for the running Cursor terminal."""
-    _ensure_dir(bridge_dir)
+    _ensure_secure_dir(bridge_dir)
     payload: dict[str, Any] = {
         "socket_path": str(socket_path),
         "tmux_target": tmux_target,

--- a/omnigent/native_bridge_security.py
+++ b/omnigent/native_bridge_security.py
@@ -1,0 +1,87 @@
+"""Shared filesystem-security helpers for native-bridge directories.
+
+Native bridges (claude-native, cursor-native, …) rendezvous through a
+per-uid directory tree under a shared *trusted parent* (e.g. ``/tmp``).
+Those trees store bearer tokens and tmux targets, so the whole ancestor
+chain below the trusted parent must be owner-only and free of symlinks
+or foreign-owned directories.
+
+``Path.mkdir(mode=0o700, parents=True, exist_ok=True)`` only applies the
+mode to the leaf and silently trusts any pre-existing ancestor — on a
+shared host an attacker could pre-create an intermediate ancestor as a
+symlink (or a world-writable directory) and redirect the bridge tree.
+This module walks each ancestor from the trusted parent down to the
+target, creating new ones with mode ``0o700`` and rejecting any existing
+ancestor that is a symlink, not a directory, owned by a different uid,
+or that has group/other permission bits set.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+
+def absolute_syntactic_path(path: Path) -> Path:
+    """
+    Return an absolute path without following symlinks.
+
+    Security validation needs to inspect symlinked ancestors with
+    ``lstat``. ``Path.resolve`` would follow an existing symlink before
+    that inspection, so this helper only expands ``~`` and normalizes
+    ``.`` / ``..`` components.
+
+    :param path: Path to normalize, e.g. ``Path("~/.omnigent/x")``.
+    :returns: Absolute path with syntactic normalization applied.
+    """
+    return Path(os.path.abspath(os.fspath(path.expanduser())))
+
+
+def ensure_secure_dir(target: Path, *, trusted_parent: Path) -> None:
+    """
+    Create or validate ``target`` as an owner-only directory chain.
+
+    Walks each ancestor from ``trusted_parent`` (exclusive) down to
+    ``target`` (inclusive), creating new ones with mode ``0o700`` and
+    rejecting any existing ancestor that is a symlink, not a directory,
+    owned by a different uid, or has group/other permission bits set.
+    Wrong-but-repairable modes on directories we own are reset to
+    ``0o700``.
+
+    :param target: Final bridge directory path to ensure, e.g.
+        ``Path("/tmp/omnigent-501/cursor-native/abc")``.
+    :param trusted_parent: Pre-existing, trusted anchor at which ancestor
+        validation stops, e.g. ``Path("/tmp")``.
+    :raises RuntimeError: If ``target`` is not below ``trusted_parent`` or
+        any ancestor fails validation.
+    """
+    target = absolute_syntactic_path(target)
+    trusted_parent = absolute_syntactic_path(trusted_parent)
+    ancestors: list[Path] = []
+    cur = target
+    while cur != trusted_parent and cur != cur.parent:
+        ancestors.append(cur)
+        cur = cur.parent
+    if cur != trusted_parent:
+        raise RuntimeError(f"bridge dir {target!s} is not under trusted parent {trusted_parent!s}")
+    ancestors.reverse()
+    my_uid = os.getuid()
+    for ancestor in ancestors:
+        try:
+            os.mkdir(ancestor, mode=0o700)
+            continue
+        except FileExistsError:
+            pass
+        st = os.lstat(ancestor)
+        if stat.S_ISLNK(st.st_mode):
+            raise RuntimeError(f"refusing to use bridge ancestor {ancestor!s}: is a symlink")
+        if not stat.S_ISDIR(st.st_mode):
+            raise RuntimeError(f"refusing to use bridge ancestor {ancestor!s}: not a directory")
+        if st.st_uid != my_uid:
+            raise RuntimeError(
+                f"refusing to use bridge ancestor {ancestor!s}: owned by uid "
+                f"{st.st_uid}, not current user ({my_uid})"
+            )
+        if (st.st_mode & 0o077) != 0:
+            os.chmod(ancestor, 0o700)

--- a/tests/test_cursor_native_bridge.py
+++ b/tests/test_cursor_native_bridge.py
@@ -1,0 +1,81 @@
+"""Filesystem-security tests for the cursor-native bridge directory.
+
+Mirrors ``tests/test_claude_native_bridge.py`` symlink-rejection +
+owner-only coverage: cursor's bridge tree records the tmux socket/target
+under a shared ``$TMPDIR``/``/tmp`` root, so its ancestor chain must be
+validated (no symlinks, no foreign owners, ``0o700``) the same way
+claude-native validates its bearer-token tree.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from omnigent.cursor_native_bridge import build_cursor_native_spawn_env
+
+
+def test_spawn_env_refuses_symlinked_ancestor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Pre-created symlinked bridge ancestor is refused, not silently followed.
+
+    Without the shared ``_ensure_secure_dir`` walk, a plain
+    ``mkdir(parents=True, exist_ok=True)`` happily traverses a symlinked
+    intermediate dir, redirecting the bridge tree (including the tmux
+    target it records) to a path an attacker controls. A regression that
+    swaps the secure walk back to a plain mkdir would let this succeed.
+    """
+    # Layout: tmp_path is the trusted parent. Place a "cursor-native"
+    # symlink that points at a separate attacker-controlled directory
+    # before any spawn-env call runs.
+    attacker_dir = tmp_path / "attacker-controlled"
+    attacker_dir.mkdir()
+    symlink = tmp_path / "cursor-native"
+    symlink.symlink_to(attacker_dir, target_is_directory=True)
+
+    monkeypatch.setattr("omnigent.cursor_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.cursor_native_bridge._BRIDGE_ROOT", symlink)
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        build_cursor_native_spawn_env("conv_abc")
+
+    # Confirm nothing was created inside the attacker-controlled directory
+    # — the refusal happened before any per-session dir was made.
+    assert list(attacker_dir.iterdir()) == []
+
+
+def test_spawn_env_restricts_filesystem_permissions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Bridge directory chain is owner-only (``0o700``), not world-readable.
+
+    ``$TMPDIR``/``/tmp`` is shared with other Unix users; the per-session
+    bridge dir records the tmux socket/target. If its perms drift to a
+    default ``0o755`` other users on the box can enter it. A regression
+    here would be invisible without an explicit stat assertion.
+    """
+    monkeypatch.setattr("omnigent.cursor_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(
+        "omnigent.cursor_native_bridge._BRIDGE_ROOT", tmp_path / "cursor-native"
+    )
+
+    env = build_cursor_native_spawn_env("conv_abc")
+    bridge_dir = Path(env["HARNESS_CURSOR_NATIVE_BRIDGE_DIR"])
+
+    dir_mode = stat.S_IMODE(bridge_dir.stat().st_mode)
+    assert dir_mode == 0o700, (
+        f"bridge dir at {bridge_dir} has mode {oct(dir_mode)}; "
+        "expected 0o700 so other host users cannot enter it"
+    )
+    # The intermediate cursor-native root must be locked down too.
+    root_mode = stat.S_IMODE((tmp_path / "cursor-native").stat().st_mode)
+    assert root_mode == 0o700, (
+        f"bridge root has mode {oct(root_mode)}; expected 0o700"
+    )

--- a/tests/test_cursor_native_bridge.py
+++ b/tests/test_cursor_native_bridge.py
@@ -109,9 +109,7 @@ def test_spawn_env_restricts_filesystem_permissions(
     here would be invisible without an explicit stat assertion.
     """
     monkeypatch.setattr("omnigent.cursor_native_bridge._TRUSTED_PARENT", tmp_path)
-    monkeypatch.setattr(
-        "omnigent.cursor_native_bridge._BRIDGE_ROOT", tmp_path / "cursor-native"
-    )
+    monkeypatch.setattr("omnigent.cursor_native_bridge._BRIDGE_ROOT", tmp_path / "cursor-native")
 
     env = build_cursor_native_spawn_env("conv_abc")
     bridge_dir = Path(env["HARNESS_CURSOR_NATIVE_BRIDGE_DIR"])
@@ -123,6 +121,4 @@ def test_spawn_env_restricts_filesystem_permissions(
     )
     # The intermediate cursor-native root must be locked down too.
     root_mode = stat.S_IMODE((tmp_path / "cursor-native").stat().st_mode)
-    assert root_mode == 0o700, (
-        f"bridge root has mode {oct(root_mode)}; expected 0o700"
-    )
+    assert root_mode == 0o700, f"bridge root has mode {oct(root_mode)}; expected 0o700"

--- a/tests/test_cursor_native_bridge.py
+++ b/tests/test_cursor_native_bridge.py
@@ -9,6 +9,7 @@ claude-native validates its bearer-token tree.
 
 from __future__ import annotations
 
+import os
 import stat
 from pathlib import Path
 
@@ -46,6 +47,52 @@ def test_spawn_env_refuses_symlinked_ancestor(
 
     # Confirm nothing was created inside the attacker-controlled directory
     # — the refusal happened before any per-session dir was made.
+    assert list(attacker_dir.iterdir()) == []
+
+
+def test_spawn_env_refuses_symlinked_intermediate_ancestor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A symlink at the *production* ``omnigent-<uid>`` ancestor is refused.
+
+    The real bridge tree is ``$TMPDIR/omnigent-<uid>/cursor-native/<hash>``,
+    so the trusted parent and the leaf's immediate parent are *not* the same
+    directory — there's an intermediate ``omnigent-<uid>`` level in between.
+    The other symlink test collapses that chain (its ``_BRIDGE_ROOT`` is a
+    direct child of ``_TRUSTED_PARENT``), so a regression that only stat'd
+    the leaf's immediate parent would still pass it. This test reproduces
+    the multi-level layout and poisons the *intermediate* ancestor, which
+    only a true ancestor walk from the trusted parent down can catch.
+
+    A regression that checked just the leaf's immediate parent
+    (``cursor-native``, here a real, locked-down dir) would silently follow
+    the symlink and redirect the bridge tree (including the tmux target it
+    records) into the attacker-controlled directory.
+    """
+    # Reproduce the real layout: tmp_path (trusted) -> omnigent-<uid>
+    # (intermediate) -> cursor-native (root) -> <hash> (leaf). Only the
+    # intermediate level is replaced with an attacker symlink; everything
+    # below it would be perfectly fine if the walk stopped at the leaf's
+    # immediate parent.
+    intermediate_name = f"omnigent-{os.getuid()}"
+    attacker_dir = tmp_path / "attacker-controlled"
+    attacker_dir.mkdir(mode=0o700)
+    intermediate = tmp_path / intermediate_name
+    intermediate.symlink_to(attacker_dir, target_is_directory=True)
+
+    monkeypatch.setattr("omnigent.cursor_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(
+        "omnigent.cursor_native_bridge._BRIDGE_ROOT",
+        intermediate / "cursor-native",
+    )
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        build_cursor_native_spawn_env("conv_abc")
+
+    # The refusal must happen at the intermediate symlink, before anything
+    # is created through it inside the attacker-controlled directory.
     assert list(attacker_dir.iterdir()) == []
 
 

--- a/tests/test_native_bridge_security.py
+++ b/tests/test_native_bridge_security.py
@@ -1,0 +1,149 @@
+"""Direct unit tests for the shared native-bridge security helpers.
+
+``omnigent.native_bridge_security.ensure_secure_dir`` is the single
+ancestor-walk that both the claude-native and cursor-native bridges call
+through their thin ``_ensure_secure_dir`` wrappers. The bridge suites
+exercise it indirectly via ``prepare_bridge_dir`` /
+``build_cursor_native_spawn_env``; this module covers ``ensure_secure_dir``
+itself so each rejection branch is locked in once, at the source, rather
+than only through a bridge.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from omnigent.native_bridge_security import absolute_syntactic_path, ensure_secure_dir
+
+
+def test_ensure_secure_dir_creates_owner_only_chain(tmp_path: Path) -> None:
+    """
+    A fresh chain below the trusted parent is created mode ``0o700``.
+
+    Every intermediate ancestor the walk creates must be owner-only, not
+    a default-umask ``0o755`` — ``/tmp`` is shared, and these dirs hold
+    bearer tokens / tmux targets.
+    """
+    target = tmp_path / f"omnigent-{os.getuid()}" / "native" / "leaf"
+
+    ensure_secure_dir(target, trusted_parent=tmp_path)
+
+    assert target.is_dir()
+    for ancestor in (target, target.parent, target.parent.parent):
+        mode = stat.S_IMODE(ancestor.stat().st_mode)
+        assert mode == 0o700, f"{ancestor} has mode {oct(mode)}, expected 0o700"
+
+
+def test_ensure_secure_dir_rejects_not_a_directory_ancestor(tmp_path: Path) -> None:
+    """
+    A regular file pre-created at an ancestor path is refused.
+
+    ``mkdir(parents=True, exist_ok=True)`` raises ``FileExistsError`` /
+    ``NotADirectoryError`` here, but the secure walk must turn it into an
+    explicit, attributable refusal rather than ever trusting a non-dir
+    sitting on the bridge path. This not-a-directory branch is untested
+    by either bridge suite, so it's covered directly here.
+    """
+    # Layout: tmp_path (trusted) -> ancestor (a regular FILE) -> ... -> leaf.
+    ancestor_file = tmp_path / f"omnigent-{os.getuid()}"
+    ancestor_file.write_text("not a dir", encoding="utf-8")
+    target = ancestor_file / "native" / "leaf"
+
+    with pytest.raises(RuntimeError, match="not a directory"):
+        ensure_secure_dir(target, trusted_parent=tmp_path)
+
+
+def test_ensure_secure_dir_rejects_not_a_directory_leaf(tmp_path: Path) -> None:
+    """
+    A regular file pre-created at the *leaf* target itself is refused.
+
+    The walk includes ``target`` in its ancestor list, so a file sitting
+    exactly where the bridge dir should be must also be rejected as
+    "not a directory", not silently accepted.
+    """
+    target = tmp_path / "leaf-file"
+    target.write_text("not a dir", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="not a directory"):
+        ensure_secure_dir(target, trusted_parent=tmp_path)
+
+
+def test_ensure_secure_dir_rejects_symlinked_ancestor(tmp_path: Path) -> None:
+    """
+    A pre-created symlinked ancestor is refused, not followed.
+
+    Direct analog of the bridge symlink tests, asserted at the shared
+    helper so the rejection is pinned independent of any caller.
+    """
+    attacker_dir = tmp_path / "attacker-controlled"
+    attacker_dir.mkdir(mode=0o700)
+    symlink = tmp_path / f"omnigent-{os.getuid()}"
+    symlink.symlink_to(attacker_dir, target_is_directory=True)
+    target = symlink / "native" / "leaf"
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        ensure_secure_dir(target, trusted_parent=tmp_path)
+
+    # Refusal happens at the symlink, before anything is created through it.
+    assert list(attacker_dir.iterdir()) == []
+
+
+def test_ensure_secure_dir_rejects_target_outside_trusted_parent(tmp_path: Path) -> None:
+    """
+    A target that isn't below the trusted parent is refused.
+
+    The walk stops when it reaches the filesystem root without ever
+    hitting ``trusted_parent``; that must raise rather than fall through
+    and start creating dirs at an arbitrary location.
+    """
+    trusted_parent = tmp_path / "trusted"
+    trusted_parent.mkdir(mode=0o700)
+    # Sibling of the trusted parent — not below it.
+    target = tmp_path / "elsewhere" / "leaf"
+
+    with pytest.raises(RuntimeError, match="not under trusted parent"):
+        ensure_secure_dir(target, trusted_parent=trusted_parent)
+
+
+def test_ensure_secure_dir_repairs_loose_permissions(tmp_path: Path) -> None:
+    """
+    An owned ancestor with group/other bits set is reset to ``0o700``.
+
+    The walk repairs (rather than rejects) a directory it owns whose mode
+    drifted to e.g. ``0o755`` — only foreign-owned / symlinked / non-dir
+    ancestors are fatal.
+    """
+    loose = tmp_path / f"omnigent-{os.getuid()}"
+    loose.mkdir(mode=0o755)
+    os.chmod(loose, 0o755)
+    target = loose / "native" / "leaf"
+
+    ensure_secure_dir(target, trusted_parent=tmp_path)
+
+    assert stat.S_IMODE(loose.stat().st_mode) == 0o700
+    assert target.is_dir()
+
+
+def test_absolute_syntactic_path_does_not_follow_symlinks(tmp_path: Path) -> None:
+    """
+    ``absolute_syntactic_path`` normalizes without resolving symlinks.
+
+    Security validation must ``lstat`` symlinked ancestors, so this
+    helper deliberately avoids ``Path.resolve`` — a symlink in the path
+    must survive normalization rather than be collapsed to its target.
+    """
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+
+    result = absolute_syntactic_path(link / ".." / "link")
+
+    # ".." is collapsed syntactically but the symlink is NOT resolved to
+    # ``real`` — the returned path still names ``link``.
+    assert result == link
+    assert result != real


### PR DESCRIPTION
## Summary
- Addresses `CURSOR_NATIVE_AUDIT_FIXES.md` item #3: `cursor_native_bridge._ensure_dir` was a plain `mkdir(parents=True, exist_ok=True)`, which silently follows a pre-created symlinked/foreign-owned ancestor under the shared `$TMPDIR`/`/tmp` root and could redirect the cursor bridge tree (which records the tmux socket/target).
- Factored claude-native's `_ensure_secure_dir` ancestor walk into a new shared module `omnigent/native_bridge_security.py` (`ensure_secure_dir(target, *, trusted_parent)` + `absolute_syntactic_path`). It walks each ancestor from the trusted parent down to the target, creating new ones `0o700` and rejecting symlinks, non-directories, foreign-owned dirs, and dirs with group/other bits.
- Wired the shared helper into `cursor_native_bridge` for `_BRIDGE_ROOT` and per-session bridge dirs (replacing `_ensure_dir`), matching claude's trusted-parent pattern.
- `claude_native_bridge` now imports the shared helper; its `_ensure_secure_dir(target)` keeps the same signature and computes the trusted parent via the existing `_trusted_parent_for_bridge_dir` (claude/codex roots unchanged — behavior identical).
- Added `tests/test_cursor_native_bridge.py` mirroring claude's symlink-rejection coverage, plus an owner-only (`0o700`) permissions assertion.

Out of scope (separate follow-up, per the task): `pi_native_bridge` still uses a plain mkdir.

## Test plan
- [x] `pytest tests/test_claude_native_bridge.py tests/inner/test_cursor_native_executor.py tests/test_cursor_native_bridge.py -q` → 155 passed
- [x] `ruff check` clean on all changed files