### PR TITLE
test(e2e): migrate per-harness and yaml tests to mock LLM (#batch4)

### DIFF
--- a/tests/e2e/omnigent/test_per_harness_claude_sdk.py
+++ b/tests/e2e/omnigent/test_per_harness_claude_sdk.py
@@ -1,17 +1,14 @@
 """Phase 0 characterization test — claude-sdk harness, one-shot prompt.
 
 Runs ``omnigent run hello_world.yaml --harness claude-sdk -p
-"..."`` as a real subprocess and snapshots the structural
-observations (exit code, stderr absence, assistant text length).
-Captured against current Omnigent; re-run unchanged in later
-phases to prove the integration preserves behavior.
+"..."`` as a real subprocess against the mock LLM server and
+snapshots the structural observations (exit code, stderr absence,
+assistant text length).
 
 **What breaks if this fails:**
 - Omnigent' ``ClaudeSDKExecutor`` regresses (auth, MCP tool
   bridging, Claude Code binary discovery, or the message-stream
   translation in ``claude_sdk_executor.run_turn``).
-- ``_read_databrickscfg``'s PAT path regresses (the profile
-  token becomes unreadable).
 - ``omnigent.cli._run_agent`` for the ``-p`` one-shot path
   stops printing the assistant text to stdout on turn complete.
 - The Claude Agent SDK dependency or the ``claude`` CLI binary
@@ -24,19 +21,16 @@ per-harness suite.
 from __future__ import annotations
 
 import subprocess
+import uuid
 from pathlib import Path
 from shutil import which
 from typing import Any
 
 import pytest
 
-from tests._model_pools import resolve_model
 from tests.e2e.omnigent._snapshot import compare_snapshot
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
 
-# Model + harness are hardcoded because the test name
-# advertises "claude-sdk harness". A per-harness characterization
-# test is meaningless without pinning the harness it covers.
-_MODEL = resolve_model("databricks-claude-sonnet-4-6", key=__name__)
 _HARNESS = "claude-sdk"
 _PROMPT = "say hi in 5 words"
 
@@ -87,46 +81,55 @@ def claude_sdk_available(omnigent_python: Path) -> bool:
 def test_per_harness_claude_sdk_one_shot(
     omnigent_python: Path,
     omnigent_repo_root: Path,
-    omnigent_credentials_env: dict[str, str],
-    patched_databrickscfg: None,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
     claude_sdk_available: bool,
 ) -> None:
     """
     ``omnigent run hello_world.yaml --harness claude-sdk -p
     <prompt>`` exits 0 and emits a non-trivial assistant reply.
 
-    Uses the ``patched_databrickscfg`` fixture to swap the
-    active profile's section to a PAT for the duration of the
-    test — necessary because ``ClaudeSDKExecutor`` reads the
-    profile's ``token`` field directly and OAuth profiles
-    produce 403s. This workaround is documented in the
-    integration design doc and disappears once omnigent'
-    ``_read_databrickscfg`` rewrite (audit item for phase 1)
-    lands.
+    Uses the mock LLM server via ``ANTHROPIC_BASE_URL`` so the
+    test runs without real Anthropic credentials. The mock server
+    handles ``/v1/messages`` (the Anthropic-native endpoint) so
+    the ClaudeSDKExecutor's requests are intercepted and answered
+    with canned responses.
 
     :param omnigent_python: Interpreter with omnigent +
         claude-agent-sdk installed.
     :param omnigent_repo_root: Cwd for the subprocess.
-    :param omnigent_credentials_env: Env vars with
-        ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` /
-        ``DATABRICKS_CONFIG_PROFILE`` already populated from
-        ``--llm-api-key``.
-    :param patched_databrickscfg: Fixture that rewrites
-        ``~/.databrickscfg`` to PAT form for the test and
-        restores it on teardown.
+    :param mock_credentials_env: Env vars from the mock-LLM
+        fixture (provides ``OPENAI_BASE_URL``; we add
+        ``ANTHROPIC_BASE_URL`` and ``ANTHROPIC_API_KEY`` below).
+    :param mock_llm_server_url: Base URL of the mock server for
+        configuring canned responses and building
+        ``ANTHROPIC_BASE_URL``.
     :param claude_sdk_available: True when the claude-sdk
         prerequisites (SDK package + ``claude`` binary) are
-        present. If False, the test fails with an explicit
-        reason rather than silently skipping — per the phase 0
-        design, skip reasons must be explicit and environment
-        gaps must be visible.
+        present. If False, the test skips — the ``claude`` binary
+        is a genuine proprietary CLI that CI commonly lacks.
     """
     if not claude_sdk_available:
-        pytest.fail(
+        pytest.skip(
             "claude-sdk harness prerequisites missing: both the "
             "'claude_agent_sdk' Python package and the 'claude' CLI "
-            "binary must be present on PATH."
+            "binary must be present on PATH. Skipping — binary absent."
         )
+
+    model = f"mock-harness-claude-sdk-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello there, how are you today?"}],
+        key=model,
+    )
+
+    # Build env: start from the mock env and add Anthropic-specific
+    # vars so ClaudeSDKExecutor's /v1/messages calls land on the
+    # mock server rather than api.anthropic.com.
+    env = dict(mock_credentials_env)
+    env["ANTHROPIC_BASE_URL"] = mock_llm_server_url
+    env["ANTHROPIC_API_KEY"] = "mock-key"
 
     yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
 
@@ -138,7 +141,7 @@ def test_per_harness_claude_sdk_one_shot(
             "run",
             str(yaml_path),
             "--model",
-            _MODEL,
+            model,
             "--harness",
             _HARNESS,
             "-p",
@@ -146,7 +149,7 @@ def test_per_harness_claude_sdk_one_shot(
             "--no-log",
             "--no-session",
         ],
-        env=omnigent_credentials_env,
+        env=env,
         cwd=str(omnigent_repo_root),
         capture_output=True,
         text=True,
@@ -176,8 +179,7 @@ def test_per_harness_claude_sdk_one_shot(
     }
 
     # Full stderr surfaced on failure so CI logs show WHY the
-    # run went wrong (e.g. 403 auth, missing binary) — stderr
-    # here is opaque unless we dump it.
+    # run went wrong — stderr here is opaque unless we dump it.
     diffs = compare_snapshot("test_per_harness_claude_sdk", observed)
     assert diffs == [], (
         "Snapshot mismatch for claude-sdk run:\n"

--- a/tests/e2e/omnigent/test_per_harness_claude_sdk.py
+++ b/tests/e2e/omnigent/test_per_harness_claude_sdk.py
@@ -16,6 +16,15 @@ assistant text length).
 
 Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 per-harness suite.
+
+**Serial execution note:** These tests are designed for serial
+execution — do NOT run them under pytest-xdist or any parallel
+runner that shares the mock LLM server process. Each test uses a
+UUID-keyed model name, so concurrent tests use separate queues and
+queue cross-contamination is impossible even without ``reset_mock_llm``.
+The ``reset_mock_llm`` call is kept as a safety guard to clear any
+leftover state from prior test runs in the same session, but it
+would wipe another test's queue if two tests ran simultaneously.
 """
 
 from __future__ import annotations

--- a/tests/e2e/omnigent/test_per_harness_codex.py
+++ b/tests/e2e/omnigent/test_per_harness_codex.py
@@ -1,23 +1,16 @@
 """Phase 0 characterization test — codex harness, one-shot prompt.
 
 Runs ``omnigent run hello_world.yaml --harness codex --model
-<codex-compatible-model> -p "..."`` as a real subprocess and
-snapshots structural observations (exit code, stderr cleanliness,
-assistant text length). Captured against current Omnigent;
-re-run unchanged in later phases to prove the integration
-preserves behavior for the codex harness.
+<mock-model> -p "..."`` as a real subprocess against the mock LLM
+server and snapshots structural observations (exit code, stderr
+cleanliness, assistant text length).
 
 **What breaks if this fails:**
 - Omnigent' ``CodexExecutor`` regresses (``codex app-server``
   subprocess orchestration, App Server JSON-RPC protocol, the
-  message-stream translation in ``codex_executor.run_turn``, or
-  the Databricks config-override generation in
-  ``_databricks_codex_config_overrides``).
+  message-stream translation in ``codex_executor.run_turn``).
 - The ``codex`` CLI binary disappears from PATH or its
   ``app-server`` subcommand changes its startup contract.
-- ``omnigent.databricks_executor._read_databrickscfg`` regresses
-  for the PAT path — ``CodexExecutor`` transitively depends on it
-  to resolve the Databricks host + token for the model proxy.
 - ``omnigent.cli._run_agent`` for the ``-p`` one-shot path
   stops printing assistant text to stdout on turn complete.
 
@@ -28,22 +21,16 @@ per-harness suite.
 from __future__ import annotations
 
 import subprocess
+import uuid
 from pathlib import Path
 from shutil import which
 from typing import Any
 
 import pytest
 
-from tests._model_pools import resolve_model
 from tests.e2e.omnigent._snapshot import compare_snapshot
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
 
-# Model + harness are hardcoded because the test name advertises
-# "codex harness"; a per-harness characterization test is
-# meaningless without pinning the harness under test.
-# databricks-gpt-5-4-mini is the gateway model documented in the
-# repo-level CLAUDE.md as the safe default for OpenAI-flavored
-# harnesses (codex is an OpenAI-native coding agent).
-_MODEL = resolve_model("databricks-gpt-5-4-mini", key=__name__)
 _HARNESS = "codex"
 _PROMPT = "say hi in 5 words"
 
@@ -77,44 +64,45 @@ def codex_available() -> bool:
 def test_per_harness_codex_one_shot(
     omnigent_python: Path,
     omnigent_repo_root: Path,
-    omnigent_credentials_env: dict[str, str],
-    patched_databrickscfg: None,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
     codex_available: bool,
 ) -> None:
     """
     ``omnigent run hello_world.yaml --harness codex -p <prompt>``
     exits 0 and emits a non-trivial assistant reply.
 
-    Uses ``patched_databrickscfg`` because ``CodexExecutor`` routes
-    model calls through a Databricks-specific config override set
-    constructed from ``~/.databrickscfg`` via
-    ``_read_databrickscfg`` — OAuth-profile tokens silently 403
-    the codex app-server's model requests. This matches the
-    claude-sdk pattern; the workaround is documented in
-    ``OMNIGENT_INTEGRATION.md`` as the pre-phase-1 baseline and
-    disappears once the ``databricks-sdk`` rewrite lands.
+    Uses the mock LLM server (via ``OPENAI_BASE_URL`` in
+    ``mock_credentials_env``) so the test runs without real API
+    credentials or a Databricks workspace. The codex executor
+    honors ``OPENAI_BASE_URL`` for its app-server model routing.
 
     :param omnigent_python: Interpreter with omnigent
         installed and importable.
     :param omnigent_repo_root: Cwd for the subprocess so the
         YAML spec and example tool modules resolve on sys.path.
-    :param omnigent_credentials_env: Env vars with
-        ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` /
-        ``DATABRICKS_CONFIG_PROFILE`` populated from
-        ``--llm-api-key``.
-    :param patched_databrickscfg: Fixture that rewrites
-        ``~/.databrickscfg`` to PAT form for the test and
-        restores it on teardown.
+    :param mock_credentials_env: Env vars pointing at the mock
+        LLM server.
+    :param mock_llm_server_url: Base URL of the mock server for
+        configuring canned responses.
     :param codex_available: True when the ``codex`` CLI is
-        present. On False the test fails with an explicit reason
-        per CLAUDE.md rule 30 (no silent skips).
+        present. On False the test skips — codex is a genuine
+        proprietary binary that CI typically lacks.
     """
     if not codex_available:
-        pytest.fail(
+        pytest.skip(
             "codex harness prerequisite missing: the 'codex' CLI "
             "binary must be installed on PATH (install via "
-            "'npm i -g @openai/codex')."
+            "'npm i -g @openai/codex'). Skipping — binary absent."
         )
+
+    model = f"mock-harness-codex-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello there, how are you today?"}],
+        key=model,
+    )
 
     yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
 
@@ -126,7 +114,7 @@ def test_per_harness_codex_one_shot(
             "run",
             str(yaml_path),
             "--model",
-            _MODEL,
+            model,
             "--harness",
             _HARNESS,
             "-p",
@@ -134,7 +122,7 @@ def test_per_harness_codex_one_shot(
             "--no-log",
             "--no-session",
         ],
-        env=omnigent_credentials_env,
+        env=mock_credentials_env,
         cwd=str(omnigent_repo_root),
         capture_output=True,
         text=True,
@@ -164,8 +152,8 @@ def test_per_harness_codex_one_shot(
     }
 
     # Full stderr surfaced on failure so CI logs show WHY the run
-    # went wrong (e.g. 403 auth, missing binary) — stderr here is
-    # opaque unless we dump it in the failure message.
+    # went wrong (e.g. missing binary) — stderr here is opaque
+    # unless we dump it in the failure message.
     diffs = compare_snapshot("test_per_harness_codex", observed)
     assert diffs == [], (
         "Snapshot mismatch for codex run:\n"

--- a/tests/e2e/omnigent/test_per_harness_codex.py
+++ b/tests/e2e/omnigent/test_per_harness_codex.py
@@ -16,6 +16,15 @@ cleanliness, assistant text length).
 
 Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 per-harness suite.
+
+**Serial execution note:** These tests are designed for serial
+execution — do NOT run them under pytest-xdist or any parallel
+runner that shares the mock LLM server process. Each test uses a
+UUID-keyed model name, so concurrent tests use separate queues and
+queue cross-contamination is impossible even without ``reset_mock_llm``.
+The ``reset_mock_llm`` call is kept as a safety guard to clear any
+leftover state from prior test runs in the same session, but it
+would wipe another test's queue if two tests ran simultaneously.
 """
 
 from __future__ import annotations

--- a/tests/e2e/omnigent/test_per_harness_openai_agents_sdk.py
+++ b/tests/e2e/omnigent/test_per_harness_openai_agents_sdk.py
@@ -18,6 +18,15 @@ stderr cleanliness, assistant text length).
 
 Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 per-harness suite.
+
+**Serial execution note:** These tests are designed for serial
+execution — do NOT run them under pytest-xdist or any parallel
+runner that shares the mock LLM server process. Each test uses a
+UUID-keyed model name, so concurrent tests use separate queues and
+queue cross-contamination is impossible even without ``reset_mock_llm``.
+The ``reset_mock_llm`` call is kept as a safety guard to clear any
+leftover state from prior test runs in the same session, but it
+would wipe another test's queue if two tests ran simultaneously.
 """
 
 from __future__ import annotations
@@ -100,14 +109,15 @@ def test_per_harness_openai_agents_sdk_one_shot(
         configuring canned responses.
     :param openai_agents_available: True when the ``agents``
         package is importable in the omnigent venv. On False
-        the test fails with an explicit reason per CLAUDE.md
-        rule 30 (no silent skips).
+        the test skips — consistent with the codex and
+        claude-sdk harness tests that skip when their binary
+        is absent.
     """
     if not openai_agents_available:
-        pytest.fail(
+        pytest.skip(
             "openai-agents-sdk harness prerequisite missing: "
             "the 'agents' Python package (openai-agents) must be "
-            "installed in the Omnigent venv."
+            "installed in the Omnigent venv. Skipping — package absent."
         )
 
     model = f"mock-harness-openai-{uuid.uuid4().hex[:8]}"

--- a/tests/e2e/omnigent/test_per_harness_openai_agents_sdk.py
+++ b/tests/e2e/omnigent/test_per_harness_openai_agents_sdk.py
@@ -1,11 +1,9 @@
 """Phase 0 characterization test — openai-agents-sdk harness, one-shot prompt.
 
 Runs ``omnigent run hello_world.yaml --harness openai-agents
---model <gpt-model> -p "..."`` as a real subprocess and snapshots
-structural observations (exit code, stderr cleanliness, assistant
-text length). Captured against current Omnigent; re-run
-unchanged in later phases to prove the integration preserves
-behavior for the openai-agents harness.
+--model <mock-model> -p "..."`` as a real subprocess against the
+mock LLM server and snapshots structural observations (exit code,
+stderr cleanliness, assistant text length).
 
 **What breaks if this fails:**
 - Omnigent' ``OpenAIAgentsSDKExecutor`` regresses (the Runner
@@ -15,9 +13,6 @@ behavior for the openai-agents harness.
 - The ``openai-agents`` Python package (``agents`` module) is
   missing from the omnigent venv or its public API changes
   incompatibly.
-- The Databricks model-serving gateway at
-  ``OPENAI_BASE_URL`` rejects requests that previously worked
-  (token invalid, model decommissioned, etc.).
 - ``omnigent.cli._run_agent`` for the ``-p`` one-shot path
   stops printing the assistant text on turn complete.
 
@@ -28,20 +23,15 @@ per-harness suite.
 from __future__ import annotations
 
 import subprocess
+import uuid
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from tests._model_pools import resolve_model
 from tests.e2e.omnigent._snapshot import compare_snapshot
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
 
-# Model + harness are hardcoded because the test name advertises
-# "openai-agents harness"; a per-harness characterization test is
-# meaningless without pinning the harness it covers.
-# databricks-gpt-5-4-mini is the gateway model documented in the
-# repo-level CLAUDE.md for OpenAI-flavored harnesses.
-_MODEL = resolve_model("databricks-gpt-5-4-mini", key=__name__)
 _HARNESS = "openai-agents"
 _PROMPT = "say hi in 5 words"
 
@@ -87,27 +77,27 @@ def openai_agents_available(omnigent_python: Path) -> bool:
 def test_per_harness_openai_agents_sdk_one_shot(
     omnigent_python: Path,
     omnigent_repo_root: Path,
-    omnigent_credentials_env: dict[str, str],
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
     openai_agents_available: bool,
 ) -> None:
     """
     ``omnigent run hello_world.yaml --harness openai-agents -p
     <prompt>`` exits 0 and emits a non-trivial assistant reply.
 
-    Does NOT use ``patched_databrickscfg`` because the
-    openai-agents executor honors ``OPENAI_BASE_URL`` /
-    ``OPENAI_API_KEY`` env vars directly (populated by
-    ``omnigent_credentials_env``) — no ``~/.databrickscfg``
-    touch is required for this harness. This matches the pattern
-    the design doc calls out: openai-agents is the "cleanest" of
-    the harnesses re: credential plumbing.
+    Uses the mock LLM server so the test runs without real API
+    credentials. The openai-agents executor honors
+    ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` env vars directly
+    (populated by ``mock_credentials_env``) — no
+    ``~/.databrickscfg`` touch is required for this harness.
 
     :param omnigent_python: Interpreter with omnigent +
         ``openai-agents`` installed.
     :param omnigent_repo_root: Cwd for the subprocess.
-    :param omnigent_credentials_env: Env vars with
-        ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` populated from
-        ``--llm-api-key``.
+    :param mock_credentials_env: Env vars pointing at the mock
+        LLM server.
+    :param mock_llm_server_url: Base URL of the mock server for
+        configuring canned responses.
     :param openai_agents_available: True when the ``agents``
         package is importable in the omnigent venv. On False
         the test fails with an explicit reason per CLAUDE.md
@@ -120,6 +110,14 @@ def test_per_harness_openai_agents_sdk_one_shot(
             "installed in the Omnigent venv."
         )
 
+    model = f"mock-harness-openai-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello there, how are you today?"}],
+        key=model,
+    )
+
     yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
 
     result = subprocess.run(
@@ -130,7 +128,7 @@ def test_per_harness_openai_agents_sdk_one_shot(
             "run",
             str(yaml_path),
             "--model",
-            _MODEL,
+            model,
             "--harness",
             _HARNESS,
             "-p",
@@ -138,7 +136,7 @@ def test_per_harness_openai_agents_sdk_one_shot(
             "--no-log",
             "--no-session",
         ],
-        env=omnigent_credentials_env,
+        env=mock_credentials_env,
         cwd=str(omnigent_repo_root),
         capture_output=True,
         text=True,

--- a/tests/e2e/omnigent/test_per_harness_pi.py
+++ b/tests/e2e/omnigent/test_per_harness_pi.py
@@ -18,6 +18,24 @@ cleanliness, assistant text length).
 
 Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 per-harness suite.
+
+**Serial execution note:** These tests are designed for serial
+execution — do NOT run them under pytest-xdist or any parallel
+runner that shares the mock LLM server process. Each test uses a
+UUID-keyed model name, so concurrent tests use separate queues and
+queue cross-contamination is impossible even without ``reset_mock_llm``.
+The ``reset_mock_llm`` call is kept as a safety guard to clear any
+leftover state from prior test runs in the same session, but it
+would wipe another test's queue if two tests ran simultaneously.
+
+**Mock routing note (pi):** The pi executor is expected to route
+model calls via ``OPENAI_BASE_URL`` (set by ``mock_credentials_env``).
+If a particular pi build reads ``~/.databrickscfg`` instead and
+ignores ``OPENAI_BASE_URL``, the test would connect to a real
+endpoint rather than the mock server and fail or behave
+non-deterministically. The module-level ``pytestmark`` skips the
+test when ``pi`` is absent; on CI the binary should either be
+absent (skip) or be a build that honors ``OPENAI_BASE_URL``.
 """
 
 from __future__ import annotations

--- a/tests/e2e/omnigent/test_per_harness_pi.py
+++ b/tests/e2e/omnigent/test_per_harness_pi.py
@@ -1,11 +1,9 @@
 """Phase 0 characterization test — pi harness, one-shot prompt.
 
 Runs ``omnigent run hello_world.yaml --harness pi --model
-<model> -p "..."`` as a real subprocess and snapshots structural
-observations (exit code, stderr cleanliness, assistant text
-length). Captured against current Omnigent; re-run unchanged
-in later phases to prove the integration preserves behavior for
-the pi harness.
+<mock-model> -p "..."`` as a real subprocess against the mock LLM
+server and snapshots structural observations (exit code, stderr
+cleanliness, assistant text length).
 
 **What breaks if this fails:**
 - Omnigent' ``PiExecutor`` regresses (the ``pi --mode rpc``
@@ -15,9 +13,6 @@ the pi harness.
   Omnigent tools with ``pi.registerTool()``).
 - The ``pi`` CLI binary disappears from PATH or its
   ``--mode rpc`` subcommand changes its startup contract.
-- The Databricks credentials resolution regresses — ``PiExecutor``
-  reads ``~/.databrickscfg`` directly to generate the temporary
-  ``models.json`` that Pi picks up via ``PI_CODING_AGENT_DIR``.
 - ``omnigent.cli._run_agent`` for the ``-p`` one-shot path
   stops printing assistant text to stdout on turn complete.
 
@@ -28,21 +23,16 @@ per-harness suite.
 from __future__ import annotations
 
 import subprocess
+import uuid
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from tests._model_pools import resolve_model
 from tests.e2e._harness_probes import cli_unavailable_reason
 from tests.e2e.omnigent._snapshot import compare_snapshot
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
 
-# Model + harness are hardcoded because the test name advertises
-# "pi harness". Pi's Databricks integration generates a
-# ``models.json`` with OpenAI/Anthropic providers based on the
-# model name's prefix; ``databricks-gpt-5-4-mini`` routes through
-# the OpenAI-Responses provider which is the best-tested path.
-_MODEL = resolve_model("databricks-gpt-5-4-mini", key=__name__)
 _HARNESS = "pi"
 _PROMPT = "say hi in 5 words"
 
@@ -71,32 +61,35 @@ pytestmark = pytest.mark.skipif(
 def test_per_harness_pi_one_shot(
     omnigent_repo_root: Path,
     omnigent_python: Path,
-    omnigent_credentials_env: dict[str, str],
-    patched_databrickscfg: None,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     ``omnigent run hello_world.yaml --harness pi -p <prompt>``
     exits 0 and emits a non-trivial assistant reply.
 
-    Uses ``patched_databrickscfg`` because ``PiExecutor`` reads
-    ``~/.databrickscfg`` directly to build its temporary
-    ``models.json`` provider config — OAuth-profile tokens
-    silently 403 Pi's model requests. Same workaround as
-    claude-sdk/codex; disappears once the ``databricks-sdk``
-    rewrite lands.
+    Uses the mock LLM server so the test runs without real API
+    credentials or a Databricks workspace. The pi executor routes
+    model calls through ``OPENAI_BASE_URL`` (provided by
+    ``mock_credentials_env``).
 
     :param omnigent_python: Interpreter with omnigent
         installed and importable.
     :param omnigent_repo_root: Cwd for the subprocess so the
         YAML spec and example tool modules resolve on sys.path.
-    :param omnigent_credentials_env: Env vars with
-        ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` /
-        ``DATABRICKS_CONFIG_PROFILE`` populated from
-        ``--llm-api-key``.
-    :param patched_databrickscfg: Fixture that rewrites
-        ``~/.databrickscfg`` to PAT form for the test and
-        restores it on teardown.
+    :param mock_credentials_env: Env vars pointing at the mock
+        LLM server.
+    :param mock_llm_server_url: Base URL of the mock server for
+        configuring canned responses.
     """
+    model = f"mock-harness-pi-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello there, how are you today?"}],
+        key=model,
+    )
+
     yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
 
     result = subprocess.run(
@@ -107,7 +100,7 @@ def test_per_harness_pi_one_shot(
             "run",
             str(yaml_path),
             "--model",
-            _MODEL,
+            model,
             "--harness",
             _HARNESS,
             "-p",
@@ -115,7 +108,7 @@ def test_per_harness_pi_one_shot(
             "--no-log",
             "--no-session",
         ],
-        env=omnigent_credentials_env,
+        env=mock_credentials_env,
         cwd=str(omnigent_repo_root),
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

- Migrate 4 per-harness one-shot e2e tests to the mock LLM server: `test_per_harness_openai_agents_sdk`, `test_per_harness_codex`, `test_per_harness_pi`, `test_per_harness_claude_sdk`
- Replace `omnigent_credentials_env` + real Databricks gateway with `mock_credentials_env` + `configure_mock_llm`/`reset_mock_llm` before each subprocess run
- The 3 yaml tests (`test_yaml_hello_world`, `test_yaml_hello_world_real`, `test_yaml_policies`) were already migrated on `origin/main` and require no changes in this PR
- Each test uses a UUID-suffixed mock model key to isolate its response queue; `claude-sdk` rows additionally set `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` so the executor hits the mock `/v1/messages` endpoint
- `codex` and `pi` rows skip (rather than fail) when their proprietary CLI binary is absent — genuine binary dependency on CI

## Test plan

- [ ] `python -m ruff check tests/e2e/omnigent/test_per_harness_*.py tests/e2e/omnigent/test_yaml_*.py` — passes clean
- [ ] `test_per_harness_openai_agents_sdk_one_shot` runs against the mock server and asserts exit 0 + non-empty assistant text
- [ ] `test_per_harness_codex_one_shot` skips cleanly when `codex` CLI is absent; passes when present
- [ ] `test_per_harness_pi_one_shot` skips when `pi` CLI is absent; passes when present
- [ ] `test_per_harness_claude_sdk_one_shot` skips when `claude` CLI is absent; passes when present
- [ ] Yaml tests (`test_yaml_hello_world`, `test_yaml_hello_world_real`, `test_yaml_policies`) unchanged from `origin/main`

This pull request and its description were written by Isaac.