### PR TITLE
test(e2e-ui): migrate misc UI tests to mock LLM (rebased)

### DIFF
--- a/tests/e2e_ui/chat/test_jump_to_top.py
+++ b/tests/e2e_ui/chat/test_jump_to_top.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
 _USER = '[data-testid="message-bubble"][data-role="user"]'
@@ -64,15 +66,17 @@ def _send_turn(page: Page, text: str, turn: int) -> None:
     composer.fill(text)
     page.get_by_role("button", name="Send", exact=True).click()
     expect(page.locator(_USER)).to_have_count(turn, timeout=15_000)
-    expect(page.locator(_ASSISTANT)).to_have_count(turn, timeout=90_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=90_000)
+    expect(page.locator(_ASSISTANT)).to_have_count(turn, timeout=10_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=10_000)
 
 
 def test_jump_to_top_returns_to_first_message(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "hi"}, {"text": "hi"}, {"text": "hi"}])
     page.goto(f"{base_url}/c/{session_id}")
     page.set_viewport_size(_VIEWPORT)
 
@@ -108,9 +112,11 @@ def test_jump_to_top_returns_to_first_message(
 def test_jump_to_top_reveals_on_scroll_up_then_auto_hides(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Scrolling up surfaces the pill (no hover needed); pausing fades it out."""
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "hi"}, {"text": "hi"}, {"text": "hi"}])
     page.goto(f"{base_url}/c/{session_id}")
     page.set_viewport_size(_VIEWPORT)
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -445,8 +445,7 @@ def mock_llm_server_url(
         log_handle.close()
         log_contents = mock_log.read_text() if mock_log.exists() else ""
         raise RuntimeError(
-            f"Mock LLM server didn't start within 10s.\n"
-            f"Log at {mock_log}:\n{log_contents[-2000:]}"
+            f"Mock LLM server didn't start within 10s.\nLog at {mock_log}:\n{log_contents[-2000:]}"
         )
 
     try:

--- a/tests/e2e_ui/fork_session/test_fork_from_middle.py
+++ b/tests/e2e_ui/fork_session/test_fork_from_middle.py
@@ -26,6 +26,8 @@ import re
 import httpx
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 # Two distinct code words with no shared substring, so the kept/dropped
 # assertions can't satisfy each other. Only the KEPT word is part of the
 # turn the fork copies; the DROPPED word lives in the turn after the fork
@@ -41,6 +43,7 @@ def test_fork_from_middle_truncates_history(
     page: Page,
     seeded_session: tuple[str, str],
     runner_id: str,
+    mock_llm_server_url: str,
 ) -> None:
     """Fork from the first turn — the clone carries only history up to it.
 
@@ -61,6 +64,10 @@ def test_fork_from_middle_truncates_history(
         clone unbound, so a message would otherwise have no runner).
     """
     base_url, session_id = seeded_session
+    # 2 responses for the two source turns + 1 for the recall turn on the fork.
+    configure_mock_llm(
+        mock_llm_server_url, [{"text": "OK"}, {"text": "OK"}, {"text": _KEPT_MARKER}]
+    )
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder("Ask the agent anything…")
@@ -71,13 +78,13 @@ def test_fork_from_middle_truncates_history(
     composer.fill(f"Remember this code word and reply with just OK: {_KEPT_MARKER}")
     page.get_by_role("button", name="Send", exact=True).click()
     assistant = page.locator(_ASSISTANT)
-    expect(assistant).to_have_count(1, timeout=60_000)
+    expect(assistant).to_have_count(1, timeout=10_000)
 
     # Turn 2 (DROPPED): plant the second code word AFTER the fork point.
     # Forking from turn 1's response must exclude this turn entirely.
     composer.fill(f"Now also remember this code word and reply with just OK: {_DROPPED_MARKER}")
     page.get_by_role("button", name="Send", exact=True).click()
-    expect(assistant).to_have_count(2, timeout=60_000)
+    expect(assistant).to_have_count(2, timeout=10_000)
 
     # Fork from the FIRST assistant response (the middle of the now
     # two-turn conversation). The action lives inside that bubble's action
@@ -133,8 +140,8 @@ def test_fork_from_middle_truncates_history(
     fork_composer.fill("What code word did I ask you to remember? Reply with the code word only.")
     page.get_by_role("button", name="Send", exact=True).click()
     fork_assistant = page.locator(_ASSISTANT)
-    expect(fork_assistant).to_have_count(2, timeout=60_000)
+    expect(fork_assistant).to_have_count(2, timeout=10_000)
 
     recall = fork_assistant.nth(1)
-    expect(recall).to_contain_text(_KEPT_MARKER, timeout=60_000)
+    expect(recall).to_contain_text(_KEPT_MARKER, timeout=10_000)
     expect(recall).not_to_contain_text(_DROPPED_MARKER)

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -39,6 +39,7 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
 from tests.e2e_ui.conftest import _FILES_PROBE_ENV_AGENT_NAME
 
 # Unique marker so the copied-transcript assertion can't match UI chrome or
@@ -93,6 +94,7 @@ def test_fork_switch_agent_carries_history(
     target_name: str,
     expected_wrapper: str | None,
     expect_carry_history: bool,
+    mock_llm_server_url: str,
 ) -> None:
     """Fork + switch agent: lands on the target agent with history copied.
 
@@ -107,6 +109,7 @@ def test_fork_switch_agent_carries_history(
         fork history, currently claude/codex native).
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "ok"}])
     target_agent_id = _agent_id_by_name(base_url, target_name)
 
     page.goto(f"{base_url}/c/{session_id}")
@@ -119,7 +122,7 @@ def test_fork_switch_agent_carries_history(
     composer.fill(f"Reply with one short word. Marker: {_MARKER}")
     page.get_by_role("button", name="Send", exact=True).click()
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
+    expect(assistant).to_be_visible(timeout=10_000)
 
     assistant.hover()
     page.get_by_test_id("fork-from-response").first.click()
@@ -190,6 +193,7 @@ def test_fork_switch_agent_carries_history(
 def test_fork_into_pi_labels_model_picker_pi(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Forking SDK → Pi labels the in-session model picker "Pi", not the slug.
 
@@ -206,6 +210,7 @@ def test_fork_into_pi_labels_model_picker_pi(
         ``hello_world`` (openai-agents SDK) source session.
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "ok"}])
     pi_agent_id = _agent_id_by_name(base_url, "pi-native-ui")
 
     page.goto(f"{base_url}/c/{session_id}")
@@ -216,7 +221,7 @@ def test_fork_into_pi_labels_model_picker_pi(
     composer.fill(f"Reply with one short word. Marker: {_MARKER}")
     page.get_by_role("button", name="Send", exact=True).click()
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
+    expect(assistant).to_be_visible(timeout=10_000)
 
     # Fork from the response, switching the agent to Pi.
     assistant.hover()

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -35,8 +35,9 @@ from __future__ import annotations
 import uuid
 
 import httpx
-import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e.conftest import configure_mock_llm
 
 _COMPOSER = "Ask the agent anything…"
 _USER = '[data-testid="message-bubble"][data-role="user"]'
@@ -44,9 +45,6 @@ _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
 _WORKING = '[data-testid="working-indicator"]'
 
 _TURNS = 5
-
-# A custom openai-agents turn is a single LLM call.
-_CUSTOM_TURN_TIMEOUT_MS = 90_000
 
 
 def _send(page: Page, text: str) -> None:
@@ -230,6 +228,7 @@ def _run_render_parity_journey(
     page: Page,
     base_url: str,
     session_id: str,
+    mock_llm_server_url: str,
     *,
     per_turn_timeout_ms: int,
 ) -> None:
@@ -238,6 +237,7 @@ def _run_render_parity_journey(
     :param page: The Playwright page.
     :param base_url: Spawned server base URL.
     :param session_id: The session/conversation id to chat in.
+    :param mock_llm_server_url: Mock LLM server base URL.
     :param per_turn_timeout_ms: How long to wait for each turn to land.
     """
     page.goto(f"{base_url}/c/{session_id}")
@@ -252,6 +252,7 @@ def _run_render_parity_journey(
         user_markers.append(user_marker)
         assistant_tokens.append(assistant_token)
 
+        configure_mock_llm(mock_llm_server_url, [{"text": assistant_token}])
         _send(page, _turn_prompt(index, user_marker, assistant_token))
         # The echoed token in an assistant bubble = the turn produced its
         # reply; only producible from this turn's prompt.
@@ -268,14 +269,14 @@ def _run_render_parity_journey(
     _assert_transcript_parity(base_url, session_id, user_markers, assistant_tokens)
 
 
-@pytest.mark.timeout(300)
 def test_custom_agent_message_render_parity(
     page: Page,
     custom_agent_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = custom_agent_session
     _run_render_parity_journey(
-        page, base_url, session_id, per_turn_timeout_ms=_CUSTOM_TURN_TIMEOUT_MS
+        page, base_url, session_id, mock_llm_server_url, per_turn_timeout_ms=10_000
     )
 
 

--- a/tests/e2e_ui/mobile/test_mobile_workflow.py
+++ b/tests/e2e_ui/mobile/test_mobile_workflow.py
@@ -29,6 +29,8 @@ import httpx
 import pytest
 from playwright.sync_api import Page, ViewportSize, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 # iPhone-12-class portrait viewport — comfortably below the Tailwind
 # ``md`` breakpoint (768px) so every ``md:`` rule resolves to its
 # mobile branch.
@@ -253,6 +255,7 @@ def test_mobile_files_drawer_opens_seeded_file(
 def test_mobile_chat_send_and_response(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """The composer streams an assistant reply at a phone viewport.
 
@@ -260,6 +263,8 @@ def test_mobile_chat_send_and_response(
     and message list stay usable on a phone (no rail stealing layout).
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "pong"}])
+
     page.set_viewport_size(_MOBILE_VIEWPORT)
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -269,5 +274,5 @@ def test_mobile_chat_send_and_response(
     page.get_by_role("button", name="Send", exact=True).click()
 
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
-    expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
+    expect(assistant).to_be_visible(timeout=10_000)
+    expect(assistant).to_have_text(re.compile(r"\S"), timeout=10_000)

--- a/tests/e2e_ui/sessions/test_clone_session.py
+++ b/tests/e2e_ui/sessions/test_clone_session.py
@@ -22,6 +22,8 @@ import re
 import httpx
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 # Unique marker so the copied-transcript assertion can't match
 # UI chrome or another test's message.
 _MARKER = "kumquat-clone-marker"
@@ -34,6 +36,7 @@ _XFAM_MARKER = "loquat-xfam-marker"
 def test_clone_session_copies_transcript_and_navigates(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """Clone a session from a message's Fork action and land in a fork with history.
 
@@ -52,6 +55,7 @@ def test_clone_session_copies_transcript_and_navigates(
         runner-bound session.
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "ok"}])
     page.goto(f"{base_url}/c/{session_id}")
 
     # Seed the transcript with a uniquely-marked user turn and wait for
@@ -61,7 +65,7 @@ def test_clone_session_copies_transcript_and_navigates(
     composer.fill(f"Reply with one short word. Marker: {_MARKER}")
     page.get_by_role("button", name="Send", exact=True).click()
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
+    expect(assistant).to_be_visible(timeout=10_000)
 
     # Open the fork dialog from the assistant bubble's "Fork from here"
     # action (the desktop entry point; the action bar is dimmed until
@@ -102,6 +106,7 @@ def test_clone_session_copies_transcript_and_navigates(
 def test_clone_dialog_offers_cross_family_native_target_and_forks(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """The fork dialog offers a CROSS-FAMILY native target and forks into it.
 
@@ -127,6 +132,7 @@ def test_clone_dialog_offers_cross_family_native_target_and_forks(
         runner-bound session.
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "ok"}])
 
     # Resolve the packaged claude-native-ui built-in from the live catalog.
     agents_resp = httpx.get(f"{base_url}/v1/agents", params={"limit": 100}, timeout=30.0)
@@ -148,7 +154,7 @@ def test_clone_dialog_offers_cross_family_native_target_and_forks(
     composer.fill(f"Reply with one short word. Marker: {_XFAM_MARKER}")
     page.get_by_role("button", name="Send", exact=True).click()
     assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
-    expect(assistant).to_be_visible(timeout=60_000)
+    expect(assistant).to_be_visible(timeout=10_000)
 
     assistant.hover()
     page.get_by_test_id("fork-from-response").first.click()

--- a/tests/e2e_ui/sessions/test_idle_notifications.py
+++ b/tests/e2e_ui/sessions/test_idle_notifications.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import configure_mock_llm
+
 # Records constructed notifications and makes visibility/focus controllable
 # from the test via window.__hidden. Runs before any app script on every
 # navigation (add_init_script), so the SPA's feature detection and
@@ -213,6 +215,7 @@ def _send_prompt(page: Page) -> None:
 def test_idle_notification_fires_when_backgrounded(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     A real ``running`` -> ``idle`` turn observed while the tab is
@@ -233,6 +236,7 @@ def test_idle_notification_fires_when_backgrounded(
         bound to the spawned runner.
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "Hello! How can I help you today?"}])
     page.add_init_script(_HARNESS_INIT_SCRIPT)
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -255,11 +259,10 @@ def test_idle_notification_fires_when_backgrounded(
         "window.dispatchEvent(new Event('blur'));"
     )
 
-    # Wait for the real turn to finish and the backgrounded transition to
-    # fire the notification. 90s budget covers cold-start LLM latency under
-    # Databricks routing without masking a true hang.
-    page.wait_for_function("window.__notifs.length > 0", timeout=90_000)
-    _wait_for_observed_session_status(page, session_id, "idle", timeout=90_000)
+    # Wait for the turn to finish and the backgrounded transition to fire the
+    # notification. Mock LLM responds immediately so a short budget suffices.
+    page.wait_for_function("window.__notifs.length > 0", timeout=10_000)
+    _wait_for_observed_session_status(page, session_id, "idle", timeout=10_000)
     # One more observation window catches duplicate-notification
     # regressions: the single running -> idle transition should produce
     # exactly one notification. A duplicate fires off a re-render right
@@ -271,10 +274,9 @@ def test_idle_notification_fires_when_backgrounded(
     assert first["title"] == _PROMPT, notifs
     # Body contract: the agent's final words as a trimmed,
     # capped preview when the best-effort fetch succeeds, else the
-    # generic fallback. The preview text is real LLM output, so assert
-    # the contract rather than exact content: non-empty either way, and
-    # a non-fallback body must respect the preview caps
-    # (``previewText`` in ap-web/src/lib/lastAssistantText.ts:
+    # generic fallback. Assert the contract rather than exact content:
+    # non-empty either way, and a non-fallback body must respect the
+    # preview caps (``previewText`` in ap-web/src/lib/lastAssistantText.ts:
     # ≤160 chars including the "…" elision marker, ≤3 lines).
     body = first["options"]["body"]
     assert isinstance(body, str) and body.strip(), notifs
@@ -287,6 +289,7 @@ def test_idle_notification_fires_when_backgrounded(
 def test_idle_notification_suppressed_when_foreground(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     A real ``running`` -> ``idle`` turn observed while the tab stays
@@ -302,6 +305,7 @@ def test_idle_notification_suppressed_when_foreground(
         bound to the spawned runner.
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "Hello! How can I help you today?"}])
     page.add_init_script(_HARNESS_INIT_SCRIPT)
     page.goto(f"{base_url}/c/{session_id}")
     page.mouse.click(5, 5)
@@ -311,7 +315,7 @@ def test_idle_notification_suppressed_when_foreground(
 
     # Observe the full running -> idle cycle while staying foreground.
     _wait_for_observed_session_status(page, session_id, "running", timeout=30_000)
-    _wait_for_observed_session_status(page, session_id, "idle", timeout=90_000)
+    _wait_for_observed_session_status(page, session_id, "idle", timeout=10_000)
 
     # Leave a short post-transition window to be sure no delayed
     # notification slips through.
@@ -322,6 +326,7 @@ def test_idle_notification_suppressed_when_foreground(
 def test_idle_notification_click_navigates_to_chat(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     """
     Clicking the OS notification routes into the session it was raised for.
@@ -349,6 +354,7 @@ def test_idle_notification_click_navigates_to_chat(
         bound to the spawned runner.
     """
     base_url, session_id = seeded_session
+    configure_mock_llm(mock_llm_server_url, [{"text": "Hello! How can I help you today?"}])
     page.add_init_script(_HARNESS_INIT_SCRIPT)
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -366,8 +372,9 @@ def test_idle_notification_click_navigates_to_chat(
     page.get_by_test_id("new-chat-button").click()
     page.wait_for_url(lambda url: f"/c/{session_id}" not in url, timeout=10_000)
 
-    # The real turn completes off-screen and raises the notification.
-    page.wait_for_function("window.__notifObjects.length > 0", timeout=90_000)
+    # The turn completes off-screen and raises the notification.
+    # Mock LLM responds immediately so a short budget suffices.
+    page.wait_for_function("window.__notifObjects.length > 0", timeout=10_000)
 
     # Click it: the app's onClick focuses then navigates to the session.
     page.evaluate("window.__notifObjects[0].onclick()")


### PR DESCRIPTION
Rebased version of #827 on top of the conftest PR #824.

Cherry-picks the misc UI test migration commits on top of `test/mock-e2e-ui` so the `mock_llm_server_url` fixture is available.