### PR TITLE
fix(polly-review): suppress partial output when subagents time out

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -332,8 +332,10 @@ jobs:
 
           # Strip any sub-agent coordination preamble that leaks before
           # the actual review.  Primary: look for the sentinel we asked the
-          # model to emit.  Fallback: first markdown heading or standalone
-          # horizontal rule.
+          # model to emit.  Fallback: first markdown heading.  If neither is
+          # found the output is intermediate narration (subagents timed out
+          # before synthesis) — write empty string so the post step is skipped
+          # and raw coordination messages are never posted as a PR comment.
           python3 -c "
           import re, pathlib
           raw = pathlib.Path('/tmp/polly_output.txt').read_text()
@@ -342,8 +344,8 @@ jobs:
           if idx >= 0:
               cleaned = raw[idx + len(sentinel):].lstrip('\n')
           else:
-              m = re.search(r'^(#{1,6} |---\s*$)', raw, re.MULTILINE)
-              cleaned = raw[m.start():] if m else raw
+              m = re.search(r'^#{1,6} ', raw, re.MULTILINE)
+              cleaned = raw[m.start():] if m else ''
           pathlib.Path('/tmp/polly_output.txt').write_text(cleaned)
           "
 


### PR DESCRIPTION
## Summary

- When a subagent (e.g. `claude_code`) times out before polly synthesizes the final review, the fallback stripping logic was posting raw coordination narration as the PR comment — e.g. `` `pi` is not on PATH ``, "Dispatching both available reviewers", "Still waiting on claude_code" — instead of staying silent
- Fixed by changing the no-sentinel fallback: when no markdown heading (`## ...`) is found in the output, `cleaned = ''`, which causes the already-gated post step (`if: steps.polly.outputs.review_text != ''`) to skip posting entirely
- Also dropped the `---` horizontal-rule branch from the fallback regex; a proper review always starts with a `##` heading

## Test plan

- [ ] Trigger a `/review` on a PR where one subagent is unavailable or slow — confirm no partial comment is posted
- [ ] Trigger a `/review` on a normal PR — confirm the full structured review still posts as expected

This pull request and its description were written by Isaac.