### PR TITLE
test(runner): de-flake required-terminal idle-exit test

### DIFF
--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -9110,14 +9110,31 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
         on_exit = callbacks.get("on_exit")
         assert callable(on_exit)
         on_exit()
-        # The harness subprocess release is the terminal's last lifecycle step;
-        # wait on it as the settle signal, then inspect the published events.
+        # Terminal-exit cleanup fans out across two independent background
+        # tasks: one publishes the resource events, a second releases the
+        # harness subprocess. Their completion order is not guaranteed, so
+        # settle on BOTH the published ``deleted`` event and the subprocess
+        # release — accumulating drained events each tick — rather than using
+        # the release as a proxy for the publish (which raced: the release
+        # task could finish first, leaving the drain empty).
+        deleted_event = {
+            "type": "session.resource.deleted",
+            "resource_id": "terminal_worker_main",
+            "resource_type": "terminal",
+            "session_id": conv_id,
+        }
+        queued_events: list[dict[str, Any]] = []
+        parent_events: list[dict[str, Any]] = []
         for _ in range(1000):
-            if pm.released:
+            queued_events.extend(
+                _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
+            )
+            parent_events.extend(
+                _drain_session_event_queue(_session_event_queues_ref.get(parent_id))
+            )
+            if pm.released and deleted_event in queued_events:
                 break
             await asyncio.sleep(0)
-        queued_events = _drain_session_event_queue(_session_event_queues_ref.get(conv_id))
-        parent_events = _drain_session_event_queue(_session_event_queues_ref.get(parent_id))
     finally:
         _session_event_queues_ref.pop(conv_id, None)
         _session_event_queues_ref.pop(parent_id, None)
@@ -9127,12 +9144,7 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
 
     # The terminal resource is still removed...
     assert terminal_registry.get(conv_id, "worker", "main") is None
-    assert {
-        "type": "session.resource.deleted",
-        "resource_id": "terminal_worker_main",
-        "resource_type": "terminal",
-        "session_id": conv_id,
-    } in queued_events
+    assert deleted_event in queued_events
     # ...but no failure is published, and the parent is not woken as failed.
     assert [
         event


### PR DESCRIPTION
## Problem

`tests/runner/test_app_sessions_native.py::test_required_terminal_exit_while_idle_does_not_fail_session` is flaky. Observed failing on an unrelated PR's CI run:

```
AssertionError: assert {'type': 'session.resource.deleted', 'resource_id': 'terminal_worker_main', ...} in []
```

## Root cause

A required terminal exiting while idle triggers cleanup that fans out across **two independent asyncio tasks** (`omnigent/runner/app.py`):

- `_publish_terminal_exit` enqueues the `session.resource.deleted` event, then spawns…
- `_release_required_terminal_session`, a *separate* task that sets `pm.released`.

The test used `pm.released` as a proxy settle signal and then drained the event queue exactly once. Because the release runs in its own task scheduled independently of the publish, under the cooperative scheduler the release could complete before the drain observed the published event — leaving `queued_events == []` and tripping the assertion.

## Fix

Settle on the actual outcome rather than a proxy: the polling loop now accumulates drained events each tick and breaks only when **both** the `session.resource.deleted` event has been observed **and** `pm.released` is set. This makes the relative completion order of the two cleanup tasks irrelevant. The event literal is de-duplicated into a `deleted_event` variable reused by the loop and the downstream assertion.

The behavioral assertions (no `failed` status, empty parent events/inbox) are unchanged and still valid — the idle path never publishes those.

## Testing

Ran the test 5× locally; passes consistently.