### PR TITLE
fix(headless): drive async orchestrators to completion in -p mode

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2258,27 +2258,37 @@ async def _query_sessions_once(
     # sub-agents and are auto-woken by inbox completions across multiple
     # turns.
     #
-    # Ordering: await_turn() opens the SSE subscription BEFORE we call
-    # refresh() to check status. This closes the race where a turn
-    # completes in the window between the status-check and the subscribe:
-    # because we're already subscribed, its CompletedEvent arrives on our
-    # open stream and is never missed. If the session was already idle
-    # when we subscribed, await_turn() returns empty after the per-turn
-    # timeout; the subsequent refresh() then shows "idle" and we exit.
+    # Fast-exit: refresh() at the TOP of each iteration catches the common
+    # case (single-turn agent, session already idle) with one HTTP round-
+    # trip (~100 ms) instead of waiting up to _PER_TURN_TIMEOUT_S for a
+    # stream subscription to time out.
     #
-    # Timeouts: 120 s per turn (not 20 min) keeps a worst-case miss
-    # bounded. A global 1800 s wall-clock budget caps the entire loop
-    # regardless of turn count or individual delays.
+    # Race window: a turn MAY complete in the gap between the top-of-loop
+    # refresh() showing "waiting" and await_turn() opening its subscription.
+    # The window is O(ms) in practice (subagents take seconds). If it fires,
+    # await_turn() times out, the bottom refresh() shows "idle", and we exit
+    # — the only cost is one _PER_TURN_TIMEOUT_S wait and possibly missing
+    # that turn's text.
+    #
+    # Timeouts: 120 s per turn bounds the race-window penalty. A global
+    # 1800 s wall-clock budget caps the loop regardless of turn count.
     _MAX_EXTRA_TURNS = 30
     _PER_TURN_TIMEOUT_S = 120.0
     _LOOP_TIMEOUT_S = 1800.0
 
     async def _drain_extra_turns() -> None:
         for _ in range(_MAX_EXTRA_TURNS):
-            extra = await chat.await_turn(timeout=_PER_TURN_TIMEOUT_S)
+            # Fast-exit for single-turn agents.
             await chat.refresh()
+            if chat.status not in ("waiting", "running", "launching"):
+                return
+            # Session still active; subscribe before the next check to
+            # reduce (not eliminate) the race where a turn completes
+            # between refresh and subscribe.
+            extra = await chat.await_turn(timeout=_PER_TURN_TIMEOUT_S)
             if extra.text:
                 all_text_parts.append(extra.text)
+            await chat.refresh()
             if chat.status not in ("waiting", "running", "launching"):
                 return
         logger.warning(

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2274,7 +2274,7 @@ async def _query_sessions_once(
     _LOOP_TIMEOUT_S = 1800.0
 
     async def _drain_extra_turns() -> None:
-        for iteration in range(_MAX_EXTRA_TURNS):
+        for _ in range(_MAX_EXTRA_TURNS):
             extra = await chat.await_turn(timeout=_PER_TURN_TIMEOUT_S)
             await chat.refresh()
             if extra.text:

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2256,20 +2256,50 @@ async def _query_sessions_once(
 
     # Multi-turn loop for async orchestrators (e.g. polly) that dispatch
     # sub-agents and are auto-woken by inbox completions across multiple
-    # turns. Each iteration subscribes to the live stream and collects
-    # the next auto-triggered turn. The loop exits when the session
-    # becomes idle (no pending sub-agents) or the turn limit is hit.
+    # turns.
+    #
+    # Ordering: await_turn() opens the SSE subscription BEFORE we call
+    # refresh() to check status. This closes the race where a turn
+    # completes in the window between the status-check and the subscribe:
+    # because we're already subscribed, its CompletedEvent arrives on our
+    # open stream and is never missed. If the session was already idle
+    # when we subscribed, await_turn() returns empty after the per-turn
+    # timeout; the subsequent refresh() then shows "idle" and we exit.
+    #
+    # Timeouts: 120 s per turn (not 20 min) keeps a worst-case miss
+    # bounded. A global 1800 s wall-clock budget caps the entire loop
+    # regardless of turn count or individual delays.
     _MAX_EXTRA_TURNS = 30
-    for _ in range(_MAX_EXTRA_TURNS):
-        await chat.refresh()
-        if chat.status not in ("waiting", "running", "launching"):
-            break
-        extra = await chat.await_turn()
-        if extra.text:
-            all_text_parts.append(extra.text)
+    _PER_TURN_TIMEOUT_S = 120.0
+    _LOOP_TIMEOUT_S = 1800.0
+
+    async def _drain_extra_turns() -> None:
+        for iteration in range(_MAX_EXTRA_TURNS):
+            extra = await chat.await_turn(timeout=_PER_TURN_TIMEOUT_S)
+            await chat.refresh()
+            if extra.text:
+                all_text_parts.append(extra.text)
+            if chat.status not in ("waiting", "running", "launching"):
+                return
+        logger.warning(
+            "headless -p hit the %d-turn guard for session %s; "
+            "the orchestrator may still be running",
+            _MAX_EXTRA_TURNS,
+            bound.id,
+        )
+
+    try:
+        async with asyncio.timeout(_LOOP_TIMEOUT_S):
+            await _drain_extra_turns()
+    except asyncio.TimeoutError:
+        logger.warning(
+            "headless -p timed out after %.0fs waiting for session %s to complete",
+            _LOOP_TIMEOUT_S,
+            bound.id,
+        )
 
     if all_text_parts:
-        return "".join(all_text_parts)
+        return "\n\n".join(p for p in all_text_parts if p)
     # No assistant text at all. If the runner persisted a terminal
     # ``error`` item (e.g. a harness start failure like the cursor SDK's
     # invalid-model rejection), surface it instead of returning ``None`` —

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2248,12 +2248,29 @@ async def _query_sessions_once(
         if reconciled is not None:
             return reconciled
         raise
+    all_text_parts: list[str] = []
     if result.text:
-        return result.text
-    reconciled = await _persisted_turn_text(client, bound.id)
-    if reconciled is not None:
-        return reconciled
-    # No assistant text for this turn. If the runner persisted a terminal
+        all_text_parts.append(result.text)
+    elif (reconciled := await _persisted_turn_text(client, bound.id)) is not None:
+        all_text_parts.append(reconciled)
+
+    # Multi-turn loop for async orchestrators (e.g. polly) that dispatch
+    # sub-agents and are auto-woken by inbox completions across multiple
+    # turns. Each iteration subscribes to the live stream and collects
+    # the next auto-triggered turn. The loop exits when the session
+    # becomes idle (no pending sub-agents) or the turn limit is hit.
+    _MAX_EXTRA_TURNS = 30
+    for _ in range(_MAX_EXTRA_TURNS):
+        await chat.refresh()
+        if chat.status not in ("waiting", "running", "launching"):
+            break
+        extra = await chat.await_turn()
+        if extra.text:
+            all_text_parts.append(extra.text)
+
+    if all_text_parts:
+        return "".join(all_text_parts)
+    # No assistant text at all. If the runner persisted a terminal
     # ``error`` item (e.g. a harness start failure like the cursor SDK's
     # invalid-model rejection), surface it instead of returning ``None`` —
     # otherwise the headless caller renders a failed turn as a silent,

--- a/sdks/python-client/omnigent_client/_sessions_chat.py
+++ b/sdks/python-client/omnigent_client/_sessions_chat.py
@@ -1112,6 +1112,9 @@ class SessionsChat:
             async with asyncio.timeout(timeout):
                 await _collect()
         except asyncio.TimeoutError:
+            # Timeout is expected when the session completes before the deadline
+            # or the race window is missed; return whatever text was collected so
+            # far per the method contract (empty QueryResult is valid).
             pass
         return QueryResult(text="".join(text_parts), files=produced)
 

--- a/sdks/python-client/omnigent_client/_sessions_chat.py
+++ b/sdks/python-client/omnigent_client/_sessions_chat.py
@@ -1066,6 +1066,55 @@ class SessionsChat:
             return self._stream_query(input, files=files)
         return await self._collect_query(input, files=files)
 
+    async def await_turn(self, *, timeout: float | None = 1200.0) -> QueryResult:
+        """
+        Collect the next auto-triggered turn without posting a message.
+
+        Used by headless runners to follow async orchestrator sessions
+        across multiple turns. Unlike :meth:`query`, no user message is
+        posted — this helper subscribes to the live stream and waits for
+        the server to start a new turn (e.g. an inbox auto-wake when a
+        sub-agent completes), then collects its text output.
+
+        A ``timeout`` guards against the race window where the turn
+        already completed before the subscription opened. If no terminal
+        event arrives within ``timeout`` seconds, the coroutine returns
+        an empty :class:`QueryResult` so the caller can refresh session
+        status and decide how to proceed.
+
+        :param timeout: Seconds to wait for the turn to complete. ``None``
+            waits indefinitely. Defaults to 1200 (20 minutes).
+        :returns: :class:`QueryResult` with the turn's text (may be empty
+            if the turn completed before we subscribed).
+        :raises OmnigentError: Propagated from :meth:`stream` if the
+            session does not exist.
+        """
+        text_parts: list[str] = []
+        produced: list[File] = []
+
+        async def _collect() -> None:
+            async for event in self.stream():
+                if isinstance(event, OutputTextDeltaEvent):
+                    if event.delta:
+                        text_parts.append(event.delta)
+                elif isinstance(event, OutputItemDoneEvent) and not text_parts:
+                    text_parts.extend(_assistant_text_from_output_item(event.item))
+                elif isinstance(event, OutputFileDoneEvent):
+                    produced.append(await self._fetch_file(event))
+                elif isinstance(event, CompletedEvent):
+                    if not text_parts:
+                        text_parts.extend(_assistant_text_from_response(event.response.output))
+                    break
+                elif isinstance(event, _TURN_TERMINAL_EVENT_TYPES):
+                    break
+
+        try:
+            async with asyncio.timeout(timeout):
+                await _collect()
+        except asyncio.TimeoutError:
+            pass
+        return QueryResult(text="".join(text_parts), files=produced)
+
     async def _collect_query(
         self,
         input: str | list[dict[str, Any]],

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3253,6 +3253,8 @@ class _FakeAPClient:
 
 def _fake_sessions_chat_cls(
     query_impl: Callable[[str], object],
+    *,
+    extra_turns: list[str] | None = None,
 ) -> type:
     """
     Build a ``SessionsChat`` replacement whose ``query`` is ``query_impl``.
@@ -3265,15 +3267,38 @@ def _fake_sessions_chat_cls(
     :param query_impl: Async callable taking the prompt and returning a
         :class:`QueryResult` or raising, e.g. one that raises
         ``OmnigentError("turn failed")``.
+    :param extra_turns: Optional list of text strings to return from
+        successive ``await_turn()`` calls, simulating async orchestrator
+        auto-wakes. When exhausted ``await_turn`` returns empty text and
+        ``status`` returns ``"idle"``.
     :returns: A class usable as a drop-in for ``SessionsChat``.
     """
+    _extra = list(extra_turns or [])
 
     class _FakeSessionsChat:
         def __init__(self, **_kwargs: object) -> None:
-            pass
+            self._status = "waiting" if _extra else "idle"
+            self._pending = list(_extra)
+
+        @property
+        def status(self) -> str:
+            return self._status
+
+        async def refresh(self) -> None:
+            # After await_turn drains a turn, mark idle when nothing left.
+            if not self._pending:
+                self._status = "idle"
 
         async def query(self, prompt: str) -> object:
             return await query_impl(prompt)
+
+        async def await_turn(self, *, timeout: float | None = None) -> QueryResult:  # noqa: ARG002
+            if self._pending:
+                text = self._pending.pop(0)
+                if not self._pending:
+                    self._status = "idle"
+                return QueryResult(text=text, files=[])
+            return QueryResult(text="", files=[])
 
     return _FakeSessionsChat
 
@@ -3413,6 +3438,42 @@ async def test_query_sessions_once_returns_text_without_reconcile_on_success(
     result = await _run_one_shot(client, _return_text, monkeypatch)
     assert result == "direct answer"
     assert client.sessions.list_items_calls == 0  # no reconcile on success
+
+
+async def test_query_sessions_once_multi_turn_async_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Extra auto-woken turns are collected and joined with the first turn's text.
+
+    Simulates an async orchestrator (e.g. polly) that dispatches sub-agents
+    in turn 1, then is auto-woken for turn 2 when they complete. The headless
+    ``-p`` path must not exit after turn 1 — it must follow the session until
+    idle and concatenate all turns.
+
+    If this fails, multi-turn orchestrators like polly will always produce
+    partial output (only turn 1's narration, never the final synthesis).
+    """
+    monkeypatch.setattr(
+        "omnigent_client.SessionsChat",
+        _fake_sessions_chat_cls(
+            _return_text,
+            extra_turns=["<!-- POLLY_REVIEW_START -->\n## Summary\nLooks good."],
+        ),
+    )
+    client = _FakeAPClient([], list_items_must_not_be_called=True)
+    result = await _query_sessions_once(
+        client=client,
+        agent_name="polly",
+        tool_handler=None,
+        prompt="review this PR",
+        session_bundle=b"bundle-bytes",
+        session_bundle_filename="agent.tar.gz",
+        runner_id="runner_test",
+    )
+    assert result is not None
+    assert "direct answer" in result
+    assert "<!-- POLLY_REVIEW_START -->" in result
+    assert "Looks good." in result
 
 
 async def test_persisted_turn_text_anchors_on_last_user_message() -> None:

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3292,7 +3292,7 @@ def _fake_sessions_chat_cls(
         async def query(self, prompt: str) -> object:
             return await query_impl(prompt)
 
-        async def await_turn(self, *, timeout: float | None = None) -> QueryResult:  # noqa: ARG002
+        async def await_turn(self, *, timeout: float | None = None) -> QueryResult:
             if self._pending:
                 text = self._pending.pop(0)
                 if not self._pending:


### PR DESCRIPTION
## Summary

- `omnigent run -p` was one-shot: `_query_sessions_once` called `chat.query(prompt)` once, received `CompletedEvent` for turn 1, and exited — leaving sub-agents still running
- polly dispatches `claude_code` and `codex` reviewers and gets auto-woken by inbox completions; the CLI exited before those wakes arrived, so the final synthesis never happened
- Root cause: `SessionsChat.send()` returns on `CompletedEvent` (end of a single turn), not on session idle — there was no mechanism to observe subsequent auto-triggered turns

## Changes

- **`SessionsChat.await_turn()`** (`sdks/python-client/omnigent_client/_sessions_chat.py`): new method that subscribes to the live stream without posting a message, collects one auto-triggered turn's text (mirrors `_collect_query`), and times out after 20 min if the race window was lost
- **`_query_sessions_once`** (`omnigent/chat.py`): after the initial `chat.query(prompt)`, loops: checks `chat.status`; if `"waiting"` or `"running"`, calls `await_turn()` and accumulates output, stopping when session becomes `"idle"` or a 30-turn guard fires

## Test plan

- [ ] Trigger a polly review on a PR — confirm the full synthesis (with `<!-- POLLY_REVIEW_START -->` sentinel) is captured after both `claude_code` and `codex` sub-agents complete
- [ ] Trigger on a simple single-turn agent — confirm no regression (loop exits immediately on `"idle"`)
- [ ] Trigger with one sub-agent unavailable — confirm partial results still posted

This pull request and its description were written by Isaac.