### PR TITLE
docs(release): release runbook + GitHub Release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,62 @@
+# Create a GitHub Release entry (the `…/releases` page) when a version tag is
+# pushed. This is METADATA ONLY — it does NOT build or publish any installable
+# artifact. PyPI publishing lives in the central secure-release repo
+# (databricks/secure-public-registry-releases-eng → `omnigent` workflow), on
+# hardened runners with OIDC Trusted Publishing and a mandatory dependency
+# scan. Keeping those concerns separate is deliberate (see RELEASING.md):
+#
+#   * This job runs NO project or third-party code — no build, no `pip
+#     install`/`npm ci`, no tests. Its only action is SHA-pinned
+#     `actions/checkout` plus `gh release create`. A malicious tagged commit
+#     therefore cannot execute anything here.
+#   * It uses the ephemeral `GITHUB_TOKEN` (no stored secret / PAT). The single
+#     elevated scope, `contents: write`, is the minimum GitHub requires to
+#     create a release and nothing else in the job uses it.
+#   * It attaches NO wheels. The release carries only generated notes and the
+#     source tarball GitHub auto-attaches, so PyPI (the scanned, securely
+#     published channel) stays the single source of installable artifacts.
+#   * The release is created as a DRAFT: a human verifies/edits the generated
+#     notes and publishes it (ideally after the prod PyPI publish lands), so a
+#     bot never makes a public release on its own.
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Least privilege: creating a release requires `contents: write`; nothing here
+# needs anything more.
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    # Inert in forks / mirrors — only the canonical repo should cut releases.
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Full history so `--generate-notes` can diff against the previous tag.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Draft release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # rc / dev tags are flagged as pre-releases.
+          pre=""
+          case "$TAG" in
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) pre="--prerelease" ;;
+          esac
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --verify-tag \
+            --generate-notes \
+            --title "$TAG" \
+            $pre
+          echo "Drafted release $TAG. Review/edit the notes and publish from the Releases page."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,151 @@
+# Releasing omnigent
+
+omnigent ships **three PyPI packages that version-lock together**:
+
+| Package | What it is |
+| --- | --- |
+| `omnigent` | core wheel (bundles the `ap-web` web UI) |
+| `omnigent-client` | Python client SDK |
+| `omnigent-ui-sdk` | terminal UI SDK |
+
+`pip install omnigent==X` must resolve `omnigent-client==X` and
+`omnigent-ui-sdk==X`, and the pins are **circular**, so every release builds and
+publishes **all three at one identical version**.
+
+## Where things run
+
+- **Source of truth** (versions, tags, GitHub Releases): **`omnigent-ai/omnigent`**
+  — use the `dhruv0811` (OSS) GitHub account.
+- **Publishing to PyPI**: the central **secure-release repo**
+  **`databricks/secure-public-registry-releases-eng`**, `omnigent` workflow —
+  use the EMU account (`dhruv-gupta_data`). Publishing runs on hardened runner
+  groups with **OIDC Trusted Publishing (no stored secrets)** and a **mandatory
+  dependency scan**. This is why we don't publish from `omnigent-ai/omnigent`.
+
+The legacy `.github/workflows/release-omnigent.yml` in this repo is a
+**deprecated manual fallback only** — its tag-push trigger was removed so a tag
+never double-publishes. Use the secure repo for real releases.
+
+> The secure `omnigent` workflow is **manual `workflow_dispatch`** — it can't see
+> this repo's tag pushes. You bump + tag here, then dispatch it with that tag.
+
+## Versioning model
+
+- `main` always carries the **next** version with a `.dev0` suffix
+  (e.g. `0.2.0.dev0`) — never a clean released number. This matches
+  MLflow / Delta / Unity Catalog and keeps every `main` build PEP 440-ordered as
+  "ahead of the last release, not yet the next one".
+- Releases are cut on **per-minor release branches** (`branch-X.Y`) and tagged
+  there (`vX.Y.Z`); patches (`vX.Y.1`, `vX.Y.2`, …) are cherry-picked onto the
+  same `branch-X.Y`. `main` is never tagged.
+
+---
+
+## Release steps (example: `v0.2.0`)
+
+### 1. Cut the release branch + tag — `omnigent-ai/omnigent` (`dhruv0811`)
+
+```bash
+gh auth switch --user dhruv0811
+git fetch origin && git checkout -b branch-0.2 origin/main
+```
+
+Set the release version in **all three** `pyproject.toml` files — the
+`version` field **and** the cross-package `==` pins — plus `uv.lock`
+(`0.2.0.dev0` → `0.2.0`):
+
+- `pyproject.toml` (`version`, `omnigent-client==`, `omnigent-ui-sdk==`)
+- `sdks/python-client/pyproject.toml` (`version`, `omnigent==`)
+- `sdks/ui/pyproject.toml` (`version`, `omnigent-client==`)
+- `uv.lock` — **hand-edit** the three `version = "…"` lines (omnigent,
+  omnigent-client, omnigent-ui-sdk) and the one `specifier = "==…"`.
+  **Do not run `uv lock`** locally: it rewrites every registry URL to the
+  internal proxy and that leaks into the lockfile (breaks CI). The published
+  lock must use `https://pypi.org/simple`.
+
+```bash
+git commit -am "release: v0.2.0"
+git tag v0.2.0
+git push -u origin branch-0.2 --tags        # pushing the tag drafts the GitHub Release (step 5)
+```
+
+Keep `main` from re-freezing — bump it to the next dev marker and push:
+
+```bash
+git checkout main
+# set 0.2.0.dev0 -> 0.3.0.dev0 in the 3 pyprojects (+ pins) and uv.lock (hand-edit)
+git commit -am "chore: bump main to 0.3.0.dev0"
+git push
+```
+
+### 2. Dry-run the gates — secure repo (`dhruv-gupta_data`)
+
+```bash
+gh auth switch --user dhruv-gupta_data
+gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
+  -f ref=v0.2.0 -f destination=test-pypi -f dry-run=true
+```
+
+Runs build + dependency scan + the gates (lockstep version/pins, web-UI-in-wheel,
+`twine check`, smoke-install) and the OIDC token exchange — **without uploading**.
+
+### 3. Publish to TestPyPI + validate
+
+```bash
+gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
+  -f ref=v0.2.0 -f destination=test-pypi -f dry-run=false
+
+# validate in a clean venv (TestPyPI for our packages, real PyPI for deps):
+python -m venv /tmp/omni-rc && /tmp/omni-rc/bin/pip install \
+  -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple omnigent==0.2.0
+/tmp/omni-rc/bin/omnigent --version    # expect 0.2.0; resolves client/ui-sdk ==0.2.0
+```
+
+### 4. Publish to PyPI (prod)
+
+Requires **admin/maintain** on the secure repo; binds the per-package
+`pypi-omnigent`, `pypi-omnigent-client`, `pypi-omnigent-ui-sdk` Trusted-Publisher
+environments (may gate on reviewer approval). The prod path also re-verifies that
+`ref` is exactly the `vX.Y.Z` tag and that the tag points at the built commit.
+
+```bash
+gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \
+  -f ref=v0.2.0 -f destination=pypi -f dry-run=false
+
+uv tool install omnigent==0.2.0        # final sanity from real PyPI
+```
+
+> Note: the dispatch's `-f ref=v0.2.0` is the **omnigent source ref**; it is
+> distinct from `gh workflow run --ref`, which selects the branch the *workflow
+> definition* runs from (the secure repo's default).
+
+### 5. Publish the GitHub Release — `omnigent-ai/omnigent` (`dhruv0811`)
+
+Pushing the `v0.2.0` tag (step 1) triggered `.github/workflows/github-release.yml`,
+which created a **draft** release with auto-generated notes (PRs since the
+previous tag). Now:
+
+1. Open <https://github.com/omnigent-ai/omnigent/releases> and find the `v0.2.0`
+   draft.
+2. **Verify and edit the notes** — lead with user-facing highlights, call out
+   breaking changes and any upgrade steps, and trim noise from the auto-generated
+   list. The notes are a draft, not the final word.
+3. **Publish the release** (ideally only after the prod PyPI publish in step 4 has
+   succeeded, so you never advertise a version that isn't installable).
+
+If the draft wasn't created (e.g. the workflow was disabled), do it manually:
+
+```bash
+gh auth switch --user dhruv0811
+gh release create v0.2.0 --repo omnigent-ai/omnigent \
+  --draft --verify-tag --generate-notes --title "v0.2.0"
+# review/edit, then publish from the Releases page (or `gh release edit v0.2.0 --draft=false`)
+```
+
+---
+
+## Patch release (e.g. `v0.2.1`)
+
+Cherry-pick the fix onto the existing `branch-0.2`, bump the three versions/pins
++ `uv.lock` to `0.2.1`, commit, tag `v0.2.1` on `branch-0.2`, push, then repeat
+steps 2–5. `main` does not change for a patch.


### PR DESCRIPTION
## What

- **`RELEASING.md`** — a runbook for cutting an omnigent release through the central secure-publishing repo (`databricks/secure-public-registry-releases-eng` → `omnigent` workflow): the dev-version / per-minor-release-branch model, the lockstep three-package version bump (incl. the hand-edit-`uv.lock` / no-`uv lock` proxy-leak caveat), TestPyPI validation → prod, and a final **verify-and-edit the release notes** step.
- **`.github/workflows/github-release.yml`** — on a `v*` tag push, drafts a GitHub Release with generated notes so the `…/releases` page is populated (today nothing does this).

## Supply-chain: does the Release workflow reintroduce risk?

No — and it's built to keep it that way. We moved PyPI publishing to the secure repo to remove the supply-chain surface (hardened runners, OIDC Trusted Publishing, no stored secrets, mandatory dependency scan). This workflow deliberately stays on the safe side of that line:

- **Builds and publishes nothing installable.** No `python -m build`, no `pip install` / `npm ci`, no tests. PyPI (the scanned, securely published channel) remains the *only* source of installable artifacts.
- **Executes no project or third-party code.** The only action is SHA-pinned `actions/checkout`; the only command is `gh release create`. A malicious tagged commit can't run anything here.
- **No stored secret / PAT** — just the ephemeral `GITHUB_TOKEN`. The single elevated scope, `contents: write`, is the minimum GitHub requires to create a release; nothing else in the job uses it.
- **Attaches no wheels** — only generated notes + the source tarball GitHub auto-attaches, so a build that bypassed the secure scan can never reach users via a release asset.
- **Drafts, doesn't publish.** A human verifies/edits the notes and publishes (ideally after the prod PyPI publish lands) — a bot never makes a public release on its own.
- **Inert in forks/mirrors** (`if: github.repository == 'omnigent-ai/omnigent'`); rc/dev tags are flagged `--prerelease`.

The remaining trust assumption is the same as for any tag: whoever can push a `v*` tag can create a (draft) release entry — which already requires repo write access, and produces only reviewable metadata.

## Notes

- Independent of #726 (the `omni upgrade` fix); branched from `main`.
- The `RELEASING.md` versioning section assumes the `<next>.dev0` main convention introduced in #726.

This pull request and its description were written by Isaac.