### PR TITLE
chore(known-failures): sanitize — drop dead comments, strip stale prefixes, fix issue refs

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -27,23 +27,6 @@
 # Note: entries here apply to every pytest invocation. If you
 # want to debug a skipped test locally, comment out its block.
 skips:
-  # Pre-existing product regressions on `main`. `mode: xfail`
-  # so the test runs and we get an XPASS signal when fixed,
-  # at which point the entry can be removed. Need their
-  # respective code owners to investigate.
-
-  # Shard 0 wedge candidate per the prior wedged run's partial log
-  # (last STARTING on gw3 with no END). Pexpect REPL + sub-agent
-  # spawn pattern.
-
-  # Shard 1 wedge candidates from run 25854221043's progress logger
-  # (last STARTING on each xdist worker with no matching END). All
-  # are test_run_omnigent_* tests doing heavy subprocess/pty fanout --
-  # same family as the shard 0 candidate above. Suspect the
-  # CrowdStrike-hardened runner's subprocess cleanup is unable to
-  # reap the test's spawned children fast enough, accumulating until
-  # the host wedges.
-
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_call_approval_allows_tool_to_run
     reason: "REPL policy-ASK banner does not surface for TOOL_CALL-phase ASK (#763): expect('approval required') times out 60/60 in run 27802341342. INPUT-phase ASKs surface fine; the tool_call elicitation->REPL path does not."
@@ -56,8 +39,6 @@ skips:
     issue: 763
     cluster: repl-policy-ask-surfacing
     mode: skip
-
-
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_tool_call_refusal_blocks_tool
     reason: "REPL policy-ASK banner does not surface for TOOL_CALL-phase ASK (#763): expect('approval required') times out 60/60 in run 27802341342. INPUT-phase ASKs surface fine; the tool_call elicitation->REPL path does not."
@@ -77,25 +58,20 @@ skips:
     cluster: repl-policy-ask-surfacing
     mode: skip
 
-  # ── Shard 1 bulk quarantine (2026-05-15) ──
-  # 46 failed + 7 errors on a local run against profile ai-oss /
-  # harness databricks. Same caveats as shard 0: bulk-quarantine
-  # first to unblock e2e PR gating, triage individually under #532.
-
   - id: tests/e2e/omnigent/test_example_secure_research_agent_os_env.py::test_secure_research_agent_os_env_one_shot
-    reason: "Shard 1 bulk: secure_research_agent os-env one-shot. Triage pending."
+    reason: "Secure_research_agent os-env one-shot. Triage pending."
     issue: 675
     cluster: sandbox-deps-env
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[claude-sdk]
-    reason: "Shard 1 bulk: no-AGENT harness round-trip claude-sdk."
+    reason: "No-AGENT harness round-trip claude-sdk."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[openai-agents]
-    reason: "Shard 1 bulk: no-AGENT harness round-trip openai-agents, same family."
+    reason: "No-AGENT harness round-trip openai-agents, same family."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
@@ -106,34 +82,17 @@ skips:
     cluster: repl-policy-ask-surfacing
     mode: skip
 
-
-  # ── Shard 1 errors (collection / fixture-level, not test body) ──
   - id: tests/e2e/test_claude_coder_sandbox.py::test_write_blocked_outside_workspace
     reason: "Distinct from the bwrap CLI-path fix (this PR): the claude-sdk Write tool is NOT blocked from creating files outside the workspace, while edit/read/glob enforcement IS (those 4 sandbox tests pass 30/30 in flake-stress run 27796759300). write_blocked fails 30/30 — a real write-path sandbox-enforcement gap. Needs its own fix."
-    issue: 0
+    issue: 770
     cluster: sandbox-deps-env
     mode: skip
-
-  # ── Shard 3 bulk quarantine (2026-05-15) ──
-  # 55 FAILED + 9 ERROR on a local run against profile ai-oss /
-  # harness databricks with -n 2 --dist=loadscope (single-process
-  # mode hung on test_run_omnigent_rate_limit_approval; xdist + per-test
-  # timeout lets the rest of the shard complete). Same bulk-first,
-  # triage-later approach as PRs #475/#482/#554/#606.
-
-  # Verified live on oss 2026-06-11: spawn / ambient_hint / parallel
-  # pass under the module's 600s signal-method timeout marker, but
-  # continuation failed 1 of 2 runs with a clean AssertionError (the
-  # sub-agent result never reached the parent via auto-wake within
-  # 240s; passed standalone in 47s). Flaky auto-wake delivery, needs
-  # product investigation before re-greening.
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_output_ask_approve_surfaces_llm_reply
     reason: "OUTPUT-phase ASK banner does not surface in the REPL (#763): expect('approval required') times out 60/60. Same surfacing gap as TOOL_CALL."
     issue: 763
     cluster: repl-policy-ask-surfacing
     mode: skip
-
 
   - id: tests/e2e/test_repl_approval_e2e.py::test_repl_output_ask_refuse_replaces_reply_with_sentinel
     reason: "OUTPUT-phase ASK banner does not surface in the REPL (#763): expect('approval required') times out 60/60. Same surfacing gap as TOOL_CALL."
@@ -142,61 +101,40 @@ skips:
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_inline_tool_streaming.py::test_repl_inline_tool_call_and_result_streaming
-    reason: "Shard 3 bulk: REPL inline tool-call streaming."
+    reason: "REPL inline tool-call streaming."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[codex]
-    reason: "Shard 3 bulk: no-AGENT harness round-trip, codex variant; same family as [claude-sdk], [openai-agents]."
+    reason: "No-AGENT harness round-trip, codex variant; same family as [claude-sdk], [openai-agents]."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
 
-
   - id: tests/e2e/test_steering_during_async_drain_e2e.py::test_steering_breaks_blocked_async_drain
-    reason: "Shard 3 bulk: steering breaks blocked async drain."
-    issue: 532
+    reason: "Steering does not interrupt a blocked async drain (#771); fails 30/30 in flake-stress run 27804139920."
+    issue: 771
     cluster: steering-cancel-compaction-state
     mode: skip
 
-
-  # ── Shard 3 errors (collection / fixture-level) ──
-
-
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_effort_command_persists_session_metadata
-    reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
+    reason: "REPL session-lifecycle / pexpect cluster."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_recover_after_runner_death
-    reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
+    reason: "REPL session-lifecycle / pexpect cluster."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_resume_reuses_daemon_runner
-    reason: "Nightly bulk: REPL session-lifecycle / pexpect cluster."
+    reason: "REPL session-lifecycle / pexpect cluster."
     issue: 523
     cluster: repl-pexpect-cli
     mode: skip
-
-
-
-  # ── Bulk-quarantine round 3 (2026-05-18, run 26017551154) ──
-  # 20 tests across all 4 shards. Agent setup migrated from
-  # POST /api/agents to multipart POST /v1/sessions in #1559.
-  # 2 are the existing files-upload 409 'conversation not bound
-  # to a runner' family. Triage under #532.
-
-  # ── Re-quarantined after #1141 path sweep (2026-05-21) ──
-  # PR #1141 fixed examples/*.yaml → tests/resources/examples/*.yaml
-  # and dropped 33 manifest entries on the affected files. Of those
-  # 33, the path fix unblocked some (now passing) and revealed new
-  # failure modes for others. The block below re-adds the still-
-  # failing ones with accurate reasons so CI doesn't re-discover
-  # them every run.
 
   - id: tests/e2e/omnigent/test_repl_multiline.py::test_repl_multiline_ctrl_j_insert
     reason: "Kept suppressed as a known shard-load/worker-killer heavy pexpect test pending a dedicated round."
@@ -251,82 +189,3 @@ skips:
     issue: 677
     cluster: run-ap-examples-harness
     mode: skip
-
-  # ──────────────────────────────────────────────────────────────
-  # Force-merge regression backlog (2026-05-22 → 2026-05-25).
-  # Tests consistently failing 3-of-3 on main runs sampled in
-  # the window. Clustered by likely shared root cause; each
-  # cluster is one investigation, not N.
-  #
-  # Per-test ``reason`` lines record the first main run where
-  # each test was observed failing. These are the FIRST RUN that
-  # reached the test on broken main -- not necessarily the
-  # introducing commit. Several mechanisms create gaps in CI
-  # signal during this window:
-  #
-  # 1. Earlier runs got cancelled by GH Actions' concurrency
-  #    cancel-in-progress when a newer commit landed. The CI
-  #    workflow had ~14 consecutive cancelled runs between
-  #    2026-05-23 00:35 and 06:06 (5.5 hours) because force-merges
-  #    fired in rapid succession.
-  # 2. E2E shards timed out before reaching some tests.
-  #
-  # First-failing-commit distribution (raw -- read with the
-  # caveat above):
-  #   305e9bb9 (#1329, "README: quick-start nits")    35 tests
-  #   1a515983 (#1340, "setup: scrub auth env vars")   6 tests
-  #   2fe283bf (#1188, "refactor - remove DBOS")       3 tests
-  #   801c389c (#1302, "persist runtime-native ...")   3 tests
-  #   ab620102 (#1305, "publish session.status ...")   3 tests
-  #   0449cd1a (#1246, "perf(sessions): kill N+1 ...") 1 test
-  #   4d60bca0 (#1312, "remove OMNIGENT_NO_DBOS")    1 test
-  #   (no SHA -- flaky-on-main, not pinned)  8 tests
-  #
-  # The 35-test cluster at #1329 is the most distorted one. A
-  # README change can't break 35 tests; #1329 is just the first
-  # CI run after the cancelled-run gap that actually reached
-  # those tests. The actual introducing-commit window is
-  # ab620102..305e9bb9 (2026-05-23 00:35 - 06:06):
-  #
-  # * The sessions-cluster tests (16) passed at ab620102 (Pytest
-  #   server-rest reported success). They broke
-  #   somewhere in the next 14 commits, almost all of which had
-  #   their CI runs cancelled, so we have no per-commit signal.
-  #   Strongest candidates given the affected modules:
-  #     #1302 (801c389c) -- persist runtime-native session id
-  #                         as conversations.external_session_id
-  #     #1312 (4d60bca0) -- remove OMNIGENT_NO_DBOS override
-  #
-  # * The earliest first-failing sha for ANY test in this set is
-  #   2fe283bf (#1188 "refactor - remove DBOS") at 00:08,
-  #   immediately after the last green E2E run (a6de1763 at
-  #   2026-05-22T07:13). #1188 is the strongest candidate for
-  #   the bulk regression source for the E2E-side breakage; a
-  #   bisect on a6de1763..2fe283bf would confirm.
-  #
-  # Issue: 0 = needs umbrella issue filed; replace with a real
-  # tracking issue per cluster as triage proceeds.
-  # ──────────────────────────────────────────────────────────────
-
-  # Cluster: server-integration sessions endpoints (likely one
-  # regression broke the whole module — fork, interrupt, reasoning
-  # effort, runner-state, repl-adapter, title-seeding all flipped
-  # red together).
-
-  # Standalone failures — no obvious cluster yet.
-
-  # ──────────────────────────────────────────────────────────────
-  # Re-triaged 2026-06-18 (flake-stress run 27761358025 on main, 20×,
-  # --no-skip-known). The old "openai-agents empty-output crash on the
-  # gateway (#2707)" framing no longer holds — and #2707 does not exist as
-  # a tracking issue. 5 tests previously in this cluster are stale-green
-  # (0/20 failures: test_coder_subagent, test_openai_coder_client_tools,
-  # test_agent_update, and both test_steering tests — the latter are
-  # mock-LLM and never touch the gateway) and were UN-QUARANTINED.
-  # The 3 phase3 tests below fail ~consistently (NOT empty output): the
-  # spawned sub-agent's result is not delivered/drained before the parent's
-  # turn replies — the parent answers "still waiting for the researcher
-  # sub-agent to complete". test_..._idle_parent is the same autowake/drain
-  # family but only rarely flaky (2/20). Heavy e2e turns that can wedge the
-  # loadscope shard, so skip (not xfail).
-  # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Cleanup pass on `tests/known_failures.yaml` — **no test-status changes** (same 31 quarantined entries), just makes the file accurate and readable after the long triage campaign:

- **Removed ~80 lines of dead/orphaned provenance comments** — the Shard-0/1/3 "wedge candidate" notes, the large "Force-merge regression backlog" block, and the empty-output re-triage note. All referred to batches/tests long since removed or re-triaged; none had live entries.
- **Stripped stale `"Shard N bulk:" / "Nightly bulk:"` reason prefixes** — the file is no longer organized by the original failing shard, so those prefixes were misleading. Substantive reason text kept.
- **Fixed the two invalid `issue:` refs:**
  - `write_blocked` `#0` → **#770** (real sandbox write-enforcement issue, filed).
  - `steering_breaks_blocked_async_drain` `#532` → **#771** (#532 was a *merged PR*, not an issue).
- **Normalized** spacing (one blank line between entries) + trailing newline.

Entry order is preserved (no cluster reorg) to keep the diff reviewable and limit conflicts with in-flight known_failures PRs; a fuller reorg-by-cluster can be a follow-up once those land.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Comments/metadata only in `known_failures.yaml` — no entries added/removed, no test or product code touched. Verified it still `yaml.safe_load`s with the same 31 entries and every `issue:` now points at a real open issue (no `#0`, no PR-number refs).

This pull request and its description were written by Isaac.
