### PR TITLE
feat(web-ui): add keyboard shortcuts overlay

### DIFF
--- a/ap-web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/ap-web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { KeyboardShortcutsDialog, openKeyboardShortcuts } from "./KeyboardShortcutsDialog";
+
+afterEach(cleanup);
+
+// jsdom's navigator is non-mac, so the modifier glyph renders as "Ctrl".
+function toggleViaHotkey() {
+  fireEvent.keyDown(window, { key: "/", ctrlKey: true });
+}
+
+describe("KeyboardShortcutsDialog", () => {
+  it("renders nothing until opened", () => {
+    render(<KeyboardShortcutsDialog />);
+    expect(screen.queryByText("Send message")).toBeNull();
+  });
+
+  it("opens on the modifier+/ hotkey and lists one shortcut from each group", () => {
+    render(<KeyboardShortcutsDialog />);
+    toggleViaHotkey();
+
+    expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
+    // General / In chats / Navigation / Slash commands — one representative each.
+    expect(screen.getByText("Show keyboard shortcuts")).toBeTruthy();
+    expect(screen.getByText("Send message")).toBeTruthy();
+    expect(screen.getByText("Recall previous prompt")).toBeTruthy();
+    expect(screen.getByText("Previous session")).toBeTruthy();
+    expect(screen.getByText("Navigate suggestions")).toBeTruthy();
+  });
+
+  it("toggles closed on a second hotkey press", async () => {
+    render(<KeyboardShortcutsDialog />);
+    toggleViaHotkey();
+    expect(screen.getByText("Send message")).toBeTruthy();
+
+    toggleViaHotkey();
+    await waitFor(() => expect(screen.queryByText("Send message")).toBeNull());
+  });
+
+  it("opens when openKeyboardShortcuts() is dispatched (menu entry path)", async () => {
+    render(<KeyboardShortcutsDialog />);
+    openKeyboardShortcuts();
+    // The event dispatch isn't wrapped in act(), so wait for the re-render.
+    expect(await screen.findByText("Send message")).toBeTruthy();
+  });
+});

--- a/ap-web/src/components/KeyboardShortcutsDialog.tsx
+++ b/ap-web/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,167 @@
+// A read-only "Keyboard shortcuts" overlay listing the shortcuts that already
+// exist in the chat surface. It is intentionally a mirror of the live
+// behavior — every row here corresponds to a handler that ships today
+// (composer `handleKeyDown`, the global session-switch / message-nav hotkeys,
+// and the approve hotkey). Nothing here binds new behavior except the dialog's
+// own opener (⌘/Ctrl + /), which this component registers.
+//
+// Self-contained: it owns its open state and listens for its opener directly
+// (a window keydown for ⌘/Ctrl+/, plus a custom event so a menu entry can open
+// it without prop-drilling). Mount it once near the app shell.
+
+import { useEffect, useState, type ReactNode } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// Custom event the dialog listens for, so non-adjacent surfaces (e.g. the
+// account menu) can open it without threading state through the tree.
+export const KEYBOARD_SHORTCUTS_EVENT = "omnigent:open-keyboard-shortcuts";
+
+/** Dispatch the open event — used by menu entries that can't reach the state. */
+export function openKeyboardShortcuts(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(KEYBOARD_SHORTCUTS_EVENT));
+}
+
+// Platform-aware modifier glyphs. macOS shows ⌘/⌥; elsewhere Ctrl/Alt — the
+// same split the underlying handlers use (`metaKey || ctrlKey`).
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
+
+/** Modifier label shown in menu hints (⌘ on macOS, Ctrl elsewhere). */
+export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
+
+// Glyphs match the in-app tooltips (e.g. UserMessageNav's "⌘⌥↑").
+const ENTER = "↵";
+const SHIFT = "⇧";
+const UP = "↑";
+const DOWN = "↓";
+
+interface Shortcut {
+  label: string;
+  /** Keys rendered left→right as chips. A chord (held together) or, for the
+   *  arrow-pairs, the two interchangeable keys for that action. */
+  keys: string[];
+}
+
+interface ShortcutGroup {
+  title: string;
+  /** Optional qualifier shown next to the group title. */
+  note?: string;
+  items: Shortcut[];
+}
+
+// ONLY shortcuts that exist today (see file header). Keep in sync with the
+// composer's `handleKeyDown` and the global hotkey hooks.
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: "General",
+    items: [{ label: "Show keyboard shortcuts", keys: [MOD_KEY, "/"] }],
+  },
+  {
+    title: "In chats",
+    items: [
+      { label: "Send message", keys: [ENTER] },
+      { label: "New line in message", keys: [SHIFT, ENTER] },
+      { label: "Recall previous prompt", keys: [UP] },
+      { label: "Recall next prompt", keys: [DOWN] },
+      { label: "Accept approval prompt", keys: [MOD_KEY, ENTER] },
+      { label: "Stop response", keys: ["Esc"] },
+    ],
+  },
+  {
+    title: "Navigation",
+    items: [
+      { label: "Previous session", keys: [MOD_KEY, UP] },
+      { label: "Next session", keys: [MOD_KEY, DOWN] },
+    ],
+  },
+  {
+    title: "Slash commands",
+    note: "while the suggestions menu is open",
+    items: [
+      { label: "Navigate suggestions", keys: [UP, DOWN] },
+      { label: "Apply highlighted command", keys: ["Tab"] },
+      { label: "Dismiss menu", keys: ["Esc"] },
+    ],
+  },
+];
+
+function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <kbd className="inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-border bg-muted px-1.5 font-sans text-xs font-medium text-muted-foreground">
+      {children}
+    </kbd>
+  );
+}
+
+export function KeyboardShortcutsDialog() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // ⌘/Ctrl + / toggles the panel. Plain `/` is the composer's slash-menu
+      // trigger, so require the modifier and no Shift/Alt to avoid clashing.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key === "/") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    const onOpenEvent = () => setOpen(true);
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener(KEYBOARD_SHORTCUTS_EVENT, onOpenEvent);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener(KEYBOARD_SHORTCUTS_EVENT, onOpenEvent);
+    };
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription className="sr-only">
+            The keyboard shortcuts available in the chat.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[70vh] overflow-y-auto pr-1">
+          {SHORTCUT_GROUPS.map((group) => (
+            <section key={group.title} className="mb-4 last:mb-0">
+              <h3 className="mb-1 text-xs font-medium text-muted-foreground">
+                {group.title}
+                {group.note ? (
+                  <span className="ml-1.5 font-normal text-muted-foreground/70">
+                    · {group.note}
+                  </span>
+                ) : null}
+              </h3>
+              <ul>
+                {group.items.map((item) => (
+                  <li
+                    key={item.label}
+                    className="flex items-center justify-between gap-4 border-b border-border/60 py-2.5 last:border-b-0"
+                  >
+                    <span className="text-sm text-foreground">{item.label}</span>
+                    <span className="flex shrink-0 items-center gap-1">
+                      {item.keys.map((key) => (
+                        <Kbd key={`${item.label}-${key}`}>{key}</Kbd>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ap-web/src/shell/AccountMenu.tsx
+++ b/ap-web/src/shell/AccountMenu.tsx
@@ -21,8 +21,16 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "@/lib/routing";
-import { KeyRoundIcon, LogOutIcon, ShieldCheckIcon, UserCogIcon, UsersIcon } from "lucide-react";
+import {
+  KeyboardIcon,
+  KeyRoundIcon,
+  LogOutIcon,
+  ShieldCheckIcon,
+  UserCogIcon,
+  UsersIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { MOD_KEY, openKeyboardShortcuts } from "@/components/KeyboardShortcutsDialog";
 import {
   Dialog,
   DialogContent,
@@ -37,6 +45,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -166,6 +175,13 @@ export function AccountMenu() {
               </DropdownMenuItem>
             </>
           )}
+          <DropdownMenuItem
+            onClick={() => openKeyboardShortcuts()}
+            className="flex items-center gap-2"
+          >
+            <KeyboardIcon /> Keyboard shortcuts
+            <DropdownMenuShortcut>{MOD_KEY} /</DropdownMenuShortcut>
+          </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
               resetPwForm();

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -60,6 +60,7 @@ import {
 import { TerminalsPanel } from "./TerminalsPanel";
 import { TodoPanel } from "./TodoPanel";
 import { PermissionsModal } from "@/components/PermissionsModal";
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
 import { WorkspacePanel } from "./WorkspacePanel";
@@ -1221,6 +1222,9 @@ export function AppShell() {
               </DialogContent>
             </Dialog>
           )}
+          {/* Keyboard-shortcuts reference. Self-contained (owns its open state +
+              ⌘/Ctrl+/ opener); ungated so it works on every route. */}
+          <KeyboardShortcutsDialog />
         </ForkDialogContextProvider>
       </TerminalFirstContextProvider>
     </FileViewerContext.Provider>


### PR DESCRIPTION

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary


Add a "Keyboard shortcuts" dialog listing the shortcuts that already exist in the chat (composer send/recall/stop, session and slash-menu navigation, approve hotkey). It is self-contained — owns its open state and opener — and is mounted once in AppShell. Open it with Cmd/Ctrl+/ 

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
