### PR TITLE
fix(upgrade): make `omni upgrade` version-aware; bump main to 0.2.0.dev0

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3577,6 +3577,7 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
     import importlib.metadata
 
     from omnigent.update_check import (
+        _UPGRADE_INDEX_TIMEOUT_SECONDS,
         _build_upgrade_suggestion,
         _find_repo_root,
         _is_newer,
@@ -3615,7 +3616,11 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
         return
 
     current = importlib.metadata.version("omnigent")
-    latest = fetch_latest_version(include_prereleases=pre)
+    # User-initiated: a more forgiving timeout + one retry so a momentarily slow
+    # mirror doesn't spuriously report the index as unreachable.
+    latest = fetch_latest_version(
+        include_prereleases=pre, timeout=_UPGRADE_INDEX_TIMEOUT_SECONDS, attempts=2
+    )
     if latest is None:
         raise click.ClickException(
             "Couldn't reach the package index to check for a newer release. Check your "

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from omnigent._runner_startup import RunnerStartupProgress
     from omnigent.onboarding.ambient import DetectedProvider
     from omnigent.onboarding.provider_config import ProviderEntry
+    from omnigent.update_check import _InstalledWheelInfo
 
 
 # Any: YAML configs have heterogeneous value types (str, int, list, etc.)
@@ -3407,6 +3408,110 @@ def _wait_for_local_sessions_to_drain() -> None:
             last = count
 
 
+def _drain_and_stop_local_server(*, force: bool) -> None:
+    """Drain (or force-stop) the local server + daemon before an upgrade.
+
+    Shared by both ``omni upgrade`` paths (registry and git): the running
+    process must stop serving BEFORE its code is swapped, so it never serves
+    half-upgraded modules. The next ``omni`` invocation respawns a fresh
+    server on the new version.
+
+    :param force: When ``False``, wait for in-flight sessions to drain first;
+        when ``True``, stop them immediately.
+    """
+    if not force:
+        _wait_for_local_sessions_to_drain()
+    if _stop_local_server_and_daemon(force=force):
+        click.echo("Stopped the background server before upgrading.")
+
+
+def _upgrade_vcs_install(
+    info: _InstalledWheelInfo, *, check_only: bool, force: bool, pre: bool
+) -> None:
+    """Update a git/VCS ``omni`` install by re-pulling its tracked ref.
+
+    A git install's version string is frozen at whatever its source branch
+    declares (e.g. ``0.1.0`` on an unbumped ``main``), so it cannot be
+    compared against PyPI — that comparison reports a build *ahead* of the
+    latest release as "behind" and never converges, because reinstalling the
+    ref can't change the version string. Instead, compare the installed commit
+    against the remote ref's HEAD, and after re-pulling verify the commit
+    actually moved rather than asserting a PyPI version the ref can't produce.
+
+    :param info: Installed-distribution metadata, with ``info.vcs_url`` set.
+    :param check_only: Report status only; exit non-zero only when we can
+        positively confirm the install is behind its tracked ref.
+    :param force: Stop in-flight sessions immediately instead of draining.
+    :param pre: Pass the installer's allow-pre-releases flag (no-op for git).
+    """
+    from omnigent.update_check import (
+        _build_upgrade_suggestion,
+        _probe_installed_distribution,
+        _remote_git_head,
+        _run_upgrade_command,
+    )
+
+    current_sha = info.commit_sha or ""
+    cur_short = current_sha[:9] if current_sha else "unknown"
+    remote_sha = _remote_git_head(info.vcs_url) if info.vcs_url else None
+    known_behind = bool(remote_sha and current_sha and remote_sha != current_sha)
+
+    if remote_sha and current_sha and remote_sha == current_sha:
+        click.echo(f"omnigent is up to date (git {cur_short}, tracking {info.vcs_url}).")
+        return
+    if known_behind:
+        # mypy: known_behind implies remote_sha is truthy.
+        click.echo(
+            f"A newer commit is available: {cur_short} → {remote_sha[:9]} "  # type: ignore[index]
+            f"(git install tracking {info.vcs_url})."
+        )
+    else:
+        click.echo(
+            f"This is a git install ({info.vcs_url} @ {cur_short}). The latest "
+            "commit couldn't be determined; re-pulling the tracked ref."
+        )
+
+    if check_only:
+        # Exit non-zero only when we KNOW it's behind, so `--check` stays a
+        # reliable CI gate; an indeterminate remote is not a failure.
+        if known_behind:
+            raise SystemExit(1)
+        return
+
+    suggestion = _build_upgrade_suggestion(info, allow_prerelease=pre)
+    if not suggestion.runnable:
+        raise click.ClickException(
+            f"No automatic upgrade command is known for this install. {suggestion.command}."
+        )
+
+    _drain_and_stop_local_server(force=force)
+
+    console = Console()
+    code = _run_upgrade_command(suggestion.command, console)
+    if code != 0:
+        raise click.ClickException(
+            f"Upgrade command exited with status {code}; your previous install is intact."
+        )
+
+    # Verify by commit, not exit code: a re-pull of a ref that hasn't moved
+    # (or a pinned ref) exits 0 without changing anything.
+    _, new_sha = _probe_installed_distribution()
+    if new_sha and current_sha and new_sha != current_sha:
+        click.echo(
+            f"✓ Updated to git {new_sha[:9]}. Re-run your command — the local "
+            "server will start on the new version."
+        )
+        return
+    if new_sha and current_sha and new_sha == current_sha:
+        click.echo(
+            f"Already on the latest commit of the tracked ref ({cur_short}); nothing changed."
+        )
+        return
+    # Couldn't read the new commit — the re-pull ran, but don't assert a
+    # result we can't confirm.
+    click.echo("Re-pulled the git ref. Run `omni upgrade --check` to confirm.")
+
+
 @cli.command("upgrade")
 @click.option(
     "--check",
@@ -3451,11 +3556,11 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
     """
     import importlib.metadata
 
-    from packaging.version import InvalidVersion, parse
-
     from omnigent.update_check import (
         _build_upgrade_suggestion,
         _find_repo_root,
+        _is_newer,
+        _probe_installed_distribution,
         _read_installed_wheel_info,
         _run_upgrade_command,
         fetch_latest_version,
@@ -3478,6 +3583,17 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
             "This is an editable install — update it with `git pull`, not `omni upgrade`."
         )
 
+    # A git/VCS install tracks a moving git ref, not a PyPI release. Its
+    # version string (a frozen ``0.1.0`` on an unbumped ``main``, say) is NOT
+    # comparable to the latest PyPI release: comparing them reports a build
+    # that is *ahead* of the release as "behind" and loops forever, because
+    # reinstalling the ref can never change that version string. For these
+    # installs "upgrade" means re-pulling the ref — compared and verified by
+    # commit, not by PyPI version.
+    if info.vcs_url:
+        _upgrade_vcs_install(info, check_only=check_only, force=force, pre=pre)
+        return
+
     current = importlib.metadata.version("omnigent")
     latest = fetch_latest_version(include_prereleases=pre)
     if latest is None:
@@ -3485,12 +3601,7 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
             "Couldn't reach the package index to check for a newer release. Check your "
             "connection (or OMNIGENT_INDEX_URL / your configured index) and try again."
         )
-    try:
-        is_behind = parse(latest) > parse(current)
-    except InvalidVersion:
-        is_behind = latest != current
-
-    if not is_behind:
+    if not _is_newer(latest, current):
         click.echo(f"omnigent is up to date (v{current}).")
         return
 
@@ -3508,13 +3619,7 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
             f"No automatic upgrade command is known for this install. {suggestion.command}."
         )
 
-    # Drain (or force-stop) the local server + daemon BEFORE swapping the
-    # code, so the running process never serves half-upgraded modules.
-    # The next command respawns a fresh server on the new version.
-    if not force:
-        _wait_for_local_sessions_to_drain()
-    if _stop_local_server_and_daemon(force=force):
-        click.echo("Stopped the background server before upgrading.")
+    _drain_and_stop_local_server(force=force)
 
     console = Console()
     code = _run_upgrade_command(suggestion.command, console)
@@ -3522,9 +3627,32 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
         raise click.ClickException(
             f"Upgrade command exited with status {code}; your previous install is intact."
         )
-    click.echo(
-        f"✓ Upgraded to v{latest}. Re-run your command — the local server will "
-        "start on the new version."
+
+    # Trust the installed version, not the installer's exit code. The running
+    # process still has the OLD version loaded, so re-read it in a fresh
+    # subprocess. A no-op upgrade (version-pinned spec, a cooldown /
+    # exclude-newer that excludes the new release, or a stale index cache)
+    # exits 0 without moving — claiming "✓ Upgraded" there is exactly the
+    # "I upgraded but it still says an update is available" bug.
+    new_version, _ = _probe_installed_distribution()
+    if new_version is None:
+        click.echo(
+            "Ran the upgrade command, but couldn't confirm the installed version. "
+            "Run `omni upgrade --check` to verify."
+        )
+        return
+    if _is_newer(new_version, current):
+        click.echo(
+            f"✓ Upgraded to v{new_version}. Re-run your command — the local "
+            "server will start on the new version."
+        )
+        return
+    raise click.ClickException(
+        f"The upgrade command ran but omnigent is still v{new_version} (expected "
+        f"v{latest}). The install is likely version-pinned, a cooldown / "
+        "exclude-newer is excluding the new release, or the index cache is stale. "
+        "Reinstall it explicitly — e.g. `uv tool upgrade --reinstall omnigent` or "
+        f"`pip install --force-reinstall 'omnigent=={latest}'`."
     )
 
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3454,15 +3454,15 @@ def _upgrade_vcs_install(
     current_sha = info.commit_sha or ""
     cur_short = current_sha[:9] if current_sha else "unknown"
     remote_sha = _remote_git_head(info.vcs_url) if info.vcs_url else None
+    remote_short = remote_sha[:9] if remote_sha else ""
     known_behind = bool(remote_sha and current_sha and remote_sha != current_sha)
 
     if remote_sha and current_sha and remote_sha == current_sha:
         click.echo(f"omnigent is up to date (git {cur_short}, tracking {info.vcs_url}).")
         return
     if known_behind:
-        # mypy: known_behind implies remote_sha is truthy.
         click.echo(
-            f"A newer commit is available: {cur_short} → {remote_sha[:9]} "  # type: ignore[index]
+            f"A newer commit is available: {cur_short} → {remote_short} "
             f"(git install tracking {info.vcs_url})."
         )
     else:
@@ -3473,10 +3473,19 @@ def _upgrade_vcs_install(
 
     if check_only:
         # Exit non-zero only when we KNOW it's behind, so `--check` stays a
-        # reliable CI gate; an indeterminate remote is not a failure.
+        # reliable CI gate; an indeterminate remote is not a failure. SystemExit
+        # (not ctx.exit) for the same reason as the PyPI path — main() runs the
+        # group with standalone_mode=False, where ctx.exit's code is dropped.
         if known_behind:
             raise SystemExit(1)
         return
+
+    if pre:
+        # ``--pre`` only steers a PyPI resolve; a git install gets exactly the
+        # commit its ref points at, so say so rather than implying it had effect.
+        click.echo(
+            "Note: --pre has no effect on a git install; the tracked ref decides the commit."
+        )
 
     suggestion = _build_upgrade_suggestion(info, allow_prerelease=pre)
     if not suggestion.runnable:
@@ -3493,8 +3502,8 @@ def _upgrade_vcs_install(
             f"Upgrade command exited with status {code}; your previous install is intact."
         )
 
-    # Verify by commit, not exit code: a re-pull of a ref that hasn't moved
-    # (or a pinned ref) exits 0 without changing anything.
+    # Verify by commit, not exit code: a re-pull of a ref that hasn't moved (or
+    # a pinned ref, or a cached reinstall) exits 0 without changing anything.
     _, new_sha = _probe_installed_distribution()
     if new_sha and current_sha and new_sha != current_sha:
         click.echo(
@@ -3502,7 +3511,18 @@ def _upgrade_vcs_install(
             "server will start on the new version."
         )
         return
+    if known_behind and new_sha and new_sha == current_sha:
+        # We positively confirmed the ref had advanced, yet the re-pull left the
+        # install on the same commit — a silent no-op that would otherwise
+        # recreate the "still behind" loop. Fail loudly, mirroring the PyPI guard.
+        raise click.ClickException(
+            f"The re-pull ran but the install is still at {cur_short} (the ref is at "
+            f"{remote_short}). The ref may be pinned or the reinstall reused a cached "
+            f"commit; try `uv tool install --reinstall {info.vcs_url}`."
+        )
     if new_sha and current_sha and new_sha == current_sha:
+        # Remote was indeterminate, so we never claimed it was behind — a
+        # no-change re-pull is fine here.
         click.echo(
             f"Already on the latest commit of the tracked ref ({cur_short}); nothing changed."
         )

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -83,6 +83,11 @@ _SIMPLE_JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
 # Keep the background index lookup snappy. It runs detached so it never
 # blocks the CLI, but a tight timeout still bounds the orphan's lifetime.
 _INDEX_TIMEOUT_SECONDS = 3.0
+# The foreground ``omni upgrade`` is user-initiated and worth waiting on, so it
+# uses a more forgiving timeout (and one retry) than the background refresh — a
+# briefly slow mirror shouldn't make ``omni upgrade --check`` spuriously report
+# "couldn't reach the index".
+_UPGRADE_INDEX_TIMEOUT_SECONDS = 10.0
 # The placeholder that PEP 610 tooling (pip, newer uv) writes into
 # ``direct_url.json`` in place of a URL's userinfo. See
 # ``_unredact_ssh_userinfo`` for why we have to repair it.
@@ -454,19 +459,29 @@ def _index_from_pip_config() -> str:
     return ""
 
 
-def fetch_latest_version(include_prereleases: bool = False) -> str | None:
+def fetch_latest_version(
+    include_prereleases: bool = False,
+    *,
+    timeout: float = _INDEX_TIMEOUT_SECONDS,
+    attempts: int = 1,
+) -> str | None:
     """Fetch the latest ``omnigent`` release from the configured index.
 
     Queries the Simple Repository API of the resolved index
     (:func:`_resolve_index_url`) — PEP 691 JSON when the index serves it,
-    PEP 503 HTML otherwise. Network call with a tight timeout, swallowing
-    every error so the update check can never break (or slow) the CLI;
-    intended for the detached background refresh, not the hot path.
+    PEP 503 HTML otherwise. Swallows every error so the update check can never
+    break the CLI. The background refresh uses the defaults (one snappy try);
+    the foreground ``omni upgrade`` passes a longer *timeout* and *attempts=2*
+    so a momentarily slow mirror doesn't spuriously read as "unreachable".
 
     :param include_prereleases: When ``False`` (default), pre-releases and
         dev releases are excluded so we never nag about a non-final build.
         When ``True`` (``omni upgrade --pre`` / TestPyPI rc validation),
         they are considered too.
+    :param timeout: Per-request timeout in seconds.
+    :param attempts: Total number of tries; a transient connection/timeout
+        error retries until they are exhausted. A definitive non-200 response
+        is never retried. Values < 1 are treated as 1.
     :returns: The latest matching version string (e.g. ``"0.2.0"`` or, with
         pre-releases, ``"0.2.0rc1"``), or ``None`` on any network / parse
         error, a non-200 response, or when no matching release is found.
@@ -475,16 +490,19 @@ def fetch_latest_version(include_prereleases: bool = False) -> str | None:
     from packaging.utils import canonicalize_name
 
     url = f"{_resolve_index_url()}/{canonicalize_name(_DIST_NAME)}/"
-    try:
-        resp = httpx.get(
-            url,
-            headers={"Accept": _SIMPLE_JSON_ACCEPT},
-            timeout=_INDEX_TIMEOUT_SECONDS,
-            follow_redirects=True,
-        )
-    except httpx.HTTPError:
-        return None
-    if resp.status_code != 200:
+    resp = None
+    for _ in range(max(1, attempts)):
+        try:
+            resp = httpx.get(
+                url,
+                headers={"Accept": _SIMPLE_JSON_ACCEPT},
+                timeout=timeout,
+                follow_redirects=True,
+            )
+            break  # got a response (any status) — don't retry a definitive reply
+        except httpx.HTTPError:
+            resp = None  # transient (timeout / connection reset) — retry if any left
+    if resp is None or resp.status_code != 200:
         return None
 
     versions = _parse_simple_versions(resp)

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -269,6 +269,15 @@ def _run_installed_wheel_check() -> None:
         # would have caught this if .git/ were reachable; there's no
         # PyPI release to compare an editable install against, so bail.
         return
+    if info.vcs_url:
+        # A git/VCS install tracks a moving ref, not a PyPI release. Its
+        # version string (e.g. a frozen ``0.1.0`` on an unbumped ``main``)
+        # is not comparable to the latest PyPI version: the nag would fire
+        # forever even on a build that is *ahead* of the latest release,
+        # and reinstalling the ref can never change that version. The
+        # ``omni upgrade`` git path re-pulls the ref and reports commit
+        # deltas instead; the passive PyPI nag is simply wrong here.
+        return
 
     cache = _read_cache()
     if (
@@ -1362,3 +1371,111 @@ def upgrade_command_for_installed() -> _UpgradeSuggestion | None:
     if info is None:
         return None
     return _build_upgrade_suggestion(info)
+
+
+def _probe_installed_distribution() -> tuple[str | None, str | None]:
+    """Read the freshly-installed version and VCS commit in a subprocess.
+
+    ``omni upgrade`` swaps the on-disk install while *this* process is
+    running, but the running interpreter already imported the old
+    ``omnigent`` and cached its metadata — re-reading in-process returns the
+    *pre-upgrade* version. A fresh ``sys.executable`` subprocess loads the
+    new metadata from disk, so it reports what the upgrade actually
+    produced. This is what lets ``omni upgrade`` verify the install really
+    advanced instead of trusting the installer's exit code (a no-op upgrade
+    — pinned spec, cooldown, stale index cache, or a git ref that can't move
+    the version — exits 0 without changing anything).
+
+    The version is read via ``importlib.metadata`` (no ``omnigent`` import,
+    so it survives even a broken upgrade); the commit is read from the
+    install's PEP 610 ``direct_url.json`` by re-running this module's own
+    detector, and is empty for registry installs.
+
+    :returns: ``(version, commit_sha)`` of the now-installed distribution.
+        Either element is ``None`` when it can't be determined (subprocess
+        failure, frozen interpreter with no ``sys.executable``, or — for the
+        commit — a non-VCS install).
+    """
+    if not sys.executable:
+        return None, None
+    probe = (
+        "import importlib.metadata as m\n"
+        "try:\n"
+        "    print(m.version('omnigent'))\n"
+        "except Exception:\n"
+        "    print('')\n"
+        "try:\n"
+        "    from omnigent.update_check import _read_installed_wheel_info as r\n"
+        "    i = r()\n"
+        "    print((i.commit_sha or '') if i is not None else '')\n"
+        "except Exception:\n"
+        "    print('')\n"
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None, None
+    if result.returncode != 0:
+        return None, None
+    lines = result.stdout.splitlines()
+    version = lines[0].strip() if lines and lines[0].strip() else None
+    commit = lines[1].strip() if len(lines) >= 2 and lines[1].strip() else None
+    return version, commit
+
+
+def _split_vcs_url(vcs_url: str) -> tuple[str, str | None]:
+    """Split a ``git+<url>[@<rev>]`` into ``(repo_url, revision)``.
+
+    Drops the ``git+`` prefix uv/pip prepend and separates a trailing
+    ``@<rev>`` (branch / tag / sha) when present. An ``@`` that is *userinfo*
+    (``git@host`` in an SSH URL) is NOT a revision: only an ``@`` after the
+    final ``/`` — i.e. past the repo path — is treated as one.
+
+    :param vcs_url: e.g. ``"git+https://host/org/repo.git@main"``.
+    :returns: ``(repo_url, revision_or_None)``, e.g.
+        ``("https://host/org/repo.git", "main")``.
+    """
+    url = vcs_url[4:] if vcs_url.startswith("git+") else vcs_url
+    at = url.rfind("@")
+    if at > url.rfind("/"):  # '@' past the final path segment → revision suffix
+        return url[:at], (url[at + 1 :] or None)
+    return url, None
+
+
+def _remote_git_head(vcs_url: str) -> str | None:
+    """Return the remote commit a ``git+`` install's ref points at, or ``None``.
+
+    Runs ``git ls-remote`` against the bare repo URL for the install's
+    revision (or ``HEAD`` when none was pinned), so ``omni upgrade`` can tell
+    whether a git install is behind its tracked ref *before* re-pulling.
+    Best-effort with a tight timeout: any failure (offline, auth, bad URL, no
+    ``git`` binary) yields ``None`` so ``--check`` degrades to "can't
+    determine" rather than crashing.
+
+    :param vcs_url: A normalized VCS URL, e.g.
+        ``"git+https://github.com/omnigent-ai/omnigent.git"`` or
+        ``"git+https://…/omnigent.git@main"``.
+    :returns: The 40-char commit SHA the ref resolves to, or ``None``.
+    """
+    url, ref = _split_vcs_url(vcs_url)
+    if not url:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", url, ref or "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    first = result.stdout.split("\n", 1)[0].strip()
+    sha = first.split("\t", 1)[0].strip() if first else ""
+    return sha or None

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -1416,6 +1416,8 @@ def _probe_installed_distribution() -> tuple[str | None, str | None]:
             [sys.executable, "-c", probe],
             capture_output=True,
             text=True,
+            # A metadata lookup is sub-second; the git timeout is reused only as
+            # a generous upper bound so a wedged interpreter can't hang the CLI.
             timeout=_GIT_TIMEOUT_SECONDS,
             check=False,
         )
@@ -1442,6 +1444,10 @@ def _split_vcs_url(vcs_url: str) -> tuple[str, str | None]:
         ``("https://host/org/repo.git", "main")``.
     """
     url = vcs_url[4:] if vcs_url.startswith("git+") else vcs_url
+    # Drop a PEP 508 / pip URL fragment (``#egg=...`` / ``#subdirectory=...``).
+    # It is never part of the remote URL or the ref, and leaving it on would
+    # make ``git ls-remote`` query a nonexistent ref and silently return None.
+    url = url.split("#", 1)[0]
     at = url.rfind("@")
     if at > url.rfind("/"):  # '@' past the final path segment → revision suffix
         return url[:at], (url[at + 1 :] or None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnigent"
-version = "0.1.0"
+version = "0.2.0.dev0"
 description = "Omnigent: declarative agent authoring and runtime framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -25,8 +25,8 @@ dependencies = [
     # one version, so a published `omnigent==X` must resolve the SDK wheels
     # built alongside it (release-omnigent.yml verifies these pins match the
     # release tag). Local/editable installs still resolve via tool.uv.sources.
-    "omnigent-client==0.1.0",
-    "omnigent-ui-sdk==0.1.0",
+    "omnigent-client==0.2.0.dev0",
+    "omnigent-ui-sdk==0.2.0.dev0",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-client"
-version = "0.1.0"
+version = "0.2.0.dev0"
 description = "Python client SDK for the omnigent server API"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -16,7 +16,7 @@ dependencies = [
     # editable alongside the root ``omnigent`` package. Version-locked
     # (==) so a published SDK always pairs with the server release it
     # shipped with (release-omnigent.yml verifies the pin).
-    "omnigent==0.1.0",
+    "omnigent==0.2.0.dev0",
     "httpx>=0.27",
     "pydantic>=2.0,<3",
 ]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-ui-sdk"
-version = "0.1.0"
+version = "0.2.0.dev0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ dependencies = [
     # at one version (release-omnigent.yml verifies the pin). A `>=`
     # floor would also reject pre-releases (e.g. 0.1.0rc1 < 0.1.0 in
     # PEP 440).
-    "omnigent-client==0.1.0",
+    "omnigent-client==0.2.0.dev0",
     "rich>=13",
     "prompt_toolkit>=3",
     "pyyaml>=6.0,<7",

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -1294,6 +1294,71 @@ def test_fetch_latest_version_pep691_json(monkeypatch: pytest.MonkeyPatch) -> No
     assert captured["headers"] == {"Accept": "application/vnd.pypi.simple.v1+json"}
 
 
+def test_fetch_latest_version_retries_transient_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``attempts=2`` retries a transient connection error, then succeeds.
+
+    Regression: the foreground ``omni upgrade`` shouldn't report the index as
+    unreachable on a single momentary blip against a slow mirror.
+    """
+    import httpx
+
+    from omnigent.update_check import fetch_latest_version
+
+    _clear_index_env(monkeypatch)
+    calls = {"n": 0}
+
+    def _get(url: str, **_kw: object) -> _FakeResp:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("transient")
+        return _FakeResp(json_body={"versions": ["0.1.0", "0.2.0"]})
+
+    monkeypatch.setattr(httpx, "get", _get)
+
+    assert fetch_latest_version(attempts=2) == "0.2.0"
+    assert calls["n"] == 2  # retried exactly once
+
+
+def test_fetch_latest_version_no_retry_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The background path (default ``attempts=1``) makes a single try."""
+    import httpx
+
+    from omnigent.update_check import fetch_latest_version
+
+    _clear_index_env(monkeypatch)
+    calls = {"n": 0}
+
+    def _get(url: str, **_kw: object) -> _FakeResp:
+        calls["n"] += 1
+        raise httpx.ConnectError("transient")
+
+    monkeypatch.setattr(httpx, "get", _get)
+
+    assert fetch_latest_version() is None
+    assert calls["n"] == 1
+
+
+def test_fetch_latest_version_does_not_retry_non_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A definitive non-200 reply is not retried, even with ``attempts=2``."""
+    import httpx
+
+    from omnigent.update_check import fetch_latest_version
+
+    _clear_index_env(monkeypatch)
+    calls = {"n": 0}
+
+    def _get(url: str, **_kw: object) -> _FakeResp:
+        calls["n"] += 1
+        return _FakeResp(status_code=503)
+
+    monkeypatch.setattr(httpx, "get", _get)
+
+    assert fetch_latest_version(attempts=2) is None
+    assert calls["n"] == 1
+
+
 def test_fetch_latest_version_from_files_when_no_versions_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -1977,3 +1977,69 @@ def test_format_version_omits_sha_when_build_info_has_empty_sha(
     # Critical: no orphan comma or empty parens from the missing SHA.
     assert "(, " not in out
     assert "()" not in out
+
+
+# --- VCS (git) install handling: passive notice + URL parsing -----------------
+
+
+def test_split_vcs_url_strips_prefix_and_separates_revision() -> None:
+    """``git+<url>@<rev>`` splits into the bare repo URL and the revision."""
+    from omnigent.update_check import _split_vcs_url
+
+    assert _split_vcs_url("git+https://github.com/o/omnigent.git") == (
+        "https://github.com/o/omnigent.git",
+        None,
+    )
+    assert _split_vcs_url("git+https://github.com/o/omnigent.git@main") == (
+        "https://github.com/o/omnigent.git",
+        "main",
+    )
+
+
+def test_split_vcs_url_ssh_userinfo_is_not_a_revision() -> None:
+    """An ``@`` in SSH userinfo (``git@host``) must not be read as a revision."""
+    from omnigent.update_check import _split_vcs_url
+
+    assert _split_vcs_url("git+ssh://git@github.com/o/omnigent.git") == (
+        "ssh://git@github.com/o/omnigent.git",
+        None,
+    )
+    # …but a real trailing revision still parses, even with SSH userinfo.
+    assert _split_vcs_url("git+ssh://git@github.com/o/omnigent.git@v1") == (
+        "ssh://git@github.com/o/omnigent.git",
+        "v1",
+    )
+
+
+def test_wheel_check_skips_vcs_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A git/VCS install is never nagged about a PyPI version.
+
+    Its version string is frozen at the source branch's (e.g. an unbumped
+    ``main`` still saying ``0.1.0``), so a PyPI-version comparison would
+    fire forever — even on a build that is *ahead* of the latest release.
+    The passive notice must bail for vcs installs just like editable ones.
+    """
+    monkeypatch.delenv("OMNIGENT_NO_UPDATE_CHECK", raising=False)
+    _point_cache_at(tmp_path, monkeypatch)
+    _write_cache(
+        _CacheEntry(
+            last_check_epoch=time.time(),
+            commits_behind=0,
+            kind="wheel",
+            latest_version="0.2.0",  # strictly newer than the dist's 0.1.0
+        )
+    )
+    dist = _write_fake_dist_info(
+        tmp_path,
+        installer="uv",
+        direct_url={"url": _FAKE_GIT_URL, "vcs_info": {"vcs": "git", "commit_id": _FAKE_COMMIT}},
+    )
+    monkeypatch.setattr("omnigent.update_check._get_distribution", lambda: dist)
+
+    _run_installed_wheel_check()
+
+    assert capsys.readouterr().err == ""

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -1996,6 +1996,24 @@ def test_split_vcs_url_strips_prefix_and_separates_revision() -> None:
     )
 
 
+def test_split_vcs_url_strips_pip_fragment() -> None:
+    """A ``#egg=`` / ``#subdirectory=`` fragment is dropped from URL and ref.
+
+    Left on, the fragment would ride along into ``git ls-remote`` and match no
+    ref, silently making the commit comparison indeterminate.
+    """
+    from omnigent.update_check import _split_vcs_url
+
+    assert _split_vcs_url("git+https://github.com/o/omnigent.git#egg=omnigent") == (
+        "https://github.com/o/omnigent.git",
+        None,
+    )
+    assert _split_vcs_url("git+https://github.com/o/omnigent.git@main#subdirectory=pkg") == (
+        "https://github.com/o/omnigent.git",
+        "main",
+    )
+
+
 def test_split_vcs_url_ssh_userinfo_is_not_a_revision() -> None:
     """An ``@`` in SSH userinfo (``git@host``) must not be read as a revision."""
     from omnigent.update_check import _split_vcs_url

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -216,7 +216,7 @@ def test_upgrade_pre_check_detects_release_candidate(
     """``--pre --check`` includes pre-releases and reports the rc as available."""
     captured: dict[str, object] = {}
 
-    def _fetch(include_prereleases: bool = False) -> str:
+    def _fetch(include_prereleases: bool = False, **_kw: object) -> str:
         captured["include_prereleases"] = include_prereleases
         return "0.1.1rc1" if include_prereleases else "0.1.0"
 
@@ -234,7 +234,7 @@ def test_upgrade_without_pre_ignores_release_candidate(
 ) -> None:
     """Without ``--pre`` the rc is invisible → reports up to date."""
 
-    def _fetch(include_prereleases: bool = False) -> str | None:
+    def _fetch(include_prereleases: bool = False, **_kw: object) -> str | None:
         return "0.1.1rc1" if include_prereleases else "0.1.0"
 
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", _fetch)
@@ -298,7 +298,7 @@ def test_upgrade_pre_passes_prerelease_flag_to_installer(
     """``--pre`` upgrade runs the uv command with ``--prerelease allow``."""
     monkeypatch.setattr(
         "omnigent.update_check.fetch_latest_version",
-        lambda include_prereleases=False: "0.1.1rc1",
+        lambda include_prereleases=False, **_kw: "0.1.1rc1",
     )
     monkeypatch.setattr("omnigent.cli._wait_for_local_sessions_to_drain", lambda: None)
     monkeypatch.setattr("omnigent.cli._stop_local_server_and_daemon", lambda *, force: False)

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -25,6 +25,19 @@ def _uv_registry_info() -> _InstalledWheelInfo:
     )
 
 
+def _git_install_info() -> _InstalledWheelInfo:
+    """A git/VCS uv-tool install → ``uv tool install --reinstall git+…``."""
+    return _InstalledWheelInfo(
+        install_time_epoch=0.0,
+        installer="uv",
+        vcs_url="git+https://github.com/omnigent-ai/omnigent.git",
+        commit_sha="a" * 40,
+        is_editable=False,
+        package_version="0.1.0",
+        detected_installer="uv",
+    )
+
+
 @pytest.fixture
 def _wheel_install(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make the running interpreter look like a registry uv-tool install.
@@ -103,6 +116,11 @@ def test_upgrade_runs_installer_and_drains_first(
         return 0
 
     monkeypatch.setattr("omnigent.update_check._run_upgrade_command", _run)
+    # The post-upgrade verification re-reads the installed version in a fresh
+    # subprocess; stub it to report the version the installer "moved" to.
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.2.0", None)
+    )
 
     result = CliRunner().invoke(cli, ["upgrade"])
 
@@ -130,6 +148,9 @@ def test_upgrade_force_skips_drain_and_force_stops(
         lambda *, force: stop_calls.append(force) or False,
     )
     monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.2.0", None)
+    )
 
     result = CliRunner().invoke(cli, ["upgrade", "--force"])
 
@@ -286,8 +307,136 @@ def test_upgrade_pre_passes_prerelease_flag_to_installer(
         "omnigent.update_check._run_upgrade_command",
         lambda command, _console: ran.append(command) or 0,
     )
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.1.1rc1", None)
+    )
 
     result = CliRunner().invoke(cli, ["upgrade", "--pre"])
 
     assert result.exit_code == 0, result.output
     assert ran == ["uv tool upgrade omnigent --prerelease allow"]
+
+
+def test_upgrade_noop_install_reports_failure_not_success(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """Regression: a no-op upgrade must NOT claim success.
+
+    The installer exits 0 but the installed version doesn't move (a pinned
+    spec, a cooldown/exclude-newer excluding the release, or a stale index
+    cache). The old code printed "✓ Upgraded to v0.2.0" anyway, so the next
+    ``--check`` kept reporting the same update — the bug this guards against.
+    """
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 0)
+    # The installer ran (exit 0) but the version is unchanged.
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.1.0", None)
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code != 0, result.output
+    assert "still v0.1.0" in result.output
+    assert "✓ Upgraded" not in result.output
+
+
+def test_upgrade_unconfirmed_version_is_honest(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """When the new version can't be read back, don't assert a version."""
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: (None, None)
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "couldn't confirm" in result.output
+    assert "✓ Upgraded" not in result.output
+
+
+def test_upgrade_git_install_up_to_date(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """A git install whose ref hasn't moved reports up to date by commit."""
+    monkeypatch.setattr("omnigent.update_check._read_installed_wheel_info", _git_install_info)
+    # fetch_latest_version must never be consulted for a git install.
+    monkeypatch.setattr(
+        "omnigent.update_check.fetch_latest_version",
+        lambda *_a, **_k: pytest.fail("git install must not query PyPI"),
+    )
+    monkeypatch.setattr("omnigent.update_check._remote_git_head", lambda _url: "a" * 40)
+
+    def _must_not_run(*_a: object, **_k: object) -> int:
+        raise AssertionError("nothing to re-pull when already at the ref HEAD")
+
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", _must_not_run)
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "up to date" in result.output
+
+
+def test_upgrade_git_check_behind_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """``--check`` on a git install behind its ref reports the delta, exits non-zero."""
+    monkeypatch.setattr("omnigent.update_check._read_installed_wheel_info", _git_install_info)
+    monkeypatch.setattr("omnigent.update_check._remote_git_head", lambda _url: "b" * 40)
+
+    def _must_not_run(*_a: object, **_k: object) -> int:
+        raise AssertionError("--check must not re-pull")
+
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", _must_not_run)
+
+    result = CliRunner().invoke(cli, ["upgrade", "--check"])
+
+    assert result.exit_code == 1, result.output
+    assert "newer commit is available" in result.output
+
+
+def test_upgrade_git_install_repulls_and_verifies_commit(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """A git install behind its ref re-pulls and reports the NEW commit."""
+    monkeypatch.setattr("omnigent.update_check._read_installed_wheel_info", _git_install_info)
+    monkeypatch.setattr("omnigent.update_check._remote_git_head", lambda _url: "b" * 40)
+
+    ran: list[str] = []
+    monkeypatch.setattr(
+        "omnigent.update_check._run_upgrade_command",
+        lambda command, _console: ran.append(command) or 0,
+    )
+    # After re-pull the install is at the new commit.
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.1.0", "b" * 40)
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert ran == ["uv tool install --reinstall git+https://github.com/omnigent-ai/omnigent.git"]
+    assert "Updated to git bbbbbbbbb" in result.output
+
+
+def test_upgrade_git_install_noop_does_not_claim_update(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """If the re-pull leaves the commit unchanged, say so — don't claim an update."""
+    monkeypatch.setattr("omnigent.update_check._read_installed_wheel_info", _git_install_info)
+    # Remote unknown (e.g. offline) → re-pull anyway, then verify by commit.
+    monkeypatch.setattr("omnigent.update_check._remote_git_head", lambda _url: None)
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.1.0", "a" * 40)
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "nothing changed" in result.output
+    assert "✓ Updated" not in result.output

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -440,3 +440,24 @@ def test_upgrade_git_install_noop_does_not_claim_update(
     assert result.exit_code == 0, result.output
     assert "nothing changed" in result.output
     assert "✓ Updated" not in result.output
+
+
+def test_upgrade_git_confirmed_behind_but_repull_noop_fails(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """Regression: known-behind git install whose re-pull doesn't move the commit
+    must FAIL, not silently exit 0 (else it recreates the loop on the git path)."""
+    monkeypatch.setattr("omnigent.update_check._read_installed_wheel_info", _git_install_info)
+    # Remote HEAD differs from the installed commit ("a"*40) → positively behind.
+    monkeypatch.setattr("omnigent.update_check._remote_git_head", lambda _url: "b" * 40)
+    monkeypatch.setattr("omnigent.update_check._run_upgrade_command", lambda *_a, **_k: 0)
+    # …but the re-pull left the install on the SAME commit (pinned ref / cached).
+    monkeypatch.setattr(
+        "omnigent.update_check._probe_installed_distribution", lambda: ("0.1.0", "a" * 40)
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+
+    assert result.exit_code != 0, result.output
+    assert "still at aaaaaaaaa" in result.output
+    assert "✓ Updated" not in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -2697,7 +2697,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.1.0"
+version = "0.2.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2889,7 +2889,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "verte
 
 [[package]]
 name = "omnigent-client"
-version = "0.1.0"
+version = "0.2.0.dev0"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -2906,7 +2906,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.1.0"
+version = "0.2.0.dev0"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.1.0" },
+    { name = "omnigent-client", specifier = "==0.2.0.dev0" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },


### PR DESCRIPTION
## Problem

<img width="863" height="470" alt="Screenshot 2026-06-18 at 5 05 54 PM" src="https://github.com/user-attachments/assets/61f0180d-082a-42bb-8ff7-33b5db92560a" />

`omni upgrade` reported `✓ Upgraded to v{latest}` whenever the installer subprocess exited `0` — it never checked that the install actually advanced. A user upgrading from a dev/source build hit an infinite loop: `omni upgrade` claimed success, but the next `omni upgrade --check` still said `v0.1.0 → v0.1.1`.

Reproduced end-to-end and traced to **three** compounding root causes:

1. **`main`'s version was frozen at a released number.** `0.1.1` was cut from a `release/*` branch and the bump never merged back, so `main`'s `pyproject` stayed `0.1.0` across 400+ commits. Every git/source build of `main` therefore read as "behind" PyPI forever — even though it's *ahead* of the release.
2. **git/VCS installs were compared against PyPI by version string.** That's meaningless for a moving ref and *unsatisfiable*: the upgrade command for a git install reinstalls the same ref, which can never change the version string → guaranteed false "upgraded" + infinite loop.
3. **No post-upgrade verification.** Any no-op upgrade (version-pinned spec, a cooldown / `exclude-newer` excluding the release, or a stale index cache) exits `0` without moving, and the old code printed `✓ Upgraded` anyway.

## Fix

1. **Bump `main` to a dev marker (`0.2.0.dev0`).** Matches the MLflow / Delta Lake / Unity Catalog convention — `main` carries the *next* version with a pre-release suffix (`.devN` / `-SNAPSHOT`), never the bare last release. Keeps it PEP 440-ordered (`0.1.1 < 0.2.0.dev0 < 0.2.0`) so the update check can't false-fire, and `omni --version` honestly marks dev builds. Updates the three lockstep `pyproject.toml`s + their `==` pins + `uv.lock`.
2. **Make `omni upgrade` git-aware.** vcs installs now compare and verify by **commit** (`git ls-remote` + a post-pull commit re-probe), not by PyPI version; the passive update nag skips vcs installs (like editable ones).
3. **Verify before claiming success.** After running the installer, re-read the installed version/commit in a fresh subprocess (the running process holds stale metadata) and only print `✓ Upgraded` if it truly advanced; otherwise report honestly and exit non-zero.

## Upgrade behavior: PyPI install vs git install

The install shape is detected from PEP 610 `direct_url.json` (`vcs_info` → git; `dir_info.editable` / reachable `.git/` → refused with "use `git pull`"; otherwise → PyPI). The two shapes track **different lines** and never cross-compare:

| | PyPI install (`uv tool install omnigent`) | Git install (`uv tool install git+…/omnigent.git[@ref]`) |
|---|---|---|
| Tracks | PyPI **release line** | the **git ref** (branch/tag) |
| Compares by | **version** (PEP 440, configured index) | **commit** (`git ls-remote` vs installed `commit_id`) |
| Upgrade command | `uv tool upgrade` / `pip install -U` / … | `uv tool install --reinstall git+<url>` |
| Success criterion | installed **version** advanced | installed **commit** changed |
| Passive "update available" nag | yes | no (silent, like editable) |
| `omni --version` | `0.1.1` | `0.2.0.dev0 (<sha>, built …)` |

So a git-`main` build is only ever asked "has my ref moved?" (never "is there a newer PyPI release?"), and a PyPI install is only asked "is there a newer release?" — and neither claims success without verifying the thing it tracks actually changed. (A git install pinned to a tag never moves, so it stays "up to date"; `uv run omni` isn't a separate shape — it runs whatever `omni` is on `PATH`.)

## Testing

- **Unit:** 109 tests pass, including new coverage for the no-op false-success guard, the git-install path (up-to-date / behind / re-pull / converge), VCS-URL parsing, and the vcs-skip in the passive notice.
- **End-to-end** re-test of all three original failure modes against the fixed code:

  | Failure case (before) | After |
  |---|---|
  | registry/main build → `v0.1.0 → v0.1.1` loop forever | `up to date (v0.2.0.dev0)`, exit 0 |
  | no-op upgrade → false `✓ Upgraded to v0.1.1` | honest failure, version unchanged, exit ≠0 |
  | git install → false `✓ Upgraded`, commit unchanged, loops | behind-by-commit → re-pull → `✓ Updated to git <sha>` → converges |

- `ruff` clean; `mypy` clean for the changed code.

## Follow-up (not in this PR)

The durable form of root cause #1 is a process fix: either merge the release bump back to `main` each cycle, or adopt `setuptools-scm` / a single `version.py` source of truth (MLflow-style) to eliminate the manual multi-file version bump.

This pull request and its description were written by Isaac.