### PR TITLE
test(known-failures): re-file 8 approval e2e tests under #763 (non-INPUT ASK surfacing)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -46,35 +46,35 @@ skips:
 
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_call_approval_allows_tool_to_run
-    reason: "Same REPL approval pexpect-timeout family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "REPL policy-ASK banner does not surface for TOOL_CALL-phase ASK (#763): expect('approval required') times out 60/60 in run 27802341342. INPUT-phase ASKs surface fine; the tool_call elicitation->REPL path does not."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_subagent_tool_call_ask_tunnels_to_root
-    reason: "Same REPL approval pexpect-timeout family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "Sub-agent ASK does not surface as a tunneled root banner (#763): agent-start/sub-agent ASK is collapsed to DENY (app.py:5328); expect('approval required') times out."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
 
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_call_refusal_blocks_tool
-    reason: "Shard 0 bulk: REPL approval pexpect-timeout family (same as other test_repl_approval_e2e entries)."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "REPL policy-ASK banner does not surface for TOOL_CALL-phase ASK (#763): expect('approval required') times out 60/60 in run 27802341342. INPUT-phase ASKs surface fine; the tool_call elicitation->REPL path does not."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_subagent_ask_tunnels_approval_to_root
-    reason: "Shard 0 bulk: REPL approval pexpect-timeout family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "Sub-agent ASK does not surface as a tunneled root banner (#763): agent-start/sub-agent ASK is collapsed to DENY (app.py:5328); expect('approval required') times out."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_result_ask_approve_surfaces_tool_output
-    reason: "Shard 0 bulk: REPL approval pexpect-timeout family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "TOOL_RESULT ASK is collapsed to DENY by design (runner cannot prompt mid-flight, policy.py:218) -> no interactive banner (#763). The test expects an interactive approve/refuse; needs an owner decision (build mid-flight ASK vs rewrite/delete)."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
   # ── Shard 1 bulk quarantine (2026-05-15) ──
@@ -101,9 +101,9 @@ skips:
     mode: skip
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_result_ask_refuse_replaces_output
-    reason: "Shard 1 bulk: REPL approval pexpect-timeout family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "TOOL_RESULT ASK is collapsed to DENY by design (runner cannot prompt mid-flight, policy.py:218) -> no interactive banner (#763). The test expects an interactive approve/refuse; needs an owner decision (build mid-flight ASK vs rewrite/delete)."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
 
@@ -134,16 +134,16 @@ skips:
   # product investigation before re-greening.
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_output_ask_approve_surfaces_llm_reply
-    reason: "Shard 3 bulk: REPL output ask-approve family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "OUTPUT-phase ASK banner does not surface in the REPL (#763): expect('approval required') times out 60/60. Same surfacing gap as TOOL_CALL."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_output_ask_refuse_replaces_reply_with_sentinel
-    reason: "Shard 3 bulk: REPL output ask-refuse family."
-    issue: 523
-    cluster: repl-pexpect-cli
+    reason: "OUTPUT-phase ASK banner does not surface in the REPL (#763): expect('approval required') times out 60/60. Same surfacing gap as TOOL_CALL."
+    issue: 763
+    cluster: repl-policy-ask-surfacing
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_inline_tool_streaming.py::test_repl_inline_tool_call_and_result_streaming


### PR DESCRIPTION
## Summary

Re-files 8 quarantined `test_repl_approval_e2e.py` tests from the wrong **#523** (REPL pexpect boot-starvation) to **#763** (REPL policy-ASK banner doesn't surface for non-INPUT phases), with accurate per-phase reasons, and moves them to a `repl-policy-ask-surfacing` cluster.

Quarantine-list-only; **no un-quarantine** — these need a product decision/fix (see #763).

Investigation (flake-stress [run 27802341342](https://github.com/omnigent-ai/omnigent/actions/runs/27802341342)): the 8 fail **60/60**, while the **6 INPUT-phase** approval tests in the same file **pass**. So the banner surfaces for INPUT but not for TOOL_CALL / TOOL_RESULT / OUTPUT / sub-agent-tunneled ASKs. Per-phase:
- **TOOL_RESULT** ASK is collapsed to DENY *by design* (runner can't prompt mid-flight — `policy.py:218`).
- **sub-agent / agent-start** ASK collapsed to DENY (`app.py:5328`).
- **TOOL_CALL** has an elicitation path (`policy.py:178`) but still doesn't surface; **OUTPUT** likewise — likely real surfacing bugs.

#763 carries the full analysis and the open owner decision (build mid-flight interactive ASK vs. accept collapse-to-DENY and rewrite/delete those tests).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`known_failures.yaml` metadata only (issue refs, reasons, cluster) — no test or product code changed, no test status change. Re-files the 8 entries under the correct tracking issue (#763) with the verified per-phase root cause, so the quarantine list reflects reality instead of the inherited #523 boot-starvation label.

This pull request and its description were written by Isaac.
