### PR TITLE
test(e2e-ui): migrate approval/collaboration tests to mock LLM (rebased)

### DIFF
--- a/tests/e2e_ui/approvals/test_approval_card.py
+++ b/tests/e2e_ui/approvals/test_approval_card.py
@@ -10,8 +10,8 @@ its "Approved" responded state and the server clears the pending prompt.
 
 The ``approval_session`` fixture (conftest) supplies an agent whose
 ``blast_radius`` guardrail gates pushes; the gate fires on the *tool call*,
-so the push never has to succeed. Real LLM in the loop → nightly + a
-generous timeout, matching the other agent-driven UI suites.
+so the push never has to succeed. Mock LLM in the loop so the suite is
+deterministic and fast.
 """
 
 from __future__ import annotations
@@ -22,13 +22,14 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _APPROVAL_CARD = '[data-testid="approval-card"]'
 
-# The agent must boot, take a turn, and emit the gated tool call before the
-# card appears — cold-start can be slow, so allow well past the streaming
-# default but under the test's 600s ceiling.
-_AGENT_TURN_TIMEOUT_MS = 120_000
+# With the mock LLM the tool call arrives almost immediately; 10 s is
+# generous enough to cover the SSE publish + React render cycle.
+_AGENT_TURN_TIMEOUT_MS = 10_000
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -38,18 +39,34 @@ def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
     return resp.json().get("pending_elicitations") or []
 
 
-@pytest.mark.nightly
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_approval_card_renders_and_approves(
     page: Page,
     approval_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Gated tool call → pending approval card → Approve → resolved."""
     base_url, session_id = approval_session
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "c1",
+                        "name": "sys_os_shell",
+                        "arguments": '{"command": "git push origin main"}',
+                    }
+                ]
+            }
+        ],
+    )
+
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder(_COMPOSER)
-    expect(composer).to_be_visible(timeout=30_000)
+    expect(composer).to_be_visible(timeout=10_000)
     composer.fill("Run the command now.")
     page.get_by_role("button", name="Send", exact=True).click()
 
@@ -65,23 +82,39 @@ def test_approval_card_renders_and_approves(
     # Card transitions to the responded "Approved" state and the parked
     # server-side prompt drains.
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
-    expect(responded).to_be_visible(timeout=30_000)
+    expect(responded).to_be_visible(timeout=10_000)
     expect(responded.get_by_text("Approved", exact=False).first).to_be_visible()
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))
 
 
-@pytest.mark.nightly
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_approval_card_reject(
     page: Page,
     approval_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Rejecting a pending approval flips the card to the rejected state."""
     base_url, session_id = approval_session
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "c1",
+                        "name": "sys_os_shell",
+                        "arguments": '{"command": "git push origin main"}',
+                    }
+                ]
+            }
+        ],
+    )
+
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder(_COMPOSER)
-    expect(composer).to_be_visible(timeout=30_000)
+    expect(composer).to_be_visible(timeout=10_000)
     composer.fill("Run the command now.")
     page.get_by_role("button", name="Send", exact=True).click()
 
@@ -90,7 +123,7 @@ def test_approval_card_reject(
     card.get_by_role("button", name="Reject").click()
 
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
-    expect(responded).to_be_visible(timeout=30_000)
+    expect(responded).to_be_visible(timeout=10_000)
     expect(responded.get_by_text("Rejected", exact=False).first).to_be_visible()
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))
 

--- a/tests/e2e_ui/approvals/test_approve_hotkey.py
+++ b/tests/e2e_ui/approvals/test_approve_hotkey.py
@@ -14,8 +14,8 @@ resolves the approval regardless of where focus sits after Send.
 
 The ``approval_session`` fixture (conftest) supplies an agent whose
 ``blast_radius`` guardrail gates pushes; the gate fires on the *tool call*, so
-the push never has to succeed. Real LLM in the loop -> nightly + a generous
-timeout, matching the other agent-driven UI suites.
+the push never has to succeed. Mock LLM in the loop so the suite is
+deterministic and fast.
 """
 
 from __future__ import annotations
@@ -26,13 +26,14 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _APPROVAL_CARD = '[data-testid="approval-card"]'
 
-# The agent must boot, take a turn, and emit the gated tool call before the
-# card appears — cold-start can be slow, so allow well past the streaming
-# default but under the test's 600s ceiling.
-_AGENT_TURN_TIMEOUT_MS = 120_000
+# With the mock LLM the tool call arrives almost immediately; 10 s is
+# generous enough to cover the SSE publish + React render cycle.
+_AGENT_TURN_TIMEOUT_MS = 10_000
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -42,18 +43,34 @@ def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
     return resp.json().get("pending_elicitations") or []
 
 
-@pytest.mark.nightly
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_ctrl_enter_accepts_pending_approval(
     page: Page,
     approval_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Gated tool call → pending card → Ctrl+Enter → resolved 'Approved'."""
     base_url, session_id = approval_session
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "c1",
+                        "name": "sys_os_shell",
+                        "arguments": '{"command": "git push origin main"}',
+                    }
+                ]
+            }
+        ],
+    )
+
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder(_COMPOSER)
-    expect(composer).to_be_visible(timeout=30_000)
+    expect(composer).to_be_visible(timeout=10_000)
     composer.fill("Run the command now.")
     page.get_by_role("button", name="Send", exact=True).click()
 
@@ -73,7 +90,7 @@ def test_ctrl_enter_accepts_pending_approval(
     # Card transitions to the responded "Approved" state and the parked
     # server-side prompt drains — same resolution the button click produces.
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
-    expect(responded).to_be_visible(timeout=30_000)
+    expect(responded).to_be_visible(timeout=10_000)
     expect(responded.get_by_text("Approved", exact=False).first).to_be_visible()
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))
 

--- a/tests/e2e_ui/approvals/test_approve_page.py
+++ b/tests/e2e_ui/approvals/test_approve_page.py
@@ -4,15 +4,15 @@ A policy ASK can be answered three ways: the in-chat ``ApprovalCard``
 (``test_approval_card.py``), the ``/inbox`` page (``test_inbox_approval.py``),
 and the standalone approval page (``pages/ApprovePage.tsx``) — the URL the REPL
 prints when a policy returns ASK in URL mode, openable by anyone with the link
-and no surrounding app shell. This suite covers that third surface: park a real
-gated-push ASK, navigate straight to ``/approve/<sid>/<eid>``, and resolve it
-there.
+and no surrounding app shell. This suite covers that third surface: park a
+mock-LLM-driven gated-push ASK, navigate straight to ``/approve/<sid>/<eid>``,
+and resolve it there.
 
 The page fetches the elicitation from ``GET /v1/sessions/<sid>/elicitations/<eid>``
 and posts the verdict to the matching ``/resolve`` endpoint — the same backing
 calls the inline card uses, just on a bare route. Driven by the same
-``approval_session`` fixture as the in-chat card test (real LLM emits the gated
-``git push``), so it carries a generous per-test timeout.
+``approval_session`` fixture as the in-chat card test with a mock LLM, so the
+suite runs fast and deterministically.
 
 The load-bearing assertion is that the server's parked prompt drains after the
 page's Approve / Reject — proof the standalone route resolves the *same*
@@ -27,11 +27,13 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _APPROVAL_CARD = '[data-testid="approval-card"]'
-# The agent must boot, take a turn, and emit the gated tool call before the
-# elicitation parks — cold-start can be slow, under the test's 600s ceiling.
-_AGENT_TURN_TIMEOUT_MS = 120_000
+# With the mock LLM the tool call arrives almost immediately; 10 s is
+# generous enough to cover the SSE publish + React render cycle.
+_AGENT_TURN_TIMEOUT_MS = 10_000
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -52,22 +54,43 @@ def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.25):
     raise AssertionError("condition not met within timeout")
 
 
-def _park_elicitation(page: Page, base_url: str, session_id: str) -> str:
+def _park_elicitation(
+    page: Page,
+    base_url: str,
+    session_id: str,
+    mock_llm_server_url: str,
+) -> str:
     """Drive the agent to a parked gated-push ASK and return its elicitation id.
 
-    Sends the deterministic "run the command" turn the ``approval_session``
-    agent answers with a gated ``git push``, waits for the in-chat pending card
-    (proof the gate fired), then reads the elicitation id from the session
-    snapshot's ``pending_elicitations`` (each event carries ``elicitation_id``).
+    Configures the mock LLM to return a ``sys_os_shell git push`` tool call
+    (which the ``blast_radius`` guardrail ASKs about), sends a turn, waits for
+    the in-chat pending card (proof the gate fired), then reads the elicitation
+    id from the session snapshot's ``pending_elicitations``.
 
     :param page: Playwright page used to send the chat turn.
     :param base_url: Spawned server base URL.
     :param session_id: The approval session id.
+    :param mock_llm_server_url: Mock LLM server URL for configuration.
     :returns: The parked elicitation's id, e.g. ``"elicit_ab12..."``.
     """
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "c1",
+                        "name": "sys_os_shell",
+                        "arguments": '{"command": "git push origin main"}',
+                    }
+                ]
+            }
+        ],
+    )
     page.goto(f"{base_url}/c/{session_id}")
     composer = page.get_by_placeholder(_COMPOSER)
-    expect(composer).to_be_visible(timeout=30_000)
+    expect(composer).to_be_visible(timeout=10_000)
     composer.fill("Run the command now.")
     page.get_by_role("button", name="Send", exact=True).click()
 
@@ -80,46 +103,48 @@ def _park_elicitation(page: Page, base_url: str, session_id: str) -> str:
     return elicitation_id
 
 
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_approve_page_approves(
     page: Page,
     approval_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Standalone page renders the pending prompt and Approve drains it."""
     base_url, session_id = approval_session
-    elicitation_id = _park_elicitation(page, base_url, session_id)
+    elicitation_id = _park_elicitation(page, base_url, session_id, mock_llm_server_url)
 
     page.goto(f"{base_url}/approve/{session_id}/{elicitation_id}")
-    expect(page.get_by_text("Approval required")).to_be_visible(timeout=30_000)
+    expect(page.get_by_text("Approval required")).to_be_visible(timeout=10_000)
 
     page.get_by_role("button", name="Approve").click()
 
     # The page confirms the verdict and the server drains the parked prompt.
-    expect(page.get_by_text("Approved", exact=False).first).to_be_visible(timeout=30_000)
+    expect(page.get_by_text("Approved", exact=False).first).to_be_visible(timeout=10_000)
     expect(page.get_by_text("You can close this page.")).to_be_visible()
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))
 
 
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_approve_page_rejects(
     page: Page,
     approval_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Reject on the standalone page also drains the parked prompt."""
     base_url, session_id = approval_session
-    elicitation_id = _park_elicitation(page, base_url, session_id)
+    elicitation_id = _park_elicitation(page, base_url, session_id, mock_llm_server_url)
 
     page.goto(f"{base_url}/approve/{session_id}/{elicitation_id}")
-    expect(page.get_by_text("Approval required")).to_be_visible(timeout=30_000)
+    expect(page.get_by_text("Approval required")).to_be_visible(timeout=10_000)
 
     page.get_by_role("button", name="Reject").click()
 
-    expect(page.get_by_text("Rejected", exact=False).first).to_be_visible(timeout=30_000)
+    expect(page.get_by_text("Rejected", exact=False).first).to_be_visible(timeout=10_000)
     expect(page.get_by_text("You can close this page.")).to_be_visible()
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))
 
 
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_approve_page_resolved_for_unknown_elicitation(
     page: Page,
     approval_session: tuple[str, str],
@@ -133,5 +158,5 @@ def test_approve_page_resolved_for_unknown_elicitation(
     base_url, session_id = approval_session
     page.goto(f"{base_url}/approve/{session_id}/elicit_does_not_exist")
 
-    expect(page.get_by_text("Elicitation resolved")).to_be_visible(timeout=30_000)
+    expect(page.get_by_text("Elicitation resolved")).to_be_visible(timeout=10_000)
     expect(page.get_by_role("button", name="Approve")).to_have_count(0)

--- a/tests/e2e_ui/approvals/test_inbox_approval.py
+++ b/tests/e2e_ui/approvals/test_inbox_approval.py
@@ -9,7 +9,7 @@ approves it from the inbox, and asserts the item drains (the row's pending
 count drops to zero, so it falls out of the inbox).
 
 Driven by the same ``approval_session`` fixture as the in-chat card test;
-real LLM → nightly + generous timeout.
+mock LLM for fast, deterministic execution.
 """
 
 from __future__ import annotations
@@ -20,10 +20,12 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _APPROVAL_CARD = '[data-testid="approval-card"]'
 _INBOX_ITEM = '[data-testid="inbox-item"]'
-_AGENT_TURN_TIMEOUT_MS = 120_000
+_AGENT_TURN_TIMEOUT_MS = 10_000
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -43,19 +45,34 @@ def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) ->
     raise AssertionError("condition not met within timeout")
 
 
-@pytest.mark.nightly
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_pending_approval_surfaces_and_resolves_in_inbox(
     page: Page,
     approval_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Gated tool call → /inbox lists the prompt → Approve there → it drains."""
     base_url, session_id = approval_session
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "c1",
+                        "name": "sys_os_shell",
+                        "arguments": '{"command": "git push origin main"}',
+                    }
+                ]
+            }
+        ],
+    )
 
     # Raise the approval from the chat surface, then leave it pending.
     page.goto(f"{base_url}/c/{session_id}")
     composer = page.get_by_placeholder(_COMPOSER)
-    expect(composer).to_be_visible(timeout=30_000)
+    expect(composer).to_be_visible(timeout=10_000)
     composer.fill("Run the command now.")
     page.get_by_role("button", name="Send", exact=True).click()
     expect(page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first).to_be_visible(
@@ -67,7 +84,7 @@ def test_pending_approval_surfaces_and_resolves_in_inbox(
     # The inbox gathers the prompt from the session's snapshot.
     page.goto(f"{base_url}/inbox")
     item = page.locator(_INBOX_ITEM).first
-    expect(item).to_be_visible(timeout=30_000)
+    expect(item).to_be_visible(timeout=10_000)
     card = item.locator(_APPROVAL_CARD)
     expect(card).to_be_visible()
     expect(card.get_by_text("Approval required")).to_be_visible()
@@ -77,4 +94,4 @@ def test_pending_approval_surfaces_and_resolves_in_inbox(
     # the item falls out of the inbox.
     card.get_by_role("button", name="Approve").click()
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))
-    expect(page.locator(_INBOX_ITEM)).to_have_count(0, timeout=30_000)
+    expect(page.locator(_INBOX_ITEM)).to_have_count(0, timeout=10_000)

--- a/tests/e2e_ui/collaboration/test_author_label.py
+++ b/tests/e2e_ui/collaboration/test_author_label.py
@@ -32,9 +32,10 @@ Scenario 3 – terminal-typed message (``external_conversation_item``):
   Posted as Alice, viewed by Bob — the badge must appear, pinning the
   ``_persist_external_conversation_item`` ``created_by`` fix.
 
-These tests drive the full browser → SPA → server stack against a real
-LLM.  They are excluded from the default ``pytest`` run and gated to
-``workflow_dispatch`` CI, like the rest of the e2e_ui suite.
+These tests drive the full browser → SPA → server stack against a mock
+LLM.  They are excluded from the default ``pytest`` run via
+``--ignore=tests/e2e_ui`` in ``pyproject.toml`` and gated to
+``workflow_dispatch`` CI for now.
 
 Selectors:
   - user bubbles: ``data-testid="message-bubble"`` + ``data-role="user"``
@@ -50,6 +51,8 @@ import uuid
 
 import httpx
 from playwright.sync_api import Browser, Page, expect
+
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
 
 # Unique per test run to avoid cross-test pollution in a long-lived
 # server process.
@@ -110,6 +113,7 @@ def _user_bubble(page: Page, text: str):
 def test_author_badge_hidden_in_solo_session(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Author badge is never rendered when there is no user identity.
 
@@ -128,8 +132,12 @@ def test_author_badge_hidden_in_solo_session(
     :param page: Playwright page (no extra headers — default local identity).
     :param seeded_session: ``(base_url, session_id)`` for a runner-bound
         session created by the fixture.
+    :param mock_llm_server_url: Mock LLM server URL.
     """
     base_url, session_id = seeded_session
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "ack"}])
+
     page.goto(f"{base_url}/c/{session_id}")
 
     marker = f"solo-author-{uuid.uuid4().hex[:8]}"
@@ -147,7 +155,7 @@ def test_author_badge_hidden_in_solo_session(
     # Wait for the turn to complete so session.input.consumed fired and
     # the bubble is now committed.
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+    expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
 
     # Still no badge on the committed bubble.
     expect(_user_bubble(page, marker).get_by_test_id("message-author")).to_have_count(0)
@@ -156,6 +164,7 @@ def test_author_badge_hidden_in_solo_session(
 def test_author_badge_skips_own_messages_and_marks_peers(
     browser: Browser,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Own messages carry no badge; a peer sees the author's avatar.
 
@@ -177,10 +186,14 @@ def test_author_badge_skips_own_messages_and_marks_peers(
         with Alice's and Bob's headers are created and closed here.
     :param seeded_session: ``(base_url, session_id)`` from the pre-created
         session fixture.
+    :param mock_llm_server_url: Mock LLM server URL.
     """
     base_url, session_id = seeded_session
     _grant_edit(base_url, session_id, _ALICE)
     _grant_edit(base_url, session_id, _BOB)
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "ack"}])
 
     marker = f"shared-author-{uuid.uuid4().hex[:8]}"
     alice_ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": _ALICE})
@@ -197,7 +210,7 @@ def test_author_badge_skips_own_messages_and_marks_peers(
         # Wait for the turn to complete so session.input.consumed fired
         # and the optimistic bubble was promoted to committed history.
         assistant = alice.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-        expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+        expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
 
         # Still no badge on Alice's own committed bubble.
         expect(_user_bubble(alice, marker).get_by_test_id("message-author")).to_have_count(0)
@@ -235,6 +248,9 @@ def test_terminal_typed_message_shows_author_badge_to_peers(
 
     Bob (not Alice) is the viewer: the badge marks OTHER contributors,
     so the author's own view would render nothing by design.
+
+    No LLM call is involved — this test uses the REST API to post the
+    external event directly.
 
     :param browser: Playwright browser session; a dedicated context with
         Bob's header is created and closed inside this test.

--- a/tests/e2e_ui/collaboration/test_collab_realtime.py
+++ b/tests/e2e_ui/collaboration/test_collab_realtime.py
@@ -35,10 +35,13 @@ import uuid
 import httpx
 from playwright.sync_api import Browser, expect
 
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
 
 def test_two_browser_contexts_sync_message_realtime(
     browser: Browser,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Owner's sent message appears live in a second context, no reload.
 
@@ -53,15 +56,17 @@ def test_two_browser_contexts_sync_message_realtime(
       at the empty-FIFO fallback).
     - The collaborator never subscribed to the live stream on session
       bind (``chatStore.switchTo`` regression).
-    - The LLM never responded (Databricks credentials / model
-      availability), which only affects the assistant-bubble checks.
 
     :param browser: Playwright session-scoped browser; two independent
         contexts stand in for two users sharing the session URL.
     :param seeded_session: ``(base_url, session_id)`` for a runner-bound
         session, created by the fixture.
+    :param mock_llm_server_url: Mock LLM server URL.
     """
     base_url, session_id = seeded_session
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "pong"}])
+
     # Unique per run so the bubble locator can't match leftover or
     # streamed-reply text — it has to be the user message we sent.
     marker = f"collab-sync-{uuid.uuid4().hex[:8]}"
@@ -105,17 +110,15 @@ def test_two_browser_contexts_sync_message_realtime(
         )
         expect(collab_user).to_be_visible(timeout=30_000)
 
-        # The streamed assistant reply reaches both subscribers. Match
-        # any non-whitespace so an empty bubble (reducer fired, produced
-        # no text) still fails. 60s covers LLM latency, as in test_smoke.
+        # The mock LLM reply reaches both subscribers.
         owner_assistant = owner.locator(
             '[data-testid="message-bubble"][data-role="assistant"]'
         ).first
         collab_assistant = collab.locator(
             '[data-testid="message-bubble"][data-role="assistant"]'
         ).first
-        expect(owner_assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
-        expect(collab_assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+        expect(owner_assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
+        expect(collab_assistant).to_have_text(re.compile(r"\S"), timeout=10_000)
     finally:
         owner_ctx.close()
         collab_ctx.close()

--- a/tests/e2e_ui/collaboration/test_sharing_journey.py
+++ b/tests/e2e_ui/collaboration/test_sharing_journey.py
@@ -32,6 +32,7 @@ import httpx
 import pytest
 from playwright.sync_api import Browser, BrowserContext, Page, expect
 
+from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
 from tests.e2e_ui.conftest import (
     _build_hello_world_bundle,
     _ensure_runner_online,
@@ -159,9 +160,14 @@ def test_share_grant_downgrade_revoke_journey(
     browser: Browser,
     live_server: str,
     shared: _SharedFixture,
+    mock_llm_server_url: str,
 ) -> None:
     sid = shared.session_id
     marker = f"bob-turn-{uuid.uuid4().hex[:8]}"
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": marker}])
+
     # The owner context is headerless (the ``local`` identity), same
     # as every other e2e_ui browser context.
     owner_ctx = browser.new_context()
@@ -187,9 +193,9 @@ def test_share_grant_downgrade_revoke_journey(
         expect(composer).to_be_visible()
         composer.fill(f"Reply with exactly this token and nothing else: {marker}")
         bob_page.get_by_role("button", name="Send", exact=True).click()
-        # Bob's own surfaces: his user bubble, then a real reply.
+        # Bob's own surfaces: his user bubble, then a mock reply.
         expect(bob_page.locator(_BUBBLE, has_text=marker).first).to_be_visible(timeout=15_000)
-        expect(bob_page.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
+        expect(bob_page.locator(_ASSISTANT).first).to_be_visible(timeout=10_000)
         # The owner's already-open tab receives Bob's message over the
         # live stream (no reload): the collab-realtime broadcast path.
         expect(owner_page.locator(_BUBBLE, has_text=marker).first).to_be_visible(timeout=30_000)

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -445,8 +445,7 @@ def mock_llm_server_url(
         log_handle.close()
         log_contents = mock_log.read_text() if mock_log.exists() else ""
         raise RuntimeError(
-            f"Mock LLM server didn't start within 10s.\n"
-            f"Log at {mock_log}:\n{log_contents[-2000:]}"
+            f"Mock LLM server didn't start within 10s.\nLog at {mock_log}:\n{log_contents[-2000:]}"
         )
 
     try:


### PR DESCRIPTION
Rebased version of #826 on top of the conftest PR #824.

Cherry-picks the approvals/collaboration test migration commits on top of `test/mock-e2e-ui` so the `mock_llm_server_url` fixture is available.