### PR TITLE
ci(release): GitHub Release workflow on tag push

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,62 @@
+# Create a GitHub Release entry (the `…/releases` page) when a version tag is
+# pushed. This is METADATA ONLY — it does NOT build or publish any installable
+# artifact. PyPI publishing lives in the central secure-release repo
+# (databricks/secure-public-registry-releases-eng → `omnigent` workflow), on
+# hardened runners with OIDC Trusted Publishing and a mandatory dependency
+# scan. Keeping those concerns separate is deliberate (see RELEASING.md):
+#
+#   * This job runs NO project or third-party code — no build, no `pip
+#     install`/`npm ci`, no tests. Its only action is SHA-pinned
+#     `actions/checkout` plus `gh release create`. A malicious tagged commit
+#     therefore cannot execute anything here.
+#   * It uses the ephemeral `GITHUB_TOKEN` (no stored secret / PAT). The single
+#     elevated scope, `contents: write`, is the minimum GitHub requires to
+#     create a release and nothing else in the job uses it.
+#   * It attaches NO wheels. The release carries only generated notes and the
+#     source tarball GitHub auto-attaches, so PyPI (the scanned, securely
+#     published channel) stays the single source of installable artifacts.
+#   * The release is created as a DRAFT: a human verifies/edits the generated
+#     notes and publishes it (ideally after the prod PyPI publish lands), so a
+#     bot never makes a public release on its own.
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Least privilege: creating a release requires `contents: write`; nothing here
+# needs anything more.
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    # Inert in forks / mirrors — only the canonical repo should cut releases.
+    if: github.repository == 'omnigent-ai/omnigent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Full history so `--generate-notes` can diff against the previous tag.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Draft release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # rc / dev tags are flagged as pre-releases.
+          pre=""
+          case "$TAG" in
+            *rc*|*dev*|*a[0-9]*|*b[0-9]*) pre="--prerelease" ;;
+          esac
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --verify-tag \
+            --generate-notes \
+            --title "$TAG" \
+            $pre
+          echo "Drafted release $TAG. Review/edit the notes and publish from the Releases page."

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -23,7 +23,9 @@ name: GitHub Release
 on:
   push:
     tags:
-      - "v*"
+      # Version tags only (v0.2.0, v0.2.0rc1, …) — `v[0-9]*` avoids triggering
+      # on non-release tags like `v-infra-*`.
+      - "v[0-9]*"
 
 # Least privilege: creating a release requires `contents: write`; nothing here
 # needs anything more.
@@ -47,11 +49,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          # rc / dev tags are flagged as pre-releases.
+          # Rerun-safe: if a release for this tag already exists (a rerun, a
+          # deleted-and-re-pushed tag, or a manual release), skip instead of
+          # failing the job. An `if` so this can't trip `set -e`.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # rc / dev / alpha / beta tags are flagged as pre-releases.
           pre=""
           case "$TAG" in
             *rc*|*dev*|*a[0-9]*|*b[0-9]*) pre="--prerelease" ;;
           esac
+          # $pre is intentionally UNQUOTED: it word-splits to nothing when empty,
+          # and is only ever "" or "--prerelease" (set just above, never from
+          # external input). Quoting it would pass an empty positional arg.
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --draft \
@@ -59,4 +71,5 @@ jobs:
             --generate-notes \
             --title "$TAG" \
             $pre
-          echo "Drafted release $TAG. Review/edit the notes and publish from the Releases page."
+          echo "Drafted release $TAG — review/edit the notes and publish from the Releases page." \
+            | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
On a `v*` tag push, drafts a GitHub Release with generated notes so the [Releases page](https://github.com/omnigent-ai/omnigent/releases) gets populated — today nothing does this.

### Does it reintroduce supply-chain risk? No.

Publishing moved to the secure repo to remove the surface where a release *builds and ships installable artifacts*. This workflow stays on the safe side of that line:

- **Builds/publishes nothing installable** — no `python -m build`, no `pip install`/`npm ci`, no tests. PyPI stays the only source of installable artifacts.
- **Runs no project or third-party code** — only SHA-pinned `actions/checkout` + `gh release create`. A malicious tagged commit can't execute anything here.
- **No stored secret/PAT** — ephemeral `GITHUB_TOKEN`; its lone elevated scope `contents: write` is the minimum GitHub requires to create a release.
- **Attaches no wheels** — only generated notes + GitHub's auto source tarball, so a build that bypassed the secure scan can't reach users as a release asset.
- **Drafts, doesn't publish** — a human verifies/edits the notes and publishes (ideally after the prod PyPI publish lands).
- Inert in forks (`if: github.repository == 'omnigent-ai/omnigent'`); rc/dev tags flagged `--prerelease`.

Residual trust is the same as any tag: whoever can push `v*` (already needs repo write) gets a reviewable *draft*.

Companion docs: the `RELEASING.md` runbook PR.

This pull request and its description were written by Isaac.