### PR TITLE
feat: implement async-tool completion auto-delivery

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4565,7 +4565,7 @@ def create_runner_app(
     # drops don't lose events — the relay drains on reconnect.
     _session_event_queues = _session_event_queues_ref
     # Per-session async inbox queues for sys_call_async /
-    # sys_read_inbox (SESSION_REARCHITECTURE Step 7 partial).
+    # sys_read_inbox (SESSION_REARCHITECTURE Step 7).
     _session_inboxes = _session_inboxes_ref
     # Per-session background async tasks keyed by handle_id.
     # Each entry is (task, cancel_event) so cancellation is instant.

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4769,6 +4769,10 @@ _AUTO_DELIVER_MAX_ATTEMPTS = 3
 _AUTO_DELIVER_RETRY_BASE_DELAY_S = 0.5
 _AUTO_DELIVER_RETRY_MAX_DELAY_S = 4.0
 
+# Thin indirection so tests can patch ``tool_dispatch._sleep`` instead of
+# the global ``asyncio.sleep`` singleton (which leaks across workers).
+_sleep = asyncio.sleep
+
 
 async def _auto_deliver_async_completion(
     payload: dict[str, Any],
@@ -4814,8 +4818,7 @@ async def _auto_deliver_async_completion(
                 isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
             )
             _logger.debug(
-                "Async-tool auto-deliver attempt %d/%d for session=%s failed "
-                "(retryable=%s): %r",
+                "Async-tool auto-deliver attempt %d/%d for session=%s failed (retryable=%s): %r",
                 attempt,
                 _AUTO_DELIVER_MAX_ATTEMPTS,
                 conversation_id,
@@ -4836,7 +4839,7 @@ async def _auto_deliver_async_completion(
                 _AUTO_DELIVER_RETRY_BASE_DELAY_S * (2 ** (attempt - 1)),
                 _AUTO_DELIVER_RETRY_MAX_DELAY_S,
             )
-            await asyncio.sleep(delay_s)
+            await _sleep(delay_s)
 
 
 def _schedule_auto_delivery(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4750,6 +4750,131 @@ def _format_async_task_item(payload: dict[str, Any]) -> str:
     return f"[System: task {handle_id} {status} — {tool}: {output}]"
 
 
+# ── Async-tool auto-delivery (SESSION_REARCHITECTURE Step 7) ─────
+#
+# When a background ``_bg()`` task completes, the result is pushed to the
+# session inbox for explicit pull via ``sys_read_inbox``. Auto-delivery
+# additionally POSTs the formatted completion as a ``[System: task ...]``
+# user message to ``/v1/sessions/{id}/events``, which persists it in
+# ``conversation_items`` and wakes the LLM if idle — mirroring the
+# sub-agent wake path in ``app.py``.  The inbox entry is NOT drained:
+# ``sys_read_inbox`` tool output is a ``function_call_output`` (not a
+# user message), so the per-conversation ``[System: task ...]`` user
+# message count stays at 1 regardless of whether the LLM also calls
+# ``sys_read_inbox``.
+
+_auto_deliver_bg_tasks: set[asyncio.Task[None]] = set()
+
+_AUTO_DELIVER_MAX_ATTEMPTS = 3
+_AUTO_DELIVER_RETRY_BASE_DELAY_S = 0.5
+_AUTO_DELIVER_RETRY_MAX_DELAY_S = 4.0
+
+
+async def _auto_deliver_async_completion(
+    payload: dict[str, Any],
+    *,
+    server_client: httpx.AsyncClient,
+    conversation_id: str,
+) -> None:
+    """
+    POST a completed async-tool payload as a user message to ``/events``.
+
+    Retries transient failures with exponential backoff, mirroring
+    :func:`omnigent.runner.app._deliver_subagent_wake_post`.  On
+    terminal failure the payload remains in the session inbox for
+    ``sys_read_inbox`` to drain — no result is lost.
+
+    :param payload: Completed/failed/cancelled async-tool inbox
+        payload with ``handle_id``, ``tool_name``, ``status``,
+        ``output`` keys.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :param conversation_id: Session id to deliver to, e.g.
+        ``"conv_abc123"``.
+    :returns: None.
+    """
+    formatted = _format_async_task_item(payload)
+    for attempt in range(1, _AUTO_DELIVER_MAX_ATTEMPTS + 1):
+        try:
+            resp = await server_client.post(
+                f"/v1/sessions/{conversation_id}/events",
+                json={
+                    "type": "message",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": formatted}],
+                    },
+                },
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            return
+        except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+            last = attempt >= _AUTO_DELIVER_MAX_ATTEMPTS
+            retryable = isinstance(exc, asyncio.TimeoutError) or (
+                isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
+            )
+            _logger.debug(
+                "Async-tool auto-deliver attempt %d/%d for session=%s failed "
+                "(retryable=%s): %r",
+                attempt,
+                _AUTO_DELIVER_MAX_ATTEMPTS,
+                conversation_id,
+                retryable,
+                exc,
+            )
+            if last or not retryable:
+                _logger.warning(
+                    "Async-tool auto-deliver failed for session=%s handle=%s "
+                    "after %d attempt(s); result remains in inbox for "
+                    "sys_read_inbox",
+                    conversation_id,
+                    payload.get("handle_id"),
+                    attempt,
+                )
+                return
+            delay_s = min(
+                _AUTO_DELIVER_RETRY_BASE_DELAY_S * (2 ** (attempt - 1)),
+                _AUTO_DELIVER_RETRY_MAX_DELAY_S,
+            )
+            await asyncio.sleep(delay_s)
+
+
+def _schedule_auto_delivery(
+    payload: dict[str, Any],
+    *,
+    server_client: httpx.AsyncClient | None,
+    conversation_id: str | None,
+) -> None:
+    """
+    Fire-and-forget auto-delivery of an async-tool completion.
+
+    Called from ``_bg()`` after each ``session_inbox.put_nowait()``.
+    Silently no-ops when the server client or conversation id is
+    unavailable (e.g. unit-test contexts without a live server).
+
+    :param payload: Inbox payload just pushed to the session queue.
+    :param server_client: HTTP client, or ``None`` in test contexts.
+    :param conversation_id: Session id, or ``None``.
+    :returns: None.
+    """
+    if server_client is None or conversation_id is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    task = loop.create_task(
+        _auto_deliver_async_completion(
+            payload,
+            server_client=server_client,
+            conversation_id=conversation_id,
+        ),
+        name=f"auto-deliver-{payload.get('handle_id', 'unknown')}",
+    )
+    task.add_done_callback(_auto_deliver_bg_tasks.discard)
+    _auto_deliver_bg_tasks.add(task)
+
+
 def _subagent_child_id(payload: dict[str, Any]) -> str | None:
     """
     Extract the child session id from a sub-agent inbox payload.
@@ -5037,7 +5162,8 @@ def _spawn_async_tool(
 
     Returns a handle immediately. On completion, the result is
     pushed to the session's inbox queue for ``sys_read_inbox``
-    to drain.
+    to drain, and auto-delivered as a ``[System: task ...]``
+    user message via ``POST /v1/sessions/{id}/events``.
 
     :param args: Must contain ``"tool"`` (target tool name) and
         ``"args"`` (JSON string of target tool arguments).
@@ -5099,43 +5225,59 @@ def _spawn_async_tool(
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if cancel_event.is_set():
-                session_inbox.put_nowait(
-                    {
-                        "handle_id": handle_id,
-                        "tool_name": target_tool,
-                        "status": "cancelled",
-                        "output": "",
-                    }
-                )
-                return ""
-            result = next(iter(done)).result()
-            session_inbox.put_nowait(
-                {
-                    "handle_id": handle_id,
-                    "tool_name": target_tool,
-                    "status": "completed",
-                    "output": result,
-                }
-            )
-            return result
-        except asyncio.CancelledError:
-            session_inbox.put_nowait(
-                {
+                cancel_payload = {
                     "handle_id": handle_id,
                     "tool_name": target_tool,
                     "status": "cancelled",
                     "output": "",
                 }
+                session_inbox.put_nowait(cancel_payload)
+                _schedule_auto_delivery(
+                    cancel_payload,
+                    server_client=server_client,
+                    conversation_id=conversation_id,
+                )
+                return ""
+            result = next(iter(done)).result()
+            completed_payload = {
+                "handle_id": handle_id,
+                "tool_name": target_tool,
+                "status": "completed",
+                "output": result,
+            }
+            session_inbox.put_nowait(completed_payload)
+            _schedule_auto_delivery(
+                completed_payload,
+                server_client=server_client,
+                conversation_id=conversation_id,
+            )
+            return result
+        except asyncio.CancelledError:
+            cancel_payload = {
+                "handle_id": handle_id,
+                "tool_name": target_tool,
+                "status": "cancelled",
+                "output": "",
+            }
+            session_inbox.put_nowait(cancel_payload)
+            _schedule_auto_delivery(
+                cancel_payload,
+                server_client=server_client,
+                conversation_id=conversation_id,
             )
             raise
         except Exception as exc:  # noqa: BLE001
-            session_inbox.put_nowait(
-                {
-                    "handle_id": handle_id,
-                    "tool_name": target_tool,
-                    "status": "failed",
-                    "output": str(exc),
-                }
+            failed_payload = {
+                "handle_id": handle_id,
+                "tool_name": target_tool,
+                "status": "failed",
+                "output": str(exc),
+            }
+            session_inbox.put_nowait(failed_payload)
+            _schedule_auto_delivery(
+                failed_payload,
+                server_client=server_client,
+                conversation_id=conversation_id,
             )
             return f"Error: {exc}"
         finally:

--- a/tests/runner/test_async_tool_auto_delivery.py
+++ b/tests/runner/test_async_tool_auto_delivery.py
@@ -82,7 +82,7 @@ async def test_auto_deliver_retries_on_5xx() -> None:
     payload = _completed_payload()
     client = _mock_server_client(503)
 
-    with patch("omnigent.runner.tool_dispatch.asyncio.sleep", new_callable=AsyncMock):
+    with patch("omnigent.runner.tool_dispatch._sleep", new_callable=AsyncMock):
         await _auto_deliver_async_completion(
             payload,
             server_client=client,
@@ -115,7 +115,7 @@ async def test_auto_deliver_handles_timeout() -> None:
     client = AsyncMock(spec=httpx.AsyncClient)
     client.post.side_effect = asyncio.TimeoutError()
 
-    with patch("omnigent.runner.tool_dispatch.asyncio.sleep", new_callable=AsyncMock):
+    with patch("omnigent.runner.tool_dispatch._sleep", new_callable=AsyncMock):
         await _auto_deliver_async_completion(
             payload,
             server_client=client,

--- a/tests/runner/test_async_tool_auto_delivery.py
+++ b/tests/runner/test_async_tool_auto_delivery.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for async-tool auto-delivery (SESSION_REARCHITECTURE Step 7).
+
+Verifies that ``_auto_deliver_async_completion`` and
+``_schedule_auto_delivery`` in :mod:`omnigent.runner.tool_dispatch`
+POST the formatted completion as a ``[System: task ...]`` user
+message to ``/v1/sessions/{id}/events``, with retry on transient
+failures and graceful degradation when the server is unreachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from omnigent.runner.tool_dispatch import (
+    _auto_deliver_async_completion,
+    _format_async_task_item,
+    _schedule_auto_delivery,
+)
+
+
+def _completed_payload(handle_id: str = "handle_abc", tool: str = "my_tool") -> dict:
+    return {
+        "handle_id": handle_id,
+        "tool_name": tool,
+        "status": "completed",
+        "output": "RESULT_MARKER_42",
+    }
+
+
+def _mock_server_client(status_code: int = 200) -> AsyncMock:
+    mock = AsyncMock(spec=httpx.AsyncClient)
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error",
+            request=httpx.Request("POST", "http://x"),
+            response=httpx.Response(status_code),
+        )
+    mock.post.return_value = resp
+    return mock
+
+
+# ─── _auto_deliver_async_completion ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auto_deliver_posts_formatted_message() -> None:
+    """The auto-delivery POSTs the formatted task item as a user message."""
+    payload = _completed_payload()
+    client = _mock_server_client()
+    conv_id = "conv_test123"
+
+    await _auto_deliver_async_completion(
+        payload,
+        server_client=client,
+        conversation_id=conv_id,
+    )
+
+    client.post.assert_called_once()
+    call_args = client.post.call_args
+    assert call_args[0][0] == f"/v1/sessions/{conv_id}/events"
+
+    body = call_args[1]["json"]
+    assert body["type"] == "message"
+    assert body["data"]["role"] == "user"
+    text = body["data"]["content"][0]["text"]
+    expected = _format_async_task_item(payload)
+    assert text == expected
+    assert "RESULT_MARKER_42" in text
+    assert text.startswith("[System: task ")
+
+
+@pytest.mark.asyncio
+async def test_auto_deliver_retries_on_5xx() -> None:
+    """Transient 5xx failures trigger retries with exponential backoff."""
+    payload = _completed_payload()
+    client = _mock_server_client(503)
+
+    with patch("omnigent.runner.tool_dispatch.asyncio.sleep", new_callable=AsyncMock):
+        await _auto_deliver_async_completion(
+            payload,
+            server_client=client,
+            conversation_id="conv_retry",
+        )
+
+    # Should have retried up to MAX_ATTEMPTS (3)
+    assert client.post.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_auto_deliver_no_retry_on_4xx() -> None:
+    """Permanent 4xx failures stop immediately without retrying."""
+    payload = _completed_payload()
+    client = _mock_server_client(400)
+
+    await _auto_deliver_async_completion(
+        payload,
+        server_client=client,
+        conversation_id="conv_no_retry",
+    )
+
+    assert client.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_deliver_handles_timeout() -> None:
+    """asyncio.TimeoutError is treated as retryable."""
+    payload = _completed_payload()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post.side_effect = asyncio.TimeoutError()
+
+    with patch("omnigent.runner.tool_dispatch.asyncio.sleep", new_callable=AsyncMock):
+        await _auto_deliver_async_completion(
+            payload,
+            server_client=client,
+            conversation_id="conv_timeout",
+        )
+
+    assert client.post.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_auto_deliver_formats_failed_payload() -> None:
+    """Failed tool results are auto-delivered with the error marker."""
+    payload = {
+        "handle_id": "handle_fail",
+        "tool_name": "boom_tool",
+        "status": "failed",
+        "output": "BOOM_ERROR_MARKER",
+    }
+    client = _mock_server_client()
+
+    await _auto_deliver_async_completion(
+        payload,
+        server_client=client,
+        conversation_id="conv_fail",
+    )
+
+    text = client.post.call_args[1]["json"]["data"]["content"][0]["text"]
+    assert "failed" in text
+    assert "BOOM_ERROR_MARKER" in text
+
+
+@pytest.mark.asyncio
+async def test_auto_deliver_formats_cancelled_payload() -> None:
+    """Cancelled tasks are auto-delivered with cancelled status."""
+    payload = {
+        "handle_id": "handle_cancel",
+        "tool_name": "slow_tool",
+        "status": "cancelled",
+        "output": "",
+    }
+    client = _mock_server_client()
+
+    await _auto_deliver_async_completion(
+        payload,
+        server_client=client,
+        conversation_id="conv_cancel",
+    )
+
+    text = client.post.call_args[1]["json"]["data"]["content"][0]["text"]
+    assert "cancelled" in text
+
+
+# ─── _schedule_auto_delivery ────────────────────────────────
+
+
+def test_schedule_noop_without_server_client() -> None:
+    """No task is created when server_client is None."""
+    payload = _completed_payload()
+    _schedule_auto_delivery(
+        payload,
+        server_client=None,
+        conversation_id="conv_x",
+    )
+    # No error, no task created — silent no-op.
+
+
+def test_schedule_noop_without_conversation_id() -> None:
+    """No task is created when conversation_id is None."""
+    payload = _completed_payload()
+    _schedule_auto_delivery(
+        payload,
+        server_client=_mock_server_client(),
+        conversation_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_creates_background_task() -> None:
+    """_schedule_auto_delivery creates an asyncio task that POSTs."""
+    payload = _completed_payload()
+    client = _mock_server_client()
+
+    _schedule_auto_delivery(
+        payload,
+        server_client=client,
+        conversation_id="conv_schedule",
+    )
+
+    # Let the event loop process the task.
+    await asyncio.sleep(0)
+
+    assert client.post.called
+    text = client.post.call_args[1]["json"]["data"]["content"][0]["text"]
+    assert "RESULT_MARKER_42" in text


### PR DESCRIPTION
## Summary
- Implements SESSION_REARCHITECTURE Step 7: when a background `_bg()` task completes, the formatted `[System: task ...]` result is auto-delivered as a persisted user message via `POST /v1/sessions/{id}/events`, waking the LLM if idle
- Mirrors the sub-agent wake retry pattern (3 attempts, exponential backoff on 5xx/timeout); on terminal failure the payload stays in the inbox for `sys_read_inbox` fallback
- Inbox entries are **not** drained during auto-delivery — `sys_read_inbox` output is a `function_call_output` (not a user message), so the `len(completion_messages) == 1` contract on persisted user messages holds regardless

Closes #522

## Test plan
- [x] 9 new unit tests in `tests/runner/test_async_tool_auto_delivery.py` (POST format, retry/no-retry, failed/cancelled payloads, schedule no-op guards)
- [x] All 942 existing runner tests pass
- [x] All 14 async inbox unit tests pass
- [x] All 3 async completion drain tests pass
- [x] Pre-existing e2e tests (`test_async_tools_e2e.py`, `test_sys_async_inbox_e2e.py`, `test_sys_async_inbox_harness_e2e.py`) should now pass when run against a live server with `--llm-api-key`

This pull request and its description were written by Isaac.