### PR TITLE
test: re-characterize session_lifecycle ×3 — server-mode startup crash, not stale-green

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -54,21 +54,21 @@ skips:
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_effort_command_persists_session_metadata
-    reason: "REPL session-lifecycle / pexpect cluster."
+    reason: "mock-LLM migrated but still CRASHES at REPL startup in --server mode: the spawned `omnigent run --model mock-session-lifecycle --harness openai-agents --server <url>` exits before reaching `state: sleeping`/`❯` (the generic 'auth or configuration problem' CLI hint masks the real error, which logs to a file). Fails 0/10 in CI flake-stress run 27816505132 AND 0/3 locally in a clean env — NOT stale-green and NOT a local artifact. #751 (resume idle sessions) + the mock migration did not green it. Daemon/server-mode startup family (cf. WT-B F1/F2/F3 triage); needs the real --server-mode startup error captured and fixed."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: repl-server-mode-startup-crash
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_recover_after_runner_death
-    reason: "REPL session-lifecycle / pexpect cluster."
+    reason: "mock-LLM migrated but still CRASHES at REPL startup in --server mode: the spawned `omnigent run --model mock-session-lifecycle --harness openai-agents --server <url>` exits before reaching `state: sleeping`/`❯` (the generic 'auth or configuration problem' CLI hint masks the real error, which logs to a file). Fails 0/10 in CI flake-stress run 27816505132 AND 0/3 locally in a clean env — NOT stale-green and NOT a local artifact. #751 (resume idle sessions) + the mock migration did not green it. Daemon/server-mode startup family (cf. WT-B F1/F2/F3 triage); needs the real --server-mode startup error captured and fixed."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: repl-server-mode-startup-crash
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_session_lifecycle.py::test_repl_resume_reuses_daemon_runner
-    reason: "REPL session-lifecycle / pexpect cluster."
+    reason: "mock-LLM migrated but still CRASHES at REPL startup in --server mode: the spawned `omnigent run --model mock-session-lifecycle --harness openai-agents --server <url>` exits before reaching `state: sleeping`/`❯` (the generic 'auth or configuration problem' CLI hint masks the real error, which logs to a file). Fails 0/10 in CI flake-stress run 27816505132 AND 0/3 locally in a clean env — NOT stale-green and NOT a local artifact. #751 (resume idle sessions) + the mock migration did not green it. Daemon/server-mode startup family (cf. WT-B F1/F2/F3 triage); needs the real --server-mode startup error captured and fixed."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: repl-server-mode-startup-crash
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_multiline.py::test_repl_multiline_ctrl_j_insert


### PR DESCRIPTION
## Summary

Triages the three quarantined `test_repl_session_lifecycle.py` tests (`resume_reuses_daemon_runner`, `recover_after_runner_death`, `effort_command_persists_session_metadata`). **Verdict: real failure, kept quarantined — re-characterized** from the vague inherited "REPL session-lifecycle / pexpect cluster" label to the precise diagnosis, and moved to a dedicated `repl-server-mode-startup-crash` cluster.

**No test status change** — `known_failures.yaml` metadata only (reasons + cluster).

### What the triage found

These are now mock-LLM (migrated) and #751 ("adopt server-relaunched runner_id to resume idle sessions") recently landed, so they looked like stale-green candidates. They are not:

- The spawned `omnigent run --model mock-session-lifecycle --harness openai-agents --server <url>` **crashes at REPL startup** — it exits before reaching `state: sleeping` / `❯`, so the test's first `expect` hits EOF.
- The visible output is only the generic `print_setup_hint` line ("If this looks like an auth or configuration problem, run `omnigent setup`…") — a **catch-all hint the top-level CLI handler prints for any crash**, not an auth diagnosis. The real error is written to a log file.
- **Fails 0/10 in CI flake-stress** ([run 27816505132](https://github.com/omnigent-ai/omnigent/actions/runs/27816505132)) **and 0/3 locally in a clean env** (shell keys stripped) — identical failure both places, so it's a genuine startup crash, not a macOS/local artifact.
- This is the daemon/server-mode startup family (cf. the earlier WT-B F1/F2/F3 triage). The mock migration referenced the mock but didn't green these, and #751 didn't fix this path.

Un-quarantining needs the real `--server`-mode startup error captured (it's masked by the catch-all hint + logged to a file) and the daemon/server-mode startup path fixed — a deeper workstream, not a triage rewrite.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`known_failures.yaml` metadata only — no test or product code changed, and all three stay quarantined. The entries now carry the verified root-cause area (server-mode REPL startup crash, masked by the catch-all CLI hint), the CI + local evidence (0/10 + 0/3), and a `repl-server-mode-startup-crash` cluster — replacing the inherited placeholder so a follow-up owner has an accurate starting point.

This pull request and its description were written by Isaac.
