### PR TITLE
ci(release): npm ci --legacy-peer-deps in the fallback release workflow

### DIFF
--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -80,10 +80,14 @@ jobs:
       #    load-bearing: the wheel packages on-disk files, so the bundle must
       #    exist before `uv build`. `rm -rf` backstops Vite's emptyOutDir
       #    against stale bundles; `npm ci` installs the exact locked deps.
+      #    `--legacy-peer-deps` matches how ap-web's lockfile is generated and
+      #    validated everywhere else (lint, e2e-ui, ap-web-tests, the regen
+      #    jobs) — required for the React 19 peer conflict; without it `npm ci`
+      #    rejects the lockfile ("Missing: yaml@1.10.3 from lock file").
       - name: Build web UI (clean, fresh)
         run: |
           rm -rf omnigent/server/static/web-ui
-          npm --prefix ap-web ci
+          npm --prefix ap-web ci --legacy-peer-deps
           npm --prefix ap-web run build # Vite outDir -> omnigent/server/static/web-ui
 
       # 2. Tag-driven: the tag must match the version in all three pyprojects


### PR DESCRIPTION
## What
`release-omnigent.yml`'s "Build web UI" step ran plain `npm --prefix ap-web ci`. Add `--legacy-peer-deps`.

## Why
`ap-web`'s lockfile is generated and validated with `--legacy-peer-deps` **everywhere else** — `lint.yml`, `e2e-ui.yml`, `ap-web-tests.yml`, and the regen jobs — because of a known **React 19 peer conflict** (called out in `e2e-ui.yml`). The two release workflows were the only npm-ci steps missing the flag, so strict `npm ci` rejects the committed lockfile:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: yaml@1.10.3 from lock file
```

Verified locally: plain `npm ci` fails this way even on npm 11.9.0; `npm ci --legacy-peer-deps` succeeds. It's the flag, not the npm version, and not a stale lock (a fresh `npm install --package-lock-only` reports the lockfile up to date).

## Scope
This fixes the **deprecated fallback** workflow. The active path — the secure-publish workflow `omnigent.yml` in `databricks/secure-public-registry-releases-eng` — needs the identical one-line fix on its side (it hit exactly this on the `v0.2.0rc1` build); that repo is EMU-only so it's a separate PR there.

This pull request and its description were written by Isaac.