### PR TITLE
fix(cursor-native): expose omnigent MCP tools

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -185,8 +185,8 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
     Return the trusted parent for an allowed bridge directory.
 
     Claude-native files live below the uid-scoped temp bridge root.
-    Codex-native reuses the relay/MCP implementation but keeps bridge
-    files below ``~/.omnigent/codex-native``. Both roots use the same
+    Codex- and Cursor-native reuse the relay/MCP implementation but keep bridge
+    files below their own bridge roots. All roots use the same
     owner-only ancestor validation; only the trusted anchor differs.
 
     :param target: Normalized bridge directory path being created or validated,
@@ -211,9 +211,15 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
             trusted_parent = codex_root.parent.parent
         return _absolute_syntactic_path(trusted_parent)
 
+    from omnigent.cursor_native_bridge import bridge_root as cursor_bridge_root
+
+    cursor_root = _absolute_syntactic_path(cursor_bridge_root())
+    if target.is_relative_to(cursor_root):
+        return _absolute_syntactic_path(cursor_root.parent.parent)
+
     raise RuntimeError(
         f"bridge dir {target!s} is not under an allowed bridge root "
-        f"({claude_root!s}, {codex_root!s})"
+        f"({claude_root!s}, {codex_root!s}, {cursor_root!s})"
     )
 
 
@@ -3314,8 +3320,29 @@ def _stdio_jsonrpc_loop(
         active tool relay.
     :returns: None when stdin reaches EOF.
     """
-    for raw_line in sys.stdin:
-        line = raw_line.strip()
+    use_content_length = False
+    while True:
+        raw_line = sys.stdin.buffer.readline()
+        if raw_line == b"":
+            return
+        if raw_line.lower().startswith(b"content-length:"):
+            use_content_length = True
+            try:
+                length = int(raw_line.decode("ascii", errors="ignore").split(":", 1)[1].strip())
+            except ValueError:
+                continue
+            while True:
+                header = sys.stdin.buffer.readline()
+                if header in {b"\r\n", b"\n", b""}:
+                    break
+            if length <= 0:
+                continue
+            raw_payload = sys.stdin.buffer.read(length)
+            if len(raw_payload) != length:
+                return
+            line = raw_payload.decode("utf-8", errors="replace").strip()
+        else:
+            line = raw_line.decode("utf-8", errors="replace").strip()
         if not line:
             continue
         try:
@@ -3350,7 +3377,7 @@ def _stdio_jsonrpc_loop(
                 # -32603 is the JSON-RPC 2.0 "Internal error" code.
                 "error": {"code": -32603, "message": f"internal error: {exc}"},
             }
-        _write_jsonrpc(response, stdout_lock)
+        _write_jsonrpc(response, stdout_lock, framed=use_content_length)
 
 
 def _handle_mcp_request(
@@ -3651,17 +3678,29 @@ def _build_tools(config: dict[str, Any]) -> tuple[dict[str, Tool], Callable[[], 
     return tools, _close_tools
 
 
-def _write_jsonrpc(payload: dict[str, Any], stdout_lock: threading.Lock) -> None:
+def _write_jsonrpc(
+    payload: dict[str, Any],
+    stdout_lock: threading.Lock,
+    *,
+    framed: bool = False,
+) -> None:
     """
     Write one JSON-RPC message to stdout.
 
     :param payload: JSON-RPC object to serialize.
     :param stdout_lock: Lock protecting stdout.
+    :param framed: When ``True``, write MCP ``Content-Length`` framed output.
     :returns: None.
     """
     raw = json.dumps(payload, separators=(",", ":"))
     with stdout_lock:
-        print(raw, flush=True)
+        if framed:
+            encoded = raw.encode("utf-8")
+            sys.stdout.buffer.write(f"Content-Length: {len(encoded)}\r\n\r\n".encode("ascii"))
+            sys.stdout.buffer.write(encoded)
+            sys.stdout.buffer.flush()
+        else:
+            print(raw, flush=True)
 
 
 def _model_from_transcript_entry(entry: dict[str, Any]) -> str | None:

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -15,7 +15,9 @@ import contextlib
 import hashlib
 import json
 import os
+import secrets
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -26,6 +28,37 @@ BRIDGE_DIR_ENV_VAR = "HARNESS_CURSOR_NATIVE_BRIDGE_DIR"
 
 _BRIDGE_ROOT = Path(os.environ.get("TMPDIR", "/tmp")) / f"omnigent-{os.getuid()}" / "cursor-native"
 _TMUX_FILE = "tmux.json"
+_BRIDGE_CONFIG_FILE = "bridge.json"
+_MCP_CONFIG_FILE = "mcp.json"
+_MCP_SERVER_NAME = "omnigent"
+_CURSOR_AUTO_APPROVE_TOOLS = [
+    "list_comments",
+    "sys_add_policy",
+    "sys_agent_download",
+    "sys_agent_get",
+    "sys_agent_list",
+    "sys_call_async",
+    "sys_cancel_async",
+    "sys_cancel_task",
+    "sys_list_models",
+    "sys_os_edit",
+    "sys_os_read",
+    "sys_os_shell",
+    "sys_os_write",
+    "sys_policy_registry",
+    "sys_session_close",
+    "sys_session_create",
+    "sys_session_get_history",
+    "sys_session_get_info",
+    "sys_session_list",
+    "sys_session_send",
+    "sys_terminal_close",
+    "sys_terminal_launch",
+    "sys_terminal_list",
+    "sys_terminal_read",
+    "sys_terminal_send",
+    "update_comment",
+]
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 10.0
 _POLL_INTERVAL_S = 0.2
@@ -47,6 +80,11 @@ def bridge_dir_for_session_id(session_id: str) -> Path:
     return _BRIDGE_ROOT / digest
 
 
+def bridge_root() -> Path:
+    """Return the configured Cursor-native bridge root."""
+    return _BRIDGE_ROOT
+
+
 def _ensure_dir(path: Path) -> None:
     """Create *path* (and parents) with owner-only permissions."""
     path.mkdir(parents=True, exist_ok=True)
@@ -61,6 +99,149 @@ def build_cursor_native_spawn_env(session_id: str) -> dict[str, str]:
     return {
         BRIDGE_DIR_ENV_VAR: str(bridge_dir),
     }
+
+
+def build_mcp_config(
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> dict[str, Any]:
+    """Build Cursor's ``.cursor/mcp.json`` for the Omnigent relay server.
+
+    Cursor prompts for MCP tool approval before it sends ``tools/call`` to the
+    server. Omnigent tools already route through the Omnigent ``/mcp`` proxy,
+    where TOOL_CALL policies publish ``response.elicitation_request`` events
+    that the web UI can render. Auto-approving the Cursor-side MCP gate avoids a
+    hidden in-terminal approval prompt blocking the call before Omnigent ever
+    sees it, while preserving Omnigent's own policy/elicitation gate.
+    """
+    python = python_executable or sys.executable
+    return {
+        "mcpServers": {
+            _MCP_SERVER_NAME: {
+                "command": python,
+                "args": [
+                    "-I",
+                    "-m",
+                    "omnigent.claude_native_bridge",
+                    "serve-mcp",
+                    "--bridge-dir",
+                    str(bridge_dir),
+                ],
+                "autoApprove": list(_CURSOR_AUTO_APPROVE_TOOLS),
+                "env": {
+                    "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+                },
+            }
+        }
+    }
+
+
+def write_mcp_bridge_config(bridge_dir: Path) -> None:
+    """Write the token config required by the shared Omnigent MCP bridge."""
+    _ensure_dir(bridge_dir)
+    config_path = bridge_dir / _BRIDGE_CONFIG_FILE
+    if config_path.exists():
+        return
+    payload = {"token": secrets.token_urlsafe(32)}
+    tmp = bridge_dir / (_BRIDGE_CONFIG_FILE + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, config_path)
+
+
+def write_mcp_config(
+    workspace: Path,
+    bridge_dir: Path,
+    *,
+    python_executable: str | None = None,
+) -> Path:
+    """Write the workspace-scoped Cursor MCP config for Omnigent tools."""
+    write_mcp_bridge_config(bridge_dir)
+    cursor_dir = workspace / ".cursor"
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    path = cursor_dir / _MCP_CONFIG_FILE
+    payload = build_mcp_config(bridge_dir, python_executable=python_executable)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    enable_mcp_for_workspace(workspace)
+    allow_mcp_tools_in_cli_config()
+    return path
+
+
+def approve_mcp_server_for_workspace(workspace: Path) -> None:
+    """Approve the workspace-scoped Omnigent MCP server in Cursor's state.
+
+    Cursor stores per-workspace MCP approvals using a private hash of the
+    concrete server config. Rather than duplicate that implementation here,
+    ask ``cursor-agent mcp enable omnigent`` to write the exact approval entry
+    for this workspace. This is best-effort: the TUI still launches if the
+    installed Cursor CLI cannot run the management subcommand, but when it can,
+    the hidden server-approval gate is cleared before startup.
+    """
+    try:
+        from omnigent.cursor_native import resolve_cursor_executable
+
+        cursor = resolve_cursor_executable()
+        subprocess.run(
+            [cursor, "mcp", "enable", _MCP_SERVER_NAME],
+            cwd=workspace,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return
+
+
+def cursor_project_key(workspace: Path) -> str:
+    """Return Cursor's project-state directory key for *workspace*."""
+    return str(workspace).strip("/").replace("/", "-") or "root"
+
+
+def enable_mcp_for_workspace(workspace: Path) -> None:
+    """Ensure Cursor does not keep the Omnigent MCP disabled for this workspace."""
+    disabled_path = (
+        Path.home() / ".cursor" / "projects" / cursor_project_key(workspace) / "mcp-disabled.json"
+    )
+    try:
+        raw = json.loads(disabled_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(raw, list) or _MCP_SERVER_NAME not in raw:
+        return
+    updated = [item for item in raw if item != _MCP_SERVER_NAME]
+    tmp = disabled_path.with_suffix(disabled_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, disabled_path)
+
+
+def allow_mcp_tools_in_cli_config() -> None:
+    """Allow Omnigent MCP tool calls in Cursor's CLI permission config."""
+    path = Path.home() / ".cursor" / "cli-config.json"
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(config, dict):
+        return
+    permissions = config.setdefault("permissions", {})
+    if not isinstance(permissions, dict):
+        return
+    allow = permissions.setdefault("allow", [])
+    if not isinstance(allow, list):
+        return
+    existing = {item for item in allow if isinstance(item, str)}
+    for tool_name in _CURSOR_AUTO_APPROVE_TOOLS:
+        entry = f"Mcp({_MCP_SERVER_NAME}:{tool_name})"
+        if entry not in existing:
+            allow.append(entry)
+            existing.add(entry)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
 
 
 def write_tmux_target(

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -49,6 +49,7 @@ _SDK_HARNESSES: frozenset[str] = frozenset(
 # ``_HARNESS_FAMILY`` entry — pi uses the ``PI_SURFACE`` sentinel — so they must
 # be gated explicitly or they fail open like an unknown harness.
 _PI_HARNESSES: frozenset[str] = frozenset({PI_SURFACE, "pi-native"})
+_CURSOR_NATIVE_HARNESSES: frozenset[str] = frozenset({"cursor-native", "native-cursor"})
 
 
 def _canonical_harness(harness: str) -> str:
@@ -100,6 +101,8 @@ def harness_is_configured(harness: str) -> bool:
     canonical = _canonical_harness(harness)
     if canonical in _SDK_HARNESSES:
         return True
+    if canonical in _CURSOR_NATIVE_HARNESSES:
+        return harness_cli_installed(CURSOR_KEY)
     if canonical == CURSOR_KEY:
         # Cursor runs in-process via ``cursor-sdk`` and authenticates with a
         # ``CURSOR_API_KEY`` (a ``cursor-agent login`` does not apply). So,
@@ -142,5 +145,6 @@ def configured_harness_map() -> dict[str, bool]:
     spellings.update(_EXECUTOR_TYPE_HARNESS_ALIASES)
     spellings.update(HARNESS_ALIASES)
     spellings.update(_PI_HARNESSES)
+    spellings.update(_CURSOR_NATIVE_HARNESSES)
     spellings.add(CURSOR_KEY)
     return {spelling: harness_is_configured(spelling) for spelling in spellings}

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -847,6 +847,7 @@ async def _auto_create_cursor_terminal(
     publish_event: Callable[[str, dict[str, Any]], None],
     *,
     server_client: httpx.AsyncClient | None,
+    ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
 ) -> SessionResourceView:
     """
     Auto-create the Cursor TUI terminal for a cursor-native session.
@@ -877,10 +878,15 @@ async def _auto_create_cursor_terminal(
     # and drop the prior terminal's stale forward cursor so the new forwarder
     # can't resume the wrong chat / a stale rowid (mirrors codex's clear_bridge_state).
     await _cancel_auto_forwarder_task(session_id)
-    from omnigent.cursor_native_bridge import bridge_dir_for_session_id
+    from omnigent.cursor_native_bridge import (
+        approve_mcp_server_for_workspace,
+        bridge_dir_for_session_id,
+        write_mcp_config,
+    )
     from omnigent.cursor_native_forwarder import clear_cursor_bridge_state
 
-    clear_cursor_bridge_state(bridge_dir_for_session_id(session_id))
+    bridge_dir = bridge_dir_for_session_id(session_id)
+    clear_cursor_bridge_state(bridge_dir)
 
     # ``_pi_native_launch_config`` is a generic session-snapshot reader
     # (workspace + terminal_launch_args); reused here, not Pi-specific.
@@ -892,8 +898,11 @@ async def _auto_create_cursor_terminal(
     # cursor TUI's cwd and the forwarder hash the SAME path — cursor keys its
     # chat store dir on ``md5(cwd)``, and a mismatch would hide the store.
     workspace = os.path.realpath(str(launch_config.workspace))
+    write_mcp_config(Path(workspace), bridge_dir)
     cursor_command = resolve_cursor_executable()
     cursor_args = list(launch_config.terminal_launch_args or [])
+    if "--approve-mcps" not in cursor_args:
+        cursor_args.append("--approve-mcps")
     terminal_view = await resource_registry.launch_required_terminal(
         session_id=session_id,
         terminal_name="cursor",
@@ -916,10 +925,10 @@ async def _auto_create_cursor_terminal(
     if terminal_registry is not None:
         instance = terminal_registry.get(session_id, "cursor", "main")
         if instance is not None and instance.running:
-            from omnigent.cursor_native_bridge import bridge_dir_for_session_id, write_tmux_target
+            from omnigent.cursor_native_bridge import write_tmux_target
 
             write_tmux_target(
-                bridge_dir_for_session_id(session_id),
+                bridge_dir,
                 socket_path=instance.socket_path,
                 tmux_target=instance.tmux_target,
             )
@@ -949,12 +958,20 @@ async def _auto_create_cursor_terminal(
 
     from omnigent.cursor_native_forwarder import supervise_cursor_forwarder
 
+    if server_client is not None and ensure_comment_relay is not None:
+        await ensure_comment_relay(
+            session_id,
+            explicit_bridge_dir=bridge_dir,
+            await_notify=False,
+        )
+    approve_mcp_server_for_workspace(Path(workspace))
+
     _forwarder_task = asyncio.create_task(
         supervise_cursor_forwarder(
             base_url=server_url,
             headers={},
             session_id=session_id,
-            bridge_dir=bridge_dir_for_session_id(session_id),
+            bridge_dir=bridge_dir,
             agent_name="cursor-native-ui",
             workspace=workspace,
             launch_epoch_ms=launch_epoch_ms,
@@ -5683,6 +5700,7 @@ def create_runner_app(
                             resource_registry,
                             _publish_event,
                             server_client=server_client,
+                            ensure_comment_relay=_ensure_comment_relay_started,
                         )
                     except Exception as exc:
                         _logger.exception(
@@ -10985,6 +11003,7 @@ def create_runner_app(
                         resource_registry,
                         _publish_event,
                         server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
                     )
                 except Exception as exc:
                     _logger.exception(

--- a/tests/e2e/test_cursor_native_cli_e2e.py
+++ b/tests/e2e/test_cursor_native_cli_e2e.py
@@ -55,8 +55,13 @@ Environment requirements (why this is opt-in, not pure-CI)
 
 from __future__ import annotations
 
+import json
 import os
+import queue
 import shutil
+import subprocess
+import sys
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -108,6 +113,35 @@ _REPLY_TIMEOUT = 180.0
 _COLD_RESUME_HINT = (
     "Terminal not running - starting a fresh Cursor session (prior chat not restored)."
 )
+
+
+def _write_json_line(stdin, payload: dict[str, object]) -> None:
+    stdin.write(json.dumps(payload) + "\n")
+    stdin.flush()
+
+
+def _read_json_line(stdout, *, timeout_s: float) -> dict[str, object]:
+    lines: queue.Queue[str] = queue.Queue(maxsize=1)
+
+    def reader() -> None:
+        lines.put(stdout.readline())
+
+    threading.Thread(target=reader, daemon=True).start()
+    try:
+        line = lines.get(timeout=timeout_s)
+    except queue.Empty as exc:
+        raise AssertionError(f"timed out waiting for MCP response after {timeout_s}s") from exc
+    assert line, "MCP process closed stdout"
+    return json.loads(line)
+
+
+def _read_jsonrpc_response(stdout, *, response_id: int, timeout_s: float) -> dict[str, object]:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        payload = _read_json_line(stdout, timeout_s=max(0.1, deadline - time.time()))
+        if payload.get("id") == response_id:
+            return payload
+    raise AssertionError(f"timed out waiting for MCP response id={response_id}")
 
 
 def _wait_for_output_contains(handle: PtyHandle, needle: str, *, timeout: float) -> str:
@@ -349,3 +383,193 @@ def test_cursor_native_cli_resume_warns_when_terminal_was_killed(
             cold_resume.terminate()
     finally:
         primary.terminate()
+
+
+def test_cursor_native_cli_exposes_omnigent_mcp_tools(
+    resume_test_server: str,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """``omnigent cursor`` wires Omnigent tools into Cursor's native MCP client.
+
+    Spawns a real cursor-native session, waits for the runner-owned Cursor TUI
+    to start, then asks ``cursor-agent``'s own MCP subcommand to discover the
+    workspace-scoped ``omnigent`` server. This catches the regressions that made
+    Cursor-native unable to call ``sys_*`` tools: missing ``bridge.json``, a
+    disabled workspace MCP server, lost ``TMPDIR`` under ``python -I``, missing
+    auto-approval config, and stdio framing incompatibility.
+
+    :param resume_test_server: Base URL of the allow-list-free test server.
+    :param tmp_path: Per-test temp dir; its ``pwd`` subdir is the launch cwd.
+    :param request: Pytest request — reads ``--profile`` for the test server.
+    """
+    profile = request.config.getoption("--profile")
+    if not profile:
+        pytest.skip("requires --profile (e.g. --profile oss) for the test server")
+
+    pwd_dir = tmp_path / "pwd"
+    pwd_dir.mkdir()
+
+    omni = str(omnigent_console_script())
+    env = cli_env(profile=profile)
+    handle = spawn_cli_background(
+        [omni, "cursor", "--server", resume_test_server, _FORCE_FLAG],
+        env=env,
+        cwd=str(pwd_dir),
+    )
+    try:
+        conversation_id = wait_for_conversation_id(handle, timeout=_CONV_ID_TIMEOUT)
+        with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+            wait_for_terminal_ready(
+                client,
+                conversation_id=conversation_id,
+                harness="cursor",
+                timeout=_TERMINAL_READY_TIMEOUT,
+            )
+
+        bridge_dir = bridge_dir_for_session_id(conversation_id)
+        mcp_config_path = pwd_dir / ".cursor" / "mcp.json"
+        assert mcp_config_path.is_file(), "cursor-native did not write .cursor/mcp.json"
+        assert (bridge_dir / "bridge.json").is_file(), "serve-mcp token bridge was not written"
+        assert (bridge_dir / "tool_relay.json").is_file(), "Omnigent tool relay was not started"
+
+        payload = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+        server = payload["mcpServers"]["omnigent"]
+        assert server["env"]["TMPDIR"]
+        assert "--bridge-dir" in server["args"]
+        assert str(bridge_dir) in server["args"]
+        assert "sys_session_list" in server["autoApprove"]
+        assert "sys_os_read" in server["autoApprove"]
+
+        cli_config_path = Path.home() / ".cursor" / "cli-config.json"
+        if cli_config_path.is_file():
+            cli_config = json.loads(cli_config_path.read_text(encoding="utf-8"))
+            allow = cli_config.get("permissions", {}).get("allow", [])
+            assert "Mcp(omnigent:sys_session_list)" in allow
+            assert "Mcp(omnigent:sys_os_read)" in allow
+
+        listed = subprocess.run(
+            ["cursor-agent", "mcp", "list"],
+            cwd=pwd_dir,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=45,
+            check=False,
+        )
+        assert listed.returncode == 0, listed.stdout
+        assert "omnigent" in listed.stdout
+        assert "ready" in listed.stdout.lower()
+
+        tools = subprocess.run(
+            ["cursor-agent", "mcp", "list-tools", "omnigent"],
+            cwd=pwd_dir,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=45,
+            check=False,
+        )
+        assert tools.returncode == 0, tools.stdout
+        assert "sys_session_list" in tools.stdout
+        assert "sys_session_send" in tools.stdout
+        assert "sys_os_read" in tools.stdout
+    finally:
+        handle.terminate()
+
+
+def test_cursor_native_cli_mcp_can_call_sys_tool(
+    resume_test_server: str,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Cursor-native's generated Omnigent MCP server can call ``sys_*`` tools.
+
+    Launches a real Cursor TUI, then calls the same generated ``.cursor/mcp.json``
+    Omnigent relay that Cursor uses. The tool call is direct JSON-RPC over the
+    generated stdio server rather than model-steered prose, so it deterministically
+    proves the Cursor-native MCP wiring can execute relayed ``sys_*`` tools.
+    """
+    profile = request.config.getoption("--profile")
+    if not profile:
+        pytest.skip("requires --profile (e.g. --profile oss) for the test server")
+
+    pwd_dir = tmp_path / "pwd"
+    pwd_dir.mkdir()
+
+    omni = str(omnigent_console_script())
+    env = cli_env(profile=profile)
+    handle = spawn_cli_background(
+        [omni, "cursor", "--server", resume_test_server, _FORCE_FLAG],
+        env=env,
+        cwd=str(pwd_dir),
+    )
+    try:
+        conversation_id = wait_for_conversation_id(handle, timeout=_CONV_ID_TIMEOUT)
+        with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+            wait_for_terminal_ready(
+                client,
+                conversation_id=conversation_id,
+                harness="cursor",
+                timeout=_TERMINAL_READY_TIMEOUT,
+            )
+
+        bridge_dir = bridge_dir_for_session_id(conversation_id)
+        mcp_config_path = pwd_dir / ".cursor" / "mcp.json"
+        payload = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+        server = payload["mcpServers"]["omnigent"]
+        proc_env = {**os.environ, **env, **server.get("env", {})}
+        proc = subprocess.Popen(
+            [server.get("command") or sys.executable, *server["args"]],
+            cwd=pwd_dir,
+            env=proc_env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        with httpx.Client(base_url=resume_test_server, timeout=30) as client:
+            try:
+                assert proc.stdin is not None
+                assert proc.stdout is not None
+                assert (bridge_dir / "tool_relay.json").is_file()
+                _write_json_line(
+                    proc.stdin,
+                    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+                )
+                initialize = _read_jsonrpc_response(proc.stdout, response_id=1, timeout_s=10.0)
+                assert initialize["id"] == 1
+
+                _write_json_line(
+                    proc.stdin,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "sys_session_list",
+                            "arguments": {},
+                        },
+                    },
+                )
+                tool_response = _read_jsonrpc_response(
+                    proc.stdout,
+                    response_id=2,
+                    timeout_s=30.0,
+                )
+                assert "error" not in tool_response, tool_response
+                text = tool_response["result"]["content"][0]["text"]
+                decoded = json.loads(text)
+                assert "error" not in decoded
+                assert "sessions" in decoded or "child_sessions" in decoded or "items" in decoded
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5.0)
+    finally:
+        handle.terminate()

--- a/tests/inner/test_cursor_native_executor.py
+++ b/tests/inner/test_cursor_native_executor.py
@@ -8,14 +8,25 @@ not here, so these need no tmux or cursor-agent.
 
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from omnigent.cursor_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
     _paste_payload_bytes,
+    allow_mcp_tools_in_cli_config,
+    approve_mcp_server_for_workspace,
     bridge_dir_for_session_id,
     build_cursor_native_spawn_env,
+    build_mcp_config,
+    cursor_project_key,
+    enable_mcp_for_workspace,
     read_tmux_info,
+    write_mcp_bridge_config,
+    write_mcp_config,
     write_tmux_target,
 )
 from omnigent.inner.cursor_native_executor import (
@@ -109,6 +120,110 @@ class TestBridge:
 
     def test_read_tmux_info_missing(self, tmp_path: Path) -> None:
         assert read_tmux_info(tmp_path) is None
+
+    def test_build_mcp_config_registers_omnigent_relay(self, tmp_path: Path) -> None:
+        config = build_mcp_config(tmp_path, python_executable="python-test")
+        server = config["mcpServers"]["omnigent"]
+        assert server["command"] == "python-test"
+        assert server["args"] == [
+            "-I",
+            "-m",
+            "omnigent.claude_native_bridge",
+            "serve-mcp",
+            "--bridge-dir",
+            str(tmp_path),
+        ]
+        assert "sys_session_send" in server["autoApprove"]
+        assert "sys_os_shell" in server["autoApprove"]
+        assert server["autoApprove"] == sorted(server["autoApprove"])
+        assert server["env"]["TMPDIR"]
+
+    def test_write_mcp_config_is_workspace_scoped(self, tmp_path: Path, monkeypatch) -> None:
+        workspace = tmp_path / "workspace"
+        bridge_dir = tmp_path / "bridge"
+        monkeypatch.setattr(
+            "omnigent.cursor_native_bridge.approve_mcp_server_for_workspace",
+            lambda _workspace: pytest.fail("approval must happen after tool relay starts"),
+        )
+        path = write_mcp_config(workspace, bridge_dir, python_executable="python-test")
+
+        assert path == workspace / ".cursor" / "mcp.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["mcpServers"]["omnigent"]["command"] == "python-test"
+        assert json.loads((bridge_dir / "bridge.json").read_text(encoding="utf-8"))["token"]
+
+    def test_write_mcp_bridge_config_is_idempotent(self, tmp_path: Path) -> None:
+        write_mcp_bridge_config(tmp_path)
+        first = (tmp_path / "bridge.json").read_text(encoding="utf-8")
+        write_mcp_bridge_config(tmp_path)
+        assert (tmp_path / "bridge.json").read_text(encoding="utf-8") == first
+
+    def test_cursor_project_key_matches_cursor_workspace_state(self) -> None:
+        assert cursor_project_key(Path("/Users/corey.zumar")) == "Users-corey.zumar"
+
+    def test_enable_mcp_for_workspace_removes_disabled_entry(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        disabled_path = (
+            tmp_path / ".cursor" / "projects" / "Users-corey.zumar" / "mcp-disabled.json"
+        )
+        disabled_path.parent.mkdir(parents=True)
+        disabled_path.write_text('["omnigent", "other"]\n', encoding="utf-8")
+
+        enable_mcp_for_workspace(Path("/Users/corey.zumar"))
+
+        assert json.loads(disabled_path.read_text(encoding="utf-8")) == ["other"]
+
+    def test_allow_mcp_tools_in_cli_config_adds_specific_allow_rules(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        config_path = tmp_path / ".cursor" / "cli-config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(
+            '{"permissions": {"allow": ["Shell(ls)", "Mcp(omnigent:sys_os_read)"]}}\n',
+            encoding="utf-8",
+        )
+
+        allow_mcp_tools_in_cli_config()
+
+        allow = json.loads(config_path.read_text(encoding="utf-8"))["permissions"]["allow"]
+        assert "Shell(ls)" in allow
+        assert allow.count("Mcp(omnigent:sys_os_read)") == 1
+        assert "Mcp(omnigent:sys_session_send)" in allow
+
+    def test_approve_mcp_server_for_workspace_uses_cursor_cli(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        calls: list[dict[str, object]] = []
+
+        monkeypatch.setattr(
+            "omnigent.cursor_native.resolve_cursor_executable",
+            lambda: "/bin/cursor-agent-test",
+        )
+
+        def fake_run(*args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return subprocess.CompletedProcess(args[0], 0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        approve_mcp_server_for_workspace(tmp_path)
+
+        assert calls == [
+            {
+                "args": (["/bin/cursor-agent-test", "mcp", "enable", "omnigent"],),
+                "kwargs": {
+                    "cwd": tmp_path,
+                    "stdin": subprocess.DEVNULL,
+                    "stdout": subprocess.DEVNULL,
+                    "stderr": subprocess.DEVNULL,
+                    "timeout": 15,
+                    "check": False,
+                },
+            }
+        ]
 
 
 class TestRegistration:

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -124,6 +124,8 @@ def test_configured_harness_map_covers_all_spellings(
         "pi-native",
         "native-pi",
         "cursor",
+        "cursor-native",
+        "native-cursor",
         # Antigravity SDK harness + its user-facing aliases.
         "antigravity",
         "agy",
@@ -156,8 +158,8 @@ def test_configured_harness_map_gates_only_cli_harnesses(
     ):
         assert result[sdk] is True, f"{sdk} should never be gated"
     # CLI-wrapping spellings — gated, so False when the binary is absent.
-    # (Cursor is excluded: it runs via the ``cursor-sdk`` package and gates on
-    # a configured ``CURSOR_API_KEY``, not a binary — covered separately.)
+    # (Bare ``cursor`` is excluded: it runs via the ``cursor-sdk`` package and
+    # gates on a configured ``CURSOR_API_KEY``, not a binary — covered separately.)
     for cli in (
         "claude-native",
         "native-claude",
@@ -165,6 +167,8 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         "codex-native",
         "native-codex",
         "pi",
+        "cursor-native",
+        "native-cursor",
     ):
         assert result[cli] is False, f"{cli} should be gated on its CLI binary"
 
@@ -212,3 +216,17 @@ def test_cursor_readiness_keys_off_api_key(
         yaml.safe_dump({"cursor": {"api_key_ref": "env:MY_CURSOR_KEY"}})
     )
     assert harness_is_configured("cursor") is True
+
+
+def test_cursor_native_readiness_keys_off_cursor_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cursor-native is configured iff the ``cursor-agent`` CLI is installed."""
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_sdk_key_does_not_matter")
+    _all_clis_installed(monkeypatch)
+    assert harness_is_configured("cursor-native") is True
+    assert harness_is_configured("native-cursor") is True
+
+    _no_clis_installed(monkeypatch)
+    assert harness_is_configured("cursor-native") is False
+    assert harness_is_configured("native-cursor") is False


### PR DESCRIPTION
## Summary
- write Cursor MCP config and bridge metadata by default for cursor-native sessions
- enable/approve the Omnigent MCP server for the workspace before Cursor starts calling tools
- add Cursor-native MCP unit coverage and live e2e coverage for listing and calling sys_* tools

## Exclusions
- no elicitation/permission bridge changes
- no uv.lock or ap-web/package-lock.json changes

## Tests
- ruff check tests/e2e/test_cursor_native_cli_e2e.py tests/inner/test_cursor_native_executor.py omnigent/cursor_native_bridge.py
- pytest tests/inner/test_cursor_native_executor.py tests/onboarding/test_harness_readiness.py -q