### PR TITLE
fix(databricks): omit tool 'strict' field the AI Gateway rejects

### DIFF
--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -98,6 +98,51 @@ def _is_legacy_databricks_serving_base_url(client: OpenAI) -> bool:
     return "/serving-endpoints" in str(client.base_url)
 
 
+def _is_databricks_gateway_base_url(client: OpenAI) -> bool:
+    """Return whether *client* targets a Databricks AI Gateway base URL.
+
+    The gateway exposes OpenAI-compatible endpoints under ``/ai-gateway/`` and
+    rejects the ``strict`` field on tool definitions, so callers omit it when
+    this is true. Duck-typed (no isinstance guard) so tests can pass fakes.
+    """
+    return "/ai-gateway/" in str(getattr(client, "base_url", ""))
+
+
+def _strip_strict_from_tools(tools: Any) -> Any:
+    """Return *tools* with the ``strict`` field removed from each tool envelope.
+
+    The Databricks AI Gateway rejects the ``strict`` field on tool definitions
+    by presence (a 400 ``tools.N.*.strict: Extra inputs are not permitted`` —
+    ``false`` fails the same as ``true``). Removes only the well-known envelope
+    locations: the tool's own ``strict`` (Responses-wire flat function/custom
+    tool) and a nested ``function``/``custom`` block's ``strict`` (Chat wire).
+    Does NOT recurse into ``parameters`` — a user JSON Schema may legitimately
+    contain a property named ``strict``. Copies the list and any mutated dicts
+    so the caller's tool objects are not aliased; non-dict entries pass through.
+
+    Shared with :mod:`omnigent.inner.openai_agents_sdk_executor` (which wraps the
+    async client) so both executors strip identically.
+
+    :param tools: The outgoing ``tools`` value (normally a list of dicts).
+    :returns: A sanitized copy when *tools* is a list; *tools* unchanged otherwise.
+    """
+    if not isinstance(tools, list):
+        return tools
+    sanitized = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            tool = dict(tool)
+            tool.pop("strict", None)
+            for envelope_key in ("function", "custom"):
+                envelope = tool.get(envelope_key)
+                if isinstance(envelope, dict):
+                    envelope = dict(envelope)
+                    envelope.pop("strict", None)
+                    tool[envelope_key] = envelope
+        sanitized.append(tool)
+    return sanitized
+
+
 def _get_openai_client(
     profile: str | None = None,
     retry_policy: RetryPolicy | None = None,
@@ -160,8 +205,18 @@ def _get_openai_client(
     )
 
 
-def _convert_tools_to_responses(tools: list[ToolSpec]) -> list[ResponsesItem]:
-    """Convert Omnigent tool schemas to Responses API function tools."""
+def _convert_tools_to_responses(
+    tools: list[ToolSpec], *, include_strict: bool = True
+) -> list[ResponsesItem]:
+    """Convert Omnigent tool schemas to Responses API function tools.
+
+    :param tools: Omnigent tool specs to convert.
+    :param include_strict: When True (default), emit ``"strict": False`` to be
+        permissive with hand-authored schemas. Set False for the Databricks AI
+        Gateway, which rejects the ``strict`` field by presence (a 400
+        ``tools.N.*.strict: Extra inputs are not permitted`` — ``false`` fails
+        the same as ``true``); the key is then omitted entirely.
+    """
     result: list[ResponsesItem] = []
     for tool in tools:
         raw_name = tool.get("name")
@@ -171,16 +226,16 @@ def _convert_tools_to_responses(tools: list[ToolSpec]) -> list[ResponsesItem]:
             continue
         raw_desc = tool.get("description")
         desc: str = raw_desc if isinstance(raw_desc, str) else ""
-        result.append(
-            {
-                "type": "function",
-                "name": raw_name,
-                "description": desc,
-                "parameters": tool.get("parameters", {"type": "object", "properties": {}}),
-                # Be permissive with hand-authored schemas in this repo.
-                "strict": False,
-            }
-        )
+        item: ResponsesItem = {
+            "type": "function",
+            "name": raw_name,
+            "description": desc,
+            "parameters": tool.get("parameters", {"type": "object", "properties": {}}),
+        }
+        if include_strict:
+            # Be permissive with hand-authored schemas in this repo.
+            item["strict"] = False
+        result.append(item)
     return result
 
 
@@ -426,6 +481,9 @@ class OpenResponsesExecutor(Executor):
         self._profile = profile
         self._client = client if client is not None else _get_openai_client(profile=profile)
         self._stream_responses = not _is_legacy_databricks_serving_base_url(self._client)
+        # The Databricks AI Gateway rejects the tool ``strict`` field by
+        # presence; omit it from converted tools when targeting the gateway.
+        self._omit_tool_strict = _is_databricks_gateway_base_url(self._client)
         self._supports_previous_response_id = True
         self._session_states: dict[str, _ResponsesSessionState] = {}
 
@@ -545,7 +603,11 @@ class OpenResponsesExecutor(Executor):
         state = self._get_or_create_session_state(session_key)
         state.interrupt_requested = False
         delta_input_items = self._build_delta_input(state, messages)
-        response_tools = _convert_tools_to_responses(tools) if tools else None
+        response_tools = (
+            _convert_tools_to_responses(tools, include_strict=not self._omit_tool_strict)
+            if tools
+            else None
+        )
 
         include = ["reasoning.encrypted_content"]
         extra_include = cfg.extra.get("include")
@@ -573,6 +635,11 @@ class OpenResponsesExecutor(Executor):
         for key in _SESSION_ONLY_EXECUTOR_EXTRA_KEYS:
             extra.pop(key, None)
         kwargs.update(extra)
+        # cfg.extra may carry its own ``tools`` that overwrote the converted set
+        # above; re-strip the final value so caller-supplied tools can't smuggle
+        # the gateway-rejected ``strict`` field past the conversion gate.
+        if self._omit_tool_strict and kwargs.get("tools"):
+            kwargs["tools"] = _strip_strict_from_tools(kwargs["tools"])
         if self._supports_previous_response_id and state.previous_response_id:
             kwargs["previous_response_id"] = state.previous_response_id
             request_input = delta_input_items

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -54,6 +54,7 @@ from .open_responses_sdk import (
     _OPENAI_KEY_PLACEHOLDER,
     _convert_messages_to_responses,
     _databricks_openai_base_url,
+    _strip_strict_from_tools,
 )
 
 logger = logging.getLogger(__name__)
@@ -954,6 +955,70 @@ def _wrap_client_for_reasoning_models(client: AsyncOpenAIClient) -> AsyncOpenAIC
     return client
 
 
+class _DatabricksToolStripResource:
+    """Wraps an async OpenAI resource so outgoing tool ``strict`` is removed.
+
+    Sits in front of ``chat.completions`` or ``responses`` and rewrites the
+    ``tools`` kwarg via :func:`_strip_strict_from_tools` before delegating, so a
+    Databricks-AI-Gateway-bound request never carries the rejected ``strict``
+    field. All other attributes and the response (incl. streams) pass through
+    unchanged.
+
+    :param resource: The real ``AsyncCompletions`` or ``AsyncResponses`` object.
+    """
+
+    def __init__(self, resource: Any) -> None:  # type: ignore[explicit-any]
+        self._resource = resource
+
+    async def create(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
+        """Strip tool ``strict`` then proxy ``create()`` verbatim."""
+        if kwargs.get("tools"):
+            kwargs["tools"] = _strip_strict_from_tools(kwargs["tools"])
+        return await self._resource.create(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:  # type: ignore[explicit-any]
+        return getattr(self._resource, name)
+
+
+class _DatabricksToolStripChat:
+    """Wraps ``AsyncChat`` to expose a strict-stripping ``completions``.
+
+    :param chat: The real ``AsyncOpenAI.chat`` object.
+    """
+
+    def __init__(self, chat: Any) -> None:  # type: ignore[explicit-any]
+        self._chat = chat
+        self.completions: _DatabricksToolStripResource = _DatabricksToolStripResource(
+            chat.completions
+        )
+
+    def __getattr__(self, name: str) -> Any:  # type: ignore[explicit-any]
+        return getattr(self._chat, name)
+
+
+def _wrap_client_for_databricks_tools(client: AsyncOpenAIClient) -> AsyncOpenAIClient:
+    """Wrap *client* so outgoing tool ``strict`` is stripped on both wires.
+
+    Replaces ``client.chat`` (chat-completions wire, used by non-GPT models)
+    and ``client.responses`` (Responses wire, used by Databricks GPT) with
+    proxies that drop the ``strict`` field the Databricks AI Gateway rejects.
+    Apply ONLY when :func:`_is_databricks_openai_client` is true, so standard
+    OpenAI structured-output ``strict`` behavior is preserved for every other
+    provider. Composes with :func:`_wrap_client_for_reasoning_models` (apply
+    this first; the reasoning proxy then wraps the strict-stripping completions).
+
+    :param client: The ``AsyncOpenAI`` (or compatible) client to wrap.
+    :returns: The same *client*, modified in-place and returned for chaining.
+    """
+    # A client may expose only one wire (chat-only / responses-only compatible
+    # clients, or a partial test double); wrap only the wire it actually has.
+    if getattr(client, "chat", None) is not None:
+        object.__setattr__(client, "chat", _DatabricksToolStripChat(client.chat))
+    if getattr(client, "responses", None) is not None:
+        object.__setattr__(client, "responses", _DatabricksToolStripResource(client.responses))
+    return client
+
+
 def _count_output_items(new_items: Sequence[object]) -> int:
     """Count run items that represent user-visible output.
 
@@ -1096,6 +1161,15 @@ class OpenAIAgentsSDKExecutor(Executor):
                 model=model,
             )
         )
+        databricks = _is_databricks_openai_client(raw_client)
+        # The Databricks AI Gateway rejects the ``strict`` field on tool
+        # definitions (by presence, even ``false``). Strip it at the request
+        # boundary on both wires — gated on the gateway base URL so standard
+        # OpenAI strict/structured-output behavior is untouched for every other
+        # provider. Applied before the reasoning wrapper so the two compose.
+        databricks_client = (
+            _wrap_client_for_databricks_tools(raw_client) if databricks else raw_client
+        )
         # Wrap the chat.completions path to strip list-type delta.content
         # (reasoning blocks emitted by models like Kimi K2).  The SDK's
         # ChatCmplStreamHandler validates delta as str; list input raises
@@ -1104,7 +1178,9 @@ class OpenAIAgentsSDKExecutor(Executor):
         # Only needed for the chat-completions path; the Responses API path
         # has its own event handling that doesn't go through ChatCmplStreamHandler.
         self._client = (
-            _wrap_client_for_reasoning_models(raw_client) if not use_responses else raw_client
+            _wrap_client_for_reasoning_models(databricks_client)
+            if not use_responses
+            else databricks_client
         )
         self._owns_client = client is None
         self._profile = profile

--- a/tests/inner/test_open_responses_sdk.py
+++ b/tests/inner/test_open_responses_sdk.py
@@ -23,6 +23,7 @@ from omnigent.inner.open_responses_sdk import (
     _convert_messages_to_responses,
     _convert_tools_to_responses,
     _databricks_openai_base_url,
+    _is_databricks_gateway_base_url,
     _normalize_response_output_items,
 )
 
@@ -100,6 +101,34 @@ class TestConvertTools(unittest.TestCase):
         self.assertEqual(result[0]["type"], "function")
         self.assertEqual(result[0]["name"], "calc")
         self.assertFalse(result[0]["strict"])
+
+    def test_strict_omitted_for_databricks_gateway(self):
+        """include_strict=False omits the key entirely (gateway rejects it)."""
+        tools = [{"name": "calc", "description": "Calculate", "parameters": {}}]
+        result = _convert_tools_to_responses(tools, include_strict=False)
+        self.assertNotIn("strict", result[0])
+        # default still emits strict: False (non-gateway providers unchanged)
+        self.assertIn("strict", _convert_tools_to_responses(tools)[0])
+
+    def test_databricks_gateway_base_url_detection(self):
+        class _C:
+            base_url = "https://x.databricks.com/ai-gateway/openai/v1"
+
+        class _Legacy:
+            base_url = "https://x.databricks.com/serving-endpoints"
+
+        self.assertTrue(_is_databricks_gateway_base_url(_C()))
+        self.assertFalse(_is_databricks_gateway_base_url(_Legacy()))
+
+    def test_executor_omit_tool_strict_flag_tracks_gateway(self):
+        class _GatewayClient:
+            base_url = "https://x.databricks.com/ai-gateway/openai/v1"
+
+        class _PlainClient:
+            base_url = "https://api.openai.com/v1"
+
+        self.assertTrue(OpenResponsesExecutor(client=_GatewayClient())._omit_tool_strict)
+        self.assertFalse(OpenResponsesExecutor(client=_PlainClient())._omit_tool_strict)
 
     def test_invalid_tool_name_is_normalized_for_provider(self):
         tools = [{"name": "sys_runtime_execute", "description": "Run code"}]

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -31,10 +31,13 @@ from omnigent.inner.executor import (
 )
 from omnigent.inner.openai_agents_sdk_executor import (
     OpenAIAgentsSDKExecutor,
+    _DatabricksToolStripResource,
     _normalize_content_blocks_for_chat,
     _normalize_responses_items_for_chat,
     _ReasoningBlockFilterStream,
     _sanitize_replay_item,
+    _strip_strict_from_tools,
+    _wrap_client_for_databricks_tools,
     _wrap_client_for_reasoning_models,
 )
 from omnigent.llms.errors import is_context_length_exceeded as _is_context_length_exceeded
@@ -417,6 +420,183 @@ def test_wrap_client_non_streaming_create_not_wrapped() -> None:
 
     result = _run(_run_inner())
     assert isinstance(result, _FakeResult)
+
+
+def test_strip_strict_from_tools_all_envelope_shapes() -> None:
+    """``strict`` is removed from flat, ``function``, and ``custom`` envelopes.
+
+    What breaks if this fails: the Databricks AI Gateway 400s tool-bearing turns
+    with ``tools.N.*.strict: Extra inputs are not permitted``.
+    """
+    tools = [
+        {"type": "function", "name": "flat", "strict": True},  # Responses wire
+        {"type": "function", "function": {"name": "nested", "strict": False}},  # Chat wire
+        {"type": "custom", "custom": {"name": "c", "strict": True}},
+    ]
+    out = _strip_strict_from_tools(tools)
+    assert out == [
+        {"type": "function", "name": "flat"},
+        {"type": "function", "function": {"name": "nested"}},
+        {"type": "custom", "custom": {"name": "c"}},
+    ]
+
+
+def test_strip_strict_does_not_mutate_caller_or_parameters() -> None:
+    """Caller tools are not aliased, and a ``strict`` property inside a JSON
+    Schema ``parameters`` is preserved (only the envelope is touched)."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "f",
+                "strict": True,
+                "parameters": {"type": "object", "properties": {"strict": {"type": "boolean"}}},
+            },
+        }
+    ]
+    out = _strip_strict_from_tools(tools)
+    # caller untouched
+    assert tools[0]["function"]["strict"] is True
+    # envelope strict gone, schema property named "strict" preserved
+    assert "strict" not in out[0]["function"]
+    assert out[0]["function"]["parameters"]["properties"]["strict"] == {"type": "boolean"}
+
+
+def test_strip_strict_passthrough_non_list_and_non_dict() -> None:
+    assert _strip_strict_from_tools(None) is None
+    sentinel = object()
+    assert _strip_strict_from_tools([sentinel]) == [sentinel]
+
+
+def test_databricks_tool_strip_wraps_both_wires() -> None:
+    """The Databricks client wrapper strips ``strict`` on chat AND responses."""
+    chat_completions = _RecordingResource()
+    responses_resource = _RecordingResource()
+
+    # Build the fake client with instance attributes set in ``__init__`` (a real
+    # closure scope) rather than class-body assignments — a class body does not
+    # see enclosing-function locals when the name is also assigned there.
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = chat_completions
+
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://x.databricks.com/ai-gateway/openai/v1"
+            self.chat = _Chat()
+            self.responses = responses_resource
+
+    tools = [{"type": "function", "function": {"name": "f", "strict": False}}]
+
+    async def _run_inner() -> None:
+        client = _Client()
+        _wrap_client_for_databricks_tools(client)
+        await client.chat.completions.create(tools=list(tools), stream=False)
+        await client.responses.create(tools=list(tools))
+
+    _run(_run_inner())
+    for rec in (chat_completions, responses_resource):
+        assert rec.seen is not None
+        assert rec.seen["tools"] == [{"type": "function", "function": {"name": "f"}}]
+
+
+class _RecordingResource:
+    def __init__(self) -> None:
+        self.seen: dict | None = None
+
+    async def create(self, **kwargs) -> object:
+        self.seen = kwargs
+        return kwargs.get("_result", "ok")
+
+    def __getattr__(self, name: str) -> object:
+        raise AttributeError(name)
+
+
+def _fake_async_client(base_url: str) -> object:
+    completions = _RecordingResource()
+    responses = _RecordingResource()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = completions
+
+        def __getattr__(self, name: str) -> object:
+            raise AttributeError(name)
+
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = base_url
+            self.chat = _Chat()
+            self.responses = responses
+
+    return _Client()
+
+
+def test_executor_installs_strip_proxy_only_for_gateway() -> None:
+    """The executor wraps the client for `/ai-gateway/` and leaves it alone otherwise.
+
+    What breaks if this fails: either tool-bearing gateway turns 400 on `strict`,
+    or non-gateway OpenAI traffic loses Structured-Outputs `strict` enforcement.
+    """
+    gw = OpenAIAgentsSDKExecutor(
+        client=_fake_async_client("https://x.databricks.com/ai-gateway/openai/v1"),
+        use_responses=True,  # skip the reasoning wrapper to assert proxy identity directly
+    )
+    assert isinstance(gw._client.chat.completions, _DatabricksToolStripResource)
+    assert isinstance(gw._client.responses, _DatabricksToolStripResource)
+    assert gw._databricks is True
+
+    plain = OpenAIAgentsSDKExecutor(
+        client=_fake_async_client("https://api.openai.com/v1"),
+        use_responses=True,
+    )
+    assert not isinstance(plain._client.chat.completions, _DatabricksToolStripResource)
+    assert plain._databricks is False
+
+
+def test_databricks_strip_composes_with_reasoning_wrapper_and_stream() -> None:
+    """Strict-strip + reasoning-stream wrapping survive the nested proxy chain."""
+
+    class _ListDeltaChunk:
+        def __init__(self) -> None:
+            self.choices = [types.SimpleNamespace(delta=types.SimpleNamespace(content=[{"x": 1}]))]
+
+    async def _fake_stream():
+        yield _ListDeltaChunk()
+
+    completions = _RecordingResource()
+
+    async def _create(**kwargs):
+        completions.seen = kwargs
+        return _fake_stream()
+
+    completions.create = _create  # type: ignore[method-assign]
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = completions
+
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://x.databricks.com/ai-gateway/openai/v1"
+            self.chat = _Chat()
+            self.responses = _RecordingResource()
+
+    async def _run_inner():
+        client = _Client()
+        _wrap_client_for_databricks_tools(client)
+        _wrap_client_for_reasoning_models(client)
+        result = await client.chat.completions.create(
+            tools=[{"type": "function", "function": {"name": "f", "strict": True}}],
+            stream=True,
+        )
+        return result, completions.seen
+
+    result, seen = _run(_run_inner())
+    # strict stripped before the underlying create saw it
+    assert seen["tools"] == [{"type": "function", "function": {"name": "f"}}]
+    # reasoning wrapper still wrapped the stream
+    assert isinstance(result, _ReasoningBlockFilterStream)
 
 
 class TestOpenAIAgentsSDKExecutor(unittest.TestCase):


### PR DESCRIPTION
## Problem

Routing any **tool-bearing** turn through the **Databricks AI Gateway** (OpenAI-compatible endpoints under `/ai-gateway/`) fails with:

```
HTTP 400 {"error_code":"BAD_REQUEST","message":"tools.0.custom.strict: Extra inputs are not permitted"}
```

The gateway translates OpenAI tool schemas into Anthropic/internal format and **rejects the `strict` field by presence** — `strict: false` fails exactly like `strict: true`; it's a "field not permitted" error, not a "value invalid" one. This hits **every** model the gateway serves over the OpenAI-compatible wire (Claude, GPT, Llama, Qwen, Gemma) — i.e. a documented provider path is broken for all tool use.

Two code paths emit `strict` today:

- `OpenAIAgentsSDKExecutor` — the openai-agents SDK's chatcmpl converter serializes `"strict": false` onto every function tool **even with** `FunctionTool(strict_json_schema=False)`.
- `OpenResponsesExecutor` — `_convert_tools_to_responses` hardcodes `"strict": False`.

`strict_json_schema=False` is not enough: the key is still serialized, and the gateway rejects its presence.

## Fix

Strip `strict` from outgoing tool definitions, **gated on the existing `/ai-gateway/` client detection** so standard OpenAI strict / Structured-Outputs behavior is untouched for every other provider.

- **`openai_agents_sdk_executor.py`** — a per-client proxy (`_wrap_client_for_databricks_tools`) over `chat.completions.create` **and** `responses.create`, applied when `_is_databricks_openai_client(client)`. Mirrors the existing `_wrap_client_for_reasoning_models` precedent and is composed *before* it so the two nest correctly. `responses` is guarded so a chat-only compatible client still constructs.
- **`open_responses_sdk.py`** — `_convert_tools_to_responses(..., include_strict=False)` omits the key for gateway clients, and `run_turn` re-strips `kwargs["tools"]` **after** the `cfg.extra` merge so a caller-supplied `tools` can't smuggle `strict` past the conversion gate.
- **`_strip_strict_from_tools`** is shared across both executors. It removes only the tool / `function` / `custom` envelope `strict` — **never** recursing into `parameters` (a user JSON Schema may legitimately have a property named `strict`) — and copies dicts so caller tool objects aren't mutated.

## Tests

Added unit coverage (no live Databricks dependency):

- envelope shapes (flat Responses-wire, nested `function`, `custom`); mutation-safety; `parameters` property named `strict` preserved;
- the per-client wrapper strips on both wires;
- executor-level **gating** — wrapped for `/ai-gateway/`, untouched for `api.openai.com`;
- **composition** with `_wrap_client_for_reasoning_models` under `stream=True` (strict stripped *and* stream still wrapped);
- `_convert_tools_to_responses` gateway omission + the `cfg.extra` merge leak.

## Notes for reviewers

- Behavior for non-Databricks providers is unchanged (gated on `/ai-gateway/`); `strict: false` is still emitted there.
- Repro: any agent with tools on a `kind: databricks` / `/ai-gateway/` provider, before this change, 400s on the first tool-bearing turn.
