### PR TITLE
fix(antigravity): thread ToolSpec parameter schemas into SDK tool registration (F09)

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import importlib
+import inspect
 import json
 import logging
 import time
@@ -114,6 +115,69 @@ _ToolCallable: TypeAlias = Callable[..., Awaitable[ToolResult]]  # type: ignore[
 ToolExecutor: TypeAlias = Callable[  # type: ignore[explicit-any]
     [str, dict[str, Any]], Awaitable[dict[str, Any]]
 ]
+
+
+# JSON-Schema primitive type -> Python annotation, used to synthesize an
+# introspectable signature on the tool callable (the SDK derives the
+# model-facing function declaration via ``inspect.signature``).
+_JSON_TYPE_TO_PY: dict[str, type] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "object": dict,
+    "array": list,
+}
+
+
+def _attach_schema_signature(fn: _ToolCallable, schema: _StrAnyDict | None) -> None:
+    """Give *fn* an introspectable signature derived from a JSON-Schema.
+
+    The Antigravity SDK builds each tool's model-facing function declaration by
+    introspecting the callable (``inspect.signature``), so a bare
+    ``*args/**kwargs`` body advertises a tool with no argument schema. This
+    attaches a synthesized :class:`inspect.Signature` (and matching
+    ``__annotations__``) reflecting the ToolSpec's ``parameters`` properties so
+    the model sees real argument names, types, and required fields. The runtime
+    body stays ``*args/**kwargs`` — this only changes what introspection reports.
+
+    Properties whose names are not valid Python identifiers are skipped (they
+    cannot become :class:`inspect.Parameter` names); the callable still accepts
+    them at call time via ``**kwargs``.
+
+    :param fn: The tool callable to annotate (mutated in place).
+    :param schema: The ToolSpec ``parameters`` JSON-Schema, or ``None``.
+    """
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict) or not props:
+        return
+    required_raw = schema.get("required") if isinstance(schema, dict) else None
+    required: set[str] = (
+        {r for r in required_raw if isinstance(r, str)}
+        if isinstance(required_raw, list)
+        else set()
+    )
+    params: list[inspect.Parameter] = []
+    annotations: _StrAnyDict = {}
+    for pname, pspec in props.items():
+        if not isinstance(pname, str) or not pname.isidentifier():
+            continue
+        ptype = pspec.get("type") if isinstance(pspec, dict) else None
+        annotation = _JSON_TYPE_TO_PY.get(ptype, str) if isinstance(ptype, str) else str
+        annotations[pname] = annotation
+        default = inspect.Parameter.empty if pname in required else None
+        params.append(
+            inspect.Parameter(
+                pname,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=annotation,
+            )
+        )
+    if not params:
+        return
+    fn.__signature__ = inspect.Signature(params)  # type: ignore[attr-defined]
+    fn.__annotations__ = annotations
 
 
 def _ensure_antigravity_sdk() -> ModuleType:
@@ -928,19 +992,26 @@ class AntigravityExecutor(Executor):
                 continue
             description = tool.get("description")
             description = description if isinstance(description, str) else ""
-            sdk_tools.append(self._make_tool_callable(name, description))
+            params = tool.get("parameters")
+            schema = params if isinstance(params, dict) else None
+            sdk_tools.append(self._make_tool_callable(name, description, schema))
         return sdk_tools
 
-    def _make_tool_callable(self, tool_name: str, description: str) -> _ToolCallable:
+    def _make_tool_callable(
+        self, tool_name: str, description: str, schema: _StrAnyDict | None = None
+    ) -> _ToolCallable:
         """Build a named async callable the SDK can register as a tool.
 
         Accepts the SDK's arg shape (kwargs, a single dict, or a JSON string)
         and forwards to :attr:`_tool_executor`. Its ``__name__`` / ``__doc__``
         are set so the SDK's function-declaration introspection picks up the
-        name and description.
+        name and description, and (when *schema* is given) a synthesized
+        ``__signature__`` so the SDK advertises the tool's real argument schema
+        rather than an empty ``*args/**kwargs`` declaration.
 
         :param tool_name: The Omnigent tool name, e.g. ``"sys_shell"``.
         :param description: Human-readable tool description for the model.
+        :param schema: The ToolSpec ``parameters`` JSON-Schema, or ``None``.
         :returns: An async callable bound to *tool_name*.
         """
 
@@ -964,6 +1035,10 @@ class AntigravityExecutor(Executor):
         _invoke.__name__ = tool_name
         _invoke.__qualname__ = tool_name
         _invoke.__doc__ = description or tool_name
+        # Thread the ToolSpec's parameter schema into an introspectable
+        # signature so the model sees real argument names/types, not an
+        # empty *args/**kwargs declaration.
+        _attach_schema_signature(_invoke, schema)
         return _invoke
 
     def _build_local_agent_config(

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -44,7 +44,6 @@ import contextlib
 import importlib
 import inspect
 import json
-import keyword
 import logging
 import time
 import uuid
@@ -118,67 +117,25 @@ ToolExecutor: TypeAlias = Callable[  # type: ignore[explicit-any]
 ]
 
 
-# JSON-Schema primitive type -> Python annotation, used to synthesize an
-# introspectable signature on the tool callable (the SDK derives the
-# model-facing function declaration via ``inspect.signature``).
-_JSON_TYPE_TO_PY: dict[str, type] = {
-    "string": str,
-    "integer": int,
-    "number": float,
-    "boolean": bool,
-    "object": dict,
-    "array": list,
-}
+def _tool_with_schema_cls() -> type:
+    """Return the SDK's ``ToolWithSchema`` wrapper class.
 
+    Resolved lazily (the optional ``google-antigravity`` package may be absent at
+    import time). ``ToolWithSchema(fn, input_schema=<dict>)`` carries the tool's
+    JSON Schema VERBATIM into the SDK: ``callable_to_tool_proto`` short-circuits
+    on it and emits ``parameters_json_schema=json.dumps(fn.input_schema)``,
+    preserving the exact ``required`` set, enums, nested objects, formats, and
+    descriptions — none of which survive the SDK's ``inspect.signature`` /
+    pydantic fallback for a bare callable.
 
-def _attach_schema_signature(fn: _ToolCallable, schema: _StrAnyDict | None) -> None:
-    """Give *fn* an introspectable signature derived from a JSON-Schema.
-
-    The Antigravity SDK builds each tool's model-facing function declaration by
-    introspecting the callable (``inspect.signature``), so a bare
-    ``*args/**kwargs`` body advertises a tool with no argument schema. This
-    attaches a synthesized :class:`inspect.Signature` (and matching
-    ``__annotations__``) reflecting the ToolSpec's ``parameters`` properties so
-    the model sees real argument names, types, and required fields. The runtime
-    body stays ``*args/**kwargs`` — this only changes what introspection reports.
-
-    Properties whose names are not valid Python parameter names are skipped
-    (they cannot become :class:`inspect.Parameter` names); the callable still
-    accepts them at call time via ``**kwargs``.
-
-    :param fn: The tool callable to annotate (mutated in place).
-    :param schema: The ToolSpec ``parameters`` JSON-Schema, or ``None``.
+    :returns: The ``ToolWithSchema`` class from ``google.antigravity``.
+    :raises ImportError: If ``google-antigravity`` is not installed (surfaced on
+        the first turn, the same place the rest of the SDK is imported).
     """
-    props = schema.get("properties") if isinstance(schema, dict) else None
-    if not isinstance(props, dict) or not props:
-        return
-    required_raw = schema.get("required") if isinstance(schema, dict) else None
-    required: set[str] = (
-        {r for r in required_raw if isinstance(r, str)}
-        if isinstance(required_raw, list)
-        else set()
-    )
-    params: list[inspect.Parameter] = []
-    annotations: _StrAnyDict = {}
-    for pname, pspec in props.items():
-        if not isinstance(pname, str) or not pname.isidentifier() or keyword.iskeyword(pname):
-            continue
-        ptype = pspec.get("type") if isinstance(pspec, dict) else None
-        annotation = _JSON_TYPE_TO_PY.get(ptype, str) if isinstance(ptype, str) else str
-        annotations[pname] = annotation
-        default = inspect.Parameter.empty if pname in required else None
-        params.append(
-            inspect.Parameter(
-                pname,
-                inspect.Parameter.KEYWORD_ONLY,
-                default=default,
-                annotation=annotation,
-            )
-        )
-    if not params:
-        return
-    fn.__signature__ = inspect.Signature(params)  # type: ignore[attr-defined]
-    fn.__annotations__ = annotations
+    _ensure_antigravity_sdk()
+    from google.antigravity.tools.tool_runner import ToolWithSchema
+
+    return ToolWithSchema
 
 
 def _ensure_antigravity_sdk() -> ModuleType:
@@ -986,20 +943,28 @@ class AntigravityExecutor(Executor):
         return _OmnigentToolCompleteHook()
 
     def _build_sdk_tools(self, tools: list[ToolSpec]) -> list[SDKTool]:
-        """Build SDK tools (plain callables) from Omnigent tool specs.
+        """Build SDK tools from Omnigent tool specs as ``ToolWithSchema`` wrappers.
 
-        The SDK introspects each callable's ``__name__`` / ``__doc__`` for its
-        function declaration. Each routes through :attr:`_tool_executor`, so
-        the agent reaches Omnigent's tool registry under policy. Returns ``[]``
-        when there are no tools or no executor bridge yet (the agent then runs
-        with its native + MCP tools only).
+        Each tool's ToolSpec ``parameters`` JSON Schema is handed to the SDK
+        VERBATIM via ``ToolWithSchema(fn, input_schema=...)``, so the model sees
+        the exact schema Omnigent advertises — correct ``required`` set, enums,
+        nested objects, array item types, formats, and descriptions all preserved
+        (the SDK's ``callable_to_tool_proto`` emits ``json.dumps(fn.input_schema)``
+        directly for a ``ToolWithSchema``). This mirrors
+        ``cursor_executor._make_custom_tools(input_schema=...)``. Each wrapped
+        callable still routes invocations through :attr:`_tool_executor`, so the
+        agent reaches Omnigent's tool registry under policy.
+
+        Returns ``[]`` when there are no tools or no executor bridge yet (the
+        agent then runs with its native + MCP tools only).
 
         :param tools: Omnigent tool specs (``name`` / ``description`` /
             ``parameters``).
-        :returns: A list of named async callables, or ``[]``.
+        :returns: A list of ``ToolWithSchema`` instances, or ``[]``.
         """
         if not tools or self._tool_executor is None:
             return []
+        tool_with_schema_cls = _tool_with_schema_cls()
         sdk_tools: list[SDKTool] = []
         for tool in tools:
             name = tool.get("name")
@@ -1008,25 +973,28 @@ class AntigravityExecutor(Executor):
             description = tool.get("description")
             description = description if isinstance(description, str) else ""
             params = tool.get("parameters")
-            schema = params if isinstance(params, dict) else None
-            sdk_tools.append(self._make_tool_callable(name, description, schema))
+            # Hand the ToolSpec's parameter schema to the SDK verbatim. Fall back
+            # to an empty-object schema (mirrors cursor) when a spec omits it.
+            schema: _StrAnyDict = (
+                params if isinstance(params, dict) else {"type": "object", "properties": {}}
+            )
+            fn = self._make_tool_callable(name, description)
+            sdk_tools.append(tool_with_schema_cls(fn, input_schema=schema))
         return sdk_tools
 
-    def _make_tool_callable(
-        self, tool_name: str, description: str, schema: _StrAnyDict | None = None
-    ) -> _ToolCallable:
-        """Build a named async callable the SDK can register as a tool.
+    def _make_tool_callable(self, tool_name: str, description: str) -> _ToolCallable:
+        """Build a named async callable that bridges an SDK tool call to Omnigent.
 
         Accepts the SDK's arg shape (kwargs, a single dict, or a JSON string)
         and forwards to :attr:`_tool_executor`. Its ``__name__`` / ``__doc__``
-        are set so the SDK's function-declaration introspection picks up the
-        name and description, and (when *schema* is given) a synthesized
-        ``__signature__`` so the SDK advertises the tool's real argument schema
-        rather than an empty ``*args/**kwargs`` declaration.
+        are set so the wrapping ``ToolWithSchema`` carries the right name and
+        description to the SDK's function declaration; the argument schema is
+        supplied separately and losslessly via ``ToolWithSchema.input_schema``
+        (see :meth:`_build_sdk_tools`), not derived from this callable's
+        signature.
 
         :param tool_name: The Omnigent tool name, e.g. ``"sys_shell"``.
         :param description: Human-readable tool description for the model.
-        :param schema: The ToolSpec ``parameters`` JSON-Schema, or ``None``.
         :returns: An async callable bound to *tool_name*.
         """
 
@@ -1046,14 +1014,11 @@ class AntigravityExecutor(Executor):
                     tool_args = {"input": args[0]}
             return await self._tool_executor(tool_name, tool_args)
 
-        # The SDK builds the function declaration from these.
+        # ToolWithSchema copies these onto itself; the SDK reads name/description
+        # from the wrapper for the function declaration.
         _invoke.__name__ = tool_name
         _invoke.__qualname__ = tool_name
         _invoke.__doc__ = description or tool_name
-        # Thread the ToolSpec's parameter schema into an introspectable
-        # signature so the model sees real argument names/types, not an
-        # empty *args/**kwargs declaration.
-        _attach_schema_signature(_invoke, schema)
         return _invoke
 
     def _build_local_agent_config(
@@ -1102,8 +1067,6 @@ class AntigravityExecutor(Executor):
         :returns: The set of accepted field names, or ``None`` when the
             signature can't be introspected.
         """
-        import inspect
-
         try:
             params = inspect.signature(config_cls).parameters
         except (TypeError, ValueError):

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -44,6 +44,7 @@ import contextlib
 import importlib
 import inspect
 import json
+import keyword
 import logging
 import time
 import uuid
@@ -141,9 +142,9 @@ def _attach_schema_signature(fn: _ToolCallable, schema: _StrAnyDict | None) -> N
     the model sees real argument names, types, and required fields. The runtime
     body stays ``*args/**kwargs`` — this only changes what introspection reports.
 
-    Properties whose names are not valid Python identifiers are skipped (they
-    cannot become :class:`inspect.Parameter` names); the callable still accepts
-    them at call time via ``**kwargs``.
+    Properties whose names are not valid Python parameter names are skipped
+    (they cannot become :class:`inspect.Parameter` names); the callable still
+    accepts them at call time via ``**kwargs``.
 
     :param fn: The tool callable to annotate (mutated in place).
     :param schema: The ToolSpec ``parameters`` JSON-Schema, or ``None``.
@@ -160,7 +161,7 @@ def _attach_schema_signature(fn: _ToolCallable, schema: _StrAnyDict | None) -> N
     params: list[inspect.Parameter] = []
     annotations: _StrAnyDict = {}
     for pname, pspec in props.items():
-        if not isinstance(pname, str) or not pname.isidentifier():
+        if not isinstance(pname, str) or not pname.isidentifier() or keyword.iskeyword(pname):
             continue
         ptype = pspec.get("type") if isinstance(pspec, dict) else None
         annotation = _JSON_TYPE_TO_PY.get(ptype, str) if isinstance(ptype, str) else str
@@ -459,13 +460,27 @@ class AntigravityExecutor(Executor):
 
     @staticmethod
     def _tool_signature(tools: list[ToolSpec]) -> str:
-        """Stable cache key for a tool set (names only — enough to detect change).
+        """Stable cache key for the SDK tool-registration surface.
 
         :param tools: Omnigent tool specs for the turn.
-        :returns: Deterministic JSON string of the sorted tool names.
+        :returns: Deterministic JSON string of the registered tool declarations.
         """
-        names = sorted(str(tool.get("name", "")) for tool in tools)
-        return json.dumps(names, separators=(",", ":"))
+        declarations: list[_StrAnyDict] = []
+        for tool in tools:
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            description = tool.get("description")
+            params = tool.get("parameters")
+            declarations.append(
+                {
+                    "name": name,
+                    "description": description if isinstance(description, str) else "",
+                    "parameters": params if isinstance(params, dict) else {},
+                }
+            )
+        declarations.sort(key=lambda item: str(item["name"]))
+        return json.dumps(declarations, sort_keys=True, separators=(",", ":"), default=str)
 
     async def close_session(self, session_key: str) -> None:
         """Close and drop the SDK agent for *session_key*, if any.

--- a/tests/e2e/omnigent/test_per_harness_antigravity.py
+++ b/tests/e2e/omnigent/test_per_harness_antigravity.py
@@ -64,6 +64,7 @@ normalization (#297) — those land with their own PRs and are tested there.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import uuid
 from pathlib import Path
@@ -101,6 +102,8 @@ _ERROR_MARKERS: tuple[str, ...] = (
 # ~10-60s; 200s keeps headroom on a contended CI host without letting a hung run
 # pin the suite forever.
 _RUN_TIMEOUT_SEC = 200
+_TOOL_SCHEMA_PRODUCT = "443242686"
+_TOOL_SCHEMA_RESULT_MARKER = f"schema-tool-result={_TOOL_SCHEMA_PRODUCT}"
 
 # Minimal antigravity-native agent spec. Single-file legacy form (``name`` /
 # ``prompt`` / ``executor``) — the form ``omnigent run <file>`` accepts without a
@@ -190,6 +193,33 @@ def antigravity_spec(tmp_path: Path) -> Path:
     """
     spec_path = tmp_path / "agent.yaml"
     spec_path.write_text(_AGENT_YAML, encoding="utf-8")
+    return spec_path
+
+
+@pytest.fixture
+def antigravity_tool_schema_spec(tmp_path: Path) -> Path:
+    """Materialize an antigravity spec with a structured-argument function tool."""
+    spec_path = tmp_path / "agent_with_calculate_tool.yaml"
+    spec_path.write_text(
+        """\
+name: antigravity_tool_schema_e2e
+prompt: |
+  You have a calculate tool. When the user asks for arithmetic, use the tool.
+  The calculate tool requires exactly one argument named expression.
+
+executor:
+  harness: antigravity
+
+tools:
+  calculate:
+    type: function
+    description: |
+      Evaluate a basic arithmetic expression. Pass exactly one argument named
+      expression containing the expression string.
+    callable: tests.resources.examples._shared.tool_functions.calculate
+""",
+        encoding="utf-8",
+    )
     return spec_path
 
 
@@ -383,6 +413,60 @@ def test_per_harness_antigravity_smoke(
         model=None,
     )
     _assert_clean_assistant_reply(fake_home / ".omnigent" / "chat.db", result, label="smoke")
+
+
+def test_per_harness_antigravity_tool_parameter_schema_bridge(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+    antigravity_tool_schema_spec: Path,
+    tmp_path: Path,
+) -> None:
+    """A real antigravity turn can call a ToolSpec-backed structured-arg tool.
+
+    This is the live e2e counterpart to
+    ``test_sys_tool_schema_threaded_into_sdk_function_declaration``: it drives
+    ``omnigent run --harness antigravity`` through the production YAML ->
+    ToolSpec -> Antigravity SDK registration path, then asks the model to call a
+    ``calculate(expression: str)`` tool. If the registered SDK callable loses
+    the ToolSpec parameter schema, the model commonly calls the tool with the
+    wrong argument shape or no argument at all; the expected tool lifecycle line
+    and final result marker then do not appear.
+    """
+    skip_reason = _antigravity_skip_reason(omnigent_python)
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    env = _antigravity_env(dict(os.environ), fake_home)
+
+    result = _run_one_shot(
+        omnigent_python=omnigent_python,
+        omnigent_repo_root=omnigent_repo_root,
+        spec_path=antigravity_tool_schema_spec,
+        env=env,
+        prompt=(
+            "Use the calculate tool to compute 48273 multiplied by 9182. "
+            f"Do not solve it mentally. After the tool returns, reply exactly "
+            f"'{_TOOL_SCHEMA_RESULT_MARKER}' and nothing else."
+        ),
+        model=_PINNED_MODEL,
+    )
+    joined = _assert_clean_assistant_reply(
+        fake_home / ".omnigent" / "chat.db", result, label="tool-schema"
+    )
+
+    assert "calculate" in result.stdout.lower(), (
+        "Antigravity did not render a calculate tool lifecycle line; the model "
+        "likely did not call the structured-argument tool.\n\n"
+        f"stdout:\n{result.stdout[-2500:]!r}\n\nstderr:\n{result.stderr[-2500:]!r}"
+    )
+    assert _TOOL_SCHEMA_RESULT_MARKER in joined.replace(",", "").lower(), (
+        "Antigravity did not persist the expected calculate-tool result marker. "
+        "If the ToolSpec parameter schema was not registered with the SDK, the "
+        "model may have called calculate with a malformed argument object.\n\n"
+        f"assistant transcript:\n{joined!r}\n\nstdout:\n{result.stdout[-2500:]!r}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -297,6 +297,38 @@ async def _drain(
     return events
 
 
+_ANNOTATION_TO_JSON_TYPE: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    dict: "object",
+    list: "array",
+}
+
+
+def _sdk_parameter_schema_from_callable(fn: Any) -> dict[str, Any]:
+    """Mirror the SDK's inspect.signature-based function-declaration step."""
+    sig = inspect.signature(fn)
+    properties: dict[str, dict[str, str]] = {}
+    required: list[str] = []
+    for pname, param in sig.parameters.items():
+        if param.kind not in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            continue
+        json_type = _ANNOTATION_TO_JSON_TYPE.get(param.annotation, "string")
+        properties[pname] = {"type": json_type}
+        if param.default is inspect.Parameter.empty:
+            required.append(pname)
+
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
 def _text_step(delta: str) -> _YieldStep:
     return _YieldStep(
         _FakeStep(
@@ -788,8 +820,79 @@ async def test_sys_tool_schema_threaded_into_sdk_function_declaration(
     # JSON-Schema types map onto Python annotations.
     assert sig.parameters["cmd"].annotation is str
     assert sig.parameters["timeout"].annotation is int
+    assert _sdk_parameter_schema_from_callable(sdk_tool) == {
+        "type": "object",
+        "properties": {
+            "cmd": {"type": "string"},
+            "timeout": {"type": "integer"},
+        },
+        "required": ["cmd"],
+    }
     # Schema is metadata only — the callable still routes through the bridge.
     assert await sdk_tool(cmd="ls") == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_tool_schema_mapping_handles_primitives_and_invalid_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Schema signature synthesis maps JSON primitives and skips invalid params."""
+    _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
+    executor = AntigravityExecutor()
+
+    async def _fake_tool_executor(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    executor._tool_executor = _fake_tool_executor
+    sdk_tools = executor._build_sdk_tools(
+        [
+            {
+                "name": "sys_mixed",
+                "description": "mixed args",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string"},
+                        "count": {"type": "integer"},
+                        "ratio": {"type": "number"},
+                        "enabled": {"type": "boolean"},
+                        "payload": {"type": "object"},
+                        "items": {"type": "array"},
+                        "unknown": {"type": "null"},
+                        "bad-name": {"type": "string"},
+                        "class": {"type": "string"},
+                        "loose": "not-a-property-schema",
+                    },
+                    "required": ["text", "count", "bad-name", "class", 7],
+                },
+            },
+            {
+                "name": "sys_empty",
+                "description": "invalid schema",
+                "parameters": {"type": "object", "properties": []},
+            },
+        ]
+    )
+
+    mixed_schema = _sdk_parameter_schema_from_callable(sdk_tools[0])
+    assert mixed_schema == {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string"},
+            "count": {"type": "integer"},
+            "ratio": {"type": "number"},
+            "enabled": {"type": "boolean"},
+            "payload": {"type": "object"},
+            "items": {"type": "array"},
+            "unknown": {"type": "string"},
+            "loose": {"type": "string"},
+        },
+        "required": ["text", "count"],
+    }
+    assert _sdk_parameter_schema_from_callable(sdk_tools[1]) == {
+        "type": "object",
+        "properties": {},
+    }
 
 
 @pytest.mark.asyncio
@@ -822,6 +925,57 @@ async def test_agent_reused_across_turns_same_session(monkeypatch: pytest.Monkey
     # the cached agent (and its SDK conversation state) was reused.
     assert len(captured["agents"]) == 1
     assert captured["agents"][0].conversation.sends == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_tool_schema_change_rebuilds_agent_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schema-only ToolSpec change must reopen the SDK agent for re-registration."""
+    captured = _install_fake_sdk(
+        monkeypatch, scripts=[[_text_step("one-reply")], [_text_step("two-reply")]]
+    )
+    executor = AntigravityExecutor()
+
+    async def _fake_tool_executor(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    executor._tool_executor = _fake_tool_executor
+    first_tools = [
+        {
+            "name": "sys_shell",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"cmd": {"type": "string"}},
+                "required": ["cmd"],
+            },
+        }
+    ]
+    second_tools = [
+        {
+            "name": "sys_shell",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        }
+    ]
+
+    await _drain(
+        executor, [{"role": "user", "content": "one", "session_id": "s1"}], first_tools
+    )
+    await _drain(
+        executor, [{"role": "user", "content": "two", "session_id": "s1"}], second_tools
+    )
+
+    assert len(captured["agents"]) == 2
+    first_tool = captured["configs"][0].tools[0]
+    second_tool = captured["configs"][1].tools[0]
+    assert list(inspect.signature(first_tool).parameters) == ["cmd"]
+    assert list(inspect.signature(second_tool).parameters) == ["command"]
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -716,6 +716,7 @@ async def test_sys_tools_exposed_as_callables_routing_through_executor(
     This is what lets an Antigravity agent drive Omnigent's sys / sub-agent
     tools under policy (needed to run Polly / Debby).
     """
+    pytest.importorskip("google.antigravity")  # opt-in SDK extra; absent in default CI lanes
     captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
     executor = AntigravityExecutor()
 
@@ -777,6 +778,7 @@ async def test_sys_tool_schema_reaches_sdk_proto_losslessly(
     * **Enums and nested objects survive.** Both were silently dropped (flattened
       to a bare ``{"type": ...}``) by the synthesis path.
     """
+    pytest.importorskip("google.antigravity")  # opt-in SDK extra; absent in default CI lanes
     captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
     executor = AntigravityExecutor()
 
@@ -839,6 +841,7 @@ async def test_tool_schema_passed_verbatim_and_empty_fallback(
     untouched. When a spec omits (or mis-types) ``parameters``, the executor
     substitutes an empty-object schema — mirroring ``cursor_executor``.
     """
+    pytest.importorskip("google.antigravity")  # opt-in SDK extra; absent in default CI lanes
     _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
     executor = AntigravityExecutor()
 
@@ -915,6 +918,7 @@ async def test_tool_schema_change_rebuilds_agent_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A schema-only ToolSpec change must reopen the SDK agent for re-registration."""
+    pytest.importorskip("google.antigravity")  # opt-in SDK extra; absent in default CI lanes
     captured = _install_fake_sdk(
         monkeypatch, scripts=[[_text_step("one-reply")], [_text_step("two-reply")]]
     )

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import collections
 import enum
+import inspect
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -736,6 +737,59 @@ async def test_sys_tools_exposed_as_callables_routing_through_executor(
         {"name": "sys_shell", "args": {"cmd": "ls"}},
         {"name": "sys_shell", "args": {"cmd": "pwd"}},
     ]
+
+
+@pytest.mark.asyncio
+async def test_sys_tool_schema_threaded_into_sdk_function_declaration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ToolSpec ``parameters`` schema reaches the SDK via the callable's signature.
+
+    The SDK builds each tool's model-facing function declaration by
+    introspecting the callable (``inspect.signature``); a bare ``*args/**kwargs``
+    body would advertise no arguments. Assert a ``sys_*`` tool's registered
+    callable exposes its real JSON-Schema arguments (names, types, required).
+    """
+    captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
+    executor = AntigravityExecutor()
+
+    async def _fake_tool_executor(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True}
+
+    executor._tool_executor = _fake_tool_executor
+
+    tool_specs = [
+        {
+            "name": "sys_shell",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cmd": {"type": "string"},
+                    "timeout": {"type": "integer"},
+                },
+                "required": ["cmd"],
+            },
+        }
+    ]
+
+    await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}], tool_specs)
+
+    sdk_tools = captured["configs"][0].tools
+    assert sdk_tools is not None and len(sdk_tools) == 1
+    sdk_tool = sdk_tools[0]
+
+    # The SDK derives the function declaration from inspect.signature(...).
+    sig = inspect.signature(sdk_tool)
+    assert list(sig.parameters) == ["cmd", "timeout"]
+    # Required field has no default; optional field defaults (so it is not required).
+    assert sig.parameters["cmd"].default is inspect.Parameter.empty
+    assert sig.parameters["timeout"].default is None
+    # JSON-Schema types map onto Python annotations.
+    assert sig.parameters["cmd"].annotation is str
+    assert sig.parameters["timeout"].annotation is int
+    # Schema is metadata only — the callable still routes through the bridge.
+    assert await sdk_tool(cmd="ls") == {"ok": True}
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import collections
 import enum
-import inspect
+import json
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -297,36 +297,21 @@ async def _drain(
     return events
 
 
-_ANNOTATION_TO_JSON_TYPE: dict[type, str] = {
-    str: "string",
-    int: "integer",
-    float: "number",
-    bool: "boolean",
-    dict: "object",
-    list: "array",
-}
+def _sdk_advertised_schema(sdk_tool: Any) -> dict[str, Any]:
+    """Return the JSON Schema the REAL SDK advertises for *sdk_tool* to the model.
 
+    Pins the actual SDK contract rather than a hand-rolled mirror: feeds the
+    executor's registered tool (a ``ToolWithSchema``) through the same
+    ``callable_to_tool_proto`` the local connection uses to build the model-facing
+    tool proto, and parses the ``parameters_json_schema`` it emits. For a
+    ``ToolWithSchema`` this is ``json.dumps(fn.input_schema)`` verbatim, so the
+    optional/required split, enums, nested objects, and array item types survive
+    intact — exactly what the model sees.
+    """
+    from google.antigravity.connections.local.local_connection import callable_to_tool_proto
 
-def _sdk_parameter_schema_from_callable(fn: Any) -> dict[str, Any]:
-    """Mirror the SDK's inspect.signature-based function-declaration step."""
-    sig = inspect.signature(fn)
-    properties: dict[str, dict[str, str]] = {}
-    required: list[str] = []
-    for pname, param in sig.parameters.items():
-        if param.kind not in (
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        ):
-            continue
-        json_type = _ANNOTATION_TO_JSON_TYPE.get(param.annotation, "string")
-        properties[pname] = {"type": json_type}
-        if param.default is inspect.Parameter.empty:
-            required.append(pname)
-
-    schema: dict[str, Any] = {"type": "object", "properties": properties}
-    if required:
-        schema["required"] = required
-    return schema
+    proto = callable_to_tool_proto(sdk_tool)
+    return json.loads(proto.parameters_json_schema)
 
 
 def _text_step(delta: str) -> _YieldStep:
@@ -756,15 +741,18 @@ async def test_sys_tools_exposed_as_callables_routing_through_executor(
     sdk_tools = captured["configs"][0].tools
     assert sdk_tools is not None and len(sdk_tools) == 1
     sdk_tool = sdk_tools[0]
-    # LocalAgentConfig.tools is list[Callable]; the SDK reads __name__/__doc__.
+    # Each tool is a ToolWithSchema wrapper; the SDK reads __name__/__doc__ off it
+    # and dispatches via __call__(**kwargs) -> fn(**kwargs).
     assert callable(sdk_tool)
     assert sdk_tool.__name__ == "sys_shell"
     assert sdk_tool.__doc__ == "Run a shell command"
 
-    # Invoking the callable (kwargs form) routes back through the bridge.
+    # Invoking the wrapper (kwargs form, the SDK's call convention) routes back
+    # through the bridge. ToolWithSchema.__call__ returns the inner coroutine.
     assert await sdk_tool(cmd="ls") == {"ok": True}
-    # Single-dict argument form also works (SDK arg-shape tolerance).
-    assert await sdk_tool({"cmd": "pwd"}) == {"ok": True}
+    # The underlying bridge callable also tolerates a single positional dict /
+    # JSON string (defensive against arg-shape drift), reached via .fn.
+    assert await sdk_tool.fn({"cmd": "pwd"}) == {"ok": True}
     assert calls == [
         {"name": "sys_shell", "args": {"cmd": "ls"}},
         {"name": "sys_shell", "args": {"cmd": "pwd"}},
@@ -772,15 +760,22 @@ async def test_sys_tools_exposed_as_callables_routing_through_executor(
 
 
 @pytest.mark.asyncio
-async def test_sys_tool_schema_threaded_into_sdk_function_declaration(
+async def test_sys_tool_schema_reaches_sdk_proto_losslessly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The ToolSpec ``parameters`` schema reaches the SDK via the callable's signature.
+    """The ToolSpec ``parameters`` schema reaches the SDK proto VERBATIM.
 
-    The SDK builds each tool's model-facing function declaration by
-    introspecting the callable (``inspect.signature``); a bare ``*args/**kwargs``
-    body would advertise no arguments. Assert a ``sys_*`` tool's registered
-    callable exposes its real JSON-Schema arguments (names, types, required).
+    Registering each tool as a ``ToolWithSchema`` makes
+    ``callable_to_tool_proto`` emit ``json.dumps(input_schema)`` directly, so the
+    schema the model sees is byte-for-byte what Omnigent advertised. This pins
+    the real SDK contract (not a hand-rolled signature mirror) and proves the
+    two bugs the prior signature-synthesis path had are fixed:
+
+    * **Optional params stay optional.** ``timeout`` has no default and is NOT in
+      ``required``; the synthesis path wrongly advertised every optional primitive
+      as required.
+    * **Enums and nested objects survive.** Both were silently dropped (flattened
+      to a bare ``{"type": ...}``) by the synthesis path.
     """
     captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
     executor = AntigravityExecutor()
@@ -790,19 +785,23 @@ async def test_sys_tool_schema_threaded_into_sdk_function_declaration(
 
     executor._tool_executor = _fake_tool_executor
 
-    tool_specs = [
-        {
-            "name": "sys_shell",
-            "description": "Run a shell command",
-            "parameters": {
+    schema = {
+        "type": "object",
+        "properties": {
+            "cmd": {"type": "string", "description": "the command"},
+            "timeout": {"type": "integer"},
+            "mode": {"type": "string", "enum": ["fast", "safe"]},
+            "env": {
                 "type": "object",
-                "properties": {
-                    "cmd": {"type": "string"},
-                    "timeout": {"type": "integer"},
-                },
-                "required": ["cmd"],
+                "properties": {"KEY": {"type": "string"}},
+                "required": ["KEY"],
             },
-        }
+            "paths": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["cmd"],
+    }
+    tool_specs = [
+        {"name": "sys_shell", "description": "Run a shell command", "parameters": schema}
     ]
 
     await _drain(executor, [{"role": "user", "content": "go", "session_id": "s1"}], tool_specs)
@@ -811,32 +810,35 @@ async def test_sys_tool_schema_threaded_into_sdk_function_declaration(
     assert sdk_tools is not None and len(sdk_tools) == 1
     sdk_tool = sdk_tools[0]
 
-    # The SDK derives the function declaration from inspect.signature(...).
-    sig = inspect.signature(sdk_tool)
-    assert list(sig.parameters) == ["cmd", "timeout"]
-    # Required field has no default; optional field defaults (so it is not required).
-    assert sig.parameters["cmd"].default is inspect.Parameter.empty
-    assert sig.parameters["timeout"].default is None
-    # JSON-Schema types map onto Python annotations.
-    assert sig.parameters["cmd"].annotation is str
-    assert sig.parameters["timeout"].annotation is int
-    assert _sdk_parameter_schema_from_callable(sdk_tool) == {
+    # The real SDK proto carries the schema verbatim — the whole point.
+    advertised = _sdk_advertised_schema(sdk_tool)
+    assert advertised == schema
+    # Spell out the load-bearing properties the synthesis path got wrong.
+    assert advertised["required"] == ["cmd"]  # timeout/mode/env/paths NOT required
+    assert advertised["properties"]["mode"]["enum"] == ["fast", "safe"]  # enum kept
+    assert advertised["properties"]["env"] == {  # nested object kept whole
         "type": "object",
-        "properties": {
-            "cmd": {"type": "string"},
-            "timeout": {"type": "integer"},
-        },
-        "required": ["cmd"],
+        "properties": {"KEY": {"type": "string"}},
+        "required": ["KEY"],
     }
-    # Schema is metadata only — the callable still routes through the bridge.
+    assert advertised["properties"]["paths"]["items"] == {"type": "string"}  # array items kept
+
+    # Schema is advertising only — the wrapper still routes calls through the bridge.
     assert await sdk_tool(cmd="ls") == {"ok": True}
 
 
 @pytest.mark.asyncio
-async def test_tool_schema_mapping_handles_primitives_and_invalid_entries(
+async def test_tool_schema_passed_verbatim_and_empty_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Schema signature synthesis maps JSON primitives and skips invalid params."""
+    """ToolSpec ``parameters`` are wrapped verbatim; a missing schema falls back.
+
+    The executor no longer rewrites the schema (the old synthesis path mangled
+    types/required/enums). It hands ``parameters`` straight to
+    ``ToolWithSchema.input_schema``, so an arbitrarily rich schema survives
+    untouched. When a spec omits (or mis-types) ``parameters``, the executor
+    substitutes an empty-object schema — mirroring ``cursor_executor``.
+    """
     _install_fake_sdk(monkeypatch, scripts=[[_text_step("done")]])
     executor = AntigravityExecutor()
 
@@ -844,55 +846,36 @@ async def test_tool_schema_mapping_handles_primitives_and_invalid_entries(
         return {"ok": True}
 
     executor._tool_executor = _fake_tool_executor
-    sdk_tools = executor._build_sdk_tools(
-        [
-            {
-                "name": "sys_mixed",
-                "description": "mixed args",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "text": {"type": "string"},
-                        "count": {"type": "integer"},
-                        "ratio": {"type": "number"},
-                        "enabled": {"type": "boolean"},
-                        "payload": {"type": "object"},
-                        "items": {"type": "array"},
-                        "unknown": {"type": "null"},
-                        "bad-name": {"type": "string"},
-                        "class": {"type": "string"},
-                        "loose": "not-a-property-schema",
-                    },
-                    "required": ["text", "count", "bad-name", "class", 7],
-                },
-            },
-            {
-                "name": "sys_empty",
-                "description": "invalid schema",
-                "parameters": {"type": "object", "properties": []},
-            },
-        ]
-    )
-
-    mixed_schema = _sdk_parameter_schema_from_callable(sdk_tools[0])
-    assert mixed_schema == {
+    rich_schema = {
         "type": "object",
         "properties": {
             "text": {"type": "string"},
-            "count": {"type": "integer"},
+            "count": {"type": "integer", "minimum": 0},
             "ratio": {"type": "number"},
             "enabled": {"type": "boolean"},
-            "payload": {"type": "object"},
-            "items": {"type": "array"},
-            "unknown": {"type": "string"},
-            "loose": {"type": "string"},
+            "payload": {"type": "object", "properties": {"k": {"type": "string"}}},
+            "items": {"type": "array", "items": {"type": "integer"}},
+            "mode": {"type": "string", "enum": ["a", "b"]},
         },
         "required": ["text", "count"],
     }
-    assert _sdk_parameter_schema_from_callable(sdk_tools[1]) == {
-        "type": "object",
-        "properties": {},
-    }
+    sdk_tools = executor._build_sdk_tools(
+        [
+            {"name": "sys_rich", "description": "rich args", "parameters": rich_schema},
+            {"name": "sys_no_params", "description": "no schema"},  # parameters omitted
+        ]
+    )
+
+    # Rich schema: identical on the wrapper AND in the SDK-emitted proto — nothing
+    # is rewritten, narrowed, or dropped (formats, enums, nesting, minimum kept).
+    assert sdk_tools[0].input_schema == rich_schema
+    assert _sdk_advertised_schema(sdk_tools[0]) == rich_schema
+
+    # Omitted parameters → empty-object schema (advertises a no-arg tool), the
+    # same fallback cursor_executor uses.
+    empty_fallback = {"type": "object", "properties": {}}
+    assert sdk_tools[1].input_schema == empty_fallback
+    assert _sdk_advertised_schema(sdk_tools[1]) == empty_fallback
 
 
 @pytest.mark.asyncio
@@ -964,18 +947,16 @@ async def test_tool_schema_change_rebuilds_agent_registration(
         }
     ]
 
-    await _drain(
-        executor, [{"role": "user", "content": "one", "session_id": "s1"}], first_tools
-    )
-    await _drain(
-        executor, [{"role": "user", "content": "two", "session_id": "s1"}], second_tools
-    )
+    await _drain(executor, [{"role": "user", "content": "one", "session_id": "s1"}], first_tools)
+    await _drain(executor, [{"role": "user", "content": "two", "session_id": "s1"}], second_tools)
 
     assert len(captured["agents"]) == 2
+    # The rebuilt agent re-registers the tool with the NEW schema — the cache key
+    # widening (description + parameters) makes a schema-only change rebuild.
     first_tool = captured["configs"][0].tools[0]
     second_tool = captured["configs"][1].tools[0]
-    assert list(inspect.signature(first_tool).parameters) == ["cmd"]
-    assert list(inspect.signature(second_tool).parameters) == ["command"]
+    assert list(first_tool.input_schema["properties"]) == ["cmd"]
+    assert list(second_tool.input_schema["properties"]) == ["command"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes **F09** from `SDK_INTEGRATION_BUG_AUDIT.md`: *Antigravity Omnigent tool parameter schemas are never passed to the SDK — the model sees tools with no argument schema.*

`AntigravityExecutor._build_sdk_tools` built each SDK tool as a bare `async def _invoke(*args, **kwargs)` callable, setting only `__name__`/`__doc__`. The Antigravity SDK derives each tool's model-facing function declaration by introspecting the callable (`inspect.signature`), so every Omnigent tool (`sys_*`, sub-agent, MCP, function tools) was advertised to the model with a name + description but **no argument schema** — no property names, types, or required fields. `ToolSpec["parameters"]` was silently discarded.

This mirrors the intent of `cursor_executor._make_custom_tools(input_schema=...)` in an SDK-compatible way for Antigravity's callable registration surface:

- Added `_attach_schema_signature(fn, schema)` which synthesizes an `inspect.Signature` (plus matching `__annotations__`) from a ToolSpec's `parameters` JSON-Schema.
- `_build_sdk_tools` now threads each tool's `parameters` into `_make_tool_callable`, which attaches the synthesized signature before the callable is registered with the SDK.
- The runtime `*args/**kwargs` body is unchanged, so argument routing through `_tool_executor` remains compatible with kwargs, dict, and JSON-string call shapes.
- Invalid Python parameter names (including keywords) are skipped for signature synthesis; the callable still accepts those names at runtime via `**kwargs`.
- The Antigravity agent cache key now includes each registered tool's name, description, and parameters schema so schema-only tool changes force SDK re-registration instead of reusing stale declarations.

## Test plan

- [x] Added `test_sys_tool_schema_threaded_into_sdk_function_declaration`, asserting a registered `sys_shell` tool exposes its JSON schema via `inspect.signature` and through a fake SDK declaration-builder helper.
- [x] Added schema edge-case coverage for primitive JSON types, unknown type fallback, invalid names, Python keywords, malformed property specs, and malformed `required` entries.
- [x] Added `test_tool_schema_change_rebuilds_agent_registration`, proving schema-only tool changes on the same session/tool name rebuild the SDK agent/config.
- [x] Added a live Antigravity e2e gate: `test_per_harness_antigravity_tool_parameter_schema_bridge`, which registers a real `calculate(expression: str)` function tool, runs `omnigent run --harness antigravity`, and asserts the tool lifecycle and final result marker. It skips cleanly unless the real Antigravity SDK + Gemini key are available.
- [x] `uv run --extra dev python -m pytest tests/inner/test_antigravity_executor.py -q` — 35 passed.
- [x] `uv run --extra dev python -m pytest tests/e2e/omnigent/test_per_harness_antigravity.py::test_per_harness_antigravity_tool_parameter_schema_bridge -q` — skipped locally due missing live prerequisites.
- [x] `uv run --extra dev ruff check omnigent/inner/antigravity_executor.py tests/inner/test_antigravity_executor.py tests/e2e/omnigent/test_per_harness_antigravity.py` — clean.