### PR TITLE
fix(antigravity): rebuild agent + conversation after interrupt_session

### DIFF
--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -439,6 +439,15 @@ class AntigravityExecutor(Executor):
         it cannot race the still-running producer task and turn a clean cancel
         into an :class:`ExecutorError`.
 
+        This deliberately departs from the peer executors, which call
+        ``close_session()`` eagerly on interrupt (see
+        :meth:`CursorExecutor.interrupt_session` and
+        :meth:`ClaudeSDKExecutor.interrupt_session`). Antigravity cannot do the
+        same: an eager close would race the still-live turn's producer task and
+        convert a clean :class:`TurnCancelled` into an :class:`ExecutorError`,
+        so we only invalidate the signature here and defer the rebuild (and
+        close) to the next turn.
+
         :param session_key: The Omnigent session id to interrupt.
         :returns: ``True`` if a live conversation was asked to cancel,
             ``False`` when the session has no open conversation.

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -296,6 +296,8 @@ class _AntigravitySessionState:
     :param agent_signature: ``(model, system_prompt, tool_signature)`` key; a
         change forces an agent rebuild. A model change thus resets the SDK
         conversation — fine since mid-session model switches are rare.
+        :meth:`interrupt_session` clears this to ``None`` so the next turn
+        rebuilds rather than reusing the cancelled conversation.
     :param pending_tools: Open tool calls keyed by call id, populated on
         :class:`ToolCallRequest` and drained by the ``PostToolCallHook``.
     :param active_queue: The current turn's event queue (the
@@ -427,6 +429,16 @@ class AntigravityExecutor(Executor):
         then raises ``AntigravityCancelledError`` or yields a ``CANCELED``
         step, which the consumer surfaces as :class:`TurnCancelled`.
 
+        A cancelled SDK conversation carries aborted state, so reusing it for
+        the next turn would resume from that broken state. Invalidating the
+        cached agent signature forces the next :meth:`run_turn` through
+        :meth:`_ensure_agent`'s rebuild path — the same teardown the
+        error / signature-change path uses — which closes the stale agent and
+        opens a fresh agent + conversation (re-seeding prior history) before it
+        sends. The close is deferred to that path rather than awaited here so
+        it cannot race the still-running producer task and turn a clean cancel
+        into an :class:`ExecutorError`.
+
         :param session_key: The Omnigent session id to interrupt.
         :returns: ``True`` if a live conversation was asked to cancel,
             ``False`` when the session has no open conversation.
@@ -437,6 +449,9 @@ class AntigravityExecutor(Executor):
         state.interrupt_requested = True
         with contextlib.suppress(Exception):
             await state.conversation.cancel()
+        # Drop the cached signature (not the agent itself — _ensure_agent needs
+        # the live agent reference to close it) so the next turn rebuilds.
+        state.agent_signature = None
         return True
 
     async def run_turn(

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -1193,3 +1193,138 @@ async def test_interrupt_session_unknown_returns_false(monkeypatch: pytest.Monke
     _install_fake_sdk(monkeypatch, scripts=[])
     executor = AntigravityExecutor()
     assert await executor.interrupt_session("never-started") is False
+
+
+class _RebuildConversation:
+    """Conversation that blocks-then-cancels on turn 1, then runs clean on turn 2.
+
+    The first conversation (``blocking=True``) streams one delta and parks on a
+    gate until ``cancel()`` releases it, then raises the SDK cancellation error
+    — modelling an interrupted in-flight turn. The second conversation
+    (``blocking=False``) is the fresh one a post-interrupt rebuild must open and
+    runs a normal turn to completion. Each records its own ``sends`` so a test
+    can prove the second turn went to the *new* conversation, not the cancelled
+    one.
+    """
+
+    def __init__(self, gate: asyncio.Event, *, blocking: bool) -> None:
+        self._gate = gate
+        self._blocking = blocking
+        self.sends: list[str] = []
+        self.cancel_called = 0
+
+    async def send(self, prompt: Any, **_kw: Any) -> None:
+        self.sends.append(prompt)
+
+    async def receive_steps(self) -> Any:
+        if self._blocking:
+            yield _FakeStep(
+                step_type=_StepType.TEXT_RESPONSE,
+                status=_StepStatus.ACTIVE,
+                content_delta="streaming",
+            )
+            await self._gate.wait()  # parked until cancel() releases us
+            raise _AntigravityCancelledError("cancelled")
+        yield _FakeStep(
+            step_type=_StepType.TEXT_RESPONSE,
+            status=_StepStatus.ACTIVE,
+            content_delta="second-reply",
+        )
+        yield _FakeStep(step_type=_StepType.FINISH, status=_StepStatus.DONE)
+
+    async def cancel(self) -> None:
+        self.cancel_called += 1
+        self._gate.set()
+
+
+def _install_rebuild_sdk(monkeypatch: pytest.MonkeyPatch, gate: asyncio.Event) -> dict[str, Any]:
+    """Install a fake SDK: first agent blocks-then-cancels, later agents run clean."""
+    captured: dict[str, Any] = {"agents": [], "conversations": []}
+
+    class _RebuildAgent:
+        def __init__(self, config: Any, *, blocking: bool) -> None:
+            self.config = config
+            self._conversation = _RebuildConversation(gate, blocking=blocking)
+            self.closed = False
+            captured["conversations"].append(self._conversation)
+
+        @property
+        def conversation(self) -> _RebuildConversation:
+            return self._conversation
+
+        async def __aenter__(self) -> _RebuildAgent:
+            return self
+
+        async def __aexit__(self, *_a: object) -> None:
+            self.closed = True
+
+    class _FakeHooks:
+        PostToolCallHook = _FakePostToolCallHook
+
+    class _FakeTypes:
+        AntigravityCancelledError = _AntigravityCancelledError
+
+    class _FakeModule:
+        LocalAgentConfig = _FakeLocalAgentConfig
+        hooks = _FakeHooks
+        types = _FakeTypes
+
+        @staticmethod
+        def Agent(config: Any) -> _RebuildAgent:
+            # Only the very first agent blocks (the turn we interrupt); the
+            # rebuilt agent runs a normal turn.
+            agent = _RebuildAgent(config, blocking=not captured["agents"])
+            captured["agents"].append(agent)
+            return agent
+
+    monkeypatch.setattr(ag, "_ensure_antigravity_sdk", lambda: _FakeModule())
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_next_turn_rebuilds_after_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After an interrupt, the next turn rebuilds rather than reusing the cancelled convo.
+
+    Regression guard for F12: ``interrupt_session`` -> ``conversation.cancel()``
+    left the cancelled SDK conversation cached, so the next turn resumed from
+    aborted state. The fix invalidates the cached agent signature on interrupt
+    so the next ``run_turn`` closes the stale agent and opens a fresh
+    agent + conversation. Same model / system_prompt / tools across both turns,
+    so without the fix the agent would be reused (1 agent) and the second send
+    would land on the cancelled conversation.
+    """
+    gate = asyncio.Event()
+    first_text = asyncio.Event()
+    captured = _install_rebuild_sdk(monkeypatch, gate)
+    executor = AntigravityExecutor()
+
+    # Turn 1: drive until the first delta (provably mid-flight), then interrupt.
+    collected: list[Any] = []
+    task = asyncio.create_task(_drive_until_first_text(executor, collected, first_text))
+    await asyncio.wait_for(first_text.wait(), timeout=5)
+    assert await executor.interrupt_session("s1") is True
+    await asyncio.wait_for(task, timeout=5)
+
+    # The interrupt produced a clean cancel (not an error) and cancelled the
+    # live conversation.
+    assert any(isinstance(e, TurnCancelled) for e in collected)
+    assert not any(isinstance(e, ExecutorError) for e in collected)
+    cancelled_conv = captured["conversations"][0]
+    assert cancelled_conv.cancel_called == 1
+
+    # Turn 2 on the SAME session/signature must NOT reuse the cancelled agent.
+    events = await _drain(executor, [{"role": "user", "content": "next", "session_id": "s1"}])
+
+    # A fresh agent was built (2 total) and the stale one was torn down — the
+    # exact rebuild path a signature change uses. Reuse (the bug) would be 1.
+    assert len(captured["agents"]) == 2
+    assert captured["agents"][0].closed is True
+    # The second turn went to the NEW conversation; the cancelled one never saw
+    # the follow-up prompt (no stale-state reuse).
+    new_conv = captured["conversations"][1]
+    assert new_conv.sends == ["next"]
+    assert "next" not in cancelled_conv.sends
+    # And the fresh turn completed normally.
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    assert completes[0].response == "second-reply"


### PR DESCRIPTION
## Summary
- **F12 fix.** `interrupt_session()` called `conversation.cancel()` but left the now-cancelled SDK conversation cached on the session state. The next turn saw a matching agent signature in `_ensure_agent` and reused the stale/aborted conversation, so it resumed from cancelled state instead of starting clean.
- The fix invalidates the cached agent signature (`state.agent_signature = None`) on interrupt. The next `run_turn` then routes through `_ensure_agent`'s **existing** rebuild path — the same teardown a model/system-prompt/tools change uses — which closes the stale agent and opens a fresh agent + conversation (re-seeding prior history) before sending.
- The close is **deferred** to that rebuild path rather than awaited inside `interrupt_session`, so it can't race the still-running producer task (which would otherwise turn a clean `TurnCancelled` into an `ExecutorError`).

## Changes
- `omnigent/inner/antigravity_executor.py`: clear `agent_signature` after a successful cancel in `interrupt_session`; updated docstrings on `interrupt_session` and the `agent_signature` field.
- `tests/inner/test_antigravity_executor.py`: new `test_next_turn_rebuilds_after_interrupt` — interrupts an in-flight turn, then asserts the next turn (same model/prompt/tools) rebuilds the agent (2 agents, stale one torn down) and sends to the fresh conversation, not the cancelled one.

## Test plan
- [x] `uv run --extra dev pytest tests/inner/test_antigravity_executor.py` — 33 passed.
- [x] Verified the new test **fails** without the fix (reverted via stash) and **passes** with it.
- [x] `ruff check` clean on both files.