### PR TITLE
docs(readme): list cursor-native and pi-native harnesses in agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ name: my_agent
 prompt: You are a helpful data analyst.
 
 executor:
-  harness: claude-sdk          # or: codex, codex-native, claude-native, cursor, openai-agents, pi, antigravity
+  harness: claude-sdk          # or: claude-native, codex, codex-native, cursor, cursor-native, openai-agents, pi, pi-native, antigravity
 
 tools:
   # A local Python function (schema auto-generated from the signature)


### PR DESCRIPTION
## Related issue

N/A — docs consistency fix with no associated issue.

## Summary

- The "Write your own agent" YAML example in `README.md` listed the native-CLI variants for Claude and Codex (`claude-native`, `codex-native`) but omitted them for Cursor and Pi.
- `cursor-native` and `pi-native` are first-class registered harnesses in `omnigent/runtime/harnesses/__init__.py` (`_HARNESS_MODULES`), each backed by its own implementation (e.g. `omnigent/cursor_native.py`, `omnigent/pi_native.py`).
- Adds the two missing native variants so all four native-CLI harnesses appear in the example, matching the registry.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Documentation-only change to a comment in `README.md`; no product code paths changed, so no automated or E2E tests were added.

Validation performed:
- Cross-checked the harness list against `omnigent/runtime/harnesses/__init__.py` (`_HARNESS_MODULES`) — confirmed `cursor-native` and `pi-native` are registered harnesses with backing modules.
- Confirmed the rendered Markdown still parses (single-line comment edit inside the existing fenced YAML block).

E2E coverage is not applicable because the change only corrects a documentation example and touches no runtime behaviour.