### PR TITLE
fix(test): workspace-rooted runner for filesystem changed-files e2e; un-quarantine

### DIFF
--- a/tests/e2e/test_filesystem_changed_files_e2e.py
+++ b/tests/e2e/test_filesystem_changed_files_e2e.py
@@ -212,7 +212,7 @@ def _build_mock_workspace_writer_bundle(mock_llm_server_url: str) -> bytes:
     return buf.getvalue()
 
 
-# ── Repo-rooted server+runner (for the agent-write tests) ──────────────────────
+# ── Workspace-rooted server+runner (for the agent-write tests) ─────────────────
 #
 # The shared ``live_server`` fixture spawns its runner with no
 # ``OMNIGENT_RUNNER_WORKSPACE``. That leaves the runner with no filesystem
@@ -221,48 +221,95 @@ def _build_mock_workspace_writer_bundle(mock_llm_server_url: str) -> bytes:
 # watcher could see them) — see ``_effective_runner_os_env_spec`` and
 # ``_resolve_session_fs_registry`` in ``omnigent/runner/app.py``. The agent-write
 # tests below need both pointed at a real workspace, so they use a dedicated
-# server+runner pair rooted at the repo (a git tree, so the diff test's
-# ``git show HEAD`` baseline works and new files surface as ``"created"``).
-# We do NOT repoint the shared ``live_server`` because ~50 other e2e modules
-# depend on its current (no-workspace) behavior.
+# server+runner pair rooted at an isolated, throwaway **git** workspace (a git
+# tree so the diff test's ``git show HEAD`` baseline works and new files surface
+# as ``"created"``). We deliberately do NOT root at the live repo checkout
+# (writes would pollute the working tree and ``git show HEAD`` would be
+# non-deterministic against a dirty tree) and we do NOT repoint the shared
+# ``live_server`` (~50 other e2e modules depend on its current no-workspace
+# behavior).
 
-_fs_repo_runner_state: dict[str, str] = {}
+# A tracked file seeded into the workspace's initial commit; the diff test
+# overwrites it and checks the diff endpoint's ``before`` against this content.
+_SEED_TRACKED_FILE = "tracked.md"
+_SEED_TRACKED_CONTENT = "# seed file\n\noriginal committed content\n"
+
+_fs_ws_runner_state: dict[str, str] = {}
 
 
 @pytest.fixture(scope="module")
-def fs_repo_runner_id() -> str:
-    """Stable runner id for the module-scoped repo-rooted server.
+def fs_workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """An isolated, throwaway git workspace for the agent-write tests.
+
+    Initializes a real git repo (so ``create_filesystem_registry`` returns a
+    :class:`GitFilesystemRegistry` and ``git show HEAD`` resolves a baseline)
+    and seeds one tracked file in an initial commit. Lives under the pytest
+    tmp root, so writes never touch the live checkout and the tree is always
+    clean at the start of the module.
+
+    :param tmp_path_factory: pytest temp path factory.
+    :returns: Path to the initialized git workspace.
+    """
+    ws = tmp_path_factory.mktemp("e2e_fs_workspace")
+    (ws / _SEED_TRACKED_FILE).write_text(_SEED_TRACKED_CONTENT, encoding="utf-8")
+    # Inline identity (``-c``) so the commit does not depend on the dev's or
+    # CI runner's global git config.
+    subprocess.run(["git", "init", "-q"], cwd=str(ws), check=True)
+    subprocess.run(["git", "add", "-A"], cwd=str(ws), check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=e2e@omnigent.test",
+            "-c",
+            "user.name=omnigent-e2e",
+            "commit",
+            "-q",
+            "-m",
+            "seed",
+        ],
+        cwd=str(ws),
+        check=True,
+    )
+    return ws
+
+
+@pytest.fixture(scope="module")
+def fs_ws_runner_id() -> str:
+    """Stable runner id for the module-scoped workspace-rooted server.
 
     :returns: Runner id string bound to a per-module binding token.
     """
     from omnigent.runner.identity import token_bound_runner_id
 
-    if "runner_id" not in _fs_repo_runner_state:
+    if "runner_id" not in _fs_ws_runner_state:
         token = secrets.token_urlsafe(32)
-        _fs_repo_runner_state["binding_token"] = token
-        _fs_repo_runner_state["runner_id"] = token_bound_runner_id(token)
-    return _fs_repo_runner_state["runner_id"]
+        _fs_ws_runner_state["binding_token"] = token
+        _fs_ws_runner_state["runner_id"] = token_bound_runner_id(token)
+    return _fs_ws_runner_state["runner_id"]
 
 
 @pytest.fixture(scope="module")
-def fs_repo_server(
+def fs_ws_server(
     llm_api_key: str,
     mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
-    fs_repo_runner_id: str,
+    fs_workspace: Path,
+    fs_ws_runner_id: str,
 ) -> Iterator[str]:
-    """Spawn an ``omnigent server`` + runner rooted at the repo working tree.
+    """Spawn an ``omnigent server`` + runner rooted at the isolated git workspace.
 
-    The runner is given ``OMNIGENT_RUNNER_WORKSPACE=_REPO_ROOT`` (and the
+    The runner is given ``OMNIGENT_RUNNER_WORKSPACE=fs_workspace`` (and the
     server CWD matches), so ``create_filesystem_registry`` builds a
-    :class:`GitFilesystemRegistry` over the repo and the agent's relative
+    :class:`GitFilesystemRegistry` over that workspace and the agent's relative
     ``sys_os_write`` lands inside it — the two prerequisites for writes to
     surface in ``GET .../changes``.
 
     :param llm_api_key: The ``--llm-api-key`` option value.
     :param mock_llm_server_url: Mock LLM server URL.
     :param tmp_path_factory: pytest temp path factory (db / artifacts / logs).
-    :param fs_repo_runner_id: Runner id to register.
+    :param fs_workspace: The isolated git workspace to root the runner at.
+    :param fs_ws_runner_id: Runner id to register.
     :returns: Server base URL, e.g. ``"http://localhost:18600"``.
     """
     port = find_free_port()
@@ -270,10 +317,13 @@ def fs_repo_server(
     artifact_dir = tmp_path_factory.mktemp("e2e_fs_artifacts")
     server_log = tmp_path_factory.mktemp("e2e_fs_logs") / "server.log"
 
-    binding_token = _fs_repo_runner_state["binding_token"]
+    binding_token = _fs_ws_runner_state["binding_token"]
     env: dict[str, str] = {
         **os.environ,
         "OPENAI_API_KEY": llm_api_key,
+        # PYTHONPATH stays the repo so the subprocess imports this worktree's
+        # omnigent; only the *workspace* (cwd / OMNIGENT_RUNNER_WORKSPACE) is
+        # the throwaway git dir.
         "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
         "OMNIGENT_SKIP_ONBOARD": "1",
         "OMNIGENT_NO_UPDATE_CHECK": "1",
@@ -295,7 +345,7 @@ def fs_repo_server(
             str(artifact_dir),
         ],
         env={**env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
-        cwd=str(_REPO_ROOT),
+        cwd=str(fs_workspace),
         stdout=log_handle,
         stderr=subprocess.STDOUT,
     )
@@ -307,19 +357,19 @@ def fs_repo_server(
         [sys.executable, "-m", "omnigent.runner._entry"],
         env={
             **env,
-            "OMNIGENT_RUNNER_ID": fs_repo_runner_id,
+            "OMNIGENT_RUNNER_ID": fs_ws_runner_id,
             "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
             "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
             "RUNNER_SERVER_URL": base_url,
             # The crux: without a workspace the runner builds no filesystem
             # registry (app.py) so writes never surface in GET .../changes,
             # and sys_os_write falls back to a throwaway tmp cwd. Root it at
-            # the repo so the GitFilesystemRegistry watches the same tree the
-            # agent writes into. The real CLI sets this via
+            # the isolated git workspace so the GitFilesystemRegistry watches
+            # the same tree the agent writes into. The real CLI sets this via
             # _start_cli_runner_process.
-            "OMNIGENT_RUNNER_WORKSPACE": str(_REPO_ROOT),
+            "OMNIGENT_RUNNER_WORKSPACE": str(fs_workspace),
         },
-        cwd=str(_REPO_ROOT),
+        cwd=str(fs_workspace),
         stdout=runner_log_handle,
         stderr=subprocess.STDOUT,
     )
@@ -329,7 +379,7 @@ def fs_repo_server(
         try:
             health_resp = httpx.get(f"{base_url}/health", timeout=2)
             runner_resp = httpx.get(
-                f"{base_url}/v1/runners/{fs_repo_runner_id}/status",
+                f"{base_url}/v1/runners/{fs_ws_runner_id}/status",
                 timeout=2,
             )
             if (
@@ -339,6 +389,9 @@ def fs_repo_server(
             ):
                 break
         except httpx.ConnectError:
+            # Expected while the server is still binding its port during
+            # startup; keep polling until the health checks pass or the loop
+            # times out (the ``else`` branch below).
             pass
         time.sleep(POLL_INTERVAL_S)
     else:
@@ -351,7 +404,7 @@ def fs_repo_server(
         log_contents = server_log.read_text() if server_log.exists() else ""
         runner_log_contents = runner_log.read_text() if runner_log.exists() else ""
         raise RuntimeError(
-            f"Repo-rooted server did not start within {HEALTH_TIMEOUT_S}s.\n"
+            f"Workspace-rooted server did not start within {HEALTH_TIMEOUT_S}s.\n"
             f"Server log: {log_contents[-3000:]}\n"
             f"Runner log: {runner_log_contents[-3000:]}"
         )
@@ -377,13 +430,13 @@ def fs_repo_server(
 
 
 @pytest.fixture(scope="module")
-def fs_repo_client(fs_repo_server: str) -> Iterator[httpx.Client]:
-    """HTTP client pointed at the repo-rooted server.
+def fs_ws_client(fs_ws_server: str) -> Iterator[httpx.Client]:
+    """HTTP client pointed at the workspace-rooted server.
 
-    :param fs_repo_server: Base URL from :func:`fs_repo_server`.
+    :param fs_ws_server: Base URL from :func:`fs_ws_server`.
     :returns: Configured ``httpx.Client``.
     """
-    with httpx.Client(base_url=fs_repo_server, timeout=60.0) as client:
+    with httpx.Client(base_url=fs_ws_server, timeout=60.0) as client:
         yield client
 
 
@@ -530,8 +583,8 @@ def test_filesystem_user_write_put_round_trip(
 
 
 def test_filesystem_changes_appear_after_agent_write(
-    fs_repo_client: httpx.Client,
-    fs_repo_runner_id: str,
+    fs_ws_client: httpx.Client,
+    fs_ws_runner_id: str,
     databricks_workspace_host: str | None,
     mock_llm_server_url: str,
 ) -> None:
@@ -553,13 +606,14 @@ def test_filesystem_changes_appear_after_agent_write(
     - ``_ensure_session_registered`` failing silently -> incorrect start
       boundary causes the file to be invisible.
 
-    Uses the repo-rooted server+runner (``fs_repo_*``) rather than the shared
-    ``live_server``: the runner needs ``OMNIGENT_RUNNER_WORKSPACE`` set so it
-    builds a filesystem registry and resolves ``sys_os_write`` into the watched
-    tree (see the fixture above).
+    Uses the isolated git-workspace server+runner (``fs_ws_*``) rather than the
+    shared ``live_server``: the runner needs ``OMNIGENT_RUNNER_WORKSPACE`` set so
+    it builds a filesystem registry and resolves ``sys_os_write`` into the
+    watched tree (see the fixtures above). The agent writes into the throwaway
+    workspace, so no repo-tree cleanup is needed.
 
-    :param fs_repo_client: HTTP client pointed at the repo-rooted server.
-    :param fs_repo_runner_id: Runner id for the repo-rooted runner.
+    :param fs_ws_client: HTTP client pointed at the workspace-rooted server.
+    :param fs_ws_runner_id: Runner id for the workspace-rooted runner.
     :param databricks_workspace_host: Workspace host URL when the
         test suite routes LLM calls through Databricks model serving.
     :param mock_llm_server_url: Mock LLM server URL.
@@ -567,7 +621,6 @@ def test_filesystem_changes_appear_after_agent_write(
     # Use a UUID suffix so parallel test runs don't collide.
     filename = f"e2e_workspace_test_{uuid.uuid4().hex[:8]}.md"
     file_content = "Hello from the workspace e2e test"
-    test_file = _REPO_ROOT / filename
 
     reset_mock_llm(mock_llm_server_url)
     configure_mock_llm(
@@ -587,76 +640,71 @@ def test_filesystem_changes_appear_after_agent_write(
         key="default",
     )
 
-    try:
-        session_id = _create_bound_session(
-            fs_repo_client,
-            live_runner_id=fs_repo_runner_id,
-            databricks_workspace_host=databricks_workspace_host,
-            initial_text=(
-                f"Write a file named '{filename}' containing exactly: "
-                f"'{file_content}'. Use sys_os_write."
-            ),
-            mock_llm_server_url=mock_llm_server_url,
-        )
+    session_id = _create_bound_session(
+        fs_ws_client,
+        live_runner_id=fs_ws_runner_id,
+        databricks_workspace_host=databricks_workspace_host,
+        initial_text=(
+            f"Write a file named '{filename}' containing exactly: "
+            f"'{file_content}'. Use sys_os_write."
+        ),
+        mock_llm_server_url=mock_llm_server_url,
+    )
 
-        terminal = _poll_until_session_idle(fs_repo_client, session_id, timeout=120)
-        assert terminal["status"] == "idle", (
-            f"Agent turn failed with status {terminal['status']!r}. "
-            "The workspace-file-writer agent did not complete successfully."
-        )
+    terminal = _poll_until_session_idle(fs_ws_client, session_id, timeout=120)
+    assert terminal["status"] == "idle", (
+        f"Agent turn failed with status {terminal['status']!r}. "
+        "The workspace-file-writer agent did not complete successfully."
+    )
 
-        # Poll the changes endpoint until the written file appears.
-        # The watchdog observer may have a brief delay before delivering the event.
-        deadline = time.monotonic() + 15
-        found_entry: dict | None = None
-        found_names: list[str] = []
-        while time.monotonic() < deadline:
-            changes_resp = fs_repo_client.get(_fs_changes_url(session_id))
-            changes_resp.raise_for_status()
-            entries = changes_resp.json()["data"]
-            found_names = [e["name"] for e in entries]
-            for entry in entries:
-                if entry["name"] == filename:
-                    found_entry = entry
-                    break
-            if found_entry is not None:
+    # Poll the changes endpoint until the written file appears.
+    # The watchdog observer may have a brief delay before delivering the event.
+    deadline = time.monotonic() + 15
+    found_entry: dict | None = None
+    found_names: list[str] = []
+    while time.monotonic() < deadline:
+        changes_resp = fs_ws_client.get(_fs_changes_url(session_id))
+        changes_resp.raise_for_status()
+        entries = changes_resp.json()["data"]
+        found_names = [e["name"] for e in entries]
+        for entry in entries:
+            if entry["name"] == filename:
+                found_entry = entry
                 break
-            time.sleep(POLL_INTERVAL_S)
+        if found_entry is not None:
+            break
+        time.sleep(POLL_INTERVAL_S)
 
-        assert found_entry is not None, (
-            f"'{filename}' did not appear in the changes listing within 15s. "
-            f"Files found: {found_names}. "
-            "Likely cause: watchdog observer not started, or the session start time "
-            "boundary excluded the write event."
-        )
-        # Status must be one of the full-word values from the F1 migration.
-        assert found_entry["status"] == "created", (
-            f"Expected status 'created', got {found_entry['status']!r}"
-        )
+    assert found_entry is not None, (
+        f"'{filename}' did not appear in the changes listing within 15s. "
+        f"Files found: {found_names}. "
+        "Likely cause: watchdog observer not started, or the session start time "
+        "boundary excluded the write event."
+    )
+    # Status must be one of the full-word values from the F1 migration.
+    assert found_entry["status"] == "created", (
+        f"Expected status 'created', got {found_entry['status']!r}"
+    )
 
-        # Verify the file content is readable via the file endpoint.
-        content_resp = fs_repo_client.get(_fs_file_url(session_id, filename))
-        content_resp.raise_for_status()
-        content_body = content_resp.json()
+    # Verify the file content is readable via the file endpoint.
+    content_resp = fs_ws_client.get(_fs_file_url(session_id, filename))
+    content_resp.raise_for_status()
+    content_body = content_resp.json()
 
-        assert content_body.get("object") == "session.environment.filesystem.file_content", (
-            f"Wrong object type in file content response: {content_body.get('object')!r}"
-        )
-        # content_type must be present.
-        assert content_body.get("content_type") is not None, (
-            "content_type must be present in file content response (migration work item #5)"
-        )
-        # The content must match what the agent was asked to write.
-        assert file_content in content_body.get("content", ""), (
-            f"File content mismatch. Expected {file_content!r} in content, "
-            f"got: {content_body.get('content', '')[:200]!r}. "
-            "Either sys_os_write wrote different content or the file endpoint "
-            "is not reading from the correct path."
-        )
-    finally:
-        # Clean up the test file so it doesn't pollute the repo working tree.
-        if test_file.exists():
-            test_file.unlink()
+    assert content_body.get("object") == "session.environment.filesystem.file_content", (
+        f"Wrong object type in file content response: {content_body.get('object')!r}"
+    )
+    # content_type must be present.
+    assert content_body.get("content_type") is not None, (
+        "content_type must be present in file content response (migration work item #5)"
+    )
+    # The content must match what the agent was asked to write.
+    assert file_content in content_body.get("content", ""), (
+        f"File content mismatch. Expected {file_content!r} in content, "
+        f"got: {content_body.get('content', '')[:200]!r}. "
+        "Either sys_os_write wrote different content or the file endpoint "
+        "is not reading from the correct path."
+    )
 
 
 def _fs_diff_url(session_id: str, path: str) -> str:
@@ -670,8 +718,9 @@ def _fs_diff_url(session_id: str, path: str) -> str:
 
 
 def test_diff_endpoint_shows_git_diff_for_modified_file(
-    fs_repo_client: httpx.Client,
-    fs_repo_runner_id: str,
+    fs_ws_client: httpx.Client,
+    fs_ws_runner_id: str,
+    fs_workspace: Path,
     databricks_workspace_host: str | None,
     mock_llm_server_url: str,
 ) -> None:
@@ -693,29 +742,29 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
     - ``git show HEAD:<path>`` path construction wrong -> ``before`` is ``None``.
     - ``after`` read path broken -> ``after`` is ``None`` or wrong content.
 
-    Uses the repo-rooted server+runner (``fs_repo_*``) so the runner's
-    GitFilesystemRegistry watches the repo working tree and ``git show HEAD``
-    resolves the tracked baseline (the shared ``live_server`` runner has no
-    workspace, so neither works).
+    Uses the isolated git-workspace server+runner (``fs_ws_*``): the agent
+    overwrites the seed file tracked in that throwaway workspace's initial
+    commit, so the runner's GitFilesystemRegistry watches it and
+    ``git show HEAD`` resolves the baseline — without touching the live repo
+    checkout (so no restore is needed and the result is deterministic).
 
-    :param fs_repo_client: HTTP client pointed at the repo-rooted server.
-    :param fs_repo_runner_id: Runner id for the repo-rooted runner.
+    :param fs_ws_client: HTTP client pointed at the workspace-rooted server.
+    :param fs_ws_runner_id: Runner id for the workspace-rooted runner.
+    :param fs_workspace: The isolated git workspace the runner is rooted at.
     :param databricks_workspace_host: Workspace host URL when the
         test suite routes LLM calls through Databricks model serving.
     :param mock_llm_server_url: Mock LLM server URL.
     """
-    import subprocess
+    # The seed file tracked in the workspace's initial commit (see the
+    # fs_workspace fixture). Overwriting it gives the diff endpoint a real
+    # git baseline to diff ``after`` against.
+    target_rel = _SEED_TRACKED_FILE
 
-    # Use a file that is already tracked in git so ``git show HEAD`` has content.
-    # tests/resources/test.md is a stable, small committed file.
-    # We restore it in the finally block via ``git checkout``.
-    target_rel = "tests/resources/test.md"
-    target_abs = _REPO_ROOT / target_rel
-
-    # Capture the committed content so we can assert against it and restore it.
+    # Capture the committed content from the workspace's own git HEAD so we
+    # assert the diff endpoint returns exactly that as ``before``.
     git_head_content = subprocess.check_output(
         ["git", "show", f"HEAD:{target_rel}"],
-        cwd=str(_REPO_ROOT),
+        cwd=str(fs_workspace),
     ).decode("utf-8", errors="replace")
 
     modified_content = f"modified by e2e diff test {uuid.uuid4().hex[:8]}"
@@ -738,77 +787,69 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
         key="default",
     )
 
-    try:
-        session_id = _create_bound_session(
-            fs_repo_client,
-            live_runner_id=fs_repo_runner_id,
-            databricks_workspace_host=databricks_workspace_host,
-            initial_text=(
-                f"Overwrite the file '{target_rel}' with exactly this content "
-                f"(no trailing newline): '{modified_content}'. Use sys_os_write."
-            ),
-            mock_llm_server_url=mock_llm_server_url,
-        )
+    session_id = _create_bound_session(
+        fs_ws_client,
+        live_runner_id=fs_ws_runner_id,
+        databricks_workspace_host=databricks_workspace_host,
+        initial_text=(
+            f"Overwrite the file '{target_rel}' with exactly this content "
+            f"(no trailing newline): '{modified_content}'. Use sys_os_write."
+        ),
+        mock_llm_server_url=mock_llm_server_url,
+    )
 
-        terminal = _poll_until_session_idle(fs_repo_client, session_id, timeout=120)
-        assert terminal["status"] == "idle", (
-            f"Agent turn failed with status {terminal['status']!r}. "
-            "The workspace-file-writer agent did not complete successfully."
-        )
+    terminal = _poll_until_session_idle(fs_ws_client, session_id, timeout=120)
+    assert terminal["status"] == "idle", (
+        f"Agent turn failed with status {terminal['status']!r}. "
+        "The workspace-file-writer agent did not complete successfully."
+    )
 
-        # Poll the changes endpoint until the target file appears as modified.
-        deadline = time.monotonic() + 15
-        found_entry: dict | None = None
-        while time.monotonic() < deadline:
-            changes_resp = fs_repo_client.get(_fs_changes_url(session_id))
-            changes_resp.raise_for_status()
-            for entry in changes_resp.json()["data"]:
-                if entry["path"] == target_rel or entry["name"] == target_abs.name:
-                    found_entry = entry
-                    break
-            if found_entry is not None:
+    # Poll the changes endpoint until the target file appears as modified.
+    deadline = time.monotonic() + 15
+    found_entry: dict | None = None
+    while time.monotonic() < deadline:
+        changes_resp = fs_ws_client.get(_fs_changes_url(session_id))
+        changes_resp.raise_for_status()
+        for entry in changes_resp.json()["data"]:
+            if entry["path"] == target_rel or entry["name"] == target_rel:
+                found_entry = entry
                 break
-            time.sleep(POLL_INTERVAL_S)
+        if found_entry is not None:
+            break
+        time.sleep(POLL_INTERVAL_S)
 
-        assert found_entry is not None, (
-            f"'{target_rel}' did not appear in the changes listing within 15s. "
-            "The watchdog observer may not have recorded the write event."
-        )
-        assert found_entry["status"] == "modified", (
-            f"Expected status 'modified' for an overwritten tracked file, "
-            f"got {found_entry['status']!r}."
-        )
+    assert found_entry is not None, (
+        f"'{target_rel}' did not appear in the changes listing within 15s. "
+        "The watchdog observer may not have recorded the write event."
+    )
+    assert found_entry["status"] == "modified", (
+        f"Expected status 'modified' for an overwritten tracked file, "
+        f"got {found_entry['status']!r}."
+    )
 
-        # Call the diff endpoint.
-        diff_resp = fs_repo_client.get(_fs_diff_url(session_id, target_rel))
-        assert diff_resp.status_code == 200, (
-            f"Expected 200 from diff endpoint, got {diff_resp.status_code}. Body: {diff_resp.text}"
-        )
-        diff_body = diff_resp.json()
+    # Call the diff endpoint.
+    diff_resp = fs_ws_client.get(_fs_diff_url(session_id, target_rel))
+    assert diff_resp.status_code == 200, (
+        f"Expected 200 from diff endpoint, got {diff_resp.status_code}. Body: {diff_resp.text}"
+    )
+    diff_body = diff_resp.json()
 
-        assert diff_body["object"] == "session.environment.filesystem.file_diff", (
-            f"Wrong object type: {diff_body.get('object')!r}"
-        )
-        # ``before`` must equal the content at git HEAD — proves get_baseline
-        # is calling ``git show HEAD:<path>`` and returning the correct bytes.
-        assert diff_body["before"] == git_head_content, (
-            f"before content does not match git HEAD.\n"
-            f"  expected: {git_head_content!r}\n"
-            f"  got:      {diff_body['before']!r}\n"
-            "get_baseline is either not calling git show or returning wrong content."
-        )
-        # ``after`` must contain the modified content — proves CallerProcessFilesystem
-        # is reading the current on-disk state, not the snapshot.
-        assert modified_content in (diff_body["after"] or ""), (
-            f"after content does not contain modified text.\n"
-            f"  expected substring: {modified_content!r}\n"
-            f"  got: {diff_body['after']!r}\n"
-            "The diff endpoint is not reading the current file content from disk."
-        )
-    finally:
-        # Restore the tracked file to its committed state so the repo stays clean.
-        subprocess.run(
-            ["git", "checkout", "--", target_rel],
-            cwd=str(_REPO_ROOT),
-            check=False,
-        )
+    assert diff_body["object"] == "session.environment.filesystem.file_diff", (
+        f"Wrong object type: {diff_body.get('object')!r}"
+    )
+    # ``before`` must equal the content at git HEAD — proves get_baseline
+    # is calling ``git show HEAD:<path>`` and returning the correct bytes.
+    assert diff_body["before"] == git_head_content, (
+        f"before content does not match git HEAD.\n"
+        f"  expected: {git_head_content!r}\n"
+        f"  got:      {diff_body['before']!r}\n"
+        "get_baseline is either not calling git show or returning wrong content."
+    )
+    # ``after`` must contain the modified content — proves CallerProcessFilesystem
+    # is reading the current on-disk state, not the snapshot.
+    assert modified_content in (diff_body["after"] or ""), (
+        f"after content does not contain modified text.\n"
+        f"  expected substring: {modified_content!r}\n"
+        f"  got: {diff_body['after']!r}\n"
+        "The diff endpoint is not reading the current file content from disk."
+    )

--- a/tests/e2e/test_filesystem_changed_files_e2e.py
+++ b/tests/e2e/test_filesystem_changed_files_e2e.py
@@ -43,20 +43,28 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import secrets
+import signal
+import subprocess
+import sys
 import tarfile
 import time
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 
 import httpx
+import pytest
 import yaml
 
 from tests.e2e.conftest import (
     build_agent_bundle,
     configure_mock_llm,
+    find_free_port,
     reset_mock_llm,
 )
-from tests.e2e.helpers import POLL_INTERVAL_S
+from tests.e2e.helpers import HEALTH_TIMEOUT_S, POLL_INTERVAL_S
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKSPACE_WRITER_DIR = _REPO_ROOT / "tests" / "resources" / "agents" / "workspace-file-writer"
@@ -204,6 +212,181 @@ def _build_mock_workspace_writer_bundle(mock_llm_server_url: str) -> bytes:
     return buf.getvalue()
 
 
+# ── Repo-rooted server+runner (for the agent-write tests) ──────────────────────
+#
+# The shared ``live_server`` fixture spawns its runner with no
+# ``OMNIGENT_RUNNER_WORKSPACE``. That leaves the runner with no filesystem
+# registry (so ``GET .../changes`` is always empty) AND resolves the agent's
+# ``sys_os_write`` cwd to a throwaway ``/tmp`` dir (so writes never land where a
+# watcher could see them) — see ``_effective_runner_os_env_spec`` and
+# ``_resolve_session_fs_registry`` in ``omnigent/runner/app.py``. The agent-write
+# tests below need both pointed at a real workspace, so they use a dedicated
+# server+runner pair rooted at the repo (a git tree, so the diff test's
+# ``git show HEAD`` baseline works and new files surface as ``"created"``).
+# We do NOT repoint the shared ``live_server`` because ~50 other e2e modules
+# depend on its current (no-workspace) behavior.
+
+_fs_repo_runner_state: dict[str, str] = {}
+
+
+@pytest.fixture(scope="module")
+def fs_repo_runner_id() -> str:
+    """Stable runner id for the module-scoped repo-rooted server.
+
+    :returns: Runner id string bound to a per-module binding token.
+    """
+    from omnigent.runner.identity import token_bound_runner_id
+
+    if "runner_id" not in _fs_repo_runner_state:
+        token = secrets.token_urlsafe(32)
+        _fs_repo_runner_state["binding_token"] = token
+        _fs_repo_runner_state["runner_id"] = token_bound_runner_id(token)
+    return _fs_repo_runner_state["runner_id"]
+
+
+@pytest.fixture(scope="module")
+def fs_repo_server(
+    llm_api_key: str,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+    fs_repo_runner_id: str,
+) -> Iterator[str]:
+    """Spawn an ``omnigent server`` + runner rooted at the repo working tree.
+
+    The runner is given ``OMNIGENT_RUNNER_WORKSPACE=_REPO_ROOT`` (and the
+    server CWD matches), so ``create_filesystem_registry`` builds a
+    :class:`GitFilesystemRegistry` over the repo and the agent's relative
+    ``sys_os_write`` lands inside it — the two prerequisites for writes to
+    surface in ``GET .../changes``.
+
+    :param llm_api_key: The ``--llm-api-key`` option value.
+    :param mock_llm_server_url: Mock LLM server URL.
+    :param tmp_path_factory: pytest temp path factory (db / artifacts / logs).
+    :param fs_repo_runner_id: Runner id to register.
+    :returns: Server base URL, e.g. ``"http://localhost:18600"``.
+    """
+    port = find_free_port()
+    db_path = tmp_path_factory.mktemp("e2e_fs") / "e2e.db"
+    artifact_dir = tmp_path_factory.mktemp("e2e_fs_artifacts")
+    server_log = tmp_path_factory.mktemp("e2e_fs_logs") / "server.log"
+
+    binding_token = _fs_repo_runner_state["binding_token"]
+    env: dict[str, str] = {
+        **os.environ,
+        "OPENAI_API_KEY": llm_api_key,
+        "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+        "OMNIGENT_SKIP_ONBOARD": "1",
+        "OMNIGENT_NO_UPDATE_CHECK": "1",
+        "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
+    }
+
+    log_handle = open(server_log, "w")  # noqa: SIM115 — closed in cleanup below
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent.cli",
+            "server",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{db_path}",
+            "--artifact-location",
+            str(artifact_dir),
+        ],
+        env={**env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
+        cwd=str(_REPO_ROOT),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://localhost:{port}"
+
+    runner_log = tmp_path_factory.mktemp("e2e_fs_runner_logs") / "runner.log"
+    runner_log_handle = open(runner_log, "w")  # noqa: SIM115 — closed in cleanup below
+    runner_proc = subprocess.Popen(
+        [sys.executable, "-m", "omnigent.runner._entry"],
+        env={
+            **env,
+            "OMNIGENT_RUNNER_ID": fs_repo_runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+            # The crux: without a workspace the runner builds no filesystem
+            # registry (app.py) so writes never surface in GET .../changes,
+            # and sys_os_write falls back to a throwaway tmp cwd. Root it at
+            # the repo so the GitFilesystemRegistry watches the same tree the
+            # agent writes into. The real CLI sets this via
+            # _start_cli_runner_process.
+            "OMNIGENT_RUNNER_WORKSPACE": str(_REPO_ROOT),
+        },
+        cwd=str(_REPO_ROOT),
+        stdout=runner_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    health_iters = int(HEALTH_TIMEOUT_S / POLL_INTERVAL_S)
+    for _ in range(health_iters):
+        try:
+            health_resp = httpx.get(f"{base_url}/health", timeout=2)
+            runner_resp = httpx.get(
+                f"{base_url}/v1/runners/{fs_repo_runner_id}/status",
+                timeout=2,
+            )
+            if (
+                health_resp.status_code == 200
+                and runner_resp.status_code == 200
+                and runner_resp.json().get("online") is True
+            ):
+                break
+        except httpx.ConnectError:
+            pass
+        time.sleep(POLL_INTERVAL_S)
+    else:
+        if runner_proc.poll() is None:
+            runner_proc.kill()
+            runner_proc.wait(timeout=5)
+        runner_log_handle.close()
+        proc.kill()
+        log_handle.close()
+        log_contents = server_log.read_text() if server_log.exists() else ""
+        runner_log_contents = runner_log.read_text() if runner_log.exists() else ""
+        raise RuntimeError(
+            f"Repo-rooted server did not start within {HEALTH_TIMEOUT_S}s.\n"
+            f"Server log: {log_contents[-3000:]}\n"
+            f"Runner log: {runner_log_contents[-3000:]}"
+        )
+
+    try:
+        yield base_url
+    finally:
+        if runner_proc.poll() is None:
+            runner_proc.send_signal(signal.SIGTERM)
+            try:
+                runner_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                runner_proc.kill()
+                runner_proc.wait(timeout=5)
+        runner_log_handle.close()
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        log_handle.close()
+
+
+@pytest.fixture(scope="module")
+def fs_repo_client(fs_repo_server: str) -> Iterator[httpx.Client]:
+    """HTTP client pointed at the repo-rooted server.
+
+    :param fs_repo_server: Base URL from :func:`fs_repo_server`.
+    :returns: Configured ``httpx.Client``.
+    """
+    with httpx.Client(base_url=fs_repo_server, timeout=60.0) as client:
+        yield client
+
+
 # ── No-LLM tests ──────────────────────────────────────────────────────────────
 
 
@@ -347,8 +530,8 @@ def test_filesystem_user_write_put_round_trip(
 
 
 def test_filesystem_changes_appear_after_agent_write(
-    http_client: httpx.Client,
-    live_runner_id: str,
+    fs_repo_client: httpx.Client,
+    fs_repo_runner_id: str,
     databricks_workspace_host: str | None,
     mock_llm_server_url: str,
 ) -> None:
@@ -370,8 +553,13 @@ def test_filesystem_changes_appear_after_agent_write(
     - ``_ensure_session_registered`` failing silently -> incorrect start
       boundary causes the file to be invisible.
 
-    :param http_client: HTTP client pointed at the live server.
-    :param live_runner_id: Runner id registered by the live server.
+    Uses the repo-rooted server+runner (``fs_repo_*``) rather than the shared
+    ``live_server``: the runner needs ``OMNIGENT_RUNNER_WORKSPACE`` set so it
+    builds a filesystem registry and resolves ``sys_os_write`` into the watched
+    tree (see the fixture above).
+
+    :param fs_repo_client: HTTP client pointed at the repo-rooted server.
+    :param fs_repo_runner_id: Runner id for the repo-rooted runner.
     :param databricks_workspace_host: Workspace host URL when the
         test suite routes LLM calls through Databricks model serving.
     :param mock_llm_server_url: Mock LLM server URL.
@@ -401,8 +589,8 @@ def test_filesystem_changes_appear_after_agent_write(
 
     try:
         session_id = _create_bound_session(
-            http_client,
-            live_runner_id=live_runner_id,
+            fs_repo_client,
+            live_runner_id=fs_repo_runner_id,
             databricks_workspace_host=databricks_workspace_host,
             initial_text=(
                 f"Write a file named '{filename}' containing exactly: "
@@ -411,7 +599,7 @@ def test_filesystem_changes_appear_after_agent_write(
             mock_llm_server_url=mock_llm_server_url,
         )
 
-        terminal = _poll_until_session_idle(http_client, session_id, timeout=120)
+        terminal = _poll_until_session_idle(fs_repo_client, session_id, timeout=120)
         assert terminal["status"] == "idle", (
             f"Agent turn failed with status {terminal['status']!r}. "
             "The workspace-file-writer agent did not complete successfully."
@@ -423,7 +611,7 @@ def test_filesystem_changes_appear_after_agent_write(
         found_entry: dict | None = None
         found_names: list[str] = []
         while time.monotonic() < deadline:
-            changes_resp = http_client.get(_fs_changes_url(session_id))
+            changes_resp = fs_repo_client.get(_fs_changes_url(session_id))
             changes_resp.raise_for_status()
             entries = changes_resp.json()["data"]
             found_names = [e["name"] for e in entries]
@@ -447,7 +635,7 @@ def test_filesystem_changes_appear_after_agent_write(
         )
 
         # Verify the file content is readable via the file endpoint.
-        content_resp = http_client.get(_fs_file_url(session_id, filename))
+        content_resp = fs_repo_client.get(_fs_file_url(session_id, filename))
         content_resp.raise_for_status()
         content_body = content_resp.json()
 
@@ -482,8 +670,8 @@ def _fs_diff_url(session_id: str, path: str) -> str:
 
 
 def test_diff_endpoint_shows_git_diff_for_modified_file(
-    http_client: httpx.Client,
-    live_runner_id: str,
+    fs_repo_client: httpx.Client,
+    fs_repo_runner_id: str,
     databricks_workspace_host: str | None,
     mock_llm_server_url: str,
 ) -> None:
@@ -505,8 +693,13 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
     - ``git show HEAD:<path>`` path construction wrong -> ``before`` is ``None``.
     - ``after`` read path broken -> ``after`` is ``None`` or wrong content.
 
-    :param http_client: HTTP client pointed at the live server.
-    :param live_runner_id: Runner id registered by the live server.
+    Uses the repo-rooted server+runner (``fs_repo_*``) so the runner's
+    GitFilesystemRegistry watches the repo working tree and ``git show HEAD``
+    resolves the tracked baseline (the shared ``live_server`` runner has no
+    workspace, so neither works).
+
+    :param fs_repo_client: HTTP client pointed at the repo-rooted server.
+    :param fs_repo_runner_id: Runner id for the repo-rooted runner.
     :param databricks_workspace_host: Workspace host URL when the
         test suite routes LLM calls through Databricks model serving.
     :param mock_llm_server_url: Mock LLM server URL.
@@ -547,8 +740,8 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
 
     try:
         session_id = _create_bound_session(
-            http_client,
-            live_runner_id=live_runner_id,
+            fs_repo_client,
+            live_runner_id=fs_repo_runner_id,
             databricks_workspace_host=databricks_workspace_host,
             initial_text=(
                 f"Overwrite the file '{target_rel}' with exactly this content "
@@ -557,7 +750,7 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
             mock_llm_server_url=mock_llm_server_url,
         )
 
-        terminal = _poll_until_session_idle(http_client, session_id, timeout=120)
+        terminal = _poll_until_session_idle(fs_repo_client, session_id, timeout=120)
         assert terminal["status"] == "idle", (
             f"Agent turn failed with status {terminal['status']!r}. "
             "The workspace-file-writer agent did not complete successfully."
@@ -567,7 +760,7 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
         deadline = time.monotonic() + 15
         found_entry: dict | None = None
         while time.monotonic() < deadline:
-            changes_resp = http_client.get(_fs_changes_url(session_id))
+            changes_resp = fs_repo_client.get(_fs_changes_url(session_id))
             changes_resp.raise_for_status()
             for entry in changes_resp.json()["data"]:
                 if entry["path"] == target_rel or entry["name"] == target_abs.name:
@@ -587,7 +780,7 @@ def test_diff_endpoint_shows_git_diff_for_modified_file(
         )
 
         # Call the diff endpoint.
-        diff_resp = http_client.get(_fs_diff_url(session_id, target_rel))
+        diff_resp = fs_repo_client.get(_fs_diff_url(session_id, target_rel))
         assert diff_resp.status_code == 200, (
             f"Expected 200 from diff endpoint, got {diff_resp.status_code}. Body: {diff_resp.text}"
         )

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -205,12 +205,6 @@ skips:
   # 2 are the existing files-upload 409 'conversation not bound
   # to a runner' family. Triage under #532.
 
-  - id: tests/e2e/test_filesystem_changed_files_e2e.py::test_diff_endpoint_shows_git_diff_for_modified_file
-    reason: "Migrated to mock LLM but underlying infrastructure issue persists: the main e2e runner fixture does not set OMNIGENT_RUNNER_WORKSPACE, so the filesystem changes tracking does not detect agent writes. Needs OMNIGENT_RUNNER_WORKSPACE wiring in the e2e runner fixture."
-    issue: 673
-    cluster: files-uploads-attachments
-    mode: skip
-
   # ── Re-quarantined after #1141 path sweep (2026-05-21) ──
   # PR #1141 fixed examples/*.yaml → tests/resources/examples/*.yaml
   # and dropped 33 manifest entries on the affected files. Of those
@@ -335,11 +329,6 @@ skips:
   # red together).
 
   # Standalone failures — no obvious cluster yet.
-  - id: tests/e2e/test_filesystem_changed_files_e2e.py::test_filesystem_changes_appear_after_agent_write
-    reason: "Migrated to mock LLM but underlying infrastructure issue persists: the main e2e runner fixture does not set OMNIGENT_RUNNER_WORKSPACE, so the filesystem changes tracking does not detect agent writes. Needs OMNIGENT_RUNNER_WORKSPACE wiring in the e2e runner fixture."
-    issue: 673
-    cluster: files-uploads-attachments
-    mode: skip
 
   # ──────────────────────────────────────────────────────────────
   # Re-triaged 2026-06-18 (flake-stress run 27761358025 on main, 20×,


### PR DESCRIPTION
## Related issue

Closes #673

## Summary

Re-greens and un-quarantines the two agent-write tests in
`tests/e2e/test_filesystem_changed_files_e2e.py`:
`test_filesystem_changes_appear_after_agent_write` and
`test_diff_endpoint_shows_git_diff_for_modified_file`.

PR #748 migrated these to mock LLM but left the real blocker, which the
quarantine reason named: the shared session-scoped `live_server` fixture
spawns its runner **without `OMNIGENT_RUNNER_WORKSPACE`**. That has two
fatal consequences (both in `omnigent/runner/app.py`):

1. With no runner workspace, `create_filesystem_registry` is never
   called, so the session's filesystem registry is `None` and
   `GET .../changes` always returns `[]`.
2. `_effective_runner_os_env_spec` resolves the agent's `sys_os_write`
   cwd to a throwaway `/tmp/omnigent-runner-os-envs/<conv>/workspace`,
   so even with a registry the write would land outside the watched
   tree.

The shared `live_server` can't simply be repointed — ~50 other e2e
modules depend on its current (no-workspace) behavior. Instead, this PR
adds a **dedicated, module-scoped server+runner pair** rooted at the
repo working tree (`OMNIGENT_RUNNER_WORKSPACE=_REPO_ROOT`), mirroring the
existing `non_git_server` pattern in `test_non_git_changed_files_e2e.py`.
Rooting at the repo (a git tree) gives a `GitFilesystemRegistry`, so the
diff test's `git show HEAD` baseline resolves and a brand-new file
surfaces as `"created"`. Only these two tests switch to the new
`fs_repo_*` fixtures; the two no-LLM tests stay on `live_server`.

Test-only change; no product code touched.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

These are the e2e tests themselves. Verified on CI via the "Flake stress
(E2E)" workflow on this branch, profile `oss`, `--no-skip-known`, 30
attempts: run 27802423026 — **30/30 pass**. Also verified locally
(`pytest tests/e2e/test_filesystem_changed_files_e2e.py --profile oss`):
all 4 tests in the file pass in ~20s.

This pull request and its description were written by Isaac.
