### PR TITLE
fix(harnesses): map Cursor display labels to SDK model ids; give Polly a model picker (#547)

### DIFF
--- a/ap-web/src/lib/cursorSdkModels.ts
+++ b/ap-web/src/lib/cursorSdkModels.ts
@@ -1,0 +1,50 @@
+/**
+ * Cursor SDK model picker options for Polly (the `cursor` brain harness).
+ *
+ * Every entry's `id` is a Cursor SDK model id (e.g. `composer-2.5`), NOT a
+ * display label — the in-chat switcher sends `id`, and the Cursor SDK rejects
+ * a friendly label like `Composer` with `invalid_argument` (#547). The `label`
+ * is the human-facing name shown in the dropdown.
+ *
+ * Lives in a leaf module (no React / store imports) so both the picker UI
+ * (`ChatPage`) and tests can read it without a circular import. Mirrors
+ * `claudeNativeModels.ts`.
+ *
+ * Sourced from the Cursor SDK's own available-models list. This is a static
+ * snapshot; the robust long-term source is the runner-backed
+ * `Cursor.models.list()` (a larger change tracked as a follow-up). The backend
+ * `cursor_executor._resolve_model` chokepoint independently normalizes/guards
+ * the value, so a model newer than this list still works.
+ */
+export const CURSOR_SDK_MODELS = [
+  // Common picks first.
+  { id: "auto", label: "Auto" },
+  { id: "composer-2.5", label: "Composer" },
+  { id: "default", label: "Default" },
+  // Anthropic.
+  { id: "claude-opus-4-8", label: "claude-opus-4-8" },
+  { id: "claude-opus-4-7", label: "claude-opus-4-7" },
+  { id: "claude-opus-4-6", label: "claude-opus-4-6" },
+  { id: "claude-opus-4-5", label: "claude-opus-4-5" },
+  { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+  { id: "claude-sonnet-4-5", label: "claude-sonnet-4-5" },
+  { id: "claude-sonnet-4", label: "claude-sonnet-4" },
+  { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
+  // OpenAI.
+  { id: "gpt-5.5", label: "gpt-5.5" },
+  { id: "gpt-5.4", label: "gpt-5.4" },
+  { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
+  { id: "gpt-5.4-nano", label: "gpt-5.4-nano" },
+  { id: "gpt-5.3-codex", label: "gpt-5.3-codex" },
+  { id: "gpt-5.2", label: "gpt-5.2" },
+  { id: "gpt-5.2-codex", label: "gpt-5.2-codex" },
+  { id: "gpt-5.1", label: "gpt-5.1" },
+  { id: "gpt-5.1-codex-max", label: "gpt-5.1-codex-max" },
+  { id: "gpt-5.1-codex-mini", label: "gpt-5.1-codex-mini" },
+  { id: "gpt-5-mini", label: "gpt-5-mini" },
+  // Google.
+  { id: "gemini-3.1-pro", label: "gemini-3.1-pro" },
+  { id: "gemini-3.5-flash", label: "gemini-3.5-flash" },
+  { id: "gemini-3-flash", label: "gemini-3-flash" },
+  { id: "gemini-2.5-flash", label: "gemini-2.5-flash" },
+] as const;

--- a/ap-web/src/pages/ChatPage.capabilities.test.ts
+++ b/ap-web/src/pages/ChatPage.capabilities.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
+import { CURSOR_SDK_MODELS } from "@/lib/cursorSdkModels";
 import {
   effortLevelsForConv,
   isModelImplicitlySelected,
+  modelOptionsForPicker,
   shouldShowEffortPicker,
   shouldShowModelPicker,
 } from "./ChatPage";
@@ -61,6 +64,31 @@ describe("shouldShowModelPicker", () => {
     expect(shouldShowModelPicker({ labels: {} })).toBe(false);
     expect(shouldShowModelPicker(null)).toBe(false);
     expect(shouldShowModelPicker(undefined)).toBe(false);
+  });
+});
+
+describe("modelOptionsForPicker", () => {
+  it("sources cursor (Polly) options from the SDK-id catalog, never display labels (#547)", () => {
+    // WHY: the picker sends `setModel(m.id)`, so every cursor option id must be
+    // a Cursor SDK id (composer-2.5), never a friendly label (Composer) the SDK
+    // rejects with invalid_argument.
+    const opts = modelOptionsForPicker(null, "cursor", []);
+    expect(opts).toBe(CURSOR_SDK_MODELS);
+    expect(opts.length).toBeGreaterThan(0);
+    // The labelled model is exposed by its SDK id, with the friendly label.
+    const composer = opts.find((m) => m.label === "Composer");
+    expect(composer?.id).toBe("composer-2.5");
+    // No option id is a capitalized display label.
+    expect(opts.every((m) => m.id === m.id.toLowerCase())).toBe(true);
+  });
+
+  it("keeps the native vendor catalogs and empty fallback", () => {
+    expect(modelOptionsForPicker("claude", "cursor", [])).toBe(CLAUDE_NATIVE_MODELS);
+    const codex = [{ id: "gpt-5.4", displayName: "GPT-5.4" }];
+    expect(modelOptionsForPicker("codex", "cursor", codex)).toBe(codex);
+    // A non-cursor brain harness with no native wrapper gets no picker rows.
+    expect(modelOptionsForPicker(null, "pi", [])).toEqual([]);
+    expect(modelOptionsForPicker(null, null, [])).toEqual([]);
   });
 });
 

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -86,6 +86,7 @@ import {
 import { getCurrentAuthorId } from "@/lib/identity";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { codexEffortLevelsForModel, findCodexModelOption } from "@/lib/codexNativeModels";
+import { CURSOR_SDK_MODELS } from "@/lib/cursorSdkModels";
 import {
   consumePendingInitialPrompt,
   type PendingInitialPrompt,
@@ -4061,6 +4062,28 @@ export function isModelImplicitlySelected(modelId: string, llmModel: string | nu
   return llmModel === modelId || llmModel.endsWith(`/${modelId}`) || llmModel.includes(modelId);
 }
 
+/**
+ * Model rows the in-chat picker should offer for a session.
+ *
+ * Native wrappers use their vendor catalog (`claude` → CLAUDE_NATIVE_MODELS,
+ * `codex` → the Codex app-server `model/list`). The `cursor` brain harness
+ * (Polly) is not a native wrapper, so it is keyed off `sessionHarness`; its
+ * options are Cursor SDK ids (never display labels), so `setModel(id)` can't
+ * hand the SDK a label like `Composer` that it rejects with `invalid_argument`
+ * (#547). Everything else has no in-chat model picker — an empty list hides
+ * the Models section.
+ */
+export function modelOptionsForPicker(
+  modelPickerKind: NativeModelPickerKind | null,
+  sessionHarness: string | null,
+  codexModelOptions: readonly CodexModelOption[],
+): ReadonlyArray<{ id: string; label?: string; displayName?: string }> {
+  if (modelPickerKind === "claude") return CLAUDE_NATIVE_MODELS;
+  if (modelPickerKind === "codex") return codexModelOptions;
+  if (sessionHarness === "cursor") return CURSOR_SDK_MODELS;
+  return [];
+}
+
 interface AgentPickerProps {
   agents: Agent[] | undefined;
   isLoading: boolean;
@@ -4119,12 +4142,10 @@ function AgentPicker({
   const selectedModel = useChatStore((s) => s.selectedModel);
   const llmModel = useChatStore((s) => s.llmModel);
 
-  const modelOptions: ReadonlyArray<{ id: string; label?: string; displayName?: string }> =
-    modelPickerKind === "claude"
-      ? CLAUDE_NATIVE_MODELS
-      : modelPickerKind === "codex"
-        ? codexModelOptions
-        : [];
+  // Effective brain harness from the session snapshot (override-aware). Read
+  // before modelOptions so the cursor brain harness can source its picker rows.
+  const sessionHarness = useChatStore((s) => s.sessionHarness);
+  const modelOptions = modelOptionsForPicker(modelPickerKind, sessionHarness, codexModelOptions);
   const isNativeModelPicker = modelPickerKind !== null;
   // Only offer the agent list when there's an actual choice. Inside a
   // session the picker is scoped to the single bound agent (the runner is
@@ -4134,10 +4155,9 @@ function AgentPicker({
   const showAgents = !isNativeModelPicker && (agents?.length ?? 0) > 1;
   const rawAgentName = agents?.find((a) => a.id === selectedId)?.name ?? agents?.[0]?.name;
   const agentDisplayName = rawAgentName ? agentDisplayLabel(rawAgentName) : rawAgentName;
-  // Effective brain harness from the session snapshot (override-aware).
-  // Only the SDK brain harnesses get a pill suffix — native wrappers
-  // already use their own "Claude" branch below.
-  const sessionHarness = useChatStore((s) => s.sessionHarness);
+  // Only the SDK brain harnesses get a pill suffix — native wrappers already
+  // use their own "Claude" branch below. `sessionHarness` is read above (it
+  // also sources the cursor model rows).
   const harnessLabel = sessionHarness ? (BRAIN_HARNESS_LABELS[sessionHarness] ?? null) : null;
 
   // Build the pill piece-by-piece so empty selections don't leave

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -84,6 +84,23 @@ ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # typ
 # ``None``).
 _DEFAULT_CURSOR_MODEL = "auto"
 
+# The in-chat model switcher / ``/model`` command can carry a human-facing
+# Cursor display LABEL rather than the Cursor SDK id. The SDK rejects the label
+# with ``invalid_argument`` (e.g. "Cannot use this model: Composer", whose valid
+# id is ``composer-2.5``) and the turn fails before the agent starts (#547).
+# Map the known label mismatches to their SDK ids before agent creation, keyed
+# by the trimmed/lower-cased input so any casing (``Composer`` / ``COMPOSER``)
+# matches. Deliberately a small mapping, NOT a full allow-list: an unrecognized
+# id passes through to the SDK unchanged, so a valid-but-unlisted model the user
+# pins is never silently downgraded to auto when Cursor's catalog moves ahead of
+# ours (the SDK still returns its own "Available models: ..." guidance for a
+# genuinely invalid id).
+_CURSOR_DISPLAY_LABEL_TO_ID = {
+    "composer": "composer-2.5",
+    "auto": "auto",
+    "default": "default",
+}
+
 # Upper bound (seconds) on one bridged-tool call: generous (sub-agent dispatches
 # can run for minutes) but finite, so a wedged tool surfaces a timeout error
 # instead of blocking the SDK's daemon callback thread forever.
@@ -93,10 +110,16 @@ _TOOL_CALL_TIMEOUT_S = 1800.0
 def _resolve_model(model: str | None) -> str:
     """Resolve the cursor model id, dropping ids cursor can't honor.
 
-    cursor-sdk accepts only Cursor model ids (``auto``, ``gpt-5``,
-    ``composer-2.5``, ...), so a gateway-routed model id (carried by a spec
+    cursor-sdk accepts only Cursor model ids (``auto``, ``composer-2.5``,
+    ``claude-opus-4-8``, ...), so a gateway-routed model id (carried by a spec
     authored for another harness) falls back to cursor's auto-select. ``None``
     likewise resolves to ``auto`` (the SDK requires a model).
+
+    A known Cursor display LABEL (e.g. ``Composer``) is mapped to its SDK id
+    (``composer-2.5``) before it reaches ``AsyncAgent.create`` — without this
+    the SDK rejects the label with ``invalid_argument`` (#547). Any other id is
+    returned unchanged so the SDK can accept a valid id (or surface its own
+    "Available models: ..." error for a genuinely invalid one).
     """
     if not model or model.startswith(("databricks-", "databricks/")):
         if model:
@@ -110,7 +133,9 @@ def _resolve_model(model: str | None) -> str:
                 _DEFAULT_CURSOR_MODEL,
             )
         return _DEFAULT_CURSOR_MODEL
-    return model
+    # Normalize a known display label (any casing) to its Cursor SDK id; pass
+    # everything else through so valid ids (incl. ones newer than our map) work.
+    return _CURSOR_DISPLAY_LABEL_TO_ID.get(model.strip().lower(), model)
 
 
 def _first_of(d: dict[str, Any], *keys: str, default: int = 0) -> int:

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -206,6 +206,25 @@ def test_resolve_model_drops_databricks_and_defaults_to_auto() -> None:
     assert _resolve_model(None) == "auto"
 
 
+def test_resolve_model_maps_cursor_display_labels_to_sdk_ids() -> None:
+    """The in-chat / `/model` switcher can carry a Cursor display LABEL
+    (``Composer``) rather than the SDK id (``composer-2.5``). The SDK rejects
+    the label with ``invalid_argument``, so _resolve_model must map known
+    display labels to their SDK ids before agent creation (issue #547)."""
+    # The reported case: the friendly label maps to its SDK id, case-insensitively.
+    assert _resolve_model("Composer") == "composer-2.5"
+    assert _resolve_model("composer") == "composer-2.5"
+    assert _resolve_model("  COMPOSER  ") == "composer-2.5"
+    # Capitalized "Auto"/"Default" normalize to the SDK's lowercase ids.
+    assert _resolve_model("Auto") == "auto"
+    assert _resolve_model("Default") == "default"
+    # A real SDK id passes through unchanged (no drift-prone allow-list that
+    # would silently downgrade a valid-but-unlisted model to auto).
+    assert _resolve_model("composer-2.5") == "composer-2.5"
+    assert _resolve_model("claude-opus-4-8") == "claude-opus-4-8"
+    assert _resolve_model("gpt-5.4") == "gpt-5.4"
+
+
 def test_resolve_model_warns_when_dropping_a_pinned_model(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Fixes #547.

## Symptom
The in-chat model switcher for Polly (Cursor SDK harness) could select a display name like `Composer` that the Cursor SDK rejects. The turn then fails before the agent starts:

```
inner executor error: Failed to start cursor-sdk agent: invalid_argument:
Cannot use this model: Composer. Available models: default, composer-2.5, ...
```

## Root cause
A model selection flows UI/`/model` → `conv.model_override` → `HARNESS_CURSOR_MODEL` → `CursorExecutor` → `_resolve_model` → `AsyncAgent.create(model=...)`. `cursor_executor._resolve_model` only remapped `databricks-*` ids to `auto` and returned every other string unchanged, so a display **label** like `Composer` (whose SDK id is `composer-2.5`) reached the SDK verbatim and was rejected. No layer on the path mapped labels → SDK ids.

## Fix
**Backend chokepoint (covers every entry path — UI, `/model`, API):** `_resolve_model` now normalizes a known Cursor display label to its SDK id before agent creation, case-insensitively (`Composer`/`COMPOSER` → `composer-2.5`, `Auto` → `auto`, `Default` → `default`). It is deliberately a small map, **not** a full allow-list: an unrecognized id passes through to the SDK unchanged, so a valid-but-unlisted model is never silently downgraded to `auto` when Cursor's catalog moves ahead of a hardcoded list (the SDK still surfaces its own "Available models: …" guidance for a genuinely invalid id). This is exactly the issue's accepted "map display labels to SDK ids before passing the model into the executor."

**UI (so the switcher only exposes valid ids):** new leaf catalog `ap-web/src/lib/cursorSdkModels.ts` of Cursor SDK ids with friendly labels (`composer-2.5` → "Composer"). The in-chat `AgentPicker` now sources Cursor (Polly) model rows from it via a new exported `modelOptionsForPicker()` helper, keyed on `sessionHarness === "cursor"`. Every option's `id` is an SDK id and the picker sends `setModel(m.id)`, so a display label can no longer reach the executor from the UI.

## Tests
- `tests/inner/test_cursor_executor.py` — `_resolve_model` maps `Composer`/`COMPOSER`/`  Composer  ` → `composer-2.5`, maps `Auto`/`Default`, and passes valid SDK ids through unchanged.
- `ap-web/.../ChatPage.capabilities.test.ts` — `modelOptionsForPicker` returns the SDK-id catalog for a cursor session (no option id is a display label), keeps the native vendor catalogs, and falls back to empty otherwise.

Verified locally: cursor-executor test suite, full ap-web vitest suite + typecheck, ruff/oxlint/prettier clean.

## Follow-up (out of scope here)
The secondary symptom — `cursor-sdk run reported an error` on a valid id (`composer-2.5`) after a failed selection — is not reproducible from repo code: the executor drops and recreates session state cleanly on failure (covered by `test_mid_turn_error_status_drops_session`), so the recurring error is a Cursor SDK/backend run-level failure on the recreated agent. The primary fix removes the trigger (no invalid id is ever sent). A robust long-term source for the picker is the runner-backed `Cursor.models.list()` rather than a static catalog.
