### PR TITLE
fix(runner): propagate pi-native agent-spec resolution errors instead of dropping the sandbox

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -748,6 +748,10 @@ async def _auto_create_pi_terminal(
         terminal.
     :param publish_event: Runner session event publisher.
     :param server_client: Runner Omnigent server client.
+    :param agent_spec: The session's resolved agent spec, passed so the Pi
+        terminal inherits the agent's ``os_env.sandbox`` rather than falling
+        back to the platform default. ``None`` only when the session has no
+        spec; callers must not pass ``None`` to paper over a resolution error.
     :returns: Created terminal resource view.
     """
     from omnigent.conversation_browser import conversation_url
@@ -5674,10 +5678,15 @@ def create_runner_app(
                 if not _has_pi_terminal:
                     _publish_terminal_pending(_publish_event, session_id, True)
                     try:
-                        try:
-                            _pi_spec = await _resolve_session_agent_spec(session_id)
-                        except OmnigentError:
-                            _pi_spec = None
+                        # Inherit the session's os_env.sandbox via its agent
+                        # spec. A genuine resolution error must propagate to the
+                        # outer handler (-> start error), not be swallowed to
+                        # agent_spec=None, which silently drops the sandbox
+                        # policy and falls back to the platform default (the
+                        # failure mode #569 fixed). _resolve_session_agent_spec
+                        # returns None legitimately when there is no spec; only
+                        # genuine errors raise.
+                        _pi_spec = await _resolve_session_agent_spec(session_id)
                         await _auto_create_pi_terminal(
                             session_id,
                             resource_registry,
@@ -10980,10 +10989,11 @@ def create_runner_app(
                         content=session_resource_view_to_dict(existing),
                     )
                 try:
-                    try:
-                        _pi_ensure_spec = await _resolve_session_agent_spec(session_id)
-                    except OmnigentError:
-                        _pi_ensure_spec = None
+                    # See _auto_create_pi_terminal: a genuine spec resolution
+                    # error must propagate to the outer handler (-> start error
+                    # response) rather than be swallowed to agent_spec=None,
+                    # which silently drops the agent's sandbox policy.
+                    _pi_ensure_spec = await _resolve_session_agent_spec(session_id)
                     terminal_view = await _auto_create_pi_terminal(
                         session_id,
                         resource_registry,


### PR DESCRIPTION
## What

Follow-up addressing the review nitpicks on #569 (pi-native terminal honoring `os_env.sandbox`).

Both pi-native terminal auto-create paths wrapped `_resolve_session_agent_spec()` in
`except OmnigentError: ... = None`:

- the create-session auto-create path (`_run_create_session_terminal_ensure` pi branch), and
- the terminal "ensure" route.

On a genuine resolution error this silently launched the Pi terminal with `agent_spec=None`,
which falls back to the platform-default sandbox - the exact failure mode #569 set out to fix.

## Fix

- Remove the inner `except OmnigentError -> None` in both pi paths so a real resolution error
  propagates to the existing outer handler (which publishes / returns a native-terminal start
  error) instead of launching with an unknown sandbox policy.
  `_resolve_session_agent_spec()` returns `None` legitimately when a session has no spec; only
  genuine errors raise, so this does not change the no-spec case.
- Document the `agent_spec` parameter on `_auto_create_pi_terminal` (its role in sandbox
  inheritance).

## Scope

Intentionally scoped to pi-native. The claude/codex sibling auto-create paths swallow-and-log
deliberately because their spec carries bundled skills (losing it is cosmetic); the pi spec
carries `os_env.sandbox`, so failing loud is the right stance. Happy to extend uniformly if
maintainers prefer.

## Test

`pytest tests/runner/test_app_sessions_native.py -k "pi or inherits_agent_sandbox or os_env_from_spec or ensure"` - 16 passed (incl. `test_auto_create_pi_terminal_inherits_agent_sandbox`); no test relied on the old swallow-to-None-on-error behavior.
