### PR TITLE
feat: default Claude SDK permission mode to auto

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1099,7 +1099,7 @@ class ClaudeSDKExecutor(Executor):
         cwd: str | None = None,
         os_env: OSEnvSpec | None = None,
         model: str | None = None,
-        permission_mode: str = "bypassPermissions",
+        permission_mode: str = "auto",
         gateway: bool = False,
         databricks_profile: str | None = None,
         gateway_host: str | None = None,
@@ -1123,8 +1123,8 @@ class ClaudeSDKExecutor(Executor):
                 sandbox the Claude CLI process itself on supported Linux
                 hosts, but does not enable native OS tools.
             model: Override the model name.
-            permission_mode: SDK permission mode (default: bypassPermissions
-                so the agent can run autonomously).
+            permission_mode: SDK permission mode (default: auto
+                so the agent runs autonomously with background safety checks).
             gateway: If True, route through a vendor-neutral gateway
                 (base URL + bearer-token command + model). Enables the
                 gateway path regardless of which producer fed it (the

--- a/omnigent/inner/claude_sdk_harness.py
+++ b/omnigent/inner/claude_sdk_harness.py
@@ -37,9 +37,10 @@ Env vars read at startup:
   the Claude CLI in. ``None`` falls back to the subprocess's
   inherited cwd.
 - ``HARNESS_CLAUDE_SDK_PERMISSION_MODE``: SDK permission mode
-  (``"bypassPermissions"``, ``"acceptEdits"``,
-  ``"plan"``, ``"default"``). Defaults to
-  ``"bypassPermissions"`` so the agent runs autonomously.
+  (``"auto"``, ``"bypassPermissions"``, ``"acceptEdits"``,
+  ``"plan"``, ``"dontAsk"``, ``"default"``). Defaults to
+  ``"auto"`` so the agent runs autonomously with background
+  safety checks.
 - ``HARNESS_CLAUDE_SDK_OS_ENV``: JSON-encoded :class:`OSEnvSpec`
   (from :func:`dataclasses.asdict`) controlling the SDK's
   native OS-tool exposure. When set, the inner executor builds
@@ -124,10 +125,10 @@ _ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_CLAUDE_SDK_GATEWAY_AUTH_REFRESH
 # auth being bypassed).
 _ENV_API_KEY_HELPER = "HARNESS_CLAUDE_SDK_API_KEY_HELPER"
 
-# Default permission mode for the Claude SDK. ``"bypassPermissions"``
-# matches the inner executor's own default and lets the agent run
-# autonomously without prompting per tool call.
-_DEFAULT_PERMISSION_MODE = "bypassPermissions"
+# Default permission mode for the Claude SDK. ``"auto"`` auto-approves
+# tool calls with background safety checks that verify actions align
+# with the request.
+_DEFAULT_PERMISSION_MODE = "auto"
 
 
 def _resolve_os_env() -> OSEnvSpec:

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -100,7 +100,7 @@ class TestConstructor(unittest.TestCase):
         self.assertIsNone(executor._os_env_spec)
         self.assertIsNone(executor._cwd)
         self.assertIsNone(executor._model_override)
-        self.assertEqual(executor._permission_mode, "bypassPermissions")
+        self.assertEqual(executor._permission_mode, "auto")
         self.assertIsNone(executor._tool_executor)
         self.assertEqual(executor._clients, {})
         self.assertEqual(executor._crashed_sessions, {})


### PR DESCRIPTION
## Summary
- Changes the default permission mode for the Claude SDK harness/executor from `bypassPermissions` to `auto`
- `auto` mode auto-approves tool calls with background safety checks that verify actions align with the request, providing a safer default
- Updates docstring to list all six valid permission modes (`auto`, `bypassPermissions`, `acceptEdits`, `plan`, `dontAsk`, `default`)

## Test plan
- [ ] Verify existing tests pass with the updated default
- [ ] Confirm `HARNESS_CLAUDE_SDK_PERMISSION_MODE` env var override still works
- [ ] Run a live session to validate auto mode behavior end-to-end

This pull request and its description were written by Isaac.