### PR TITLE
test: fix + un-quarantine /model command show/set/reset (#523)

### DIFF
--- a/tests/e2e/omnigent/test_repl_model_e2e.py
+++ b/tests/e2e/omnigent/test_repl_model_e2e.py
@@ -46,10 +46,12 @@ def test_repl_model_command_show_set_reset(
 
     Asserts each transition:
 
-    1. Initial ``/model`` echoes ``(agent default)``.
+    1. Initial ``/model`` renders the ``Active:`` readout with no
+       in-session override (``no model pinned``).
     2. ``/model <name>`` confirms ``model set to <name>``.
-    3. Subsequent ``/model`` echoes the override (session state persisted).
-    4. ``/model default`` confirms reset to ``agent default``.
+    3. Subsequent ``/model`` shows ``<name>`` in the ``Active:`` readout
+       (session override persisted).
+    4. ``/model default`` confirms ``model reset to agent default``.
 
     :param omnigent_python: Interpreter with omnigent installed.
     :param omnigent_repo_root: Working directory for the subprocess.
@@ -78,25 +80,32 @@ def test_repl_model_command_show_set_reset(
         # REPL is ready.
         child.expect(r"❯ ", timeout=_BOOT_TIMEOUT)
 
+        # No-arg /model renders the active-credential readout:
+        #   "Active:  <model | (no model pinned …)>  ·  <provider>  ·  <source>"
+        # (this replaced the legacy "model: (agent default)" line; see
+        # _build_model_readout_lines in omnigent/repl/_repl.py). With no
+        # in-session override yet, the model slot reads "no model pinned" —
+        # ``--model`` sets the routing model, not the /model session override
+        # the readout tracks (``session.model_override``).
         _submit_slash_command(child, "/model")
-        # ``(agent default)`` is the canonical phrase the no-override
-        # show branch emits — search the slash-command handler for
-        # the matching string if you rename it.
-        child.expect(r"model: \(agent default\)", timeout=10)
-        # Usage hint is always printed alongside the show line.
-        child.expect("usage: /model", timeout=10)
+        child.expect("Active:", timeout=10)
+        child.expect("no model pinned", timeout=10)
 
         _submit_slash_command(child, f"/model {_OVERRIDE_MODEL}")
+        # Set confirmation: "model set to <name> for future responses".
         child.expect(f"model set to {_OVERRIDE_MODEL}", timeout=10)
 
-        # Same drain trick test_repl_effort_e2e.py uses: nudge a
-        # fresh prompt to confirm the input buffer is clear before
-        # firing the next slash command.
+        # Nudge a fresh prompt to confirm the input buffer is clear before
+        # the next slash command.
         child.send("\r")
         child.expect(r"❯ ", timeout=10)
 
+        # After the set, the readout's model slot shows the override (prior
+        # occurrences — the set confirmation — are already consumed, so the
+        # next match is the fresh readout line).
         _submit_slash_command(child, "/model")
-        child.expect(f"model: {_OVERRIDE_MODEL}", timeout=10)
+        child.expect("Active:", timeout=10)
+        child.expect(_OVERRIDE_MODEL, timeout=10)
 
         _submit_slash_command(child, "/model default")
         child.expect("model reset to agent default", timeout=10)

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -72,11 +72,6 @@ skips:
     mode: skip
 
 
-  - id: tests/e2e/omnigent/test_repl_model_e2e.py::test_repl_model_command_show_set_reset
-    reason: "REPL pexpect TIMEOUT post-path-fix: /model success line not appearing in pexpect after Rich markup output. Needs REPL output-capture investigation."
-    issue: 523
-    cluster: repl-pexpect-cli
-    mode: skip
 
   - id: tests/e2e/omnigent/test_repl_overview_terminal_visibility.py::test_repl_overview_terminal_visibility
     reason: "REPL pexpect TIMEOUT post-path-fix. Same family as test_repl_ctrl_o_overview (opens the debug overview)."


### PR DESCRIPTION
## Related issue

#523 (REPL pexpect cluster)

## Summary

Fixes and un-quarantines `test_repl_model_command_show_set_reset`. The quarantine reason was stale ("/model success line not appearing after Rich markup output"); the test is mock-LLM and boots fine. The real failure was **stale assertions against a rewritten `/model` readout** — not mock wiring:

- The no-arg `/model` show was rewritten from a `model: (agent default)` line to an **active-credential readout**: `Active:  <model | (no model pinned …)>  ·  <provider>  ·  <source>` (`_build_model_readout_lines`, `omnigent/repl/_repl.py:4084`). The `usage: /model` line now only prints when **no** provider resolves, so that assertion is dropped.
- **Initial show reads "no model pinned"**: `--model` sets the *routing* model, not the `/model` session override (`session.model_override`) the readout tracks. The override is unset until an explicit `/model <name>`, so the initial readout correctly reports no pin.
- **After `/model <name>`**: the readout's model slot shows the override.

The set confirmation (`model set to <name> for future responses`, `_repl.py:4428`) and reset confirmation (`model reset to agent default`, `_repl.py:4339`) were unchanged, so those two assertions still hold. Only the two **show** assertions needed rewriting (to the `Active:` readout) plus dropping the obsolete `usage: /model` line.

## Verification

- 4/4 locally (mock, no credentials).
- 30× CI flake-stress: [run 27834500874](https://github.com/omnigent-ai/omnigent/actions/runs/27834500874).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Test-only change. The `/model` show/set/reset state machine is now asserted against the current `Active:` readout contract instead of the retired `model: (agent default)` vocabulary; set/reset confirmations were unchanged and still verified. Confirmed 4/4 locally and 30× in CI flake-stress before un-quarantining. No product code changed.

This pull request and its description were written by Isaac.
