### PR TITLE
chore(known_failures): repoint compaction e2e to boot-starvation (#523)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -371,9 +371,9 @@ skips:
 
   # Standalone failures — no obvious cluster yet.
   - id: tests/e2e/omnigent/test_compaction_sessions_native_e2e.py::test_compaction_fires_and_agent_retains_context
-    reason: "Force-merge backlog (standalone). First observed failing at 801c389c (2026-05-23T00:35:30Z, E2E)."
-    issue: 679
-    cluster: steering-cancel-compaction-state
+    reason: "Not a compaction bug: the pexpect `omnigent run` child never finishes booting -- it stays on 'Starting the local server...' and never reaches the 'sleeping' ready state within the 120s _BOOT_TIMEOUT (fails at line 163, before any compaction assertion runs). Boot-starvation, same family as the repl-pexpect-cli tests, so repointed off the compaction tracker (#679, mis-filed) to #523. Fails 30/30 in flake-stress run 27799636357 (main, --no-skip-known, 2 workers, 2026-06-19)."
+    issue: 523
+    cluster: repl-pexpect-cli
     mode: skip
   - id: tests/e2e/test_filesystem_changed_files_e2e.py::test_filesystem_changes_appear_after_agent_write
     reason: "Force-merge backlog (standalone). First observed failing at 305e9bb9 (2026-05-23T06:06:59Z, E2E)."


### PR DESCRIPTION
## Related issue

N/A — quarantine-metadata chore. References #523 and #679 but intentionally
closes neither (both remain open/unfixed).

## Summary

- `tests/e2e/omnigent/test_compaction_sessions_native_e2e.py::test_compaction_fires_and_agent_retains_context`
  was quarantined under the compaction tracker (**#679**) with the stale reason
  *"Force-merge backlog (standalone). First observed failing at 801c389c."*
- A 30× flake-stress run on `main` (`--no-skip-known`, run
  [27799636357](https://github.com/omnigent-ai/omnigent/actions/runs/27799636357))
  shows it fails **30/30** — but **not** in compaction. It dies at the pexpect
  boot phase: the `omnigent run` child stays on `Starting the local server...`
  and never reaches the `sleeping` ready state within the 120s `_BOOT_TIMEOUT`
  (fails at `test_compaction_sessions_native_e2e.py:163`, before any compaction
  assertion executes).
- That is the same in-process local-server boot-starvation tracked by **#523**
  ("REPL pexpect e2e tests starve on boot…"), so this PR repoints
  `issue: 679 → 523`, reclusters `steering-cancel-compaction-state →
  repl-pexpect-cli`, and rewrites the reason to the empirically-observed
  signature. It stays `mode: skip` (consistent failure; pexpect boot test, and
  `main` has no e2e reruns).

No test logic, no product code, and no other quarantine entries change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Metadata-only change to `tests/known_failures.yaml`; no code paths are touched,
so there is nothing new to test. The reclassification itself was verified
empirically:

- `gh workflow run` "Flake stress (E2E)" on `main`, 30 attempts, 2 workers,
  profile `oss`, `--no-skip-known`, run
  [27799636357](https://github.com/omnigent-ai/omnigent/actions/runs/27799636357):
  the test failed 30/30, every failure being
  `Failed: Pattern 'sleeping' not found within 120.0s` at line 163 (boot), not a
  compaction assertion.
- `uv run --extra dev python -c "import yaml; yaml.safe_load(open('tests/known_failures.yaml'))"`
  confirms the file still parses and the entry's `id` is unchanged (so the
  `pytest_collection_modifyitems` stale-entry warning stays clean).

This pull request and its description were written by Isaac.
