### PR TITLE
fix(test): make codex_shell_not_disabled await worker result; un-quarantine

### DIFF
--- a/tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py
+++ b/tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py
@@ -524,6 +524,7 @@ _CODEX_REGRESSION_TODO_BODY = (
 _CODEX_NONEXISTENT_ERROR = "/nonexistent"
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_run_omnigent_coding_supervisor_codex_shell_not_disabled(
     omnigent_python: Path,
     omnigent_repo_root: Path,
@@ -610,12 +611,18 @@ def test_run_omnigent_coding_supervisor_codex_shell_not_disabled(
                 # pushes the codex_worker to actually cat the file
                 # rather than paraphrase from its own knowledge —
                 # the sentinel marker can only reach stdout via a
-                # real shell read.
+                # real shell read. "When the worker returns, include
+                # … in your final answer" is load-bearing: the
+                # codex_worker is an async AgentTool, so without it the
+                # supervisor fire-and-forgets ("Launched the worker…")
+                # and ends the turn before the result is drained back
+                # (same wait-for-return phrasing as the green
+                # spawns_codex_worker_to_list_files sibling).
                 (
                     f"Launch one codex_worker named 'codex-regression' and "
-                    f"ask it to read {_CODEX_REGRESSION_TODO_NAME} in the "
-                    f"current working directory and reply with the file's "
-                    f"contents verbatim."
+                    f"ask it to read the file {_CODEX_REGRESSION_TODO_NAME} in "
+                    f"the current working directory. When the worker returns, "
+                    f"include the file's contents verbatim in your final answer."
                 ),
             ],
             env=omnigent_credentials_env,

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -375,11 +375,6 @@ skips:
     issue: 673
     cluster: files-uploads-attachments
     mode: skip
-  - id: tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_codex_shell_not_disabled
-    reason: "Consistent real failure (40/40 in flake-stress run 27765495452): codex worker doesn't read the fixture file — codex shell_tool / supervisor-delegation regression, NOT a flake."
-    issue: 678
-    cluster: subagent-supervisor-routing
-    mode: skip
 
   # ──────────────────────────────────────────────────────────────
   # Re-triaged 2026-06-18 (flake-stress run 27761358025 on main, 20×,


### PR DESCRIPTION
## Related issue

Closes #678

## Summary

Re-greens and un-quarantines
`tests/e2e/omnigent/test_run_omnigent_coding_supervisor.py::test_run_omnigent_coding_supervisor_codex_shell_not_disabled`.

The quarantine reason blamed a codex `shell_tool`-disable regression, but
that is **not** the cause: codex's shell stays enabled (`/nonexistent`
never appears) and the codex_worker's sandbox resolves to
`danger-full-access`. The real failure was the test's prompt. The
codex_worker is an **async** `AgentTool`, and the prompt
("Launch … and ask it to read … and reply verbatim") read as
fire-and-forget — so the supervisor ended its turn reporting
*"Launched the worker…"* before the worker's result was drained back,
and the sentinel never reached stdout (failed 30/30).

Fix: reword the prompt to the same wait-for-return phrasing the green
sibling `test_..._spawns_codex_worker_to_list_files` already uses —
*"When the worker returns, include … in your final answer"* — and add
that sibling's `@pytest.mark.flaky(reruns=2)` marker for the inherent
codex-spawn variance (app-server boot + thread negotiation).

Test-only change; no product code touched.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

This is the e2e test itself. Verified on CI via the "Flake stress (E2E)"
workflow on this branch, profile `oss`, `--no-skip-known`, 30 attempts:
run 27801749954 — **30/30 pass** (the sentinel is present and
`/nonexistent` is absent in every attempt). Also verified locally
(`pytest … --profile oss`): passes in ~43s with a real codex sub-agent
spawn.

This pull request and its description were written by Isaac.
