### PR TITLE
fix(claude-native): keep the private tmux server alive past inner-CLI exit (#540)

### DIFF
--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -713,6 +713,12 @@ class TerminalEnvSpec:
     :param tmux_start_on_attach: Delay the terminal command until the
         first tmux client attaches. Used for TUIs that must query the
         real attached terminal during startup.
+    :param keep_alive_after_exit: Keep the private tmux server alive after
+        the pane's inner process exits (``remain-on-exit`` / ``exit-empty
+        off``), so a single CLI exit no longer reaps the server and cascades
+        into ``no server running``. Opt-in because it changes the
+        ``has-session``-means-alive contract; enabled for the claude-native
+        agent terminal (#540), whose liveness is decided by ``#{pane_dead}``.
     """
 
     command: str | None = None
@@ -727,6 +733,7 @@ class TerminalEnvSpec:
     session_prefix: str = "omni_"
     tmux_allow_passthrough: bool = False
     tmux_start_on_attach: bool = False
+    keep_alive_after_exit: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -94,6 +94,7 @@ def _tmux_managed_option_commands(
     scrollback: int,
     *,
     allow_passthrough: bool = False,
+    keep_alive_after_exit: bool = False,
 ) -> list[list[str]]:
     """
     Build tmux commands for Omnigent-managed global options.
@@ -101,6 +102,11 @@ def _tmux_managed_option_commands(
     :param scrollback: Tmux history limit, e.g. ``10000``.
     :param allow_passthrough: Whether to allow pane programs to send
         passthrough escape sequences to the real attached terminal.
+    :param keep_alive_after_exit: When ``True``, keep the private tmux server
+        alive after the pane's process exits (see
+        :func:`_tmux_session_persistence_commands`). Opt-in because it changes
+        the ``has-session``-means-alive contract that liveness probes rely on;
+        callers that enable it must use pane-dead-aware liveness checks.
     :returns: List of tmux commands to run before ``new-session``.
     """
     commands = [
@@ -108,9 +114,46 @@ def _tmux_managed_option_commands(
         *_tmux_lockdown_commands(),
         *_tmux_status_option_commands(),
     ]
+    if keep_alive_after_exit:
+        commands.extend(_tmux_session_persistence_commands())
     if allow_passthrough:
         commands.append(["set-option", "-g", "allow-passthrough", "on"])
     return commands
+
+
+def _tmux_session_persistence_commands() -> list[list[str]]:
+    """Keep the private tmux server alive when the pane's process exits.
+
+    Each managed terminal runs exactly ONE inner CLI (claude / codex / cursor /
+    pi / a shell) in a private, single-pane tmux server. Under tmux's defaults
+    (``exit-empty on`` + ``remain-on-exit off``) the instant that CLI exits —
+    a crash, ``/exit``, or an environment-specific early exit (issue #540: a
+    claude-native sub-agent on WSL2 that renders its prompt then exits) — the
+    pane closes, the lone session is destroyed, and the server exits on its
+    private socket. Every later control command (send-keys, model / effort
+    change, interrupt, stop) then fails with ``no server running`` and the CLI's
+    final output is gone, so a single child-process exit becomes an
+    unrecoverable, undiagnosable cascade and delegated messages are silently
+    lost.
+
+    ``remain-on-exit on`` keeps the dead pane — and therefore the session and
+    server — present after the inner process exits, so the socket stays usable
+    and the pane's last output stays capturable for diagnostics. The idle
+    watcher then reports the exit deterministically by detecting the dead pane
+    (see :meth:`TerminalInstance._pane_is_dead`) instead of racing the server's
+    disappearance. ``exit-empty off`` is belt-and-suspenders for the case where
+    the session is removed without the server being explicitly killed. Both use
+    ``-q`` so a tmux too old to know the option does not fail launch;
+    :meth:`TerminalInstance.close` still tears the server down unconditionally
+    via ``kill-server``, so nothing leaks.
+
+    :returns: Tmux option commands that keep the server alive past inner-CLI
+        exit.
+    """
+    return [
+        ["set-option", "-gq", "remain-on-exit", "on"],
+        ["set-option", "-sq", "exit-empty", "off"],
+    ]
 
 
 def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
@@ -721,6 +764,13 @@ class TerminalInstance:
     scrollback: int = 10000
     tmux_allow_passthrough: bool = False
     tmux_start_on_attach: bool = False
+    # Keep the private tmux server alive after the pane's inner process exits
+    # (``remain-on-exit`` / ``exit-empty off``). Opt-in per terminal because it
+    # changes the ``has-session``-means-alive contract: with it on, liveness is
+    # decided by ``#{pane_dead}`` (see :meth:`is_alive`), not session existence.
+    # Enabled for the claude-native agent terminal so a single inner-CLI exit no
+    # longer reaps the server and cascades into ``no server running`` (#540).
+    keep_alive_after_exit: bool = False
     running: bool = False
     launch_cwd: str | None = None
     # Owned per-launch egress proxy. ``None`` when the sandbox
@@ -891,6 +941,7 @@ class TerminalInstance:
             *_tmux_managed_option_commands(
                 self.scrollback,
                 allow_passthrough=self.tmux_allow_passthrough,
+                keep_alive_after_exit=self.keep_alive_after_exit,
             ),
             [
                 "set-option",
@@ -1209,6 +1260,14 @@ class TerminalInstance:
                 return
 
             self._remember_pane_snapshot(snapshot)
+            if await self._pane_is_dead_async():
+                # remain-on-exit kept the server alive after the inner CLI
+                # exited; report the exit rather than treating the frozen pane
+                # as an idle agent.
+                self.running = False
+                if on_exit is not None:
+                    await _fire(on_exit, "exit")
+                return
             if detector.tick(snapshot) and not await _fire(on_idle, "idle"):
                 return
 
@@ -1351,6 +1410,16 @@ class TerminalInstance:
                     self._fire_watch_callback(on_exit, "exit")
                 return
             self._remember_pane_snapshot(snapshot)
+            if self._pane_is_dead():
+                # The inner CLI exited but remain-on-exit kept the server, so
+                # capture-pane still succeeds (the snapshot above is the final
+                # frame, now remembered for diagnostics). Report the exit
+                # deterministically instead of mistaking the frozen pane for an
+                # idle agent and leaving the session hung.
+                self.running = False
+                if on_exit is not None:
+                    self._fire_watch_callback(on_exit, "exit")
+                return
             # A pane change that lands within the recent-interaction window
             # is a client-driven repaint (attach/detach reflow, focus,
             # mouse, keystroke — stamped via note_client_interaction), not
@@ -1388,6 +1457,30 @@ class TerminalInstance:
             return self._tmux_output_sync("capture-pane", "-t", self.tmux_target, "-p", "-e")
         except RuntimeError:
             return None
+
+    def _pane_is_dead(self) -> bool:
+        """
+        Report whether the pane's process exited while tmux kept the pane.
+
+        With ``remain-on-exit on`` (see
+        :func:`_tmux_session_persistence_commands`) the private server survives
+        the inner CLI's exit, so a *dead pane* — not a vanished server — is how
+        a normal or early exit now presents. The threaded idle watcher uses this
+        to report the exit deterministically once ``capture-pane`` still
+        succeeds against the surviving server.
+
+        :returns: ``True`` when tmux reports ``#{pane_dead}`` as ``1``.
+            ``False`` when the pane is live, or when the probe itself fails
+            (server already gone) — the caller's capture step already handles
+            the vanished-server path.
+        """
+        try:
+            out = self._tmux_output_sync(
+                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead}"
+            )
+        except RuntimeError:
+            return False
+        return "1" in out.split()
 
     def _fire_watch_callback(self, callback: Callable[[], None], kind: str) -> bool:
         """
@@ -1439,36 +1532,65 @@ class TerminalInstance:
 
     async def is_alive(self) -> bool:
         """
-        Check if the tmux session is still running.
+        Check if the terminal's inner process is still running.
 
-        When tmux reports the session gone, or the probe cannot start,
-        this method marks ``self.running`` false. That side effect is
-        intentional: subsequent pollers use the in-memory flag as a
-        fast path instead of forking ``tmux has-session`` repeatedly
-        after the server has exited.
+        Probes the pane's ``#{pane_dead}`` flag rather than mere session
+        existence: with ``remain-on-exit on`` (see
+        :func:`_tmux_session_persistence_commands`) the session and server
+        deliberately outlive the inner CLI's exit, so a live session no longer
+        implies a live process. The terminal is alive only when the session
+        exists AND its pane process has not exited.
 
-        :returns: ``True`` when ``tmux has-session`` confirms the
-            session is alive; otherwise ``False``.
+        When the session is gone (probe exits non-zero), the pane is dead, or
+        the probe cannot start, this marks ``self.running`` false. That side
+        effect is intentional: subsequent pollers use the in-memory flag as a
+        fast path instead of re-forking tmux after the process has exited.
+
+        :returns: ``True`` when the session exists and its pane process is
+            still running; otherwise ``False``.
         """
         if not self.running:
             return False
         try:
             proc = await asyncio.create_subprocess_exec(
                 *self._tmux_base_cmd(),
-                "has-session",
+                "list-panes",
                 "-t",
                 self.tmux_target,
-                stdout=asyncio.subprocess.DEVNULL,
+                "-F",
+                "#{pane_dead}",
+                stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
             )
-            await proc.communicate()
-            if proc.returncode != 0:
+            stdout, _ = await proc.communicate()
+            # rc != 0 → session/server gone; a "1" line → the pane process
+            # exited but the session was kept alive by remain-on-exit. Both mean
+            # not-alive. (``list-panes`` errors on an unknown target, unlike
+            # ``display-message``, which silently falls back to another pane.)
+            panes = stdout.decode().split()
+            if proc.returncode != 0 or not panes or "1" in panes:
                 self.running = False
                 return False
             return True
         except OSError:
             self.running = False
             return False
+
+    async def _pane_is_dead_async(self) -> bool:
+        """
+        Async sibling of :meth:`_pane_is_dead` for the asyncio idle watcher.
+
+        :returns: ``True`` when tmux reports ``#{pane_dead}`` as ``1``;
+            ``False`` when the pane is live or the probe fails (server gone,
+            which the caller's capture step handles).
+        """
+        try:
+            out = await self._tmux_output(
+                "list-panes", "-t", self.tmux_target, "-F", "#{pane_dead}"
+            )
+        except RuntimeError:
+            return False
+        return "1" in out.split()
 
     async def _tmux(self, *args: str) -> None:
         """Run a tmux command against this instance's server."""
@@ -1673,6 +1795,7 @@ def create_terminal_instance(
         scrollback=spec.scrollback,
         tmux_allow_passthrough=spec.tmux_allow_passthrough,
         tmux_start_on_attach=spec.tmux_start_on_attach,
+        keep_alive_after_exit=spec.keep_alive_after_exit,
     )
 
     return TerminalCreateResult(instance=instance, cwd=cwd)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2502,6 +2502,14 @@ async def _auto_create_claude_terminal(
         # configuration rather than inheriting it from the runner.
         env_unset=["DATABRICKS_CONFIG_PROFILE"],
         scrollback=50000,
+        # Keep the private tmux server alive if the `claude` CLI exits (e.g. a
+        # sub-agent worker whose CLI exits right after rendering its prompt on
+        # some hosts — #540). Without this, that exit reaps the server and every
+        # later control command (send-keys / model / effort / interrupt / stop)
+        # fails with "no server running", and the delegated message is silently
+        # lost. With it, the dead pane persists (capturable for diagnostics) and
+        # the watcher reports the exit deterministically via `#{pane_dead}`.
+        keep_alive_after_exit=True,
     )
     _logger.info(
         "Claude terminal tmux launch requested: session=%s command=%s args_count=%d "

--- a/omnigent/terminals/ws_bridge.py
+++ b/omnigent/terminals/ws_bridge.py
@@ -246,51 +246,63 @@ async def _sleep(seconds: float) -> None:
 
 async def _tmux_session_alive(socket_path: str, tmux_target: str) -> bool:
     """
-    Return whether the tmux session behind the bridge is still alive.
+    Return whether the agent behind the bridge is still alive.
 
-    Runs ``tmux -S <socket> has-session -t <target>`` against the same
-    private server the bridge attached to. This is what distinguishes a
-    *detach* (the ``tmux attach`` child exits but the session keeps
-    running, so ``has-session`` succeeds) from a genuine session exit
-    (Claude quit / the session was killed, so ``has-session`` fails).
+    Probes ``tmux -S <socket> list-panes -t <target> -F '#{pane_dead}'`` against
+    the same private server the bridge attached to. This distinguishes a *detach*
+    (the ``tmux attach`` child exits but the agent keeps running) from a genuine
+    exit (Claude quit / the session was killed). The pane-dead flag — not bare
+    session existence — is the signal because the claude-native terminal opts
+    into ``remain-on-exit`` (#540): there the session deliberately outlives the
+    inner CLI, so a plain ``has-session`` would wrongly report a crashed agent
+    as merely detached and the client would reconnect to a dead pane forever.
+    For terminals without ``remain-on-exit`` the inner process's exit destroys
+    the session, the probe exits non-zero, and the verdict is unchanged.
 
-    Fails conservative: any probe error (tmux missing, spawn failure,
-    timeout) returns ``False`` so the caller falls back to the
-    pre-existing terminal-gone close code rather than wrongly reporting
-    a dead session as alive.
+    Fails conservative: any probe error (tmux missing, spawn failure, timeout,
+    or a non-zero exit from a vanished session) returns ``False`` so the caller
+    falls back to the terminal-gone close code rather than wrongly reporting a
+    dead agent as alive.
 
     :param socket_path: Filesystem path to the tmux server socket,
         e.g. ``"/tmp/omnigent-xyz/tmux.sock"``.
     :param tmux_target: The ``-t`` target identifying the session,
         e.g. ``"main"``.
-    :returns: ``True`` only when ``has-session`` exits 0; ``False`` on
-        a missing session or any probe failure.
+    :returns: ``True`` only when the session exists and its pane process has
+        not exited; ``False`` on a missing/dead session or any probe failure.
     """
     try:
         proc = await asyncio.create_subprocess_exec(
             "tmux",
             "-S",
             socket_path,
-            "has-session",
+            "list-panes",
             "-t",
             tmux_target,
-            stdout=asyncio.subprocess.DEVNULL,
+            "-F",
+            "#{pane_dead}",
+            stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
     except (OSError, ValueError):
-        _logger.debug("tmux-attach: has-session spawn failed", exc_info=True)
+        _logger.debug("tmux-attach: pane-dead probe spawn failed", exc_info=True)
         return False
     try:
-        returncode = await asyncio.wait_for(
-            proc.wait(),
+        stdout, _ = await asyncio.wait_for(
+            proc.communicate(),
             timeout=_TMUX_HAS_SESSION_TIMEOUT_S,
         )
     except (asyncio.TimeoutError, OSError):
-        _logger.debug("tmux-attach: has-session probe timed out", exc_info=True)
+        _logger.debug("tmux-attach: pane-dead probe timed out", exc_info=True)
         with contextlib.suppress(ProcessLookupError):
             proc.kill()
         return False
-    return returncode == 0
+    # ``list-panes`` errors on an unknown/dead session (unlike ``display-message``,
+    # which silently falls back to another pane). rc != 0 → session gone; a "1"
+    # line → the inner process exited but the session was kept alive by
+    # remain-on-exit. Both mean the agent is gone.
+    panes = stdout.decode().split()
+    return proc.returncode == 0 and bool(panes) and "1" not in panes
 
 
 async def _write_all_nonblocking(

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import shutil
+import subprocess
 import sys
 import threading
 from dataclasses import dataclass
@@ -106,6 +109,324 @@ def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> N
 
     assert exited.wait(timeout=1.0)
     assert instance.last_pane_text() == "startup failed\ntry config"
+
+
+@dataclass
+class _ProcessWithStdout:
+    """
+    Subprocess stand-in that returns canned stdout (for ``is_alive`` probes).
+
+    :param stdout: Bytes the fake process writes to stdout.
+    :param returncode: Process exit status.
+    """
+
+    stdout: bytes = b""
+    returncode: int = 0
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        """
+        Return the canned stdout and empty stderr.
+
+        :returns: ``(stdout, stderr)`` byte strings.
+        """
+        return self.stdout, b""
+
+
+def test_threaded_idle_watcher_reports_exit_on_dead_pane(tmp_path: Path) -> None:
+    """
+    A dead pane (process exited, server kept by remain-on-exit) fires on_exit.
+
+    Issue #540: with ``remain-on-exit on`` the inner CLI's exit no longer takes
+    down the server, so ``capture-pane`` keeps succeeding. The watcher must
+    still report the exit by noticing the dead pane — otherwise the session
+    hangs, mistaking the frozen final frame for an idle agent. The last pane
+    text must survive so the exit can be diagnosed.
+
+    :param tmp_path: Temporary directory for the placeholder tmux socket.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    exited = threading.Event()
+    # capture-pane still succeeds (server alive); the pane is dead.
+    instance._capture_pane_for_idle_or_none = lambda: "claude exited: boom\nbye"  # type: ignore[method-assign]
+    instance._pane_is_dead = lambda: True  # type: ignore[method-assign]
+
+    instance.start_idle_watcher_thread(on_exit=exited.set, poll_interval_s=0.01)
+
+    assert exited.wait(timeout=1.0)
+    assert instance.running is False
+    assert instance.last_pane_text() == "claude exited: boom\nbye"
+
+
+@pytest.mark.asyncio
+async def test_is_alive_false_when_pane_dead(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``is_alive`` reports False for a dead pane even though the session exists.
+
+    With ``remain-on-exit on`` the session outlives the inner process, so a
+    plain ``has-session`` would wrongly report the agent as alive. ``is_alive``
+    must probe ``#{pane_dead}`` and treat a dead pane as not-alive so the
+    existing death-driven teardown still fires.
+
+    :param tmp_path: Temporary directory for the placeholder tmux socket.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    captured: list[list[str]] = []
+
+    async def fake_create_subprocess_exec(
+        *cmd: str,
+        stdout: object,
+        stderr: object,
+    ) -> _ProcessWithStdout:
+        """Capture argv and report a dead pane (``#{pane_dead}`` -> ``1``)."""
+        del stdout, stderr
+        captured.append(list(cmd))
+        return _ProcessWithStdout(stdout=b"1\n", returncode=0)
+
+    monkeypatch.setattr(
+        terminal_mod,
+        "asyncio",
+        SimpleNamespace(
+            create_subprocess_exec=fake_create_subprocess_exec,
+            subprocess=terminal_mod.asyncio.subprocess,
+        ),
+    )
+
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+
+    assert await instance.is_alive() is False
+    assert instance.running is False
+    # Must probe the pane-dead flag, not merely whether the session exists.
+    assert captured, "is_alive never forked a tmux probe"
+    assert captured[-1][-1] == "#{pane_dead}"
+
+
+@pytest.mark.asyncio
+async def test_is_alive_true_when_pane_live(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``is_alive`` reports True when the pane process is still running.
+
+    :param tmp_path: Temporary directory for the placeholder tmux socket.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    async def fake_create_subprocess_exec(
+        *cmd: str,
+        stdout: object,
+        stderr: object,
+    ) -> _ProcessWithStdout:
+        """Report a live pane (``#{pane_dead}`` -> ``0``)."""
+        del cmd, stdout, stderr
+        return _ProcessWithStdout(stdout=b"0\n", returncode=0)
+
+    monkeypatch.setattr(
+        terminal_mod,
+        "asyncio",
+        SimpleNamespace(
+            create_subprocess_exec=fake_create_subprocess_exec,
+            subprocess=terminal_mod.asyncio.subprocess,
+        ),
+    )
+
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+
+    assert await instance.is_alive() is True
+    assert instance.running is True
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="requires a real tmux binary")
+@pytest.mark.asyncio
+async def test_server_survives_inner_process_exit_real_tmux(tmp_path: Path) -> None:
+    """
+    The private tmux server outlives an inner-process exit (issue #540).
+
+    Launches a real tmux terminal whose inner command exits immediately. With
+    the default ``exit-empty on`` the server would vanish and every later
+    control command would fail with ``no server running``. With
+    ``remain-on-exit on`` / ``exit-empty off`` the server and session must stay
+    up (so control commands keep working and the dead pane stays capturable)
+    while ``is_alive`` still reports the inner process as gone.
+
+    :param tmp_path: Temporary directory for the real tmux socket.
+    """
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        command="sh",
+        args=["-c", "exit 0"],
+        keep_alive_after_exit=True,
+    )
+    try:
+        await instance.launch(cwd=tmp_path)
+
+        # Wait for the inner `sh` to exit. is_alive() flips running -> False
+        # once the pane is dead.
+        for _ in range(250):
+            if not await instance.is_alive():
+                break
+            await asyncio.sleep(0.02)
+        else:  # pragma: no cover - only on a hang/regression
+            raise AssertionError("inner process never reported as exited")
+
+        # The crux: the private tmux SERVER must still be reachable after the
+        # inner process exited — has-session succeeds rather than failing with
+        # "no server running on <socket>".
+        probe = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                str(instance.socket_path),
+                "has-session",
+                "-t",
+                instance.tmux_target,
+            ],
+            capture_output=True,
+            timeout=5,
+        )
+        assert probe.returncode == 0, (
+            "tmux server/session died when the inner process exited — "
+            "exit-empty/remain-on-exit were not applied: "
+            f"{probe.stderr.decode().strip()!r}"
+        )
+    finally:
+        await instance.close()
+
+
+async def _capture_launch_argv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    keep_alive_after_exit: bool,
+) -> list[str]:
+    """
+    Launch a terminal with mocked tmux and return the single setup argv.
+
+    :param tmp_path: Temporary directory for the fake tmux socket.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param keep_alive_after_exit: Value for the instance's opt-in flag.
+    :returns: The flattened tmux launch argv.
+    """
+    captured: list[list[str]] = []
+
+    async def fake_create_subprocess_exec(
+        *cmd: str,
+        stdout: object,
+        stderr: object,
+        env: dict[str, str],
+    ) -> _SuccessfulProcess:
+        """Capture the tmux argv and return a successful process."""
+        del stdout, stderr, env
+        captured.append(list(cmd))
+        return _SuccessfulProcess()
+
+    monkeypatch.setattr(
+        terminal_mod,
+        "asyncio",
+        SimpleNamespace(
+            create_subprocess_exec=fake_create_subprocess_exec,
+            subprocess=terminal_mod.asyncio.subprocess,
+        ),
+    )
+
+    instance = TerminalInstance(
+        name="bash",
+        session_key="s1",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        keep_alive_after_exit=keep_alive_after_exit,
+    )
+    await instance.launch(cwd=tmp_path)
+    assert len(captured) == 1
+    return captured[0]
+
+
+@pytest.mark.parametrize("keep_alive", [True, False])
+def test_create_terminal_instance_propagates_keep_alive_after_exit(
+    tmp_path: Path,
+    keep_alive: bool,
+) -> None:
+    """
+    ``create_terminal_instance`` carries ``keep_alive_after_exit`` from the spec
+    to the instance.
+
+    Guards the single plumbing line that wires the claude-native opt-in (#540)
+    to the launch options: dropping it would silently ignore the flag and
+    reintroduce the server-death cascade with no other test failing.
+
+    :param tmp_path: Temporary directory used as the terminal cwd.
+    :param keep_alive: Spec value to propagate.
+    """
+    spec = TerminalEnvSpec(
+        command="bash",
+        os_env=OSEnvSpec(type="caller_process", cwd=str(tmp_path)),
+        keep_alive_after_exit=keep_alive,
+    )
+    result = create_terminal_instance(name="bash", session_key="s1", spec=spec)
+    try:
+        assert result.instance.keep_alive_after_exit is keep_alive
+    finally:
+        shutil.rmtree(result.instance.private_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_launch_keeps_server_alive_when_opted_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With ``keep_alive_after_exit`` set, launch sets remain-on-exit / exit-empty
+    so an inner-CLI exit can't reap the private tmux server (issue #540). ``-q``
+    keeps older tmux from failing launch on an unknown option.
+
+    :param tmp_path: Temporary directory for the fake tmux socket.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=True)
+    assert contains_subsequence(cmd, ["set-option", "-gq", "remain-on-exit", "on"])
+    assert contains_subsequence(cmd, ["set-option", "-sq", "exit-empty", "off"])
+
+
+@pytest.mark.asyncio
+async def test_launch_omits_keep_alive_options_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Keeping the server alive past exit is opt-in: a default terminal must NOT
+    set remain-on-exit / exit-empty, preserving the ``has-session``-means-alive
+    contract for codex / cursor / REPL / generic terminals.
+
+    :param tmp_path: Temporary directory for the fake tmux socket.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
+    cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=False)
+    assert not contains_subsequence(cmd, ["set-option", "-gq", "remain-on-exit", "on"])
+    assert not contains_subsequence(cmd, ["set-option", "-sq", "exit-empty", "off"])
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -10470,6 +10470,10 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
     spec = captured["spec"]
     assert spec.command == "claude"
     assert spec.env["ENABLE_TOOL_SEARCH"] == "true"
+    # The claude-native terminal must opt into keeping its private tmux server
+    # alive past an inner-CLI exit, so a sub-agent worker whose `claude` exits
+    # early no longer cascades into "no server running" (#540).
+    assert spec.keep_alive_after_exit is True
     args = spec.args
     settings = json.loads(args[args.index("--settings") + 1])
     assert "PermissionRequest" in settings["hooks"]

--- a/tests/terminals/test_ws_bridge.py
+++ b/tests/terminals/test_ws_bridge.py
@@ -369,6 +369,57 @@ async def test_tmux_session_alive_tracks_real_session(tmp_path: Path) -> None:
     assert await _tmux_session_alive(str(tmp_path / "absent.sock"), "main") is False
 
 
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux required")
+@pytest.mark.asyncio
+async def test_tmux_session_alive_false_for_dead_pane(tmp_path: Path) -> None:
+    """
+    A kept-alive session whose pane process exited reads as not-alive.
+
+    The claude-native terminal opts into ``remain-on-exit`` (#540), so a crashed
+    agent leaves a dead pane on a still-present session. The probe must report
+    that as gone via ``#{pane_dead}`` — otherwise a detach-vs-exit decision
+    would treat the crash as a mere detach and the web client would reconnect
+    to a dead pane forever instead of closing.
+
+    :param tmp_path: Pytest tmp directory for the private socket.
+    """
+    socket_path = tmp_path / "tmux.sock"
+    base = ["tmux", "-S", str(socket_path), "-f", "/dev/null"]
+    # One command sequence on a fresh server (";" separates tmux commands):
+    # set remain-on-exit globally BEFORE new-session so the session inherits it
+    # and survives the inner process exiting. A bare set-option can't run first
+    # on its own — no server exists yet to connect to.
+    subprocess.run(
+        [
+            *base,
+            "set-option",
+            "-g",
+            "remain-on-exit",
+            "on",
+            ";",
+            "new-session",
+            "-d",
+            "-s",
+            "main",
+            "sh -c 'exit 0'",
+        ],
+        check=True,
+    )
+    try:
+        for _ in range(250):
+            if await _tmux_session_alive(str(socket_path), "main") is False:
+                break
+            await asyncio.sleep(0.02)
+        else:  # pragma: no cover - only on a hang/regression
+            raise AssertionError("dead pane was never reported as not-alive")
+        # The session itself is still present (remain-on-exit), proving the
+        # not-alive verdict came from the dead pane, not a vanished session.
+        has = subprocess.run([*base, "has-session", "-t", "main"], capture_output=True)
+        assert has.returncode == 0, "session vanished; remain-on-exit was not honored"
+    finally:
+        subprocess.run([*base, "kill-server"], capture_output=True, check=False)
+
+
 class _ParkingFakeWebSocket:
     """
     WebSocket fake whose client side never ends, isolating the PTY side.
@@ -1297,9 +1348,11 @@ async def test_tmux_session_alive_returns_false_on_timeout(
     """
 
     class _HangingProcess:
-        async def wait(self) -> int:
+        returncode: int | None = None
+
+        async def communicate(self) -> tuple[bytes, bytes]:
             await asyncio.sleep(999)
-            return 0
+            return b"", b""
 
         def kill(self) -> None:
             pass


### PR DESCRIPTION
## Summary

Fixes #540. A claude-native sub-agent (e.g. the Polly example, orchestrated headless) registered "ready" but never received delegated messages — its backing tmux server died, and every later `send-keys` / model-change / effort-change / interrupt / stop failed with `rc=1 "no server running on <socket>"`. The bridge re-created the terminal on a fresh socket, which died the same way, so messages were silently lost.

## Root cause

Each managed terminal runs exactly **one** inner CLI in a private, single-pane tmux server launched with `-f /dev/null` (no config loaded). tmux's default `exit-empty on` reaps the **whole server** the instant that CLI exits — so a single child-process exit becomes an unrecoverable "no server running" socket, and every control command and the message delivery then fail.

The `claude` CLI exits in the reporter's environment (WSL2, claude 2.1.179) right after rendering its prompt. **codex** survives the same lifecycle because its inner process is a persistent daemon, which is why only the claude-native worker was affected. (Confirmed the claude-native spec is *not* doing anything different at start — it renders "ready", then the CLI exits; the defect is that omnigent turns that exit into an opaque, cascading, silent failure.)

## Fix

Make the private server resilient to an inner-CLI exit, **opt-in per terminal** so other harnesses are unchanged:

- **`keep_alive_after_exit` flag** on `TerminalEnvSpec` / `TerminalInstance`. When set, launch adds `set-option -gq remain-on-exit on` + `set-option -sq exit-empty off`, so the dead pane — and thus the session and server — persist after the inner process exits. The socket stays usable (control commands no longer hit "no server running") and the pane's final output stays capturable for diagnostics. **Enabled for the claude-native agent terminal only**; codex / cursor / pi / REPL / generic terminals keep the default behavior.

- **Pane-dead-aware liveness.** Because `remain-on-exit` deliberately outlives the inner process, "session exists == agent alive" no longer holds. `is_alive`, both idle watchers (which now report the exit deterministically via `_pane_is_dead`), and `ws_bridge._tmux_session_alive` now probe `tmux list-panes -t <target> -F '#{pane_dead}'`. `list-panes` **errors on an unknown target** (unlike `display-message`, which silently falls back to another pane), so it doubles as an existence check. This is **behavior-preserving for non-opt-in terminals**: their session vanishes on exit, the probe exits non-zero, and the verdict is unchanged.

## Effect

An inner-CLI exit becomes a clean, deterministic, **diagnosable** terminal exit (the watcher fires `on_exit` with the final pane text available, which flows to the existing crash-classification path) instead of an opaque, cascading "no server running" failure with silent message loss. The recreate-on-dead-server death loop no longer triggers because the server doesn't vanish.

**Scope note:** this does not change whether the third-party `claude` CLI stays running on a given host (outside Omnigent's control) — it stops a single CLI exit from silently taking down the whole session, and surfaces the exit instead.

## Tests

- Launch options present when opted in / **absent by default**.
- `keep_alive_after_exit` propagates `TerminalEnvSpec` → `create_terminal_instance` → `TerminalInstance`, and the claude-native spec opts in.
- `is_alive` false on a dead pane / true on a live pane; the idle watcher fires `on_exit` for a dead pane with the last pane text preserved.
- `ws_bridge._tmux_session_alive` reports a dead-pane session as not-alive (real-tmux), while the detach case (live pane) still reads alive.
- A **real-tmux regression test** proving the private server survives an inner-process exit (fails on the pre-fix default).

All affected suites pass (`tests/inner`, `tests/terminals`, `tests/runner`, `tests/repl`, `tests/test_claude_native*`); the only failures in the local run are pre-existing bwrap/user-namespace sandbox tests unrelated to this change (they fail identically on a clean tree in this environment).
