### PR TITLE
fix(pi-native): don't arm interrupt replay window on idle interrupts (F18)

### DIFF
--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -242,6 +242,7 @@ module.exports = function (pi) {
   let sequence = 0;
   let turnOrdinal = 0;
   let activeResponseId = null;
+  let agentRunning = false;
   let latestContext = null;
   let pendingInterruptUntil = 0;
   const postedToolCalls = new Set();
@@ -288,10 +289,10 @@ module.exports = function (pi) {
     // throw), so an interrupt that arrives with no live turn must NOT arm the
     // replay window — otherwise the 30s window poisons the next legitimately
     // started turn (F18). Only arm when a turn is genuinely in-flight: prefer
-    // the SDK's isIdle(), and fall back to activeResponseId (null between/before
-    // turns) on SDK versions that don't expose it.
+    // the SDK's isIdle(), and fall back to the agent loop state on SDK versions
+    // that don't expose it.
     const idle = safeIsIdle(ctx);
-    const turnIsIdle = idle === null ? !activeResponseId : idle;
+    const turnIsIdle = idle === null ? !agentRunning : idle;
     if (turnIsIdle) return false;
     const accepted = interruptActiveContext(ctx);
     if (!accepted) return false;
@@ -420,10 +421,11 @@ module.exports = function (pi) {
     rememberContext(ctx);
     // A brand-new agent loop must never inherit a replay window armed before it
     // began (e.g. a spuriously-armed window from an interrupt that landed while
-    // idle). A legitimate mid-turn interrupt arms AFTER this point (in
-    // turn_start onward) within the same loop, so clearing here does not regress
-    // it; agent_end also clears once the loop completes. See F18.
+    // idle). A legitimate interrupt that arrives after this point belongs to
+    // this loop and can still arm/replay; agent_end clears once the loop
+    // completes. See F18.
     clearPendingInterrupt();
+    agentRunning = true;
     setOmnigentStatus(config, ctx, "running");
     activeResponseId = null;
     turnOrdinal = 0;
@@ -443,6 +445,7 @@ module.exports = function (pi) {
   pi.on("agent_end", async (_event, ctx) => {
     rememberContext(ctx);
     clearPendingInterrupt();
+    agentRunning = false;
     setOmnigentStatus(config, ctx, "idle");
     activeResponseId = null;
     await postEvent(config, {

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -242,6 +242,12 @@ module.exports = function (pi) {
   let sequence = 0;
   let turnOrdinal = 0;
   let activeResponseId = null;
+  // Dedicated loop-state flag, set on agent_start / cleared on agent_end. Used
+  // as the no-isIdle() fallback for requestInterrupt instead of
+  // !activeResponseId: agent_start resets activeResponseId to null and only
+  // turn_start assigns it, so an interrupt landing in that gap (after
+  // agent_start, before turn_start) would look idle by activeResponseId yet the
+  // loop is genuinely running — agentRunning arms it correctly. See F18.
   let agentRunning = false;
   let latestContext = null;
   let pendingInterruptUntil = 0;
@@ -276,6 +282,8 @@ module.exports = function (pi) {
   function safeIsIdle(ctx) {
     // Returns true/false from the SDK's isIdle(), or null when the signal is
     // unavailable (older SDK) or throws, so the caller can fall back.
+    // Deliberately returns null (not true) on throw so callers fall back to loop
+    // state (!agentRunning) rather than blindly treating the agent as idle.
     if (!ctx || typeof ctx.isIdle !== "function") return null;
     try {
       return ctx.isIdle();

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -222,9 +222,11 @@ function startInboxPoller(pi, config, handleInterrupt) {
         // always consume the file (below). If there is no live turn to abort
         // right now, the interrupt is simply dropped — leaving the file would
         // re-read it every tick forever and, once a later turn creates an
-        // abortable context, abort that unrelated turn. requestInterrupt arms
-        // the pendingInterrupt window when it does catch a running turn, so a
-        // turn starting just after this still gets aborted via replay.
+        // abortable context, abort that unrelated turn. requestInterrupt only
+        // arms the pendingInterrupt window when it catches a genuinely running
+        // turn (idle interrupts are dropped, not armed — see F18), so a turn
+        // already in flight still gets aborted via replay without poisoning the
+        // next freshly-started turn.
         if (typeof handleInterrupt === "function") handleInterrupt();
       }
       if (id !== null) rememberSeen(id);
@@ -270,7 +272,27 @@ module.exports = function (pi) {
     return true;
   }
 
+  function safeIsIdle(ctx) {
+    // Returns true/false from the SDK's isIdle(), or null when the signal is
+    // unavailable (older SDK) or throws, so the caller can fall back.
+    if (!ctx || typeof ctx.isIdle !== "function") return null;
+    try {
+      return ctx.isIdle();
+    } catch (_err) {
+      return null;
+    }
+  }
+
   function requestInterrupt(ctx) {
+    // ctx.abort() is a silent no-op when the Pi agent is idle (it does NOT
+    // throw), so an interrupt that arrives with no live turn must NOT arm the
+    // replay window — otherwise the 30s window poisons the next legitimately
+    // started turn (F18). Only arm when a turn is genuinely in-flight: prefer
+    // the SDK's isIdle(), and fall back to activeResponseId (null between/before
+    // turns) on SDK versions that don't expose it.
+    const idle = safeIsIdle(ctx);
+    const turnIsIdle = idle === null ? !activeResponseId : idle;
+    if (turnIsIdle) return false;
     const accepted = interruptActiveContext(ctx);
     if (!accepted) return false;
     pendingInterruptUntil = Date.now() + pendingInterruptMs;
@@ -396,7 +418,12 @@ module.exports = function (pi) {
 
   pi.on("agent_start", async (_event, ctx) => {
     rememberContext(ctx);
-    replayPendingInterrupt(ctx);
+    // A brand-new agent loop must never inherit a replay window armed before it
+    // began (e.g. a spuriously-armed window from an interrupt that landed while
+    // idle). A legitimate mid-turn interrupt arms AFTER this point (in
+    // turn_start onward) within the same loop, so clearing here does not regress
+    // it; agent_end also clears once the loop completes. See F18.
+    clearPendingInterrupt();
     setOmnigentStatus(config, ctx, "running");
     activeResponseId = null;
     turnOrdinal = 0;

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
@@ -190,8 +190,37 @@ async function testMidTurnInterruptStillAborts() {
   );
 }
 
+async function testAgentLoopInterruptFallbackNoIsIdleBeforeTurnStart() {
+  // No isIdle(), and an interrupt lands after agent_start but before
+  // turn_start. Older SDKs without isIdle() still need to treat this as part of
+  // the live agent loop, not as an idle interrupt to drop.
+  const h = makeHarness();
+  const turnCtx = makeCtx({}); // no isIdle method
+  await h.handlers.session_start({}, turnCtx); // starts the inbox poller
+  await h.handlers.agent_start({}, turnCtx);
+
+  await deliverInterrupt(h);
+
+  assert(
+    "agent-loop interrupt aborts before turn_start (active loop fallback)",
+    turnCtx.abortCount >= 1,
+    `abortCount=${turnCtx.abortCount}`,
+  );
+
+  await h.handlers.turn_start({ turnIndex: 1 }, turnCtx);
+  const toolResult = await h.handlers.tool_call(
+    { toolCallId: "t1", toolName: "do_thing", input: {} },
+    turnCtx,
+  );
+  assert(
+    "agent-loop interrupt before turn_start replays to block tool_call",
+    !!toolResult && toolResult.block === true,
+    JSON.stringify(toolResult),
+  );
+}
+
 async function testMidTurnInterruptFallbackNoIsIdle() {
-  // No isIdle() but a turn is active (activeResponseId set) -> must still arm.
+  // No isIdle() but an agent loop is active -> must still arm.
   const h = makeHarness();
   const turnCtx = makeCtx({}); // no isIdle method
   await h.handlers.session_start({}, turnCtx); // starts the inbox poller
@@ -248,6 +277,7 @@ async function testAgentStartClearsStaleWindow() {
     await testIdleInterruptDoesNotPoisonNextTurn();
     await testIdleInterruptFallbackNoIsIdle();
     await testMidTurnInterruptStillAborts();
+    await testAgentLoopInterruptFallbackNoIsIdleBeforeTurnStart();
     await testMidTurnInterruptFallbackNoIsIdle();
     await testAgentStartClearsStaleWindow();
   } finally {

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
@@ -1,0 +1,261 @@
+// Unit test for the pi-native bridge extension's interrupt / replay logic.
+//
+// Regression coverage for F18 (SDK_INTEGRATION_BUG_AUDIT.md): an interrupt that
+// arrives while Pi is idle used to arm a 30s replay window that aborted the next
+// legitimately-started turn. ExtensionContext.abort() is a silent no-op when the
+// agent is idle (it does not throw), so the old requestInterrupt() armed the
+// window unconditionally and replayPendingInterrupt() then killed the next turn.
+//
+// This test drives the real extension through its public surface: it registers
+// the event handlers with a mock `pi`, and delivers interrupts through the real
+// inbox poller (a temp inbox directory). No network is used (postEvent fails
+// closed when config has no serverUrl).
+//
+// Run with: node omnigent/resources/pi_native/omnigent_pi_native_extension.test.js
+//
+// Manual reproduction of the original bug (for context):
+//   1. Start a native Pi session linked to Omnigent and let it go idle.
+//   2. Hit "stop"/interrupt while no turn is running (between turns).
+//   3. Send a fresh user message within 30 seconds.
+//   Before the fix: the fresh turn is aborted immediately at agent_start /
+//   turn_start (and tool calls are blocked) before producing output. After the
+//   fix: the idle interrupt is dropped and the fresh turn runs normally.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const EXT_PATH = path.resolve(__dirname, "omnigent_pi_native_extension.js");
+
+const harnesses = [];
+
+// Build a fresh extension instance with its own temp inbox directory. Each call
+// produces independent closure state (activeResponseId, pendingInterruptUntil,
+// latestContext, ...).
+function makeHarness() {
+  const inboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-inbox-"));
+  const configPath = path.join(inboxDir, "config.json");
+  fs.writeFileSync(configPath, JSON.stringify({ inboxDir }));
+  process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
+
+  const handlers = {};
+  const pi = {
+    on: (name, fn) => {
+      handlers[name] = fn;
+    },
+    registerCommand: () => {},
+    sendUserMessage: () => {},
+  };
+
+  // Fresh module-function invocation -> fresh closures.
+  delete require.cache[EXT_PATH];
+  const mod = require(EXT_PATH);
+  mod(pi);
+
+  const h = { pi, handlers, inboxDir };
+  harnesses.push(h);
+  return h;
+}
+
+// ctx mock. `idle` may be true/false (exposes isIdle()) or undefined (no isIdle
+// method at all, exercising the activeResponseId fallback path).
+function makeCtx({ idle } = {}) {
+  const ctx = {
+    abortCount: 0,
+    abort() {
+      this.abortCount += 1;
+    },
+  };
+  if (idle !== undefined) ctx.isIdle = () => idle;
+  return ctx;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Drop an interrupt into the inbox and wait until the poller has consumed it
+// (the poller unlinks the file after invoking handleInterrupt -> requestInterrupt).
+async function deliverInterrupt(h) {
+  const file = path.join(h.inboxDir, `int-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  fs.writeFileSync(file, JSON.stringify({ type: "interrupt" }));
+  const deadline = Date.now() + 3000;
+  while (fs.existsSync(file)) {
+    if (Date.now() > deadline) throw new Error("interrupt file was not consumed by poller");
+    await sleep(20);
+  }
+  // The poller runs requestInterrupt synchronously before unlinking, so by the
+  // time the file is gone the interrupt has been processed.
+}
+
+function assert(name, cond, detail) {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+}
+
+async function testIdleInterruptDoesNotPoisonNextTurn() {
+  const h = makeHarness();
+  const idleCtx = makeCtx({ idle: true });
+  await h.handlers.session_start({}, idleCtx);
+
+  await deliverInterrupt(h);
+
+  assert(
+    "idle interrupt (isIdle) does not abort the idle context",
+    idleCtx.abortCount === 0,
+    `abortCount=${idleCtx.abortCount}`,
+  );
+
+  // A fresh, legitimate turn starts within the (old) 30s window.
+  const turnCtx = makeCtx({ idle: false });
+  await h.handlers.agent_start({}, turnCtx);
+  await h.handlers.turn_start({ turnIndex: 1 }, turnCtx);
+  const toolResult = await h.handlers.tool_call(
+    { toolCallId: "t1", toolName: "do_thing", input: {} },
+    turnCtx,
+  );
+
+  assert(
+    "fresh turn after idle interrupt is NOT aborted",
+    turnCtx.abortCount === 0,
+    `abortCount=${turnCtx.abortCount}`,
+  );
+  assert(
+    "fresh turn's tool_call is NOT blocked after idle interrupt",
+    !toolResult || toolResult.block !== true,
+    JSON.stringify(toolResult),
+  );
+}
+
+async function testIdleInterruptFallbackNoIsIdle() {
+  // No isIdle() on ctx -> requestInterrupt falls back to !activeResponseId.
+  // Between turns activeResponseId is null, so this must behave as idle.
+  const h = makeHarness();
+  const idleCtx = makeCtx({}); // no isIdle method
+  await h.handlers.session_start({}, idleCtx);
+
+  await deliverInterrupt(h);
+
+  assert(
+    "idle interrupt (activeResponseId fallback) does not arm the window",
+    idleCtx.abortCount === 0,
+    `abortCount=${idleCtx.abortCount}`,
+  );
+
+  const turnCtx = makeCtx({}); // no isIdle method
+  await h.handlers.agent_start({}, turnCtx);
+  await h.handlers.turn_start({ turnIndex: 1 }, turnCtx);
+  const toolResult = await h.handlers.tool_call(
+    { toolCallId: "t1", toolName: "do_thing", input: {} },
+    turnCtx,
+  );
+
+  assert(
+    "fresh turn after fallback idle interrupt is NOT aborted",
+    turnCtx.abortCount === 0,
+    `abortCount=${turnCtx.abortCount}`,
+  );
+  assert(
+    "fresh turn's tool_call is NOT blocked (fallback)",
+    !toolResult || toolResult.block !== true,
+    JSON.stringify(toolResult),
+  );
+}
+
+async function testMidTurnInterruptStillAborts() {
+  // Regression guard: a genuine mid-turn interrupt must still abort and replay.
+  const h = makeHarness();
+  const turnCtx = makeCtx({ idle: false });
+  await h.handlers.session_start({}, turnCtx); // starts the inbox poller
+  await h.handlers.agent_start({}, turnCtx);
+  await h.handlers.turn_start({ turnIndex: 1 }, turnCtx);
+
+  await deliverInterrupt(h);
+
+  assert(
+    "mid-turn interrupt aborts the live turn",
+    turnCtx.abortCount >= 1,
+    `abortCount=${turnCtx.abortCount}`,
+  );
+
+  // Replay must keep aborting within the window and block in-flight tool calls.
+  const toolResult = await h.handlers.tool_call(
+    { toolCallId: "t1", toolName: "do_thing", input: {} },
+    turnCtx,
+  );
+  assert(
+    "mid-turn interrupt blocks subsequent tool_call (replay)",
+    !!toolResult && toolResult.block === true,
+    JSON.stringify(toolResult),
+  );
+}
+
+async function testMidTurnInterruptFallbackNoIsIdle() {
+  // No isIdle() but a turn is active (activeResponseId set) -> must still arm.
+  const h = makeHarness();
+  const turnCtx = makeCtx({}); // no isIdle method
+  await h.handlers.session_start({}, turnCtx); // starts the inbox poller
+  await h.handlers.agent_start({}, turnCtx);
+  await h.handlers.turn_start({ turnIndex: 1 }, turnCtx);
+
+  await deliverInterrupt(h);
+
+  assert(
+    "mid-turn interrupt aborts (activeResponseId fallback)",
+    turnCtx.abortCount >= 1,
+    `abortCount=${turnCtx.abortCount}`,
+  );
+}
+
+async function testAgentStartClearsStaleWindow() {
+  // Belt-and-suspenders: even if a window is armed during a live turn, a brand
+  // new agent loop must start clean and not abort its first tool call.
+  const h = makeHarness();
+  const turnCtx = makeCtx({ idle: false });
+  await h.handlers.session_start({}, turnCtx); // starts the inbox poller
+  await h.handlers.agent_start({}, turnCtx);
+  await h.handlers.turn_start({ turnIndex: 1 }, turnCtx);
+  await deliverInterrupt(h);
+  assert(
+    "window armed during live turn (precondition)",
+    turnCtx.abortCount >= 1,
+    `abortCount=${turnCtx.abortCount}`,
+  );
+
+  // A new agent loop begins (e.g. the user's next message) within 30s.
+  const nextCtx = makeCtx({ idle: false });
+  await h.handlers.agent_start({}, nextCtx);
+  await h.handlers.turn_start({ turnIndex: 1 }, nextCtx);
+  const toolResult = await h.handlers.tool_call(
+    { toolCallId: "t2", toolName: "do_thing", input: {} },
+    nextCtx,
+  );
+
+  assert(
+    "new agent loop clears stale window (no abort)",
+    nextCtx.abortCount === 0,
+    `abortCount=${nextCtx.abortCount}`,
+  );
+  assert(
+    "new agent loop's tool_call is NOT blocked",
+    !toolResult || toolResult.block !== true,
+    JSON.stringify(toolResult),
+  );
+}
+
+(async () => {
+  try {
+    await testIdleInterruptDoesNotPoisonNextTurn();
+    await testIdleInterruptFallbackNoIsIdle();
+    await testMidTurnInterruptStillAborts();
+    await testMidTurnInterruptFallbackNoIsIdle();
+    await testAgentStartClearsStaleWindow();
+  } finally {
+    for (const h of harnesses) {
+      if (h.pi.__omnigentInboxPoller) clearInterval(h.pi.__omnigentInboxPoller);
+      try {
+        fs.rmSync(h.inboxDir, { recursive: true, force: true });
+      } catch (_err) {}
+    }
+  }
+})();

--- a/tests/test_pi_native_interrupt_replay_e2e.py
+++ b/tests/test_pi_native_interrupt_replay_e2e.py
@@ -1,0 +1,267 @@
+"""End-to-end tests for pi-native bridge interrupt replay semantics."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnigent import pi_native_bridge
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is required to execute the pi-native extension",
+)
+
+
+def _prepare_bridge(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """
+    Prepare a real pi-native bridge directory and generated extension files.
+
+    This uses the same bridge helpers the runner uses for native Pi sessions, so
+    the test covers the Python enqueue contract, generated config, extension
+    loading, and the JS inbox poller together.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    extension_path, config_path = pi_native_bridge.write_extension_files(
+        bridge_dir,
+        session_id="conv_f18_e2e",
+        server_url="",
+        conversation_url="",
+    )
+    return bridge_dir, extension_path, config_path
+
+
+def _run_extension_scenario(
+    tmp_path: Path,
+    *,
+    extension_path: Path,
+    config_path: Path,
+    scenario: str,
+) -> subprocess.CompletedProcess[str]:
+    """
+    Run a focused Node scenario against a generated pi-native extension file.
+
+    The scenario script mocks only the Pi event bus/context. Interrupt delivery
+    is not mocked: the Python side has already written an inbox payload via
+    ``enqueue_interrupt()``, and the real extension poller consumes it.
+    """
+    script = tmp_path / f"{scenario}.mjs"
+    script.write_text(
+        textwrap.dedent(
+            r"""
+            import { createRequire } from "module";
+            import fs from "fs";
+
+            const require = createRequire(import.meta.url);
+            const extensionPath = process.env.PI_NATIVE_EXTENSION_PATH;
+            const configPath = process.env.OMNIGENT_PI_NATIVE_CONFIG;
+            const scenario = process.env.PI_NATIVE_INTERRUPT_SCENARIO;
+            const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+
+            function assert(cond, message) {
+              if (!cond) throw new Error(message);
+            }
+
+            function makeCtx(idle) {
+              const ctx = {
+                abortCount: 0,
+                abort() {
+                  this.abortCount += 1;
+                },
+              };
+              if (idle !== undefined) ctx.isIdle = () => idle;
+              return ctx;
+            }
+
+            function sleep(ms) {
+              return new Promise((resolve) => setTimeout(resolve, ms));
+            }
+
+            async function waitForInboxEmpty() {
+              const deadline = Date.now() + 3000;
+              while (true) {
+                const pending = fs
+                  .readdirSync(config.inboxDir)
+                  .filter((name) => name.endsWith(".json"));
+                if (pending.length === 0) return;
+                if (Date.now() > deadline) {
+                  throw new Error(`inbox did not drain: ${pending.join(",")}`);
+                }
+                await sleep(20);
+              }
+            }
+
+            const handlers = {};
+            const pi = {
+              on(name, fn) {
+                handlers[name] = fn;
+              },
+              registerCommand() {},
+              sendUserMessage() {},
+            };
+
+            require(extensionPath)(pi);
+
+            try {
+              if (scenario === "idle_interrupt_then_next_turn") {
+                const idleCtx = makeCtx(true);
+                await handlers.session_start({}, idleCtx);
+                await waitForInboxEmpty();
+                assert(
+                  idleCtx.abortCount === 0,
+                  `idle interrupt aborted idle ctx ${idleCtx.abortCount} time(s)`,
+                );
+
+                const nextCtx = makeCtx(false);
+                await handlers.agent_start({}, nextCtx);
+                await handlers.turn_start({ turnIndex: 1 }, nextCtx);
+                const toolResult = await handlers.tool_call(
+                  { toolCallId: "t1", toolName: "do_thing", input: {} },
+                  nextCtx,
+                );
+                assert(
+                  nextCtx.abortCount === 0,
+                  `idle interrupt poisoned next turn with ${nextCtx.abortCount} abort(s)`,
+                );
+                assert(
+                  !toolResult || toolResult.block !== true,
+                  `idle interrupt blocked next turn tool_call: ${JSON.stringify(toolResult)}`,
+                );
+              } else if (scenario === "agent_loop_interrupt_without_is_idle") {
+                const turnCtx = makeCtx(undefined);
+                await handlers.session_start({}, turnCtx);
+                await handlers.agent_start({}, turnCtx);
+                await waitForInboxEmpty();
+                assert(
+                  turnCtx.abortCount >= 1,
+                  `agent-loop interrupt did not abort without isIdle (${turnCtx.abortCount})`,
+                );
+
+                await handlers.turn_start({ turnIndex: 1 }, turnCtx);
+                const toolResult = await handlers.tool_call(
+                  { toolCallId: "t1", toolName: "do_thing", input: {} },
+                  turnCtx,
+                );
+                assert(
+                  toolResult && toolResult.block === true,
+                  `agent-loop interrupt did not replay/block: ${JSON.stringify(toolResult)}`,
+                );
+              } else if (scenario === "mid_turn_interrupt_replays") {
+                const turnCtx = makeCtx(false);
+                await handlers.session_start({}, turnCtx);
+                await handlers.agent_start({}, turnCtx);
+                await handlers.turn_start({ turnIndex: 1 }, turnCtx);
+                await waitForInboxEmpty();
+                assert(
+                  turnCtx.abortCount >= 1,
+                  `mid-turn interrupt did not abort live turn (${turnCtx.abortCount})`,
+                );
+
+                const toolResult = await handlers.tool_call(
+                  { toolCallId: "t1", toolName: "do_thing", input: {} },
+                  turnCtx,
+                );
+                assert(
+                  toolResult && toolResult.block === true,
+                  `mid-turn interrupt did not replay/block: ${JSON.stringify(toolResult)}`,
+                );
+              } else {
+                throw new Error(`unknown scenario: ${scenario}`);
+              }
+            } finally {
+              if (pi.__omnigentInboxPoller) clearInterval(pi.__omnigentInboxPoller);
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "OMNIGENT_PI_NATIVE_CONFIG": str(config_path),
+        "PI_NATIVE_EXTENSION_PATH": str(extension_path),
+        "PI_NATIVE_INTERRUPT_SCENARIO": scenario,
+    }
+    return subprocess.run(
+        ["node", str(script)],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_python_bridge_idle_interrupt_does_not_poison_next_turn(tmp_path: Path) -> None:
+    """
+    F18 end-to-end regression: Python bridge interrupt -> JS poller -> next turn.
+
+    The interrupt is queued through ``pi_native_bridge.enqueue_interrupt()``
+    before the extension starts, matching the runner's on-disk contract. The
+    extension consumes it while the mocked Pi context reports idle. The next
+    legitimate turn begins within the original 30 second replay window and must
+    not be aborted or have its tool call blocked.
+    """
+    bridge_dir, extension_path, config_path = _prepare_bridge(tmp_path)
+    pi_native_bridge.enqueue_interrupt(bridge_dir)
+
+    result = _run_extension_scenario(
+        tmp_path,
+        extension_path=extension_path,
+        config_path=config_path,
+        scenario="idle_interrupt_then_next_turn",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_python_bridge_mid_turn_interrupt_still_replays(tmp_path: Path) -> None:
+    """
+    End-to-end regression guard for legitimate mid-turn interrupts.
+
+    The same Python bridge enqueue path must still abort an already-started Pi
+    turn and keep replaying within the window so an in-flight tool call is
+    blocked with ``Interrupted by user``.
+    """
+    bridge_dir, extension_path, config_path = _prepare_bridge(tmp_path)
+    pi_native_bridge.enqueue_interrupt(bridge_dir)
+
+    result = _run_extension_scenario(
+        tmp_path,
+        extension_path=extension_path,
+        config_path=config_path,
+        scenario="mid_turn_interrupt_replays",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_python_bridge_agent_loop_interrupt_without_is_idle_still_replays(
+    tmp_path: Path,
+) -> None:
+    """
+    End-to-end guard for older SDKs that lack ``ExtensionContext.isIdle()``.
+
+    If an interrupt lands after ``agent_start`` but before ``turn_start``, the
+    extension has no ``activeResponseId`` yet. The no-``isIdle`` fallback must
+    still treat this as a live agent loop so the interrupt aborts/replays instead
+    of being dropped.
+    """
+    bridge_dir, extension_path, config_path = _prepare_bridge(tmp_path)
+    pi_native_bridge.enqueue_interrupt(bridge_dir)
+
+    result = _run_extension_scenario(
+        tmp_path,
+        extension_path=extension_path,
+        config_path=config_path,
+        scenario="agent_loop_interrupt_without_is_idle",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Fixes **F18** from `SDK_INTEGRATION_BUG_AUDIT.md`: a pi-native interrupt received while Pi is idle armed a 30s replay window that aborted the next legitimately-started turn.

`interruptActiveContext()` returned `true` whenever `ctx.abort()` didn't throw — but the Pi SDK's `abort()` is a **silent no-op when the agent is idle** (`Agent.abort()` optional-chains on a missing `activeRun`). So an interrupt that landed while Pi was idle (or in the gap between turns) still armed `pendingInterruptUntil = now + 30_000`. `replayPendingInterrupt()` runs at the head of nearly every event handler, so the next user turn that started within 30s was aborted at `agent_start`/`turn_start` and had its tool calls blocked.

## Changes

- **Only arm the replay window when a turn is genuinely in-flight.** `requestInterrupt()` now checks idleness before arming: it prefers the SDK's `ctx.isIdle()` and falls back to agent-loop state for SDK versions that don't expose `isIdle()`. Idle interrupts are dropped, not armed.
- **Clear any stale window at `agent_start`** so a brand-new agent loop can never inherit a previously-armed window. Interrupts arriving after `agent_start` still belong to that loop and can arm/replay.
- **Node regression test** `omnigent_pi_native_extension.test.js` drives the real extension (inbox poller + event handlers via a temp inbox dir) and covers idle interrupts, mid-turn replay, stale-window clearing, and older-SDK fallback behavior.
- **Python-to-JS bridge e2e test** `tests/test_pi_native_interrupt_replay_e2e.py` uses `pi_native_bridge.write_extension_files()` and `enqueue_interrupt()` to queue real bridge inbox files, then runs the generated extension in Node and verifies both idle-drop and live-turn replay semantics end to end.

## Test plan

- [x] `uv run --extra dev python -m ruff check tests/test_pi_native_interrupt_replay_e2e.py`
- [x] `node omnigent/resources/pi_native/omnigent_pi_native_extension.test.js`
- [x] `uv run --extra dev python -m pytest -q tests/test_pi_native_bridge.py tests/test_pi_native_interrupt_replay_e2e.py` → 9 passed (plus the repo's existing known-failures warning)
- [x] Verified the original Node regression test fails against the pre-fix extension for F18 while mid-turn regression guards remain green.

Manual repro steps are documented in the Node test docstring.