### PR TITLE
fix(examples): rename os_env secure-research tool to search_web; un-skip #675

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -34,14 +34,6 @@ skips:
     cluster: repl-policy-ask-surfacing
     mode: skip
 
-
-
-  - id: tests/e2e/omnigent/test_example_secure_research_agent_os_env.py::test_secure_research_agent_os_env_one_shot
-    reason: "Secure_research_agent os-env one-shot. Triage pending."
-    issue: 675
-    cluster: sandbox-deps-env
-    mode: skip
-
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[claude-sdk]
     reason: "No-AGENT `omnigent run --harness` live round-trip hangs >180s in CI -> pytest-timeout thread-kill -> xdist worker crash; claude-sdk fails 30/30 in flake-stress 27808074172. Auth is NOT the cause: CI sets DATABRICKS_BEARER and the harness auth-commands short-circuit on it, so the hang is post-auth in the round-trip. Environment-wide, not harness-specific (codex + openai-agents siblings hang identically). The test's _COMPLETION_TIMEOUT=240 also exceeds the e2e --timeout=180 cap. Not locally reproducible (oss OAuth + macOS PTY diverge from CI); needs CI-env debugging."
     issue: 523

--- a/tests/resources/agents/secure_research_agent_os_env/secure_research_agent_os_env.yaml
+++ b/tests/resources/agents/secure_research_agent_os_env/secure_research_agent_os_env.yaml
@@ -54,7 +54,11 @@ executor:
   model: databricks-claude-sonnet-4-6
 
 tools:
-  web_search:
+  # NB: the tool is named ``search_web`` (not ``web_search``) because
+  # ``web_search`` is a reserved builtin tool name — declaring a local
+  # tool with that name fails spec validation. The sibling
+  # ``secure_research_agent.yaml`` uses ``search_web`` for the same reason.
+  search_web:
     type: function
     description: Search the web for public information.
     callable: tests.resources.examples._shared.tool_functions.web_search
@@ -67,14 +71,14 @@ tools:
 policies:
   taint_web_search:
     type: function
-    on: [tool_call:web_search]
+    on: [tool_call:search_web]
     function:
       path: omnigent.policies.function.make_fixed_action_callable
       arguments:
         action: allow
         set_labels: {integrity: "0"}
         on_phases: [tool_call]
-        on_tools: [web_search]
+        on_tools: [search_web]
     set_labels: [integrity]
 
   taint_confidential_read:


### PR DESCRIPTION
## Related issue

Closes #675

## Summary

- `tests/e2e/omnigent/test_example_secure_research_agent_os_env.py::test_secure_research_agent_os_env_one_shot` was failing (and skip-listed under #675) because the example YAML named a custom tool `web_search`, which is now a **reserved builtin** tool name (`WebSearchTool`).
- The spec validator (`omnigent/spec/validator.py:_validate_local_tools`) rejects any local tool that shadows a builtin, so `omnigent run` exited 1 with: `local_tools[1].name: tool name 'web_search' collides with a reserved builtin tool name`.
- The YAML was valid when written — `web_search` became reserved later. The sibling `secure_research_agent.yaml` already names the same tool `search_web` (callable unchanged) for this exact reason; the os_env variant just missed the rename.

### Fix

- Rename `tools.web_search` → `tools.search_web` in `secure_research_agent_os_env.yaml` (callable `tool_functions.web_search` unchanged) + a comment documenting the reserved-name constraint.
- Update policy `taint_web_search`: `on: [tool_call:search_web]` and `on_tools: [search_web]`.
- Drop the `#675` entry from `known_failures.yaml`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

The previously-skipped E2E test now runs and passes against the mock LLM (no real key, ~9s):

```
.venv/bin/python -m pytest \
  tests/e2e/omnigent/test_example_secure_research_agent_os_env.py --timeout=180
```

The test drives a one-shot `omnigent run` of the example and asserts a clean exit — exactly the path that was failing on the reserved-name collision. No new test is needed; un-skipping the existing one restores coverage. The sibling `test_example_secure_research_agent.py` continues to pass, confirming the `search_web` naming is the correct convention.
