### PR TITLE
fix(desktop): click an OS notification to open its chat

### DIFF
--- a/ap-web/electron/src/main.js
+++ b/ap-web/electron/src/main.js
@@ -1677,13 +1677,23 @@ function registerIpc() {
       title,
       body: String(params?.body ?? ""),
     });
+    // In-app path the SPA wants opened on click (e.g. "/c/conv_abc"). Captured
+    // here so the click handler can tell the renderer where to route.
+    const navigatePath = typeof params?.navigatePath === "string" ? params.navigatePath : "";
     // Focus the window that fired the notification (so a click lands on the
     // right one in a multi-window setup), falling back to any open window.
+    // Then tell that window's SPA to navigate to the notification's
+    // conversation — focusing alone left the user on whatever chat was open.
     notification.on("click", () => {
       const win = BrowserWindow.fromWebContents(event.sender) ?? activeWindow();
       if (win) {
         if (win.isMinimized()) win.restore();
         win.focus();
+      }
+      // Route only the originating window (it owns that conversation's state);
+      // guard against a sender reloaded/closed since the toast was posted.
+      if (navigatePath && !event.sender.isDestroyed()) {
+        event.sender.send("omnigent:notification-activated", navigatePath);
       }
     });
     notification.show();

--- a/ap-web/electron/src/main.js
+++ b/ap-web/electron/src/main.js
@@ -1682,18 +1682,22 @@ function registerIpc() {
     const navigatePath = typeof params?.navigatePath === "string" ? params.navigatePath : "";
     // Focus the window that fired the notification (so a click lands on the
     // right one in a multi-window setup), falling back to any open window.
-    // Then tell that window's SPA to navigate to the notification's
-    // conversation — focusing alone left the user on whatever chat was open.
     notification.on("click", () => {
       const win = BrowserWindow.fromWebContents(event.sender) ?? activeWindow();
       if (win) {
         if (win.isMinimized()) win.restore();
         win.focus();
       }
-      // Route only the originating window (it owns that conversation's state);
-      // guard against a sender reloaded/closed since the toast was posted.
+      // Route only the originating window (it owns that conversation's state).
+      // isDestroyed() and send() aren't atomic — the window can close between
+      // them — so the try/catch absorbs the benign "Object has been destroyed"
+      // throw instead of crashing the main process from this async callback.
       if (navigatePath && !event.sender.isDestroyed()) {
-        event.sender.send("omnigent:notification-activated", navigatePath);
+        try {
+          event.sender.send("omnigent:notification-activated", navigatePath);
+        } catch {
+          // Sender went away after the notification was posted; nothing to do.
+        }
       }
     });
     notification.show();

--- a/ap-web/electron/src/preload.js
+++ b/ap-web/electron/src/preload.js
@@ -27,13 +27,28 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
   },
   /**
    * Fire an OS notification. Resolves true when shown, false otherwise.
-   * @param {{title: string, body?: string}} params
+   * @param {{title: string, body?: string, navigatePath?: string}} params
    */
   notify: (params) =>
     ipcRenderer.invoke("omnigent:notify", {
       title: params?.title,
       body: params?.body,
+      navigatePath: params?.navigatePath,
     }),
+  /**
+   * Subscribe to OS-notification clicks. The main process sends the in-app
+   * path the clicked notification carried, which we forward to the SPA so it
+   * can route there. Returns an unsubscribe function.
+   * @param {(path: string) => void} callback
+   * @returns {() => void}
+   */
+  onNotificationActivated: (callback) => {
+    const listener = (_event, path) => {
+      if (typeof path === "string" && path) callback(path);
+    };
+    ipcRenderer.on("omnigent:notification-activated", listener);
+    return () => ipcRenderer.removeListener("omnigent:notification-activated", listener);
+  },
   /**
    * Title-bar server picker data: the window's current server origin and the
    * recently-connected server URLs (most recent first). Resolves null on

--- a/ap-web/electron/src/preload.js
+++ b/ap-web/electron/src/preload.js
@@ -44,7 +44,10 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
    */
   onNotificationActivated: (callback) => {
     const listener = (_event, path) => {
-      if (typeof path === "string" && path) callback(path);
+      // Defense-in-depth: only forward in-app, same-origin paths. A leading
+      // "/" rejects absolute/cross-origin URLs and `javascript:` shapes before
+      // the renderer routes on the value, even if main ever sends junk.
+      if (typeof path === "string" && path.startsWith("/")) callback(path);
     };
     ipcRenderer.on("omnigent:notification-activated", listener);
     return () => ipcRenderer.removeListener("omnigent:notification-activated", listener);

--- a/ap-web/src/hooks/useIdleNotifications.test.tsx
+++ b/ap-web/src/hooks/useIdleNotifications.test.tsx
@@ -21,6 +21,9 @@ vi.mock("@/lib/browserNotifications", () => ({
 vi.mock("@/lib/nativeBridge", () => ({
   isNativeShell: vi.fn(),
   setBadgeCount: vi.fn().mockResolvedValue(undefined),
+  // Returns an unsubscribe fn; tests that exercise native click routing
+  // capture the registered callback via this mock's calls.
+  onNativeNotificationActivated: vi.fn().mockReturnValue(() => {}),
 }));
 
 // The turn-end notification body is enriched by an async fetch of the agent's
@@ -38,7 +41,7 @@ import {
   requestNotificationPermission,
   showNotification,
 } from "@/lib/browserNotifications";
-import { isNativeShell, setBadgeCount } from "@/lib/nativeBridge";
+import { isNativeShell, onNativeNotificationActivated, setBadgeCount } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
 import { markConversationSeen } from "@/hooks/useUnseenConversations";
 import { useIdleNotifications } from "./useIdleNotifications";
@@ -48,6 +51,7 @@ const getPermMock = vi.mocked(getNotificationPermission);
 const requestPermMock = vi.mocked(requestNotificationPermission);
 const showMock = vi.mocked(showNotification);
 const isNativeMock = vi.mocked(isNativeShell);
+const onNativeActivatedMock = vi.mocked(onNativeNotificationActivated);
 const setBadgeMock = vi.mocked(setBadgeCount);
 const fetchPreviewMock = vi.mocked(fetchLastAssistantText);
 
@@ -95,6 +99,8 @@ beforeEach(() => {
   showMock.mockReset();
   requestPermMock.mockReset();
   setBadgeMock.mockClear();
+  onNativeActivatedMock.mockClear();
+  onNativeActivatedMock.mockReturnValue(() => {});
   fetchPreviewMock.mockReset();
   fetchPreviewMock.mockResolvedValue(undefined);
   getPermMock.mockReturnValue("granted");
@@ -158,6 +164,25 @@ describe("useIdleNotifications turn-end transitions", () => {
 
     showMock.mock.calls[0][0].onClick?.();
     // Click routes to the session's chat page.
+    expect(navigateMock).toHaveBeenCalledWith("/c/a");
+    // The desktop shell can't carry the onClick closure across IPC, so the
+    // same destination is also passed as a plain path for the native path.
+    expect(showMock.mock.calls[0][0].navigatePath).toBe("/c/a");
+  });
+
+  it("routes to the conversation when the desktop shell reports a notification click", async () => {
+    isNativeMock.mockReturnValue(true);
+    setConversations([conv("a", "running")]);
+    renderHook(() => useIdleNotifications());
+
+    // The hook registers one native-activation listener; grab its callback
+    // and simulate the shell delivering a clicked notification's path.
+    expect(onNativeActivatedMock).toHaveBeenCalledOnce();
+    const activatedCb = onNativeActivatedMock.mock.calls[0][0];
+    act(() => {
+      activatedCb("/c/a");
+    });
+
     expect(navigateMock).toHaveBeenCalledWith("/c/a");
   });
 

--- a/ap-web/src/hooks/useIdleNotifications.ts
+++ b/ap-web/src/hooks/useIdleNotifications.ts
@@ -35,7 +35,7 @@ import {
   requestNotificationPermission,
   showNotification,
 } from "@/lib/browserNotifications";
-import { isNativeShell, setBadgeCount } from "@/lib/nativeBridge";
+import { isNativeShell, onNativeNotificationActivated, setBadgeCount } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
 import {
   buildElicitationMap,
@@ -124,6 +124,21 @@ export function useIdleNotifications(activeConversationId?: string): void {
   const activeIdRef = useRef<string | undefined>(activeConversationId);
   activeIdRef.current = activeConversationId;
 
+  // Keep the latest `navigate` readable from the once-mounted native-click
+  // listener below without re-subscribing whenever the router identity changes.
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  // Desktop shell only: clicking an OS notification can't run the web
+  // `onClick` closure (it never crosses the IPC boundary), so the shell sends
+  // back the notification's in-app path and we route to it here — making a
+  // native toast click open its conversation, matching the browser path.
+  useEffect(() => {
+    return onNativeNotificationActivated((path) => navigateRef.current(path));
+    // navigateRef is stable; the listener is mounted once for the app's life.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Send the badge count when it differs from the last one sent. No-op in a
   // plain browser (`setBadgeCount` is inert outside the desktop shell).
   const pushBadge = (count: number) => {
@@ -209,13 +224,18 @@ function notify(
   body: string,
   navigate: ReturnType<typeof useNavigate>,
 ): void {
+  const path = `/c/${conversation.id}`;
   showNotification({
     title: conversationDisplayLabel(conversation),
     body,
     // Tag by id so a later update for the same session replaces its
     // toast instead of stacking duplicates.
     tag: `omnigent:session:${conversation.id}`,
-    onClick: () => navigate(`/c/${conversation.id}`),
+    // Browser path: run navigation directly on click. Desktop shell path:
+    // `navigatePath` is forwarded over IPC and routed on click instead, since
+    // this closure can't cross the process boundary.
+    onClick: () => navigate(path),
+    navigatePath: path,
   });
 }
 

--- a/ap-web/src/lib/browserNotifications.test.ts
+++ b/ap-web/src/lib/browserNotifications.test.ts
@@ -127,4 +127,29 @@ describe("showNotification", () => {
     expect(onClick).toHaveBeenCalledOnce();
     expect(instances[0].close).toHaveBeenCalledOnce();
   });
+
+  it("hands off to the native shell (with navigatePath) instead of a web toast", () => {
+    // Under the Electron shell, showNotification routes to the OS notification
+    // and forwards navigatePath (not the onClick closure, which can't cross
+    // IPC) so the shell can open the conversation on click. No web toast.
+    installNotification("granted");
+    const electronNotify = vi.fn().mockResolvedValue(true);
+    (window as unknown as Record<string, unknown>).omnigentDesktop = {
+      kind: "electron",
+      setBadgeCount: vi.fn(),
+      notify: electronNotify,
+    };
+    try {
+      const result = showNotification({ title: "X", body: "done", navigatePath: "/c/a" });
+      expect(result).toBeNull();
+      expect(instances).toHaveLength(0);
+      expect(electronNotify).toHaveBeenCalledWith({
+        title: "X",
+        body: "done",
+        navigatePath: "/c/a",
+      });
+    } finally {
+      delete (window as unknown as Record<string, unknown>).omnigentDesktop;
+    }
+  });
 });

--- a/ap-web/src/lib/browserNotifications.ts
+++ b/ap-web/src/lib/browserNotifications.ts
@@ -55,6 +55,13 @@ export interface ShowNotificationParams {
   tag?: string;
   /** Invoked when the user clicks the notification (after focusing). */
   onClick?: () => void;
+  /**
+   * In-app path to open when the notification is clicked, e.g. `"/c/abc"`.
+   * The browser path runs `onClick` directly; the Electron path can't carry a
+   * JS closure across the process boundary, so it forwards this string to the
+   * shell, which routes to it on click (see `onNativeNotificationActivated`).
+   */
+  navigatePath?: string;
 }
 
 /**
@@ -69,13 +76,16 @@ export function showNotification({
   body,
   tag,
   onClick,
+  navigatePath,
 }: ShowNotificationParams): Notification | null {
   // Desktop shell: hand off to the native OS notification and skip the web
   // toast entirely. `nativeNotify` is async/best-effort; we don't await it
   // (callers treat this function as fire-and-forget) and return null because
-  // no web `Notification` object is created in the native path.
+  // no web `Notification` object is created in the native path. We forward
+  // `navigatePath` (not the `onClick` closure, which can't cross the IPC
+  // boundary) so the shell can route to the conversation on click.
   if (isNativeShell()) {
-    void nativeNotify({ title, body });
+    void nativeNotify({ title, body, navigatePath });
     return null;
   }
   if (!isNotificationSupported() || Notification.permission !== "granted") return null;

--- a/ap-web/src/lib/nativeBridge.test.ts
+++ b/ap-web/src/lib/nativeBridge.test.ts
@@ -4,20 +4,33 @@ import {
   isElectronShell,
   isNativeShell,
   nativeNotify,
+  onNativeNotificationActivated,
   setBadgeCount as bridgeSetBadge,
 } from "./nativeBridge";
 
 // The Electron preload bridge mock, installed on window.omnigentDesktop.
 const electronSetBadge = vi.fn();
 const electronNotify = vi.fn().mockResolvedValue(true);
+const electronUnsubscribe = vi.fn();
+const electronOnNotificationActivated = vi.fn().mockReturnValue(electronUnsubscribe);
 
-/** Simulate running inside / outside the Electron shell via the preload key. */
-function setElectron(on: boolean): void {
+/**
+ * Simulate running inside / outside the Electron shell via the preload key.
+ * `withClickRouting` toggles the optional `onNotificationActivated` method so
+ * tests can also exercise a shell too old to support click routing.
+ */
+function setElectron(on: boolean, withClickRouting = true): void {
   if (on) {
     (window as unknown as Record<string, unknown>).omnigentDesktop = {
       kind: "electron",
       setBadgeCount: (...args: unknown[]) => electronSetBadge(...args),
       notify: (...args: unknown[]) => electronNotify(...args),
+      ...(withClickRouting
+        ? {
+            onNotificationActivated: (...args: unknown[]) =>
+              electronOnNotificationActivated(...args),
+          }
+        : {}),
     };
   } else {
     delete (window as unknown as Record<string, unknown>).omnigentDesktop;
@@ -64,13 +77,64 @@ describe("nativeNotify", () => {
   it("routes the notification through the Electron bridge with title+body", async () => {
     setElectron(true);
     await expect(nativeNotify({ title: "Session 1", body: "done" })).resolves.toBe(true);
-    expect(electronNotify).toHaveBeenCalledWith({ title: "Session 1", body: "done" });
+    expect(electronNotify).toHaveBeenCalledWith({
+      title: "Session 1",
+      body: "done",
+      navigatePath: undefined,
+    });
+  });
+
+  it("forwards navigatePath so the shell can route on click", async () => {
+    setElectron(true);
+    await nativeNotify({ title: "Session 1", body: "done", navigatePath: "/c/a" });
+    expect(electronNotify).toHaveBeenCalledWith({
+      title: "Session 1",
+      body: "done",
+      navigatePath: "/c/a",
+    });
   });
 
   it("returns false when the bridge throws", async () => {
     setElectron(true);
     electronNotify.mockRejectedValueOnce(new Error("ipc down"));
     await expect(nativeNotify({ title: "t" })).resolves.toBe(false);
+  });
+});
+
+describe("onNativeNotificationActivated", () => {
+  it("returns a no-op unsubscribe outside the shell", () => {
+    setElectron(false);
+    const cb = vi.fn();
+    const unsubscribe = onNativeNotificationActivated(cb);
+    // No bridge -> nothing subscribed, and the returned unsubscribe is safe.
+    expect(electronOnNotificationActivated).not.toHaveBeenCalled();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("returns a no-op unsubscribe under a shell lacking click routing", () => {
+    setElectron(true, false);
+    const cb = vi.fn();
+    const unsubscribe = onNativeNotificationActivated(cb);
+    expect(electronOnNotificationActivated).not.toHaveBeenCalled();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("subscribes through the bridge and returns its unsubscribe", () => {
+    setElectron(true);
+    const cb = vi.fn();
+    const unsubscribe = onNativeNotificationActivated(cb);
+    expect(electronOnNotificationActivated).toHaveBeenCalledWith(cb);
+    unsubscribe();
+    expect(electronUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("returns a no-op unsubscribe when the bridge throws", () => {
+    setElectron(true);
+    electronOnNotificationActivated.mockImplementationOnce(() => {
+      throw new Error("ipc down");
+    });
+    const unsubscribe = onNativeNotificationActivated(vi.fn());
+    expect(() => unsubscribe()).not.toThrow();
   });
 });
 

--- a/ap-web/src/lib/nativeBridge.ts
+++ b/ap-web/src/lib/nativeBridge.ts
@@ -33,6 +33,14 @@ interface ElectronDesktopApi {
   setBadgeCount: (count: number) => void;
   /** Fire an OS notification; resolves true when it was shown. */
   notify: (params: NativeNotifyParams) => Promise<boolean>;
+  // Optional: a shell older than this SPA may lack notification-click routing,
+  // in which case clicking a desktop toast only focuses the window (the prior
+  // behavior) instead of also navigating.
+  /**
+   * Subscribe to OS-notification clicks. The main process sends the in-app
+   * path the notification carried (its `navigatePath`); returns an unsubscribe.
+   */
+  onNotificationActivated?: (callback: (path: string) => void) => () => void;
   // The server-picker trio is optional: the SPA is server-served and may be
   // newer than the installed shell, whose preload then lacks these methods.
   /** Current server origin + recent servers, or null on a foreign page. */
@@ -92,6 +100,13 @@ export interface NativeNotifyParams {
   title: string;
   /** Secondary line, e.g. "Agent finished and is ready for your input." */
   body?: string;
+  /**
+   * In-app path the shell should open when the user clicks this notification,
+   * e.g. `"/c/conv_abc123"`. A click closure can't cross the process boundary,
+   * so we forward the destination as a string and route to it on click via
+   * `onNativeNotificationActivated`. Omitted -> click only focuses the window.
+   */
+  navigatePath?: string;
 }
 
 /**
@@ -102,16 +117,41 @@ export interface NativeNotifyParams {
  * not running under Electron or anything went wrong (so the caller can fall
  * back to the Web Notifications API).
  */
-export async function nativeNotify({ title, body }: NativeNotifyParams): Promise<boolean> {
+export async function nativeNotify({
+  title,
+  body,
+  navigatePath,
+}: NativeNotifyParams): Promise<boolean> {
   const electron = electronApi();
   if (!electron) return false;
   try {
-    return await electron.notify({ title, body });
+    return await electron.notify({ title, body, navigatePath });
   } catch (err) {
     // Only reachable inside the desktop shell. Log rather than swallow so a
     // broken bridge is visible instead of silently dropping notifications.
     console.warn("[nativeBridge] electron notify failed:", err);
     return false;
+  }
+}
+
+/**
+ * Subscribe to native notification clicks from the desktop shell. The shell
+ * fires the in-app path the clicked notification carried (its `navigatePath`),
+ * so the renderer can route to it — restoring the in-browser behavior where
+ * clicking a toast opens its conversation.
+ *
+ * Returns an unsubscribe function. A no-op (returning a no-op unsubscribe)
+ * outside the Electron shell or under a shell too old to support click
+ * routing, so callers can register it unconditionally.
+ */
+export function onNativeNotificationActivated(callback: (path: string) => void): () => void {
+  const electron = electronApi();
+  if (!electron?.onNotificationActivated) return () => {};
+  try {
+    return electron.onNotificationActivated(callback);
+  } catch (err) {
+    console.warn("[nativeBridge] electron onNotificationActivated failed:", err);
+    return () => {};
   }
 }
 

--- a/tests/e2e_ui/sessions/test_idle_notifications.py
+++ b/tests/e2e_ui/sessions/test_idle_notifications.py
@@ -41,6 +41,10 @@ from playwright.sync_api import Page, expect
 # permission read see the stub, not the real (unobservable) API.
 _HARNESS_INIT_SCRIPT = """
 window.__notifs = [];
+// The live notification instances (kept out of __notifs, which is read via
+// page.evaluate and so must stay JSON-serializable). The click test invokes
+// __notifObjects[i].onclick() to exercise the app's click->navigate handler.
+window.__notifObjects = [];
 window.__hidden = false;
 window.__sessionStatuses = [];
 window.__streamStatuses = [];
@@ -123,6 +127,7 @@ class FakeNotification {
     this.options = options || {};
     this.onclick = null;
     window.__notifs.push({ title: title, options: options || {} });
+    window.__notifObjects.push(this);
   }
   close() {}
   static permission = "granted";
@@ -312,3 +317,58 @@ def test_idle_notification_suppressed_when_foreground(
     # notification slips through.
     page.wait_for_timeout(3_000)
     assert page.evaluate("window.__notifs.length") == 0, "foreground transition must not notify"
+
+
+def test_idle_notification_click_navigates_to_chat(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """
+    Clicking the OS notification routes into the session it was raised for.
+
+    This is the user-facing contract behind the notification's click
+    handler: ``useIdleNotifications`` builds ``/c/{id}`` and wires it as
+    the notification's ``onClick`` (and, under the desktop shell, as the
+    ``navigatePath`` forwarded over IPC). The browser path runs that
+    closure directly; this test exercises it end-to-end.
+
+    Flow: open the seeded session, send a real prompt, wait until app
+    traffic reports it ``running`` (seeding the baseline), then navigate
+    AWAY to the new-session screen ("/") via the in-app sidebar link — a
+    client-side navigation that keeps ``useIdleNotifications`` mounted, and
+    leaves no conversation actively viewed so the turn-end still notifies.
+    When the real turn finishes the notification fires; invoking its
+    ``onclick`` must route the app back to ``/c/{session_id}``.
+
+    A failure means the notification's click handler no longer navigates to
+    its conversation (the desktop "click does nothing but focus" bug, or a
+    regression in the shared path-building wiring).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` of a real session
+        bound to the spawned runner.
+    """
+    base_url, session_id = seeded_session
+    page.add_init_script(_HARNESS_INIT_SCRIPT)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # User gesture mirrors the real lazy-permission flow (stub reports
+    # "granted", so this is harmless).
+    page.mouse.click(5, 5)
+
+    _reset_session_status_probe(page)
+    _send_prompt(page)
+
+    # Reach the running baseline while still viewing the session, then leave
+    # for the new-session screen so the turn-end isn't suppressed as
+    # actively-viewed and a click has somewhere to navigate FROM.
+    _wait_for_observed_session_status(page, session_id, "running", timeout=30_000)
+    page.get_by_test_id("new-chat-button").click()
+    page.wait_for_url(lambda url: f"/c/{session_id}" not in url, timeout=10_000)
+
+    # The real turn completes off-screen and raises the notification.
+    page.wait_for_function("window.__notifObjects.length > 0", timeout=90_000)
+
+    # Click it: the app's onClick focuses then navigates to the session.
+    page.evaluate("window.__notifObjects[0].onclick()")
+    page.wait_for_url(f"**/c/{session_id}", timeout=10_000)


### PR DESCRIPTION
## Summary
- Clicking a desktop (Electron) notification only **focused** the Omnigent window and left the user on whatever chat was already open — it never switched into the chat the notification was about.
- Root cause: in the browser, `showNotification` wires `notification.onclick` to `navigate(\`/c/{id}\`)`. In the Electron shell that closure can't cross the IPC boundary, so the native path forwarded only `title`/`body` and the main-process click handler did `win.focus()` and nothing else.
- Fix: thread the destination path (`navigatePath`, e.g. `/c/<id>`) through `showNotification` → `nativeNotify` → preload → main. On click, the main process focuses the firing window **and** sends the path back over a new `omnigent:notification-activated` IPC channel; the renderer subscribes via `onNativeNotificationActivated` and routes to it — matching the browser behavior.

## Changes
- `src/lib/nativeBridge.ts`: add `navigatePath` to `NativeNotifyParams`; add `onNativeNotificationActivated` subscription helper (no-op outside Electron / on older shells).
- `src/lib/browserNotifications.ts`: add `navigatePath` to `ShowNotificationParams` and forward it on the native path.
- `electron/src/preload.js`: forward `navigatePath`; expose `onNotificationActivated` over the `omnigent:notification-activated` channel.
- `electron/src/main.js`: capture `navigatePath` and, on notification click, send it back to the originating window's renderer (guarded against a destroyed sender).
- `src/hooks/useIdleNotifications.ts`: pass `navigatePath`; register the native-click listener once and route via `navigate`.

## Compatibility
- Browser path is unchanged (still uses `onClick`).
- A desktop shell older than this bundle (no `onNotificationActivated`) degrades gracefully to the previous focus-only behavior.

## Test plan
- [x] `vitest` unit tests for `nativeBridge`, `browserNotifications`, and `useIdleNotifications` (54 passing), including:
  - `navigatePath` forwarded through `nativeNotify` and `showNotification`'s native branch
  - `onNativeNotificationActivated` subscribe/unsubscribe + graceful no-ops
  - renderer routes to the conversation when the shell reports a notification click
- [x] `tsc -b` type-check passes
- [x] `prettier --check` clean on changed files
- [ ] Manual: in the desktop app, trigger a notification for a non-open chat, click it, and confirm it switches into that chat.