### PR TITLE
fix(runner): deliver sys_session_create child completions to the parent inbox (#848)

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1424,6 +1424,7 @@ def _finalize_created_session(
     agent_id: str,
     title: Any,
     publish_event: Callable[[str, dict[str, Any]], None] | None,
+    has_initial_turn: bool,
 ) -> str:
     """
     Register fan-out, emit ``session.created``, and build the handle.
@@ -1434,12 +1435,22 @@ def _finalize_created_session(
     conversation row), and returns the handle the orchestrator uses to
     drive / monitor the child.
 
+    When *has_initial_turn* is set (the create queued a first user message),
+    also registers the child's sub-agent work so that turn's completion is
+    delivered to the parent's ``sys_read_inbox`` + auto-wakes the parent.
+
     :param data: The :class:`SessionResponse` JSON from the create call.
     :param conversation_id: The caller (parent) session id.
     :param agent_id: The launched agent id, e.g. ``"ag_abc123"``.
     :param title: The caller-supplied title (or non-str when absent).
     :param publish_event: Callback that enqueues an SSE event on the
         caller's outbound queue; ``None`` for in-process callers.
+    :param has_initial_turn: Whether the create queued an initial user
+        message (so a child turn actually runs). Sub-agent work is registered
+        only then — a message-less "create idle, drive later" session starts no
+        turn, so registering work would leave a ``launching`` entry that never
+        completes and would block the next ``sys_session_send`` (its
+        already-running guard); that send re-registers the work itself.
     :returns: JSON handle ``{conversation_id, kind, agent_id,
         agent_name, title, status}``.
     """
@@ -1448,13 +1459,34 @@ def _finalize_created_session(
 
     child_id = data["id"]
     label = title if isinstance(title, str) else ""
+    agent_label = data.get("agent_name") or "agent"
     _runner_app.register_child_session(
         child_id,
         parent_session_id=conversation_id,
         title=label,
-        tool=data.get("agent_name") or "agent",
+        tool=agent_label,
         session_name=label,
     )
+    # Track the child's work so the initial turn's completion is delivered to
+    # the parent's ``sys_read_inbox`` queue and auto-wakes the parent — the same
+    # completion contract BOTH ``sys_session_send`` paths register (named at
+    # ~1169, by-session_id at ~1319). Without it a ``sys_session_create`` child
+    # completes silently: ``register_child_session`` only fans status/preview
+    # deltas onto the parent's stream, it does not deliver completions, so the
+    # orchestrator must busy-poll ``sys_session_get_history`` to recover the
+    # result (#848). Gated on ``has_initial_turn``: a message-less create starts
+    # no turn, so a work entry would never complete (leaking a ``launching``
+    # entry) and would trip the next ``sys_session_send``'s already-running
+    # guard; that send registers the work itself. ``register_subagent_work`` is
+    # idempotent, so a later send to a message-launched child re-registers fine.
+    if has_initial_turn:
+        _runner_app.register_subagent_work(
+            parent_session_id=conversation_id,
+            child_session_id=child_id,
+            agent=agent_label,
+            title=label,
+            wrapper_label=_session_wrapper_label(data),
+        )
     evt = SessionCreatedEvent(
         type="session.created",
         conversation_id=conversation_id,
@@ -1575,6 +1607,8 @@ async def _execute_session_create(
         agent_id=str(agent_id),
         title=args.get("title"),
         publish_event=publish_event,
+        # The create body queues an initial turn only when a message is given.
+        has_initial_turn=bool(args.get("message")),
     )
 
 
@@ -1811,6 +1845,8 @@ async def _session_create_from_config_path(
         agent_id=created_agent_id,
         title=args.get("title"),
         publish_event=publish_event,
+        # A first turn runs only when an initial message was posted above.
+        has_initial_turn=bool(isinstance(message, str) and message),
     )
 
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -5878,27 +5878,136 @@ async def test_sys_session_create_spawns_child_under_caller() -> None:
             )
         return httpx.Response(404, json={"error": str(request.url)})
 
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(_server_handler),
-        base_url="http://server",
-    ) as server_client:
-        output = await execute_tool(
-            tool_name="sys_session_create",
-            arguments=json.dumps({"agent_id": "ag_x", "title": "auth", "message": "start"}),
-            server_client=server_client,
-            conversation_id="conv_caller",
-        )
+    from omnigent.runner import app as runner_app
 
-    # Child-only: parent forced to the caller; agent + title + queued
-    # message threaded through to the create body.
-    assert captured["parent_session_id"] == "conv_caller"
-    assert captured["agent_id"] == "ag_x"
-    assert captured["title"] == "auth"
-    assert captured["initial_items"][0]["data"]["content"][0]["text"] == "start"
-    handle = json.loads(output)
-    assert handle["conversation_id"] == "conv_child"
-    assert handle["agent_id"] == "ag_x"
-    assert handle["agent_name"] == "researcher"
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(_server_handler),
+            base_url="http://server",
+        ) as server_client:
+            output = await execute_tool(
+                tool_name="sys_session_create",
+                arguments=json.dumps({"agent_id": "ag_x", "title": "auth", "message": "start"}),
+                server_client=server_client,
+                conversation_id="conv_caller",
+            )
+
+        # Child-only: parent forced to the caller; agent + title + queued
+        # message threaded through to the create body.
+        assert captured["parent_session_id"] == "conv_caller"
+        assert captured["agent_id"] == "ag_x"
+        assert captured["title"] == "auth"
+        assert captured["initial_items"][0]["data"]["content"][0]["text"] == "start"
+        handle = json.loads(output)
+        assert handle["conversation_id"] == "conv_child"
+        assert handle["agent_id"] == "ag_x"
+        assert handle["agent_name"] == "researcher"
+    finally:
+        # The create now registers child + sub-agent work (completion delivery,
+        # #848); drop both so the shared "conv_child" id doesn't leak into other
+        # tests' runner-app registries.
+        runner_app.unregister_subagent_work("conv_child")
+        runner_app.unregister_child_session("conv_child")
+
+
+@pytest.mark.asyncio
+async def test_sys_session_create_registers_subagent_work_for_completion_delivery() -> None:
+    """
+    ``sys_session_create`` registers the child's sub-agent work so its turn
+    completion is delivered to the parent's ``sys_read_inbox`` + auto-wakes the
+    parent — parity with both ``sys_session_send`` paths (#848).
+
+    Without the work entry the child completes silently and the orchestrator
+    must busy-poll ``sys_session_get_history`` to recover the result, so the
+    presence of the entry (with the resolved agent/title) is the regression
+    guard. ``register_child_session`` alone (status fan-out) does NOT deliver
+    completions.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            return httpx.Response(
+                201,
+                json={
+                    "id": "conv_child_work",
+                    "agent_id": "ag_x",
+                    "agent_name": "researcher",
+                    "status": "idle",
+                    "labels": {"omnigent.wrapper": "cursor-native-ui"},
+                },
+            )
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(_server_handler),
+            base_url="http://server",
+        ) as server_client:
+            await execute_tool(
+                tool_name="sys_session_create",
+                arguments=json.dumps({"agent_id": "ag_x", "title": "review", "message": "go"}),
+                server_client=server_client,
+                conversation_id="conv_caller_work",
+            )
+
+        entry = runner_app.get_subagent_work("conv_child_work")
+        assert entry is not None, (
+            "sys_session_create child not registered for completion delivery; "
+            "_finalize_created_session must call register_subagent_work"
+        )
+        assert entry.parent_session_id == "conv_caller_work"
+        assert entry.agent == "researcher"
+        assert entry.title == "review"
+        assert entry.wrapper_label == "cursor-native-ui"
+    finally:
+        runner_app.unregister_subagent_work("conv_child_work")
+        runner_app.unregister_child_session("conv_child_work")
+
+
+@pytest.mark.asyncio
+async def test_sys_session_create_without_message_does_not_register_work() -> None:
+    """
+    A message-less ``sys_session_create`` (create idle, drive later) registers
+    NO sub-agent work.
+
+    Such a create starts no turn, so a work entry would never reach completion
+    (leaking a ``launching`` entry) and — worse — would trip the next
+    ``sys_session_send``'s already-running guard, permanently blocking the
+    documented create-then-drive pattern. The follow-up send registers the work
+    itself, so the create must not.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            return httpx.Response(
+                201,
+                json={"id": "conv_child_idle", "agent_id": "ag_x", "agent_name": "researcher"},
+            )
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(_server_handler),
+            base_url="http://server",
+        ) as server_client:
+            await execute_tool(
+                tool_name="sys_session_create",
+                arguments=json.dumps({"agent_id": "ag_x", "title": "idle-child"}),
+                server_client=server_client,
+                conversation_id="conv_caller_idle",
+            )
+
+        assert runner_app.get_subagent_work("conv_child_idle") is None, (
+            "message-less create must NOT register sub-agent work; the later "
+            "sys_session_send registers it"
+        )
+    finally:
+        runner_app.unregister_subagent_work("conv_child_idle")
+        runner_app.unregister_child_session("conv_child_idle")
 
 
 @pytest.mark.asyncio
@@ -6024,6 +6133,14 @@ async def test_sys_session_create_bundle_mode_uploads_child_under_caller(
             conversation_id="conv_caller",
             runner_workspace=tmp_path,
         )
+
+    from omnigent.runner import app as runner_app
+
+    # The create registers child + sub-agent work for completion delivery
+    # (#848); drop both so the shared "conv_child" id doesn't leak into other
+    # tests' runner-app registries.
+    runner_app.unregister_subagent_work("conv_child")
+    runner_app.unregister_child_session("conv_child")
 
     # Exactly one multipart create; parent forced to the caller
     # (child-only) and the title threaded into the metadata part.


### PR DESCRIPTION
## Summary

Partial fix for #848. A child session launched via `sys_session_create` (and driven via `sys_session_send`) completed its turn **without notifying the parent orchestrator** — no completion landed in the parent's `sys_read_inbox` and the parent was never auto-woken, forcing the orchestrator to busy-poll `sys_session_get_history`. Declared `sys_session_send` sub-agents (`claude_code` / `codex`) don't have this problem.

## Root cause

The completion → parent-inbox + auto-wake delivery is driven by a `register_subagent_work` entry (consumed by `_deliver_subagent_completion` → parent inbox + `_schedule_subagent_wake`). **Both** `sys_session_send` paths register it; `sys_session_create`'s finalizer (`_finalize_created_session`) registered only `register_child_session` — which fans status/preview deltas onto the parent's stream but does **not** deliver completions. So a `sys_session_create` child completed silently.

## Fix

`_finalize_created_session` now also calls `register_subagent_work` (agent name / title / wrapper from the create response), for both the `agent_id` and `config_path` create modes — parity with both `sys_session_send` paths.

**Gated on whether the create queued an initial message.** A message-less "create idle, drive later" session starts no turn, so a work entry would never complete (leaking a `launching` entry) and would trip the next `sys_session_send`'s already-running guard — permanently blocking the documented create-then-drive pattern. The follow-up send registers the work itself.

## Scope — honest about what this does and doesn't fix

This fixes the **harness-agnostic create-side delivery gap**: a `sys_session_create` child of any harness whose turn-end emits the completion event (`external_session_status: idle`) now delivers + auto-wakes the parent.

It does **not** by itself fix the cursor-native delivery (#848's headline), because the cursor harness never emits that completion event. Investigation (incl. adversarial review of a candidate quiescence-based cursor fix) showed a quiescence-inferred completion is **unsafe** for cursor: the runner's sub-agent delivery is one-shot (`delivered=True` latches), so a premature idle would deliver a *partial* result and cause the real final completion to be dropped as `ALREADY_DELIVERED`. claude/codex avoid this because they have an authoritative turn-end signal (a Stop hook / app-server event); cursor-agent exposes none. A correct cursor fix therefore needs a real cursor turn-end signal, not a timer — so it's deliberately left out of this PR rather than shipped as a data-loss risk.

Also out of scope (tracked in the issue): the intermittent empty turns (#2) and the degraded `sub_agent_name`/`session_not_a_sub_agent` close lifecycle (#3).

## Tests

- The create registers sub-agent work with the correct `parent`/`agent`/`title`/`wrapper`, for both the `agent_id` and `config_path` modes (and that `register_child_session` alone is not mistaken for delivery).
- A message-less create registers **no** work entry (regression guard for the launching-leak / send-blocking failure mode).

All `tests/runner/test_runner_dispatch.py` pass.
