### PR TITLE
test(yaml-tools): verify headless tool round-trip via sentinel; un-skip #677

### DIFF
--- a/tests/e2e/omnigent/snapshots/test_yaml_hello_world.json
+++ b/tests/e2e/omnigent/snapshots/test_yaml_hello_world.json
@@ -1,5 +1,5 @@
 {
     "exit_code": {"kind": "exact", "value": 0},
     "stderr_is_clean": {"kind": "exact", "value": true},
-    "stdout": {"kind": "contains", "value": "calculate"}
+    "stdout": {"kind": "contains", "value": "TOOL_ROUNDTRIP_OK_7"}
 }

--- a/tests/e2e/omnigent/test_yaml_hello_world.py
+++ b/tests/e2e/omnigent/test_yaml_hello_world.py
@@ -15,8 +15,12 @@ still picks up openai-agents without needing the ``claude`` / ``codex``
 - Per-YAML defaults fail to pick up the ``callable:`` dotted
   paths via ``importlib.import_module`` — the tool never gets
   registered and the agent can't invoke it.
-- ``omnigent.cli`` one-shot path stops streaming tool-call
-  lifecycle lines (``◦ <tool>`` / ``• <tool>``) to stdout.
+- The YAML→tools round-trip breaks: the forced ``calculate``
+  tool_call never executes / its result never returns, so the
+  mock's final response (carrying the sentinel) is never reached.
+  (Headless ``-p`` does not stream ``◦/• <tool>`` lifecycle lines
+  to stdout — see #783 — so the tool is verified via the sentinel,
+  not those markers.)
 
 Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 YAML→agent characterization.
@@ -40,13 +44,18 @@ from tests.e2e.omnigent._snapshot import compare_snapshot
 
 _PROMPT = "What is 3 + 4? Use the calculate tool."
 
-# ``agent_with_tools.yaml`` defines a ``calculate`` tool. The
-# REPL's tool-lifecycle lines look like
-# ``◦ calculate`` (start) and ``• calculate (NNms)`` (complete).
-# We snapshot the substring ``"calculate"`` so the comparator
-# succeeds as long as either line appears, regardless of the
-# exact timing format.
-_EXPECTED_TOOL_NAME = "calculate"
+# Headless ``-p`` mode no longer streams ``◦/• <tool>`` tool-lifecycle
+# markers to stdout — since #783 it accumulates assistant text across
+# auto-triggered turns until the session is idle, then prints that. So
+# we cannot assert the tool name appears in stdout anymore.
+#
+# Instead the mock's FINAL (second) response carries a unique sentinel.
+# The mock serves that second response only after the harness has
+# executed the forced ``calculate`` tool_call and sent its result back
+# (the second LLM request), so the sentinel reaching stdout proves the
+# whole YAML→tools round-trip happened — you cannot get the final answer
+# without going through the tool.
+_TOOL_ROUNDTRIP_SENTINEL = "TOOL_ROUNDTRIP_OK_7"
 
 # Minimum assistant-text length. The prompt asks a direct
 # arithmetic question so the reply is typically short but must
@@ -159,7 +168,7 @@ def test_yaml_agent_with_tools(
                     }
                 ],
             },
-            {"text": "The answer is 7."},
+            {"text": f"The answer is 7. {_TOOL_ROUNDTRIP_SENTINEL}"},
         ],
         key=mock_model,
     )
@@ -192,10 +201,11 @@ def test_yaml_agent_with_tools(
 
     observed: dict[str, Any] = {
         "exit_code": result.returncode,
-        # Combined stdout because the tool-lifecycle lines
-        # (``◦ calculate`` / ``• calculate``) and the assistant
-        # reply both land on stdout, not stderr. The snapshot's
-        # ``contains`` comparator checks for the tool name.
+        # Headless ``-p`` does NOT stream ``◦/• <tool>`` lifecycle markers
+        # (#783). The snapshot checks the final-answer sentinel instead;
+        # because the mock only serves that final text after the forced
+        # ``calculate`` tool_call round-trips, the sentinel in stdout is
+        # itself the proof that the tool ran.
         "stdout": result.stdout,
         "stderr_is_clean": result.stderr.strip() == "",
     }
@@ -216,14 +226,17 @@ def test_yaml_agent_with_tools(
         f"chars after stripping tool lifecycle lines; got "
         f"{stripped!r} (full stdout: {result.stdout!r})"
     )
-    # Belt-and-braces — the snapshot's ``contains`` comparator
-    # already covers this, but naming the assertion explicitly
-    # makes the failure message self-explanatory if the
-    # snapshot file is ever accidentally deleted.
-    assert _EXPECTED_TOOL_NAME in result.stdout, (
-        f"Expected tool name {_EXPECTED_TOOL_NAME!r} not found "
-        f"in stdout; the {harness} harness did not invoke "
-        f"the calculate tool.\n\nstdout:\n{result.stdout!r}"
+    # Belt-and-braces — the snapshot's ``contains`` comparator already
+    # covers this, but naming the assertion explicitly makes the failure
+    # message self-explanatory if the snapshot file is ever deleted. The
+    # sentinel lives only in the mock's SECOND response, which is served
+    # only after the forced ``calculate`` tool_call executes and its
+    # result is sent back — so its presence proves the tool round-trip.
+    assert _TOOL_ROUNDTRIP_SENTINEL in result.stdout, (
+        f"Final-answer sentinel {_TOOL_ROUNDTRIP_SENTINEL!r} not found in "
+        f"stdout; the {harness} harness did not complete the calculate "
+        f"tool round-trip (the final response is unreachable without it).\n\n"
+        f"stdout:\n{result.stdout!r}"
     )
 
 

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -120,20 +120,9 @@ skips:
     cluster: repl-pexpect-cli
     mode: skip
 
-  - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[claude-sdk]
-    reason: "Tool-call lifecycle markers ('◦ calculate' / '• calculate') not rendering to stdout after path fix; harness answers '3 + 4 = 7' directly without invoking the calculate tool, so the snapshot's stdout-contains-'calculate' check fails. Investigate per-harness tool surfacing."
-    issue: 677
-    cluster: repl-pexpect-cli
+  - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[pi]
+    reason: "pi harness does not complete the headless `-p` tool round-trip: it makes only ONE LLM request (receives the forced calculate tool_call) then exits 0 with empty stdout — the tool is never dispatched and no follow-up call is made. Distinct from #677 (stale stdout-marker expectation, now fixed for the claude-sdk/codex/openai-agents rows); reproduces only locally since pi's CLI is absent in CI (row skipped there). Needs a tracking issue + pi headless-dispatch investigation."
+    issue: 0
+    cluster: pi-headless-tool-roundtrip
     mode: skip
 
-  - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[codex]
-    reason: "Snapshot mismatch on the tool-call lifecycle markers (◦ calculate / • calculate) not rendered to stdout in oneshot mode. Fails consistently 30/30 in flake-stress run 27798661226 (not flaky). See #677."
-    issue: 677
-    cluster: run-ap-examples-harness
-    mode: skip
-
-  - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[openai-agents]
-    reason: "Snapshot mismatch on the tool-call lifecycle markers (◦/• calculate) not rendered to stdout in oneshot mode. Fails consistently 30/30 in flake-stress run 27798661226 (was logged 7/8-flaky; now consistent). Same cause as the [codex] variant — see #677."
-    issue: 677
-    cluster: run-ap-examples-harness
-    mode: skip

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -117,4 +117,3 @@ skips:
     issue: 0
     cluster: pi-headless-tool-roundtrip
     mode: skip
-


### PR DESCRIPTION
## Related issue

Closes #677

## Summary

- `test_yaml_agent_with_tools` asserted the `calculate` tool name appears in one-shot `omnigent run -p` stdout (the `◦/• calculate` tool-lifecycle markers). That expectation went **stale with #783**: headless `-p` no longer streams tool-lifecycle markers — it accumulates assistant text across auto-triggered turns until the session is idle, then prints that. The tool still runs; only the rendering changed. So **#677 was a stale test expectation, not a product bug**.
- **Fix:** the mock's final (second) response now carries a unique sentinel (`TOOL_ROUNDTRIP_OK_7`). The mock serves that response only after the harness executes the forced `calculate` tool_call and sends its result back, so the sentinel reaching stdout proves the full YAML→tools round-trip — you can't reach the final answer without going through the tool. The snapshot and the explicit assertion now check the sentinel.
- Un-skipped the `claude-sdk` / `codex` / `openai-agents` rows (dropped their #677 entries from `known_failures.yaml`).

### `pi` quarantined separately (a distinct, real bug)

While un-skipping, the `pi` row surfaced a **different** failure: in headless `-p` it makes only **one** LLM request (receives the forced `calculate` tool_call) then exits 0 with **empty stdout** — the tool is never dispatched and no follow-up call happens. This is unrelated to #677's rendering change and is invisible in CI (pi's CLI is absent there, so the row is skipped); it reproduces only locally. Quarantined with `issue: 0` (needs a tracking issue) and an accurate reason, in a new `pi-headless-tool-roundtrip` cluster, pending investigation of the pi harness's headless dispatch path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Reworked the previously-skipped E2E test to match the post-#783 headless behavior and verify the tool round-trip via a sentinel:

```
.venv/bin/python -m pytest tests/e2e/omnigent/test_yaml_hello_world.py --timeout=120
```

Result locally: **3 passed (claude-sdk, codex, openai-agents), 1 skipped (pi)**. The sentinel assertion is harness-agnostic — it lives only in the mock's second response, which is unreachable without the forced `calculate` tool_call executing and returning its result. A probe confirmed the working harnesses each make 2 mock requests with a `function_call_output` (tool result fed back), while `pi` makes only 1 (hence its separate quarantine).
