### PR TITLE
ci: exclude tests/e2e_ui from e2e workflow triggers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,11 +20,11 @@ on:
     - cron: "0 9 * * *"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
   push:
     branches:
       - 'fork-e2e/**'
-    paths-ignore: ['ap-web/**']
+    paths-ignore: ['ap-web/**', 'tests/e2e_ui/**']
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Summary
- Adds `tests/e2e_ui/**` to `paths-ignore` for `pull_request` and `push` triggers in `e2e.yml`
- Changes to the e2e_ui test suite no longer trigger the live-LLM e2e workflow

## Test plan
- [ ] Verify that PRs touching only `tests/e2e_ui/` files do not trigger the E2E Tests workflow
- [ ] Verify that PRs touching other files still trigger e2e as expected

This pull request and its description were written by Isaac.