### PR TITLE
ci(e2e-ui): remove OPENAI_API_KEY/BASE_URL from test runner env

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -258,11 +258,12 @@ jobs:
         # --ui-skip-build: the SPA was built in the previous step.
         # --tracing/--screenshot/--video default to off; retain-on-failure
         # keeps green runs cheap while capturing artifacts on failures.
-        # OPENAI_API_KEY / OPENAI_BASE_URL flow into the spawned server via
-        # the conftest's live_server fixture for the openai-agents harness.
+        # OPENAI_API_KEY / OPENAI_BASE_URL are set by the conftest's
+        # live_server fixture to point at the in-process mock LLM server —
+        # no real gateway credentials needed for the openai-agents harness.
+        # Native render-parity tests (claude-sdk/codex) still use the
+        # ~/.omnigent/config.yaml written in the step above.
         env:
-          OPENAI_API_KEY: ${{ env.LLM_API_KEY }}
-          OPENAI_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
           # Scheduled / manually dispatched runs are the full pass;
           # PR and push runs exclude @pytest.mark.nightly tests.
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

Removes `OPENAI_API_KEY` and `OPENAI_BASE_URL` from the UI e2e test runner environment. These were previously needed so the spawned omnigent server could reach the Databricks LLM gateway.

## Why this is safe now

The `live_server` fixture in `tests/e2e_ui/conftest.py` (added in #824) now:
- Starts a local mock LLM server subprocess
- Injects `OPENAI_BASE_URL=mock_url/v1` and `OPENAI_API_KEY=mock-key` directly into the spawned server's env

The CI job-level env vars are overridden by the fixture anyway, so removing them from the workflow has no effect on the openai-agents tests.

## What's kept

- `LLM_API_KEY` secret exposure (still needed by "Configure native-claude/codex gateway provider" step)
- The gateway provider config step itself (for native render-parity tests that drive real Claude Code / Codex CLIs)

This pull request and its description were written by Isaac.