### PR TITLE
fix(web-ui): split codex reasoning-summary paragraphs on part boundary (#654)

### DIFF
--- a/ap-web/src/lib/blockStream.test.ts
+++ b/ap-web/src/lib/blockStream.test.ts
@@ -418,6 +418,34 @@ describe("BlockStream — reasoning", () => {
     expect(startIdx).toBeLessThan(chunkIdx);
   });
 
+  it("reasoning_summary_part_done flushes the held tail and separates consecutive parts", () => {
+    // Issue #654: Codex reasoning-summary paragraphs stream as one
+    // continuous run of ReasoningSummaryDelta with no \n in the text and
+    // no fresh ReasoningStarted between parts. The paragraph boundary
+    // arrives out-of-band as response.reasoning_summary_part.done. Without
+    // handling it, part one's trailing fragment ("names.") stays buffered
+    // and renders late, glued onto part two ("names.I have…"). The boundary
+    // event must flush the held tail AND insert a "\n\n" separator.
+    const blocks = reduce([
+      { type: "response_created", response: makeResponse() },
+      { type: "reasoning_summary_delta", delta: "drilling into folder names." },
+      { type: "reasoning_summary_part_done" },
+      { type: "reasoning_summary_delta", delta: "I have the runner now." },
+      { type: "text_delta", delta: "Answer" },
+      { type: "message_done", content: [], itemId: "", responseId: "" },
+      { type: "response_completed", response: makeResponse() },
+    ]);
+
+    const chunks = blocks.filter((b): b is ReasoningChunk => b.type === "reasoning_chunk");
+    const joined = chunks.map((c) => c.text).join("");
+    // Symptom 2: a paragraph separator lands between the two parts.
+    expect(joined).toContain("names.\n\nI have the runner now.");
+    expect(joined).not.toContain("names.I have");
+    // Symptom 1: part one's tail flushes AT the boundary (a chunk ending
+    // in "names.\n\n"), not late and glued onto part two.
+    expect(chunks.some((c) => c.text === "names.\n\n")).toBe(true);
+  });
+
   it("interleaved text→reasoning→text closes each text section (no orphan, no concatenation)", () => {
     // think→speak→think→speak in one response: reasoning must close text
     // or the pre-reasoning text orphans and the final text_done concatenates.

--- a/ap-web/src/lib/blockStream.ts
+++ b/ap-web/src/lib/blockStream.ts
@@ -443,6 +443,28 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
       return;
     }
 
+    case "reasoning_summary_part_done": {
+      // A summary part (paragraph) finished. Codex reasoning summaries
+      // stream as one continuous run of reasoning_summary_delta with no
+      // newline and no fresh reasoning_started between parts; the
+      // boundary arrives out-of-band here. Flush this part's held tail
+      // and insert a separator so the next part renders on its own line
+      // instead of glued onto this one ("…names.I have…"). See issue
+      // #654. Mirrors the reasoning_started-between-parts branch above.
+      // No-op outside reasoning or before any content streamed (no
+      // leading separator).
+      if (state.inReasoning && (state.reasoningAccumulated || state.reasoningChunksEmitted)) {
+        yield {
+          type: "reasoning_chunk",
+          ctx: ctx(state),
+          text: state.reasoningAccumulated + "\n\n",
+        } satisfies ReasoningChunk;
+        state.reasoningAccumulated = "";
+        state.reasoningChunksEmitted = true;
+      }
+      return;
+    }
+
     // ── Text ────────────────────────────────────────
     case "text_delta": {
       yield* closeReasoning(state);

--- a/ap-web/src/lib/events.ts
+++ b/ap-web/src/lib/events.ts
@@ -114,6 +114,18 @@ export interface ReasoningSummaryDelta {
   delta: string;
 }
 
+/**
+ * `response.reasoning_summary_part.done` — a summary paragraph ended.
+ *
+ * The Responses API delimits successive reasoning-summary paragraphs
+ * with this boundary; the `reasoning_summary_delta` fragments within a
+ * part carry no trailing newline. The reducer uses it to flush the
+ * held tail and insert a paragraph separator (issue #654).
+ */
+export interface ReasoningSummaryPartDone {
+  type: "reasoning_summary_part_done";
+}
+
 // ── Parsed output items ─────────────────────────────────
 
 /** A tool call from `output_item.done` (type `function_call`). */
@@ -756,6 +768,7 @@ export type StreamEvent =
   | ReasoningStarted
   | ReasoningDelta
   | ReasoningSummaryDelta
+  | ReasoningSummaryPartDone
   | ToolCall
   | ToolResult
   | NativeToolCall

--- a/ap-web/src/lib/sse.test.ts
+++ b/ap-web/src/lib/sse.test.ts
@@ -60,3 +60,13 @@ describe("parseEvent — response.output_text.delta", () => {
     expect(parseEvent("response.output_text.delta", { delta: { text: "bad" } })).toBeNull();
   });
 });
+
+describe("parseEvent — response.reasoning_summary_part.done", () => {
+  it("maps the reasoning-summary part boundary to reasoning_summary_part_done", () => {
+    // Issue #654: the Responses-API paragraph boundary must reach the
+    // reducer so consecutive reasoning parts render separated.
+    expect(parseEvent("response.reasoning_summary_part.done", {})).toEqual({
+      type: "reasoning_summary_part_done",
+    });
+  });
+});

--- a/ap-web/src/lib/sse.ts
+++ b/ap-web/src/lib/sse.ts
@@ -23,6 +23,7 @@ import type {
   ReasoningDelta,
   ReasoningStarted,
   ReasoningSummaryDelta,
+  ReasoningSummaryPartDone,
   ResponseCancelled,
   ResponseCompleted,
   ResponseCreated,
@@ -333,6 +334,9 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
     if (typeof delta === "string")
       return { type: "reasoning_summary_delta", delta } satisfies ReasoningSummaryDelta;
     return null;
+  }
+  if (eventType === "response.reasoning_summary_part.done") {
+    return { type: "reasoning_summary_part_done" } satisfies ReasoningSummaryPartDone;
   }
 
   // Output items.

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -949,6 +949,7 @@ def _server_event_to_sdk_event(event: object) -> object | None:
         ReasoningDelta,
         ReasoningStarted,
         ReasoningSummaryDelta,
+        ReasoningSummaryPartDone,
         ResponseCancelled,
         ResponseCompleted,
         ResponseCreated,
@@ -980,6 +981,7 @@ def _server_event_to_sdk_event(event: object) -> object | None:
         OutputTextDeltaEvent,
         QueuedEvent,
         ReasoningStartedEvent,
+        ReasoningSummaryPartDoneEvent,
         ReasoningSummaryTextDeltaEvent,
         ReasoningTextDeltaEvent,
     )
@@ -1012,6 +1014,8 @@ def _server_event_to_sdk_event(event: object) -> object | None:
         return ReasoningDelta(delta=event.delta)
     if isinstance(event, ReasoningSummaryTextDeltaEvent):
         return ReasoningSummaryDelta(delta=event.delta)
+    if isinstance(event, ReasoningSummaryPartDoneEvent):
+        return ReasoningSummaryPartDone()
     if isinstance(event, ElicitationRequestEvent):
         params = event.params
         return ElicitationRequest(

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2620,6 +2620,27 @@ class ReasoningSummaryTextDeltaEvent(_SSEEventBase):
     delta: str
 
 
+class ReasoningSummaryPartDoneEvent(_SSEEventBase):
+    """
+    A reasoning-summary part (paragraph) finished.
+
+    The Responses API delimits successive reasoning-summary
+    paragraphs with ``response.reasoning_summary_part.done`` (one per
+    completed part), while the ``reasoning_summary_text.delta``
+    fragments within a part carry no trailing newline of their own.
+    Without this boundary, consecutive parts render run together
+    ("...folder names.I have the runner...") and the part's trailing
+    fragment streams late, glued onto the next paragraph. Consumers
+    (the ap-web / SDK ``BlockStream`` reducers) use this event to
+    flush the held tail and insert a paragraph separator. See issue
+    #654.
+
+    :param type: Always ``"response.reasoning_summary_part.done"``.
+    """
+
+    type: Literal["response.reasoning_summary_part.done"]
+
+
 class OutputItemDoneEvent(_SSEEventBase):
     """
     A conversation output item completed during the turn.
@@ -3430,6 +3451,7 @@ ServerStreamEvent = Annotated[
     | ReasoningStartedEvent
     | ReasoningTextDeltaEvent
     | ReasoningSummaryTextDeltaEvent
+    | ReasoningSummaryPartDoneEvent
     # ── Persistent (POST + SSE replay) — wraps conv-store items
     | OutputItemDoneEvent
     # ── Transient (SSE-only) — file annotations / keepalive ────

--- a/sdks/python-client/omnigent_client/_events.py
+++ b/sdks/python-client/omnigent_client/_events.py
@@ -116,6 +116,17 @@ class ReasoningSummaryDelta:
     delta: str
 
 
+@dataclass
+class ReasoningSummaryPartDone:
+    """``response.reasoning_summary_part.done`` — a summary paragraph ended.
+
+    The Responses API delimits successive reasoning-summary paragraphs
+    with this boundary; the ``ReasoningSummaryDelta`` fragments within a
+    part carry no trailing newline. The reducer uses it to flush the
+    held tail and insert a paragraph separator (issue #654).
+    """
+
+
 # ── Parsed output items ─────────────────────────────────
 
 
@@ -326,6 +337,7 @@ StreamEvent = (
     | ReasoningStarted
     | ReasoningDelta
     | ReasoningSummaryDelta
+    | ReasoningSummaryPartDone
     | ToolCall
     | ToolResult
     | NativeToolCall

--- a/sdks/python-client/omnigent_client/_sse.py
+++ b/sdks/python-client/omnigent_client/_sse.py
@@ -25,6 +25,7 @@ from ._events import (
     ReasoningDelta,
     ReasoningStarted,
     ReasoningSummaryDelta,
+    ReasoningSummaryPartDone,
     ResponseCancelled,
     ResponseCompleted,
     ResponseCreated,
@@ -74,6 +75,7 @@ _T_RESPONSE_OUTPUT_TEXT_DELTA = _wire_type(_srv_events.OutputTextDeltaEvent)
 _T_RESPONSE_REASONING_STARTED = _wire_type(_srv_events.ReasoningStartedEvent)
 _T_RESPONSE_REASONING_TEXT_DELTA = _wire_type(_srv_events.ReasoningTextDeltaEvent)
 _T_RESPONSE_REASONING_SUMMARY_TEXT_DELTA = _wire_type(_srv_events.ReasoningSummaryTextDeltaEvent)
+_T_RESPONSE_REASONING_SUMMARY_PART_DONE = _wire_type(_srv_events.ReasoningSummaryPartDoneEvent)
 _T_RESPONSE_OUTPUT_ITEM_DONE = _wire_type(_srv_events.OutputItemDoneEvent)
 _T_RESPONSE_OUTPUT_FILE_DONE = _wire_type(_srv_events.OutputFileDoneEvent)
 _T_RESPONSE_RETRY = _wire_type(_srv_events.RetryEvent)
@@ -198,6 +200,8 @@ def _parse_event(event_type: str, data: dict[str, Any]) -> StreamEvent | None:
         if isinstance(delta, str):
             return ReasoningSummaryDelta(delta=delta)
         return None
+    if event_type == _T_RESPONSE_REASONING_SUMMARY_PART_DONE:
+        return ReasoningSummaryPartDone()
 
     # Output items
     if event_type == _T_RESPONSE_OUTPUT_ITEM_DONE:

--- a/sdks/python-client/omnigent_client/_stream.py
+++ b/sdks/python-client/omnigent_client/_stream.py
@@ -39,6 +39,7 @@ from ._events import (
     ReasoningDelta,
     ReasoningStarted,
     ReasoningSummaryDelta,
+    ReasoningSummaryPartDone,
     ResponseCancelled,
     ResponseCompleted,
     ResponseCreated,
@@ -320,6 +321,22 @@ class BlockStream:
                         )
                         reasoning_accumulated = reasoning_accumulated[last_space + 1 :]
                         reasoning_chunks_emitted = True
+
+            elif isinstance(event, ReasoningSummaryPartDone):
+                # A summary part (paragraph) finished. Codex reasoning
+                # summaries stream as one continuous run of
+                # ReasoningSummaryDelta with no newline and no fresh
+                # ReasoningStarted between parts; the boundary arrives
+                # out-of-band here. Flush this part's held tail and insert
+                # a separator so the next part renders on its own line
+                # instead of glued onto this one ("…names.I have…"). See
+                # issue #654. Mirrors the ReasoningStarted-between-parts
+                # branch above. No-op outside reasoning or before any
+                # content streamed (no leading separator).
+                if in_reasoning and (reasoning_accumulated or reasoning_chunks_emitted):
+                    yield ReasoningChunk(text=reasoning_accumulated + "\n\n", ctx=_ctx())
+                    reasoning_accumulated = ""
+                    reasoning_chunks_emitted = True
 
             # ── Text ─────────────────────────────────
             elif isinstance(event, TextDelta):

--- a/tests/frontends/sdk/test_stream.py
+++ b/tests/frontends/sdk/test_stream.py
@@ -20,6 +20,7 @@ from omnigent_client._events import (
     ReasoningDelta,
     ReasoningStarted,
     ReasoningSummaryDelta,
+    ReasoningSummaryPartDone,
     ResponseCompleted,
     ResponseCreated,
     ResponseInProgress,
@@ -264,6 +265,42 @@ async def test_consecutive_reasoning_blocks_are_separated(
     joined = "".join(b.text for b in blocks if isinstance(b, ReasoningChunk))
     assert "First thought.\n\nSecond thought." in joined, joined
     assert "First thought.Second thought." not in joined, joined
+
+
+@pytest.mark.asyncio()
+async def test_reasoning_summary_part_done_separates_and_flushes(
+    block_stream: BlockStream,
+) -> None:
+    """
+    Issue #654: Codex reasoning-summary paragraphs stream as one
+    continuous run of ``ReasoningSummaryDelta`` with no newline in the
+    text and no fresh ``ReasoningStarted`` between parts. The paragraph
+    boundary arrives out-of-band as
+    ``response.reasoning_summary_part.done``. Without handling it, part
+    one's trailing fragment ("names.") stays buffered and renders late,
+    glued onto part two ("names.I have..."). The boundary must flush the
+    held tail AND insert a "\\n\\n" separator.
+    """
+    session = FakeSession(
+        [
+            ResponseCreated(response=_make_response()),
+            ReasoningSummaryDelta(delta="drilling into folder names."),
+            ReasoningSummaryPartDone(),
+            ReasoningSummaryDelta(delta="I have the runner now."),
+            TextDelta(delta="Answer"),
+            MessageDone(content=[]),
+            ResponseCompleted(response=_make_response()),
+        ]
+    )
+
+    blocks = [b async for b in block_stream.stream(session, "test")]  # type: ignore[arg-type]
+    chunks = [b for b in blocks if isinstance(b, ReasoningChunk)]
+    joined = "".join(b.text for b in chunks)
+    # Symptom 2: a paragraph separator lands between the two parts.
+    assert "names.\n\nI have the runner now." in joined, joined
+    assert "names.I have" not in joined, joined
+    # Symptom 1: part one's tail flushes AT the boundary, not late.
+    assert any(b.text == "names.\n\n" for b in chunks), [b.text for b in chunks]
 
 
 @pytest.mark.asyncio()

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -35,6 +35,7 @@ from omnigent.server.schemas import (
     OutputTextDeltaEvent,
     QueuedEvent,
     ReasoningStartedEvent,
+    ReasoningSummaryPartDoneEvent,
     ReasoningSummaryTextDeltaEvent,
     ReasoningTextDeltaEvent,
     ResponseObject,
@@ -80,6 +81,24 @@ def test_reasoning_summary_text_delta_roundtrip() -> None:
         "type": "response.reasoning_summary_text.delta",
         "delta": "Will use search",
     }
+
+
+def test_reasoning_summary_part_done_roundtrip() -> None:
+    """ReasoningSummaryPartDoneEvent has no fields beyond type (issue #654)."""
+    event = ReasoningSummaryPartDoneEvent(type="response.reasoning_summary_part.done")
+    assert event.model_dump(exclude_none=True) == {
+        "type": "response.reasoning_summary_part.done",
+    }
+
+
+def test_reasoning_summary_part_done_parses_through_union() -> None:
+    """A reasoning-summary part boundary POSTed by a producer (e.g. a
+    custom Codex harness forwarding the Responses stream) is recognized
+    by the discriminated union and not dropped as unknown."""
+    parsed = TypeAdapter(ServerStreamEvent).validate_python(
+        {"type": "response.reasoning_summary_part.done"}
+    )
+    assert isinstance(parsed, ReasoningSummaryPartDoneEvent)
 
 
 def test_output_item_done_roundtrip() -> None:


### PR DESCRIPTION
Fixes #654.

## Symptoms
When a codex agent streams reasoning, the omnigent web UI's "Thinking…" panel:
1. **appears to hang mid-sentence** — a paragraph's final word streams late, and
2. **doesn't split paragraphs** — the next paragraph is glued onto the previous one with no separator (`…just the folder names.I have the runner's main HTTP app now.`).

## Root cause (one cause, both symptoms)
Codex reasoning summaries arrive as a single continuous run of `response.reasoning_summary_text.delta` events whose text carries **no newline**, and with **no fresh `response.reasoning.started`** between paragraphs. The Responses API delimits successive summary paragraphs with **`response.reasoning_summary_part.done`** — but omnigent didn't model that event, so the SSE parsers dropped it as unknown.

The shared `BlockStream` reducer (`ap-web/src/lib/blockStream.ts` and its python-client mirror `omnigent_client/_stream.py`) inserts a paragraph separator and flushes the held tail in exactly one place: a fresh `reasoning_started` while already in-reasoning. With no between-part signal ever reaching it, the reducer:
- held each paragraph's post-last-space tail in `reasoningAccumulated` until the *next* delta arrived → the last word streamed late (symptom 1), and
- never inserted a `\n\n` between parts → paragraphs rendered run-together (symptom 2).

## Fix
Model the boundary end to end as `response.reasoning_summary_part.done` and act on it in the reducer:
- **`omnigent/server/schemas.py`** — add `ReasoningSummaryPartDoneEvent` to the SSE union (so a producer forwarding the Responses stream — e.g. a custom codex harness — can post it and the server forwards it).
- **`ap-web` `events.ts` / `sse.ts`** and **python-client `_events.py` / `_sse.py`** — parse the wire event into a typed `ReasoningSummaryPartDone`.
- **`blockStream.ts` + `_stream.py`** — on the boundary, flush the held tail and insert `\n\n`, reusing the existing `reasoning_started`-between-parts mechanism (no leading/spurious separators).
- **`omnigent/repl/_repl.py`** — translate the new server event to the SDK event so the CLI reducer renders separated parts too.

The change is additive (no behavior change for any existing event) and keeps the TS/Python reducer parity.

## Tests
- `blockStream.test.ts` + `tests/frontends/sdk/test_stream.py` — mirrored reducer tests asserting the separator lands between parts and the tail flushes **at** the boundary (RED before the fix, GREEN after).
- `sse.test.ts` — SSE parse of `response.reasoning_summary_part.done`.
- `tests/server/test_schemas.py` — schema round-trip + discriminated-union recognition.

Verified locally: full ap-web vitest suite + typecheck, and the python SDK/server/REPL/executor-adapter suites pass; ruff/oxlint/prettier clean.
