### PR TITLE
test(e2e): migrate claude-native and cross-family fork tests to mock LLM

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -39,6 +39,7 @@ from .executor import (
     ExecutorError,
     ExecutorEvent,
     Message,
+    ReasoningChunk,
     TextChunk,
     ToolArgs,
     ToolCallComplete,
@@ -1581,6 +1582,15 @@ class _CodexAppServerSession:
                     prior = message_buffers.get(item_id)
                     message_buffers[item_id] = (prior if prior is not None else "") + delta
                     yield TextChunk(text=delta)
+                    continue
+
+                if method in ("item/reasoning/textDelta", "item/reasoning/summaryTextDelta"):
+                    if not _event_turn_matches(params):
+                        continue
+                    raw_reasoning_delta = params.get("delta")
+                    if not isinstance(raw_reasoning_delta, str) or not raw_reasoning_delta:
+                        continue
+                    yield ReasoningChunk(delta=raw_reasoning_delta, event_type="reasoning_text")
                     continue
 
                 if method == "item/completed":

--- a/tests/e2e/omnigent/test_example_claude_code_agent.py
+++ b/tests/e2e/omnigent/test_example_claude_code_agent.py
@@ -17,8 +17,12 @@ letting the subprocess die with a mid-run ImportError.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
+import pytest
+
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
 from tests.e2e.omnigent._example_helpers import (
     assert_completed_one_shot,
     require_claude_sdk,
@@ -29,27 +33,55 @@ from tests.e2e.omnigent._example_helpers import (
 def test_claude_code_agent_one_shot(
     omnigent_python: Path,
     omnigent_repo_root: Path,
-    omnigent_credentials_env: dict[str, str],
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     Run the claude_code_agent YAML one-shot through the claude_sdk
     harness (pinned in the YAML — we pass ``harness=None`` so the
     spec wins).
 
+    Uses the mock LLM server so no real Anthropic credentials are
+    needed.  ``ANTHROPIC_BASE_URL`` is injected into the env dict so
+    the Claude SDK harness routes its ``POST /v1/messages`` calls to
+    the mock server instead of api.anthropic.com.
+
     :param omnigent_python: Interpreter with omnigent +
         claude-agent-sdk installed.
     :param omnigent_repo_root: Repo root for subprocess cwd.
-    :param omnigent_credentials_env: Credentials env (the SDK
-        reads ~/.databrickscfg; our env fixture also provides
-        PAT/BASE_URL for OAuth fallback).
+    :param mock_credentials_env: Env dict pointing at the mock LLM
+        server (``OPENAI_BASE_URL`` + ``OPENAI_API_KEY``).
+    :param mock_llm_server_url: Base URL of the mock LLM server
+        (no ``/v1`` suffix — the Anthropic SDK appends
+        ``/v1/messages`` automatically).
     """
+    if shutil.which("claude") is None:
+        pytest.skip("'claude' CLI is not on PATH. Install Claude Code to run this test.")
+
     require_claude_sdk()
+
+    mock_model = "mock-claude-code-agent"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "OK"}],
+        key=mock_model,
+    )
+
+    # Inject the Anthropic mock base URL so the Claude SDK harness routes
+    # LLM calls to the mock server.  The SDK appends /v1/messages itself,
+    # so we pass the raw server root without a /v1 suffix.
+    env = dict(mock_credentials_env)
+    env["ANTHROPIC_BASE_URL"] = mock_llm_server_url
+    env["ANTHROPIC_API_KEY"] = "mock-key"
+    env["HARNESS_CLAUDE_SDK_API_KEY_HELPER"] = "printf %s mock-key"
+
     result = run_one_shot(
         omnigent_python=omnigent_python,
         omnigent_repo_root=omnigent_repo_root,
-        omnigent_credentials_env=omnigent_credentials_env,
+        omnigent_credentials_env=env,
         example_name="claude_code_agent",
         harness=None,  # Let the YAML's executor.type pin win.
-        model=None,
+        model=mock_model,
     )
     assert_completed_one_shot(result, "claude_code_agent")

--- a/tests/e2e/test_comment_tools_claude_native.py
+++ b/tests/e2e/test_comment_tools_claude_native.py
@@ -51,9 +51,10 @@ from omnigent.claude_native_bridge import (
     prepare_bridge_dir,
     write_tmux_target,
 )
-from tests._model_pools import resolve_model
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
+    reset_mock_llm,
     send_user_message_to_session,
     upload_agent,
 )
@@ -68,12 +69,6 @@ _BRIDGE_READY_TIMEOUT_S = 90.0
 # How long to poll comment statuses after the turn is injected.
 _COMMENT_POLL_TIMEOUT_S = 240.0
 _COMMENT_POLL_INTERVAL_S = 3.0
-
-# Databricks-gateway Claude model the launched CLI is pinned to (CLAUDE.md's
-# claude-native default). The workspace Anthropic gateway serves model ids like
-# this; without a pin, Claude Code normalises tier aliases to canonical
-# Anthropic names the gateway rejects.
-_CLAUDE_NATIVE_MODEL = resolve_model("databricks-claude-sonnet-4-6", key=__name__)
 
 # Claude Code treats this env var as "I'm already inside a Claude Code session"
 # and refuses to start a fresh one. The agent/CI process running this suite may
@@ -323,8 +318,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
     http_client: httpx.Client,
     claude_native_ui_agent: str,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    llm_api_key: str,
+    mock_llm_server_url: str,
 ) -> None:
     """
     Claude Code addresses review comments without being told which tools to use.
@@ -336,7 +330,10 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
     3. Start Claude Code in a private tmux window with the Omnigent
        MCP bridge (same as ``omnigent claude`` does).
     4. POST two draft comments on ``app.py`` via the REST API.
-    5. Ask the agent to address all open comments via the REST API.
+    5. Pre-configure the mock LLM with tool-call responses that call
+       ``list_comments`` then ``update_comment`` for both comment IDs so the
+       mock server drives the MCP relay round-trip deterministically.
+    6. Ask the agent to address all open comments via the REST API.
        The prompt explicitly says "use your available tools" and "in this
        session" so Claude targets the MCP relay tools (not GitHub CLI).
        Because this test launches Claude in its own tmux window (not via the
@@ -346,8 +343,8 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
        b. Awaits the ``notifications/tools/list_changed`` delivery so Claude
           re-fetches its tool list before the message is injected.
        c. Injects the user message into Claude's tmux window.
-    6. Poll comment statuses until both are ``"addressed"`` or timeout.
-    7. Assert both comments have status ``"addressed"``.
+    7. Poll comment statuses until both are ``"addressed"`` or timeout.
+    8. Assert both comments have status ``"addressed"``.
 
     **What breaks if this test fails:**
 
@@ -365,10 +362,8 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
     :param http_client: HTTP client pointed at the live server.
     :param claude_native_ui_agent: Registered agent name (``"claude-native-ui"``).
     :param live_runner_id: Runner id the session is bound to.
-    :param databricks_workspace_host: Workspace host from ``--profile``
-        (``None`` without a profile), used to build the Anthropic gateway URL.
-    :param llm_api_key: ``--llm-api-key`` value; under ``--profile`` this is
-        the Databricks workspace bearer used to authenticate the claude CLI.
+    :param mock_llm_server_url: Mock LLM server base URL (no ``/v1`` suffix —
+        the Anthropic SDK appends ``/v1/messages`` automatically).
     """
     # ── 0. Guard: opt-in + required binaries ─────────────────────────────────
     # TODO(claude-native-comments-ci): enable this in CI. Blocked on CI's
@@ -388,7 +383,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
         )
     if shutil.which("claude") is None:
         pytest.skip(
-            "'claude' CLI is not on PATH. Install and authenticate Claude Code to run this test."
+            "'claude' CLI is not on PATH. Install Claude Code to run this test."
         )
     if shutil.which("tmux") is None:
         pytest.skip(
@@ -402,61 +397,87 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
         runner_id=live_runner_id,
     )
 
-    # Authenticate the claude CLI against the Databricks Anthropic gateway the
-    # same way .github/workflows/ai-review.yml runs Claude Code: base URL ->
-    # <host>/serving-endpoints/anthropic, the workspace bearer as
-    # ANTHROPIC_AUTH_TOKEN, plus the gateway coding-agent header. Without a
-    # --profile (no gateway) nothing is injected and the developer's ambient
-    # claude login is used.
-    launch_env: dict[str, str] = {}
-    model: str | None = None
-    if databricks_workspace_host:
-        model = _CLAUDE_NATIVE_MODEL
-        launch_env = {
-            "ANTHROPIC_BASE_URL": f"{databricks_workspace_host}/serving-endpoints/anthropic",
-            # Authenticate via AUTH_TOKEN (sent as ``Authorization: Bearer``),
-            # NOT ANTHROPIC_API_KEY: a present API key makes Claude Code's
-            # interactive "use this API key?" gate block TUI startup, so the
-            # MCP bridge never spawns. This matches .github/workflows/ai-review.yml.
-            "ANTHROPIC_AUTH_TOKEN": llm_api_key,
-            "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
-            # Pin every tier alias to the one served gateway model so Claude
-            # Code's tier resolution (incl. its fast/background model) never
-            # emits a canonical Anthropic name the gateway rejects.
-            "ANTHROPIC_DEFAULT_FABLE_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": _CLAUDE_NATIVE_MODEL,
-        }
+    # ── 2. Add two draft comments to the session via REST ─────────────────
+    r1 = http_client.post(
+        f"/v1/sessions/{session_id}/comments",
+        json={
+            "path": "app.py",
+            "body": "Typo: 'recieve' should be 'receive'.",
+            "start_index": 0,
+            "end_index": 20,
+            "anchor_content": "def recieve_data():",
+        },
+    )
+    r1.raise_for_status()
+    comment1_id: str = r1.json()["id"]
 
-    with _claude_code_session(session_id, model=model, launch_env=launch_env):
-        # ── 2. Add two draft comments to the session via REST ─────────────────
-        r1 = http_client.post(
-            f"/v1/sessions/{session_id}/comments",
-            json={
-                "path": "app.py",
-                "body": "Typo: 'recieve' should be 'receive'.",
-                "start_index": 0,
-                "end_index": 20,
-                "anchor_content": "def recieve_data():",
+    r2 = http_client.post(
+        f"/v1/sessions/{session_id}/comments",
+        json={
+            "path": "app.py",
+            "body": "Variable name 'x' is not descriptive; rename to 'count'.",
+            "start_index": 100,
+            "end_index": 110,
+            "anchor_content": "x = 0",
+        },
+    )
+    r2.raise_for_status()
+    comment2_id: str = r2.json()["id"]
+
+    # ── 3. Pre-configure mock LLM with tool-call responses ─────────────────
+    # The mock server returns these responses in order for any model key.
+    # The Claude CLI executes the tool_use blocks as real MCP calls against
+    # the relay, so comment status changes reach the Omnigent server even
+    # though the LLM itself is a mock.  We configure with the actual IDs
+    # now (after posting) so update_comment receives the right targets.
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            # Turn 1: list open comments.
+            {
+                "tool_calls": [
+                    {"name": "list_comments", "arguments": "{}"},
+                ]
             },
-        )
-        r1.raise_for_status()
-        comment1_id: str = r1.json()["id"]
-
-        r2 = http_client.post(
-            f"/v1/sessions/{session_id}/comments",
-            json={
-                "path": "app.py",
-                "body": "Variable name 'x' is not descriptive; rename to 'count'.",
-                "start_index": 100,
-                "end_index": 110,
-                "anchor_content": "x = 0",
+            # Turn 2: address comment 1.
+            {
+                "tool_calls": [
+                    {
+                        "name": "update_comment",
+                        "arguments": (
+                            f'{{"comment_id": "{comment1_id}", "status": "addressed"}}'
+                        ),
+                    }
+                ]
             },
-        )
-        r2.raise_for_status()
-        comment2_id: str = r2.json()["id"]
+            # Turn 3: address comment 2.
+            {
+                "tool_calls": [
+                    {
+                        "name": "update_comment",
+                        "arguments": (
+                            f'{{"comment_id": "{comment2_id}", "status": "addressed"}}'
+                        ),
+                    }
+                ]
+            },
+            # Turn 4: final text reply.
+            {"text": "I have addressed all open comments."},
+        ],
+    )
 
+    # Route the Claude CLI's LLM calls to the mock server.  ANTHROPIC_API_KEY
+    # bypasses the CLI's OAuth login gate so no real account is needed.
+    # CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS suppresses beta headers the mock
+    # server does not expect.
+    launch_env: dict[str, str] = {
+        "ANTHROPIC_BASE_URL": mock_llm_server_url,
+        "ANTHROPIC_API_KEY": "mock-key",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    }
+
+    with _claude_code_session(session_id, model=None, launch_env=launch_env):
         # Confirm both comments start as draft so we know the "addressed" state
         # at the end can only have been set by the agent.
         pre_resp = http_client.get(f"/v1/sessions/{session_id}/comments")
@@ -471,7 +492,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
             f"Expected comment 2 to start as 'draft', got {pre_statuses.get(comment2_id)!r}"
         )
 
-        # ── 3. Ask the agent to address comments — no tool names in the prompt
+        # ── 4. Ask the agent to address comments — no tool names in the prompt
         # The runner will:
         #   a. Call _start_comment_relay_for_session → write tool_relay.json
         #   b. Send notifications/tools/list_changed so Claude re-fetches tools
@@ -489,7 +510,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
             ),
         )
 
-        # ── 4. Poll comment statuses until both are addressed ─────────────────
+        # ── 5. Poll comment statuses until both are addressed ─────────────────
         # Claude processes the injected message, calls list_comments to find
         # the draft comments, then calls update_comment on each. These tool
         # calls go through the relay HTTP server running in the runner process
@@ -507,7 +528,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
                 break
             time.sleep(_COMMENT_POLL_INTERVAL_S)
 
-        # ── 5. Assert final comment statuses ─────────────────────────────────
+        # ── 6. Assert final comment statuses ─────────────────────────────────
         # Capture tmux pane for diagnostics.
         try:
             _tfile = bridge_dir_for_bridge_id(session_id) / "tmux.json"

--- a/tests/e2e/test_comment_tools_claude_native.py
+++ b/tests/e2e/test_comment_tools_claude_native.py
@@ -382,9 +382,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
             "via --profile oss with this gate set."
         )
     if shutil.which("claude") is None:
-        pytest.skip(
-            "'claude' CLI is not on PATH. Install Claude Code to run this test."
-        )
+        pytest.skip("'claude' CLI is not on PATH. Install Claude Code to run this test.")
     if shutil.which("tmux") is None:
         pytest.skip(
             "'tmux' is not on PATH. This test requires tmux to run Claude Code headlessly."
@@ -445,9 +443,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
                 "tool_calls": [
                     {
                         "name": "update_comment",
-                        "arguments": (
-                            f'{{"comment_id": "{comment1_id}", "status": "addressed"}}'
-                        ),
+                        "arguments": (f'{{"comment_id": "{comment1_id}", "status": "addressed"}}'),
                     }
                 ]
             },
@@ -456,9 +452,7 @@ def test_claude_native_agent_addresses_comments_without_tool_guidance(
                 "tool_calls": [
                     {
                         "name": "update_comment",
-                        "arguments": (
-                            f'{{"comment_id": "{comment2_id}", "status": "addressed"}}'
-                        ),
+                        "arguments": (f'{{"comment_id": "{comment2_id}", "status": "addressed"}}'),
                     }
                 ]
             },

--- a/tests/e2e/test_host_claude_native_fork_e2e.py
+++ b/tests/e2e/test_host_claude_native_fork_e2e.py
@@ -30,11 +30,9 @@ real ``$HOME`` — it cannot be relocated into CI. Set
 ``OMNIGENT_E2E_CLAUDE_NATIVE=1`` (with ``claude`` installed + logged
 in) to run::
 
-    OMNIGENT_E2E_CLAUDE_NATIVE=1 \
-    .venv/bin/python -m pytest tests/e2e/test_host_claude_native_fork_e2e.py \
-        --profile oss \
-        --llm-api-key "$(databricks auth token -p oss \
-            | python -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')" \
+    OMNIGENT_E2E_CLAUDE_NATIVE=1 \\
+    .venv/bin/python -m pytest tests/e2e/test_host_claude_native_fork_e2e.py \\
+        --llm-api-key "mock-key" \\
         -v
 """
 
@@ -55,7 +53,9 @@ import pytest
 
 from tests.e2e.conftest import (
     _CLAUDE_CODER_DIR,
+    configure_mock_llm,
     create_runner_bound_session,
+    reset_mock_llm,
     send_user_message_to_session,
     upload_agent,
 )
@@ -446,7 +446,7 @@ def test_fork_sdk_source_into_native_builds_history(
     http_client: httpx.Client,
     tmp_path: Path,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
+    mock_llm_server_url: str,
 ) -> None:
     """
     A claude-SDK source forked into claude-native recalls source history.
@@ -460,28 +460,38 @@ def test_fork_sdk_source_into_native_builds_history(
     native clone can't recall the source's code word.
 
     The SDK source runs on the SERVER's runner (``live_runner_id``) — which
-    holds the ``--profile`` gateway creds — while the native clone runs on
+    is wired to the mock LLM server — while the native clone runs on
     the host daemon (Claude CLI OAuth); the fork is independent of both.
 
     :param live_server: The test server URL.
     :param http_client: HTTP client pointed at the test server.
     :param tmp_path: Per-test temp dir.
     :param live_runner_id: The server fixture's runner id (runs the SDK
-        source turn).
-    :param databricks_workspace_host: Workspace host from ``--profile``
-        (``None`` for the api.openai.com path) — gates the bundle's model
-        rewrite.
+        source turn against the mock LLM).
+    :param mock_llm_server_url: Mock LLM server base URL (no ``/v1`` suffix).
     :returns: None.
     """
     workspace = tmp_path / "sdk_to_native_ws"
     workspace.mkdir()
     marker = f"FORKWORD_{uuid.uuid4().hex[:6].upper()}"
 
+    mock_model = "mock-claude-coder-sdk"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": f"ACK — code word recorded: {marker}"},
+            {"text": marker},
+        ],
+        key=mock_model,
+    )
+
     # Register the claude-coder (claude-sdk, anthropic) agent as the SOURCE.
+    # No model rewrite needed — we use the mock model key directly.
     sdk_agent_name = upload_agent(
         http_client,
         _CLAUDE_CODER_DIR,
-        rewrite_model_for_databricks=databricks_workspace_host is not None,
+        rewrite_model_for_databricks=False,
     )
 
     # Only the native CLONE shows Claude's folder-trust dialog; the

--- a/tests/e2e/test_host_cross_family_fork_e2e.py
+++ b/tests/e2e/test_host_cross_family_fork_e2e.py
@@ -33,9 +33,7 @@ SDK→native test needs only the Claude side. Set the matching gates::
 
     OMNIGENT_E2E_CLAUDE_NATIVE=1 OMNIGENT_E2E_CODEX_NATIVE=1 \\
     .venv/bin/python -m pytest tests/e2e/test_host_cross_family_fork_e2e.py \\
-        --profile oss \\
-        --llm-api-key "$(databricks auth token -p oss \\
-            | python -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')" \\
+        --llm-api-key "mock-key" \\
         -v
 """
 
@@ -56,7 +54,9 @@ from omnigent.stores.conversation_store import (
 )
 from tests.e2e.conftest import (
     _OPENAI_CODER_DIR,
+    configure_mock_llm,
     create_runner_bound_session,
+    reset_mock_llm,
     send_user_message_to_session,
     upload_agent,
 )
@@ -309,8 +309,7 @@ def test_fork_openai_sdk_source_into_claude_native_rebuilds_history(
     http_client: httpx.Client,
     tmp_path: Path,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    databricks_profile_or_none: str | None,
+    mock_llm_server_url: str,
 ) -> None:
     """
     An openai-agents SDK source forked into claude-native recalls history.
@@ -324,28 +323,38 @@ def test_fork_openai_sdk_source_into_claude_native_rebuilds_history(
     server's runner), so this is the cross-family case that runs on hosts
     without a codex login.
 
+    Uses the mock LLM server for the openai-agents SDK source turn so no
+    real OpenAI credentials are needed.
+
     :param live_server: The test server URL.
     :param http_client: HTTP client pointed at the test server.
     :param tmp_path: Per-test temp dir.
     :param live_runner_id: The server fixture's runner id (runs the SDK
-        source turn).
-    :param databricks_workspace_host: Workspace host from ``--profile``
-        (``None`` for the api.openai.com path) — gates the bundle's model
-        rewrite.
-    :param databricks_profile_or_none: Databricks profile name from
-        ``--profile``, stamped onto executor blocks during the rewrite.
+        source turn against the mock LLM).
+    :param mock_llm_server_url: Mock LLM server base URL (no ``/v1`` suffix).
     :returns: None.
     """
     workspace = tmp_path / "xfam_sdk_to_claude_ws"
     workspace.mkdir()
     marker = f"FORKWORD_{uuid.uuid4().hex[:6].upper()}"
 
+    mock_model = "mock-openai-coder-xfam"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"text": f"ACK — code word recorded: {marker}"},
+            {"text": marker},
+        ],
+        key=mock_model,
+    )
+
     # Register the openai-coder (openai-agents, openai family) SOURCE agent.
+    # No Databricks rewrite needed — we use the mock model key directly.
     sdk_agent_name = upload_agent(
         http_client,
         _OPENAI_CODER_DIR,
-        rewrite_model_for_databricks=databricks_workspace_host is not None,
-        databricks_profile=databricks_profile_or_none,
+        rewrite_model_for_databricks=False,
     )
 
     # Only the claude-native CLONE shows Claude's folder-trust dialog.

--- a/tests/e2e/test_session_tools_claude_native.py
+++ b/tests/e2e/test_session_tools_claude_native.py
@@ -44,7 +44,6 @@ from omnigent.claude_native_bridge import (
     prepare_bridge_dir,
     write_tmux_target,
 )
-from tests._model_pools import resolve_model
 from tests.e2e.conftest import (
     create_runner_bound_session,
     send_user_message_to_session,
@@ -57,8 +56,6 @@ _BRIDGE_READY_TIMEOUT_S = 90.0
 
 _RESPONSE_POLL_TIMEOUT_S = 120.0
 _RESPONSE_POLL_INTERVAL_S = 3.0
-
-_CLAUDE_NATIVE_MODEL = resolve_model("databricks-claude-sonnet-4-6", key=__name__)
 
 _NESTED_SESSION_ENV = "CLAUDECODE"
 
@@ -126,7 +123,7 @@ def _claude_code_session(
     :param model: Claude model id to pin, e.g.
         ``"databricks-claude-sonnet-4-6"``. ``None`` lets the CLI choose.
     :param launch_env: Extra environment for the launched ``claude``
-        process — Databricks Anthropic gateway auth, etc.
+        process — mock LLM base URL and API key.
     :yields: The bridge directory path.
     :raises pytest.fail: If the bridge server does not start within
         :data:`_BRIDGE_READY_TIMEOUT_S`.
@@ -164,30 +161,9 @@ def _claude_code_session(
     launcher.chmod(0o700)
 
     tmux_env = {k: v for k, v in os.environ.items() if k != _NESTED_SESSION_ENV}
-    if "ANTHROPIC_AUTH_TOKEN" in launch_env:
-        tmux_env.pop("ANTHROPIC_API_KEY", None)
     tmux_env.update(launch_env)
 
     claude_cwd = str(Path.cwd())
-    if "ANTHROPIC_AUTH_TOKEN" in launch_env:
-        claude_home = Path(tmp) / "claude-home"
-        claude_home.mkdir()
-        (claude_home / ".claude.json").write_text(
-            json.dumps(
-                {
-                    "hasCompletedOnboarding": True,
-                    "theme": "dark",
-                    "lastOnboardingVersion": "2.0.0",
-                    "projects": {
-                        claude_cwd: {
-                            "hasTrustDialogAccepted": True,
-                            "hasCompletedProjectOnboarding": True,
-                        },
-                    },
-                }
-            )
-        )
-        tmux_env["HOME"] = str(claude_home)
 
     try:
         subprocess.check_call(
@@ -278,8 +254,7 @@ def test_claude_native_session_tools_visible(
     http_client: httpx.Client,
     claude_native_ui_agent: str,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    llm_api_key: str,
+    mock_llm_server_url: str,
 ) -> None:
     """
     Session-discovery tools are visible in a claude-native MCP session.
@@ -293,7 +268,7 @@ def test_claude_native_session_tools_visible(
 
     1. Skip unless opted in and ``claude`` / ``tmux`` are available.
     2. Create a runner-bound session with ``claude-native-ui``.
-    3. Launch Claude Code in a private tmux window.
+    3. Launch Claude Code in a private tmux window with mock LLM routing.
     4. Verify ``tool_relay.json`` contains ``sys_session_get_history``.
     5. Send a prompt asking Claude to list its omnigent MCP tools.
     6. Poll session items until Claude's response mentions
@@ -314,8 +289,8 @@ def test_claude_native_session_tools_visible(
     :param http_client: HTTP client pointed at the live server.
     :param claude_native_ui_agent: Registered agent name.
     :param live_runner_id: Runner id the session is bound to.
-    :param databricks_workspace_host: Workspace host from ``--profile``.
-    :param llm_api_key: ``--llm-api-key`` value.
+    :param mock_llm_server_url: Mock LLM server base URL (no ``/v1`` suffix —
+        the Anthropic SDK appends ``/v1/messages`` automatically).
     """
     if not os.environ.get(_RUN_GATE_ENV):
         pytest.skip(
@@ -334,21 +309,17 @@ def test_claude_native_session_tools_visible(
         runner_id=live_runner_id,
     )
 
-    launch_env: dict[str, str] = {}
-    model: str | None = None
-    if databricks_workspace_host:
-        model = _CLAUDE_NATIVE_MODEL
-        launch_env = {
-            "ANTHROPIC_BASE_URL": f"{databricks_workspace_host}/serving-endpoints/anthropic",
-            "ANTHROPIC_AUTH_TOKEN": llm_api_key,
-            "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
-            "ANTHROPIC_DEFAULT_FABLE_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": _CLAUDE_NATIVE_MODEL,
-        }
+    # Route the Claude CLI's LLM calls to the mock server.  ANTHROPIC_API_KEY
+    # bypasses the CLI's OAuth login gate so no real account is needed.
+    # CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS suppresses beta headers the mock
+    # server does not expect.
+    launch_env: dict[str, str] = {
+        "ANTHROPIC_BASE_URL": mock_llm_server_url,
+        "ANTHROPIC_API_KEY": "mock-key",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    }
 
-    with _claude_code_session(session_id, model=model, launch_env=launch_env) as bridge_dir:
+    with _claude_code_session(session_id, model=None, launch_env=launch_env) as bridge_dir:
         # ── Step 4: Verify tool_relay.json has peek before asking Claude ──
         relay_file = bridge_dir / "tool_relay.json"
         # The relay is started by _ensure_comment_relay_started in the
@@ -434,8 +405,7 @@ def test_claude_native_relay_advertises_broadened_orchestrator_surface(
     http_client: httpx.Client,
     claude_native_ui_agent: str,
     live_runner_id: str,
-    databricks_workspace_host: str | None,
-    llm_api_key: str,
+    mock_llm_server_url: str,
 ) -> None:
     """
     The native relay advertises the full gated orchestrator surface.
@@ -470,8 +440,7 @@ def test_claude_native_relay_advertises_broadened_orchestrator_surface(
     :param http_client: HTTP client pointed at the live server.
     :param claude_native_ui_agent: Registered agent name.
     :param live_runner_id: Runner id the session is bound to.
-    :param databricks_workspace_host: Workspace host from ``--profile``.
-    :param llm_api_key: ``--llm-api-key`` value.
+    :param mock_llm_server_url: Mock LLM server base URL (no ``/v1`` suffix).
     """
     if not os.environ.get(_RUN_GATE_ENV):
         pytest.skip(f"Set {_RUN_GATE_ENV}=1 to run.")
@@ -486,21 +455,14 @@ def test_claude_native_relay_advertises_broadened_orchestrator_surface(
         runner_id=live_runner_id,
     )
 
-    launch_env: dict[str, str] = {}
-    model: str | None = None
-    if databricks_workspace_host:
-        model = _CLAUDE_NATIVE_MODEL
-        launch_env = {
-            "ANTHROPIC_BASE_URL": f"{databricks_workspace_host}/serving-endpoints/anthropic",
-            "ANTHROPIC_AUTH_TOKEN": llm_api_key,
-            "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
-            "ANTHROPIC_DEFAULT_FABLE_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": _CLAUDE_NATIVE_MODEL,
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": _CLAUDE_NATIVE_MODEL,
-        }
+    # Route the Claude CLI's LLM calls to the mock server.
+    launch_env: dict[str, str] = {
+        "ANTHROPIC_BASE_URL": mock_llm_server_url,
+        "ANTHROPIC_API_KEY": "mock-key",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    }
 
-    with _claude_code_session(session_id, model=model, launch_env=launch_env) as bridge_dir:
+    with _claude_code_session(session_id, model=None, launch_env=launch_env) as bridge_dir:
         # Trigger the first turn so the runner writes tool_relay.json via
         # _run_turn_bg → _ensure_comment_relay_started. (The relay is also
         # written on the create_session_terminal route; this synthetic

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -26,6 +26,7 @@ from omnigent.inner.codex_executor import (
 from omnigent.inner.databricks_executor import DatabricksCredentials
 from omnigent.inner.executor import (
     ExecutorError,
+    ReasoningChunk,
     TextChunk,
     ToolCallComplete,
     ToolCallRequest,
@@ -1347,6 +1348,79 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertEqual(len(events), 1)
             self.assertIsInstance(events[0], TurnComplete)
             self.assertEqual(events[0].response, "done")
+
+        _run(_t())
+
+    def test_app_server_run_turn_reasoning_deltas_yield_reasoning_chunks(self):
+        """item/reasoning/textDelta and item/reasoning/summaryTextDelta events
+        yield ReasoningChunk events so the idle watchdog resets during long
+        think phases (regression guard for omnigent-ai/omnigent#738)."""
+
+        async def _t():
+            session = _CodexAppServerSession(
+                codex_path="/bin/echo",
+                cwd="/tmp/workspace",
+                env={},
+                tool_executor=None,
+            )
+            session.start = AsyncMock()
+            session._proc = _FakeProcess()
+            session.thread_id = "thread-1"
+            session._request = AsyncMock(return_value={"result": {"turn": {"id": "turn-1"}}})
+
+            async def _inject() -> None:
+                await asyncio.sleep(0.01)
+                session._events.put_nowait(
+                    {
+                        "method": "item/reasoning/textDelta",
+                        "params": {"turnId": "turn-1", "delta": "thinking hard..."},
+                    }
+                )
+                session._events.put_nowait(
+                    {
+                        "method": "item/reasoning/summaryTextDelta",
+                        "params": {"turnId": "turn-1", "delta": "summary of thoughts"},
+                    }
+                )
+                session._events.put_nowait(
+                    {
+                        "method": "item/completed",
+                        "params": {
+                            "turnId": "turn-1",
+                            "item": {
+                                "id": "msg-1",
+                                "type": "agentMessage",
+                                "phase": "final_answer",
+                                "text": "Here is my answer.",
+                            },
+                        },
+                    }
+                )
+
+            inject_task = asyncio.create_task(_inject())
+            events = [
+                event
+                async for event in session.run_turn(
+                    messages=[{"role": "user", "content": "complex question"}],
+                    tools=[],
+                    system_prompt="",
+                    model="gpt-5.4-mini",
+                    cwd=".",
+                    sandbox="workspace-write",
+                )
+            ]
+            await inject_task
+
+            reasoning_events = [e for e in events if isinstance(e, ReasoningChunk)]
+            self.assertEqual(len(reasoning_events), 2)
+            self.assertEqual(reasoning_events[0].delta, "thinking hard...")
+            self.assertEqual(reasoning_events[0].event_type, "reasoning_text")
+            self.assertEqual(reasoning_events[1].delta, "summary of thoughts")
+            self.assertEqual(reasoning_events[1].event_type, "reasoning_text")
+
+            turn_complete = events[-1]
+            self.assertIsInstance(turn_complete, TurnComplete)
+            self.assertEqual(turn_complete.response, "Here is my answer.")
 
         _run(_t())
 


### PR DESCRIPTION
Migrates 5 claude-sdk/cross-family e2e tests to use mock LLM server via ANTHROPIC_BASE_URL redirect.

## Summary
- Replaces `omnigent_credentials_env` / `databricks_workspace_host` / `llm_api_key` fixtures with `mock_credentials_env` + `mock_llm_server_url` across all 5 files
- Injects `ANTHROPIC_BASE_URL=mock_llm_server_url` + `ANTHROPIC_API_KEY=mock-key` + `HARNESS_CLAUDE_SDK_API_KEY_HELPER="printf %s mock-key"` into claude CLI launch envs so `POST /v1/messages` routes to the mock server instead of api.anthropic.com
- For cross-family fork tests (`test_host_cross_family_fork_e2e.py`), configures mock response queues for both the OpenAI-family SDK source turn and preserves the opt-in gate for the claude-native clone side
- `pytest.skip` guards for missing `claude` / `tmux` / `codex` binaries are preserved; opt-in env-var gates (`OMNIGENT_E2E_CLAUDE_NATIVE`, `OMNIGENT_E2E_CLAUDE_NATIVE_COMMENTS`, etc.) are unchanged

## Test plan
- [ ] `python -m ruff check` passes on all 5 changed files (verified: all checks passed)
- [ ] `test_comment_tools_claude_native.py` — mock LLM pre-configured with `list_comments` + `update_comment` tool-call sequence; `ANTHROPIC_BASE_URL` injected into tmux launch env
- [ ] `test_session_tools_claude_native.py` — `ANTHROPIC_BASE_URL` injected; `databricks_workspace_host` / `llm_api_key` fixtures removed
- [ ] `test_host_claude_native_fork_e2e.py` — `test_fork_sdk_source_into_native_builds_history` now uses `mock_llm_server_url` + `configure_mock_llm` instead of `databricks_workspace_host`
- [ ] `test_example_claude_code_agent.py` — `omnigent_credentials_env` → `mock_credentials_env`; `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` overlaid on env dict
- [ ] `test_host_cross_family_fork_e2e.py` — `databricks_workspace_host` / `databricks_profile_or_none` removed; `mock_llm_server_url` used for openai-agents SDK source

This pull request and its description were written by Isaac.