### PR TITLE
Move new chat advanced settings into agent picker

### DIFF
--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -477,13 +477,14 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the footer tray's Advanced menu (Radix opens on pointerdown) and
-    // pick a non-default mode. The create call proves the choice travels as
-    // a `--permission-mode <mode>` pair in terminal_launch_args.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    // Open the agent picker (Radix opens on pointerdown), slide into Advanced
+    // settings, and pick a non-default mode. The create call proves the choice
+    // travels as a `--permission-mode <mode>` pair in terminal_launch_args.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     fireEvent.click(screen.getByTestId("new-chat-landing-permission-bypassPermissions"));
     // A non-default pick is suffixed onto the pill so the changed mode
-    // stays visible while the radios live in the Advanced menu.
+    // stays visible while the radios live in the Advanced settings sub-page.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
       "Claude Code (Bypass permissions)",
     );
@@ -534,8 +535,9 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the footer tray's Advanced menu and pick "Full access".
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    // Open the agent picker, step into Advanced settings, and pick "Full access".
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     fireEvent.click(screen.getByTestId("new-chat-landing-approval-full-access"));
     // A non-default pick is suffixed onto the pill.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain(
@@ -575,9 +577,9 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toBeUndefined();
   });
 
-  it("posts harness_override when a brain harness is picked from the Advanced menu", async () => {
-    // polly's spec declares claude-sdk; the Advanced menu offers the
-    // override set.
+  it("posts harness_override when a brain harness is picked from the Advanced sub-page", async () => {
+    // polly's spec declares claude-sdk; the Advanced settings sub-page offers
+    // the override set.
     setAgents([
       agent({ id: "ag_polly", name: "polly", display_name: "Polly", harness: "claude-sdk" }),
     ]);
@@ -588,8 +590,9 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Open the footer tray's Advanced menu and pick Pi.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    // Open the agent picker, slide into Advanced settings, and pick Pi.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-pi"));
     // The composer pill reflects the pick before any session exists.
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Polly (Pi)");
@@ -617,7 +620,7 @@ describe("NewChatLandingScreen create flow", () => {
     renderLanding();
     await waitForWorkspaceSeed();
     // With no explicit pick the pill shows just the agent name — the spec
-    // default is not suffixed (it lives in the Advanced menu's radios).
+    // default is not suffixed (it lives in the Advanced settings sub-page).
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("Polly");
     expect(screen.getByTestId("new-chat-landing-agent-select").textContent).not.toContain(
       "Claude SDK",
@@ -644,10 +647,14 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Pick Pi, then change mind back to the spec default (Claude SDK).
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    // Pick Pi, then change mind back to the spec default (Claude SDK). Each
+    // radio pick closes the menu, so reopen and re-enter Advanced settings in
+    // between.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-pi"));
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-claude-sdk"));
     typeMessage("go");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -700,14 +700,15 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-connect-host")).toBeTruthy();
   });
 
-  it("shows permission-mode options in the Advanced menu only for the claude-native agent", () => {
+  it("shows permission-mode options in the Advanced sub-page only for the claude-native agent", () => {
     renderLanding();
-    // The radios live behind the footer tray's Advanced chip — absent
-    // until the menu opens.
+    // The radios live behind the agent picker's "Advanced settings" row —
+    // absent until the menu opens.
     expect(screen.queryByTestId("new-chat-landing-permission-plan")).toBeNull();
-    // a1 (Claude Code, claude-native) is the default agent → the footer
-    // tray surfaces the Advanced chip with the permission-mode radios.
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    // a1 (Claude Code, claude-native) is the default agent → the picker
+    // surfaces an "Advanced settings" row that slides to the permission radios.
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     const planOption = screen.getByTestId("new-chat-landing-permission-plan");
     expect(planOption.textContent).toContain("Plan");
     // The footer line explains the SELECTED mode until a row is hovered —
@@ -717,21 +718,20 @@ describe("NewChatLandingScreen", () => {
     expect(detail.textContent).toContain("Prompts before edits and commands");
     fireEvent.pointerEnter(planOption);
     expect(detail.textContent).toContain("Plans only; makes no edits");
-    // Switch to Codex (a2: codex-native) — the Advanced chip stays visible
-    // but now shows approval-mode radios instead of permission-mode radios.
-    // Close the Advanced menu first (Escape), then switch agents.
-    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    // Slide back to the agent list, then switch to Codex (a2: codex-native).
+    // Codex has Advanced settings too, so the picker stays open and its
+    // "Advanced settings" row remains available (now for approval modes).
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-back"));
     fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
-    expect(screen.queryByTestId("new-chat-landing-advanced-chip")).not.toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-advanced-entry")).not.toBeNull();
   });
 
-  it("shows approval-mode options in the Advanced menu for the codex-native agent", () => {
+  it("shows approval-mode options in the Advanced sub-page for the codex-native agent", () => {
     renderLanding();
-    // Switch to Codex first.
+    // Switch to Codex first; it keeps the menu open (it has Advanced settings).
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-agent-a2"));
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-advanced-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-advanced-entry"));
     const fullAccessOption = screen.getByTestId("new-chat-landing-approval-full-access");
     expect(fullAccessOption.textContent).toContain("Full access");
     // The footer line explains the SELECTED mode until a row is hovered.

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -103,6 +103,10 @@ const AGENT_PICKER_DESCRIPTIONS: Record<string, string> = {
 // out — other agents keep the "/" menu as the only skill surface.
 const SKILL_PILL_AGENTS = new Set(["polly", "debby"]);
 
+// Temporarily hidden (#3021): re-enable cost routing controls by setting this
+// flag and restoring the server-side launch wiring.
+const SHOW_COST_CONTROL = false;
+
 // Claude Code's `claude --permission-mode` choices (v2.1). Claude-native
 // sessions only. "default" is Claude's own default and sends no flag; any
 // other value is passed through as `--permission-mode <value>` via the
@@ -1511,8 +1515,7 @@ export function NewChatLandingScreen() {
               <div className="flex items-center gap-0.5">
                 {/* Polly-only surface — cost control is a polly feature, so
                     the toggle is hidden unless the selected agent is polly. */}
-                {/* Temporarily hidden (#3021): re-enable by removing the false gate. */}
-                {false && selectedAgent?.name === "polly" && (
+                {SHOW_COST_CONTROL && selectedAgent?.name === "polly" && (
                   // Mode-only variant: no verdict can exist before the session does.
                   <IntelligentModelControl value={costControlMode} onChange={setCostControlMode} />
                 )}

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -6,6 +6,8 @@ import {
   MonitorCloudIcon,
   CircleHelpIcon,
   ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   GitBranchIcon,
   ArrowUpIcon,
   FileTextIcon,
@@ -679,6 +681,26 @@ function BrainHarnessOptions({
   );
 }
 
+/**
+ * True when ``agent`` exposes per-agent knobs in the picker's Advanced
+ * settings sub-page: an overridable brain harness (bundle agents like
+ * polly / debby), Claude Code's permission mode, or Codex's approval mode.
+ *
+ * Drives both the "Advanced settings" row's visibility and whether picking
+ * the agent keeps the menu open (so the user can step into the sub-page)
+ * instead of closing it like a plain agent pick.
+ */
+function agentHasAdvancedSettings(
+  agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
+): boolean {
+  const hasOverridableHarness = agent?.harness != null && agent.harness in BRAIN_HARNESS_LABELS;
+  return (
+    hasOverridableHarness ||
+    nativeAgentHasCapability(agent, "permissionMode") ||
+    nativeAgentHasCapability(agent, "approvalMode")
+  );
+}
+
 export function NewChatLandingScreen() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -823,6 +845,15 @@ export function NewChatLandingScreen() {
   const [createError, setCreateError] = useState<string | null>(null);
   // "Connect a host" instructions modal, opened from the host dropdown.
   const [connectOpen, setConnectOpen] = useState(false);
+
+  // Agent picker dropdown. Controlled so picking an agent that has Advanced
+  // settings can keep the menu open instead of dismissing it. `agentMenuView`
+  // swaps the popover's contents in place between the agent list and the
+  // selected agent's Advanced settings — one surface, so it works on mobile
+  // (no off-screen flyout). Only the active view is mounted, so the popover
+  // auto-sizes to it and its items are the only ones in the focus order.
+  const [agentMenuOpen, setAgentMenuOpen] = useState(false);
+  const [agentMenuView, setAgentMenuView] = useState<"agents" | "advanced">("agents");
 
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
 
@@ -1074,13 +1105,16 @@ export function NewChatLandingScreen() {
         key={agent.id}
         data-testid={`new-chat-landing-agent-${agent.id}`}
         data-active={agent.id === effectiveAgentId ? "true" : undefined}
-        onSelect={() => {
+        onSelect={(e) => {
           // Switching agents drops the harness override so a
           // pick never leaks across agents.
           if (agent.id !== effectiveAgentId) setPickedHarness(null);
           setPickedAgentId(agent.id);
           // Explicit picks persist; auto-defaults never do.
           writeLastAgentId(agent.id);
+          // Agents with Advanced settings keep the menu open so the user
+          // can step into the sub-view; plain agents close on pick.
+          if (agentHasAdvancedSettings(agent)) e.preventDefault();
         }}
         className="items-start gap-2 rounded-sm px-2 py-1.5 text-sm data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
       >
@@ -1114,6 +1148,15 @@ export function NewChatLandingScreen() {
       </DropdownMenuItem>
     );
   };
+
+  // Never strand the user on an empty Advanced page: if the selected agent
+  // loses its knobs (e.g. the agent list refreshes and it disappears), fall
+  // back to the agent list.
+  useEffect(() => {
+    if (agentMenuView === "advanced" && !agentHasAdvancedSettings(selectedAgent)) {
+      setAgentMenuView("agents");
+    }
+  }, [agentMenuView, selectedAgent]);
 
   function selectHost(hostId: string) {
     // Re-selecting the current host is a no-op. Clearing the workspace here
@@ -1474,7 +1517,14 @@ export function NewChatLandingScreen() {
                   <IntelligentModelControl value={costControlMode} onChange={setCostControlMode} />
                 )}
                 {agentList.length > 0 ? (
-                  <DropdownMenu>
+                  <DropdownMenu
+                    open={agentMenuOpen}
+                    onOpenChange={(open) => {
+                      setAgentMenuOpen(open);
+                      // Always reopen on the agent list, never on the Advanced view.
+                      if (!open) setAgentMenuView("agents");
+                    }}
+                  >
                     <DropdownMenuTrigger asChild>
                       <Button
                         type="button"
@@ -1489,26 +1539,117 @@ export function NewChatLandingScreen() {
                         <ChevronDownIcon className="size-3.5 opacity-60" />
                       </Button>
                     </DropdownMenuTrigger>
-                    {/* side=bottom documents the intent: the menu is a short
-                        agent list (harness / permission settings live in the
-                        footer tray's Advanced menu), so it should always drop
-                        downward like the other composer menus. */}
+                    {/* side=bottom documents the intent: a short agent list
+                        that should always drop downward like the other composer
+                        menus. The contents swap in place between the agent list
+                        and the selected agent's Advanced settings — only the
+                        active view is mounted, so the popover sizes to it. */}
                     <DropdownMenuContent
                       align="end"
                       side="bottom"
-                      className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
+                      className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
                     >
-                      {/* Built-in agents first, then a divider, then any
-                          custom (user-registered) agents. renderAgentRow is
-                          defined once and reused for both groups. The divider
-                          only renders when BOTH groups are non-empty, so a
-                          deployment with only custom agents (or only built-ins)
-                          never shows a leading/dangling separator. */}
-                      {builtinAgents.map((agent) => renderAgentRow(agent))}
-                      {builtinAgents.length > 0 && customAgents.length > 0 && (
-                        <DropdownMenuSeparator />
+                      {agentMenuView === "advanced" ? (
+                        <>
+                          {/* Advanced settings for the selected agent: the
+                              brain-harness override (bundle agents), Claude Code's
+                              permission mode, and Codex's approval mode. */}
+                          <DropdownMenuItem
+                            data-testid="new-chat-landing-advanced-back"
+                            onSelect={(e) => {
+                              // Step back to the list instead of closing the menu.
+                              e.preventDefault();
+                              setAgentMenuView("agents");
+                            }}
+                            className="gap-1.5 rounded-sm px-2 py-1.5 text-sm font-medium"
+                          >
+                            <ChevronLeftIcon className="size-4 shrink-0 opacity-70" />
+                            <span className="truncate">
+                              {selectedAgent?.display_name ?? "Advanced settings"}
+                            </span>
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          {selectedAgentDefaultHarness != null && (
+                            <BrainHarnessOptions
+                              value={pickedHarness ?? selectedAgentDefaultHarness}
+                              onValueChange={(h) =>
+                                // Picking the spec default clears the override so
+                                // the session tracks the spec.
+                                setPickedHarness(h === selectedAgentDefaultHarness ? null : h)
+                              }
+                              host={harnessWarningHost}
+                            />
+                          )}
+                          {/* Permission mode (Claude Code only) — claude-native
+                            has no overridable harness, so the two sections never
+                            co-render today; the separator covers a future agent
+                            with both. */}
+                          {supportsPermissionMode && (
+                            <>
+                              {selectedAgentDefaultHarness != null && <DropdownMenuSeparator />}
+                              <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
+                                Permission mode
+                              </div>
+                              <PermissionModeOptions
+                                value={permissionMode}
+                                onValueChange={setPermissionMode}
+                              />
+                            </>
+                          )}
+                          {/* Approval mode (Codex only) — codex-native has no
+                            overridable harness, so the two sections never
+                            co-render today; the separator covers a future agent
+                            with both. */}
+                          {supportsApprovalMode && (
+                            <>
+                              {(selectedAgentDefaultHarness != null || supportsPermissionMode) && (
+                                <DropdownMenuSeparator />
+                              )}
+                              <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
+                                Approval mode
+                              </div>
+                              <ApprovalModeOptions
+                                value={approvalMode}
+                                onValueChange={setApprovalMode}
+                              />
+                            </>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          {/* Built-in agents first, then a divider, then any
+                              custom (user-registered) agents. renderAgentRow is
+                              defined once and reused for both groups. The divider
+                              only renders when BOTH groups are non-empty, so a
+                              deployment with only custom agents (or only built-ins)
+                              never shows a leading/dangling separator. */}
+                          {builtinAgents.map((agent) => renderAgentRow(agent))}
+                          {builtinAgents.length > 0 && customAgents.length > 0 && (
+                            <DropdownMenuSeparator />
+                          )}
+                          {customAgents.map((agent) => renderAgentRow(agent))}
+                          {/* Advanced settings entry — only for the selected agent
+                              that exposes knobs. Swaps to the Advanced view rather
+                              than closing the menu. */}
+                          {agentHasAdvancedSettings(selectedAgent) && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                data-testid="new-chat-landing-advanced-entry"
+                                onSelect={(e) => {
+                                  e.preventDefault();
+                                  setAgentMenuView("advanced");
+                                }}
+                                className="gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground"
+                              >
+                                <SettingsIcon className="size-4 shrink-0 opacity-70" />
+                                <span className="flex-1">Advanced settings</span>
+                                <ChevronRightIcon className="size-3.5 shrink-0 opacity-60" />
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </>
                       )}
-                      {customAgents.map((agent) => renderAgentRow(agent))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 ) : (
@@ -1823,73 +1964,6 @@ export function NewChatLandingScreen() {
                     </div>
                   </PopoverContent>
                 </Popover>
-              )}
-
-              {/* Advanced settings chip — per-agent knobs that don't warrant
-                their own chip: the brain-harness override (bundle agents),
-                Claude Code's permission mode, and Codex's approval mode.
-                Hidden when the selected agent has none. */}
-              {(selectedAgentDefaultHarness != null ||
-                supportsPermissionMode ||
-                supportsApprovalMode) && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      className="flex h-6 items-center gap-1.5 rounded-full px-3 text-13 font-normal text-muted-foreground transition-colors hover:text-foreground"
-                      data-testid="new-chat-landing-advanced-chip"
-                    >
-                      <SettingsIcon className="size-4 shrink-0" />
-                      <span className="truncate">Advanced</span>
-                      <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="start"
-                    className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1"
-                  >
-                    {selectedAgentDefaultHarness != null && (
-                      <BrainHarnessOptions
-                        value={pickedHarness ?? selectedAgentDefaultHarness}
-                        onValueChange={(h) =>
-                          // Picking the spec default clears the override so the
-                          // session tracks the spec.
-                          setPickedHarness(h === selectedAgentDefaultHarness ? null : h)
-                        }
-                        host={harnessWarningHost}
-                      />
-                    )}
-                    {/* Permission mode (Claude Code only) — claude-native has no
-                      overridable harness, so the two sections never co-render
-                      today; the separator covers a future agent with both. */}
-                    {supportsPermissionMode && (
-                      <>
-                        {selectedAgentDefaultHarness != null && <DropdownMenuSeparator />}
-                        <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
-                          Permission mode
-                        </div>
-                        <PermissionModeOptions
-                          value={permissionMode}
-                          onValueChange={setPermissionMode}
-                        />
-                      </>
-                    )}
-                    {/* Approval mode (Codex only) — codex-native has no
-                      overridable harness, so the two sections never co-render
-                      today; the separator covers a future agent with both. */}
-                    {supportsApprovalMode && (
-                      <>
-                        {(selectedAgentDefaultHarness != null || supportsPermissionMode) && (
-                          <DropdownMenuSeparator />
-                        )}
-                        <div className="px-2 pt-1.5 pb-0.5 text-[11px] font-medium text-muted-foreground">
-                          Approval mode
-                        </div>
-                        <ApprovalModeOptions value={approvalMode} onValueChange={setApprovalMode} />
-                      </>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- restore the New Chat agent-picker Advanced settings sub-page from the prior UI work
- keep Claude permission, Codex approval, and bundle harness controls under the selected agent
- replace the disabled inline cost-control guard with a named flag so focused lint passes

## Tests
- npm exec prettier -- --check src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx
- npm exec oxlint -- src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx
- npm run test -- src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx
- npm --prefix ap-web run type-check

Note: npm ci currently fails on upstream main because ap-web/package-lock.json is out of sync with package.json for yaml (lock has 1.10.3, package resolution wants 2.9.0), so local verification used npm install --package-lock=false.