### PR TITLE
test: un-quarantine harness_without_agent[pi] — stale-green (#523)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -34,15 +34,6 @@ skips:
     cluster: mock-claude-sdk-cli-unsupported
     mode: skip
 
-  - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[pi]
-    reason: "No-AGENT `omnigent run --harness` live round-trip crashes the xdist worker — same family as the [claude-sdk]/[codex]/[openai-agents] siblings. Surfaced once pi was enabled in CI (PR #809); previously the [pi] row skipped because the pi CLI was absent. See [claude-sdk] entry for the full diagnosis."
-    issue: 523
-    cluster: no-agent-harness-roundtrip-hang
-    mode: skip
-
-
-
-
   - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[pi]
     reason: "pi harness does not complete the headless `-p` tool round-trip: it makes only ONE LLM request (receives the forced calculate tool_call) then exits 0 with empty stdout — the tool is never dispatched and no follow-up call is made. Distinct from #677 (stale stdout-marker expectation, fixed for the claude-sdk/codex/openai-agents rows). See #807 for the full diagnosis."
     issue: 807


### PR DESCRIPTION
## Summary

Un-quarantines `test_run_harness_without_agent_live_repl_round_trip[pi]` (#523) — it's **stale-green**. It was quarantined for hanging >180s in CI (xdist worker crash) when pi was first enabled in CI (#809), but that no longer reproduces:

- Passes **locally** (pi 0.75.5, ~14s).
- Passes **30/30 in CI flake-stress** ([run 27865158002](https://github.com/omnigent-ai/omnigent/actions/runs/27865158002)).

The hang was environment-specific and has since cleared. No code change — just drop the entry.

This pull request and its description were written by Isaac.
