### PR TITLE
fix(codex): yield ReasoningChunk for reasoning-phase deltas to reset idle watchdog

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -39,6 +39,7 @@ from .executor import (
     ExecutorError,
     ExecutorEvent,
     Message,
+    ReasoningChunk,
     TextChunk,
     ToolArgs,
     ToolCallComplete,
@@ -1581,6 +1582,15 @@ class _CodexAppServerSession:
                     prior = message_buffers.get(item_id)
                     message_buffers[item_id] = (prior if prior is not None else "") + delta
                     yield TextChunk(text=delta)
+                    continue
+
+                if method in ("item/reasoning/textDelta", "item/reasoning/summaryTextDelta"):
+                    if not _event_turn_matches(params):
+                        continue
+                    raw_reasoning_delta = params.get("delta")
+                    if not isinstance(raw_reasoning_delta, str) or not raw_reasoning_delta:
+                        continue
+                    yield ReasoningChunk(delta=raw_reasoning_delta, event_type="reasoning_text")
                     continue
 
                 if method == "item/completed":

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -26,6 +26,7 @@ from omnigent.inner.codex_executor import (
 from omnigent.inner.databricks_executor import DatabricksCredentials
 from omnigent.inner.executor import (
     ExecutorError,
+    ReasoningChunk,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -1347,6 +1348,79 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertEqual(len(events), 1)
             self.assertIsInstance(events[0], TurnComplete)
             self.assertEqual(events[0].response, "done")
+
+        _run(_t())
+
+    def test_app_server_run_turn_reasoning_deltas_yield_reasoning_chunks(self):
+        """item/reasoning/textDelta and item/reasoning/summaryTextDelta events
+        yield ReasoningChunk events so the idle watchdog resets during long
+        think phases (regression guard for omnigent-ai/omnigent#738)."""
+
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session.thread_id = "thread-1"
+            session._request = AsyncMock(return_value={"result": {"turn": {"id": "turn-1"}}})
+
+            async def _inject() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {
+                        "method": "item/reasoning/textDelta",
+                        "params": {"turnId": "turn-1", "delta": "thinking hard..."},
+                    }
+                )
+                session._events.put_nowait(
+                    {
+                        "method": "item/reasoning/summaryTextDelta",
+                        "params": {"turnId": "turn-1", "delta": "summary of thoughts"},
+                    }
+                )
+                session._events.put_nowait(
+                    {
+                        "method": "item/completed",
+                        "params": {
+                            "turnId": "turn-1",
+                            "item": {
+                                "id": "msg-1",
+                                "type": "agentMessage",
+                                "phase": "final_answer",
+                                "text": "Here is my answer.",
+                            },
+                        },
+                    }
+                )
+
+            inject_task = asyncio.create_task(_inject())
+            events = [
+                event
+                async for event in session.run_turn(
+                    messages=[{"role": "user", "content": "complex question"}],
+                    tools=[],
+                    system_prompt="",
+                    model="gpt-5.4-mini",
+                    cwd=".",
+                    sandbox="workspace-write",
+                )
+            ]
+            await inject_task
+
+            reasoning_events = [e for e in events if isinstance(e, ReasoningChunk)]
+            self.assertEqual(len(reasoning_events), 2)
+            self.assertEqual(reasoning_events[0].delta, "thinking hard...")
+            self.assertEqual(reasoning_events[0].event_type, "reasoning_text")
+            self.assertEqual(reasoning_events[1].delta, "summary of thoughts")
+            self.assertEqual(reasoning_events[1].event_type, "reasoning_text")
+
+            turn_complete = events[-1]
+            self.assertIsInstance(turn_complete, TurnComplete)
+            self.assertEqual(turn_complete.response, "Here is my answer.")
 
         _run(_t())
 


### PR DESCRIPTION
## Summary

Fixes #738. `CodexExecutor.run_turn` had no handler for `item/reasoning/textDelta` or `item/reasoning/summaryTextDelta` events from the Codex app server. During a long think phase these events fell through the dispatch loop silently — no `yield`, no `ctx.emit`, no watchdog reset — causing the scaffold's per-turn idle watchdog (`HARNESS_TURN_TIMEOUT_S`, default 240s) to fire and kill the turn.

- Adds a branch in the `run_turn` event loop for both `item/reasoning/textDelta` and `item/reasoning/summaryTextDelta` that yields `ReasoningChunk(delta=..., event_type="reasoning_text")`, matching the pattern used by the claude-sdk, cursor, pi, and antigravity executors
- Reasoning text is kept out of `message_buffers` / `final_response` so it does not leak into the assistant answer
- Adds `ReasoningChunk` to the executor import

## Test plan

- [ ] `tests/inner/test_codex_executor.py::TestCodexExecutor::test_app_server_run_turn_reasoning_deltas_yield_reasoning_chunks` — new unit test verifying both `item/reasoning/textDelta` and `item/reasoning/summaryTextDelta` yield `ReasoningChunk` events with correct `delta` and `event_type`, and that `TurnComplete.response` contains only the final answer text
- [ ] Full `tests/inner/test_codex_executor.py` suite passes (77 tests, excluding the pre-existing `test_constructor_databricks_flag_no_creds_raises` failure unrelated to this change)

This pull request and its description were written by Isaac.