### PR TITLE
test: fix + un-quarantine multi-line Ctrl+J input (#523)

### DIFF
--- a/tests/e2e/omnigent/test_repl_multiline.py
+++ b/tests/e2e/omnigent/test_repl_multiline.py
@@ -4,8 +4,8 @@ Drives the REPL under pexpect, types the first half of a
 prompt, sends ``Ctrl+J`` to insert a newline mid-input, types the
 second half, and finally submits with Enter. Asserts the full
 multi-line message reached the agent by looking for BOTH halves
-in the rendered ``You>`` banner that the REPL echoes to
-scrollback before streaming the assistant response.
+in the user turn the REPL echoes to scrollback (under the ``❯``
+prompt glyph) before streaming the assistant response (under ``◆``).
 
 Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
 REPL pexpect suite — "Multi-line input".
@@ -107,8 +107,11 @@ def test_repl_multiline_ctrl_j_insert(
         "exit_code": exit_code,
         "first_line_present": _FIRST_LINE in combined_stripped,
         "second_line_present": _SECOND_LINE in combined_stripped,
-        "user_banner_present": "You>" in combined_stripped,
-        "agent_banner_present": "Agent>" in combined_stripped,
+        # The turn banners are glyphs now, not the legacy "You>"/"Agent>"
+        # text labels: the user prompt echoes under "❯" and the assistant
+        # reply under "◆" (e.g. "❯ line-one-alpha" / "◆ <reply>").
+        "user_banner_present": "❯" in combined_stripped,
+        "agent_banner_present": "◆" in combined_stripped,
     }
     diffs = compare_snapshot("test_repl_multiline", observed)
     assert diffs == [], (

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -65,11 +65,6 @@ skips:
     cluster: repl-server-mode-startup-crash
     mode: skip
 
-  - id: tests/e2e/omnigent/test_repl_multiline.py::test_repl_multiline_ctrl_j_insert
-    reason: "Kept suppressed as a known shard-load/worker-killer heavy pexpect test pending a dedicated round."
-    issue: 523
-    cluster: repl-pexpect-cli
-    mode: skip
 
 
 


### PR DESCRIPTION
## Related issue

#523 (REPL pexpect cluster)

## Summary

Fixes and un-quarantines `test_repl_multiline_ctrl_j_insert`. The failure was **stale banner markers**, not mock wiring or a Ctrl+J bug:

The test asserted the turn banners `You>` (user) and `Agent>` (agent), but those text labels were retired — the REPL now echoes the user turn under the **`❯`** prompt glyph and the assistant reply under **`◆`**. The captured buffer confirms the multi-line input works end-to-end:

```
❯ line-one-alpha
line-two-beta

◆ I received your multi-line input.
```

`first_line_present` and `second_line_present` already passed — only the two banner assertions (`You>`/`Agent>`) were stale.

**Fix:** assert the `❯` / `◆` glyph banners instead of `You>` / `Agent>`, and update the docstring. The snapshot is unchanged (both banners are still present — just under the new glyphs).

## Verification

- 3/3 locally (mock, no credentials).
- 30× CI flake-stress: [run 27835783163](https://github.com/omnigent-ai/omnigent/actions/runs/27835783163).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Test-only change. The Ctrl+J multi-line compose + submit flow is still fully exercised (both input halves reach the agent, the reply renders); only the retired `You>`/`Agent>` banner labels were swapped for the current `❯`/`◆` glyphs. Verified 3/3 locally and 30× in CI flake-stress before un-quarantining. No product code changed.

This pull request and its description were written by Isaac.
