### PR TITLE
ci(actions): bump actions/checkout to v7.0.0 for safer pull_request_target defaults

### DIFF
--- a/.github/workflows/ap-web-tests.yml
+++ b/.github/workflows/ap-web-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Node.js
         uses: ./.github/actions/setup-node

--- a/.github/workflows/auto-assign-reviewer-test.yml
+++ b/.github/workflows/auto-assign-reviewer-test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       - name: Run reviewer-assignment unit test

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -46,7 +46,7 @@ jobs:
       # Trusted default branch only (.github sparse). Never the PR head, so no
       # PR-authored code runs.
       - name: Check out .github
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github

--- a/.github/workflows/autoformat-pr.yml
+++ b/.github/workflows/autoformat-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout default-branch helper
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github/scripts/pr-template

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -209,7 +209,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -289,7 +289,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/duplicate-prs-test.yml
+++ b/.github/workflows/duplicate-prs-test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       - name: Run duplicate-PR unit test

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -34,7 +34,7 @@ jobs:
       # Trusted default branch only (.github sparse). Pin the ref explicitly so
       # manual workflow_dispatch runs can't execute a script from another
       # branch. Never the PR head, so no PR-authored code runs.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/e2e-ui-required.yml
+++ b/.github/workflows/e2e-ui-required.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out gate scripts from main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main             # trusted base; never the PR head
           sparse-checkout: .github/scripts

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -77,7 +77,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Check out CI scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Triggering ref (not main): the script must exist on it, and it
           # only shards tests -- no secrets exposure, so the PR's copy is fine.
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Check out CI scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Triggering ref (not main): the script must exist on it, and it
           # only shards tests -- no secrets exposure, so the PR's copy is fine.
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Same-repo PRs test the merge result (refs/pull/N/merge -- absent
           # when the PR conflicts, so a conflicted PR fails checkout by design).

--- a/.github/workflows/flake-stress-e2e.yml
+++ b/.github/workflows/flake-stress-e2e.yml
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.inputs.target_branch }}
 

--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.inputs.target_branch }}
 

--- a/.github/workflows/fork-e2e-mirror.yml
+++ b/.github/workflows/fork-e2e-mirror.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Check out gate scripts from main
         if: steps.ctx.outputs.is_fork == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main             # trusted; never the PR head
           sparse-checkout: .github/scripts

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Check out CI scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Triggering ref (not pinned to main): the script must exist on the
           # running ref, and it is not a security gate -- it only selects which
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Check out repo
         if: steps.creds.outputs.available == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/merge-ready.yml
+++ b/.github/workflows/merge-ready.yml
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main             # trusted gate scripts; never the PR head
           sparse-checkout: .github/scripts/merge-ready

--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -243,7 +243,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up crane
         uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0  # v0.6

--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -42,7 +42,7 @@ jobs:
       # Checkout main only for load-maintainers.sh; the PR branch is checked
       # out later (regen job), after authorization passes.
       - name: Checkout (for the maintainer script)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Load maintainers from .github/MAINTAINER
         id: maint
@@ -114,7 +114,7 @@ jobs:
       # build backends, which must not find a push token on disk. The App token
       # is minted only after `uv lock` and enters only at the push step.
       - name: Checkout the PR branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ needs.authorize.outputs.head }}
           persist-credentials: false

--- a/.github/workflows/oss-regenerate-and-smoke.yml
+++ b/.github/workflows/oss-regenerate-and-smoke.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up uv (clean public resolution, no proxy cache)
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4

--- a/.github/workflows/oss-scorecard.yml
+++ b/.github/workflows/oss-scorecard.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         if: steps.gate.outputs.ready == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -127,7 +127,7 @@ jobs:
       # out untrusted PR code in a privileged workflow.
       - name: Check out repo
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout default-branch script
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github/scripts/pr-size

--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up uv (clean public resolution, no proxy cache)
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Check out trust check from main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main             # trusted; never the PR head
           sparse-checkout: .github/scripts/security-scan

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,7 +47,7 @@ jobs:
       UV_INDEX_URL: https://pypi.org/simple
     steps:
       - name: Check out scanner from main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main             # trusted; never the PR head
           sparse-checkout: |
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check out PR head for static analysis
         if: ${{ steps.gate.outputs.scan == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # untrusted: only statically scanned
           path: pr


### PR DESCRIPTION
## What

Bumps all `actions/checkout` pins to **v7.0.0** (`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`) across 26 workflow files, collapsing the prior `v6.0.2` and `v4` pins into a single version.

## Why

Per the [GitHub changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/), `actions/checkout` v7 ships safer defaults that refuse to fetch **fork PR head** code in `pull_request_target` / `workflow_run` workflows when unsafe ref patterns (e.g. `ref: ${{ github.event.pull_request.head.sha }}`) are detected — closing "pwn request" vulnerabilities.

The enforcement backports to **all supported majors on 2026-07-16**, and pinned SHAs must be upgraded manually, so bumping now keeps us ahead of that and on one consistent version.

## Safety

Verified before bumping that none of the affected workflows hit v7's new refusal:

- Every `pull_request_target` workflow (`auto-assign-reviewer`, `merge-ready`, `pr-size`, `fork-e2e-mirror`, `e2e-ui-required`, etc.) checks out `ref: main` / the default branch — **trusted refs, never the fork head**.
- The `workflow_run` runner workflows (`maintainer-approval-rerun-run`, `rerun-security-gate-run`) use `actions/github-script`, not `actions/checkout`, resolving fork SHAs via the API.

No `allow-unsafe-pr-checkout` opt-out is needed.