### PR TITLE
fix(cursor): correct "harness not configured" hint for native cursor

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -48,6 +48,7 @@ from omnigent.host.git_worktree import (
     remove_worktree,
 )
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
+from omnigent.onboarding.harness_install import harness_setup_hint
 from omnigent.onboarding.harness_readiness import (
     configured_harness_map,
     harness_is_configured,
@@ -710,8 +711,7 @@ class HostProcess:
                 status="failed",
                 error=(
                     f"harness {frame.harness!r} is not configured on host "
-                    f"{self._identity.name!r} — run `omnigent setup` on that "
-                    "machine to install the CLI and set a default credential"
+                    f"{self._identity.name!r} — {harness_setup_hint(frame.harness)}"
                 ),
                 error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
             )

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -132,16 +132,20 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
 # :data:`_HARNESS_INSTALL` family key. Only the CLI-backed harnesses appear
 # here — the ones that cannot launch without a binary on ``PATH``:
 # ``claude-native`` wraps the ``claude`` CLI, ``codex-native`` the ``codex``
-# CLI, and ``pi`` / ``pi-native`` the ``pi`` CLI.
+# CLI, ``pi`` / ``pi-native`` the ``pi`` CLI, and ``cursor-native`` /
+# ``native-cursor`` the ``cursor-agent`` CLI (the native Cursor TUI, installed
+# via Cursor's curl installer rather than npm — see its ``install_hint``).
 # SDK-based harnesses run in-process and are deliberately absent, so they
 # resolve to "no CLI required": ``claude-sdk``, ``codex``, ``openai-agents-sdk``,
-# and ``cursor`` (which drives the ``cursor-sdk``
-# Python package over its own bundled bridge, NOT the ``cursor-agent`` CLI).
+# and the SDK ``cursor`` harness (which drives the ``cursor-sdk`` Python package
+# over its own bundled bridge, NOT the ``cursor-agent`` CLI).
 _HARNESS_NAME_TO_KEY: dict[str, str] = {
     "claude-native": ANTHROPIC_FAMILY,
     "codex-native": OPENAI_FAMILY,
     PI_KEY: PI_KEY,
     "pi-native": PI_KEY,
+    "cursor-native": CURSOR_KEY,
+    "native-cursor": CURSOR_KEY,
 }
 
 
@@ -181,6 +185,35 @@ def missing_harness_cli(harness: str) -> HarnessInstallSpec | None:
     if shutil.which(spec.binary) is not None:
         return None
     return spec
+
+
+def harness_setup_hint(harness: str | None) -> str:
+    """Return actionable remediation when *harness* can't launch on a machine.
+
+    Most CLI harnesses (``claude``/``codex``/``pi``) install via npm and a
+    model credential, both of which ``omnigent setup`` handles — so they route
+    there. But a harness whose CLI ships out-of-band (``cursor-agent``, via
+    Cursor's own curl installer rather than npm — it carries an ``install_hint``
+    and no ``package``) is **not** installed by ``omnigent setup``: pointing a
+    native-Cursor user there is a dead end, since setup only configures the
+    SDK-based ``cursor`` harness (``cursor-sdk`` + ``CURSOR_API_KEY``). For
+    those, name the vendor installer and the CLI's own login instead.
+
+    :param harness: An executor harness identifier, e.g. ``"cursor-native"``,
+        ``"claude-native"``, or ``"codex"``; ``None`` falls back to the
+        ``omnigent setup`` hint.
+    :returns: A remediation clause for the "harness not configured" message,
+        e.g. ``"install the cursor-agent CLI on that machine with `curl
+        https://cursor.com/install -fsS | bash`, then run `cursor-agent
+        login`"`` for native Cursor, or the ``omnigent setup`` hint otherwise.
+    """
+    spec = required_cli_for_harness(harness or "")
+    if spec is not None and spec.package is None and spec.install_hint:
+        login = ""
+        if spec.login_args:
+            login = f", then run `{spec.binary} {' '.join(spec.login_args)}`"
+        return f"install the {spec.binary} CLI on that machine with `{spec.install_hint}`{login}"
+    return "run `omnigent setup` on that machine to install the CLI and set a default credential"
 
 
 def harness_install_spec(key: str) -> HarnessInstallSpec | None:

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -49,6 +49,13 @@ _SDK_HARNESSES: frozenset[str] = frozenset(
 # ``_HARNESS_FAMILY`` entry — pi uses the ``PI_SURFACE`` sentinel — so they must
 # be gated explicitly or they fail open like an unknown harness.
 _PI_HARNESSES: frozenset[str] = frozenset({PI_SURFACE, "pi-native"})
+
+# Native Cursor harnesses. These boot the ``cursor-agent`` TUI (``omni cursor``)
+# and so, like the other native CLI harnesses, can't launch without that binary
+# on ``PATH`` — gate them on it. Distinct from the SDK ``cursor`` harness
+# (``CURSOR_KEY`` below), which runs in-process via ``cursor-sdk`` and gates on
+# a ``CURSOR_API_KEY`` instead. Without these entries they'd fail open like an
+# unknown harness, letting a binary-less launch die inside the executor.
 _CURSOR_NATIVE_HARNESSES: frozenset[str] = frozenset({"cursor-native", "native-cursor"})
 
 
@@ -102,6 +109,10 @@ def harness_is_configured(harness: str) -> bool:
     if canonical in _SDK_HARNESSES:
         return True
     if canonical in _CURSOR_NATIVE_HARNESSES:
+        # Native Cursor (``omni cursor``) wraps the ``cursor-agent`` CLI — gate
+        # on that binary, like ``claude-native`` / ``codex-native``. (Login
+        # state surfaces at run time; the daemon gates only on binary presence,
+        # mirroring the other native harnesses.)
         return harness_cli_installed(CURSOR_KEY)
     if canonical == CURSOR_KEY:
         # Cursor runs in-process via ``cursor-sdk`` and authenticates with a

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -224,6 +224,45 @@ async def test_handle_launch_refuses_unconfigured_harness(
     assert host._runners == {}
 
 
+async def test_handle_launch_native_cursor_message_points_at_cursor_installer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A native-Cursor refusal must name the ``cursor-agent`` installer and
+    login, not ``omnigent setup`` — which only configures the SDK ``cursor``
+    harness and never installs the ``cursor-agent`` CLI ``omni cursor`` boots.
+
+    Here ``harness_setup_hint`` is the real function (only the readiness check
+    is forced False), so this exercises the connect.py → hint wiring end to end.
+    """
+    host = _make_host_process()
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        "omnigent.host.connect.harness_is_configured",
+        lambda harness: False,
+    )
+
+    frame = HostLaunchRunnerFrame(
+        request_id="req_cursor_native",
+        binding_token="token_abc",
+        workspace=str(workspace),
+        harness="cursor-native",
+    )
+    result = await host._handle_launch(frame)
+
+    assert result.status == "failed"
+    assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    message = result.error or ""
+    assert "'cursor-native'" in message
+    assert "test-laptop" in message
+    assert "cursor.com/install" in message
+    assert "cursor-agent login" in message
+    assert "omnigent setup" not in message
+    assert host._runners == {}
+
+
 async def test_handle_launch_configured_harness_proceeds_to_spawn(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -85,6 +85,10 @@ def test_unknown_key_has_no_spec_and_is_not_installed() -> None:
         ("claude-native", "claude"),
         ("codex-native", "codex"),
         ("pi", "pi"),
+        # Native Cursor wraps the cursor-agent CLI (distinct from the SDK
+        # ``cursor`` harness, which needs no binary — see the test below).
+        ("cursor-native", "cursor-agent"),
+        ("native-cursor", "cursor-agent"),
     ],
 )
 def test_required_cli_for_cli_backed_harness(harness: str, binary: str) -> None:
@@ -97,6 +101,30 @@ def test_required_cli_for_cli_backed_harness(harness: str, binary: str) -> None:
     spec = hi.required_cli_for_harness(harness)
     assert spec is not None
     assert spec.binary == binary
+
+
+@pytest.mark.parametrize("harness", ["cursor-native", "native-cursor"])
+def test_setup_hint_for_native_cursor_points_at_vendor_installer(harness: str) -> None:
+    """Native Cursor's "not configured" hint names the curl installer + login,
+    never ``omnigent setup`` — which only configures the SDK ``cursor`` harness
+    (``cursor-sdk`` + ``CURSOR_API_KEY``) and never installs ``cursor-agent``.
+
+    A regression to the generic hint sends a native-Cursor user down a dead end
+    (the exact bug this fixes).
+    """
+    hint = hi.harness_setup_hint(harness)
+    assert "cursor-agent" in hint
+    assert "cursor.com/install" in hint
+    assert "cursor-agent login" in hint
+    assert "omnigent setup" not in hint
+
+
+@pytest.mark.parametrize("harness", ["claude-native", "codex", "pi", "claude-sdk", None])
+def test_setup_hint_defaults_to_omnigent_setup(harness: str | None) -> None:
+    """Harnesses whose CLI ``omnigent setup`` installs (npm CLIs) — and the
+    SDK / unknown / ``None`` cases — route to the ``omnigent setup`` hint."""
+    hint = hi.harness_setup_hint(harness)
+    assert "omnigent setup" in hint
 
 
 @pytest.mark.parametrize("harness", ["cursor", "claude-sdk", "openai-agents"])

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -74,10 +74,21 @@ def test_sdk_and_unknown_harnesses_are_never_gated(
     assert harness_is_configured(harness) is True
 
 
-# CLI-wrapping harnesses are gated on their binary being on PATH.
+# CLI-wrapping harnesses are gated on their binary being on PATH. Native Cursor
+# (``omni cursor``) joins the list: it wraps the ``cursor-agent`` CLI, unlike the
+# SDK ``cursor`` harness which gates on a key (covered separately below).
 @pytest.mark.parametrize(
     "harness",
-    ["claude-native", "native-claude", "codex", "codex-native", "native-codex", "pi"],
+    [
+        "claude-native",
+        "native-claude",
+        "codex",
+        "codex-native",
+        "native-codex",
+        "pi",
+        "cursor-native",
+        "native-cursor",
+    ],
 )
 def test_cli_harness_configured_only_when_binary_installed(
     monkeypatch: pytest.MonkeyPatch, harness: str
@@ -124,6 +135,7 @@ def test_configured_harness_map_covers_all_spellings(
         "pi-native",
         "native-pi",
         "cursor",
+        # Native Cursor (``omni cursor``) — gates on the cursor-agent CLI.
         "cursor-native",
         "native-cursor",
         # Antigravity SDK harness + its user-facing aliases.
@@ -158,8 +170,10 @@ def test_configured_harness_map_gates_only_cli_harnesses(
     ):
         assert result[sdk] is True, f"{sdk} should never be gated"
     # CLI-wrapping spellings — gated, so False when the binary is absent.
-    # (Bare ``cursor`` is excluded: it runs via the ``cursor-sdk`` package and
-    # gates on a configured ``CURSOR_API_KEY``, not a binary — covered separately.)
+    # (The SDK ``cursor`` harness is excluded: it runs via the ``cursor-sdk``
+    # package and gates on a configured ``CURSOR_API_KEY``, not a binary —
+    # covered separately. Native Cursor (``cursor-native`` / ``native-cursor``)
+    # wraps the ``cursor-agent`` CLI, so it IS gated on the binary.)
     for cli in (
         "claude-native",
         "native-claude",
@@ -218,15 +232,26 @@ def test_cursor_readiness_keys_off_api_key(
     assert harness_is_configured("cursor") is True
 
 
-def test_cursor_native_readiness_keys_off_cursor_agent(
+def test_native_cursor_keys_off_binary_not_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cursor-native is configured iff the ``cursor-agent`` CLI is installed."""
-    monkeypatch.setenv("CURSOR_API_KEY", "crsr_sdk_key_does_not_matter")
-    _all_clis_installed(monkeypatch)
-    assert harness_is_configured("cursor-native") is True
-    assert harness_is_configured("native-cursor") is True
+    """Native Cursor (``omni cursor``) gates on the cursor-agent CLI, not a key.
 
+    The mirror image of :func:`test_cursor_readiness_keys_off_api_key`: native
+    Cursor boots the ``cursor-agent`` TUI, so its readiness is the binary on
+    ``PATH`` — a ``CURSOR_API_KEY`` (which configures the SDK ``cursor`` harness)
+    does not make it launchable. Conflating the two would tell a native-Cursor
+    user with a key set "you're ready" and then die booting a CLI that isn't
+    installed.
+    """
+    # A key set but no binary → not configured (the SDK key doesn't help here).
     _no_clis_installed(monkeypatch)
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_from_env")
     assert harness_is_configured("cursor-native") is False
     assert harness_is_configured("native-cursor") is False
+
+    # Binary present → configured, even with no key.
+    _all_clis_installed(monkeypatch)
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    assert harness_is_configured("cursor-native") is True
+    assert harness_is_configured("native-cursor") is True


### PR DESCRIPTION
## Problem

`omni cursor` fails with a misleading error when the native Cursor harness can't launch:

```
host failed to launch runner: harness 'cursor-native' is not configured on host
'LXGC04F2M9' — run `omnigent setup` on that machine to install the CLI and set a
default credential
```

`omni cursor` uses the **`cursor-native`** harness, which boots the `cursor-agent` TUI CLI. But `omnigent setup` only configures the **SDK** cursor harness (`cursor-sdk` + `CURSOR_API_KEY`) — it never installs `cursor-agent`. So the remediation is a dead end for native-cursor users, who actually need:

```
curl https://cursor.com/install -fsS | bash   # install cursor-agent
cursor-agent login                              # log in
```

## Root cause

`cursor-native` was only half-wired:
- `harness_is_configured("cursor-native")` fell through to the unknown-harness **fail-open** path — it was never gated on the `cursor-agent` binary, so a binary-less launch died inside the executor instead of failing cleanly at the gate.
- `cursor-native` wasn't in `_HARNESS_NAME_TO_KEY`, so the "not configured" message couldn't be tailored to it and hardcoded `omnigent setup`.

## Fix

- **`harness_install.py`** — wire `cursor-native`/`native-cursor` → `CURSOR_KEY` (binary `cursor-agent`); add `harness_setup_hint()`, which points CLIs that ship out-of-band (cursor-agent's curl installer, with an `install_hint` and no npm `package`) at the vendor installer + the CLI's own login, and routes everything else (npm CLIs, SDK/unknown) to `omnigent setup`.
- **`harness_readiness.py`** — gate `cursor-native`/`native-cursor` on the `cursor-agent` binary (parallel to `claude-native`/`codex-native`); add them to `configured_harness_map()`. The SDK `cursor` harness still gates on the API key, unchanged.
- **`connect.py`** — build the launch-refusal message via `harness_setup_hint(frame.harness)`.

New message for native cursor:

> harness 'cursor-native' is not configured on host 'LXGC04F2M9' — install the cursor-agent CLI on that machine with `curl https://cursor.com/install -fsS | bash`, then run `cursor-agent login`

## Tests

- `test_harness_readiness.py` — native cursor gates on the binary (not the key); `configured_harness_map` covers the new spellings.
- `test_harness_install.py` — `required_cli_for_harness` resolves `cursor-native` → `cursor-agent`; `harness_setup_hint` points native cursor at the installer + login and defaults others to `omnigent setup`.
- `test_connect.py` — end-to-end wiring: a `cursor-native` refusal names the installer + login, never `omnigent setup`.

Before:
<img width="1240" height="82" alt="image" src="https://github.com/user-attachments/assets/e3920272-c497-439c-be83-7333fd99cd86" />

After:
<img width="1243" height="84" alt="image" src="https://github.com/user-attachments/assets/40ac3343-5b37-4a66-a3b2-67d6fd95cc31" />


All targeted + integration launch tests pass; ruff clean.