### PR TITLE
test: re-characterize overview-visibility ×3 — blocked on tool-call marker render (#523)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -74,21 +74,21 @@ skips:
 
 
   - id: tests/e2e/omnigent/test_repl_overview_terminal_visibility.py::test_repl_overview_terminal_visibility
-    reason: "REPL pexpect TIMEOUT post-path-fix. Same family as test_repl_ctrl_o_overview (opens the debug overview)."
+    reason: "Blocked on the tool-call lifecycle-marker rendering gap (same family as #677), NOT a stale marker. Probed live 2026-06-20: after the prompt that should fire sys_terminal_launch, the turn runs to idle WITHOUT rendering the sync line '• sys_terminal_launch (Nms)' the test waits on -> expect times out. Compounding: this test uses the open-responses harness, which did not execute the mock tool-call at all and under which Ctrl+O opened no overview. Also needs the Ctrl+G->Ctrl+O keybinding fix (necessary but insufficient). Needs the tool-call-marker render (and open-responses tool execution) fixed first."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: repl-toolcall-marker-render
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_overview_subagent_visibility.py::test_repl_overview_subagent_visibility[claude-sdk]
-    reason: "Suspected worker-death contributor on shard 0 alongside test_repl_multiline_ctrl_j_insert. Investigate together."
+    reason: "Blocked on the tool-call lifecycle-marker rendering gap (same family as #677): the test syncs on the supervisor's 'sys_session_send (<worker>:' tool-call line, which does not render (probed live 2026-06-20 via the [codex] sibling: no tool-call marker surfaces after submit, and Ctrl+O then opens no overview). Also needs the Ctrl+G->Ctrl+O keybinding fix (necessary but insufficient), and the claude_worker sub-agent needs the claude CLI on a mock-served path. claude-sdk row also can't run locally (claude is a shell alias). Needs the tool-call-marker render fixed first."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: repl-toolcall-marker-render
     mode: skip
 
   - id: tests/e2e/omnigent/test_repl_overview_subagent_visibility.py::test_repl_overview_subagent_visibility[codex]
-    reason: "Same family as the [claude-sdk] variant; suspected worker-death contributor on shard 0."
+    reason: "Blocked on the tool-call lifecycle-marker rendering gap (same family as #677): probed live 2026-06-20 — after the delegate prompt the supervisor turn does not render the 'sys_session_send (codex_worker:' sync line the test waits on, and a follow-up Ctrl+O opens no overview. Also needs the Ctrl+G->Ctrl+O keybinding fix (necessary but insufficient), plus the codex_worker sub-agent on a mock-served path. Needs the tool-call-marker render fixed first."
     issue: 523
-    cluster: repl-pexpect-cli
+    cluster: repl-toolcall-marker-render
     mode: skip
 
   - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[pi]


### PR DESCRIPTION
## Related issue

#523 (REPL pexpect cluster)

## Summary

Triages the three `#523` overview-visibility tests (`overview_terminal_visibility`, `overview_subagent_visibility[claude-sdk|codex]`). **Verdict: real blocker, kept quarantined — re-characterized** from vague inherited reasons to the precise diagnosis, and moved to a dedicated `repl-toolcall-marker-render` cluster.

Unlike the clean stale-marker fixes in this cluster (ctrl_g #834, /model #836, multiline #838), these are **not** a simple keybinding/marker swap. They are blocked **upstream** on the tool-call lifecycle-marker rendering gap (same family as #677), so the `Ctrl+G → Ctrl+O` keybinding fix is **necessary but insufficient**.

**Probed live (2026-06-20):**
- `terminal_visibility`: after the prompt that should fire `sys_terminal_launch`, the turn runs to idle **without rendering** the `• sys_terminal_launch (Nms)` sync line the test waits on → `expect` times out. Compounding: this test uses the **`open-responses`** harness, which did not execute the mock tool-call at all, and under which **Ctrl+O opened no overview**.
- `subagent_visibility[codex]`: the supervisor turn never renders the `sys_session_send (codex_worker:` sync line; a follow-up Ctrl+O opens no overview. (`[claude-sdk]` can't run locally — `claude` is a shell alias here.)

So all three never reach the overview step. The fix order is: **tool-call-marker rendering first** (the #677 root cause), then the `Ctrl+G→Ctrl+O` keybinding, then verify the overview content markers.

**No test status change** — `known_failures.yaml` metadata only (reasons + cluster).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

`known_failures.yaml` metadata only — no test or product code changed, all three stay quarantined. The entries now carry the verified root cause (tool-call lifecycle-marker not rendering; same family as #677), the confirmed `Ctrl+G→Ctrl+O` keybinding staleness, and the `open-responses` harness caveat for the terminal variant — replacing the stale inherited placeholders. They sit in a `repl-toolcall-marker-render` cluster that names the shared blocker, so a follow-up owner can fix the rendering once and unblock all three (plus #677, and likely `inline_tool_streaming`).

This pull request and its description were written by Isaac.
