### PR TITLE
test: re-characterize harness_without_agent ×3 — CI round-trip hang, not auth

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -55,15 +55,15 @@ skips:
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[claude-sdk]
-    reason: "No-AGENT harness round-trip claude-sdk."
+    reason: "No-AGENT `omnigent run --harness` live round-trip hangs >180s in CI -> pytest-timeout thread-kill -> xdist worker crash; claude-sdk fails 30/30 in flake-stress 27808074172. Auth is NOT the cause: CI sets DATABRICKS_BEARER and the harness auth-commands short-circuit on it, so the hang is post-auth in the round-trip. Environment-wide, not harness-specific (codex + openai-agents siblings hang identically). The test's _COMPLETION_TIMEOUT=240 also exceeds the e2e --timeout=180 cap. Not locally reproducible (oss OAuth + macOS PTY diverge from CI); needs CI-env debugging."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: no-agent-harness-roundtrip-hang
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[openai-agents]
-    reason: "No-AGENT harness round-trip openai-agents, same family."
+    reason: "No-AGENT `omnigent run --harness` live round-trip hangs >180s in CI -> xdist worker crash; openai-agents fails 10/10 in flake-stress 27809210955. Same post-auth round-trip hang as the [claude-sdk]/[codex] siblings -- notably the in-process SDK harness hangs too, confirming the cause is environment-wide rather than CLI-subprocess-specific. See [claude-sdk] entry for the full diagnosis."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: no-agent-harness-roundtrip-hang
     mode: skip
 
 
@@ -92,9 +92,9 @@ skips:
     mode: skip
 
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[codex]
-    reason: "No-AGENT harness round-trip, codex variant; same family as [claude-sdk], [openai-agents]."
+    reason: "No-AGENT `omnigent run --harness` live round-trip hangs >180s in CI -> xdist worker crash; codex fails 6/6 in flake-stress 27808990899. Same post-auth round-trip hang as the [claude-sdk]/[openai-agents] siblings (locally codex fast-fails on the databricks auth-command instead, an oss-OAuth repro artifact, not the CI failure). See [claude-sdk] entry for the full diagnosis."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: no-agent-harness-roundtrip-hang
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_effort_command_persists_session_metadata


### PR DESCRIPTION
## Summary

Triages the three quarantined `test_run_harness_without_agent_live_repl_round_trip[claude-sdk|codex|openai-agents]` entries (the #523 "No-AGENT harness round-trip" group). **Verdict: real failure, kept quarantined — but re-characterized** from vague inherited labels to a precise, evidence-backed diagnosis, and moved out of the misleading `repl-pexpect-cli` cluster into a dedicated `no-agent-harness-roundtrip-hang` cluster.

**No test status change** — this is `known_failures.yaml` metadata only (reasons + cluster).

### What the investigation found

The no-AGENT `omnigent run --harness <h>` live round-trip **hangs >180s in CI** → pytest-timeout thread-kill → **xdist worker crash** (`[gw0] node down: Not properly terminated`), consistently, for all three harnesses:

| Variant | Result | Flake-stress run |
|---|---|---|
| `[claude-sdk]` | 30/30 fail | [27808074172](https://github.com/omnigent-ai/omnigent/actions/runs/27808074172) |
| `[openai-agents]` | 10/10 fail | [27809210955](https://github.com/omnigent-ai/omnigent/actions/runs/27809210955) |
| `[codex]` | 6/6 fail | [27808990899](https://github.com/omnigent-ai/omnigent/actions/runs/27808990899) |

Key conclusions:
- **Not stale-green** — fails 100% in CI, not flaky.
- **Not an auth-bridge issue.** CI sets `DATABRICKS_BEARER` (`=$LLM_API_KEY` in `GITHUB_ENV`) and every harness auth-command short-circuits on it (`codex_executor.py:700`, `claude_sdk_executor.py:854`), so auth succeeds — the hang is **post-auth**, in the round-trip itself.
- **Environment-wide, not harness-type-specific.** It hits the in-process SDK harness (`openai-agents`) too, not just the CLI-subprocess harnesses — ruling out a codex/claude-sdk CLI quirk.
- **Test bug compounding it:** the test's `_COMPLETION_TIMEOUT=240` exceeds the e2e `--timeout=180` cap, so even a slow-but-working round-trip can't pass, and the failure manifests as a worker crash (which aborts the whole session) rather than a clean fail.
- **Not locally reproducible** — local oss OAuth + macOS PTY diverge from CI (locally the round-trip either fast-fails on the databricks auth-command or EOFs, never the CI hang). Root-causing requires the CI environment; this is left to a follow-up owner.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`known_failures.yaml` metadata only — no test or product code changed, and no test status change (all three stay quarantined). The three entries now carry the verified root cause (CI round-trip hang, auth ruled out, flake-stress run IDs) instead of the inherited "No-AGENT harness round-trip" placeholder, and sit in a `no-agent-harness-roundtrip-hang` cluster that accurately reflects the shared cause. This makes the quarantine list honest and gives a follow-up owner a precise starting point.

This pull request and its description were written by Isaac.
