### PR TITLE
fix(sessions): don’t misresolve a sibling same-tool prompt as "Resolved elsewhere"

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -1330,13 +1330,17 @@ def _signal_terminal_resolved_harness_elicitation(
     resolves a parked prompt for the SAME ``tool_name`` in the same
     session. That is what stops an unrelated auto-allowed tool's output
     from clearing a different tool's pending prompt. Among
-    same-named parked prompts it prefers an exact ``tool_input`` match;
-    if none match exactly but exactly one same-named prompt is parked it
-    resolves that one (the hook payload and the transcript can serialize
-    identical input differently, so a single unambiguous candidate is
-    treated as the match). If several same-named prompts are parked and
-    none match by input it stays conservative and resolves none — the
-    web verdict or timeout still applies.
+    same-named parked prompts it prefers an exact ``tool_input`` match.
+    When the result carried no input (``tool_input is None``, e.g. a
+    Codex result) and exactly one same-named prompt is parked, it
+    resolves that lone prompt — with nothing to match on, the single
+    candidate is the only reasonable target. But when the input IS known
+    and matches none of the parked prompts it stays conservative and
+    resolves none: the matching prompt was already resolved (e.g. a web
+    verdict on an earlier prompt of a parallel same-tool batch), so
+    resolving the lone survivor would misattribute this result and flip an
+    unanswered prompt to "Resolved elsewhere", forcing the user to the
+    native terminal. The web verdict or timeout still applies.
 
     Best-effort and idempotent: a no-op when no parked prompt matches
     (e.g. the web UI already resolved it, the tool needed no permission,
@@ -1363,7 +1367,13 @@ def _signal_terminal_resolved_harness_elicitation(
         if parked.tool_input == tool_input:
             parked.resolved_elsewhere.set()
             return
-    if len(candidates) == 1:
+    # No exact match. Fall back to the lone candidate ONLY when the result
+    # carried no input to match on (``tool_input is None``). A known input
+    # that matches nothing means its own prompt was already resolved, so the
+    # lone survivor is a DIFFERENT prompt the user has not answered yet —
+    # resolving it would wrongly badge it "Resolved elsewhere" (the parallel
+    # same-tool batch bug). Resolve none; the web verdict or timeout settles it.
+    if tool_input is None and len(candidates) == 1:
         candidates[0].resolved_elsewhere.set()
 
 

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -2806,6 +2806,118 @@ async def test_tool_output_resolves_only_the_matching_same_name_prompt(
     pending_elicitations.reset_for_tests()
 
 
+async def test_resolved_prompt_output_does_not_clear_other_same_name_prompt(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A mirrored result for an ALREADY-RESOLVED prompt must not clear a
+    different, still-pending prompt of the same tool.
+
+    Reproduces the reported "Resolved elsewhere" bug for a parallel
+    same-tool batch (e.g. several ``Read`` prompts surfaced at once):
+
+    - Two ``Bash`` prompts park with distinct inputs: A (``ls``) and
+      B (``rm x``).
+    - The user approves A in the web UI. Its hook returns ``allow`` and
+      A leaves the parked set; B is still live and unanswered.
+    - Claude runs A's command; its ``function_call`` /
+      ``function_call_output`` mirror back. The result carries A's input
+      (``ls``), which matches no still-parked prompt — A is already gone.
+
+    The terminal-resolved fast path must NOT misattribute A's output to
+    the lone remaining candidate B: B's input (``rm x``) is not A's
+    (``ls``). Without the fix the ``len(candidates) == 1`` fallback flips
+    B to "Resolved elsewhere", forcing the user to the native terminal to
+    answer a prompt the web card silently abandoned. Companion to
+    ``test_tool_output_resolves_only_the_matching_same_name_prompt`` (the
+    exact-match case); this guards the no-match case.
+    """
+    from omnigent.runtime import pending_elicitations
+
+    pending_elicitations.reset_for_tests()
+    agent = await create_test_agent(client, "test-resolved-output-no-cross-clear")
+    session_id = await _create_session(client, agent["id"])
+
+    captured: list[dict[str, Any]] = []
+    capture_task = asyncio.create_task(_subscribe_into(session_id, captured))
+    await asyncio.sleep(0.05)
+
+    # Park two Bash prompts with distinct inputs.
+    payload_a = {**await _claude_permission_payload("Bash"), "tool_input": {"command": "ls"}}
+    payload_b = {**await _claude_permission_payload("Bash"), "tool_input": {"command": "rm x"}}
+    hook_a = asyncio.create_task(
+        client.post(f"/v1/sessions/{session_id}/hooks/permission-request", json=payload_a)
+    )
+    elicit_a = (
+        await _wait_for_event(
+            captured,
+            lambda e: e.get("type") == "response.elicitation_request",
+        )
+    )["elicitation_id"]
+    hook_b = asyncio.create_task(
+        client.post(f"/v1/sessions/{session_id}/hooks/permission-request", json=payload_b)
+    )
+    elicit_b = (
+        await _wait_for_event(
+            captured,
+            lambda e: (
+                e.get("type") == "response.elicitation_request"
+                and e.get("elicitation_id") != elicit_a
+            ),
+        )
+    )["elicitation_id"]
+    assert pending_elicitations.count_for(session_id) == 2
+
+    # The user approves A in the web UI; its hook returns allow and A
+    # leaves the parked set. B stays live and unanswered.
+    verdict_a = await _post_approval(client, session_id, elicit_a, "accept")
+    assert verdict_a.status_code == 202, verdict_a.text
+    assert (await hook_a).status_code == 200
+    assert pending_elicitations.count_for(session_id) == 1
+
+    # Claude runs A's command; mirror A's tool_use then tool_result. The
+    # result's input ("ls") matches no still-parked prompt (A is gone).
+    call_id = "toolu_bash_a"
+    await _post_external_conversation_item(
+        client,
+        session_id,
+        "function_call",
+        {
+            "agent": "Claude",
+            "name": "Bash",
+            "arguments": json.dumps({"command": "ls"}),
+            "call_id": call_id,
+        },
+        source_id="src_fc_a",
+        response_id="resp_a",
+    )
+    await _post_external_conversation_item(
+        client,
+        session_id,
+        "function_call_output",
+        {"call_id": call_id, "output": "file1\n"},
+        source_id="src_fco_a",
+        response_id="resp_a",
+    )
+
+    # Give any wrong resolution of B a chance to surface before asserting.
+    await asyncio.sleep(0.1)
+    resolved_b = [
+        e
+        for e in captured
+        if e.get("type") == "response.elicitation_resolved" and e.get("elicitation_id") == elicit_b
+    ]
+    assert resolved_b == [], "prompt B (command 'rm x') must stay live"
+    assert pending_elicitations.count_for(session_id) == 1
+
+    # Cleanup: resolve B via web verdict so its parked hook returns.
+    verdict_b = await _post_approval(client, session_id, elicit_b, "accept")
+    assert verdict_b.status_code == 202, verdict_b.text
+    await hook_b
+    capture_task.cancel()
+    pending_elicitations.reset_for_tests()
+
+
 async def test_pre_permission_tool_call_does_not_deny_permission_hook(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Problem

In a native (claude-native) session, when Claude surfaces **several permission prompts for the same tool at once** — e.g. a parallel `Read` batch — approving one prompt in the web UI could silently flip a *different*, still-pending prompt to **"Resolved elsewhere"**, forcing the user to answer it in the native terminal instead.

### Root cause

`_signal_terminal_resolved_harness_elicitation` resolves a parked prompt when a mirrored `function_call_output` arrives. It prefers an exact `tool_input` match, but otherwise fell back to resolving the lone remaining same-named candidate:

```python
if len(candidates) == 1:
    candidates[0].resolved_elsewhere.set()
```

Sequence that triggers the bug:
1. Two same-tool prompts park with distinct inputs — A and B.
2. The user approves **A** in the web UI; A leaves the parked set, B stays live.
3. Claude runs A; the mirrored `function_call_output` for **A** arrives with A's input.
4. A's input matches no *still-parked* prompt (A is gone), so the `len(candidates) == 1` fallback resolves the lone survivor **B** — which the user never answered.

## Fix

Restrict the single-candidate fallback to results that carry **no input** (`tool_input is None`, e.g. Codex), where there is nothing to match on. When the input *is* known and matches no parked prompt, resolve none: the matching prompt was already settled, so the survivor is a different, unanswered prompt that the web verdict or timeout should settle.

## Tests

- Adds `test_resolved_prompt_output_does_not_clear_other_same_name_prompt` — parks two same-tool prompts, approves one via the web UI, mirrors that call's output, and asserts the other stays live. **Fails before the fix, passes after.**
- Full `test_sessions_permission_request_hook.py` and `test_sessions_elicitation_resolve_url.py` suites pass; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
