### PR TITLE
fix(test): skip os_env-inherit for harnesses without a *_worker tool; re-triage runner-wedge cluster

### DIFF
--- a/tests/e2e/omnigent/test_run_omnigent_os_env_inherit.py
+++ b/tests/e2e/omnigent/test_run_omnigent_os_env_inherit.py
@@ -190,8 +190,14 @@ def test_run_omnigent_propagates_os_env_inherit_to_spawned_worker(
     :param model: The harness-routed model identifier from
         :data:`HARNESS_HARNESS_MODELS`.
     """
-    worker_type = _WORKER_TYPE_BY_HARNESS[harness]
-    required_binary = _REQUIRED_BINARY_BY_HARNESS[harness]
+    worker_type = _WORKER_TYPE_BY_HARNESS.get(harness)
+    required_binary = _REQUIRED_BINARY_BY_HARNESS.get(harness)
+    if worker_type is None or required_binary is None:
+        pytest.skip(
+            f"{harness!r} has no inline ``<harness>_worker`` AgentTool "
+            "convention (only claude-sdk/codex/pi do), so the "
+            "os_env-inherit-to-spawned-worker invariant does not apply."
+        )
     for entry in _ROOT_ANCHOR_ENTRIES:
         assert (omnigent_repo_root / entry).exists(), (
             f"Expected anchor {entry!r} missing from "

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -36,9 +36,9 @@ skips:
   # (last STARTING on gw3 with no END). Pexpect REPL + sub-agent
   # spawn pattern.
   - id: tests/e2e/omnigent/test_run_omnigent_ctrl_g_subagent_dedup.py::test_run_omnigent_ctrl_g_deduplicates_subagent_across_spawn_and_send
-    reason: "Wedges hardened CI runner."
-    issue: 671
-    cluster: runner-wedge-subprocess-fanout
+    reason: "Sub-agent spawn/turn does not complete (pexpect.TIMEOUT) — parent never gets the spawned sub-agent result in time. Fails 30/30 even at workers=1 (run 27800002759); NOT a runner wedge. Same end-of-turn drain gap as #682."
+    issue: 682
+    cluster: subagent-result-delivery
     mode: skip
 
   # Shard 1 wedge candidates from run 25854221043's progress logger
@@ -49,15 +49,15 @@ skips:
   # reap the test's spawned children fast enough, accumulating until
   # the host wedges.
   - id: tests/e2e/omnigent/test_run_omnigent_os_env_inherit.py::test_run_omnigent_propagates_os_env_inherit_to_spawned_worker[claude-sdk]
-    reason: "Wedges hardened CI runner via os_env subprocess fanout."
-    issue: 671
-    cluster: runner-wedge-subprocess-fanout
+    reason: "Flaky sub-agent result-delivery: the spawned claude_worker file-listing result intermittently does not reach the parent before timeout (~half of attempts in run 27800002759, even serial). os_env propagation itself works when the result lands; the flake is the #682 drain gap."
+    issue: 682
+    cluster: subagent-result-delivery
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_omnigent_twelve_shells.py::test_twelve_parallel_shells_complete_under_ap
-    reason: "Wedges hardened CI runner via 12 parallel pty shells."
-    issue: 671
-    cluster: runner-wedge-subprocess-fanout
+    reason: "Fan-out tool-result-delivery race: the LLM responds before all 12 parallel shell tool results land ('did NOT confirm all 12 shells finished'). Fails 30/30 even at workers=1 (run 27800002759); NOT a runner wedge. Canonical repro for the #522 async tool-result end-of-turn drain."
+    issue: 522
+    cluster: async-tool-result-delivery
     mode: skip
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_call_approval_allows_tool_to_run
@@ -101,11 +101,6 @@ skips:
     reason: "Shard 1 bulk: secure_research_agent os-env one-shot. Triage pending."
     issue: 675
     cluster: sandbox-deps-env
-    mode: skip
-  - id: tests/e2e/omnigent/test_run_omnigent_os_env_inherit.py::test_run_omnigent_propagates_os_env_inherit_to_spawned_worker[openai-agents]
-    reason: "Shard 1 bulk: os_env propagation, same family as the [claude-sdk] variant."
-    issue: 671
-    cluster: runner-wedge-subprocess-fanout
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[claude-sdk]
@@ -170,9 +165,9 @@ skips:
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_omnigent_os_env_inherit.py::test_run_omnigent_propagates_os_env_inherit_to_spawned_worker[codex]
-    reason: "Shard 3 bulk: os_env propagation, codex variant. Same runner-wedge family."
-    issue: 671
-    cluster: runner-wedge-subprocess-fanout
+    reason: "Flaky sub-agent result-delivery: the spawned codex_worker result intermittently does not reach the parent before timeout (~quarter of attempts in run 27800002759, even serial). Same #682 drain gap; os_env propagation works when the result lands."
+    issue: 682
+    cluster: subagent-result-delivery
     mode: skip
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_output_ask_refuse_replaces_reply_with_sentinel


### PR DESCRIPTION
## Summary

Triages the `runner-wedge-subprocess-fanout` cluster (#671, 5 tests). Flake-stress ([run 27800002759](https://github.com/omnigent-ai/omnigent/actions/runs/27800002759), 30×, **workers=1 *and* workers=2**) shows **none of them wedge the host** — they fail/flake even run serially. The "wedges hardened CI runner" framing was wrong (both flake-stress and `e2e.yml` run on `ubuntu-latest`). The real causes split three ways:

**Fixed (test bug) → un-quarantined:**
- `test_run_omnigent_os_env_inherit.py::...[openai-agents]` — `KeyError: 'openai-agents'`. The test is parametrized over the shared `HARNESS_HARNESS_MODELS` matrix (which includes `openai-agents`), but `_WORKER_TYPE_BY_HARNESS` only maps `claude-sdk`/`codex`/`pi`. `openai-agents` has no inline `<harness>_worker` AgentTool, so the os_env-inherit-to-worker invariant doesn't apply to it. Fixed with a `.get()` + `pytest.skip` guard (mirroring the existing skip-on-missing-binary path). Verified it now **skips cleanly**; removed its `known_failures` entry.

**Re-characterized (real cause = the async end-of-turn result-delivery gap, not a wedge) → kept quarantined:**
- `test_twelve_parallel_shells_complete_under_ap` → **#522**. It asserts *"the LLM may respond before tool results land"* — the canonical fan-out tool-result-delivery race.
- `ctrl_g_subagent_dedup`, `os_env_inherit[claude-sdk]`, `os_env_inherit[codex]` → **#682**. They spawn a sub-agent and time out waiting for its result (sub-agent result-delivery). `[claude-sdk]`/`[codex]` are flaky (pass often; the os_env propagation itself works when the result lands).

The `runner-wedge-subprocess-fanout` cluster is now empty.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

The `os_env_inherit` skip-guard is verified locally: `[openai-agents]` now skips (`1 skipped in 0.07s`) instead of `KeyError`, and `[claude-sdk]`/`[codex]` still collect/run. No product code changed — the skip is the correct outcome (openai-agents has no `*_worker` AgentTool, so the invariant is N/A). The other 4 tests stay quarantined with accurate causes pointed at the owning issues (#522 tool-result delivery, #682 sub-agent delivery); they need that end-of-turn-drain product fix, not a runner change. `twelve_shells` in particular is a clean deterministic repro for #522.

This pull request and its description were written by Isaac.
