### PR TITLE
feat(policy): extend GitHub policy to cover cache, codespace, project, variable, and key management gh groups

### DIFF
--- a/omnigent/policies/builtins/github.py
+++ b/omnigent/policies/builtins/github.py
@@ -581,12 +581,44 @@ _GH_WRITE_ACTIONS: dict[str, frozenset[str]] = {
     "secret": frozenset({"set", "delete"}),
     "label": frozenset({"create", "delete", "edit"}),
     "gist": frozenset({"create", "edit", "delete"}),
+    "cache": frozenset({"delete"}),
+    "codespace": frozenset({"create", "delete", "stop", "rebuild"}),
+    "project": frozenset(
+        {
+            "create",
+            "delete",
+            "edit",
+            "close",
+            "mark-template",
+            "field-create",
+            "field-delete",
+            "item-add",
+            "item-archive",
+            "item-create",
+            "item-delete",
+            "item-edit",
+        }
+    ),
+    "variable": frozenset({"set", "delete"}),
+    "ssh-key": frozenset({"add", "delete"}),
+    "gpg-key": frozenset({"add", "delete"}),
 }
 
 # gh groups that are GitHub-aware but never touch a specific repo's contents —
 # ignore them (auth, local config, etc.).
 _GH_IGNORE_GROUPS: frozenset[str] = frozenset(
-    {"auth", "config", "alias", "extension", "completion"}
+    {
+        "auth",
+        "config",
+        "alias",
+        "extension",
+        "completion",
+        "browse",
+        "copilot",
+        "licenses",
+        "search",
+        "status",
+    }
 )
 
 

--- a/tests/policies/builtins/test_github.py
+++ b/tests/policies/builtins/test_github.py
@@ -557,6 +557,77 @@ def test_shell_gh_unlock_unpin_classified_as_write(command: str) -> None:
     assert result is not None and result["result"] == "DENY"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh cache delete --all --repo octo/secret",
+        "gh codespace create --repo octo/secret",
+        "gh codespace delete --repo octo/secret",
+        "gh codespace stop --repo octo/secret",
+        "gh codespace rebuild --repo octo/secret",
+        "gh project create --repo octo/secret",
+        "gh project delete --repo octo/secret",
+        "gh project edit --repo octo/secret",
+        "gh project close --repo octo/secret",
+        "gh project item-add --repo octo/secret",
+        "gh project item-delete --repo octo/secret",
+        "gh variable set FOO --repo octo/secret",
+        "gh variable delete FOO --repo octo/secret",
+        "gh ssh-key add key.pub --repo octo/secret",
+        "gh ssh-key delete 123 --repo octo/secret",
+        "gh gpg-key add key.asc --repo octo/secret",
+        "gh gpg-key delete 123 --repo octo/secret",
+    ],
+)
+def test_shell_gh_extended_groups_classified_as_write(command: str) -> None:
+    """Write actions under cache/codespace/project/variable/ssh-key/gpg-key groups
+    are denied for non-allowlisted repos.
+    """
+    policy = github_policy(write_repos=[_REPO])
+    result = policy(_sh(command))
+    assert result is not None and result["result"] == "DENY"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh cache list --repo octo/secret",
+        "gh codespace list",
+        "gh project list --repo octo/secret",
+        "gh project view --repo octo/secret",
+        "gh variable list --repo octo/secret",
+        "gh ssh-key list",
+        "gh gpg-key list",
+    ],
+)
+def test_shell_gh_extended_groups_read_actions_are_reads(command: str) -> None:
+    """Non-write actions under extended groups are reads, not writes.
+
+    With read_all=True (default) they abstain; they must NOT be wrongly denied as
+    writes.
+    """
+    policy = github_policy(write_repos=[_REPO])
+    assert policy(_sh(command)) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh browse --repo octo/secret",
+        "gh copilot explain 'what is git'",
+        "gh licenses list",
+        "gh search repos omnigent",
+        "gh status",
+    ],
+)
+def test_shell_gh_ignore_groups_abstain(command: str) -> None:
+    """Groups in _GH_IGNORE_GROUPS (browse/copilot/licenses/search/status) are
+    abstained on — they touch no repo content and gating them would be noisy.
+    """
+    policy = github_policy(read_all=False, read_repos=[_REPO], write_repos=[_REPO])
+    assert policy(_sh(command)) is None
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Layer 2 — spec resolution through resolve_function_policy
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add 6 missing `gh` CLI command groups to `_GH_WRITE_ACTIONS`: `cache` (`delete`), `codespace` (`create/delete/stop/rebuild`), `project` (12 write actions), `variable` (`set/delete`), `ssh-key` (`add/delete`), `gpg-key` (`add/delete`).
- Add 5 local/read-only groups to `_GH_IGNORE_GROUPS` (`browse`, `copilot`, `licenses`, `search`, `status`) so they don't trigger false ASKs under restricted-read mode.
- Add 3 parametrized test functions (29 new test cases) covering write classification, read classification, and ignore-group abstention for all new groups.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `python -m pytest tests/policies/builtins/test_github.py -v` — all 96 tests pass (67 existing + 29 new). New tests verify that write actions under each added group are denied for non-allowlisted repos, that read actions (e.g. `list`, `view`) under those groups are not wrongly classified as writes, and that the newly ignored groups abstain entirely. No E2E coverage needed — the policy is a pure function with no runtime dependencies.