### PR TITLE
fix(web-ui): open links in HTML artifact previews in a new tab (#777)

### DIFF
--- a/ap-web/src/shell/CodeViewer.test.tsx
+++ b/ap-web/src/shell/CodeViewer.test.tsx
@@ -213,3 +213,25 @@ describe("CodeViewer truncated preview", () => {
     expect(screen.queryByText(/too large to load fully/)).toBeNull();
   });
 });
+
+describe("CodeViewer HTML preview link handling", () => {
+  // Regression for #777: links in a rendered HTML artifact did nothing on
+  // click because the preview iframe had sandbox="" (no popups) and links
+  // carried no target. The preview must inject a new-tab default and allow
+  // popups, while still withholding scripts and same-origin.
+  it("injects a new-tab base default and a popup-allowing sandbox", () => {
+    const { container } = renderViewer(
+      '<html><head></head><body><a href="https://example.com">x</a></body></html>',
+      true,
+      "report.html",
+      { viewMode: "preview" },
+    );
+    const iframe = container.querySelector('iframe[title="HTML preview"]');
+    expect(iframe).not.toBeNull();
+    expect(iframe!.getAttribute("srcdoc")).toContain('<base target="_blank">');
+    const sandbox = iframe!.getAttribute("sandbox") ?? "";
+    expect(sandbox).toContain("allow-popups");
+    expect(sandbox).not.toContain("allow-scripts");
+    expect(sandbox).not.toContain("allow-same-origin");
+  });
+});

--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -45,6 +45,7 @@ import {
   indexToLine,
   isBinaryPath,
   lineOverlapsSelection,
+  withBlankLinkTarget,
 } from "./codeViewerHelpers";
 import { renderLineTokens } from "./codeViewerRendering";
 import { TruncatedBanner } from "./TruncatedBanner";
@@ -392,8 +393,12 @@ export function CodeViewer({
         <MarkdownPreview content={content} />
       ) : (
         <iframe
-          srcDoc={content}
-          sandbox=""
+          srcDoc={withBlankLinkTarget(content)}
+          // Keep the preview script-less and origin-less (no allow-scripts /
+          // allow-same-origin). allow-popups lets a `target="_blank"` link
+          // actually open; allow-popups-to-escape-sandbox means the opened
+          // tab is a normal page, not itself sandboxed.
+          sandbox="allow-popups allow-popups-to-escape-sandbox"
           title="HTML preview"
           className="w-full h-full border-0"
         />

--- a/ap-web/src/shell/codeViewerHelpers.test.ts
+++ b/ap-web/src/shell/codeViewerHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   indexToLine,
   isBinaryPath,
   lineOverlapsSelection,
+  withBlankLinkTarget,
 } from "./codeViewerHelpers";
 
 // ---------------------------------------------------------------------------
@@ -66,6 +67,44 @@ describe("detectLang", () => {
     expect(detectLang("App.vue")).toBe("vue");
     expect(detectLang("schema.graphql")).toBe("graphql");
     expect(detectLang("Program.cs")).toBe("csharp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withBlankLinkTarget — make HTML-artifact preview links open in a new tab
+// ---------------------------------------------------------------------------
+
+describe("withBlankLinkTarget", () => {
+  it('injects <base target="_blank"> just inside an existing <head>', () => {
+    const html =
+      '<html><head><title>x</title></head><body><a href="/p">p</a></body></html>';
+    const out = withBlankLinkTarget(html);
+    expect(out).toBe(
+      '<html><head><base target="_blank"><title>x</title></head><body><a href="/p">p</a></body></html>',
+    );
+    // The <base> precedes the first link so it wins as the document default.
+    expect(out.indexOf("<base")).toBeLessThan(out.indexOf("<a "));
+  });
+
+  it("falls back to just after <html> when there is no <head>", () => {
+    const out = withBlankLinkTarget('<html><body><a href="/p">p</a></body></html>');
+    expect(out).toBe('<html><base target="_blank"><body><a href="/p">p</a></body></html>');
+  });
+
+  it("prepends when the fragment has neither <head> nor <html>", () => {
+    expect(withBlankLinkTarget('<a href="/p">p</a>')).toBe(
+      '<base target="_blank"><a href="/p">p</a>',
+    );
+  });
+
+  it("matches <head>/<html> case-insensitively and keeps attributes", () => {
+    const out = withBlankLinkTarget('<HTML><HEAD lang="en"></HEAD></HTML>');
+    expect(out).toBe('<HTML><HEAD lang="en"><base target="_blank"></HEAD></HTML>');
+  });
+
+  it("leaves a document that already declares its own <base> unchanged", () => {
+    const html = '<head><base href="/app/" target="_self"></head>';
+    expect(withBlankLinkTarget(html)).toBe(html);
   });
 });
 

--- a/ap-web/src/shell/codeViewerHelpers.ts
+++ b/ap-web/src/shell/codeViewerHelpers.ts
@@ -250,6 +250,34 @@ export function getSelectionOffsets(
   return { start_index, end_index };
 }
 
+/**
+ * Inject `<base target="_blank">` into an HTML-artifact preview so that
+ * links open in a new tab instead of trying to navigate the sandboxed
+ * preview iframe (which silently does nothing). A link that already names
+ * its own target keeps it — the injected `<base>` only supplies the default
+ * for links that don't set one.
+ *
+ * The tag is placed just after the opening `<head>` when one exists, else
+ * after `<html>`, else prepended — so it precedes any `<a>` and wins as the
+ * document default. Returns `html` unchanged when a `<base>` is already
+ * present (authored documents that set their own default are left alone).
+ */
+export function withBlankLinkTarget(html: string): string {
+  if (/<base\b/i.test(html)) return html;
+  const baseTag = '<base target="_blank">';
+  const headMatch = html.match(/<head\b[^>]*>/i);
+  if (headMatch) {
+    const at = headMatch.index! + headMatch[0].length;
+    return html.slice(0, at) + baseTag + html.slice(at);
+  }
+  const htmlMatch = html.match(/<html\b[^>]*>/i);
+  if (htmlMatch) {
+    const at = htmlMatch.index! + htmlMatch[0].length;
+    return html.slice(0, at) + baseTag + html.slice(at);
+  }
+  return baseTag + html;
+}
+
 /** Return the 1-based line number that contains `index` in `rawLines`. */
 export function indexToLine(index: number, rawLines: string[]): number {
   let remaining = index;

--- a/tests/e2e_ui/files/test_html_preview_links.py
+++ b/tests/e2e_ui/files/test_html_preview_links.py
@@ -1,0 +1,111 @@
+"""E2E: HTML-artifact preview opens links in a new tab.
+
+Regression for #777: a plain ``<a href>`` inside a rendered HTML artifact did
+nothing on click, because the preview iframe used ``sandbox=""`` (no popups,
+no top-navigation) and the links carried no ``target``. The fix injects
+``<base target="_blank">`` into the preview document and widens the iframe
+sandbox to ``allow-popups allow-popups-to-escape-sandbox`` so links open in a
+new tab. Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_HTML_FILE_PATH = "report.html"
+
+# A minimal HTML artifact with a single external link that names no target.
+_HTML_CONTENT = """\
+<!doctype html>
+<html>
+  <head><title>Report</title></head>
+  <body>
+    <h1>Quarterly Report</h1>
+    <a href="https://example.databricks.com/docs">project homepage</a>
+  </body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_html_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str, str]]:
+    """Seed the HTML file and yield (base_url, session_id, path).
+
+    :param seeded_session: Runner-bound (base_url, session_id) pair.
+    :returns: ``(base_url, session_id, file_path)`` for the test body.
+    """
+    base_url, session_id = seeded_session
+    file_url = (
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_HTML_FILE_PATH}"
+    )
+    resp = httpx.put(
+        file_url,
+        json={"content": _HTML_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    yield (base_url, session_id, _HTML_FILE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_html_preview_links_open_in_new_tab(
+    page: Page,
+    seeded_html_session: tuple[str, str, str],
+) -> None:
+    """The HTML preview iframe defaults links to a new tab and allows popups."""
+    base_url, session_id, _file_path = seeded_html_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    file_button = page.get_by_role("button", name=re.compile(rf"^{re.escape(_HTML_FILE_PATH)}\b"))
+    expect(file_button).to_be_visible(timeout=30_000)
+    file_button.click()
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    # HTML files default to the preview surface (no rich-text editor mode), so
+    # the iframe is present without toggling.
+    preview = file_viewer.locator('iframe[title="HTML preview"]')
+    expect(preview).to_be_visible(timeout=10_000)
+
+    # The sandbox must permit popups (so target=_blank actually opens) while
+    # still withholding scripts and same-origin access.
+    sandbox = preview.get_attribute("sandbox")
+    assert sandbox is not None
+    assert "allow-popups" in sandbox
+    assert "allow-scripts" not in sandbox
+    assert "allow-same-origin" not in sandbox
+
+    # The injected <base target="_blank"> makes the un-targeted link default to
+    # a new tab; without it the click would no-op inside the sandboxed frame.
+    srcdoc = preview.get_attribute("srcdoc")
+    assert srcdoc is not None
+    assert '<base target="_blank">' in srcdoc
+
+    # And the link resolves to a new-tab navigation at the DOM level inside the
+    # frame (the <base> default applies; the anchor itself names no target).
+    frame = preview.content_frame
+    assert frame is not None
+    link = frame.locator('a:has-text("project homepage")')
+    expect(link).to_have_attribute("href", "https://example.databricks.com/docs")


### PR DESCRIPTION
## What

Fixes #777. Clicking a link inside a rendered HTML artifact did nothing unless the link explicitly set `target="_blank"`.

## Why

The HTML-artifact preview renders into an iframe with `sandbox=""` (`ap-web/src/shell/CodeViewer.tsx`). An empty sandbox blocks **both** top-navigation and popups, so an un-targeted `<a href>`:

- can only navigate the iframe itself — pointless in the small preview pane, and
- a `target="_blank"` popup is denied outright (no `allow-popups`).

Net effect: links appear dead.

## Fix

- Inject `<base target="_blank">` into the preview document so every link that doesn't name its own target defaults to opening in a new tab. A document that already declares a `<base>` is left untouched.
- Widen the iframe sandbox to `allow-popups allow-popups-to-escape-sandbox` so that new tab can actually open, and the opened page is a normal (un-sandboxed) tab.

Scripts and same-origin remain withheld (`allow-scripts` / `allow-same-origin` are **not** added), so the preview gains no new code-execution capability — this is purely a navigation fix.

## Tests

- `withBlankLinkTarget` is a pure helper in `codeViewerHelpers.ts` with unit tests (`<head>` / `<html>` / bare-fragment / case-insensitivity / pre-existing-`<base>` cases).
- A `CodeViewer` component test locks the iframe wiring (base default present, popups allowed, scripts/same-origin withheld).
- A Playwright test under `tests/e2e_ui/files/test_html_preview_links.py` seeds an `.html` artifact and asserts the rendered preview iframe.

All pass locally: `ap-web` vitest (CodeViewer + helpers), `tsc --noEmit`, eslint, and the new `e2e_ui` test against the built SPA.

This pull request and its description were written by Isaac.