### PR TITLE
ci(polly-review): bump review models to opus-4-8 / gpt-5-5; tighten output prompt

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -230,13 +230,13 @@ jobs:
                       'anthropic': {
                           'base_url': gw + '/anthropic',
                           'api_key_ref': 'env:LLM_API_KEY',
-                          'models': {'default': 'databricks-claude-sonnet-4-6'},
+                          'models': {'default': 'databricks-claude-opus-4-8'},
                       },
                       'openai': {
                           'base_url': host + '/ai-gateway/codex/v1',
                           'api_key_ref': 'env:LLM_API_KEY',
                           'wire_api': 'responses',
-                          'models': {'default': 'databricks-gpt-5-4-mini'},
+                          'models': {'default': 'databricks-gpt-5-5'},
                       },
                   }
               }
@@ -302,7 +302,7 @@ jobs:
 
           IMPORTANT: Your output will be posted directly as a PR comment. Output
           ONLY the final structured review — no coordination messages, no status
-          updates about dispatching sub-agents, no "waiting for results" narration.
+          updates about dispatching sub-agents, no referring to "reviewers", no "waiting for results" narration.
           Begin your response with the exact marker <!-- POLLY_REVIEW_START -->
           on its own line, then the review content. Nothing before the marker
           will be shown.

--- a/ap-web/package-lock.json
+++ b/ap-web/package-lock.json
@@ -97,13 +97,13 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.127",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.127.tgz",
-      "integrity": "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==",
+      "version": "3.0.129",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.129.tgz",
+      "integrity": "sha512-KEQpZGJuCksc4iFxYtVHeHHG7yH0izGFzJLmRZlriI0hFIzJF9bT2AzJoaTHUI6minlxtP0WKYh84dP18o/Cuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27",
+        "@ai-sdk/provider-utils": "4.0.29",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
-      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.29.tgz",
+      "integrity": "sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -889,9 +889,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.3.tgz",
+      "integrity": "sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==",
       "dev": true,
       "funding": [
         {
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.71.2",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.71.2.tgz",
-      "integrity": "sha512-Xj9T3Wr+Bo4ILKf9PZJBYJ4SJiZGC/pqIdzOMbX9jgAFb0oGuKkusLleYHN/N6zanZixNvmuMVWYR1T3YJuVTA==",
+      "version": "1.71.3",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.71.3.tgz",
+      "integrity": "sha512-WSmox5aD+XxJEUEOTk7gKLpd5+Iz9Nik89Zpbu5DijMln6LsFiv3xpNKBMc/b9sSkUlKvAblzrhik2TqKFE7NA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^11.1.0",
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@lobehub/ui": {
-      "version": "5.15.12",
-      "resolved": "https://registry.npmjs.org/@lobehub/ui/-/ui-5.15.12.tgz",
-      "integrity": "sha512-Pyie7j2UzbdTDqCdHjR3J9dw6ewpoqHDrwnkWWMDtJpqeEzPywLhwen90DQ6ETHfXrlbsIfuczgoEkBKirtAPg==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@lobehub/ui/-/ui-5.15.15.tgz",
+      "integrity": "sha512-nbake8F9Lp6/g1AaBnbt+l0Q8/u5/RjpSeE67ABOf5BV2MMV4Vhac5rTkkS7F4DpRYXug7i4A/ZvGwn3/F+jmA==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^2.1.2",
@@ -1789,30 +1789,30 @@
         "@giscus/react": "^3.1.0",
         "@mdx-js/mdx": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
-        "@pierre/diffs": "^1.1.19",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@shikijs/core": "^4.0.2",
-        "@shikijs/transformers": "^4.0.2",
+        "@pierre/diffs": "1.2.8",
+        "@radix-ui/react-slot": "^1.2.5",
+        "@shikijs/core": "^4.2.0",
+        "@shikijs/transformers": "^4.2.0",
         "@splinetool/runtime": "0.9.526",
         "ahooks": "^3.9.7",
         "antd-style": "^4.1.0",
         "chroma-js": "^3.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dayjs": "^1.11.20",
+        "dayjs": "^1.11.21",
         "emoji-mart": "^5.6.0",
-        "es-toolkit": "^1.46.0",
+        "es-toolkit": "^1.47.0",
         "fast-deep-equal": "^3.1.3",
-        "immer": "^11.1.4",
-        "katex": "^0.16.45",
+        "immer": "^11.1.8",
+        "katex": "^0.16.47",
         "leva": "^0.10.1",
-        "lucide-react": "^1.11.0",
+        "lucide-react": "^1.17.0",
         "marked": "^17.0.6",
-        "mermaid": "^11.14.0",
-        "motion": "^12.38.0",
+        "mermaid": "^11.15.0",
+        "motion": "^12.40.0",
         "numeral": "^2.0.6",
         "polished": "^4.3.1",
-        "query-string": "^9.3.1",
+        "query-string": "^9.4.0",
         "rc-collapse": "^4.0.0",
         "rc-footer": "^0.6.8",
         "rc-image": "^7.12.0",
@@ -1820,8 +1820,8 @@
         "rc-menu": "^9.16.1",
         "re-resizable": "^6.11.2",
         "react-avatar-editor": "^15.1.0",
-        "react-error-boundary": "^6.1.1",
-        "react-hotkeys-hook": "^5.2.4",
+        "react-error-boundary": "^6.1.2",
+        "react-hotkeys-hook": "^5.3.2",
         "react-markdown": "^10.1.0",
         "react-merge-refs": "^3.0.2",
         "react-rnd": "^10.5.3",
@@ -1835,14 +1835,14 @@
         "remark-github": "^12.0.0",
         "remark-math": "^6.0.0",
         "remend": "^1.3.0",
-        "shiki": "^4.0.2",
-        "shiki-stream": "^0.1.4",
+        "shiki": "^4.2.0",
+        "shiki-stream": "^0.1.5",
         "swr": "^2.4.1",
         "ts-md5": "^2.0.1",
         "unified": "^11.0.5",
         "url-join": "^5.0.0",
         "use-merge-value": "^1.2.0",
-        "uuid": "^13.0.0",
+        "uuid": "^13.0.2",
         "virtua": "^0.49.1"
       },
       "peerDependencies": {
@@ -2004,14 +2004,14 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -4102,9 +4102,9 @@
       "license": "MIT"
     },
     "node_modules/@rc-component/async-validator": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.1.tgz",
-      "integrity": "sha512-T03+Wk31Kz/28OC+rLlHtSNwD5Io3OWw6rPFPAp898sqALB/XnTrr3trB3mPoj379v0aRaW6t09HUG6dUyHR3g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-6.0.0.tgz",
+      "integrity": "sha512-D3AGQwdyE58gmvx6waVSXJ80JGO+IY5L2O8HDnSOex7JNlzB3GuN/4hyHNTdhy2qtOhkpbIjmeAN3tL993wKbA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.4"
@@ -4114,14 +4114,14 @@
       }
     },
     "node_modules/@rc-component/cascader": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.15.0.tgz",
-      "integrity": "sha512-ZzpMtwFCRo3fbXHuDnncARJMZQjdqA2w7aDuPofNQt+aDx39st1hgfIpEwTBLhe2Hqsvs/zOr8RTtgxTkCPySw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.16.1.tgz",
+      "integrity": "sha512-wxLopwM+EBed0zNNGdnGE4coYoqcO+XD42fHgn+pDvO+XzhNFbdgSlSNXdKocIYqccvqgWvoxDPNb0OVRdi59A==",
       "license": "MIT",
       "dependencies": {
-        "@rc-component/select": "~1.6.0",
-        "@rc-component/tree": "~1.3.0",
-        "@rc-component/util": "^1.4.0",
+        "@rc-component/select": "~1.7.1",
+        "@rc-component/tree": "~1.3.2",
+        "@rc-component/util": "^1.11.1",
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
@@ -4235,12 +4235,12 @@
       }
     },
     "node_modules/@rc-component/form": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.2.tgz",
-      "integrity": "sha512-ZidCvOLmM9Xr+3vzk4UAoR7Aj1W/5IHyrzlBB7sNkygpTeRVrohQSo4TN7W/nARTH+nt8zSAPsn4BEl4zLEO2g==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.3.tgz",
+      "integrity": "sha512-jNkat3uxZ246ELudKwnjQhnDI8+rSxgLxjztvQU3Mrb0G+LwDyOrPu9RNfekOjqU5GQ5QJepi225x+9LhCizJw==",
       "license": "MIT",
       "dependencies": {
-        "@rc-component/async-validator": "^5.1.0",
+        "@rc-component/async-validator": "^6.0.0",
         "@rc-component/util": "^1.11.1",
         "clsx": "^2.1.1"
       },
@@ -4409,12 +4409,12 @@
       }
     },
     "node_modules/@rc-component/pagination": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
-      "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.3.0.tgz",
+      "integrity": "sha512-12ahTY+HPITg1L2bjWKXUqBJe/oOnpA2QsChdCjthqLVf/e19StiCsv8OLKpWoHbc+8PFEkNjRqRqrLoRBHjFw==",
       "license": "MIT",
       "dependencies": {
-        "@rc-component/util": "^1.3.0",
+        "@rc-component/util": "^1.11.1",
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
@@ -4492,9 +4492,9 @@
       }
     },
     "node_modules/@rc-component/qrcode": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.2.tgz",
-      "integrity": "sha512-CTXG18eP3sO3gc+96ep9HyVI/RzMup7L59apM/D0wWo1SHRdwOb7xyD4bMbmpu4dPlTch59Kxb8lU7U9ME60fg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-2.0.0.tgz",
+      "integrity": "sha512-aAv3QhPP1xyafuTZOxub6a54pCeBnN3IwQkpETrBtthq4BL5IgxnCbuoBWPDpdLw1y1j6BgBUCAKV92+yX06Dw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7"
@@ -4554,15 +4554,15 @@
       }
     },
     "node_modules/@rc-component/select": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
-      "integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.7.1.tgz",
+      "integrity": "sha512-GZ1cMJk2xQh0VHyOQjjG8drYL4iu24NcbkXioUcReQOCUr+ub/3fmRonZe6cRPEZhWMbJdeHsqnEltogDaZ5Tg==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/trigger": "^3.0.0",
-        "@rc-component/util": "^1.3.0",
-        "@rc-component/virtual-list": "^1.0.1",
+        "@rc-component/util": "^1.11.1",
+        "@rc-component/virtual-list": "^1.2.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -4716,12 +4716,12 @@
       }
     },
     "node_modules/@rc-component/tree-select": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.9.0.tgz",
-      "integrity": "sha512-GXcFe15a+trUl1/J3OHWQhsVWFpwFpGFK2cqYWZ1sK22Zs3KZTvMwDpzr75PIo1s6QVioVxpE/pRwRopkeDQ6w==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.10.0.tgz",
+      "integrity": "sha512-E1U4pn2LAbXEhLJdzIzid7WYbIuFbkTIctuFoeC6weppf8UbPR3+YYB6/ay0c0ksand4gXMRQpa1Z60Auo7VJA==",
       "license": "MIT",
       "dependencies": {
-        "@rc-component/select": "~1.6.0",
+        "@rc-component/select": "~1.7.0",
         "@rc-component/tree": "~1.3.0",
         "@rc-component/util": "^1.4.0",
         "clsx": "^2.1.1"
@@ -5194,6 +5194,34 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/stream/-/stream-4.2.0.tgz",
+      "integrity": "sha512-OaMUUStdIZ+l1GJad9uVACR3Xvgwo4y+RmEuDMU62cgFMMg1IBCaIFmvzAR2HiCpGtwoc/qPfpNnP+ivgrPXZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "solid-js": "^1.9.0",
+        "vue": "^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/@shikijs/themes": {
@@ -6747,9 +6775,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -7151,9 +7179,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7203,14 +7231,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.199",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.199.tgz",
-      "integrity": "sha512-6H9RPEjzBQECM+eU1JxAh6jHcZPU/6q5QZ8D8QV8agubf0Mm/kcBlwqrFcFtup6RQzmEvMkVaQOoLCZ8bQ13lA==",
+      "version": "6.0.203",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.203.tgz",
+      "integrity": "sha512-2Qi1ZPGF/FnlvnRqntVgRbUYGeA5ZKFYwTtgu8rcUzMmddArM/nLsvCW69Ip99B1cop6XHRHl+GCKk9t9B+GDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.127",
+        "@ai-sdk/gateway": "3.0.129",
         "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27",
+        "@ai-sdk/provider-utils": "4.0.29",
         "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
@@ -7316,54 +7344,54 @@
       }
     },
     "node_modules/antd": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-6.4.3.tgz",
-      "integrity": "sha512-6H2avkxCGfxcF67r3J2mwm9Ck50el1pks/73vfM1wDsPL/tPtj5vHuauMgJFnrqmq7CH3g8aoZ0VBQbt+jpAsw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.4.4.tgz",
+      "integrity": "sha512-lgPz4KhfhiYddV/qPYo0ieqWimCVgV2OQF72mbeGNixE753JWNnmEc7UNGy08wBS/zZ7hxrmX0pc5aX7EUaIIg==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
         "@ant-design/cssinjs": "^2.1.2",
         "@ant-design/cssinjs-utils": "^2.1.2",
         "@ant-design/fast-color": "^3.0.1",
-        "@ant-design/icons": "^6.2.3",
+        "@ant-design/icons": "^6.2.5",
         "@ant-design/react-slick": "~2.0.0",
         "@babel/runtime": "^7.29.2",
-        "@rc-component/cascader": "~1.15.0",
+        "@rc-component/cascader": "~1.16.1",
         "@rc-component/checkbox": "~2.0.0",
         "@rc-component/collapse": "~1.2.0",
         "@rc-component/color-picker": "~3.1.1",
         "@rc-component/dialog": "~1.9.0",
         "@rc-component/drawer": "~1.4.2",
         "@rc-component/dropdown": "~1.0.2",
-        "@rc-component/form": "~1.8.1",
+        "@rc-component/form": "~1.8.3",
         "@rc-component/image": "~1.9.0",
-        "@rc-component/input": "~1.3.0",
+        "@rc-component/input": "~1.3.1",
         "@rc-component/input-number": "~1.6.2",
         "@rc-component/mentions": "~1.9.0",
-        "@rc-component/menu": "~1.3.0",
-        "@rc-component/motion": "^1.3.2",
+        "@rc-component/menu": "~1.3.1",
+        "@rc-component/motion": "^1.3.3",
         "@rc-component/mutate-observer": "^2.0.1",
         "@rc-component/notification": "~2.0.7",
-        "@rc-component/pagination": "~1.2.0",
+        "@rc-component/pagination": "~1.3.0",
         "@rc-component/picker": "~1.10.0",
         "@rc-component/progress": "~1.0.2",
-        "@rc-component/qrcode": "~1.1.1",
+        "@rc-component/qrcode": "~2.0.0",
         "@rc-component/rate": "~1.0.1",
         "@rc-component/resize-observer": "^1.1.2",
         "@rc-component/segmented": "~1.3.0",
-        "@rc-component/select": "~1.6.15",
+        "@rc-component/select": "~1.7.1",
         "@rc-component/slider": "~1.0.1",
         "@rc-component/steps": "~1.2.2",
         "@rc-component/switch": "~1.0.3",
-        "@rc-component/table": "~1.10.0",
-        "@rc-component/tabs": "~1.9.0",
+        "@rc-component/table": "~1.10.2",
+        "@rc-component/tabs": "~1.9.1",
         "@rc-component/tooltip": "~1.4.0",
         "@rc-component/tour": "~2.4.0",
-        "@rc-component/tree": "~1.3.1",
-        "@rc-component/tree-select": "~1.9.0",
-        "@rc-component/trigger": "^3.9.0",
-        "@rc-component/upload": "~1.1.0",
-        "@rc-component/util": "^1.11.0",
+        "@rc-component/tree": "~1.3.2",
+        "@rc-component/tree-select": "~1.10.0",
+        "@rc-component/trigger": "^3.9.1",
+        "@rc-component/upload": "~1.1.1",
+        "@rc-component/util": "^1.11.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.11",
         "scroll-into-view-if-needed": "^3.1.0",
@@ -7458,9 +7486,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
-      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7549,9 +7577,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.35",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
-      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7745,9 +7773,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001797",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8916,9 +8944,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8983,9 +9011,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.370",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz",
-      "integrity": "sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -9038,9 +9066,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
-      "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9133,9 +9161,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
-      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -11607,9 +11635,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
-      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.18.0.tgz",
+      "integrity": "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -12046,9 +12074,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-chrome": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.1.tgz",
-      "integrity": "sha512-1+x2l0mNulHKZN0lBxGJwJ+TV2W/KzLjaAd//UCGZz8GE5O5YNafFskWTcv/D6Ty0d9drX9SSfimOzGwob8eVQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.2.tgz",
+      "integrity": "sha512-4ai1ITN8wBhwugQcRgqe3tN0z6OSKGOXqHLNrS04MgKFfsLqu6Dm8MPq02pI9Y9ZKoXtFjIl85jOryIW9es3BA==",
       "license": "MIT",
       "dependencies": {
         "ce-la-react": "^0.3.2"
@@ -13358,9 +13386,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -14005,9 +14033,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.7",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
-      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "version": "1.25.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.8.tgz",
+      "integrity": "sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==",
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
@@ -14058,12 +14086,12 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.8",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
-      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "version": "1.41.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.9.tgz",
+      "integrity": "sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==",
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "^1.20.0",
+        "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -15557,9 +15585,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15736,9 +15764,9 @@
       }
     },
     "node_modules/shadcn/node_modules/postcss-selector-parser": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
-      "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15798,12 +15826,13 @@
       }
     },
     "node_modules/shiki-stream": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/shiki-stream/-/shiki-stream-0.1.4.tgz",
-      "integrity": "sha512-4pz6JGSDmVTTkPJ/ueixHkFAXY4ySCc+unvCaDZV7hqq/sdJZirRxgIXSuNSKgiFlGTgRR97sdu2R8K55sPsrw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/shiki-stream/-/shiki-stream-0.1.5.tgz",
+      "integrity": "sha512-DzkqVlqf02Tp4zTFNgJp+3rOG2RkuoONBq+Pm2sHslAlJ5M0QbR1devn4dr9SgcBTrtHTf6Rqyj3wVJi0g16Bw==",
+      "deprecated": "shiki-stream is now @shikijs/stream, please migrate by renaming the package",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "^3.0.0"
+        "@shikijs/stream": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -15823,28 +15852,6 @@
         "vue": {
           "optional": true
         }
-      }
-    },
-    "node_modules/shiki-stream/node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "node_modules/shiki-stream/node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {
@@ -16497,9 +16504,9 @@
       }
     },
     "node_modules/ts-dedent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
-      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.10"


### PR DESCRIPTION
## Related issue

N/A (CI tuning)

## Summary

Tune the Polly AI review workflow (`.github/workflows/polly-review.yml`):

- Bump the reviewer model defaults — anthropic `databricks-claude-sonnet-4-6` → `databricks-claude-opus-4-8`, openai `databricks-gpt-5-4-mini` → `databricks-gpt-5-5`.
- Tighten the output-format instruction so the review never refers to "reviewers" (alongside the existing no-coordination / no-"waiting for results" narration rules).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage rationale

Workflow-config change only (model-id bumps + a prompt wording tweak); no application code paths affected. Verified by validating the run on a real PR review.
