### PR TITLE
test: un-quarantine test_agent_with_os_env_fork_one_shot (stale-green, 30/30)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -108,11 +108,6 @@ skips:
 
 
   # ── Shard 1 errors (collection / fixture-level, not test body) ──
-  - id: tests/e2e/omnigent/test_example_agent_with_os_env_fork.py::test_agent_with_os_env_fork_one_shot
-    reason: "Shards 0/1 bulk: agent_with_os_env_fork one-shot exits 0 with no stdout."
-    issue: 675
-    cluster: sandbox-deps-env
-    mode: skip
   - id: tests/e2e/test_claude_coder_sandbox.py::test_write_blocked_outside_workspace
     reason: "Distinct from the bwrap CLI-path fix (this PR): the claude-sdk Write tool is NOT blocked from creating files outside the workspace, while edit/read/glob enforcement IS (those 4 sandbox tests pass 30/30 in flake-stress run 27796759300). write_blocked fails 30/30 — a real write-path sandbox-enforcement gap. Needs its own fix."
     issue: 0


### PR DESCRIPTION
## Summary

Un-quarantines `tests/e2e/omnigent/test_example_agent_with_os_env_fork.py::test_agent_with_os_env_fork_one_shot` — it's stale-green. Flake-stress ([run 27804139920](https://github.com/omnigent-ai/omnigent/actions/runs/27804139920), 30×, `--no-skip-known`) passes it **30/30**; the old "exits 0 with no stdout" reason no longer holds. Its sibling `test_secure_research_agent_os_env_one_shot` still fails 30/30 and stays quarantined (#675).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Quarantine-list-only; the test passed 30/30 in CI flake-stress (run 27804139920). No code changes.

This pull request and its description were written by Isaac.
