### PR TITLE
test: un-quarantine inline_tool_streaming — stale-green (#523)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -34,13 +34,6 @@ skips:
     cluster: mock-claude-sdk-cli-unsupported
     mode: skip
 
-  - id: tests/e2e/omnigent/test_repl_inline_tool_streaming.py::test_repl_inline_tool_call_and_result_streaming
-    reason: "REPL inline tool-call streaming."
-    issue: 523
-    cluster: repl-pexpect-cli
-    mode: skip
-
-
   - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[pi]
     reason: "No-AGENT `omnigent run --harness` live round-trip crashes the xdist worker — same family as the [claude-sdk]/[codex]/[openai-agents] siblings. Surfaced once pi was enabled in CI (PR #809); previously the [pi] row skipped because the pi CLI was absent. See [claude-sdk] entry for the full diagnosis."
     issue: 523


### PR DESCRIPTION
## Summary

Un-quarantines `test_repl_inline_tool_call_and_result_streaming`, previously skipped under the `repl-pexpect-cli` cluster (#523) as a suspected shard-0 "worker-death contributor" with only a placeholder reason. **It's stale-green** — the test already passes as written; no code change is needed.

## Why it's safe

- Uses the mock-compatible `openai-agents` harness (renders tool calls inline).
- Uses the proper `await_turn_complete` helper with **current** glyphs (`running_marker="working"`, `completion_pattern="❯ "`) — no stale UI markers.
- Asserts the `done-streaming` marker after a `get_current_time` tool-call round-trip.

The quarantine predates the REPL marker/harness stabilization that greened the rest of the cluster (#834, #836, #838).

## Verification

- Green **6× locally** (~16s each), including un-quarantined collection (without `--no-skip-known`).
- 30× CI flake-stress gate kicked off against this branch (link added in a comment).

This pull request and its description were written by Isaac.
