### PR TITLE
feat(collections): group sessions in the sidebar by topic

### DIFF
--- a/ap-web/src/hooks/useConversations.test.ts
+++ b/ap-web/src/hooks/useConversations.test.ts
@@ -15,8 +15,8 @@ import {
   useBulkDeleteConversations,
   useBulkStopSessions,
   useConversations,
-  useCollections,
-  useMoveToCollection,
+  useGroups,
+  useMoveToGroup,
   useRenameConversation,
   useStopAndDeleteConversation,
   useStopSession,
@@ -662,19 +662,19 @@ describe("useBulkStopSessions", () => {
   });
 });
 
-describe("useCollections", () => {
-  it("GETs /v1/sessions/collections and returns the collection list", async () => {
-    const collections = ["Customer X", "Sprint 42"];
-    fetchMock.mockResolvedValueOnce(mockResponse(collections));
+describe("useGroups", () => {
+  it("GETs /v1/sessions/groups and returns the group list", async () => {
+    const groups = ["Customer X", "Sprint 42"];
+    fetchMock.mockResolvedValueOnce(mockResponse(groups));
 
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useCollections(), { wrapper });
+    const { result } = renderHook(() => useGroups(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/collections");
-    expect(result.current.data).toEqual(collections);
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/groups");
+    expect(result.current.data).toEqual(groups);
   });
 
   it("throws on non-2xx", async () => {
@@ -682,14 +682,14 @@ describe("useCollections", () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useCollections(), { wrapper });
+    const { result } = renderHook(() => useGroups(), { wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
 });
 
-describe("useMoveToCollection", () => {
-  it("PATCHes /v1/sessions/{id} with the collection label", async () => {
+describe("useMoveToGroup", () => {
+  it("PATCHes /v1/sessions/{id} with the group label", async () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         id: "conv_move",
@@ -697,24 +697,24 @@ describe("useMoveToCollection", () => {
         title: "t",
         created_at: 0,
         updated_at: 1,
-        labels: { collection: "Sprint 42" },
+        labels: { group: "Sprint 42" },
       }),
     );
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useMoveToCollection(), { wrapper });
+    const { result } = renderHook(() => useMoveToGroup(), { wrapper });
 
-    result.current.mutate({ id: "conv_move", collection: "Sprint 42" });
+    result.current.mutate({ id: "conv_move", group: "Sprint 42" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/v1/sessions/conv_move");
     expect(init.method).toBe("PATCH");
-    expect(JSON.parse(init.body as string)).toEqual({ labels: { collection: "Sprint 42" } });
+    expect(JSON.parse(init.body as string)).toEqual({ labels: { group: "Sprint 42" } });
   });
 
-  it("invalidates both the conversations and collections queries on success", async () => {
+  it("invalidates both the conversations and groups queries on success", async () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({
         id: "conv_move",
@@ -729,14 +729,14 @@ describe("useMoveToCollection", () => {
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useMoveToCollection(), { wrapper });
+    const { result } = renderHook(() => useMoveToGroup(), { wrapper });
 
-    result.current.mutate({ id: "conv_move", collection: "" });
+    result.current.mutate({ id: "conv_move", group: "" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Both keys must refresh: conversations so the row re-groups into its new
-    // section, collections so the sidebar counts update.
+    // section, groups so the sidebar counts update.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["collections"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["groups"] });
   });
 });

--- a/ap-web/src/hooks/useConversations.test.ts
+++ b/ap-web/src/hooks/useConversations.test.ts
@@ -15,6 +15,8 @@ import {
   useBulkDeleteConversations,
   useBulkStopSessions,
   useConversations,
+  useCollections,
+  useMoveToCollection,
   useRenameConversation,
   useStopAndDeleteConversation,
   useStopSession,
@@ -657,5 +659,84 @@ describe("useBulkStopSessions", () => {
     const err = rendered.result.current.error as any;
     expect(err.succeeded).toEqual(["conv_a"]);
     expect(err.failed).toEqual(["conv_b"]);
+  });
+});
+
+describe("useCollections", () => {
+  it("GETs /v1/sessions/collections and returns the collection list", async () => {
+    const collections = ["Customer X", "Sprint 42"];
+    fetchMock.mockResolvedValueOnce(mockResponse(collections));
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useCollections(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/sessions/collections");
+    expect(result.current.data).toEqual(collections);
+  });
+
+  it("throws on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, { ok: false, status: 500 }));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useCollections(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useMoveToCollection", () => {
+  it("PATCHes /v1/sessions/{id} with the collection label", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "conv_move",
+        object: "conversation",
+        title: "t",
+        created_at: 0,
+        updated_at: 1,
+        labels: { collection: "Sprint 42" },
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useMoveToCollection(), { wrapper });
+
+    result.current.mutate({ id: "conv_move", collection: "Sprint 42" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_move");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ labels: { collection: "Sprint 42" } });
+  });
+
+  it("invalidates both the conversations and collections queries on success", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: "conv_move",
+        object: "conversation",
+        title: "t",
+        created_at: 0,
+        updated_at: 1,
+        labels: {},
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useMoveToCollection(), { wrapper });
+
+    result.current.mutate({ id: "conv_move", collection: "" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Both keys must refresh: conversations so the row re-groups into its new
+    // section, collections so the sidebar counts update.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["collections"] });
   });
 });

--- a/ap-web/src/hooks/useConversations.ts
+++ b/ap-web/src/hooks/useConversations.ts
@@ -18,7 +18,13 @@
 // `ActiveChatOverride`) so sends don't reorder it.
 
 import { useMemo } from "react";
-import { useInfiniteQuery, useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import {
   filtersFromConversationQueryKey,
@@ -596,4 +602,51 @@ export function usePinnedConversationBackfill(
     return backfilled;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedIds]);
+}
+
+// ── Collection hooks ─────────────────────────────────────────────────────────────
+
+/** Fetch all collection names from `GET /v1/sessions/collections`. */
+export function useCollections() {
+  return useQuery<string[]>({
+    queryKey: ["collections"],
+    queryFn: async () => {
+      const res = await authenticatedFetch("/v1/sessions/collections");
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      return (await res.json()) as string[];
+    },
+    staleTime: 30_000,
+  });
+}
+
+async function moveConversationToCollection(id: string, collection: string): Promise<Conversation> {
+  const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    // Empty string signals "remove from collection" (server deletes the label row).
+    body: JSON.stringify({ labels: { collection } }),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return (await res.json()) as Conversation;
+}
+
+/**
+ * Move a session to a collection (or remove it from all collections when `collection=""`).
+ *
+ * Invalidates both the conversations list (so sidebar sections re-group) and
+ * the collections list (so counts update). Patch-in-place is skipped here — collection
+ * changes affect which sidebar section a session belongs to, so a full
+ * re-render of the list is correct.
+ */
+export function useMoveToCollection() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, collection }: { id: string; collection: string }) =>
+      moveConversationToCollection(id, collection),
+    onSuccess: (updated) => {
+      markConversationSeen(updated.id, updated.updated_at);
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["collections"] });
+    },
+  });
 }

--- a/ap-web/src/hooks/useConversations.ts
+++ b/ap-web/src/hooks/useConversations.ts
@@ -604,14 +604,14 @@ export function usePinnedConversationBackfill(
   }, [resolvedIds]);
 }
 
-// ── Collection hooks ─────────────────────────────────────────────────────────────
+// ── Group hooks ─────────────────────────────────────────────────────────────
 
-/** Fetch all collection names from `GET /v1/sessions/collections`. */
-export function useCollections() {
+/** Fetch all group names from `GET /v1/sessions/groups`. */
+export function useGroups() {
   return useQuery<string[]>({
-    queryKey: ["collections"],
+    queryKey: ["groups"],
     queryFn: async () => {
-      const res = await authenticatedFetch("/v1/sessions/collections");
+      const res = await authenticatedFetch("/v1/sessions/groups");
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       return (await res.json()) as string[];
     },
@@ -619,34 +619,57 @@ export function useCollections() {
   });
 }
 
-async function moveConversationToCollection(id: string, collection: string): Promise<Conversation> {
+async function moveConversationToGroup(id: string, group: string): Promise<Conversation> {
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(id)}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    // Empty string signals "remove from collection" (server deletes the label row).
-    body: JSON.stringify({ labels: { collection } }),
+    // Empty string signals "remove from group" (server deletes the label row).
+    body: JSON.stringify({ labels: { group } }),
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as Conversation;
 }
 
+export function useBulkMoveToGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ ids, group }: { ids: string[]; group: string }) => {
+      const results = await Promise.allSettled(ids.map((id) => moveConversationToGroup(id, group)));
+      const failed: string[] = [];
+      for (let i = 0; i < results.length; i++) {
+        if (results[i].status === "rejected") failed.push(ids[i]);
+        else
+          markConversationSeen(
+            ids[i],
+            (results[i] as PromiseFulfilledResult<Conversation>).value.updated_at,
+          );
+      }
+      if (failed.length > 0) throw { failed, total: ids.length };
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
+    },
+  });
+}
+
 /**
- * Move a session to a collection (or remove it from all collections when `collection=""`).
+ * Move a session to a group (or remove it from all groups when `group=""`).
  *
  * Invalidates both the conversations list (so sidebar sections re-group) and
- * the collections list (so counts update). Patch-in-place is skipped here — collection
+ * the groups list (so counts update). Patch-in-place is skipped here — group
  * changes affect which sidebar section a session belongs to, so a full
  * re-render of the list is correct.
  */
-export function useMoveToCollection() {
+export function useMoveToGroup() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, collection }: { id: string; collection: string }) =>
-      moveConversationToCollection(id, collection),
+    mutationFn: ({ id, group }: { id: string; group: string }) =>
+      moveConversationToGroup(id, group),
     onSuccess: (updated) => {
       markConversationSeen(updated.id, updated.updated_at);
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      void queryClient.invalidateQueries({ queryKey: ["collections"] });
+      void queryClient.invalidateQueries({ queryKey: ["groups"] });
     },
   });
 }

--- a/ap-web/src/shell/NewChatDialog.flow.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.flow.test.tsx
@@ -62,6 +62,9 @@ vi.mock("@/hooks/useDirectorySessions", () => ({
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useRunnerHealthRegistration: () => new Map<string, boolean>(),
 }));
+vi.mock("@/hooks/useConversations", () => ({
+  useGroups: () => ({ data: [] }),
+}));
 
 function host(overrides: Partial<Host> = {}): Host {
   return {

--- a/ap-web/src/shell/NewChatDialog.test.tsx
+++ b/ap-web/src/shell/NewChatDialog.test.tsx
@@ -48,6 +48,9 @@ vi.mock("@/hooks/useDirectorySessions", () => ({
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useRunnerHealthRegistration: vi.fn(),
 }));
+vi.mock("@/hooks/useConversations", () => ({
+  useGroups: vi.fn(() => ({ data: [] })),
+}));
 
 const authenticatedFetchMock = vi.mocked(authenticatedFetch);
 const useHostsMock = vi.mocked(useHosts);

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -11,6 +11,8 @@ import {
   FileTextIcon,
   FolderIcon,
   ImageIcon,
+  BookmarkIcon,
+  BookmarkPlusIcon,
   PaperclipIcon,
   PlusIcon,
   SettingsIcon,
@@ -59,6 +61,7 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
 import type { Conversation } from "@/hooks/useConversations";
+import { useGroups } from "@/hooks/useConversations";
 import { OttoEyes } from "@/components/OttoEyes";
 import { SkillPills } from "@/components/SkillPills";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
@@ -688,6 +691,7 @@ export function NewChatLandingScreen() {
   // Sessions the caller can access, to warn when a new session would share a
   // working directory with a live one (see the conflict tooltip below).
   const { data: directorySessions } = useDirectorySessions(true);
+  const { data: groups = [] } = useGroups();
 
   const agentList = useMemo(() => {
     const displayRank = (name: string) => {
@@ -798,6 +802,11 @@ export function NewChatLandingScreen() {
   const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>("");
   const [workspace, setWorkspace] = useState<string>("");
   const [branchName, setBranchName] = useState<string>("");
+  const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
+  const [groupSearch, setGroupSearch] = useState<string>("");
+  const [groupPopoverOpen, setGroupPopoverOpen] = useState(false);
+  const [newGroupInput, setNewGroupInput] = useState<string>("");
+  const [showNewGroupInput, setShowNewGroupInput] = useState(false);
   const [baseBranch, setBaseBranch] = useState<string>("");
   // Permission mode for Claude Code (claude --permission-mode). Only
   // meaningful for the claude-native wrapper; ignored otherwise. Lives in
@@ -1208,6 +1217,18 @@ export function NewChatLandingScreen() {
       const data = (await res.json()) as { id: string };
       // Sandbox creates have no user-picked workspace to remember.
       if (!sandboxSelected) addRecent(workspaceTrimmed);
+      // Apply group label if the user picked one — fire-and-forget, same
+      // as the conversations refetch below. A failure here doesn't block
+      // navigation; the user can always move the session via the kebab.
+      if (selectedGroup) {
+        void authenticatedFetch(`/v1/sessions/${data.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ labels: { group: selectedGroup } }),
+        }).then(() => {
+          void queryClient.invalidateQueries({ queryKey: ["groups"] });
+        });
+      }
       // Fire-and-forget: don't block navigation on the sidebar list refresh.
       // The background refetch (or the WS session_added push) backfills the
       // new session's row within ~1s of landing in the chat; the chat itself
@@ -1824,6 +1845,122 @@ export function NewChatLandingScreen() {
                   </PopoverContent>
                 </Popover>
               )}
+
+              {/* Group chip — optional; assigns the new session to an
+                existing group or creates one inline. Skipped = session
+                lands under Recent (same as today). */}
+              <DropdownMenu
+                open={groupPopoverOpen}
+                onOpenChange={(open) => {
+                  setGroupPopoverOpen(open);
+                  if (!open) {
+                    setGroupSearch("");
+                    setShowNewGroupInput(false);
+                    setNewGroupInput("");
+                  }
+                }}
+              >
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex h-6 items-center gap-1.5 rounded-full px-3 text-13 font-normal text-muted-foreground transition-colors hover:text-foreground"
+                    data-testid="new-chat-landing-group-chip"
+                  >
+                    <BookmarkIcon className="size-4 shrink-0" />
+                    <span className={`max-w-32 truncate ${selectedGroup ? "text-foreground" : ""}`}>
+                      {selectedGroup ?? "No group"}
+                    </span>
+                    <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-56 p-1">
+                  <div className="px-2 py-1.5">
+                    <input
+                      type="text"
+                      className="w-full rounded-md border border-input bg-background px-2 py-1 text-xs outline-none focus-visible:border-ring"
+                      placeholder="Search groups…"
+                      value={groupSearch}
+                      onChange={(e) => setGroupSearch(e.target.value)}
+                      onKeyDown={(e) => e.stopPropagation()}
+                      data-testid="new-chat-group-search"
+                    />
+                  </div>
+                  <DropdownMenuSeparator />
+                  {groups
+                    .filter((c) => c.toLowerCase().includes(groupSearch.toLowerCase()))
+                    .map((c) => (
+                      <DropdownMenuItem
+                        key={c}
+                        onSelect={() => {
+                          setSelectedGroup(c === selectedGroup ? null : c);
+                          setGroupPopoverOpen(false);
+                        }}
+                        data-active={c === selectedGroup ? "true" : undefined}
+                        className="text-xs data-[active=true]:bg-accent/60"
+                        data-testid="new-chat-group-option"
+                      >
+                        <BookmarkIcon className="size-3.5 text-muted-foreground" />
+                        <span className="truncate">{c}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  {groups.length === 0 && !showNewGroupInput && (
+                    <div className="px-2 py-1.5 text-xs text-muted-foreground">No groups yet.</div>
+                  )}
+                  <DropdownMenuSeparator />
+                  {showNewGroupInput ? (
+                    <div className="px-2 py-1.5">
+                      <input
+                        autoFocus
+                        type="text"
+                        className="w-full rounded-md border border-input bg-background px-2 py-1 text-xs outline-none focus-visible:border-ring"
+                        placeholder="Group name…"
+                        value={newGroupInput}
+                        onChange={(e) => setNewGroupInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          e.stopPropagation();
+                          if (e.key === "Enter" && newGroupInput.trim()) {
+                            setSelectedGroup(newGroupInput.trim());
+                            setGroupPopoverOpen(false);
+                          }
+                          if (e.key === "Escape") {
+                            setShowNewGroupInput(false);
+                            setNewGroupInput("");
+                          }
+                        }}
+                        data-testid="new-chat-new-group-input"
+                      />
+                    </div>
+                  ) : (
+                    <DropdownMenuItem
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        setShowNewGroupInput(true);
+                      }}
+                      className="text-xs text-muted-foreground"
+                      data-testid="new-chat-new-group"
+                    >
+                      <BookmarkPlusIcon className="size-3.5" />
+                      New group…
+                    </DropdownMenuItem>
+                  )}
+                  {selectedGroup && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={() => {
+                          setSelectedGroup(null);
+                          setGroupPopoverOpen(false);
+                        }}
+                        className="text-xs text-muted-foreground"
+                        data-testid="new-chat-remove-group"
+                      >
+                        <XIcon className="size-3.5" />
+                        Remove from group
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
 
               {/* Advanced settings chip — per-agent knobs that don't warrant
                 their own chip: the brain-harness override (bundle agents),

--- a/ap-web/src/shell/Sidebar.archive.test.tsx
+++ b/ap-web/src/shell/Sidebar.archive.test.tsx
@@ -38,8 +38,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
-  useCollections: () => ({ data: [] }),
-  useMoveToCollection: () => ({ mutate: vi.fn() }),
+  useGroups: () => ({ data: [] }),
+  useMoveToGroup: () => ({ mutate: vi.fn() }),
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));

--- a/ap-web/src/shell/Sidebar.archive.test.tsx
+++ b/ap-web/src/shell/Sidebar.archive.test.tsx
@@ -38,6 +38,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
+  useCollections: () => ({ data: [] }),
+  useMoveToCollection: () => ({ mutate: vi.fn() }),
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));

--- a/ap-web/src/shell/Sidebar.delete.test.tsx
+++ b/ap-web/src/shell/Sidebar.delete.test.tsx
@@ -37,6 +37,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
+  useCollections: () => ({ data: [] }),
+  useMoveToCollection: () => ({ mutate: vi.fn() }),
 }));
 
 // Heavy sibling widgets in the sidebar pull their own hooks/providers;

--- a/ap-web/src/shell/Sidebar.delete.test.tsx
+++ b/ap-web/src/shell/Sidebar.delete.test.tsx
@@ -37,8 +37,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useCollections: () => ({ data: [] }),
-  useMoveToCollection: () => ({ mutate: vi.fn() }),
+  useGroups: () => ({ data: [] }),
+  useMoveToGroup: () => ({ mutate: vi.fn() }),
 }));
 
 // Heavy sibling widgets in the sidebar pull their own hooks/providers;

--- a/ap-web/src/shell/Sidebar.rowActions.test.tsx
+++ b/ap-web/src/shell/Sidebar.rowActions.test.tsx
@@ -35,6 +35,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
+  useCollections: () => ({ data: [] }),
+  useMoveToCollection: () => ({ mutate: vi.fn() }),
 }));
 
 // Heavy sibling widgets pull their own hooks/providers; stub them so this

--- a/ap-web/src/shell/Sidebar.rowActions.test.tsx
+++ b/ap-web/src/shell/Sidebar.rowActions.test.tsx
@@ -35,8 +35,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  useCollections: () => ({ data: [] }),
-  useMoveToCollection: () => ({ mutate: vi.fn() }),
+  useGroups: () => ({ data: [] }),
+  useMoveToGroup: () => ({ mutate: vi.fn() }),
 }));
 
 // Heavy sibling widgets pull their own hooks/providers; stub them so this

--- a/ap-web/src/shell/Sidebar.stop.test.tsx
+++ b/ap-web/src/shell/Sidebar.stop.test.tsx
@@ -36,6 +36,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
+  useCollections: () => ({ data: [] }),
+  useMoveToCollection: () => ({ mutate: vi.fn() }),
 }));
 
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({

--- a/ap-web/src/shell/Sidebar.stop.test.tsx
+++ b/ap-web/src/shell/Sidebar.stop.test.tsx
@@ -36,8 +36,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useStopSession: () => mocks.stop,
-  useCollections: () => ({ data: [] }),
-  useMoveToCollection: () => ({ mutate: vi.fn() }),
+  useGroups: () => ({ data: [] }),
+  useMoveToGroup: () => ({ mutate: vi.fn() }),
 }));
 
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({

--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -368,10 +368,7 @@ describe("Sidebar collection sections", () => {
       conv("conv_pinned", "Claude Code", { labels: { collection: "Customer X" } }),
     ]);
     // Pin one of the collectioned sessions via localStorage (client-side pins).
-    localStorage.setItem(
-      "omnigent:pinned-conversation-ids",
-      JSON.stringify(["conv_pinned"]),
-    );
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pinned"]));
     renderSidebar();
 
     // No global "Pinned" section — the pinned session stays in its collection.
@@ -453,21 +450,12 @@ describe("Sidebar default section collapse", () => {
     mockConversations([conv("conv_pin", "Claude Code"), conv("conv_recent", "Claude Code")]);
     renderSidebar();
 
-    expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    expect(screen.getByRole("button", { name: /Recent/ })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /Recent/ })).toHaveAttribute("aria-expanded", "true");
   });
 
   it("honors a persisted collapse of Recent across remount", () => {
-    localStorage.setItem(
-      "omnigent:collapsed-sidebar-sections",
-      JSON.stringify(["Recent"]),
-    );
+    localStorage.setItem("omnigent:collapsed-sidebar-sections", JSON.stringify(["Recent"]));
     mockConversations([conv("conv_recent", "Claude Code")]);
     renderSidebar();
 
@@ -485,10 +473,7 @@ describe("Sidebar default section collapse", () => {
 describe("Sidebar pin marker visibility", () => {
   it("keeps the pin button visible at rest once a conversation is pinned", () => {
     mockConversations([conv("conv_pin", "Claude Code")]);
-    localStorage.setItem(
-      "omnigent:pinned-conversation-ids",
-      JSON.stringify(["conv_pin"]),
-    );
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pin"]));
     renderSidebar();
 
     const pinned = screen.getByText("Pinned").closest("section")!;
@@ -502,13 +487,8 @@ describe("Sidebar pin marker visibility", () => {
     // Pinned in storage AND archived: archive wins, so the row sits in the
     // Archived group with NO pin button at all (not even on hover) — pinning
     // is meaningless there.
-    mockConversations([
-      conv("conv_pa", "Claude Code", { archived: true }),
-    ]);
-    localStorage.setItem(
-      "omnigent:pinned-conversation-ids",
-      JSON.stringify(["conv_pa"]),
-    );
+    mockConversations([conv("conv_pa", "Claude Code", { archived: true })]);
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pa"]));
     renderSidebar();
 
     fireEvent.click(screen.getByRole("button", { name: "Archived" }));
@@ -537,10 +517,10 @@ describe("Sidebar move-to-collection action", () => {
     // Open the row's kebab menu (Radix opens on pointerdown, not click), then
     // open the "Move to collection" submenu flyout.
     const row = screen.getByRole("link", { name: /conv_move/ }).closest("li")!;
-    fireEvent.pointerDown(
-      within(row).getByRole("button", { name: "Conversation actions" }),
-      { button: 0, ctrlKey: false },
-    );
+    fireEvent.pointerDown(within(row).getByRole("button", { name: "Conversation actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
     fireEvent.click(await screen.findByTestId("move-to-collection"));
 
     // Collections render as menu items inside the submenu; picking one fires the

--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -11,6 +11,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 
+// Collection mocks are declared via vi.hoisted so they exist before the hoisted
+// vi.mock factory runs. collectionsMock is mutated per-test to drive collection
+// sections; moveToCollectionSpy captures kebab-menu "Move to collection" calls.
+const { collectionsMock, moveToCollectionSpy } = vi.hoisted(() => ({
+  collectionsMock: [] as string[],
+  moveToCollectionSpy: vi.fn(),
+}));
+
 // Mutation hooks are only invoked on row actions; stub them. useConversations
 // is the data source under test, so it's a controllable mock.
 vi.mock("@/hooks/useConversations", () => ({
@@ -24,6 +32,11 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useStopSession: () => ({ mutate: vi.fn() }),
+  // Collection feature: the sidebar reads the collection list to build collection
+  // sections, and rows fire useMoveToCollection from the kebab menu. Both must
+  // be stubbed or the Sidebar throws on render.
+  useCollections: () => ({ data: collectionsMock }),
+  useMoveToCollection: () => ({ mutate: moveToCollectionSpy }),
 }));
 // Header / dialog children that pull their own context — stub to keep the
 // test scoped to the conversation list + funnel.
@@ -99,6 +112,8 @@ function renderSidebar(open = true) {
 beforeEach(() => {
   useConvMock.mockReset();
   localStorage.clear();
+  collectionsMock.length = 0;
+  moveToCollectionSpy.mockReset();
 });
 afterEach(cleanup);
 
@@ -302,6 +317,236 @@ describe("Sidebar load-more vs collapsed Recent", () => {
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Recent" }));
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+  });
+});
+
+// Collection feature: sessions carrying a `collection` label are peeled out of
+// "Recent" into a dedicated section named after the collection, rendered between
+// Pinned and Recent. The collection list comes from useCollections() (mocked here).
+describe("Sidebar collection sections", () => {
+  it("groups sessions by their collection label, separate from Recent", () => {
+    collectionsMock.push("Customer X");
+    mockConversations([
+      conv("conv_unfiled", "Claude Code"),
+      conv("conv_filed", "Claude Code", { labels: { collection: "Customer X" } }),
+    ]);
+    renderSidebar();
+
+    // Collections default collapsed, so the row is hidden until the header is
+    // clicked. The unfiled session stays visible in Recent regardless.
+    const recentSection = screen.getByText("Recent").closest("section")!;
+    expect(within(recentSection).getByText("conv_unfiled")).toBeInTheDocument();
+    expect(within(recentSection).queryByText("conv_filed")).toBeNull();
+    expect(screen.queryByText("conv_filed")).toBeNull();
+
+    // Expanding the collection reveals its session under the collection section.
+    fireEvent.click(screen.getByRole("button", { name: /Customer X/ }));
+    const collectionSection = screen.getByText("Customer X").closest("section")!;
+    expect(within(collectionSection).getByText("conv_filed")).toBeInTheDocument();
+    expect(within(recentSection).queryByText("conv_filed")).toBeNull();
+  });
+
+  it("starts collections collapsed and shows their session count", () => {
+    collectionsMock.push("Customer X");
+    mockConversations([
+      conv("conv_filed", "Claude Code", { labels: { collection: "Customer X" } }),
+    ]);
+    renderSidebar();
+
+    // Header is present (with the rendered count) but the row is hidden, and
+    // the toggle reports collapsed via aria-expanded.
+    const header = screen.getByRole("button", { name: /Customer X/ });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    expect(within(header).getByText("1")).toBeInTheDocument();
+    expect(screen.queryByText("conv_filed")).toBeNull();
+  });
+
+  it("keeps a pinned session inside its collection, sorted first", () => {
+    collectionsMock.push("Customer X");
+    mockConversations([
+      conv("conv_plain", "Claude Code", { labels: { collection: "Customer X" } }),
+      conv("conv_pinned", "Claude Code", { labels: { collection: "Customer X" } }),
+    ]);
+    // Pin one of the collectioned sessions via localStorage (client-side pins).
+    localStorage.setItem(
+      "omnigent:pinned-conversation-ids",
+      JSON.stringify(["conv_pinned"]),
+    );
+    renderSidebar();
+
+    // No global "Pinned" section — the pinned session stays in its collection.
+    expect(screen.queryByText("Pinned")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Customer X/ }));
+    const collectionSection = screen.getByText("Customer X").closest("section")!;
+    const rows = within(collectionSection).getAllByRole("link");
+    // Pinned row sorts to the top of the collection.
+    expect(rows[0]).toHaveTextContent("conv_pinned");
+    expect(rows[1]).toHaveTextContent("conv_plain");
+  });
+
+  it("does not render a collection section when useCollections returns nothing", () => {
+    // A session with a stale collection label but no matching collection entry stays
+    // in Recent — collections are driven by the collection list, not the labels alone.
+    mockConversations([conv("conv_filed", "Claude Code", { labels: { collection: "Ghost" } })]);
+    renderSidebar();
+
+    expect(screen.queryByText("Ghost")).toBeNull();
+    const recentSection = screen.getByText("Recent").closest("section")!;
+    expect(within(recentSection).getByText("conv_filed")).toBeInTheDocument();
+  });
+});
+
+// A collapsed collection bubbles up its hidden rows' marker, using the same
+// SessionStateBadge a row shows. Only while collapsed.
+describe("Sidebar collapsed collection marker", () => {
+  it("shows the row's session-state badge on a collapsed collection", () => {
+    collectionsMock.push("Customer X");
+    mockConversations([
+      conv("conv_awaiting", "Claude Code", {
+        labels: { collection: "Customer X" },
+        pending_elicitations_count: 1,
+      }),
+    ]);
+    renderSidebar();
+
+    // Collapsed by default → the row is hidden, but its "Needs response"
+    // marker surfaces on the collection header.
+    const header = screen.getByRole("button", { name: /Customer X/ });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    expect(within(header).getByText("Needs response")).toBeInTheDocument();
+  });
+
+  it("drops the header marker once the collection is expanded", () => {
+    collectionsMock.push("Customer X");
+    mockConversations([
+      conv("conv_awaiting", "Claude Code", {
+        labels: { collection: "Customer X" },
+        pending_elicitations_count: 1,
+      }),
+    ]);
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: /Customer X/ }));
+    const header = screen.getByRole("button", { name: /Customer X/ });
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    // The visible row now owns the badge; the header no longer carries it.
+    expect(within(header).queryByText("Needs response")).toBeNull();
+  });
+
+  it("shows no header marker when no collectioned row has one", () => {
+    collectionsMock.push("Customer X");
+    mockConversations([
+      conv("conv_plain", "Claude Code", { labels: { collection: "Customer X" } }),
+    ]);
+    renderSidebar();
+
+    const header = screen.getByRole("button", { name: /Customer X/ });
+    expect(within(header).queryByText("Needs response")).toBeNull();
+  });
+});
+
+// Pinned and Recent are expanded by default (only Archived starts collapsed),
+// but a collapse the user makes persists across reloads.
+describe("Sidebar default section collapse", () => {
+  it("expands Pinned and Recent by default when there is no stored preference", () => {
+    localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pin"]));
+    mockConversations([conv("conv_pin", "Claude Code"), conv("conv_recent", "Claude Code")]);
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: /Pinned/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /Recent/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("honors a persisted collapse of Recent across remount", () => {
+    localStorage.setItem(
+      "omnigent:collapsed-sidebar-sections",
+      JSON.stringify(["Recent"]),
+    );
+    mockConversations([conv("conv_recent", "Claude Code")]);
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: /Recent/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByText("conv_recent")).toBeNull();
+  });
+});
+
+// The quick-pin affordance is hover-revealed on unpinned rows, but a pinned
+// row must keep its pin marker visible at rest so the pinned state reads
+// without hovering.
+describe("Sidebar pin marker visibility", () => {
+  it("keeps the pin button visible at rest once a conversation is pinned", () => {
+    mockConversations([conv("conv_pin", "Claude Code")]);
+    localStorage.setItem(
+      "omnigent:pinned-conversation-ids",
+      JSON.stringify(["conv_pin"]),
+    );
+    renderSidebar();
+
+    const pinned = screen.getByText("Pinned").closest("section")!;
+    const pinButton = within(pinned).getByTestId("quick-pin-conversation");
+    // Pinned: always opaque (no hover-gated opacity-0).
+    expect(pinButton.className).toContain("opacity-100");
+    expect(pinButton.className).not.toContain("md:opacity-0");
+  });
+
+  it("omits the pin affordance entirely on an archived row", () => {
+    // Pinned in storage AND archived: archive wins, so the row sits in the
+    // Archived group with NO pin button at all (not even on hover) — pinning
+    // is meaningless there.
+    mockConversations([
+      conv("conv_pa", "Claude Code", { archived: true }),
+    ]);
+    localStorage.setItem(
+      "omnigent:pinned-conversation-ids",
+      JSON.stringify(["conv_pa"]),
+    );
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    const archived = screen.getByText("Archived").closest("section")!;
+    expect(within(archived).queryByTestId("quick-pin-conversation")).toBeNull();
+  });
+
+  it("hides the pin affordance until hover on an unpinned row", () => {
+    mockConversations([conv("conv_plain", "Claude Code")]);
+    renderSidebar();
+
+    const pinButton = screen.getByTestId("quick-pin-conversation");
+    // Unpinned: hover-gated reveal (opacity-0 until group-hover).
+    expect(pinButton.className).toContain("md:opacity-0");
+  });
+});
+
+// The kebab menu's "Move to collection" item opens the collection picker; selecting a
+// collection fires useMoveToCollection with the row id and chosen collection name.
+describe("Sidebar move-to-collection action", () => {
+  it("moves a session into a collection selected from the picker", async () => {
+    collectionsMock.push("Sprint 42");
+    mockConversations([conv("conv_move", "Claude Code")]);
+    renderSidebar();
+
+    // Open the row's kebab menu (Radix opens on pointerdown, not click), then
+    // open the "Move to collection" submenu flyout.
+    const row = screen.getByRole("link", { name: /conv_move/ }).closest("li")!;
+    fireEvent.pointerDown(
+      within(row).getByRole("button", { name: "Conversation actions" }),
+      { button: 0, ctrlKey: false },
+    );
+    fireEvent.click(await screen.findByTestId("move-to-collection"));
+
+    // Collections render as menu items inside the submenu; picking one fires the
+    // mutation with id + collection.
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Sprint 42/ }));
+    expect(moveToCollectionSpy).toHaveBeenCalledWith({ id: "conv_move", collection: "Sprint 42" });
   });
 });
 

--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -11,12 +11,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 
-// Collection mocks are declared via vi.hoisted so they exist before the hoisted
-// vi.mock factory runs. collectionsMock is mutated per-test to drive collection
-// sections; moveToCollectionSpy captures kebab-menu "Move to collection" calls.
-const { collectionsMock, moveToCollectionSpy } = vi.hoisted(() => ({
-  collectionsMock: [] as string[],
-  moveToCollectionSpy: vi.fn(),
+// Group mocks are declared via vi.hoisted so they exist before the hoisted
+// vi.mock factory runs. groupsMock is mutated per-test to drive group
+// sections; moveToGroupSpy captures kebab-menu "Move to group" calls.
+const { groupsMock, moveToGroupSpy } = vi.hoisted(() => ({
+  groupsMock: [] as string[],
+  moveToGroupSpy: vi.fn(),
 }));
 
 // Mutation hooks are only invoked on row actions; stub them. useConversations
@@ -32,11 +32,11 @@ vi.mock("@/hooks/useConversations", () => ({
   usePinnedConversationBackfill: () => [],
   useRenameConversation: () => ({ mutate: vi.fn() }),
   useStopSession: () => ({ mutate: vi.fn() }),
-  // Collection feature: the sidebar reads the collection list to build collection
-  // sections, and rows fire useMoveToCollection from the kebab menu. Both must
+  // Group feature: the sidebar reads the group list to build group
+  // sections, and rows fire useMoveToGroup from the kebab menu. Both must
   // be stubbed or the Sidebar throws on render.
-  useCollections: () => ({ data: collectionsMock }),
-  useMoveToCollection: () => ({ mutate: moveToCollectionSpy }),
+  useGroups: () => ({ data: groupsMock }),
+  useMoveToGroup: () => ({ mutate: moveToGroupSpy }),
 }));
 // Header / dialog children that pull their own context — stub to keep the
 // test scoped to the conversation list + funnel.
@@ -112,8 +112,8 @@ function renderSidebar(open = true) {
 beforeEach(() => {
   useConvMock.mockReset();
   localStorage.clear();
-  collectionsMock.length = 0;
-  moveToCollectionSpy.mockReset();
+  groupsMock.length = 0;
+  moveToGroupSpy.mockReset();
 });
 afterEach(cleanup);
 
@@ -320,37 +320,35 @@ describe("Sidebar load-more vs collapsed Recent", () => {
   });
 });
 
-// Collection feature: sessions carrying a `collection` label are peeled out of
-// "Recent" into a dedicated section named after the collection, rendered between
-// Pinned and Recent. The collection list comes from useCollections() (mocked here).
-describe("Sidebar collection sections", () => {
-  it("groups sessions by their collection label, separate from Recent", () => {
-    collectionsMock.push("Customer X");
+// Group feature: sessions carrying a `group` label are peeled out of
+// "Recent" into a dedicated section named after the group, rendered between
+// Pinned and Recent. The group list comes from useGroups() (mocked here).
+describe("Sidebar group sections", () => {
+  it("groups sessions by their group label, separate from Recent", () => {
+    groupsMock.push("Customer X");
     mockConversations([
       conv("conv_unfiled", "Claude Code"),
-      conv("conv_filed", "Claude Code", { labels: { collection: "Customer X" } }),
+      conv("conv_filed", "Claude Code", { labels: { group: "Customer X" } }),
     ]);
     renderSidebar();
 
-    // Collections default collapsed, so the row is hidden until the header is
+    // Groups default collapsed, so the row is hidden until the header is
     // clicked. The unfiled session stays visible in Recent regardless.
     const recentSection = screen.getByText("Recent").closest("section")!;
     expect(within(recentSection).getByText("conv_unfiled")).toBeInTheDocument();
     expect(within(recentSection).queryByText("conv_filed")).toBeNull();
     expect(screen.queryByText("conv_filed")).toBeNull();
 
-    // Expanding the collection reveals its session under the collection section.
+    // Expanding the group reveals its session under the group section.
     fireEvent.click(screen.getByRole("button", { name: /Customer X/ }));
-    const collectionSection = screen.getByText("Customer X").closest("section")!;
-    expect(within(collectionSection).getByText("conv_filed")).toBeInTheDocument();
+    const groupSection = screen.getByText("Customer X").closest("section")!;
+    expect(within(groupSection).getByText("conv_filed")).toBeInTheDocument();
     expect(within(recentSection).queryByText("conv_filed")).toBeNull();
   });
 
-  it("starts collections collapsed and shows their session count", () => {
-    collectionsMock.push("Customer X");
-    mockConversations([
-      conv("conv_filed", "Claude Code", { labels: { collection: "Customer X" } }),
-    ]);
+  it("starts groups collapsed and shows their session count", () => {
+    groupsMock.push("Customer X");
+    mockConversations([conv("conv_filed", "Claude Code", { labels: { group: "Customer X" } })]);
     renderSidebar();
 
     // Header is present (with the rendered count) but the row is hidden, and
@@ -361,30 +359,30 @@ describe("Sidebar collection sections", () => {
     expect(screen.queryByText("conv_filed")).toBeNull();
   });
 
-  it("keeps a pinned session inside its collection, sorted first", () => {
-    collectionsMock.push("Customer X");
+  it("keeps a pinned session inside its group, sorted first", () => {
+    groupsMock.push("Customer X");
     mockConversations([
-      conv("conv_plain", "Claude Code", { labels: { collection: "Customer X" } }),
-      conv("conv_pinned", "Claude Code", { labels: { collection: "Customer X" } }),
+      conv("conv_plain", "Claude Code", { labels: { group: "Customer X" } }),
+      conv("conv_pinned", "Claude Code", { labels: { group: "Customer X" } }),
     ]);
     // Pin one of the collectioned sessions via localStorage (client-side pins).
     localStorage.setItem("omnigent:pinned-conversation-ids", JSON.stringify(["conv_pinned"]));
     renderSidebar();
 
-    // No global "Pinned" section — the pinned session stays in its collection.
+    // No global "Pinned" section — the pinned session stays in its group.
     expect(screen.queryByText("Pinned")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /Customer X/ }));
-    const collectionSection = screen.getByText("Customer X").closest("section")!;
-    const rows = within(collectionSection).getAllByRole("link");
-    // Pinned row sorts to the top of the collection.
+    const groupSection = screen.getByText("Customer X").closest("section")!;
+    const rows = within(groupSection).getAllByRole("link");
+    // Pinned row sorts to the top of the group.
     expect(rows[0]).toHaveTextContent("conv_pinned");
     expect(rows[1]).toHaveTextContent("conv_plain");
   });
 
-  it("does not render a collection section when useCollections returns nothing", () => {
-    // A session with a stale collection label but no matching collection entry stays
-    // in Recent — collections are driven by the collection list, not the labels alone.
-    mockConversations([conv("conv_filed", "Claude Code", { labels: { collection: "Ghost" } })]);
+  it("does not render a group section when useGroups returns nothing", () => {
+    // A session with a stale group label but no matching group entry stays
+    // in Recent — groups are driven by the group list, not the labels alone.
+    mockConversations([conv("conv_filed", "Claude Code", { labels: { group: "Ghost" } })]);
     renderSidebar();
 
     expect(screen.queryByText("Ghost")).toBeNull();
@@ -393,31 +391,31 @@ describe("Sidebar collection sections", () => {
   });
 });
 
-// A collapsed collection bubbles up its hidden rows' marker, using the same
+// A collapsed group bubbles up its hidden rows' marker, using the same
 // SessionStateBadge a row shows. Only while collapsed.
-describe("Sidebar collapsed collection marker", () => {
-  it("shows the row's session-state badge on a collapsed collection", () => {
-    collectionsMock.push("Customer X");
+describe("Sidebar collapsed group marker", () => {
+  it("shows the row's session-state badge on a collapsed group", () => {
+    groupsMock.push("Customer X");
     mockConversations([
       conv("conv_awaiting", "Claude Code", {
-        labels: { collection: "Customer X" },
+        labels: { group: "Customer X" },
         pending_elicitations_count: 1,
       }),
     ]);
     renderSidebar();
 
     // Collapsed by default → the row is hidden, but its "Needs response"
-    // marker surfaces on the collection header.
+    // marker surfaces on the group header.
     const header = screen.getByRole("button", { name: /Customer X/ });
     expect(header).toHaveAttribute("aria-expanded", "false");
     expect(within(header).getByText("Needs response")).toBeInTheDocument();
   });
 
-  it("drops the header marker once the collection is expanded", () => {
-    collectionsMock.push("Customer X");
+  it("drops the header marker once the group is expanded", () => {
+    groupsMock.push("Customer X");
     mockConversations([
       conv("conv_awaiting", "Claude Code", {
-        labels: { collection: "Customer X" },
+        labels: { group: "Customer X" },
         pending_elicitations_count: 1,
       }),
     ]);
@@ -430,11 +428,9 @@ describe("Sidebar collapsed collection marker", () => {
     expect(within(header).queryByText("Needs response")).toBeNull();
   });
 
-  it("shows no header marker when no collectioned row has one", () => {
-    collectionsMock.push("Customer X");
-    mockConversations([
-      conv("conv_plain", "Claude Code", { labels: { collection: "Customer X" } }),
-    ]);
+  it("shows no header marker when no grouped row has one", () => {
+    groupsMock.push("Customer X");
+    mockConversations([conv("conv_plain", "Claude Code", { labels: { group: "Customer X" } })]);
     renderSidebar();
 
     const header = screen.getByRole("button", { name: /Customer X/ });
@@ -506,27 +502,27 @@ describe("Sidebar pin marker visibility", () => {
   });
 });
 
-// The kebab menu's "Move to collection" item opens the collection picker; selecting a
-// collection fires useMoveToCollection with the row id and chosen collection name.
-describe("Sidebar move-to-collection action", () => {
-  it("moves a session into a collection selected from the picker", async () => {
-    collectionsMock.push("Sprint 42");
+// The kebab menu's "Move to group" item opens the group picker; selecting a
+// group fires useMoveToGroup with the row id and chosen group name.
+describe("Sidebar move-to-group action", () => {
+  it("moves a session into a group selected from the picker", async () => {
+    groupsMock.push("Sprint 42");
     mockConversations([conv("conv_move", "Claude Code")]);
     renderSidebar();
 
     // Open the row's kebab menu (Radix opens on pointerdown, not click), then
-    // open the "Move to collection" submenu flyout.
+    // open the "Move to group" submenu flyout.
     const row = screen.getByRole("link", { name: /conv_move/ }).closest("li")!;
     fireEvent.pointerDown(within(row).getByRole("button", { name: "Conversation actions" }), {
       button: 0,
       ctrlKey: false,
     });
-    fireEvent.click(await screen.findByTestId("move-to-collection"));
+    fireEvent.click(await screen.findByTestId("move-to-group"));
 
-    // Collections render as menu items inside the submenu; picking one fires the
-    // mutation with id + collection.
+    // Groups render as menu items inside the submenu; picking one fires the
+    // mutation with id + group.
     fireEvent.click(await screen.findByRole("menuitem", { name: /Sprint 42/ }));
-    expect(moveToCollectionSpy).toHaveBeenCalledWith({ id: "conv_move", collection: "Sprint 42" });
+    expect(moveToGroupSpy).toHaveBeenCalledWith({ id: "conv_move", group: "Sprint 42" });
   });
 });
 

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -18,8 +18,8 @@ import {
   ChevronRightIcon,
   CircleStopIcon,
   ClockIcon,
-  FolderIcon,
-  FolderInputIcon,
+  BookmarkIcon,
+  BookmarkPlusIcon,
   GitBranchIcon,
   InboxIcon,
   ListChecksIcon,
@@ -51,6 +51,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -61,9 +62,10 @@ import {
   useArchiveConversation,
   useBulkArchiveConversations,
   useBulkDeleteConversations,
-  useCollections,
+  useBulkMoveToGroup,
+  useGroups,
   useConversations,
-  useMoveToCollection,
+  useMoveToGroup,
   usePinnedConversationBackfill,
   useRenameConversation,
   useStopAndDeleteConversation,
@@ -90,7 +92,7 @@ import {
   COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
   computeNextActiveOverride,
   conversationDisplayLabel,
-  EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY,
+  EXPANDED_GROUP_SECTIONS_STORAGE_KEY,
   normalizePinnedConversationIds,
   PINNED_CONVERSATION_IDS_STORAGE_KEY,
   sortByUpdatedAtDesc,
@@ -468,8 +470,8 @@ function ConversationList({
     [conversationsQuery.data],
   );
 
-  // Collection names for grouping sessions by their "collection" label.
-  const { data: collectionNames = [] } = useCollections();
+  // Group names for grouping sessions by their "group" label.
+  const { data: groupNames = [] } = useGroups();
 
   // Backfill pinned sessions that aren't in the loaded set.
   const loadedIds = useMemo(() => new Set(allConversations.map((c) => c.id)), [allConversations]);
@@ -494,23 +496,23 @@ function ConversationList({
     const allWithBackfill = [...allConversations, ...pinnedBackfill];
     const notArchived = allWithBackfill.filter((c) => c.archived !== true);
 
-    // Collections are built first. A collectioned session STAYS in its collection even
-    // when pinned (B2): pinning sorts the row to the top of its collection rather
+    // Groups are built first. A grouped session STAYS in its group even
+    // when pinned (B2): pinning sorts the row to the top of its group rather
     // than pulling it out into the global Pinned section. Archived rows are
-    // excluded — they belong to the Archived group regardless of collection label.
-    const collectedIds = new Set<string>();
-    const collectionGroups: { name: string; conversations: Conversation[] }[] = collectionNames
+    // excluded — they belong to the Archived group regardless of group label.
+    const groupedIds = new Set<string>();
+    const groupSections: { name: string; conversations: Conversation[] }[] = groupNames
       .map((name) => {
-        const inCollection = notArchived.filter((c) => c.labels?.["collection"] === name);
-        inCollection.forEach((c) => collectedIds.add(c.id));
+        const inGroup = notArchived.filter((c) => c.labels?.["group"] === name);
+        inGroup.forEach((c) => groupedIds.add(c.id));
         // Pinned-first, then by recency — both buckets share the same sort.
         const conversations = [
           ...sortByUpdatedAtDesc(
-            inCollection.filter((c) => pinnedSet.has(c.id)),
+            inGroup.filter((c) => pinnedSet.has(c.id)),
             activeOverride,
           ),
           ...sortByUpdatedAtDesc(
-            inCollection.filter((c) => !pinnedSet.has(c.id)),
+            inGroup.filter((c) => !pinnedSet.has(c.id)),
             activeOverride,
           ),
         ];
@@ -519,17 +521,17 @@ function ConversationList({
       .filter((g) => g.conversations.length > 0);
 
     // The global Pinned section now holds only pinned sessions that are NOT
-    // in a collection — collectioned pins live under their collection instead.
+    // in a group — grouped pins live under their group instead.
     const pinned = sortByUpdatedAtDesc(
-      notArchived.filter((c) => pinnedSet.has(c.id) && !collectedIds.has(c.id)),
+      notArchived.filter((c) => pinnedSet.has(c.id) && !groupedIds.has(c.id)),
       activeOverride,
     );
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
 
     // Recent / Shared: the remainder — not archived, not globally pinned, and
-    // not in any collection.
+    // not in any group.
     const rest = allConversations.filter(
-      (c) => c.archived !== true && !pinnedIdSet.has(c.id) && !collectedIds.has(c.id),
+      (c) => c.archived !== true && !pinnedIdSet.has(c.id) && !groupedIds.has(c.id),
     );
     const sessions = sortByUpdatedAtDesc(rest.filter(isOwnedByViewer), activeOverride);
     const shared = sortByUpdatedAtDesc(
@@ -540,8 +542,8 @@ function ConversationList({
       allWithBackfill.filter((c) => c.archived === true),
       activeOverride,
     );
-    return { pinned, sessions, shared, archived, collectionGroups };
-  }, [allConversations, pinnedBackfill, pinnedSet, activeOverride, collectionNames]);
+    return { pinned, sessions, shared, archived, groupSections };
+  }, [allConversations, pinnedBackfill, pinnedSet, activeOverride, groupNames]);
 
   // Collapsed section titles — persisted like pins so the preference
   // survives reloads. Lifted here (not per-section state) because the
@@ -559,18 +561,16 @@ function ConversationList({
     });
   }, []);
 
-  // Collections default to COLLAPSED, so we track the inverse — names the user has
-  // expanded — persisted across reloads. A collection shows its rows only while
+  // Groups default to COLLAPSED, so we track the inverse — names the user has
+  // expanded — persisted across reloads. A group shows its rows only while
   // its name is in this set.
-  const [expandedCollections, setExpandedCollections] = useState<string[]>(
-    readExpandedCollectionSections,
-  );
-  const toggleCollectionExpanded = useCallback((collectionName: string) => {
-    setExpandedCollections((prev) => {
-      const next = prev.includes(collectionName)
-        ? prev.filter((n) => n !== collectionName)
-        : [...prev, collectionName];
-      writeExpandedCollectionSections(next);
+  const [expandedGroups, setExpandedGroups] = useState<string[]>(readExpandedGroupSections);
+  const toggleGroupExpanded = useCallback((groupName: string) => {
+    setExpandedGroups((prev) => {
+      const next = prev.includes(groupName)
+        ? prev.filter((n) => n !== groupName)
+        : [...prev, groupName];
+      writeExpandedGroupSections(next);
       return next;
     });
   }, []);
@@ -580,18 +580,18 @@ function ConversationList({
   const orderedConversationIds = useMemo(() => {
     const visible = (title: string, list: readonly Conversation[]) =>
       collapsedSections.includes(title) ? [] : list;
-    // Collections are collapsed unless explicitly expanded (inverse of the fixed
+    // Groups are collapsed unless explicitly expanded (inverse of the fixed
     // sections above).
-    const collectionVisible = (name: string, list: readonly Conversation[]) =>
-      expandedCollections.includes(name) ? list : [];
+    const groupVisible = (name: string, list: readonly Conversation[]) =>
+      expandedGroups.includes(name) ? list : [];
     return [
-      ...sections.collectionGroups.flatMap((g) => collectionVisible(g.name, g.conversations)),
+      ...sections.groupSections.flatMap((g) => groupVisible(g.name, g.conversations)),
       ...visible("Pinned", sections.pinned),
       ...visible("Recent", sections.sessions),
       ...visible("Shared with me", sections.shared),
       ...visible("Archived", sections.archived),
     ].map((c) => c.id);
-  }, [sections, collapsedSections, expandedCollections]);
+  }, [sections, collapsedSections, expandedGroups]);
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Only normalize pinned ids once all pages are loaded; a pin that
@@ -633,7 +633,7 @@ function ConversationList({
     sections.sessions.length +
     sections.shared.length +
     sections.archived.length +
-    sections.collectionGroups.reduce((sum, g) => sum + g.conversations.length, 0);
+    sections.groupSections.reduce((sum, g) => sum + g.conversations.length, 0);
 
   // Section structure comes from the muted micro-headers + whitespace
   // alone (Linear-style) — no divider rules between groups.
@@ -643,18 +643,18 @@ function ConversationList({
         <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
       ) : (
         <>
-          {sections.collectionGroups.map((group) => (
+          {sections.groupSections.map((group) => (
             <ConversationSection
               key={group.name}
               title={group.name}
-              icon={<FolderIcon className="size-3 mr-1 inline-block" />}
+              icon={<BookmarkIcon className="size-3 mr-1 inline-block" />}
               count={group.conversations.length}
-              marker={collectionMarkerState(group.conversations)}
+              marker={groupMarkerState(group.conversations)}
               conversations={group.conversations}
               pinnedConversationIds={pinnedConversationIds}
-              // Collections default collapsed: shown only when explicitly expanded.
-              collapsed={!expandedCollections.includes(group.name)}
-              onToggleCollapsed={() => toggleCollectionExpanded(group.name)}
+              // Groups default collapsed: shown only when explicitly expanded.
+              collapsed={!expandedGroups.includes(group.name)}
+              onToggleCollapsed={() => toggleGroupExpanded(group.name)}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -754,12 +754,12 @@ function ConversationList({
 }
 
 /**
- * Aggregate the sidebar marker for a collection from its conversations, using
+ * Aggregate the sidebar marker for a group from its conversations, using
  * the same precedence a row uses (awaiting > unseen > running). Returned as a
- * {@link SessionState} so a collapsed collection header can render the exact
+ * {@link SessionState} so a collapsed group header can render the exact
  * same {@link SessionStateBadge} the rows do. ``null`` = no marker.
  */
-function collectionMarkerState(conversations: Conversation[]): SessionState | null {
+function groupMarkerState(conversations: Conversation[]): SessionState | null {
   let awaiting = 0;
   let unseen = false;
   let running = false;
@@ -910,7 +910,7 @@ function ConversationRow({
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
   const archive = useArchiveConversation();
-  const moveToCollection = useMoveToCollection();
+  const moveToGroup = useMoveToGroup();
   // Archive stops the runner first (resource hygiene): a hidden session
   // shouldn't keep a runner alive. This is NOT the user-facing Stop action
   // (the kebab's "Stop session" item below, backed by its own mutation) —
@@ -1285,17 +1285,17 @@ function ConversationRow({
             )}
             {canEdit && (
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger data-testid="move-to-collection">
-                  <FolderInputIcon className="size-3.5" />
-                  Move to collection
+                <DropdownMenuSubTrigger data-testid="move-to-group">
+                  <BookmarkPlusIcon className="size-3.5" />
+                  Move to…
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-56 p-1">
                   {/* A native submenu flyout — no separate popover layer, so no
                       open/dismiss race with the parent menu. */}
-                  <CollectionPickerMenu
-                    currentCollection={conversation.labels?.["collection"] ?? null}
-                    onSelect={(collection) => {
-                      moveToCollection.mutate({ id: conversation.id, collection });
+                  <GroupPickerMenu
+                    currentGroup={conversation.labels?.["group"] ?? null}
+                    onSelect={(group) => {
+                      moveToGroup.mutate({ id: conversation.id, group });
                       setMenuOpen(false);
                     }}
                   />
@@ -1565,27 +1565,27 @@ function ArchivingRow({ label }: { label: string }) {
   );
 }
 
-// ── CollectionPickerMenu ─────────────────────────────────────────────────────────
+// ── GroupPickerMenu ─────────────────────────────────────────────────────────
 
 /**
- * Collection picker rendered as the body of a {@link DropdownMenuSubContent}.
+ * Group picker rendered as the body of a {@link DropdownMenuSubContent}.
  *
  * Lives inside the kebab menu's submenu flyout rather than a separate popover —
  * that avoids the open/dismiss race that made a standalone popover flash open
- * and vanish. The search / new-collection inputs stop key events from bubbling so
+ * and vanish. The search / new-group inputs stop key events from bubbling so
  * the menu's built-in typeahead and arrow-key navigation don't hijack typing.
  */
-function CollectionPickerMenu({
-  currentCollection,
+function GroupPickerMenu({
+  currentGroup,
   onSelect,
 }: {
-  currentCollection: string | null;
-  onSelect: (collection: string) => void;
+  currentGroup: string | null;
+  onSelect: (group: string) => void;
 }) {
-  const { data: collections = [] } = useCollections();
+  const { data: groups = [] } = useGroups();
   const [search, setSearch] = useState("");
   const [creatingNew, setCreatingNew] = useState(false);
-  const [newCollectionName, setNewCollectionName] = useState("");
+  const [newGroupName, setNewGroupName] = useState("");
   const newInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -1595,13 +1595,13 @@ function CollectionPickerMenu({
   }, [creatingNew]);
 
   const filtered = search
-    ? collections.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
-    : collections;
+    ? groups.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
+    : groups;
 
-  function handleNewCollectionCommit() {
-    const name = newCollectionName.trim();
+  function handleNewGroupCommit() {
+    const name = newGroupName.trim();
     setCreatingNew(false);
-    setNewCollectionName("");
+    setNewGroupName("");
     if (name) onSelect(name);
   }
 
@@ -1614,7 +1614,7 @@ function CollectionPickerMenu({
       <div className="px-2 py-1.5">
         <input
           className="w-full rounded border border-input bg-transparent px-2 py-1 text-xs outline-none placeholder:text-muted-foreground"
-          placeholder="Search collections…"
+          placeholder="Search groups…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={swallowKeys}
@@ -1623,36 +1623,34 @@ function CollectionPickerMenu({
       <div className="max-h-48 overflow-y-auto">
         {filtered.map((name) => (
           <DropdownMenuItem key={name} onSelect={() => onSelect(name)}>
-            <FolderIcon className="size-3.5 shrink-0" />
+            <BookmarkIcon className="size-3.5 shrink-0" />
             <span className="flex-1 truncate text-left">{name}</span>
-            {currentCollection === name && (
-              <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
-            )}
+            {currentGroup === name && <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />}
           </DropdownMenuItem>
         ))}
         {filtered.length === 0 && !creatingNew && (
-          <p className="px-2 py-1.5 text-xs text-muted-foreground">No collections yet.</p>
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">No groups yet.</p>
         )}
       </div>
       <div className="border-t pt-1">
         {creatingNew ? (
           <div className="flex items-center gap-1 px-2 py-1">
-            <FolderIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <BookmarkIcon className="size-3.5 shrink-0 text-muted-foreground" />
             <input
               ref={newInputRef}
               className="flex-1 bg-transparent text-xs outline-none"
-              placeholder="Collection name…"
-              value={newCollectionName}
-              onChange={(e) => setNewCollectionName(e.target.value)}
+              placeholder="Group name…"
+              value={newGroupName}
+              onChange={(e) => setNewGroupName(e.target.value)}
               onKeyDown={(e) => {
                 e.stopPropagation();
                 if (e.key === "Enter") {
                   e.preventDefault();
-                  handleNewCollectionCommit();
+                  handleNewGroupCommit();
                 }
                 if (e.key === "Escape") {
                   setCreatingNew(false);
-                  setNewCollectionName("");
+                  setNewGroupName("");
                 }
               }}
             />
@@ -1665,15 +1663,18 @@ function CollectionPickerMenu({
               setCreatingNew(true);
             }}
           >
-            <FolderIcon className="size-3.5 shrink-0" />
-            New collection…
+            <BookmarkPlusIcon className="size-3.5 shrink-0" />
+            New group…
           </DropdownMenuItem>
         )}
-        {currentCollection && (
-          <DropdownMenuItem variant="destructive" onSelect={() => onSelect("")}>
-            <XIcon className="size-3.5 shrink-0" />
-            Remove from collection
-          </DropdownMenuItem>
+        {currentGroup && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => onSelect("")}>
+              <XIcon className="size-3.5 shrink-0" />
+              Remove from group
+            </DropdownMenuItem>
+          </>
         )}
       </div>
     </>
@@ -1791,6 +1792,8 @@ function BulkActionBar({
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
   const bulkArchive = useBulkArchiveConversations();
   const bulkDelete = useBulkDeleteConversations();
+  const bulkMoveToGroup = useBulkMoveToGroup();
+  const { data: groups = [] } = useGroups();
 
   const selectedConversations = useMemo(
     () => allConversations.filter((c) => selectedIds.has(c.id)),
@@ -1815,11 +1818,24 @@ function BulkActionBar({
   const allSelectedSameArchiveGroup =
     ownedSelected.length > 0 && (archivedSelected.length === 0 || nonArchivedSelected.length === 0);
 
+  const allNonArchivedInGroup = useMemo(
+    () => nonArchivedSelected.length > 0 && nonArchivedSelected.every((c) => !!c.labels?.["group"]),
+    [nonArchivedSelected],
+  );
+
   const count = selectedIds.size;
   const allSelected = count > 0 && count === allConversations.length;
-  const isBusy = bulkArchive.isPending || bulkDelete.isPending;
+  const isBusy = bulkArchive.isPending || bulkDelete.isPending || bulkMoveToGroup.isPending;
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [groupSearch, setGroupSearch] = useState("");
+
+  function handleMoveToGroup(group: string) {
+    const ids = nonArchivedSelected.map((c) => c.id);
+    if (ids.length === 0) return;
+    setGroupSearch("");
+    bulkMoveToGroup.mutate({ ids, group }, { onSuccess: () => onDeselectAll() });
+  }
 
   function handleArchive() {
     if (nonArchivedSelected.length === 0) return;
@@ -1888,6 +1904,64 @@ function BulkActionBar({
           </Button>
           {count > 0 && (
             <div className="flex items-center gap-1.5 md:hidden">
+              {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
+                <DropdownMenu
+                  onOpenChange={(open) => {
+                    if (!open) setGroupSearch("");
+                  }}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5 text-xs"
+                      disabled={isBusy}
+                      data-testid="bulk-move-to-group"
+                    >
+                      {bulkMoveToGroup.isPending ? (
+                        <Loader2Icon className="size-3 animate-spin" />
+                      ) : (
+                        <BookmarkPlusIcon className="size-3" />
+                      )}
+                      Move…
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="w-52 p-1">
+                    <div className="px-2 py-1.5">
+                      <input
+                        type="text"
+                        className="w-full rounded-md border border-input bg-background px-2 py-1 text-xs outline-none focus-visible:border-ring"
+                        placeholder="Search groups…"
+                        value={groupSearch}
+                        onChange={(e) => setGroupSearch(e.target.value)}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      />
+                    </div>
+                    <DropdownMenuSeparator />
+                    {groups
+                      .filter((g) => g.toLowerCase().includes(groupSearch.toLowerCase()))
+                      .map((g) => (
+                        <DropdownMenuItem key={g} onSelect={() => handleMoveToGroup(g)}>
+                          <BookmarkIcon className="size-3.5 shrink-0" />
+                          <span className="truncate">{g}</span>
+                        </DropdownMenuItem>
+                      ))}
+                    {groups.length === 0 && (
+                      <p className="px-2 py-1.5 text-xs text-muted-foreground">No groups yet.</p>
+                    )}
+                    {allNonArchivedInGroup && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onSelect={() => handleMoveToGroup("")}>
+                          <XIcon className="size-3.5 shrink-0" />
+                          Remove from group
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
               {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
                 <Button
                   type="button"
@@ -1959,6 +2033,60 @@ function BulkActionBar({
 
         {count > 0 && (
           <div className="hidden items-center gap-1.5 px-2 md:flex">
+            {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
+              <DropdownMenu
+                onOpenChange={(open) => {
+                  if (!open) setGroupSearch("");
+                }}
+              >
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5 text-xs"
+                    disabled={isBusy}
+                    data-testid="bulk-move-to-group"
+                  >
+                    {bulkMoveToGroup.isPending ? (
+                      <Loader2Icon className="size-3 animate-spin" />
+                    ) : (
+                      <BookmarkPlusIcon className="size-3" />
+                    )}
+                    Move to…
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-52 p-1">
+                  <div className="px-2 py-1.5">
+                    <input
+                      type="text"
+                      className="w-full rounded-md border border-input bg-background px-2 py-1 text-xs outline-none focus-visible:border-ring"
+                      placeholder="Search groups…"
+                      value={groupSearch}
+                      onChange={(e) => setGroupSearch(e.target.value)}
+                      onKeyDown={(e) => e.stopPropagation()}
+                    />
+                  </div>
+                  <DropdownMenuSeparator />
+                  {groups
+                    .filter((g) => g.toLowerCase().includes(groupSearch.toLowerCase()))
+                    .map((g) => (
+                      <DropdownMenuItem key={g} onSelect={() => handleMoveToGroup(g)}>
+                        <BookmarkIcon className="size-3.5 shrink-0" />
+                        <span className="truncate">{g}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  {groups.length === 0 && (
+                    <p className="px-2 py-1.5 text-xs text-muted-foreground">No groups yet.</p>
+                  )}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onSelect={() => handleMoveToGroup("")}>
+                    <XIcon className="size-3.5 shrink-0" />
+                    Remove from group
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
             {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
               <Button
                 type="button"
@@ -2126,12 +2254,12 @@ function writeCollapsedSidebarSections(titles: string[]) {
   }
 }
 
-// Collections default to collapsed, so the persisted set is the EXPANDED names
-// (empty by default = every collection starts collapsed).
-function readExpandedCollectionSections(): string[] {
+// Groups default to collapsed, so the persisted set is the EXPANDED names
+// (empty by default = every group starts collapsed).
+function readExpandedGroupSections(): string[] {
   if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY);
+    const raw = window.localStorage.getItem(EXPANDED_GROUP_SECTIONS_STORAGE_KEY);
     if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -2141,10 +2269,10 @@ function readExpandedCollectionSections(): string[] {
   }
 }
 
-function writeExpandedCollectionSections(names: string[]) {
+function writeExpandedGroupSections(names: string[]) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY, JSON.stringify(names));
+    window.localStorage.setItem(EXPANDED_GROUP_SECTIONS_STORAGE_KEY, JSON.stringify(names));
   } catch {
     // Same as collapse state — a lost local preference is harmless.
   }

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type MouseEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -13,8 +14,12 @@ import {
   ArchiveIcon,
   ArchiveRestoreIcon,
   CheckIcon,
+  CheckIcon as CheckMarkIcon,
   ChevronRightIcon,
   CircleStopIcon,
+  ClockIcon,
+  FolderIcon,
+  FolderInputIcon,
   GitBranchIcon,
   InboxIcon,
   ListChecksIcon,
@@ -29,6 +34,7 @@ import {
   SquareIcon,
   SquareCheckIcon,
   Trash2Icon,
+  UsersIcon,
   XIcon,
 } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/routing";
@@ -45,6 +51,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -52,7 +61,9 @@ import {
   useArchiveConversation,
   useBulkArchiveConversations,
   useBulkDeleteConversations,
+  useCollections,
   useConversations,
+  useMoveToCollection,
   usePinnedConversationBackfill,
   useRenameConversation,
   useStopAndDeleteConversation,
@@ -65,7 +76,7 @@ import { useCommentInbox } from "@/hooks/useCommentInbox";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { isSessionStoppable } from "@/lib/sessionStop";
 import { isOwnerLevel } from "@/lib/permissionsApi";
-import { getSessionState } from "@/hooks/useSessionState";
+import { getSessionState, type SessionState } from "@/hooks/useSessionState";
 import { isConversationUnseen } from "@/hooks/useUnseenConversations";
 import { sumPendingApprovals } from "@/lib/inbox";
 import { cn } from "@/lib/utils";
@@ -79,6 +90,7 @@ import {
   COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
   computeNextActiveOverride,
   conversationDisplayLabel,
+  EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY,
   normalizePinnedConversationIds,
   PINNED_CONVERSATION_IDS_STORAGE_KEY,
   sortByUpdatedAtDesc,
@@ -456,6 +468,9 @@ function ConversationList({
     [conversationsQuery.data],
   );
 
+  // Collection names for grouping sessions by their "collection" label.
+  const { data: collectionNames = [] } = useCollections();
+
   // Backfill pinned sessions that aren't in the loaded set.
   const loadedIds = useMemo(() => new Set(allConversations.map((c) => c.id)), [allConversations]);
   const pinnedBackfill = usePinnedConversationBackfill(pinnedConversationIds, loadedIds);
@@ -477,23 +492,56 @@ function ConversationList({
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
   const sections = useMemo(() => {
     const allWithBackfill = [...allConversations, ...pinnedBackfill];
+    const notArchived = allWithBackfill.filter((c) => c.archived !== true);
+
+    // Collections are built first. A collectioned session STAYS in its collection even
+    // when pinned (B2): pinning sorts the row to the top of its collection rather
+    // than pulling it out into the global Pinned section. Archived rows are
+    // excluded — they belong to the Archived group regardless of collection label.
+    const collectedIds = new Set<string>();
+    const collectionGroups: { name: string; conversations: Conversation[] }[] = collectionNames
+      .map((name) => {
+        const inCollection = notArchived.filter((c) => c.labels?.["collection"] === name);
+        inCollection.forEach((c) => collectedIds.add(c.id));
+        // Pinned-first, then by recency — both buckets share the same sort.
+        const conversations = [
+          ...sortByUpdatedAtDesc(
+            inCollection.filter((c) => pinnedSet.has(c.id)),
+            activeOverride,
+          ),
+          ...sortByUpdatedAtDesc(
+            inCollection.filter((c) => !pinnedSet.has(c.id)),
+            activeOverride,
+          ),
+        ];
+        return { name, conversations };
+      })
+      .filter((g) => g.conversations.length > 0);
+
+    // The global Pinned section now holds only pinned sessions that are NOT
+    // in a collection — collectioned pins live under their collection instead.
     const pinned = sortByUpdatedAtDesc(
-      allWithBackfill.filter((c) => pinnedSet.has(c.id) && c.archived !== true),
+      notArchived.filter((c) => pinnedSet.has(c.id) && !collectedIds.has(c.id)),
       activeOverride,
     );
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
-    const active = allConversations.filter((c) => !pinnedIdSet.has(c.id) && c.archived !== true);
-    const sessions = sortByUpdatedAtDesc(active.filter(isOwnedByViewer), activeOverride);
+
+    // Recent / Shared: the remainder — not archived, not globally pinned, and
+    // not in any collection.
+    const rest = allConversations.filter(
+      (c) => c.archived !== true && !pinnedIdSet.has(c.id) && !collectedIds.has(c.id),
+    );
+    const sessions = sortByUpdatedAtDesc(rest.filter(isOwnedByViewer), activeOverride);
     const shared = sortByUpdatedAtDesc(
-      active.filter((c) => !isOwnedByViewer(c)),
+      rest.filter((c) => !isOwnedByViewer(c)),
       activeOverride,
     );
     const archived = sortByUpdatedAtDesc(
       allWithBackfill.filter((c) => c.archived === true),
       activeOverride,
     );
-    return { pinned, sessions, shared, archived };
-  }, [allConversations, pinnedBackfill, pinnedSet, activeOverride]);
+    return { pinned, sessions, shared, archived, collectionGroups };
+  }, [allConversations, pinnedBackfill, pinnedSet, activeOverride, collectionNames]);
 
   // Collapsed section titles — persisted like pins so the preference
   // survives reloads. Lifted here (not per-section state) because the
@@ -511,18 +559,39 @@ function ConversationList({
     });
   }, []);
 
+  // Collections default to COLLAPSED, so we track the inverse — names the user has
+  // expanded — persisted across reloads. A collection shows its rows only while
+  // its name is in this set.
+  const [expandedCollections, setExpandedCollections] = useState<string[]>(
+    readExpandedCollectionSections,
+  );
+  const toggleCollectionExpanded = useCallback((collectionName: string) => {
+    setExpandedCollections((prev) => {
+      const next = prev.includes(collectionName)
+        ? prev.filter((n) => n !== collectionName)
+        : [...prev, collectionName];
+      writeExpandedCollectionSections(next);
+      return next;
+    });
+  }, []);
+
   // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
   // session hotkey. Titles must match the <ConversationSection> props below.
   const orderedConversationIds = useMemo(() => {
     const visible = (title: string, list: readonly Conversation[]) =>
       collapsedSections.includes(title) ? [] : list;
+    // Collections are collapsed unless explicitly expanded (inverse of the fixed
+    // sections above).
+    const collectionVisible = (name: string, list: readonly Conversation[]) =>
+      expandedCollections.includes(name) ? list : [];
     return [
+      ...sections.collectionGroups.flatMap((g) => collectionVisible(g.name, g.conversations)),
       ...visible("Pinned", sections.pinned),
       ...visible("Recent", sections.sessions),
       ...visible("Shared with me", sections.shared),
       ...visible("Archived", sections.archived),
     ].map((c) => c.id);
-  }, [sections, collapsedSections]);
+  }, [sections, collapsedSections, expandedCollections]);
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Only normalize pinned ids once all pages are loaded; a pin that
@@ -563,7 +632,8 @@ function ConversationList({
     sections.pinned.length +
     sections.sessions.length +
     sections.shared.length +
-    sections.archived.length;
+    sections.archived.length +
+    sections.collectionGroups.reduce((sum, g) => sum + g.conversations.length, 0);
 
   // Section structure comes from the muted micro-headers + whitespace
   // alone (Linear-style) — no divider rules between groups.
@@ -573,13 +643,34 @@ function ConversationList({
         <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
       ) : (
         <>
+          {sections.collectionGroups.map((group) => (
+            <ConversationSection
+              key={group.name}
+              title={group.name}
+              icon={<FolderIcon className="size-3 mr-1 inline-block" />}
+              count={group.conversations.length}
+              marker={collectionMarkerState(group.conversations)}
+              conversations={group.conversations}
+              pinnedConversationIds={pinnedConversationIds}
+              // Collections default collapsed: shown only when explicitly expanded.
+              collapsed={!expandedCollections.includes(group.name)}
+              onToggleCollapsed={() => toggleCollectionExpanded(group.name)}
+              onRowClick={onRowClick}
+              onTogglePinned={onTogglePinned}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={onToggleSelected}
+            />
+          ))}
           {sections.pinned.length > 0 && (
             <ConversationSection
               title="Pinned"
+              icon={<PinIcon className="size-3 mr-1 inline-block" />}
+              count={sections.pinned.length}
               conversations={sections.pinned}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              collapsed={collapsedSections.includes("Pinned")}
+              onToggleCollapsed={() => toggleSectionCollapsed("Pinned")}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -590,10 +681,12 @@ function ConversationList({
           {sections.sessions.length > 0 && (
             <ConversationSection
               title="Recent"
+              icon={<ClockIcon className="size-3 mr-1 inline-block" />}
+              count={sections.sessions.length}
               conversations={sections.sessions}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              collapsed={collapsedSections.includes("Recent")}
+              onToggleCollapsed={() => toggleSectionCollapsed("Recent")}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -604,10 +697,12 @@ function ConversationList({
           {sections.shared.length > 0 && (
             <ConversationSection
               title="Shared with me"
+              icon={<UsersIcon className="size-3 mr-1 inline-block" />}
+              count={sections.shared.length}
               conversations={sections.shared}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              collapsed={collapsedSections.includes("Shared with me")}
+              onToggleCollapsed={() => toggleSectionCollapsed("Shared with me")}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -618,10 +713,12 @@ function ConversationList({
           {sections.archived.length > 0 && (
             <ConversationSection
               title="Archived"
+              icon={<ArchiveIcon className="size-3 mr-1 inline-block" />}
+              count={sections.archived.length}
               conversations={sections.archived}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              collapsed={collapsedSections.includes("Archived")}
+              onToggleCollapsed={() => toggleSectionCollapsed("Archived")}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -656,11 +753,40 @@ function ConversationList({
   );
 }
 
+/**
+ * Aggregate the sidebar marker for a collection from its conversations, using
+ * the same precedence a row uses (awaiting > unseen > running). Returned as a
+ * {@link SessionState} so a collapsed collection header can render the exact
+ * same {@link SessionStateBadge} the rows do. ``null`` = no marker.
+ */
+function collectionMarkerState(conversations: Conversation[]): SessionState | null {
+  let awaiting = 0;
+  let unseen = false;
+  let running = false;
+  for (const c of conversations) {
+    const pending = c.pending_elicitations_count ?? 0;
+    if (pending > 0) {
+      awaiting += pending;
+    } else if (isConversationUnseen(c.id, c.updated_at, c.status)) {
+      unseen = true;
+    } else if (c.status === "running") {
+      running = true;
+    }
+  }
+  if (awaiting > 0) return { kind: "awaiting", count: awaiting };
+  if (unseen) return { kind: "unseen" };
+  if (running) return { kind: "running" };
+  return null;
+}
+
 function ConversationSection({
   title,
+  icon,
+  count,
+  marker,
   conversations,
   pinnedConversationIds,
-  collapsedSections,
+  collapsed,
   onToggleCollapsed,
   onRowClick,
   onTogglePinned,
@@ -669,38 +795,69 @@ function ConversationSection({
   onToggleSelected,
 }: {
   title?: string;
+  /** Optional icon rendered before the title (e.g. collection icon). */
+  icon?: ReactNode;
+  /** Optional count badge after the title (e.g. collection session count). */
+  count?: number;
+  /** When collapsed, the aggregate marker of hidden rows (same badge as a row). */
+  marker?: SessionState | null;
   conversations: Conversation[];
   pinnedConversationIds: string[];
-  collapsedSections: string[];
-  onToggleCollapsed: (sectionTitle: string) => void;
+  /** Whether this section is currently collapsed. */
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
   onRowClick: (e: MouseEvent<HTMLAnchorElement>) => void;
   onTogglePinned: (conversationId: string) => void;
   selectionMode: boolean;
   selectedIds: Set<string>;
   onToggleSelected: (conversationId: string) => void;
 }) {
-  const collapsed = title != null && collapsedSections.includes(title);
+  // An untitled section is always open — there's no header to collapse it.
+  const isCollapsed = title != null && collapsed;
   return (
     <section>
       {title && (
         <h2>
           <button
             type="button"
-            aria-expanded={!collapsed}
-            onClick={() => onToggleCollapsed(title)}
+            aria-expanded={!isCollapsed}
+            onClick={onToggleCollapsed}
             className="group flex w-full items-center gap-1 rounded-md px-2 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
           >
-            {title}
-            <ChevronRightIcon
-              className={cn(
-                "size-3.5 shrink-0 transition-transform",
-                !collapsed && "rotate-90 opacity-0 group-hover:opacity-100",
+            {icon}
+            <span className="truncate">{title}</span>
+            {/* Count + chevron are pinned to the right edge so every section
+                header aligns, whether or not it has a count. */}
+            <span className="ml-auto flex shrink-0 items-center gap-1">
+              {isCollapsed && marker && (
+                // A hidden row inside this collapsed section carries a marker —
+                // surface the exact same badge a row would show. Extra right
+                // margin keeps the dot off the count.
+                <span className="mr-1 flex items-center">
+                  <SessionStateBadge state={marker} />
+                </span>
               )}
-            />
+              {count != null && (
+                // Decorative: aria-hidden keeps the header's accessible name
+                // the bare title (e.g. "Archived"), not "Archived 3".
+                <span aria-hidden className="tabular-nums opacity-60">
+                  {count}
+                </span>
+              )}
+              {/* Chevron trails the count (Codex/Cursor-style). Hidden until
+                  hover when expanded; always visible when collapsed so the
+                  hidden content stays discoverable. */}
+              <ChevronRightIcon
+                className={cn(
+                  "size-3.5 shrink-0 transition-transform",
+                  !isCollapsed && "rotate-90 opacity-0 group-hover:opacity-100",
+                )}
+              />
+            </span>
           </button>
         </h2>
       )}
-      {!collapsed && (
+      {!isCollapsed && (
         <ul className="flex flex-col gap-0.5">
           {conversations.map((conv) => (
             <ConversationRow
@@ -753,6 +910,7 @@ function ConversationRow({
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
   const archive = useArchiveConversation();
+  const moveToCollection = useMoveToCollection();
   // Archive stops the runner first (resource hygiene): a hidden session
   // shouldn't keep a runner alive. This is NOT the user-facing Stop action
   // (the kebab's "Stop session" item below, backed by its own mutation) —
@@ -766,6 +924,9 @@ function ConversationRow({
   const [isEditing, setIsEditing] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
+  // The kebab menu is controlled so the collection submenu can close the whole
+  // menu after a pick (a plain click inside the submenu wouldn't otherwise).
+  const [menuOpen, setMenuOpen] = useState(false);
   // Opt-in "delete local branch" checkbox (worktree sessions only).
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
@@ -976,7 +1137,10 @@ function ConversationRow({
           {relativeTime(conversation.updated_at * 1000)}
         </span>
       )}
-      {!selectionMode && (
+      {/* Archived rows omit the pin entirely: pinning is meaningless there
+          (archive outranks pin), so there's no pin action even on hover. Also
+          hidden while selecting (bulk mode owns the row controls). */}
+      {!selectionMode && !isArchived && (
         <Button
           type="button"
           variant="ghost"
@@ -984,9 +1148,18 @@ function ConversationRow({
           aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
           data-testid="quick-pin-conversation"
           className={cn(
-            "-translate-y-1/2 absolute top-1/2 right-9 transition-opacity",
-            "md:opacity-0 md:group-hover:opacity-100",
-            "md:group-has-[:focus-visible]:opacity-100 md:group-has-[[aria-expanded=true]]:opacity-100",
+            // `group/pin` scopes the icon swap below to hovering THIS button,
+            // not the whole row.
+            "group/pin -translate-y-1/2 absolute top-1/2 right-9 transition-opacity",
+            // A pinned row keeps its pin marker visible at rest (it's the badge
+            // that signals the pinned state); an unpinned row reveals the pin
+            // affordance only on hover/focus or while the kebab menu is open.
+            isPinned
+              ? "opacity-100"
+              : cn(
+                  "md:opacity-0 md:group-hover:opacity-100",
+                  "md:group-has-[:focus-visible]:opacity-100 md:group-has-[[aria-expanded=true]]:opacity-100",
+                ),
           )}
           onClick={(e) => {
             // Keep the toggle click off the surrounding Link (no navigation).
@@ -995,11 +1168,20 @@ function ConversationRow({
             onTogglePinned(conversation.id);
           }}
         >
-          {isPinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
+          {isPinned ? (
+            <>
+              {/* Pinned: solid pin at rest as the state marker; swap to the
+                  unpin glyph only while hovering this button. */}
+              <PinIcon className="size-3.5 group-hover/pin:hidden" />
+              <PinOffIcon className="hidden size-3.5 group-hover/pin:inline" />
+            </>
+          ) : (
+            <PinIcon className="size-3.5" />
+          )}
         </Button>
       )}
       {!selectionMode && (
-        <DropdownMenu>
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
           <DropdownMenuTrigger asChild>
             <Button
               type="button"
@@ -1100,6 +1282,25 @@ function ConversationRow({
                   You need edit permissions to rename this session
                 </TooltipContent>
               </Tooltip>
+            )}
+            {canEdit && (
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger data-testid="move-to-collection">
+                  <FolderInputIcon className="size-3.5" />
+                  Move to collection
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-56 p-1">
+                  {/* A native submenu flyout — no separate popover layer, so no
+                      open/dismiss race with the parent menu. */}
+                  <CollectionPickerMenu
+                    currentCollection={conversation.labels?.["collection"] ?? null}
+                    onSelect={(collection) => {
+                      moveToCollection.mutate({ id: conversation.id, collection });
+                      setMenuOpen(false);
+                    }}
+                  />
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
             )}
             {/* Stop session — only on stoppable sessions whose runner isn't
               already known-offline (canStop). Owner-gated like Delete:
@@ -1363,6 +1564,123 @@ function ArchivingRow({ label }: { label: string }) {
     </div>
   );
 }
+
+// ── CollectionPickerMenu ─────────────────────────────────────────────────────────
+
+/**
+ * Collection picker rendered as the body of a {@link DropdownMenuSubContent}.
+ *
+ * Lives inside the kebab menu's submenu flyout rather than a separate popover —
+ * that avoids the open/dismiss race that made a standalone popover flash open
+ * and vanish. The search / new-collection inputs stop key events from bubbling so
+ * the menu's built-in typeahead and arrow-key navigation don't hijack typing.
+ */
+function CollectionPickerMenu({
+  currentCollection,
+  onSelect,
+}: {
+  currentCollection: string | null;
+  onSelect: (collection: string) => void;
+}) {
+  const { data: collections = [] } = useCollections();
+  const [search, setSearch] = useState("");
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [newCollectionName, setNewCollectionName] = useState("");
+  const newInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (creatingNew) {
+      newInputRef.current?.focus();
+    }
+  }, [creatingNew]);
+
+  const filtered = search
+    ? collections.filter((name) => name.toLowerCase().includes(search.toLowerCase()))
+    : collections;
+
+  function handleNewCollectionCommit() {
+    const name = newCollectionName.trim();
+    setCreatingNew(false);
+    setNewCollectionName("");
+    if (name) onSelect(name);
+  }
+
+  // Keep keystrokes inside the inputs from reaching the menu's typeahead /
+  // navigation handlers (which would otherwise steal letters and arrows).
+  const swallowKeys = (e: KeyboardEvent<HTMLInputElement>) => e.stopPropagation();
+
+  return (
+    <>
+      <div className="px-2 py-1.5">
+        <input
+          className="w-full rounded border border-input bg-transparent px-2 py-1 text-xs outline-none placeholder:text-muted-foreground"
+          placeholder="Search collections…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={swallowKeys}
+        />
+      </div>
+      <div className="max-h-48 overflow-y-auto">
+        {filtered.map((name) => (
+          <DropdownMenuItem key={name} onSelect={() => onSelect(name)}>
+            <FolderIcon className="size-3.5 shrink-0" />
+            <span className="flex-1 truncate text-left">{name}</span>
+            {currentCollection === name && (
+              <CheckMarkIcon className="size-3.5 shrink-0 text-primary" />
+            )}
+          </DropdownMenuItem>
+        ))}
+        {filtered.length === 0 && !creatingNew && (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">No collections yet.</p>
+        )}
+      </div>
+      <div className="border-t pt-1">
+        {creatingNew ? (
+          <div className="flex items-center gap-1 px-2 py-1">
+            <FolderIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <input
+              ref={newInputRef}
+              className="flex-1 bg-transparent text-xs outline-none"
+              placeholder="Collection name…"
+              value={newCollectionName}
+              onChange={(e) => setNewCollectionName(e.target.value)}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleNewCollectionCommit();
+                }
+                if (e.key === "Escape") {
+                  setCreatingNew(false);
+                  setNewCollectionName("");
+                }
+              }}
+            />
+          </div>
+        ) : (
+          <DropdownMenuItem
+            // Keep the menu open so the inline input can take over in place.
+            onSelect={(e) => {
+              e.preventDefault();
+              setCreatingNew(true);
+            }}
+          >
+            <FolderIcon className="size-3.5 shrink-0" />
+            New collection…
+          </DropdownMenuItem>
+        )}
+        {currentCollection && (
+          <DropdownMenuItem variant="destructive" onSelect={() => onSelect("")}>
+            <XIcon className="size-3.5 shrink-0" />
+            Remove from collection
+          </DropdownMenuItem>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ── ConversationEditRow ──────────────────────────────────────────────────────
 
 interface ConversationEditRowProps {
   initialTitle: string;
@@ -1779,8 +2097,9 @@ function writePinnedConversationIds(ids: string[]) {
   }
 }
 
-// Archived starts collapsed until the user touches any section header —
-// once they do, the stored array (even an empty one) is the preference.
+// Default collapse state: only Archived starts collapsed. Pinned and Recent
+// are expanded by default — but once the user toggles any header, the stored
+// array (even an empty one) becomes the preference and persists across reloads.
 const DEFAULT_COLLAPSED_SIDEBAR_SECTIONS = ["Archived"];
 
 function readCollapsedSidebarSections(): string[] {
@@ -1804,6 +2123,30 @@ function writeCollapsedSidebarSections(titles: string[]) {
     window.localStorage.setItem(COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY, JSON.stringify(titles));
   } catch {
     // Collapse state is a local navigation preference; losing it is fine.
+  }
+}
+
+// Collections default to collapsed, so the persisted set is the EXPANDED names
+// (empty by default = every collection starts collapsed).
+function readExpandedCollectionSections(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === "string");
+  } catch {
+    return [];
+  }
+}
+
+function writeExpandedCollectionSections(names: string[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY, JSON.stringify(names));
+  } catch {
+    // Same as collapse state — a lost local preference is harmless.
   }
 }
 

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -7,11 +7,11 @@ export const PINNED_CONVERSATION_IDS_STORAGE_KEY = "omnigent:pinned-conversation
 // Keyed by display title — stable identifiers for these fixed groups.
 export const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "omnigent:collapsed-sidebar-sections";
 
-// Names of collection sections the user has expanded. Collections default to
-// COLLAPSED (so the sidebar stays short as collection count grows), so this is
-// the inverse of the fixed-section collapse set: a collection shows its rows only
+// Names of group sections the user has expanded. Groups default to
+// COLLAPSED (so the sidebar stays short as group count grows), so this is
+// the inverse of the fixed-section collapse set: a group shows its rows only
 // when its name is present here.
-export const EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY = "omnigent:expanded-collection-sections";
+export const EXPANDED_GROUP_SECTIONS_STORAGE_KEY = "omnigent:expanded-group-sections";
 
 // Snapshot of the active chat's updated_at at the moment the user
 // entered it. Used as the sort key for the active row so subsequent

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -7,6 +7,12 @@ export const PINNED_CONVERSATION_IDS_STORAGE_KEY = "omnigent:pinned-conversation
 // Keyed by display title — stable identifiers for these fixed groups.
 export const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "omnigent:collapsed-sidebar-sections";
 
+// Names of collection sections the user has expanded. Collections default to
+// COLLAPSED (so the sidebar stays short as collection count grows), so this is
+// the inverse of the fixed-section collapse set: a collection shows its rows only
+// when its name is present here.
+export const EXPANDED_COLLECTION_SECTIONS_STORAGE_KEY = "omnigent:expanded-collection-sections";
+
 // Snapshot of the active chat's updated_at at the moment the user
 // entered it. Used as the sort key for the active row so subsequent
 // updated_at bumps (the user sending a message) don't move it.

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12497,6 +12497,35 @@ def create_sessions_router(
             )
         return result
 
+    # ── GET /sessions/collections ────────────────────────────────────
+    #
+    # MUST be registered before ``GET /sessions/{session_id}``: FastAPI
+    # matches routes in registration order, so a literal ``/sessions/collections``
+    # would otherwise be captured by the ``{session_id}`` path param and 404
+    # as a missing conversation.
+
+    @router.get(
+        "/sessions/collections",
+        response_model=None,
+    )
+    async def list_session_collections(
+        request: Request,
+    ) -> list[str]:
+        """
+        Return all collection names for the authenticated user, ordered
+        alphabetically.
+
+        Collections are implicit: they exist while at least one session
+        has a ``conversation_labels`` row with ``key="collection"``.
+
+        :returns: List of collection names.
+        """
+        user_id = _require_user(request, auth_provider)
+        return await asyncio.to_thread(
+            conversation_store.list_collections,
+            accessible_by=user_id,
+        )
+
     # ── GET /sessions/{session_id} ───────────────────────────────
 
     @router.get(
@@ -12622,6 +12651,7 @@ def create_sessions_router(
         search_query: str | None = Query(default=None),
         include_archived: bool = Query(default=False),
         kind: str = Query(default="default", pattern="^(default|sub_agent|any)$"),
+        collection: str | None = Query(default=None),
     ) -> PaginatedList:
         """
         List sessions with cursor-based pagination.
@@ -12698,6 +12728,7 @@ def create_sessions_router(
             sort_by=sort_by,
             search_query=normalized_query,
             include_archived=include_archived,
+            collection=collection,
         )
         # list_conversations may return rows with agent_id=None for
         # legacy conversations; skip them before building the batch IDs.
@@ -13463,6 +13494,12 @@ def create_sessions_router(
                 _codex_plan_enabled,
                 _runner_result,
             )
+        # The "collection" label is special: an empty-string value means "remove
+        # from collection" (delete the label row) rather than upsert an empty value.
+        # Split it out before the bulk upsert so other labels are unaffected.
+        if labels_to_set and labels_to_set.get("collection") == "":
+            labels_to_set = {k: v for k, v in labels_to_set.items() if k != "collection"}
+            await asyncio.to_thread(conversation_store.delete_label, session_id, "collection")
         if labels_to_set:
             await asyncio.to_thread(conversation_store.set_labels, session_id, labels_to_set)
         if requested_codex_collaboration_mode is not None:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -12497,32 +12497,32 @@ def create_sessions_router(
             )
         return result
 
-    # ── GET /sessions/collections ────────────────────────────────────
+    # ── GET /sessions/groups ────────────────────────────────────
     #
     # MUST be registered before ``GET /sessions/{session_id}``: FastAPI
-    # matches routes in registration order, so a literal ``/sessions/collections``
+    # matches routes in registration order, so a literal ``/sessions/groups``
     # would otherwise be captured by the ``{session_id}`` path param and 404
     # as a missing conversation.
 
     @router.get(
-        "/sessions/collections",
+        "/sessions/groups",
         response_model=None,
     )
-    async def list_session_collections(
+    async def list_session_groups(
         request: Request,
     ) -> list[str]:
         """
-        Return all collection names for the authenticated user, ordered
+        Return all group names for the authenticated user, ordered
         alphabetically.
 
-        Collections are implicit: they exist while at least one session
-        has a ``conversation_labels`` row with ``key="collection"``.
+        Groups are implicit: they exist while at least one session
+        has a ``conversation_labels`` row with ``key="group"``.
 
-        :returns: List of collection names.
+        :returns: List of group names.
         """
         user_id = _require_user(request, auth_provider)
         return await asyncio.to_thread(
-            conversation_store.list_collections,
+            conversation_store.list_groups,
             accessible_by=user_id,
         )
 
@@ -12651,7 +12651,7 @@ def create_sessions_router(
         search_query: str | None = Query(default=None),
         include_archived: bool = Query(default=False),
         kind: str = Query(default="default", pattern="^(default|sub_agent|any)$"),
-        collection: str | None = Query(default=None),
+        group: str | None = Query(default=None),
     ) -> PaginatedList:
         """
         List sessions with cursor-based pagination.
@@ -12728,7 +12728,7 @@ def create_sessions_router(
             sort_by=sort_by,
             search_query=normalized_query,
             include_archived=include_archived,
-            collection=collection,
+            group=group,
         )
         # list_conversations may return rows with agent_id=None for
         # legacy conversations; skip them before building the batch IDs.
@@ -13494,12 +13494,12 @@ def create_sessions_router(
                 _codex_plan_enabled,
                 _runner_result,
             )
-        # The "collection" label is special: an empty-string value means "remove
-        # from collection" (delete the label row) rather than upsert an empty value.
+        # The "group" label is special: an empty-string value means "remove
+        # from group" (delete the label row) rather than upsert an empty value.
         # Split it out before the bulk upsert so other labels are unaffected.
-        if labels_to_set and labels_to_set.get("collection") == "":
-            labels_to_set = {k: v for k, v in labels_to_set.items() if k != "collection"}
-            await asyncio.to_thread(conversation_store.delete_label, session_id, "collection")
+        if labels_to_set and labels_to_set.get("group") == "":
+            labels_to_set = {k: v for k, v in labels_to_set.items() if k != "group"}
+            await asyncio.to_thread(conversation_store.delete_label, session_id, "group")
         if labels_to_set:
             await asyncio.to_thread(conversation_store.set_labels, session_id, labels_to_set)
         if requested_codex_collaboration_mode is not None:

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1449,26 +1449,26 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         return persisted
 
-    def list_collections(
+    def list_groups(
         self,
         accessible_by: str | None = None,
     ) -> list[str]:
         """
-        Return all distinct collection names, ordered alphabetically.
+        Return all distinct group names, ordered alphabetically.
 
-        Collections are implicit: they exist as long as at least one
-        ``conversation_labels`` row with ``key="collection"`` references
+        Groups are implicit: they exist as long as at least one
+        ``conversation_labels`` row with ``key="group"`` references
         them.
 
         :param accessible_by: When set, restrict to sessions that
             ``accessible_by`` has a permission row for (mirrors the
             ``list_conversations`` ACL filter).
-        :returns: List of collection names ordered ascending.
+        :returns: List of group names ordered ascending.
         """
         with self._session() as session:
             stmt = (
                 select(SqlConversationLabel.value)
-                .where(SqlConversationLabel.key == "collection")
+                .where(SqlConversationLabel.key == "group")
                 .distinct()
                 .order_by(SqlConversationLabel.value)
             )
@@ -1492,7 +1492,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         No-op if the label does not exist.
 
         :param conversation_id: The conversation to update.
-        :param key: The label key to remove, e.g. ``"collection"``.
+        :param key: The label key to remove, e.g. ``"group"``.
         """
         with self._session() as session:
             session.execute(
@@ -1518,7 +1518,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         search_query: str | None = None,
         accessible_by: str | None = None,
         include_archived: bool = False,
-        collection: str | None = None,
+        group: str | None = None,
     ) -> PagedList[Conversation]:
         """
         List conversations with cursor-based pagination.
@@ -1563,10 +1563,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param include_archived: When ``False`` (default), exclude
             rows where ``archived`` is true. When ``True``, include
             archived rows alongside non-archived ones.
-        :param collection: When set to a non-empty string, only return
+        :param group: When set to a non-empty string, only return
             sessions that have a ``conversation_labels`` row with
-            ``key="collection"`` and ``value=collection``. When set to an
-            empty string ``""``, only return sessions with NO collection
+            ``key="group"`` and ``value=group``. When set to an
+            empty string ``""``, only return sessions with NO group
             label (i.e., unfiled sessions). ``None`` disables the
             filter.
         :returns: A :class:`PagedList` of :class:`Conversation`
@@ -1618,23 +1618,23 @@ class SqlAlchemyConversationStore(ConversationStore):
                     .distinct()
                 )
                 stmt = stmt.where(or_(title_match, content_match))
-            if collection is not None:
-                if collection == "":
-                    # Unfiled: sessions with no collection label at all.
+            if group is not None:
+                if group == "":
+                    # Unfiled: sessions with no group label at all.
                     stmt = stmt.where(
                         SqlConversation.id.not_in(
                             select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.key == "collection"
+                                SqlConversationLabel.key == "group"
                             )
                         )
                     )
                 else:
-                    # Specific collection: session must have this collection label.
+                    # Specific group: session must have this group label.
                     stmt = stmt.where(
                         SqlConversation.id.in_(
                             select(SqlConversationLabel.conversation_id).where(
-                                SqlConversationLabel.key == "collection",
-                                SqlConversationLabel.value == collection,
+                                SqlConversationLabel.key == "group",
+                                SqlConversationLabel.value == group,
                             )
                         )
                     )

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -1449,6 +1449,59 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         return persisted
 
+    def list_collections(
+        self,
+        accessible_by: str | None = None,
+    ) -> list[str]:
+        """
+        Return all distinct collection names, ordered alphabetically.
+
+        Collections are implicit: they exist as long as at least one
+        ``conversation_labels`` row with ``key="collection"`` references
+        them.
+
+        :param accessible_by: When set, restrict to sessions that
+            ``accessible_by`` has a permission row for (mirrors the
+            ``list_conversations`` ACL filter).
+        :returns: List of collection names ordered ascending.
+        """
+        with self._session() as session:
+            stmt = (
+                select(SqlConversationLabel.value)
+                .where(SqlConversationLabel.key == "collection")
+                .distinct()
+                .order_by(SqlConversationLabel.value)
+            )
+            if accessible_by is not None:
+                from omnigent.db.db_models import SqlSessionPermission
+
+                accessible_ids = select(SqlSessionPermission.conversation_id).where(
+                    SqlSessionPermission.user_id == accessible_by
+                )
+                stmt = stmt.where(SqlConversationLabel.conversation_id.in_(accessible_ids))
+            return [row[0] for row in session.execute(stmt).all()]
+
+    def delete_label(
+        self,
+        conversation_id: str,
+        key: str,
+    ) -> None:
+        """
+        Delete a single label key from a conversation.
+
+        No-op if the label does not exist.
+
+        :param conversation_id: The conversation to update.
+        :param key: The label key to remove, e.g. ``"collection"``.
+        """
+        with self._session() as session:
+            session.execute(
+                delete(SqlConversationLabel).where(
+                    SqlConversationLabel.conversation_id == conversation_id,
+                    SqlConversationLabel.key == key,
+                )
+            )
+
     def list_conversations(
         self,
         limit: int = 20,
@@ -1465,6 +1518,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         search_query: str | None = None,
         accessible_by: str | None = None,
         include_archived: bool = False,
+        collection: str | None = None,
     ) -> PagedList[Conversation]:
         """
         List conversations with cursor-based pagination.
@@ -1509,6 +1563,12 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param include_archived: When ``False`` (default), exclude
             rows where ``archived`` is true. When ``True``, include
             archived rows alongside non-archived ones.
+        :param collection: When set to a non-empty string, only return
+            sessions that have a ``conversation_labels`` row with
+            ``key="collection"`` and ``value=collection``. When set to an
+            empty string ``""``, only return sessions with NO collection
+            label (i.e., unfiled sessions). ``None`` disables the
+            filter.
         :returns: A :class:`PagedList` of :class:`Conversation`
             objects.
         """
@@ -1558,6 +1618,26 @@ class SqlAlchemyConversationStore(ConversationStore):
                     .distinct()
                 )
                 stmt = stmt.where(or_(title_match, content_match))
+            if collection is not None:
+                if collection == "":
+                    # Unfiled: sessions with no collection label at all.
+                    stmt = stmt.where(
+                        SqlConversation.id.not_in(
+                            select(SqlConversationLabel.conversation_id).where(
+                                SqlConversationLabel.key == "collection"
+                            )
+                        )
+                    )
+                else:
+                    # Specific collection: session must have this collection label.
+                    stmt = stmt.where(
+                        SqlConversation.id.in_(
+                            select(SqlConversationLabel.conversation_id).where(
+                                SqlConversationLabel.key == "collection",
+                                SqlConversationLabel.value == collection,
+                            )
+                        )
+                    )
             if after:
                 stmt = self._apply_cursor(
                     stmt,

--- a/openapi.json
+++ b/openapi.json
@@ -4803,7 +4803,7 @@
           },
           {
             "in": "query",
-            "name": "collection",
+            "name": "group",
             "required": false,
             "schema": {
               "anyOf": [
@@ -4814,7 +4814,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Collection"
+              "title": "Group"
             }
           }
         ],
@@ -4862,10 +4862,10 @@
         ]
       }
     },
-    "/v1/sessions/collections": {
+    "/v1/sessions/groups": {
       "get": {
-        "description": "Return all collection names for the authenticated user, ordered\nalphabetically.\n\nCollections are implicit: they exist while at least one session\nhas a ``conversation_labels`` row with ``key=\"collection\"``.\n\n:returns: List of collection names.",
-        "operationId": "list_session_collections_v1_sessions_collections_get",
+        "description": "Return all group names for the authenticated user, ordered\nalphabetically.\n\nGroups are implicit: they exist while at least one session\nhas a ``conversation_labels`` row with ``key=\"group\"``.\n\n:returns: List of group names.",
+        "operationId": "list_session_groups_v1_sessions_groups_get",
         "responses": {
           "200": {
             "content": {
@@ -4876,7 +4876,7 @@
             "description": "Successful Response"
           }
         },
-        "summary": "List Session Collections",
+        "summary": "List Session Groups",
         "tags": [
           "sessions"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -4800,6 +4800,22 @@
               "title": "Kind",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "collection",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Collection"
+            }
           }
         ],
         "responses": {
@@ -4841,6 +4857,26 @@
           }
         },
         "summary": "Create Session",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/v1/sessions/collections": {
+      "get": {
+        "description": "Return all collection names for the authenticated user, ordered\nalphabetically.\n\nCollections are implicit: they exist while at least one session\nhas a ``conversation_labels`` row with ``key=\"collection\"``.\n\n:returns: List of collection names.",
+        "operationId": "list_session_collections_v1_sessions_collections_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Session Collections",
         "tags": [
           "sessions"
         ]

--- a/tests/e2e_ui/sessions/test_sidebar_collections.py
+++ b/tests/e2e_ui/sessions/test_sidebar_collections.py
@@ -1,0 +1,136 @@
+"""Browser e2e for the sidebar's session collections.
+
+Collections group conversations under named, collapsible sidebar sections.
+Membership is stored server-side as a ``conversation_labels`` row with the
+reserved key ``"collection"`` (no new table — see
+``sqlalchemy_store.list_collections`` / the ``collection`` filter on
+``list_conversations``). The web UI moves a session via the row kebab's
+**"Move to collection"** submenu (``data-testid="move-to-collection"``), which
+calls ``PATCH /v1/sessions/{id}`` with ``{labels:{collection}}`` (an empty
+value removes the label).
+
+These drive the real chain the ``Sidebar`` unit tests mock out: the kebab
+submenu → the PATCH → the refreshed ``GET /v1/sessions/collections`` and
+``GET /v1/sessions`` lists → the row landing under (or leaving) a collection
+section. Collections render collapsed by default, so the tests expand the
+section to assert membership.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _set_title(base_url: str, session_id: str, title: str) -> None:
+    """Give a session a unique title via ``PATCH /v1/sessions/{id}`` so its row
+    is easy to spot among other tests' sessions in the shared server."""
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _section(page: Page, title: str) -> Locator:
+    """Locate the sidebar ``<section>`` whose collapse-header button reads
+    *title* (e.g. "Recent" or a collection name). The per-section count is
+    ``aria-hidden``, so the header's accessible name stays the bare title."""
+    return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _move_to_new_collection(page: Page, row: Locator, name: str) -> None:
+    """Drive the row kebab → "Move to collection" → "New collection…" flow,
+    typing *name* and committing with Enter."""
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    # Open the submenu flyout, then start the inline new-collection input.
+    page.get_by_test_id("move-to-collection").click()
+    page.get_by_role("menuitem", name="New collection…").click()
+    new_input = page.get_by_placeholder("Collection name…")
+    new_input.fill(name)
+    new_input.press("Enter")
+
+
+def test_move_session_into_new_collection(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Creating a collection from the kebab moves the row into it.
+
+    The session starts under "Recent"; after "Move to collection → New
+    collection…", a collection section with that name appears and the row
+    lives under it (once expanded) and no longer under "Recent".
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-col-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+    collection = f"Project {uuid.uuid4().hex[:6]}"
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+
+    _move_to_new_collection(page, row, collection)
+
+    # The collection header appears; collections render collapsed by default,
+    # so expand it before asserting membership.
+    header = page.get_by_role("button", name=collection, exact=True)
+    expect(header).to_be_visible()
+    expect(header).to_have_attribute("aria-expanded", "false")
+    header.click()
+
+    expect(_section(page, collection).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+
+def test_remove_session_from_collection(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Removing a session from its collection drops it back under "Recent".
+
+    Moves the row into a fresh collection first, then uses the kebab's
+    "Remove from collection" item and asserts the row returns to "Recent".
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-col-rm-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+    collection = f"Project {uuid.uuid4().hex[:6]}"
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    _move_to_new_collection(page, row, collection)
+
+    header = page.get_by_role("button", name=collection, exact=True)
+    expect(header).to_be_visible()
+    header.click()
+
+    # Remove via the kebab's "Remove from collection" item (only shown when the
+    # session is in a collection).
+    collection_row = (
+        _section(page, collection)
+        .locator("li")
+        .filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+    )
+    collection_row.hover()
+    collection_row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("move-to-collection").click()
+    page.get_by_role("menuitem", name=re.compile("Remove from collection")).click()
+
+    # Back under "Recent", and the now-empty collection section is gone.
+    expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(page.get_by_role("button", name=collection, exact=True)).to_have_count(0)

--- a/tests/e2e_ui/sessions/test_sidebar_groups.py
+++ b/tests/e2e_ui/sessions/test_sidebar_groups.py
@@ -1,18 +1,18 @@
-"""Browser e2e for the sidebar's session collections.
+"""Browser e2e for the sidebar's session groups.
 
-Collections group conversations under named, collapsible sidebar sections.
+Groups group conversations under named, collapsible sidebar sections.
 Membership is stored server-side as a ``conversation_labels`` row with the
-reserved key ``"collection"`` (no new table — see
-``sqlalchemy_store.list_collections`` / the ``collection`` filter on
+reserved key ``"group"`` (no new table — see
+``sqlalchemy_store.list_groups`` / the ``group`` filter on
 ``list_conversations``). The web UI moves a session via the row kebab's
-**"Move to collection"** submenu (``data-testid="move-to-collection"``), which
-calls ``PATCH /v1/sessions/{id}`` with ``{labels:{collection}}`` (an empty
+**"Move to group"** submenu (``data-testid="move-to-group"``), which
+calls ``PATCH /v1/sessions/{id}`` with ``{labels:{group}}`` (an empty
 value removes the label).
 
 These drive the real chain the ``Sidebar`` unit tests mock out: the kebab
-submenu → the PATCH → the refreshed ``GET /v1/sessions/collections`` and
-``GET /v1/sessions`` lists → the row landing under (or leaving) a collection
-section. Collections render collapsed by default, so the tests expand the
+submenu → the PATCH → the refreshed ``GET /v1/sessions/groups`` and
+``GET /v1/sessions`` lists → the row landing under (or leaving) a group
+section. Groups render collapsed by default, so the tests expand the
 section to assert membership.
 """
 
@@ -38,7 +38,7 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
 
 def _section(page: Page, title: str) -> Locator:
     """Locate the sidebar ``<section>`` whose collapse-header button reads
-    *title* (e.g. "Recent" or a collection name). The per-section count is
+    *title* (e.g. "Recent" or a group name). The per-section count is
     ``aria-hidden``, so the header's accessible name stays the bare title."""
     return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
 
@@ -48,33 +48,33 @@ def _row(page: Page, session_id: str) -> Locator:
     return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
 
 
-def _move_to_new_collection(page: Page, row: Locator, name: str) -> None:
-    """Drive the row kebab → "Move to collection" → "New collection…" flow,
+def _move_to_new_group(page: Page, row: Locator, name: str) -> None:
+    """Drive the row kebab → "Move to group" → "New group…" flow,
     typing *name* and committing with Enter."""
     row.hover()
     row.get_by_test_id("conversation-actions").click()
-    # Open the submenu flyout, then start the inline new-collection input.
-    page.get_by_test_id("move-to-collection").click()
-    page.get_by_role("menuitem", name="New collection…").click()
-    new_input = page.get_by_placeholder("Collection name…")
+    # Open the submenu flyout, then start the inline new-group input.
+    page.get_by_test_id("move-to-group").click()
+    page.get_by_role("menuitem", name="New group…").click()
+    new_input = page.get_by_placeholder("Group name…")
     new_input.fill(name)
     new_input.press("Enter")
 
 
-def test_move_session_into_new_collection(
+def test_move_session_into_new_group(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Creating a collection from the kebab moves the row into it.
+    """Creating a group from the kebab moves the row into it.
 
-    The session starts under "Recent"; after "Move to collection → New
-    collection…", a collection section with that name appears and the row
+    The session starts under "Recent"; after "Move to group → New
+    group…", a group section with that name appears and the row
     lives under it (once expanded) and no longer under "Recent".
     """
     base_url, session_id = seeded_session
     title = f"e2e-col-{uuid.uuid4().hex[:8]}"
     _set_title(base_url, session_id, title)
-    collection = f"Project {uuid.uuid4().hex[:6]}"
+    group = f"Project {uuid.uuid4().hex[:6]}"
 
     page.goto(f"{base_url}/c/{session_id}")
 
@@ -82,55 +82,55 @@ def test_move_session_into_new_collection(
     expect(row).to_be_visible()
     expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
 
-    _move_to_new_collection(page, row, collection)
+    _move_to_new_group(page, row, group)
 
-    # The collection header appears; collections render collapsed by default,
+    # The group header appears; groups render collapsed by default,
     # so expand it before asserting membership.
-    header = page.get_by_role("button", name=collection, exact=True)
+    header = page.get_by_role("button", name=group, exact=True)
     expect(header).to_be_visible()
     expect(header).to_have_attribute("aria-expanded", "false")
     header.click()
 
-    expect(_section(page, collection).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+    expect(_section(page, group).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
 
 
-def test_remove_session_from_collection(
+def test_remove_session_from_group(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Removing a session from its collection drops it back under "Recent".
+    """Removing a session from its group drops it back under "Recent".
 
-    Moves the row into a fresh collection first, then uses the kebab's
-    "Remove from collection" item and asserts the row returns to "Recent".
+    Moves the row into a fresh group first, then uses the kebab's
+    "Remove from group" item and asserts the row returns to "Recent".
     """
     base_url, session_id = seeded_session
     title = f"e2e-col-rm-{uuid.uuid4().hex[:8]}"
     _set_title(base_url, session_id, title)
-    collection = f"Project {uuid.uuid4().hex[:6]}"
+    group = f"Project {uuid.uuid4().hex[:6]}"
 
     page.goto(f"{base_url}/c/{session_id}")
 
     row = _row(page, session_id)
     expect(row).to_be_visible()
-    _move_to_new_collection(page, row, collection)
+    _move_to_new_group(page, row, group)
 
-    header = page.get_by_role("button", name=collection, exact=True)
+    header = page.get_by_role("button", name=group, exact=True)
     expect(header).to_be_visible()
     header.click()
 
-    # Remove via the kebab's "Remove from collection" item (only shown when the
-    # session is in a collection).
-    collection_row = (
-        _section(page, collection)
+    # Remove via the kebab's "Remove from group" item (only shown when the
+    # session is in a group).
+    group_row = (
+        _section(page, group)
         .locator("li")
         .filter(has=page.locator(f'a[href="/c/{session_id}"]'))
     )
-    collection_row.hover()
-    collection_row.get_by_test_id("conversation-actions").click()
-    page.get_by_test_id("move-to-collection").click()
-    page.get_by_role("menuitem", name=re.compile("Remove from collection")).click()
+    group_row.hover()
+    group_row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("move-to-group").click()
+    page.get_by_role("menuitem", name=re.compile("Remove from group")).click()
 
-    # Back under "Recent", and the now-empty collection section is gone.
+    # Back under "Recent", and the now-empty group section is gone.
     expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
-    expect(page.get_by_role("button", name=collection, exact=True)).to_have_count(0)
+    expect(page.get_by_role("button", name=group, exact=True)).to_have_count(0)

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -137,88 +137,88 @@ async def test_patch_session_not_found(client: httpx.AsyncClient) -> None:
     assert resp.status_code == 404
 
 
-# ── GET /v1/sessions/collections ────────────────────────────────────────
+# ── GET /v1/sessions/groups ────────────────────────────────────────
 
 
-async def test_list_collections_empty(client: httpx.AsyncClient) -> None:
-    """No collection labels anywhere → empty collection list."""
-    resp = await client.get("/v1/sessions/collections")
+async def test_list_groups_empty(client: httpx.AsyncClient) -> None:
+    """No group labels anywhere → empty group list."""
+    resp = await client.get("/v1/sessions/groups")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
-async def test_list_collections_returns_names_sorted(
+async def test_list_groups_returns_names_sorted(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """Collections surface as a sorted list of names."""
+    """Groups surface as a sorted list of names."""
     conv_store = SqlAlchemyConversationStore(db_uri)
     a = conv_store.create_conversation()
     b = conv_store.create_conversation()
-    conv_store.set_labels(a.id, {"collection": "Sprint 42"})
-    conv_store.set_labels(b.id, {"collection": "Customer X"})
+    conv_store.set_labels(a.id, {"group": "Sprint 42"})
+    conv_store.set_labels(b.id, {"group": "Customer X"})
 
-    resp = await client.get("/v1/sessions/collections")
+    resp = await client.get("/v1/sessions/groups")
     assert resp.status_code == 200
     assert resp.json() == ["Customer X", "Sprint 42"]
 
 
-# ── GET /v1/sessions?collection= (filter) ───────────────────────────────
+# ── GET /v1/sessions?group= (filter) ───────────────────────────────
 
 
-async def test_list_sessions_filtered_by_collection(
+async def test_list_sessions_filtered_by_group(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """``?collection=X`` returns only sessions in that collection."""
+    """``?group=X`` returns only sessions in that group."""
     agent_store = SqlAlchemyAgentStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     # GET /v1/sessions filters has_agent_id=True, so bind the conversations to
     # a seeded agent — otherwise the list comes back empty.
     agent_id = generate_agent_id()
-    agent_store.create(agent_id, name="collection-agent", bundle_location="test:///bundle")
+    agent_store.create(agent_id, name="group-agent", bundle_location="test:///bundle")
     filed = conv_store.create_conversation(agent_id=agent_id)
     conv_store.create_conversation(agent_id=agent_id)  # unfiled
-    conv_store.set_labels(filed.id, {"collection": "X"})
+    conv_store.set_labels(filed.id, {"group": "X"})
 
-    resp = await client.get("/v1/sessions?collection=X")
+    resp = await client.get("/v1/sessions?group=X")
     assert resp.status_code == 200
     ids = [s["id"] for s in resp.json()["data"]]
     assert ids == [filed.id]
 
 
-async def test_list_sessions_empty_collection_returns_unfiled(
+async def test_list_sessions_empty_group_returns_unfiled(
     client: httpx.AsyncClient,
     db_uri: str,
 ) -> None:
-    """``?collection=`` (empty) returns only sessions with no collection label."""
+    """``?group=`` (empty) returns only sessions with no group label."""
     agent_store = SqlAlchemyAgentStore(db_uri)
     conv_store = SqlAlchemyConversationStore(db_uri)
     agent_id = generate_agent_id()
-    agent_store.create(agent_id, name="collection-agent", bundle_location="test:///bundle")
+    agent_store.create(agent_id, name="group-agent", bundle_location="test:///bundle")
     filed = conv_store.create_conversation(agent_id=agent_id)
     unfiled = conv_store.create_conversation(agent_id=agent_id)
-    conv_store.set_labels(filed.id, {"collection": "X"})
+    conv_store.set_labels(filed.id, {"group": "X"})
 
-    resp = await client.get("/v1/sessions?collection=")
+    resp = await client.get("/v1/sessions?group=")
     assert resp.status_code == 200
     ids = [s["id"] for s in resp.json()["data"]]
     assert unfiled.id in ids
     assert filed.id not in ids
 
 
-# ── PATCH /v1/sessions/{id} collection label ────────────────────────────
+# ── PATCH /v1/sessions/{id} group label ────────────────────────────
 
 
-async def test_patch_session_sets_collection_label(
+async def test_patch_session_sets_group_label(
     client: httpx.AsyncClient,
     session_id: str,
     db_uri: str,
 ) -> None:
-    """PATCH with ``labels: {collection: X}`` upserts the collection label."""
+    """PATCH with ``labels: {group: X}`` upserts the group label."""
     resp = await client.patch(
         f"/v1/sessions/{session_id}",
-        json={"labels": {"collection": "Sprint 42"}},
+        json={"labels": {"group": "Sprint 42"}},
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
@@ -226,26 +226,26 @@ async def test_patch_session_sets_collection_label(
     conv_store = SqlAlchemyConversationStore(db_uri)
     conv = conv_store.get_conversation(session_id)
     assert conv is not None
-    assert conv.labels.get("collection") == "Sprint 42"
+    assert conv.labels.get("group") == "Sprint 42"
 
 
-async def test_patch_session_empty_collection_removes_label(
+async def test_patch_session_empty_group_removes_label(
     client: httpx.AsyncClient,
     session_id: str,
     db_uri: str,
 ) -> None:
-    """PATCH with ``labels: {collection: ""}`` removes the collection label rather
+    """PATCH with ``labels: {group: ""}`` removes the group label rather
     than persisting an empty value — so the session returns to Unfiled."""
     conv_store = SqlAlchemyConversationStore(db_uri)
-    conv_store.set_labels(session_id, {"collection": "Sprint 42"})
+    conv_store.set_labels(session_id, {"group": "Sprint 42"})
 
     resp = await client.patch(
         f"/v1/sessions/{session_id}",
-        json={"labels": {"collection": ""}},
+        json={"labels": {"group": ""}},
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 200
 
     conv = conv_store.get_conversation(session_id)
     assert conv is not None
-    assert "collection" not in conv.labels
+    assert "group" not in conv.labels

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -135,3 +135,117 @@ async def test_patch_session_not_found(client: httpx.AsyncClient) -> None:
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 404
+
+
+# ── GET /v1/sessions/collections ────────────────────────────────────────
+
+
+async def test_list_collections_empty(client: httpx.AsyncClient) -> None:
+    """No collection labels anywhere → empty collection list."""
+    resp = await client.get("/v1/sessions/collections")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_collections_returns_names_sorted(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Collections surface as a sorted list of names."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    a = conv_store.create_conversation()
+    b = conv_store.create_conversation()
+    conv_store.set_labels(a.id, {"collection": "Sprint 42"})
+    conv_store.set_labels(b.id, {"collection": "Customer X"})
+
+    resp = await client.get("/v1/sessions/collections")
+    assert resp.status_code == 200
+    assert resp.json() == ["Customer X", "Sprint 42"]
+
+
+# ── GET /v1/sessions?collection= (filter) ───────────────────────────────
+
+
+async def test_list_sessions_filtered_by_collection(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """``?collection=X`` returns only sessions in that collection."""
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    # GET /v1/sessions filters has_agent_id=True, so bind the conversations to
+    # a seeded agent — otherwise the list comes back empty.
+    agent_id = generate_agent_id()
+    agent_store.create(agent_id, name="collection-agent", bundle_location="test:///bundle")
+    filed = conv_store.create_conversation(agent_id=agent_id)
+    conv_store.create_conversation(agent_id=agent_id)  # unfiled
+    conv_store.set_labels(filed.id, {"collection": "X"})
+
+    resp = await client.get("/v1/sessions?collection=X")
+    assert resp.status_code == 200
+    ids = [s["id"] for s in resp.json()["data"]]
+    assert ids == [filed.id]
+
+
+async def test_list_sessions_empty_collection_returns_unfiled(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """``?collection=`` (empty) returns only sessions with no collection label."""
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = generate_agent_id()
+    agent_store.create(agent_id, name="collection-agent", bundle_location="test:///bundle")
+    filed = conv_store.create_conversation(agent_id=agent_id)
+    unfiled = conv_store.create_conversation(agent_id=agent_id)
+    conv_store.set_labels(filed.id, {"collection": "X"})
+
+    resp = await client.get("/v1/sessions?collection=")
+    assert resp.status_code == 200
+    ids = [s["id"] for s in resp.json()["data"]]
+    assert unfiled.id in ids
+    assert filed.id not in ids
+
+
+# ── PATCH /v1/sessions/{id} collection label ────────────────────────────
+
+
+async def test_patch_session_sets_collection_label(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """PATCH with ``labels: {collection: X}`` upserts the collection label."""
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"collection": "Sprint 42"}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.labels.get("collection") == "Sprint 42"
+
+
+async def test_patch_session_empty_collection_removes_label(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """PATCH with ``labels: {collection: ""}`` removes the collection label rather
+    than persisting an empty value — so the session returns to Unfiled."""
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv_store.set_labels(session_id, {"collection": "Sprint 42"})
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"collection": ""}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert "collection" not in conv.labels

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4176,3 +4176,126 @@ def test_append_many_batches_stay_contiguous(
     assert _stored_next_position(conversation_store, conv.id) == total
     listed = conversation_store.list_items(conv.id, limit=total)
     assert len(listed.data) == total
+
+
+# ── Collections (conversation_labels key="collection") ───────
+
+
+def test_list_collections_returns_distinct_names_sorted(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``list_collections`` returns each distinct collection name once, ordered
+    alphabetically. Sessions with no collection label don't create phantom
+    collections, and a collection shared by two sessions appears a single time."""
+    a1 = conversation_store.create_conversation()
+    a2 = conversation_store.create_conversation()
+    b1 = conversation_store.create_conversation()
+    conversation_store.create_conversation()  # unfiled — must not appear
+
+    conversation_store.set_labels(a1.id, {"collection": "Sprint 42"})
+    conversation_store.set_labels(a2.id, {"collection": "Sprint 42"})
+    conversation_store.set_labels(b1.id, {"collection": "Customer X"})
+
+    # Alphabetical, de-duplicated. A missing DISTINCT would list "Sprint 42"
+    # twice.
+    assert conversation_store.list_collections() == ["Customer X", "Sprint 42"]
+
+
+def test_list_collections_empty_when_no_collection_labels(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Non-collection labels (e.g. guardrail keys) never surface as collections."""
+    conv = conversation_store.create_conversation()
+    conversation_store.set_labels(conv.id, {"integrity": "1", "sensitivity": "public"})
+    assert conversation_store.list_collections() == []
+
+
+def test_list_collections_scoped_by_accessible_by(
+    conversation_store: SqlAlchemyConversationStore,
+    db_uri: str,
+) -> None:
+    """When ``accessible_by`` is set, only collections on sessions the user has a
+    permission row for are returned — mirroring the list_conversations ACL."""
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    mine = conversation_store.create_conversation()
+    theirs = conversation_store.create_conversation()
+    conversation_store.set_labels(mine.id, {"collection": "Mine"})
+    conversation_store.set_labels(theirs.id, {"collection": "Theirs"})
+
+    perms = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice@example.com", "bob@example.com"):
+        perms.ensure_user(user)
+    perms.grant("alice@example.com", mine.id, 4)
+    perms.grant("bob@example.com", theirs.id, 4)
+
+    # Alice only sees her collection; Theirs is invisible to her.
+    assert conversation_store.list_collections(accessible_by="alice@example.com") == ["Mine"]
+
+
+def test_delete_label_removes_only_target_key(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``delete_label`` drops the named key and leaves siblings intact — so
+    removing a session from its collection doesn't wipe guardrail labels."""
+    conv = conversation_store.create_conversation()
+    conversation_store.set_labels(conv.id, {"collection": "X", "integrity": "1"})
+
+    conversation_store.delete_label(conv.id, "collection")
+
+    got = conversation_store.get_conversation(conv.id)
+    assert got is not None
+    assert got.labels == {"integrity": "1"}
+
+
+def test_delete_label_is_noop_when_absent(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Deleting a label that doesn't exist is a no-op, not an error."""
+    conv = conversation_store.create_conversation()
+    conversation_store.delete_label(conv.id, "collection")  # must not raise
+    got = conversation_store.get_conversation(conv.id)
+    assert got is not None
+    assert got.labels == {}
+
+
+def test_list_conversations_filters_by_collection(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``collection="X"`` returns only sessions carrying that exact collection label."""
+    filed = conversation_store.create_conversation()
+    other = conversation_store.create_conversation()
+    conversation_store.create_conversation()  # unfiled
+
+    conversation_store.set_labels(filed.id, {"collection": "X"})
+    conversation_store.set_labels(other.id, {"collection": "Y"})
+
+    ids = {c.id for c in conversation_store.list_conversations(collection="X").data}
+    assert ids == {filed.id}
+
+
+def test_list_conversations_empty_collection_returns_unfiled(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``collection=""`` returns only sessions with NO collection label (Unfiled)."""
+    filed = conversation_store.create_conversation()
+    unfiled = conversation_store.create_conversation()
+    conversation_store.set_labels(filed.id, {"collection": "X"})
+
+    ids = {c.id for c in conversation_store.list_conversations(collection="").data}
+    assert unfiled.id in ids
+    assert filed.id not in ids
+
+
+def test_list_conversations_collection_none_disables_filter(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``collection=None`` (the default) returns filed and unfiled alike."""
+    filed = conversation_store.create_conversation()
+    unfiled = conversation_store.create_conversation()
+    conversation_store.set_labels(filed.id, {"collection": "X"})
+
+    ids = {c.id for c in conversation_store.list_conversations().data}
+    assert ids >= {filed.id, unfiled.id}

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4178,43 +4178,43 @@ def test_append_many_batches_stay_contiguous(
     assert len(listed.data) == total
 
 
-# ── Collections (conversation_labels key="collection") ───────
+# ── Groups (conversation_labels key="group") ───────
 
 
-def test_list_collections_returns_distinct_names_sorted(
+def test_list_groups_returns_distinct_names_sorted(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """``list_collections`` returns each distinct collection name once, ordered
-    alphabetically. Sessions with no collection label don't create phantom
-    collections, and a collection shared by two sessions appears a single time."""
+    """``list_groups`` returns each distinct group name once, ordered
+    alphabetically. Sessions with no group label don't create phantom
+    groups, and a group shared by two sessions appears a single time."""
     a1 = conversation_store.create_conversation()
     a2 = conversation_store.create_conversation()
     b1 = conversation_store.create_conversation()
     conversation_store.create_conversation()  # unfiled — must not appear
 
-    conversation_store.set_labels(a1.id, {"collection": "Sprint 42"})
-    conversation_store.set_labels(a2.id, {"collection": "Sprint 42"})
-    conversation_store.set_labels(b1.id, {"collection": "Customer X"})
+    conversation_store.set_labels(a1.id, {"group": "Sprint 42"})
+    conversation_store.set_labels(a2.id, {"group": "Sprint 42"})
+    conversation_store.set_labels(b1.id, {"group": "Customer X"})
 
     # Alphabetical, de-duplicated. A missing DISTINCT would list "Sprint 42"
     # twice.
-    assert conversation_store.list_collections() == ["Customer X", "Sprint 42"]
+    assert conversation_store.list_groups() == ["Customer X", "Sprint 42"]
 
 
-def test_list_collections_empty_when_no_collection_labels(
+def test_list_groups_empty_when_no_group_labels(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """Non-collection labels (e.g. guardrail keys) never surface as collections."""
+    """Non-group labels (e.g. guardrail keys) never surface as groups."""
     conv = conversation_store.create_conversation()
     conversation_store.set_labels(conv.id, {"integrity": "1", "sensitivity": "public"})
-    assert conversation_store.list_collections() == []
+    assert conversation_store.list_groups() == []
 
 
-def test_list_collections_scoped_by_accessible_by(
+def test_list_groups_scoped_by_accessible_by(
     conversation_store: SqlAlchemyConversationStore,
     db_uri: str,
 ) -> None:
-    """When ``accessible_by`` is set, only collections on sessions the user has a
+    """When ``accessible_by`` is set, only groups on sessions the user has a
     permission row for are returned — mirroring the list_conversations ACL."""
     from omnigent.stores.permission_store.sqlalchemy_store import (
         SqlAlchemyPermissionStore,
@@ -4222,8 +4222,8 @@ def test_list_collections_scoped_by_accessible_by(
 
     mine = conversation_store.create_conversation()
     theirs = conversation_store.create_conversation()
-    conversation_store.set_labels(mine.id, {"collection": "Mine"})
-    conversation_store.set_labels(theirs.id, {"collection": "Theirs"})
+    conversation_store.set_labels(mine.id, {"group": "Mine"})
+    conversation_store.set_labels(theirs.id, {"group": "Theirs"})
 
     perms = SqlAlchemyPermissionStore(db_uri)
     for user in ("alice@example.com", "bob@example.com"):
@@ -4231,19 +4231,19 @@ def test_list_collections_scoped_by_accessible_by(
     perms.grant("alice@example.com", mine.id, 4)
     perms.grant("bob@example.com", theirs.id, 4)
 
-    # Alice only sees her collection; Theirs is invisible to her.
-    assert conversation_store.list_collections(accessible_by="alice@example.com") == ["Mine"]
+    # Alice only sees her group; Theirs is invisible to her.
+    assert conversation_store.list_groups(accessible_by="alice@example.com") == ["Mine"]
 
 
 def test_delete_label_removes_only_target_key(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
     """``delete_label`` drops the named key and leaves siblings intact — so
-    removing a session from its collection doesn't wipe guardrail labels."""
+    removing a session from its group doesn't wipe guardrail labels."""
     conv = conversation_store.create_conversation()
-    conversation_store.set_labels(conv.id, {"collection": "X", "integrity": "1"})
+    conversation_store.set_labels(conv.id, {"group": "X", "integrity": "1"})
 
-    conversation_store.delete_label(conv.id, "collection")
+    conversation_store.delete_label(conv.id, "group")
 
     got = conversation_store.get_conversation(conv.id)
     assert got is not None
@@ -4255,47 +4255,47 @@ def test_delete_label_is_noop_when_absent(
 ) -> None:
     """Deleting a label that doesn't exist is a no-op, not an error."""
     conv = conversation_store.create_conversation()
-    conversation_store.delete_label(conv.id, "collection")  # must not raise
+    conversation_store.delete_label(conv.id, "group")  # must not raise
     got = conversation_store.get_conversation(conv.id)
     assert got is not None
     assert got.labels == {}
 
 
-def test_list_conversations_filters_by_collection(
+def test_list_conversations_filters_by_group(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """``collection="X"`` returns only sessions carrying that exact collection label."""
+    """``group="X"`` returns only sessions carrying that exact group label."""
     filed = conversation_store.create_conversation()
     other = conversation_store.create_conversation()
     conversation_store.create_conversation()  # unfiled
 
-    conversation_store.set_labels(filed.id, {"collection": "X"})
-    conversation_store.set_labels(other.id, {"collection": "Y"})
+    conversation_store.set_labels(filed.id, {"group": "X"})
+    conversation_store.set_labels(other.id, {"group": "Y"})
 
-    ids = {c.id for c in conversation_store.list_conversations(collection="X").data}
+    ids = {c.id for c in conversation_store.list_conversations(group="X").data}
     assert ids == {filed.id}
 
 
-def test_list_conversations_empty_collection_returns_unfiled(
+def test_list_conversations_empty_group_returns_unfiled(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """``collection=""`` returns only sessions with NO collection label (Unfiled)."""
+    """``group=""`` returns only sessions with NO group label (Unfiled)."""
     filed = conversation_store.create_conversation()
     unfiled = conversation_store.create_conversation()
-    conversation_store.set_labels(filed.id, {"collection": "X"})
+    conversation_store.set_labels(filed.id, {"group": "X"})
 
-    ids = {c.id for c in conversation_store.list_conversations(collection="").data}
+    ids = {c.id for c in conversation_store.list_conversations(group="").data}
     assert unfiled.id in ids
     assert filed.id not in ids
 
 
-def test_list_conversations_collection_none_disables_filter(
+def test_list_conversations_group_none_disables_filter(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """``collection=None`` (the default) returns filed and unfiled alike."""
+    """``group=None`` (the default) returns filed and unfiled alike."""
     filed = conversation_store.create_conversation()
     unfiled = conversation_store.create_conversation()
-    conversation_store.set_labels(filed.id, {"collection": "X"})
+    conversation_store.set_labels(filed.id, {"group": "X"})
 
     ids = {c.id for c in conversation_store.list_conversations().data}
     assert ids >= {filed.id, unfiled.id}


### PR DESCRIPTION
## Related issue

Closes omnigent-ai/omnigent#863

## Summary

Adds the ability to organize sessions into **collections** in the sidebar — group related conversations (a customer engagement, a sprint, a research thread) instead of scrolling through a single flat "Recent" list.

* **"Move to collection"** action in the row kebab (native Radix submenu): pick an existing collection, create one inline, or remove from it.
* Collections render as **collapsible sidebar sections** (`Collections → Pinned → Recent → Shared with me → Archived`), collapsed by default, with per-section icons + counts. A collapsed collection surfaces the same `SessionStateBadge` as its hidden rows when one carries a marker (unread / needs-response / running).
* Pinning a session inside a collection keeps it there (sorted first); the global Pinned section holds only un-collectioned pins. Precedence: **Archived > Pinned > Collection > Recent**.
* **Implicit collections** — reuses the existing `conversation_labels` table (reserved key `"collection"`). A collection exists while ≥1 session references it and vanishes when its last session leaves. **No DB migration, no new dependencies.**

Named "collections" (not "folders") to avoid confusion with the runner workspace folders in the file pickers.

**ELI5:** Conversations are sticky notes; a collection is a labeled tray. Dropping a note into a tray just writes the tray's name on the note — no new filing cabinet, and an empty tray disappears on its own.

```
PATCH /v1/sessions/{id} {labels:{collection:"X"}}      ← drop into tray ("" removes)
        │
        ▼
conversation_labels (key="collection", value="X")       ← the only storage
        │
        ├─ GET /v1/sessions/collections  → ["X", ...]    (distinct names, ACL-scoped)
        └─ GET /v1/sessions?collection=X  → rows in X     (""=unfiled)
                                  │
                                  ▼
                       Sidebar groups rows by label
```

### Acceptance criteria (from omnigent-ai/omnigent#863)

- [X] A session can be moved into a new or existing collection, and removed from it
- [X] The sidebar groups sessions by collection, with per-collection counts
- [X] Collections are scoped to sessions the user can access (same ACL as the session list)
- [X] Filtering the session list by collection at the API level (`?collection=`), incl. unfiled
- [X] No schema migration required

### Screenshots

#### Sidebar with collections (Project A expanded with a pinned row first, Project B collapsed with count):

<img src="https://github.com/user-attachments/assets/6762bff5-10c7-46cd-a598-6d8ca09aa2ca " alt="collections-sidebar" width="320" data-linear-height="868" />

#### "Move to collection" submenu (search / new collection / remove):

<img src="https://github.com/user-attachments/assets/449282c3-5270-4a01-9389-aa2b0ced16db " alt="collections-move-submenu" width="542" data-linear-height="699" />

#### Collapsed collection surfacing a hidden row's marker:

<img src="https://github.com/user-attachments/assets/3d10c36e-bfaa-4283-8543-7a20ced74d0a " alt="collections-collapsed-marker" width="318" data-linear-height="250" />

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [X] Integration tests added / updated
- [X] E2E tests added / updated
- [X] Manual verification completed
- [X] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

**Backend** (`uv run pytest tests/stores/test_conversation_store.py tests/server/routes/test_sessions_crud.py tests/server/test_openapi_drift.py` → 166 passed; `ruff check` / `ruff format --check` clean):

* Store unit tests: `list_collections` (distinct/sorted/ACL-scoped), `delete_label` (target-only + no-op), `list_conversations(collection=…)` (specific / `""` unfiled / `None` disables).
* Route integration tests (through the ASGI client): `GET /v1/sessions/collections`, `?collection=` filter incl. unfiled, `PATCH` set/remove. `openapi.json` is regenerated and `test_openapi_drift` passes.

**Frontend** (`npm test` → full vitest suite green; `tsc -b --noEmit` and `npm run build` clean):

* Hook unit tests: `useCollections` (GET + error) and `useMoveToCollection` (PATCH body + invalidation of `conversations` / `collections`).
* Sidebar component tests: collection grouping, default-collapsed + count, pin-in-collection ordering, the move-to-collection submenu flow, the collapsed-collection aggregate marker (shown collapsed / dropped when expanded / absent when none), and default-expanded-but-persisted collapse for Pinned/Recent.

**E2E UI** (`uv run pytest tests/e2e_ui/sessions/test_sidebar_collections.py` → 2 passed): Playwright flow against a real spawned `omnigent server` — move a session into a new collection via the kebab submenu and remove it, asserting it regroups under the collection section and back to Recent.

Manually verified against a local `omnigent server` + Vite dev: created/removed collections, pin-in-collection ordering, the collapsed-collection marker, and coexistence with the existing bulk-selection mode.