### PR TITLE
test: un-quarantine overview_terminal_visibility — open-responses mock-incompat + stale markers (#523)

### DIFF
--- a/tests/e2e/omnigent/test_repl_overview_terminal_visibility.py
+++ b/tests/e2e/omnigent/test_repl_overview_terminal_visibility.py
@@ -5,9 +5,16 @@ Migrated to mock LLM: uses canned tool-call responses to trigger
 
 Uses ``examples/terminal_workers.yaml`` so the REPL hosts a
 terminal-supervisor. Sends a prompt that (via the mock response)
-invokes ``sys_terminal_launch``, waits for the completion line, opens
+invokes ``sys_terminal_launch``, waits for the turn to complete, opens
 the overview, cycles to the terminal target, and asserts the overview
 pane renders the tmux ``attach`` instruction line.
+
+The supervisor runs the ``openai-agents`` harness (not the YAML's
+default ``open-responses``): under the mock LLM server, ``open-responses``
+fails to spawn on the runner (``harness_spawn_failed`` / ``runner_error``)
+so the terminal never launches — a mock-incompatibility analogous to the
+documented ``claude-sdk`` case, not a stale marker. ``openai-agents`` is
+mock-compatible and exercises the same terminal-launch + overview path.
 
 **What breaks if this fails:**
 - ``_collect_overview_targets`` stops including terminal instances.
@@ -18,10 +25,12 @@ pane renders the tmux ``attach`` instruction line.
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from shutil import which
 from typing import Any
 
+import pexpect
 import pytest
 
 from tests.e2e.omnigent._pexpect_harness import (
@@ -31,12 +40,11 @@ from tests.e2e.omnigent._pexpect_harness import (
     submit_prompt,
     wait_for_ready,
 )
-from tests.e2e.omnigent._repl_test_helpers import drain_for
 from tests.e2e.omnigent._snapshot import compare_snapshot
 from tests.e2e.omnigent.conftest import configure_mock_llm
 
 _MODEL = "mock-overview-terminal"
-_HARNESS = "open-responses"
+_HARNESS = "openai-agents"
 
 _PROMPT = (
     'Call sys_terminal_launch(terminal="shell", session="probe") '
@@ -124,29 +132,30 @@ def test_repl_overview_terminal_visibility(
     try:
         wait_for_ready(child, timeout=_BOOT_TIMEOUT)
         submit_prompt(child, _PROMPT)
-        # Wait for the ``sys_terminal_launch`` completion line.
-        # Once it appears, the launch has finished and
-        # ``_terminal_instances[("shell", "probe")]`` is registered.
-        child.expect(
-            r"• sys_terminal_launch \(\d+ms\)",
-            timeout=_COMPLETION_TIMEOUT,
-        )
-        # Drain the completion line so the subsequent overview render
-        # isn't masked by tool-call tail bytes.
-        drain_for(child, 2.0)
-        # Open the overview.
-        child.sendcontrol("g")
-        drain_for(child, _OVERVIEW_DRAIN_TIMEOUT)
-        # Tab cycles through targets: main → shell:probe.
+        # Sync on the supervisor's FINAL reply text, which renders only after
+        # sys_terminal_launch executed and registered the terminal as an
+        # overview target. (The old "• sys_terminal_launch (Nms)" completion
+        # line is retired — the tool-call now renders as
+        # "⏵ sys_terminal_launch({...})" — and that line carries ANSI between
+        # the name and "(", so syncing on it is unreliable.)
+        child.expect("launching the terminal", timeout=_COMPLETION_TIMEOUT)
+        # Open the overview (Ctrl+O; binding moved off Ctrl+G — Warp intercepts
+        # Ctrl+G, see _repl.py "Why Ctrl+O and not Ctrl+G").
+        child.sendcontrol("o")
+        # Wait for the sidebar to paint the terminal target ("💻 shell:probe").
+        child.expect(_TERMINAL_LABEL, timeout=_EXPECT_TERMINAL_TIMEOUT)
+        # Tab cycles main → shell:probe so the terminal detail pane (the tmux
+        # attach instructions, "tmux -S <sock> attach …") renders.
         child.send("\t")
-        # Wait for the terminal pane's "Terminal:" header to render.
-        child.expect(f"Terminal: {_TERMINAL_LABEL}", timeout=_EXPECT_TERMINAL_TIMEOUT)
-        terminal_pane_tail = drain_for(child, _OVERVIEW_DRAIN_TIMEOUT)
-        terminal_stripped = (
-            strip_ansi(child.before or "")
-            + f"Terminal: {_TERMINAL_LABEL}"
-            + strip_ansi(terminal_pane_tail)
-        )
+        # Accumulate the detail pane. The status-bar clock ticks ~1×/s, so a
+        # drain that bails on a 0.3s idle gap is unreliable — force a
+        # fixed-duration read with an impossible-pattern expect.
+        with contextlib.suppress(pexpect.TIMEOUT):
+            child.expect("ZZZ_NEVER_MATCHES_DRAIN", timeout=_OVERVIEW_DRAIN_TIMEOUT)
+        terminal_stripped = _TERMINAL_LABEL + strip_ansi(child.before or "")
+        # Close the overlay before teardown ('q'); leaving it open blocks the
+        # Ctrl+D / "/quit" exit handshake (see test_repl_ctrl_o_overview).
+        child.send("q")
         clean_exit(child, timeout=_EXIT_TIMEOUT)
         exit_code = child.exitstatus
     finally:

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -68,12 +68,6 @@ skips:
 
 
 
-  - id: tests/e2e/omnigent/test_repl_overview_terminal_visibility.py::test_repl_overview_terminal_visibility
-    reason: "Blocked on the tool-call lifecycle-marker rendering gap (same family as #677), NOT a stale marker. Probed live 2026-06-20: after the prompt that should fire sys_terminal_launch, the turn runs to idle WITHOUT rendering the sync line '• sys_terminal_launch (Nms)' the test waits on -> expect times out. Compounding: this test uses the open-responses harness, which did not execute the mock tool-call at all and under which Ctrl+O opened no overview. Also needs the Ctrl+G->Ctrl+O keybinding fix (necessary but insufficient). Needs the tool-call-marker render (and open-responses tool execution) fixed first."
-    issue: 523
-    cluster: repl-toolcall-marker-render
-    mode: skip
-
   - id: tests/e2e/omnigent/test_repl_overview_subagent_visibility.py::test_repl_overview_subagent_visibility[claude-sdk]
     reason: "Blocked on the tool-call lifecycle-marker rendering gap (same family as #677): the test syncs on the supervisor's 'sys_session_send (<worker>:' tool-call line, which does not render (probed live 2026-06-20 via the [codex] sibling: no tool-call marker surfaces after submit, and Ctrl+O then opens no overview). Also needs the Ctrl+G->Ctrl+O keybinding fix (necessary but insufficient), and the claude_worker sub-agent needs the claude CLI on a mock-served path. claude-sdk row also can't run locally (claude is a shell alias). Needs the tool-call-marker render fixed first."
     issue: 523


### PR DESCRIPTION
## Summary

Un-quarantines `test_repl_overview_terminal_visibility` (#523), which #841 re-characterized as "blocked on tool-call marker render." **That diagnosis was wrong** — it came from `drain_for`-based probes that bail after a 0.3s idle gap (the same artifact that misdiagnosed the subagent sibling, see #844). Re-probed live with an impossible-pattern capture:

### Real root cause: harness, not marker

Under the mock LLM server, the `open-responses` supervisor **fails to spawn on the runner**:

```
{"error":"harness_spawn_failed","detail":"Request failed on the runner; …"}
omnigent.last_task_error_code=runner_error
```

so `sys_terminal_launch` never executes and no terminal is ever registered. This is a **mock-incompatibility** analogous to the documented `claude-sdk` case in `known_failures.yaml` ("mock-incompatible … should be excluded from the mock matrix") — **not** a product regression in the terminal/overview path.

Switched the supervisor harness **`open-responses` → `openai-agents`** (mock-compatible, matches the sibling `overview_subagent_visibility`). Under `openai-agents` the tool executes (`⏵ sys_terminal_launch({...})`), the terminal registers, and the overview sidebar shows `💻 shell:probe` with the `tmux -S … attach` command in its detail pane.

> ⚠️ **Flagging for your call:** if `open-responses` failing to spawn under the mock is considered a real regression rather than mock-incompatibility, that deserves a separate issue. It doesn't block this test's purpose (terminal-overview rendering), so I switched the harness rather than gate on it — same call as the `claude-sdk` precedent. Happy to file an issue / revert the harness switch if you'd rather investigate open-responses.

### Stale markers (same as #844)

- `Ctrl+G` → `Ctrl+O` (Ctrl+O **does** open the overview — the earlier "opened nothing" was also a drain artifact).
- Sync on the supervisor's final reply text (the `• sys_terminal_launch (Nms)` completion line is retired; the new `⏵ sys_terminal_launch(` render carries ANSI between name and `(`).
- Terminal detail header is no longer `Terminal: shell:probe` → match the sidebar label `shell:probe`, read `tmux -S … attach` from the detail pane.
- Close the overlay (`q`) before `clean_exit`.

Assertions unchanged (label + tmux socket flag + attach verb); **snapshot unchanged**.

## Verification

- Green **7× locally** (~22s each), including un-quarantined collection.
- 30× CI flake-stress gate kicked off against this branch (link in a comment).

This pull request and its description were written by Isaac.
