### PR TITLE
feat(claude-sdk): add compact_session() for in-place /compact on a live SDK session

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1487,6 +1487,54 @@ class ClaudeSDKExecutor(Executor):
             await self._gateway_shim.aclose()
             self._gateway_shim = None
 
+    async def compact_session(self, session_key: str) -> dict[str, Any]:
+        """
+        Trigger an in-place ``/compact`` on the live SDK session.
+
+        The Claude Agent SDK has no first-class ``compact()`` control request
+        (see anthropics/claude-agent-sdk-python#23), but the SDK-spawned
+        ``claude`` CLI routes a user message whose content is ``/compact``
+        through the same slash-command dispatcher the interactive terminal
+        uses. This actually shrinks the model's real context in place (no
+        teardown / reseed, prompt cache preserved) — the SDK analog of
+        ``_handle_claude_native_compact`` injecting ``/compact`` into the tmux
+        pane. Success is reported by the SDK as a ``compact_boundary`` system
+        event carrying ``compact_metadata`` (``pre_tokens`` / ``post_tokens`` /
+        ``trigger``). Verified against claude-agent-sdk 0.2.94.
+
+        Must be called between turns (the live client must be idle).
+
+        :param session_key: The SDK session identifier to compact.
+        :returns: A result dict with ``status`` one of ``"success"`` /
+            ``"no_session"`` / ``"error"``; on success also includes
+            ``pre_tokens``, ``post_tokens``, and ``trigger`` from the
+            ``compact_boundary`` event.
+        """
+        state = self._clients.get(session_key)
+        if state is None:
+            # No live session yet — nothing to compact in place. The caller
+            # (runner) can fall back to its server-side transcript compaction.
+            return {"status": "no_session"}
+        try:
+            await state.client.query("/compact", session_id=session_key)
+            result: dict[str, Any] = {"status": "unknown"}
+            async for message in state.client.receive_response():
+                data = getattr(message, "data", None)
+                if isinstance(data, dict) and data.get("subtype") == "compact_boundary":
+                    meta = data.get("compact_metadata") or {}
+                    result = {
+                        "status": "success",
+                        "pre_tokens": meta.get("pre_tokens"),
+                        "post_tokens": meta.get("post_tokens"),
+                        "trigger": meta.get("trigger"),
+                    }
+            return result
+        except Exception as exc:  # noqa: BLE001 — surface failure to the caller
+            logger.warning(
+                "Claude SDK /compact failed for session %s: %s", session_key, exc
+            )
+            return {"status": "error", "error": str(exc)}
+
     async def interrupt_session(self, session_key: str) -> bool:
         state = self._clients.get(session_key)
         if state is None:

--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -547,6 +547,23 @@ class Executor:
         """Ask the executor to interrupt a currently running turn, if supported."""
         return False
 
+    async def compact_session(self, session_key: str) -> dict[str, Any]:  # noqa: ARG002 — default no-op; subclasses override to support in-place compaction
+        """
+        Compact a live session's context in place, if supported.
+
+        Executors backed by a harness that owns its own context (e.g. the
+        Claude Agent SDK) should override this to trigger the harness's own
+        compaction — the runner's transcript-side compaction cannot shrink
+        that context. The default reports the capability is absent so callers
+        fall back to runner/server-side compaction.
+
+        :param session_key: The session to compact.
+        :returns: A result dict with ``status`` — ``"unsupported"`` by
+            default; overrides return ``"success"`` (with ``pre_tokens`` /
+            ``post_tokens`` / ``trigger``), ``"no_session"``, or ``"error"``.
+        """
+        return {"status": "unsupported"}
+
     async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:  # noqa: ARG002 — default no-op; subclasses override to support live queueing
         """Send a new user message to a live session without interrupting it, if supported."""
         return False

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7581,6 +7581,61 @@ def create_runner_app(
             )
         return Response(status_code=204)
 
+    async def _handle_claude_sdk_compact(conv_id: str) -> Response:
+        """
+        Compact a claude-sdk session in place via the harness.
+
+        The claude-sdk harness owns its own context, so — like claude-native
+        injecting ``/compact`` into the tmux pane — explicit compaction must
+        run inside the harness, not as the Omnigent server's transcript-side
+        summary (which can't shrink the SDK's real context and errors when the
+        agent pins no model). Forwards a ``compact`` event to the harness
+        subprocess, which drives the SDK's own ``/compact``
+        (:meth:`ClaudeSDKExecutor.compact_session`).
+
+        Returns 200 (handled — server skips its AP-side compaction) on a
+        successful compaction or when there is no live session to compact;
+        409 when a turn is in flight; 503 on a forward/compaction error.
+        Mirrors the proactive path's ``response.compaction.in_progress`` /
+        ``response.compaction.completed`` SSE so the UI shows the indicator.
+
+        :param conv_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
+        :returns: 200 / 409 / 503 per the outcome above.
+        """
+        if process_manager is None:
+            return Response(status_code=204)
+        _publish_event(
+            conv_id,
+            {"type": "response.compaction.in_progress", "session_id": conv_id},
+        )
+        try:
+            result = await process_manager.forward_compact(conv_id)
+        finally:
+            _publish_event(
+                conv_id,
+                {"type": "response.compaction.completed", "session_id": conv_id},
+            )
+        if result is None:
+            return JSONResponse(
+                status_code=503,
+                content={"error": "claude_sdk_compact_failed", "detail": "harness forward failed"},
+            )
+        out_status = result.get("status")
+        _logger.info("claude-sdk /compact for %s: %s", conv_id, result)
+        if out_status == "busy":
+            return JSONResponse(
+                status_code=409,
+                content={"error": "compact_busy", "detail": "a turn is in flight"},
+            )
+        if out_status == "error":
+            return JSONResponse(
+                status_code=503,
+                content={"error": "claude_sdk_compact_failed", "detail": result.get("error")},
+            )
+        # success / no_session / unsupported: handled in-harness — 200 so the
+        # server does NOT fall back to its (erroring, desyncing) AP-side path.
+        return Response(status_code=200)
+
     async def _handle_claude_native_compact(conv_id: str) -> Response:
         """
         Type ``/compact`` into Claude's tmux pane.
@@ -10513,6 +10568,10 @@ def create_runner_app(
                 return await _handle_claude_native_compact(conversation_id)
             if _session_harness_name(conversation_id) == "codex-native":
                 return await _handle_codex_native_compact(conversation_id)
+            if _session_harness_name(conversation_id) == "claude-sdk":
+                # claude-sdk owns its context: compact in place via the harness
+                # (SDK /compact) rather than the server's transcript-side path.
+                return await _handle_claude_sdk_compact(conversation_id)
             return Response(status_code=204)
 
         if body_type == "cost_approval_popup":

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -44,6 +44,7 @@ from collections.abc import Callable
 from typing import Any
 
 from fastapi import Response
+from fastapi.responses import JSONResponse
 
 from omnigent.inner.executor import (
     Executor,
@@ -525,6 +526,25 @@ class ExecutorAdapter(HarnessApp):
         if self._executor is not None:
             await self._executor.interrupt_session(self._session_key)
         return response
+
+    async def _handle_compact_event(self) -> Response:
+        """Compact the live executor session in place.
+
+        Drives the inner :meth:`Executor.compact_session` (e.g. the Claude
+        Agent SDK's own ``/compact``). Must run between turns — the live
+        client must be idle — so a turn in flight returns ``"busy"`` and no
+        live executor yet returns ``"no_session"``. All outcomes are 200 +
+        JSON (compaction is best-effort, not a turn): the runner reads the
+        ``status`` to decide whether to fall back.
+
+        :returns: 200 with the executor's compact-result JSON.
+        """
+        if self._in_flight:
+            return JSONResponse(status_code=200, content={"status": "busy"})
+        if self._executor is None:
+            return JSONResponse(status_code=200, content={"status": "no_session"})
+        result = await self._executor.compact_session(self._session_key)
+        return JSONResponse(status_code=200, content=result)
 
     async def _watch_injections(self, ctx: TurnContext, executor: Executor) -> None:
         """

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -46,7 +46,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, FastAPI, Request, Response, status
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnigent.errors import ErrorCode, OmnigentError
@@ -337,13 +337,36 @@ class PolicyVerdictEvent(BaseModel):
     data: dict[str, Any] | None = None
 
 
+class CompactEvent(BaseModel):
+    """
+    Downward ``compact`` event — compact the live session in place.
+
+    For a harness that owns its own context (e.g. the Claude Agent SDK),
+    the runner forwards this so the harness compacts its real context
+    rather than the runner summarizing only its transcript copy. Runs
+    between turns; the harness reports the outcome in the response body
+    (``status`` ``"success"`` / ``"no_session"`` / ``"unsupported"`` /
+    ``"busy"`` / ``"error"``) so the runner can decide whether to fall
+    back. Best-effort — a no-op outcome is not an error.
+
+    :param type: Event discriminator; always ``"compact"``.
+    """
+
+    type: Literal["compact"]
+
+
 # Discriminated union of every downward event the harness accepts on
 # ``POST /v1/sessions/{conversation_id}/events``. FastAPI / Pydantic
 # v2 dispatches by the ``type`` field at request-validation time;
 # unknown values raise 422 (fail-loud per
 # ``designs/DESIGN_PRINCIPLES.md``).
 InboundEventRequest = Annotated[
-    MessageEvent | InterruptEvent | ToolResultEvent | ApprovalEvent | PolicyVerdictEvent,
+    MessageEvent
+    | InterruptEvent
+    | ToolResultEvent
+    | ApprovalEvent
+    | PolicyVerdictEvent
+    | CompactEvent,
     Field(discriminator="type"),
 ]
 
@@ -1074,6 +1097,8 @@ class HarnessApp:
             )
         if isinstance(body, PolicyVerdictEvent):
             return await self._handle_policy_verdict_event(body)
+        if isinstance(body, CompactEvent):
+            return await self._handle_compact_event()
         # Pydantic's discriminated-union validator should reject
         # unknown variants before we reach this branch; if it ever
         # falls through, fail loud rather than silently no-op.
@@ -1081,6 +1106,21 @@ class HarnessApp:
             f"unsupported inbound event type {type(body).__name__!r}",
             code=ErrorCode.INVALID_INPUT,
         )
+
+    async def _handle_compact_event(self) -> Response:
+        """
+        Apply a :class:`CompactEvent` — compact the live session in place.
+
+        Base behaviour: report the harness has no in-place compaction
+        (``status: "unsupported"``) so the runner falls back to its own
+        transcript-side compaction. Harnesses backed by an executor that
+        owns its context (e.g. :class:`ExecutorAdapter` over the Claude
+        Agent SDK) override this to drive the executor's
+        :meth:`Executor.compact_session`.
+
+        :returns: 200 with a JSON ``{"status": ...}`` body.
+        """
+        return JSONResponse(status_code=status.HTTP_200_OK, content={"status": "unsupported"})
 
     async def _handle_interrupt_event(self) -> Response:
         """

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -29,6 +29,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -661,6 +662,64 @@ class HarnessProcessManager:
             )
             return False
         return True
+
+    async def forward_compact(
+        self,
+        conversation_id: str,
+        timeout_s: float = 60.0,
+    ) -> dict[str, Any] | None:
+        """
+        Forward a ``compact`` event to the harness subprocess.
+
+        Sends ``{"type": "compact"}`` to
+        ``POST /v1/sessions/{conversation_id}/events`` so a harness that owns
+        its own context (e.g. the Claude Agent SDK) compacts in place, and
+        returns the harness's result body (``status`` ``"success"`` with
+        ``pre_tokens`` / ``post_tokens``, or ``"no_session"`` /
+        ``"unsupported"`` / ``"busy"`` / ``"error"``).
+
+        Best-effort: no entry registered for this conversation returns
+        ``{"status": "no_session"}`` (the runner can fall back); network /
+        HTTP / parse failures are logged and return ``None``. The timeout is
+        generous because the harness runs a real summarization LLM call.
+
+        :param conversation_id: The Omnigent conversation id whose harness
+            subprocess should compact.
+        :param timeout_s: Max seconds to wait for the harness response.
+        :returns: The harness compact-result dict, or ``None`` on transport
+            error.
+        """
+        async with self._registry_lock:
+            entry = self._entries.get(conversation_id)
+        if entry is None:
+            # No live harness (e.g. default-LLM agent, or not yet spawned).
+            return {"status": "no_session"}
+        try:
+            compact_url = f"/v1/sessions/{conversation_id}/events"
+            resp = await asyncio.wait_for(
+                entry.client.post(compact_url, json={"type": "compact"}),
+                timeout=timeout_s,
+            )
+        except (httpx.HTTPError, asyncio.TimeoutError):
+            _logger.exception(
+                "harness compact forward failed: conversation_id=%s", conversation_id
+            )
+            return None
+        if resp.status_code >= 400:
+            _logger.warning(
+                "harness compact returned %d for conversation_id=%s",
+                resp.status_code,
+                conversation_id,
+            )
+            return None
+        try:
+            return resp.json()
+        except (ValueError, RuntimeError):
+            _logger.exception(
+                "harness compact response parse failed: conversation_id=%s",
+                conversation_id,
+            )
+            return None
 
     def has_session(self, conversation_id: str) -> bool:
         """

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -3376,3 +3376,73 @@ class TestToolCallPolicyGate(unittest.TestCase):
             self.assertIsNone(captured["can_use_tool"])
 
         _run(_t())
+
+
+# ---------------------------------------------------------------------------
+# Tests: in-place /compact on a live SDK session (compact_session)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSdkMessage:
+    """Minimal stand-in for a claude_agent_sdk SystemMessage (carries .data)."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class TestCompactSession(unittest.TestCase):
+    def _make_executor(self):
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        return ClaudeSDKExecutor()
+
+    def test_no_live_session_returns_no_session(self):
+        executor = self._make_executor()
+        result = _run(executor.compact_session("missing"))
+        self.assertEqual(result["status"], "no_session")
+
+    def test_reports_boundary_metadata(self):
+        from omnigent.inner.claude_sdk_executor import _ClaudeClientState
+
+        executor = self._make_executor()
+
+        async def _receive():
+            yield _FakeSdkMessage({"subtype": "status", "status": "compacting"})
+            yield _FakeSdkMessage(
+                {
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {
+                        "trigger": "manual",
+                        "pre_tokens": 40590,
+                        "post_tokens": 7496,
+                    },
+                }
+            )
+
+        client = Mock()
+        client.query = AsyncMock()
+        client.receive_response = Mock(return_value=_receive())
+        executor._clients["s1"] = _ClaudeClientState(client=client, model="claude-opus-4-8")
+
+        result = _run(executor.compact_session("s1"))
+
+        # It must drive the slash command, not a normal prompt.
+        client.query.assert_awaited_once()
+        self.assertEqual(client.query.call_args.args[0], "/compact")
+        # And surface the compact_boundary metadata.
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["pre_tokens"], 40590)
+        self.assertEqual(result["post_tokens"], 7496)
+        self.assertEqual(result["trigger"], "manual")
+
+    def test_query_failure_returns_error(self):
+        from omnigent.inner.claude_sdk_executor import _ClaudeClientState
+
+        executor = self._make_executor()
+        client = Mock()
+        client.query = AsyncMock(side_effect=RuntimeError("boom"))
+        executor._clients["s1"] = _ClaudeClientState(client=client, model="m")
+
+        result = _run(executor.compact_session("s1"))
+        self.assertEqual(result["status"], "error")
+        self.assertIn("boom", result["error"])

--- a/tests/inner/test_executor.py
+++ b/tests/inner/test_executor.py
@@ -148,5 +148,12 @@ class TestSplitTransientTail(unittest.TestCase):
         self.assertEqual(split.transient, [])
 
 
+class TestCompactSessionDefault(unittest.TestCase):
+    def test_default_compact_session_is_unsupported(self):
+        """The base Executor reports no in-place compaction so callers fall back."""
+        result = _run(MockExecutor().compact_session("s1"))
+        self.assertEqual(result, {"status": "unsupported"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -1754,3 +1754,79 @@ async def test_interrupt_drops_inner_session_synchronously() -> None:
         "interrupt must drop the inner session so the next turn rebuilds fresh "
         f"instead of resuming the abandoned generation; got {executor.interrupted!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# CompactEvent → _handle_compact_event → executor.compact_session
+# ---------------------------------------------------------------------------
+
+
+class _CompactStubExecutor:
+    """Executor stub recording compact_session calls for the adapter tests."""
+
+    def __init__(self, result: dict) -> None:
+        self._result = result
+        self.compact_calls: list[str] = []
+
+    async def compact_session(self, session_key: str) -> dict:
+        self.compact_calls.append(session_key)
+        return self._result
+
+    async def close(self) -> None:
+        """Match Executor.close()."""
+
+    async def close_session(self, session_key: str) -> None:
+        """Match Executor.close_session()."""
+        del session_key
+
+
+async def test_handle_compact_event_drives_executor_compact_session() -> None:
+    import json
+
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    stub = _CompactStubExecutor({"status": "success", "pre_tokens": 100, "post_tokens": 10})
+    adapter = ExecutorAdapter(executor_factory=lambda: stub, session_key="s1")
+    adapter._executor = stub  # a turn would normally set this
+    adapter._in_flight = {}
+
+    resp = await adapter._handle_compact_event()
+
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {"status": "success", "pre_tokens": 100, "post_tokens": 10}
+    # It compacted the adapter's session_key (the key the inner client is under).
+    assert stub.compact_calls == ["s1"]
+
+
+async def test_handle_compact_event_busy_when_turn_in_flight() -> None:
+    import json
+
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    stub = _CompactStubExecutor({"status": "success"})
+    adapter = ExecutorAdapter(executor_factory=lambda: stub, session_key="s1")
+    adapter._executor = stub
+    adapter._in_flight = {"resp_1": object()}  # a turn is running
+
+    resp = await adapter._handle_compact_event()
+
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {"status": "busy"}
+    assert stub.compact_calls == []  # must NOT compact mid-turn
+
+
+async def test_handle_compact_event_no_session_before_first_turn() -> None:
+    import json
+
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    stub = _CompactStubExecutor({"status": "success"})
+    adapter = ExecutorAdapter(executor_factory=lambda: stub, session_key="s1")
+    adapter._in_flight = {}
+    # adapter._executor is None until a turn runs.
+
+    resp = await adapter._handle_compact_event()
+
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {"status": "no_session"}
+    assert stub.compact_calls == []

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -810,3 +810,64 @@ async def test_orphan_sweep_escalates_to_sigkill(
 
     assert calls == 2
     assert killed == [(12345, signal.SIGTERM), (12345, signal.SIGKILL)]
+
+
+# ---------------------------------------------------------------------------
+# forward_compact — runner → harness compact forward
+# ---------------------------------------------------------------------------
+
+
+async def test_forward_compact_no_entry_returns_no_session() -> None:
+    """No live harness entry → graceful no_session (runner can fall back)."""
+    mgr = HarnessProcessManager()
+    result = await mgr.forward_compact("conv_missing")
+    assert result == {"status": "no_session"}
+
+
+async def test_forward_compact_posts_event_and_returns_result() -> None:
+    """Posts {"type":"compact"} to the harness and returns its parsed body."""
+    import types
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self) -> dict:
+            return {"status": "success", "pre_tokens": 200, "post_tokens": 20}
+
+    class _Client:
+        async def post(self, url: str, json: dict) -> "_Resp":
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+    mgr = HarnessProcessManager()
+    mgr._entries["conv_1"] = types.SimpleNamespace(client=_Client())
+
+    result = await mgr.forward_compact("conv_1")
+
+    assert result == {"status": "success", "pre_tokens": 200, "post_tokens": 20}
+    assert captured["url"] == "/v1/sessions/conv_1/events"
+    assert captured["json"] == {"type": "compact"}
+
+
+async def test_forward_compact_http_error_returns_none() -> None:
+    """A 4xx/5xx from the harness → None (logged; runner treats as failure)."""
+    import types
+
+    class _Resp:
+        status_code = 503
+
+        def json(self) -> dict:  # pragma: no cover - not reached on >=400
+            return {}
+
+    class _Client:
+        async def post(self, url: str, json: dict) -> "_Resp":
+            del url, json
+            return _Resp()
+
+    mgr = HarnessProcessManager()
+    mgr._entries["conv_1"] = types.SimpleNamespace(client=_Client())
+
+    assert await mgr.forward_compact("conv_1") is None


### PR DESCRIPTION
## Related issue

N/A

## Summary

Real in-place `/compact` for the `claude-sdk` harness, in two parts:

1. **Primitive** — `ClaudeSDKExecutor.compact_session()`: the SDK has no
   first-class `compact()` ([anthropics/claude-agent-sdk-python#23](https://github.com/anthropics/claude-agent-sdk-python/issues/23)),
   but the SDK-spawned `claude` CLI runs `/compact` when sent as a user message.
   This drives that and returns the `compact_boundary` metadata
   (`pre_tokens`/`post_tokens`/`trigger`). Verified live against
   claude-agent-sdk 0.2.94 (38163 → 6949, trigger=manual).
2. **Wiring** — routes the explicit `/compact` control for `claude-sdk` to the
   harness's own compaction instead of the server-side transcript summarizer
   (which can't shrink the SDK's real context and errored "Compaction requires a
   configured LLM model" for model-less agents like Polly). Mirrors the native
   harnesses' `/compact` routing.

Chain (mirrors the `interrupt` round-trip + the native `/compact` dispatch):
`Executor.compact_session()` base default (`"unsupported"`) → `CompactEvent` on
the harness events endpoint → `ExecutorAdapter._handle_compact_event` (guarded
to run between turns) → `HarnessProcessManager.forward_compact()` →
runner `_handle_claude_sdk_compact()` + a `claude-sdk` branch in the `/compact`
dispatch (alongside `claude-native`/`codex-native`), publishing the
`response.compaction.in_progress`/`completed` SSE. claude-sdk never returns 204,
so the server never falls back to its erroring AP-side path.

## ELI5

For Claude Code in a terminal, Omnigent compacts by typing `/compact` into the
pane. The SDK had no equivalent, so its `/compact` fell back to summarizing
Omnigent's transcript copy — which doesn't shrink Claude's real context and
errored when the agent pinned no model. Turns out you can compact the SDK too:
send `/compact` as a message and its underlying CLI compacts itself. This adds
that and wires the `/compact` command to it, the same way the native harnesses
are wired.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Unit: `compact_session` (no-session / boundary-metadata / error); base
`Executor.compact_session` default = `unsupported`; `ExecutorAdapter._handle_compact_event`
(success / busy-when-in-flight / no_session); `HarnessProcessManager.forward_compact`
(no-entry → no_session / posts `{"type":"compact"}` and returns the body /
http-error → None). Ran with the harness + runner suites
(`test_executor_adapter.py`, `test_process_manager.py`, `test_scaffold.py`,
`test_app_scaffold.py`, `test_runner_dispatch.py`) — green, no regressions.

Manual: `/compact` via the SDK reduced context 38163 → 6949 (compact_boundary,
trigger=manual) against claude-agent-sdk 0.2.94.

No new E2E: the path is unit-tested at every hop; full end-to-end is exercised
manually via `omnigent run examples/polly/` + `/compact`.

This pull request and its description were written by Isaac.
