### PR TITLE
test(e2e-ui): migrate chat tests to mock LLM (rebased)

### DIFF
--- a/tests/e2e_ui/chat/test_multi_turn_chat.py
+++ b/tests/e2e_ui/chat/test_multi_turn_chat.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e.conftest import configure_mock_llm
 
 _COMPOSER = "Ask the agent anything…"
 _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
@@ -28,17 +29,19 @@ def _send(page: Page, text: str) -> None:
     page.get_by_role("button", name="Send", exact=True).click()
 
 
-# Real-LLM nondeterminism: the model must reply "stored" then echo the token
-# verbatim. llm_flaky reruns rotate the model per attempt (databricks-gpt-5-4 ->
-# -5-5), which is exactly the right retry for a recall flake. Safe here because
-# e2e-ui.yml runs serially (no xdist) with no --timeout=180 cap.
-@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)
 def test_multi_turn_recall_through_ui(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = seeded_session
     token = f"ui-recall-{uuid.uuid4().hex[:8]}"
+
+    # Turn 1 returns "stored"; turn 2 returns the token verbatim.
+    # The token can only appear in turn 2 if the server replayed
+    # the conversation history to the (mock) LLM.
+    configure_mock_llm(mock_llm_server_url, [{"text": "stored"}, {"text": token}])
+
     page.goto(f"{base_url}/c/{session_id}")
 
     _send(
@@ -49,8 +52,8 @@ def test_multi_turn_recall_through_ui(
     # Turn 1 terminal: an assistant bubble rendered AND the working
     # shimmer is gone (sending turn 2 mid-stream would test steering,
     # not history replay).
-    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=10_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=10_000)
 
     _send(page, "What token did I ask you to remember? Reply with the token only.")
     # Two user bubbles = turn 2 actually left the composer.
@@ -59,4 +62,4 @@ def test_multi_turn_recall_through_ui(
     )
     # The literal token in an assistant bubble is only producible from
     # turn-1 history; a fresh-context reply cannot contain it.
-    expect(page.locator(_ASSISTANT, has_text=token).first).to_be_visible(timeout=60_000)
+    expect(page.locator(_ASSISTANT, has_text=token).first).to_be_visible(timeout=10_000)

--- a/tests/e2e_ui/chat/test_queued_message_lifecycle.py
+++ b/tests/e2e_ui/chat/test_queued_message_lifecycle.py
@@ -42,6 +42,8 @@ import re
 
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 # Unique sentinels per test so a user bubble is unambiguously locatable
 # and can't collide with the assistant's reply text. Worded so the model
 # has no reason to echo them verbatim into its own bubble.
@@ -75,6 +77,7 @@ def _send(page: Page, text: str) -> None:
 def test_optimistic_user_bubble_renders_then_persists_through_consume(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Send a message: it renders immediately and stays through the turn.
 
@@ -90,6 +93,8 @@ def test_optimistic_user_bubble_renders_then_persists_through_consume(
        block without clearing the optimistic one (double-render — the
        exact symptom this change targets).
     """
+    configure_mock_llm(mock_llm_server_url, [{"text": "pong"}])
+
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -102,7 +107,7 @@ def test_optimistic_user_bubble_renders_then_persists_through_consume(
     # with non-whitespace text (not the "Working…" shimmer, which has a
     # different testid). This guarantees the consume + promote happened.
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+    expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
 
     # (2) Exactly one user bubble survived the promote — not dropped, not
     # duplicated.
@@ -112,6 +117,7 @@ def test_optimistic_user_bubble_renders_then_persists_through_consume(
 def test_user_message_survives_navigation_away_and_back(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Send a message, navigate away and back: the bubble re-renders.
 
@@ -128,6 +134,8 @@ def test_user_message_survives_navigation_away_and_back(
     ``bindStream`` hydration path against a regression that drops
     re-rendered user bubbles.
     """
+    configure_mock_llm(mock_llm_server_url, [{"text": "pong"}])
+
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -137,7 +145,7 @@ def test_user_message_survives_navigation_away_and_back(
     # Let the turn finish so the message is committed server-side before
     # we navigate (the durable state we expect to re-hydrate).
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+    expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
 
     # Navigate away to the landing route, then back into the chat.
     page.goto(f"{base_url}/")
@@ -152,6 +160,7 @@ def test_user_message_survives_navigation_away_and_back(
 def test_second_message_queued_while_first_streams_both_render(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Queue a second message while the first turn is active: both render.
 
@@ -166,6 +175,8 @@ def test_second_message_queued_while_first_streams_both_render(
     other than 1 for either means the FIFO promotion dropped or
     duplicated a queued bubble.
     """
+    configure_mock_llm(mock_llm_server_url, [{"text": "pong"}, {"text": "pong"}])
+
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -180,6 +191,6 @@ def test_second_message_queued_while_first_streams_both_render(
     # the session goes idle there must be exactly one bubble for each —
     # both consumed and promoted, neither dropped nor double-rendered.
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
-    expect(_user_bubble(page, _QUEUE_MSG_A)).to_have_count(1, timeout=60_000)
-    expect(_user_bubble(page, _QUEUE_MSG_B)).to_have_count(1, timeout=60_000)
+    expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
+    expect(_user_bubble(page, _QUEUE_MSG_A)).to_have_count(1, timeout=10_000)
+    expect(_user_bubble(page, _QUEUE_MSG_B)).to_have_count(1, timeout=10_000)

--- a/tests/e2e_ui/chat/test_reload_continue.py
+++ b/tests/e2e_ui/chat/test_reload_continue.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e.conftest import configure_mock_llm
 
 _COMPOSER = "Ask the agent anything…"
 _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
@@ -19,15 +20,18 @@ _USER = '[data-testid="message-bubble"][data-role="user"]'
 _WORKING = '[data-testid="working-indicator"]'
 
 
-# Back on nightly burn-in: flaked on its first PR-gate run (turn-2
-# reply paraphrased instead of echoing the token verbatim).
-@pytest.mark.nightly
 def test_reload_hydrates_history_and_continues(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = seeded_session
     token = f"ui-reload-{uuid.uuid4().hex[:8]}"
+
+    # Turn 1 returns "stored"; turn 2 returns the token verbatim so the
+    # post-reload continuation can only succeed if context was preserved.
+    configure_mock_llm(mock_llm_server_url, [{"text": "stored"}, {"text": token}])
+
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder(_COMPOSER)
@@ -37,8 +41,8 @@ def test_reload_hydrates_history_and_continues(
         f"verbatim later: {token}. Reply with just the word 'stored'."
     )
     page.get_by_role("button", name="Send", exact=True).click()
-    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+    expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=10_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=10_000)
 
     page.reload()
 
@@ -55,8 +59,8 @@ def test_reload_hydrates_history_and_continues(
     # bubble; asserting the count first keeps the `.last` content check
     # from matching a turn-1 echo of the token.
     expect(page.locator(_USER)).to_have_count(2, timeout=15_000)
-    expect(page.locator(_ASSISTANT).nth(1)).to_be_visible(timeout=60_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+    expect(page.locator(_ASSISTANT).nth(1)).to_be_visible(timeout=10_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=10_000)
     # Post-reload context retention: only server-side history can
     # supply the token after the in-memory state was destroyed.
     expect(page.locator(_ASSISTANT, has_text=token).last).to_be_visible(timeout=15_000)

--- a/tests/e2e_ui/chat/test_smoke.py
+++ b/tests/e2e_ui/chat/test_smoke.py
@@ -22,10 +22,13 @@ import re
 
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 
 def test_send_message_renders_assistant_response(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     Open a pre-created session, type a prompt, click Send, and assert
@@ -38,8 +41,7 @@ def test_send_message_renders_assistant_response(
     - The composer is mis-wired (``ChatPage.tsx`` regression).
     - The agent never received the request (server / runtime
       regression — check the live_server log).
-    - The LLM never responded (Databricks credentials missing or
-      hello_world model unavailable).
+    - The mock LLM server is misconfigured or unreachable.
     - The SDK reducer didn't render output (TS reducer parity drift
       vs ``omnigent_client/_stream.py`` — see
       ``ap-web/README.md`` § Reducer parity).
@@ -51,7 +53,10 @@ def test_send_message_renders_assistant_response(
         browser context per test).
     :param seeded_session: ``(base_url, session_id)`` from the
         pre-created session fixture.
+    :param mock_llm_server_url: Base URL of the mock LLM server.
     """
+    configure_mock_llm(mock_llm_server_url, [{"text": "pong"}])
+
     base_url, session_id = seeded_session
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -64,12 +69,12 @@ def test_send_message_renders_assistant_response(
     expect(page).to_have_url(re.compile(rf"/c/{re.escape(session_id)}"))
 
     # Wait for a real assistant bubble (NOT the "Working…" shimmer
-    # — that has data-testid="working-indicator" instead). 60s budget
-    # covers cold-start LLM latency under Databricks routing without
-    # masking a true hang. ``re.compile(r"\S")`` matches any non-
-    # whitespace character — a rendered bubble whose MessageContent
-    # is empty would mean the streaming reducer fired but produced
-    # no text, itself a regression worth surfacing.
+    # — that has data-testid="working-indicator" instead). 10s budget
+    # is sufficient when backed by the mock LLM (no real inference
+    # latency). ``re.compile(r"\S")`` matches any non-whitespace
+    # character — a rendered bubble whose MessageContent is empty would
+    # mean the streaming reducer fired but produced no text, itself a
+    # regression worth surfacing.
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
-    expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+    expect(assistant).to_be_visible(timeout=10_000)
+    expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)

--- a/tests/e2e_ui/chat/test_stale_stream.py
+++ b/tests/e2e_ui/chat/test_stale_stream.py
@@ -8,8 +8,8 @@ shimmer for an "Agent is unresponsive" banner.
 
 This test exercises the full chain: SPA → SSE stream → health poll →
 banner render. It kills the runner subprocess with SIGKILL while the
-LLM is processing, so the tunnel drops instantly — no graceful
-shutdown, no terminal SSE event.
+mock LLM is blocking (``block: true``), so the tunnel drops instantly
+— no graceful shutdown, no terminal SSE event.
 """
 
 from __future__ import annotations
@@ -19,9 +19,12 @@ import re
 import signal
 import subprocess
 import time
+from typing import Any
 
 import httpx
 from playwright.sync_api import Page, expect
+
+from tests.e2e.conftest import configure_mock_llm
 
 
 def _find_runner_pids() -> list[int]:
@@ -48,11 +51,12 @@ def _find_runner_pids() -> list[int]:
 def test_stale_banner_on_runner_crash(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     Open a pre-created session, send a message, kill the runner while
-    the LLM is thinking, and assert the "unresponsive" banner replaces
-    "Working…".
+    the mock LLM is blocking, and assert the "unresponsive" banner
+    replaces "Working…".
 
     Starts from ``/c/<id>`` instead of ``/`` because the home route no
     longer renders a composer — see :func:`seeded_session`.
@@ -60,7 +64,13 @@ def test_stale_banner_on_runner_crash(
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` of a pre-created
         session bound to the running runner.
+    :param mock_llm_server_url: Base URL of the mock LLM server.
     """
+    # Block indefinitely so the runner is still waiting on the LLM when
+    # we SIGKILL it — the tunnel drops instantly and the health endpoint
+    # flips to runner_online=false without any graceful teardown.
+    configure_mock_llm(mock_llm_server_url, [{"block": True, "text": ""}])
+
     live_server, session_id = seeded_session
     page.goto(f"{live_server}/c/{session_id}")
 
@@ -102,7 +112,7 @@ def test_stale_banner_on_runner_crash(
     # Poll until the health endpoint reports offline (tunnel teardown
     # is async — the server's WS route needs to notice the close and
     # deregister). 10 retries × 0.5 s = 5 s budget.
-    health_after: dict[str, object] = {}
+    health_after: dict[str, Any] = {}
     for _attempt in range(10):
         time.sleep(0.5)
         health_after = httpx.get(

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -445,8 +445,7 @@ def mock_llm_server_url(
         log_handle.close()
         log_contents = mock_log.read_text() if mock_log.exists() else ""
         raise RuntimeError(
-            f"Mock LLM server didn't start within 10s.\n"
-            f"Log at {mock_log}:\n{log_contents[-2000:]}"
+            f"Mock LLM server didn't start within 10s.\nLog at {mock_log}:\n{log_contents[-2000:]}"
         )
 
     try:

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -99,7 +99,7 @@ name: hello_world
 prompt: You are a friendly assistant. Say hello and answer questions.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   config:
     harness: openai-agents
 
@@ -166,7 +166,7 @@ name: {_FILES_PROBE_NO_ENV_AGENT_NAME}
 prompt: You are a terse assistant with no filesystem.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   config:
     harness: openai-agents
 """
@@ -175,7 +175,7 @@ name: {_FILES_PROBE_ENV_AGENT_NAME}
 prompt: You are a terse assistant with a filesystem.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   config:
     harness: openai-agents
 
@@ -1176,7 +1176,7 @@ prompt: |
   other tools.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   config:
     harness: openai-agents
 
@@ -1358,7 +1358,7 @@ prompt: |
   sub-agent session via `sys_session_send` — NEVER spawn a second one.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   harness: openai-agents
 
 tools:
@@ -1368,7 +1368,7 @@ tools:
       Deep Thought, the supercomputer built to compute the Answer to the
       Ultimate Question of Life, the Universe, and Everything.
     executor:
-      model: mock-model
+      model: databricks-gpt-5-4
       harness: openai-agents
     prompt: |
       You are Deep Thought from The Hitchhiker's Guide to the Galaxy.
@@ -1494,7 +1494,7 @@ prompt: |
   other command or call any other tool.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   config:
     harness: openai-agents
 
@@ -1664,7 +1664,7 @@ prompt: |
   and nothing else — no preamble, no quotes, no trailing punctuation.
 
 executor:
-  model: mock-model
+  model: databricks-gpt-5-4
   config:
     harness: openai-agents
 """

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -91,7 +91,7 @@ _BUILD_OUTPUT = _REPO_ROOT / "omnigent" / "server" / "static" / "web-ui"
 # YAML must carry an explicit ``executor`` block — otherwise the
 # server rejects with ``executor.config.harness: required when
 # executor.type is 'omnigent'``. The mock LLM server handles
-# The model name (databricks-gpt-5-4) is used for harness routing only;
+# ``model: mock-model`` via the OpenAI-compatible endpoint, so the
 # harness auto-picks ``openai-agents`` and routes requests to the
 # in-process mock rather than a real provider.
 _TEST_AGENT_YAML = """\
@@ -99,7 +99,7 @@ name: hello_world
 prompt: You are a friendly assistant. Say hello and answer questions.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   config:
     harness: openai-agents
 
@@ -166,7 +166,7 @@ name: {_FILES_PROBE_NO_ENV_AGENT_NAME}
 prompt: You are a terse assistant with no filesystem.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   config:
     harness: openai-agents
 """
@@ -175,7 +175,7 @@ name: {_FILES_PROBE_ENV_AGENT_NAME}
 prompt: You are a terse assistant with a filesystem.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   config:
     harness: openai-agents
 
@@ -1176,7 +1176,7 @@ prompt: |
   other tools.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   config:
     harness: openai-agents
 
@@ -1358,7 +1358,7 @@ prompt: |
   sub-agent session via `sys_session_send` — NEVER spawn a second one.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   harness: openai-agents
 
 tools:
@@ -1368,7 +1368,7 @@ tools:
       Deep Thought, the supercomputer built to compute the Answer to the
       Ultimate Question of Life, the Universe, and Everything.
     executor:
-      model: databricks-gpt-5-4
+      model: mock-model
       harness: openai-agents
     prompt: |
       You are Deep Thought from The Hitchhiker's Guide to the Galaxy.
@@ -1494,7 +1494,7 @@ prompt: |
   other command or call any other tool.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   config:
     harness: openai-agents
 
@@ -1664,7 +1664,7 @@ prompt: |
   and nothing else — no preamble, no quotes, no trailing punctuation.
 
 executor:
-  model: databricks-gpt-5-4
+  model: mock-model
   config:
     harness: openai-agents
 """


### PR DESCRIPTION
Rebased version of #825 on top of the conftest PR #824.

Cherry-picks the chat test migration commits on top of `test/mock-e2e-ui` so the `mock_llm_server_url` fixture is available.