### PR TITLE
chore: bump main to 0.3.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnigent"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 description = "Omnigent: declarative agent authoring and runtime framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -25,8 +25,8 @@ dependencies = [
     # one version, so a published `omnigent==X` must resolve the SDK wheels
     # built alongside it (release-omnigent.yml verifies these pins match the
     # release tag). Local/editable installs still resolve via tool.uv.sources.
-    "omnigent-client==0.2.0.dev0",
-    "omnigent-ui-sdk==0.2.0.dev0",
+    "omnigent-client==0.3.0.dev0",
+    "omnigent-ui-sdk==0.3.0.dev0",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     "openai>=1.0,<3",

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-client"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 description = "Python client SDK for the omnigent server API"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -16,7 +16,7 @@ dependencies = [
     # editable alongside the root ``omnigent`` package. Version-locked
     # (==) so a published SDK always pairs with the server release it
     # shipped with (release-omnigent.yml verifies the pin).
-    "omnigent==0.2.0.dev0",
+    "omnigent==0.3.0.dev0",
     "httpx>=0.27",
     "pydantic>=2.0,<3",
 ]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-ui-sdk"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ dependencies = [
     # at one version (release-omnigent.yml verifies the pin). A `>=`
     # floor would also reject pre-releases (e.g. 0.1.0rc1 < 0.1.0 in
     # PEP 440).
-    "omnigent-client==0.2.0.dev0",
+    "omnigent-client==0.3.0.dev0",
     "rich>=13",
     "prompt_toolkit>=3",
     "pyyaml>=6.0,<7",

--- a/uv.lock
+++ b/uv.lock
@@ -2697,7 +2697,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2889,7 +2889,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "verte
 
 [[package]]
 name = "omnigent-client"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -2906,7 +2906,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.2.0.dev0"
+version = "0.3.0.dev0"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.2.0.dev0" },
+    { name = "omnigent-client", specifier = "==0.3.0.dev0" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },


### PR DESCRIPTION
0.2.0 shipped from `release/v0.2.0`, so move `main` off the released version to the next dev marker.

- Bumps the three lockstep packages (`version` + cross-`==`-pins) and `uv.lock` from `0.2.0.dev0` → `0.3.0.dev0`.
- Keeps every `main` build PEP 440-ordered as *ahead of 0.2.0, not yet 0.3.0*, so the update check and `omni upgrade` never treat a dev build as a stale release (the loop the dev-marker convention prevents).
- `uv.lock` was hand-edited (not regenerated with `uv lock`, which rewrites registry URLs to the internal proxy and leaks into the lockfile).

Patches (0.2.1, …) continue to come off `release/v0.2.0`, not `main`.

This pull request and its description were written by Isaac.