### PR TITLE
test: triage run-ap-examples — un-quarantine 2, remove stale headless test, re-characterize 2 (#677)

### DIFF
--- a/tests/e2e/omnigent/test_run_omnigent_quiet_startup.py
+++ b/tests/e2e/omnigent/test_run_omnigent_quiet_startup.py
@@ -28,8 +28,6 @@ leaked through.
 
 from __future__ import annotations
 
-import os
-import subprocess
 from pathlib import Path
 
 from tests._model_pools import resolve_model
@@ -149,79 +147,4 @@ def test_run_omnigent_startup_does_not_leak_server_logs(
         f"~30 lines of DBOS / alembic init noise. "
         f"Combined stripped output (last 4000 chars):\n"
         f"{combined_stripped[-4000:]}"
-    )
-
-
-def test_run_prompt_mode_is_headless_for_local_agent(
-    omnigent_python: Path,
-    omnigent_repo_root: Path,
-    databricks_workspace: tuple[str, str],
-    tmp_path: Path,
-) -> None:
-    """
-    ``omnigent run <agent> -p`` sends one Omnigent turn, prints the
-    assistant text, and exits without starting the Rich REPL UI.
-
-    This is the e2e regression for the headless prompt-mode bug. It deliberately
-    matches the reported local command shape,
-    ``examples/databricks_coding_agent.yaml -p`` — with Databricks
-    routing coming from the global config's ``auth:`` block (the
-    ``--profile`` CLI flag was removed from the omnigent CLI).
-    """
-    yaml_path = omnigent_repo_root / "examples" / "databricks_coding_agent.yaml"
-    profile, _ = databricks_workspace
-    prompt = "hi"
-    argv = [
-        str(omnigent_python),
-        "-m",
-        "omnigent",
-        "run",
-        str(yaml_path),
-        "-p",
-        prompt,
-    ]
-
-    # The removed ``--profile`` flag is replaced by an ``auth:`` block in
-    # an isolated ``OMNIGENT_CONFIG_HOME`` — the supported source of
-    # Databricks model/gateway routing for spawned CLIs.
-    config_home = tmp_path / "omnigent-config"
-    config_home.mkdir()
-    (config_home / "config.yaml").write_text(
-        f"auth:\n  type: databricks\n  profile: {profile}\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["OMNIGENT_CONFIG_HOME"] = str(config_home)
-    env["DATABRICKS_CONFIG_PROFILE"] = profile
-
-    result = subprocess.run(
-        argv,
-        env=env,
-        cwd=str(omnigent_repo_root),
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-    stripped = strip_ansi(result.stdout + result.stderr)
-
-    assert result.returncode == 0, (
-        f"headless prompt command failed; stdout/stderr:\n{stripped[-4000:]}"
-    )
-    assert "What can I help you with" in stripped, (
-        "headless prompt command did not print assistant output; stdout/stderr:\n"
-        f"{stripped[-4000:]}"
-    )
-    forbidden = [
-        "Traceback (most recent call last)",
-        "AttributeError:",
-        "╭",
-        "╰",
-        "state: sleeping",
-        "Use /help",
-    ]
-    leaked = [item for item in forbidden if item in stripped]
-    assert not leaked, (
-        "``omnigent run -p`` should be headless and must not "
-        f"print tracebacks or REPL UI. Leaked markers: {leaked}. "
-        f"Output tail:\n{stripped[-4000:]}"
     )

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -120,12 +120,6 @@ skips:
     cluster: repl-pexpect-cli
     mode: skip
 
-  - id: tests/e2e/test_decorated_tools_e2e.py::test_decorated_tools_varied_signatures_e2e
-    reason: "openai-agents harness test hits platform.openai.com directly and 401s under the Databricks gateway profile (dapi PAT rejected as OpenAI key); needs gateway-routing/base_url fix before it can run in CI. Passes only with a real OPENAI_API_KEY locally."
-    issue: 676
-    cluster: run-ap-examples-harness
-    mode: skip
-
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_result_ask_refuse_replaces_output
     reason: "Shard 1 bulk: REPL approval pexpect-timeout family."
     issue: 523
@@ -186,22 +180,11 @@ skips:
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
-  - id: tests/e2e/omnigent/test_run_omnigent_example_agents.py::test_run_omnigent_example_yaml[agent_with_tools_calculate]
-    reason: "Flaky on gateway flake-stress (7/8 pass); intermittent tool/harness behavior, keep suppressed until stable."
-    issue: 677
-    cluster: run-ap-examples-harness
-    mode: skip
 
   - id: tests/e2e/omnigent/test_repl_inline_tool_streaming.py::test_repl_inline_tool_call_and_result_streaming
     reason: "Shard 3 bulk: REPL inline tool-call streaming."
     issue: 523
     cluster: repl-pexpect-cli
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_run_omnigent_quiet_startup.py::test_run_prompt_mode_is_headless_for_local_agent
-    reason: "fixture uses claude-sdk harness which 401s on the gateway (~/.databrickscfg auth); needs a gateway-compatible harness/model."
-    issue: 676
-    cluster: run-ap-examples-harness
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[codex]
@@ -314,13 +297,13 @@ skips:
     mode: skip
 
   - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[codex]
-    reason: "Same tool-call-rendering issue as the [claude-sdk] variant: codex says 'I'll compute it with the calculator tool now.7' but no '◦ calculate' lifecycle marker appears in stdout."
+    reason: "Snapshot mismatch on the tool-call lifecycle markers (◦ calculate / • calculate) not rendered to stdout in oneshot mode. Fails consistently 30/30 in flake-stress run 27798661226 (not flaky). See #677."
     issue: 677
     cluster: run-ap-examples-harness
     mode: skip
 
   - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[openai-agents]
-    reason: "Flaky on gateway flake-stress (7/8 pass); intermittent tool-call lifecycle rendering, keep suppressed until stable."
+    reason: "Snapshot mismatch on the tool-call lifecycle markers (◦/• calculate) not rendered to stdout in oneshot mode. Fails consistently 30/30 in flake-stress run 27798661226 (was logged 7/8-flaky; now consistent). Same cause as the [codex] variant — see #677."
     issue: 677
     cluster: run-ap-examples-harness
     mode: skip


### PR DESCRIPTION
## Summary

Triages the `run-ap-examples-harness` quarantine cluster via flake-stress ([run 27798661226](https://github.com/omnigent-ai/omnigent/actions/runs/27798661226), 30×, `--no-skip-known`). Rebased onto #733 (which repointed the `issue:` fields).

**Un-quarantined (30/30):**
- `test_decorated_tools_e2e.py::test_decorated_tools_varied_signatures_e2e` — its quarantine reason was the openai-agents harness 401'ing on `platform.openai.com`; that **base_url-routing bug was fixed by #629/#645**, and it's now solidly green.
- `test_run_omnigent_example_agents.py::test_run_omnigent_example_yaml[agent_with_tools_calculate]` — was logged "7/8 flaky"; now 30/30.

**Removed (stale + redundant):**
- `test_run_omnigent_quiet_startup.py::test_run_prompt_mode_is_headless_for_local_agent` — it points at `examples/databricks_coding_agent.yaml`, which was **never tracked in this repo** (dead-on-arrival; the old "claude-sdk 401" reason was wrong — it actually fails with `Agent path not found`). The headless `-p` / no-REPL-leak behavior is already covered by the ~10 oneshot tests (`test_per_harness_*`, `test_config_defaults_e2e`, the example tests). Deleted the test function + its now-orphaned imports; the file's other test (`...does_not_leak_server_logs`) is kept.

**Kept quarantined, re-characterized (fail 30/30 — consistent, not flaky; #677):**
- `test_yaml_agent_with_tools[codex]` and `[openai-agents]` — `AssertionError: Snapshot mismatch` on the `◦`/`•` tool-call lifecycle markers not rendered to stdout in oneshot mode. Same cause for both variants.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Quarantine-list + dead-test removal; no product code touched. The 2 un-quarantined tests passed 30/30 in CI flake-stress (run 27798661226). The removed headless test could never pass here (dead fixture path) and its behavior is redundantly covered by the oneshot test suite. The 2 kept `yaml` tests fail 30/30 in that same run and are now recorded with their actual cause (`◦/•` marker rendering → #677) instead of the stale "7/8 flaky" reason.

This pull request and its description were written by Isaac.
