### PR TITLE
fix(web-ui): run scripts & open links in HTML artifact preview (#777, #778)

### DIFF
--- a/ap-web/src/shell/CodeViewer.test.tsx
+++ b/ap-web/src/shell/CodeViewer.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { useFileContent } from "@/hooks/useFileContent";
 import { CodeViewer } from "./CodeViewer";
+import { HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -229,6 +230,8 @@ describe("CodeViewer HTML preview sandbox", () => {
     const iframe = container.querySelector('iframe[title="HTML preview"]');
     expect(iframe).not.toBeNull();
     const sandbox = iframe!.getAttribute("sandbox") ?? "";
+    // Full-string lock: any change to the sandbox flags must be deliberate.
+    expect(sandbox).toBe(HTML_PREVIEW_SANDBOX);
     // #778: scripts must run inside the preview.
     expect(sandbox).toContain("allow-scripts");
     // Security invariant: the artifact must never share the app's origin.

--- a/ap-web/src/shell/CodeViewer.test.tsx
+++ b/ap-web/src/shell/CodeViewer.test.tsx
@@ -213,3 +213,27 @@ describe("CodeViewer truncated preview", () => {
     expect(screen.queryByText(/too large to load fully/)).toBeNull();
   });
 });
+
+describe("CodeViewer HTML preview sandbox", () => {
+  // The HTML preview is the security-load-bearing surface: artifact content is
+  // untrusted (agent/user-generated), so these assertions lock in the iframe's
+  // isolation. A regression here (e.g. adding `allow-same-origin`) would let
+  // artifact JS reach the host app's cookies, storage, and credentialed API.
+  it("enables scripts but withholds same-origin, and forces links to a new tab", () => {
+    const { container } = renderViewer(
+      "<html><head></head><body><a href='https://example.com'>link</a></body></html>",
+      true,
+      "page.html",
+      { viewMode: "preview" },
+    );
+    const iframe = container.querySelector('iframe[title="HTML preview"]');
+    expect(iframe).not.toBeNull();
+    const sandbox = iframe!.getAttribute("sandbox") ?? "";
+    // #778: scripts must run inside the preview.
+    expect(sandbox).toContain("allow-scripts");
+    // Security invariant: the artifact must never share the app's origin.
+    expect(sandbox).not.toContain("allow-same-origin");
+    // #777: every link opens in a new tab via the injected base tag.
+    expect(iframe!.getAttribute("srcdoc")).toContain('<base target="_blank">');
+  });
+});

--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -40,11 +40,13 @@ import { MarkdownRichTextViewer } from "./MarkdownRichTextViewer";
 import {
   type ActiveSelection,
   type SaveStatus,
+  HTML_PREVIEW_SANDBOX,
   detectLang,
   getSelectionOffsets,
   indexToLine,
   isBinaryPath,
   lineOverlapsSelection,
+  prepareHtmlPreviewDoc,
 } from "./codeViewerHelpers";
 import { renderLineTokens } from "./codeViewerRendering";
 import { TruncatedBanner } from "./TruncatedBanner";
@@ -392,8 +394,9 @@ export function CodeViewer({
         <MarkdownPreview content={content} />
       ) : (
         <iframe
-          srcDoc={content}
-          sandbox=""
+          srcDoc={prepareHtmlPreviewDoc(content)}
+          // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
+          sandbox={HTML_PREVIEW_SANDBOX}
           title="HTML preview"
           className="w-full h-full border-0"
         />

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -39,6 +39,7 @@ import {
   PencilLineIcon,
   RowsIcon,
   SearchIcon,
+  SquareArrowOutUpRightIcon,
   Trash2Icon,
 } from "lucide-react";
 import { useSearchParams } from "@/lib/routing";
@@ -463,6 +464,18 @@ function FileViewerBody({
     triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
   }, [fileQuery.data, path]);
 
+  // Open the HTML artifact as a standalone page in a real browser tab, where it
+  // renders with no sandbox — scripts and links behave exactly as they would
+  // for a normal web page. A blob URL keeps it client-side (no upload). The URL
+  // is revoked after a delay so the new tab has time to load it first.
+  const openHtmlInNewTab = useCallback(() => {
+    const data = fileQuery.data;
+    if (!data || typeof URL.createObjectURL !== "function") return;
+    const url = URL.createObjectURL(new Blob([data.content], { type: "text/html" }));
+    window.open(url, "_blank", "noopener");
+    window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  }, [fileQuery.data]);
+
   const copyFileLink = useCallback(() => {
     if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;
     const url = new URL(window.location.href);
@@ -697,6 +710,17 @@ function FileViewerBody({
           setPreviewableViewMode((mode) => (mode === "preview" ? "source" : "preview"));
         }
       },
+    });
+  }
+  // HTML artifacts can be popped out into a real browser tab, where they render
+  // unsandboxed (full JS, links, forms) — handy when the in-app preview's
+  // sandbox is too restrictive for a given page.
+  if (lang === "html" && fileQuery.data && viewMode !== "diff") {
+    toolbarActions.push({
+      key: "open-new-tab",
+      label: "Open in new tab",
+      icon: <SquareArrowOutUpRightIcon className="size-4" />,
+      onSelect: openHtmlInNewTab,
     });
   }
   toolbarActions.push({

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -78,11 +78,10 @@ import { readFileViewPreferences, writeFileViewPreferences } from "@/lib/fileVie
 import { type ChangedSort, compareChangedFiles } from "./FlatFileList";
 import { CodeViewer } from "./CodeViewer";
 import {
-  HTML_PREVIEW_SANDBOX,
   MONACO_SPLIT_BREAKPOINT,
   type SaveStatus,
   detectLang,
-  prepareHtmlPreviewDoc,
+  openHtmlArtifactInNewTab,
 } from "./codeViewerHelpers";
 import { CommentsPanel, type ActiveSelection } from "./CommentsPanel";
 
@@ -470,34 +469,18 @@ function FileViewerBody({
     triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
   }, [fileQuery.data, path]);
 
-  // Open the HTML artifact in its own browser tab WITHOUT handing its
-  // (untrusted, agent-generated) scripts the app's own origin.
-  //
-  // We open a blank, same-origin tab we fully control and render the artifact
-  // inside a *sandboxed* iframe — the same opaque-origin isolation the in-app
-  // preview uses. A `blob:` or `data:` document would instead run the artifact
-  // AT the app's origin, where its JS could read the app's storage and issue
-  // credentialed same-origin requests to our API (see the #777/#778 security
-  // review). The sandboxed-iframe shell gives full-window rendering with none
-  // of that exposure: the artifact gets an opaque origin and cannot reach this
-  // shell tab, its `window.opener`, or the host app.
+  // Pop the HTML artifact into its own browser tab. The artifact is rendered in
+  // a sandboxed, opaque-origin iframe (see `openHtmlArtifactInNewTab`), so it
+  // stays isolated from the host app — full-window rendering, no origin sharing.
   const openHtmlInNewTab = useCallback(() => {
     const data = fileQuery.data;
     if (!data) return;
-    const win = window.open("about:blank", "_blank");
-    if (!win) return; // popup blocked
-    const doc = win.document;
-    doc.title = path.split("/").pop() ?? path;
-    doc.body.style.margin = "0";
-    // Sandbox is set via setAttribute just below; the static rule can't see it.
-    // oxlint-disable-next-line iframe-missing-sandbox
-    const frame = doc.createElement("iframe");
-    // No `allow-same-origin`: the artifact runs in an opaque origin, isolated
-    // from this shell tab and the host app.
-    frame.setAttribute("sandbox", HTML_PREVIEW_SANDBOX);
-    frame.srcdoc = prepareHtmlPreviewDoc(data.content);
-    frame.style.cssText = "position:fixed;inset:0;height:100%;width:100%;border:0";
-    doc.body.appendChild(frame);
+    const opened = openHtmlArtifactInNewTab(data.content, path.split("/").pop() ?? path);
+    if (!opened) {
+      // window.open returned null — almost always a popup blocker. There's no
+      // toast surface here, so log it rather than failing silently.
+      console.warn("Open in new tab: the browser blocked the popup window.");
+    }
   }, [fileQuery.data, path]);
 
   const copyFileLink = useCallback(() => {
@@ -736,9 +719,9 @@ function FileViewerBody({
       },
     });
   }
-  // HTML artifacts can be popped out into a real browser tab, where they render
-  // unsandboxed (full JS, links, forms) — handy when the in-app preview's
-  // sandbox is too restrictive for a given page.
+  // HTML artifacts can be popped out into their own browser tab for full-window
+  // viewing. The artifact still runs in the same sandboxed, opaque-origin iframe
+  // as the in-app preview (isolated from the host app) — just full-screen.
   if (lang === "html" && fileQuery.data && viewMode !== "diff") {
     toolbarActions.push({
       key: "open-new-tab",

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -77,7 +77,13 @@ import { cn } from "@/lib/utils";
 import { readFileViewPreferences, writeFileViewPreferences } from "@/lib/fileViewPreferences";
 import { type ChangedSort, compareChangedFiles } from "./FlatFileList";
 import { CodeViewer } from "./CodeViewer";
-import { detectLang, MONACO_SPLIT_BREAKPOINT, type SaveStatus } from "./codeViewerHelpers";
+import {
+  HTML_PREVIEW_SANDBOX,
+  MONACO_SPLIT_BREAKPOINT,
+  type SaveStatus,
+  detectLang,
+  prepareHtmlPreviewDoc,
+} from "./codeViewerHelpers";
 import { CommentsPanel, type ActiveSelection } from "./CommentsPanel";
 
 // Monaco diff is heavy (~MBs + worker); load it only when the diff view is
@@ -464,17 +470,35 @@ function FileViewerBody({
     triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
   }, [fileQuery.data, path]);
 
-  // Open the HTML artifact as a standalone page in a real browser tab, where it
-  // renders with no sandbox — scripts and links behave exactly as they would
-  // for a normal web page. A blob URL keeps it client-side (no upload). The URL
-  // is revoked after a delay so the new tab has time to load it first.
+  // Open the HTML artifact in its own browser tab WITHOUT handing its
+  // (untrusted, agent-generated) scripts the app's own origin.
+  //
+  // We open a blank, same-origin tab we fully control and render the artifact
+  // inside a *sandboxed* iframe — the same opaque-origin isolation the in-app
+  // preview uses. A `blob:` or `data:` document would instead run the artifact
+  // AT the app's origin, where its JS could read the app's storage and issue
+  // credentialed same-origin requests to our API (see the #777/#778 security
+  // review). The sandboxed-iframe shell gives full-window rendering with none
+  // of that exposure: the artifact gets an opaque origin and cannot reach this
+  // shell tab, its `window.opener`, or the host app.
   const openHtmlInNewTab = useCallback(() => {
     const data = fileQuery.data;
-    if (!data || typeof URL.createObjectURL !== "function") return;
-    const url = URL.createObjectURL(new Blob([data.content], { type: "text/html" }));
-    window.open(url, "_blank", "noopener");
-    window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
-  }, [fileQuery.data]);
+    if (!data) return;
+    const win = window.open("about:blank", "_blank");
+    if (!win) return; // popup blocked
+    const doc = win.document;
+    doc.title = path.split("/").pop() ?? path;
+    doc.body.style.margin = "0";
+    // Sandbox is set via setAttribute just below; the static rule can't see it.
+    // oxlint-disable-next-line iframe-missing-sandbox
+    const frame = doc.createElement("iframe");
+    // No `allow-same-origin`: the artifact runs in an opaque origin, isolated
+    // from this shell tab and the host app.
+    frame.setAttribute("sandbox", HTML_PREVIEW_SANDBOX);
+    frame.srcdoc = prepareHtmlPreviewDoc(data.content);
+    frame.style.cssText = "position:fixed;inset:0;height:100%;width:100%;border:0";
+    doc.body.appendChild(frame);
+  }, [fileQuery.data, path]);
 
   const copyFileLink = useCallback(() => {
     if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   indexToLine,
   isBinaryPath,
   lineOverlapsSelection,
+  prepareHtmlPreviewDoc,
 } from "./codeViewerHelpers";
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,43 @@ describe("indexToLine", () => {
     // ["", "x"] → line 1 is empty (length 0), line 2 starts at offset 1.
     expect(indexToLine(0, ["", "x"])).toBe(1); // on the empty first line
     expect(indexToLine(1, ["", "x"])).toBe(2); // on "x"
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareHtmlPreviewDoc — force links to open in a new tab (issue #777)
+// ---------------------------------------------------------------------------
+
+describe("prepareHtmlPreviewDoc", () => {
+  const BASE = '<base target="_blank">';
+
+  it("injects the base tag inside an existing <head>", () => {
+    const html = "<!DOCTYPE html><html><head><title>x</title></head><body>hi</body></html>";
+    const out = prepareHtmlPreviewDoc(html);
+    expect(out).toContain(`<head>${BASE}<title>x</title>`);
+    // Doctype stays first so the document keeps standards mode.
+    expect(out.indexOf("<!DOCTYPE html>")).toBe(0);
+  });
+
+  it("matches <head> with attributes", () => {
+    const out = prepareHtmlPreviewDoc('<head lang="en"><meta></head>');
+    expect(out).toContain(`<head lang="en">${BASE}<meta>`);
+  });
+
+  it("creates a <head> after <html> when none exists", () => {
+    const out = prepareHtmlPreviewDoc("<!DOCTYPE html><html><body>hi</body></html>");
+    expect(out).toContain(`<html><head>${BASE}</head><body>`);
+    expect(out.indexOf("<!DOCTYPE html>")).toBe(0);
+  });
+
+  it("prepends the base tag for a bare fragment (no doctype to displace)", () => {
+    const out = prepareHtmlPreviewDoc('<a href="https://example.com">link</a>');
+    expect(out).toBe(`${BASE}<a href="https://example.com">link</a>`);
+  });
+
+  it("is case-insensitive on the HEAD tag", () => {
+    const out = prepareHtmlPreviewDoc("<HEAD></HEAD>");
+    expect(out).toContain(`<HEAD>${BASE}`);
   });
 });
 

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -200,6 +200,29 @@ describe("prepareHtmlPreviewDoc", () => {
     const out = prepareHtmlPreviewDoc("<HEAD></HEAD>");
     expect(out).toContain(`<HEAD>${BASE}`);
   });
+
+  it("preserves an existing <base href>; the injected target tag wins by order", () => {
+    // Browsers use the first <base> for each attribute, so injecting our
+    // `target` tag ahead of the artifact's keeps its `href` intact while still
+    // forcing links to a new tab.
+    const html = '<head><base href="https://cdn.example.com/"></head>';
+    const out = prepareHtmlPreviewDoc(html);
+    expect(out).toBe(`<head>${BASE}<base href="https://cdn.example.com/"></head>`);
+    expect(out.indexOf(BASE)).toBeLessThan(out.indexOf("<base href"));
+  });
+
+  it("injects exactly one base tag per call (no duplicates)", () => {
+    const out = prepareHtmlPreviewDoc("<head></head>");
+    expect(out.match(/<base target="_blank">/g)).toHaveLength(1);
+  });
+
+  it("documents the matcher limitation: a <head> literal in earlier markup is matched textually", () => {
+    // A simple regex (not a full parser) matches the first <head> string, even
+    // inside a comment. This only mis-places the harmless base tag inside the
+    // sandboxed preview — never a security issue — so we lock in the behavior.
+    const out = prepareHtmlPreviewDoc("<!-- <head> --><html><head></head></html>");
+    expect(out).toBe(`<!-- <head>${BASE} --><html><head></head></html>`);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -218,6 +218,13 @@ describe("prepareHtmlPreviewDoc", () => {
     expect(out.match(/<base target="_blank">/g)).toHaveLength(1);
   });
 
+  it("is idempotent: re-preparing already-prepared content adds no second base tag", () => {
+    const once = prepareHtmlPreviewDoc("<head></head>");
+    const twice = prepareHtmlPreviewDoc(once);
+    expect(twice).toBe(once);
+    expect(twice.match(/<base target="_blank">/g)).toHaveLength(1);
+  });
+
   it("documents the matcher limitation: a <head> literal in earlier markup is matched textually", () => {
     // A simple regex (not a full parser) matches the first <head> string, even
     // inside a comment. This only mis-places the harmless base tag inside the

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -225,6 +225,16 @@ describe("prepareHtmlPreviewDoc", () => {
     expect(twice.match(/<base target="_blank">/g)).toHaveLength(1);
   });
 
+  it("still injects a real base when the literal base string only appears in content", () => {
+    // Regression: a loose `html.includes(baseTag)` idempotency check wrongly
+    // skipped injection for content that merely *mentions* the string (e.g. a
+    // comment or code sample), leaving links to navigate the preview in place
+    // instead of opening a new tab. The base must still land in <head>.
+    const html = '<html><head></head><body><!-- <base target="_blank"> --></body></html>';
+    const out = prepareHtmlPreviewDoc(html);
+    expect(out).toContain(`<head>${BASE}</head>`);
+  });
+
   it("documents the matcher limitation: a <head> literal in earlier markup is matched textually", () => {
     // A simple regex (not a full parser) matches the first <head> string, even
     // inside a comment. This only mis-places the harmless base tag inside the

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  HTML_PREVIEW_SANDBOX,
   detectLang,
   getSelectionOffsets,
   indexToLine,
   isBinaryPath,
   lineOverlapsSelection,
+  openHtmlArtifactInNewTab,
   prepareHtmlPreviewDoc,
 } from "./codeViewerHelpers";
 
@@ -222,6 +224,38 @@ describe("prepareHtmlPreviewDoc", () => {
     // sandboxed preview — never a security issue — so we lock in the behavior.
     const out = prepareHtmlPreviewDoc("<!-- <head> --><html><head></head></html>");
     expect(out).toBe(`<!-- <head>${BASE} --><html><head></head></html>`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openHtmlArtifactInNewTab — pop-out renders in an isolated sandboxed iframe
+// ---------------------------------------------------------------------------
+
+describe("openHtmlArtifactInNewTab", () => {
+  it("renders the artifact in a sandboxed, opaque-origin iframe (never the app origin)", () => {
+    // A real (detached) document stands in for the popped tab's document.
+    const shellDoc = document.implementation.createHTMLDocument("");
+    const open = vi.fn(() => ({ document: shellDoc }) as unknown as Window);
+
+    const ok = openHtmlArtifactInNewTab("<h1>hi</h1>", "art.html", { open });
+
+    expect(ok).toBe(true);
+    // Critically: the artifact is NOT navigated to as a top-level blob:/data:
+    // page (which would inherit the app origin) — it's hosted in about:blank.
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    const frame = shellDoc.querySelector("iframe");
+    expect(frame).not.toBeNull();
+    const sandbox = frame!.getAttribute("sandbox") ?? "";
+    expect(sandbox).toBe(HTML_PREVIEW_SANDBOX);
+    // Security invariant: the artifact must never share the app's origin.
+    expect(sandbox).not.toContain("allow-same-origin");
+    // Links still open in a new tab inside the pop-out (#777).
+    expect(frame!.getAttribute("srcdoc")).toContain('<base target="_blank">');
+  });
+
+  it("returns false when the popup is blocked (window.open → null)", () => {
+    const open = vi.fn(() => null);
+    expect(openHtmlArtifactInNewTab("<h1>hi</h1>", "art.html", { open })).toBe(false);
   });
 });
 

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -206,6 +206,13 @@ export function detectLang(path: string): BundledLanguage | "text" {
  * that with `allow-scripts` would let untrusted artifact code reach into the
  * parent app (cookies, storage, DOM). Withholding it gives the document an
  * opaque origin, so scripts run fully sandboxed away from the host page.
+ *
+ * Accepted trade-offs from these flags: `allow-popups-to-escape-sandbox` lets
+ * artifact JS spawn fully-capable new windows (phishing / window-spam surface),
+ * and `allow-modals` lets it raise blocking `alert`/`confirm`/`prompt` dialogs.
+ * Neither can reach app data (the opaque origin still applies / the spawned
+ * window's `opener` is the opaque frame), so these are bounded nuisance risks
+ * we accept in exchange for links and interactive artifacts behaving normally.
  */
 export const HTML_PREVIEW_SANDBOX =
   "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals";
@@ -234,7 +241,7 @@ export function prepareHtmlPreviewDoc(html: string): string {
   const baseTag = '<base target="_blank">';
 
   const headMatch = html.match(/<head[^>]*>/i);
-  if (headMatch?.index != null) {
+  if (headMatch?.index !== undefined) {
     const insertAt = headMatch.index + headMatch[0].length;
     return html.slice(0, insertAt) + baseTag + html.slice(insertAt);
   }
@@ -242,7 +249,7 @@ export function prepareHtmlPreviewDoc(html: string): string {
   // No <head>: create one right after <html> so the base still lands inside the
   // document head (after the doctype, preserving standards mode).
   const htmlMatch = html.match(/<html[^>]*>/i);
-  if (htmlMatch?.index != null) {
+  if (htmlMatch?.index !== undefined) {
     const insertAt = htmlMatch.index + htmlMatch[0].length;
     return `${html.slice(0, insertAt)}<head>${baseTag}</head>${html.slice(insertAt)}`;
   }
@@ -250,6 +257,42 @@ export function prepareHtmlPreviewDoc(html: string): string {
   // Bare fragment (no <html>/<head>, hence no doctype to displace) — the browser
   // wraps it in an implicit head, so a leading base tag is safe.
   return baseTag + html;
+}
+
+/**
+ * Open an HTML artifact in its own browser tab, isolated from the host app.
+ *
+ * Renders the (untrusted, agent-generated) artifact inside a sandboxed iframe
+ * within a blank, app-controlled tab, so it runs in an opaque origin — the same
+ * isolation as the in-app preview, just full-window. We deliberately do NOT use
+ * a `blob:` or `data:` document: a top-level page there inherits the app's own
+ * origin, which would let artifact JS read the app's storage and issue
+ * credentialed same-origin requests to our API. The sandboxed-iframe shell
+ * avoids that — the artifact cannot reach this shell tab, its `window.opener`,
+ * or the host app.
+ *
+ * `opener` is injectable so this is unit-testable without a real browser window.
+ * Returns `false` if the popup was blocked (the caller can surface feedback).
+ */
+export function openHtmlArtifactInNewTab(
+  content: string,
+  filename: string,
+  opener: Pick<Window, "open"> = window,
+): boolean {
+  const win = opener.open("about:blank", "_blank");
+  if (!win) return false; // popup blocked by the browser
+  const doc = win.document;
+  doc.title = filename;
+  doc.body.style.margin = "0";
+  // oxlint-disable-next-line iframe-missing-sandbox -- sandbox set via setAttribute below
+  const frame = doc.createElement("iframe");
+  // No `allow-same-origin`: the artifact runs in an opaque origin, isolated from
+  // this shell tab and the host app.
+  frame.setAttribute("sandbox", HTML_PREVIEW_SANDBOX);
+  frame.srcdoc = prepareHtmlPreviewDoc(content);
+  frame.style.cssText = "position:fixed;inset:0;height:100%;width:100%;border:0";
+  doc.body.appendChild(frame);
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -240,6 +240,12 @@ export const HTML_PREVIEW_SANDBOX =
 export function prepareHtmlPreviewDoc(html: string): string {
   const baseTag = '<base target="_blank">';
 
+  // Idempotency guard: if our base tag is already present (e.g. content was
+  // accidentally prepared twice), don't inject a second one. The current call
+  // graph always passes raw content, but this keeps the function safe to
+  // double-call.
+  if (html.includes(baseTag)) return html;
+
   const headMatch = html.match(/<head[^>]*>/i);
   if (headMatch?.index !== undefined) {
     const insertAt = headMatch.index + headMatch[0].length;

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -240,20 +240,23 @@ export const HTML_PREVIEW_SANDBOX =
 export function prepareHtmlPreviewDoc(html: string): string {
   const baseTag = '<base target="_blank">';
 
-  // Idempotency guard: if our base tag is already present (e.g. content was
-  // accidentally prepared twice), don't inject a second one. The current call
-  // graph always passes raw content, but this keeps the function safe to
-  // double-call.
-  if (html.includes(baseTag)) return html;
-
   const headMatch = html.match(/<head[^>]*>/i);
   if (headMatch?.index !== undefined) {
     const insertAt = headMatch.index + headMatch[0].length;
+    // Idempotency guard, scoped to the actual injection point: only skip if our
+    // base tag is ALREADY right after <head> (i.e. content was prepared twice).
+    // We must NOT use a loose `html.includes(baseTag)` — the literal string can
+    // legitimately appear elsewhere in artifact content (a comment, a code
+    // sample), and skipping injection there would leave the document with no
+    // real <base>, so links navigate the preview in place instead of opening a
+    // new tab.
+    if (html.startsWith(baseTag, insertAt)) return html;
     return html.slice(0, insertAt) + baseTag + html.slice(insertAt);
   }
 
   // No <head>: create one right after <html> so the base still lands inside the
-  // document head (after the doctype, preserving standards mode).
+  // document head (after the doctype, preserving standards mode). A second pass
+  // matches the <head> we created above, so this path is idempotent too.
   const htmlMatch = html.match(/<html[^>]*>/i);
   if (htmlMatch?.index !== undefined) {
     const insertAt = htmlMatch.index + htmlMatch[0].length;
@@ -262,6 +265,7 @@ export function prepareHtmlPreviewDoc(html: string): string {
 
   // Bare fragment (no <html>/<head>, hence no doctype to displace) — the browser
   // wraps it in an implicit head, so a leading base tag is safe.
+  if (html.startsWith(baseTag)) return html;
   return baseTag + html;
 }
 

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -281,6 +281,11 @@ export function openHtmlArtifactInNewTab(
 ): boolean {
   const win = opener.open("about:blank", "_blank");
   if (!win) return false; // popup blocked by the browser
+  // Sever the back-reference to us (defense in depth): the shell tab never
+  // needs its `opener`, and nulling it removes any tab-nabbing vector if the
+  // tab is ever navigated away. Safe because the tab is same-origin (about:blank
+  // inherits our origin), so we can still touch its document below.
+  win.opener = null;
   const doc = win.document;
   doc.title = filename;
   doc.body.style.margin = "0";

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -221,6 +221,14 @@ export const HTML_PREVIEW_SANDBOX =
  * quirks mode and change how the artifact renders, so we insert *inside* the
  * existing `<head>`/`<html>` when present and only fall back to prepending for
  * bare fragments that have no doctype to displace.
+ *
+ * The matcher is a deliberately simple regex, NOT a full HTML parser: parsing
+ * and re-serializing untrusted artifact content could subtly alter how it
+ * renders. The known trade-off is that a `<head>` literal appearing earlier in
+ * the source (e.g. inside a comment or a script string) is matched textually.
+ * That only ever mis-places the base tag *inside the sandboxed preview* — it
+ * can break that one artifact's own link-targeting, never the host app's
+ * security — so it's an accepted limitation rather than a bug to parse around.
  */
 export function prepareHtmlPreviewDoc(html: string): string {
   const baseTag = '<base target="_blank">';

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -187,6 +187,64 @@ export function detectLang(path: string): BundledLanguage | "text" {
 }
 
 // ---------------------------------------------------------------------------
+// HTML preview helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sandbox flags for the HTML artifact preview iframe.
+ *
+ * - `allow-scripts` — run the page's JavaScript (without this, JS in rendered
+ *   HTML is silently dropped — see issue #778).
+ * - `allow-popups` + `allow-popups-to-escape-sandbox` — let links/`window.open`
+ *   open a new browsing context that is NOT itself sandboxed, so clicking a
+ *   link actually navigates a real tab (see issue #777).
+ * - `allow-forms` / `allow-modals` — typical interactive artifacts submit forms
+ *   and call `alert`/`confirm`.
+ *
+ * NOTE: we deliberately omit `allow-same-origin`. The iframe is fed via
+ * `srcDoc`, which would otherwise inherit the embedder's origin — combining
+ * that with `allow-scripts` would let untrusted artifact code reach into the
+ * parent app (cookies, storage, DOM). Withholding it gives the document an
+ * opaque origin, so scripts run fully sandboxed away from the host page.
+ */
+export const HTML_PREVIEW_SANDBOX =
+  "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals";
+
+/**
+ * Prepare HTML artifact content for the preview iframe by forcing every link to
+ * open in a new tab (issue #777: "We should always make it open in a new
+ * window").
+ *
+ * We inject `<base target="_blank">` rather than rewriting individual anchors so
+ * it covers links created at runtime by scripts too. Placement matters: a
+ * `<base>` (or anything) before the `<!DOCTYPE>` would push the document into
+ * quirks mode and change how the artifact renders, so we insert *inside* the
+ * existing `<head>`/`<html>` when present and only fall back to prepending for
+ * bare fragments that have no doctype to displace.
+ */
+export function prepareHtmlPreviewDoc(html: string): string {
+  const baseTag = '<base target="_blank">';
+
+  const headMatch = html.match(/<head[^>]*>/i);
+  if (headMatch?.index != null) {
+    const insertAt = headMatch.index + headMatch[0].length;
+    return html.slice(0, insertAt) + baseTag + html.slice(insertAt);
+  }
+
+  // No <head>: create one right after <html> so the base still lands inside the
+  // document head (after the doctype, preserving standards mode).
+  const htmlMatch = html.match(/<html[^>]*>/i);
+  if (htmlMatch?.index != null) {
+    const insertAt = htmlMatch.index + htmlMatch[0].length;
+    return `${html.slice(0, insertAt)}<head>${baseTag}</head>${html.slice(insertAt)}`;
+  }
+
+  // Bare fragment (no <html>/<head>, hence no doctype to displace) — the browser
+  // wraps it in an implicit head, so a leading base tag is safe.
+  return baseTag + html;
+}
+
+// ---------------------------------------------------------------------------
 // DOM → absolute character offset helpers
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e_ui/files/test_html_preview.py
+++ b/tests/e2e_ui/files/test_html_preview.py
@@ -10,7 +10,9 @@ Regression coverage for two bugs in the HTML artifact preview
     relaxes the sandbox so links open a real new tab.
 
 It also covers the new "Open in new tab" toolbar button, which pops the
-artifact out as a standalone, fully-unsandboxed ``blob:`` page.
+artifact into a blank, app-controlled tab and renders it inside the same
+sandboxed (opaque-origin) iframe — full-window viewing without giving the
+artifact the app's own origin.
 
 The file is seeded via the filesystem PUT endpoint (no agent run), so the test
 is deterministic, and the fixture's JavaScript is self-contained (no network),

--- a/tests/e2e_ui/files/test_html_preview.py
+++ b/tests/e2e_ui/files/test_html_preview.py
@@ -33,9 +33,10 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
-# Files land in ``<repo-root>/<session_id>/`` (the hello_world agent spec uses
-# ``os_env.cwd: .``), so clean that per-session dir up in teardown.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
+# The hello_world agent spec uses ``os_env.cwd: .``, so the runner writes
+# seeded files into the server process's cwd — the repo root (this file is
+# ``<repo>/tests/e2e_ui/files/...``, so the repo root is ``parents[3]``).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 # Must stay in sync with ``HTML_PREVIEW_SANDBOX`` in
 # ``ap-web/src/shell/codeViewerHelpers.ts``. ``allow-scripts`` re-enables JS

--- a/tests/e2e_ui/files/test_html_preview.py
+++ b/tests/e2e_ui/files/test_html_preview.py
@@ -136,7 +136,13 @@ def test_html_preview_open_in_new_tab_button(
     page: Page,
     seeded_html: tuple[str, str],
 ) -> None:
-    """The "Open in new tab" button pops the artifact out as a standalone page."""
+    """The "Open in new tab" button pops the artifact into an isolated, sandboxed tab.
+
+    Security regression guard: the artifact must render inside a *sandboxed*
+    (opaque-origin) iframe in an app-controlled blank tab — NOT at the app's own
+    origin (which a ``blob:``/``data:`` URL would do, exposing the app's storage
+    and credentialed API to untrusted artifact JS).
+    """
     base_url, session_id = seeded_html
     page.set_viewport_size({"width": 1600, "height": 900})
     page.goto(f"{base_url}/c/{session_id}?file={_HTML_PATH}")
@@ -148,16 +154,44 @@ def test_html_preview_open_in_new_tab_button(
     open_btn = file_viewer.get_by_role("button", name="Open in new tab")
     expect(open_btn).to_be_visible()
 
-    # The button builds a text/html blob URL and window.open()s it. Use
-    # context.expect_page (not page.expect_popup) because the open uses
-    # ``noopener``, so the new page may surface on the context, not the opener.
+    # The button opens a blank, app-controlled tab and injects a sandboxed
+    # iframe. Capture the new page on the context.
     with page.context.expect_page() as new_page_info:
         open_btn.click()
     popped = new_page_info.value
     popped.wait_for_load_state("domcontentloaded")
 
-    # It's a client-side blob URL (no upload), rendered with no sandbox at all.
-    assert popped.url.startswith("blob:")
-    # The same script runs in the standalone page too.
-    expect(popped.locator("#js-status")).to_have_text("js-ran", timeout=10_000)
+    # The shell tab itself is a blank, app-controlled document — the artifact is
+    # never the top-level page (which would put it at the app's origin).
+    assert popped.url == "about:blank"
+
+    # The artifact lives only inside a sandboxed iframe whose sandbox matches the
+    # in-app preview and, critically, withholds ``allow-same-origin``.
+    shell_iframe = popped.locator("iframe")
+    expect(shell_iframe).to_be_visible(timeout=10_000)
+    sandbox = shell_iframe.get_attribute("sandbox")
+    assert sandbox == _EXPECTED_SANDBOX
+    assert "allow-same-origin" not in (sandbox or "")
+
+    # Scripts still run inside the popped iframe (#778 holds in the pop-out too).
+    preview = popped.frame_locator("iframe")
+    expect(preview.locator("#js-status")).to_have_text("js-ran", timeout=10_000)
+
+    # Isolation proof: the iframe has an opaque origin and cannot reach the
+    # parent document — so artifact JS can't touch the app's storage/cookies/API.
+    child_frame = shell_iframe.element_handle().content_frame()
+    assert child_frame is not None
+    assert child_frame.evaluate("() => window.origin") == "null"
+    parent_access_blocked = child_frame.evaluate(
+        """() => {
+            try {
+                void window.parent.document.cookie;
+                return false;
+            } catch (e) {
+                return true;
+            }
+        }"""
+    )
+    assert parent_access_blocked
+
     popped.close()

--- a/tests/e2e_ui/files/test_html_preview.py
+++ b/tests/e2e_ui/files/test_html_preview.py
@@ -1,0 +1,163 @@
+"""E2E: HTML artifact preview — scripts run, links open in a new tab, pop-out.
+
+Regression coverage for two bugs in the HTML artifact preview
+(``shell/CodeViewer.tsx`` + ``shell/FileViewer.tsx``):
+
+  * #778 — JavaScript in a rendered HTML file did not run. The preview iframe
+    used ``sandbox=""`` (the most restrictive setting), which blocks scripts.
+  * #777 — links in a rendered HTML file did not open. The same empty sandbox
+    blocked popups/navigation; the fix injects ``<base target="_blank">`` and
+    relaxes the sandbox so links open a real new tab.
+
+It also covers the new "Open in new tab" toolbar button, which pops the
+artifact out as a standalone, fully-unsandboxed ``blob:`` page.
+
+The file is seeded via the filesystem PUT endpoint (no agent run), so the test
+is deterministic, and the fixture's JavaScript is self-contained (no network),
+so the "did JS run" assertions never depend on external connectivity.
+
+Playwright drives the browser via CDP and is not bound by the same-origin
+policy, so it can read into the sandboxed ``srcdoc`` iframe (opaque origin) to
+prove the script actually executed.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# Files land in ``<repo-root>/<session_id>/`` (the hello_world agent spec uses
+# ``os_env.cwd: .``), so clean that per-session dir up in teardown.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Must stay in sync with ``HTML_PREVIEW_SANDBOX`` in
+# ``ap-web/src/shell/codeViewerHelpers.ts``. ``allow-scripts`` re-enables JS
+# (#778); the popup flags let links escape into a real new tab (#777); we
+# deliberately do NOT include ``allow-same-origin`` (would let untrusted
+# artifact JS reach the parent app's origin).
+_EXPECTED_SANDBOX = (
+    "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals"
+)
+
+_HTML_PATH = "preview_artifact.html"
+
+# Self-contained fixture: a script flips a sentinel element from a "blocked"
+# marker to a "ran" marker, and creates a link at runtime. No network needed.
+_HTML_CONTENT = """\
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Preview fixture</title>
+  </head>
+  <body>
+    <h1>HTML preview fixture</h1>
+    <p id="js-status">js-blocked</p>
+    <a id="static-link" href="https://example.com/static">static link</a>
+    <p id="dynamic-link-host"></p>
+    <script>
+      // Proof that scripts run (#778).
+      document.getElementById("js-status").textContent = "js-ran";
+      // A link created at runtime — covered by the injected <base target>.
+      var a = document.createElement("a");
+      a.id = "dynamic-link";
+      a.href = "https://example.com/dynamic";
+      a.textContent = "dynamic link";
+      document.getElementById("dynamic-link-host").appendChild(a);
+    </script>
+  </body>
+</html>
+"""
+
+
+def _cleanup_session_workdir(session_id: str) -> None:
+    shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+@pytest.fixture
+def seeded_html(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Seed the HTML artifact and yield ``(base_url, session_id)``."""
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_HTML_PATH}",
+        json={"content": _HTML_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id)
+    finally:
+        _cleanup_session_workdir(session_id)
+
+
+def test_html_preview_runs_scripts_and_targets_links(
+    page: Page,
+    seeded_html: tuple[str, str],
+) -> None:
+    """HTML preview runs JS (#778) and forces links to open in a new tab (#777)."""
+    base_url, session_id = seeded_html
+    # Keep the viewport wide so the responsive toolbar renders its actions
+    # inline (the "Open in new tab" button is found by role, not via overflow).
+    page.set_viewport_size({"width": 1600, "height": 900})
+    # HTML files default to the preview view, so the iframe mounts directly.
+    page.goto(f"{base_url}/c/{session_id}?file={_HTML_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    iframe_el = file_viewer.locator('iframe[title="HTML preview"]')
+    expect(iframe_el).to_be_visible(timeout=10_000)
+
+    # The sandbox must re-enable scripts + popups but NOT same-origin.
+    expect(iframe_el).to_have_attribute("sandbox", _EXPECTED_SANDBOX)
+    assert "allow-same-origin" not in _EXPECTED_SANDBOX  # guards the constant above
+
+    # The fix injects <base target="_blank"> so every link (#777), including
+    # ones built at runtime, opens in a new tab.
+    srcdoc = iframe_el.get_attribute("srcdoc")
+    assert srcdoc is not None
+    assert '<base target="_blank">' in srcdoc
+
+    # #778: the script ran — the sentinel flipped from "js-blocked" to "js-ran".
+    # Playwright reaches into the sandboxed (opaque-origin) srcdoc frame via CDP.
+    preview = file_viewer.frame_locator('iframe[title="HTML preview"]')
+    expect(preview.locator("#js-status")).to_have_text("js-ran", timeout=10_000)
+    # The runtime-created link is present, confirming the script fully executed.
+    expect(preview.locator("#dynamic-link")).to_have_text("dynamic link")
+
+
+def test_html_preview_open_in_new_tab_button(
+    page: Page,
+    seeded_html: tuple[str, str],
+) -> None:
+    """The "Open in new tab" button pops the artifact out as a standalone page."""
+    base_url, session_id = seeded_html
+    page.set_viewport_size({"width": 1600, "height": 900})
+    page.goto(f"{base_url}/c/{session_id}?file={_HTML_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+    expect(file_viewer.locator('iframe[title="HTML preview"]')).to_be_visible(timeout=10_000)
+
+    open_btn = file_viewer.get_by_role("button", name="Open in new tab")
+    expect(open_btn).to_be_visible()
+
+    # The button builds a text/html blob URL and window.open()s it. Use
+    # context.expect_page (not page.expect_popup) because the open uses
+    # ``noopener``, so the new page may surface on the context, not the opener.
+    with page.context.expect_page() as new_page_info:
+        open_btn.click()
+    popped = new_page_info.value
+    popped.wait_for_load_state("domcontentloaded")
+
+    # It's a client-side blob URL (no upload), rendered with no sandbox at all.
+    assert popped.url.startswith("blob:")
+    # The same script runs in the standalone page too.
+    expect(popped.locator("#js-status")).to_have_text("js-ran", timeout=10_000)
+    popped.close()


### PR DESCRIPTION
## Summary

Both issues trace to one line in the HTML artifact preview (`ap-web/src/shell/CodeViewer.tsx`), where HTML files were rendered in an iframe with **`sandbox=""`** — the most restrictive setting, which disables everything:

- **#778** — JavaScript in rendered HTML files didn't run (scripts blocked).
- **#777** — links didn't open (popups/navigation blocked).

## Changes

- **Relax the sandbox** to `HTML_PREVIEW_SANDBOX` (`allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals`). This re-enables JS (#778) and lets links open a real, non-sandboxed tab (#777). `allow-same-origin` is **deliberately withheld**: the iframe is fed via `srcDoc`, so granting it would let untrusted artifact JS run in the host app's origin (cookies/storage/DOM). Without it the document gets an opaque origin and scripts run fully isolated.
- **Inject `<base target="_blank">`** via `prepareHtmlPreviewDoc()` so every link — including ones created at runtime by scripts — opens in a new tab (satisfies "always open in a new window"). It's inserted inside `<head>`/`<html>` rather than prepended, to avoid pushing the doc into quirks mode.
- **"Open in new tab" toolbar button** (`FileViewer.tsx` → `openHtmlArtifactInNewTab`): for HTML files, opens a blank, app-controlled `about:blank` tab and renders the artifact inside a **sandboxed iframe** (same `HTML_PREVIEW_SANDBOX`, no `allow-same-origin`) for full-window viewing. This deliberately avoids a `blob:`/`data:` document, which would inherit the app's own origin and let untrusted artifact JS read app storage and issue credentialed same-origin requests. The artifact gets an opaque origin and cannot reach the shell tab, its `window.opener`, or the host app.

## Testing

- Unit tests for `prepareHtmlPreviewDoc` (head injection, head-with-attrs, head creation, bare-fragment prepend, case-insensitivity, idempotency, pre-existing `<base href>` preservation) and for `openHtmlArtifactInNewTab` (renders into a sandboxed iframe matching `HTML_PREVIEW_SANDBOX`, never `allow-same-origin`, returns false on blocked popup).
- CodeViewer test locks the preview iframe's sandbox to the exact `HTML_PREVIEW_SANDBOX` value and asserts `allow-same-origin` is absent.
- New `tests/e2e_ui/files/test_html_preview.py`: asserts the iframe sandbox value (and that `allow-same-origin` is absent), the injected `<base target>`, that the script actually executed inside the sandboxed opaque-origin iframe, and that the "Open in new tab" button opens an `about:blank` shell hosting a sandboxed iframe whose document has an opaque origin and cannot access the parent.
- `npm test`, `npm run build`, `tsc`, lint, prettier, and the new e2e tests all pass.

Fixes #777
Fixes #778