### PR TITLE
Feat/add litellm provider

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1524,10 +1524,11 @@ def _native_claude_config_from_entry(
         DATABRICKS_KIND,
         GATEWAY_KIND,
         KEY_KIND,
+        LITELLM_KIND,
         LOCAL_KIND,
     )
 
-    if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+    if entry.kind in (KEY_KIND, GATEWAY_KIND, LITELLM_KIND, LOCAL_KIND):
         return _provider_config_for_native_claude(entry)
     if entry.kind == DATABRICKS_KIND:
         _logger.info("native-claude routing: Databricks ucode profile %r", entry.profile)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7604,10 +7604,21 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         name = f"{cli_name}-subscription"
         entry = build_subscription_provider_entry(cli_name)
 
-    elif kind == "gateway":
-        name = prompt_text("Name for this gateway", default="gateway")
-        base_url = prompt_text("Gateway base_url (OpenAI/Anthropic-compatible)")
-        pasted = prompt_text("Gateway API key", hide_input=True)
+    elif kind in ("gateway", "litellm"):
+        is_litellm_kind = kind == "litellm"
+        if is_litellm_kind:
+            _default_name = "litellm"
+            _url_prompt = "LiteLLM proxy URL"
+            _key_prompt = "LiteLLM proxy API key"
+            _name_prompt = "Name for this LiteLLM gateway"
+        else:
+            _default_name = "gateway"
+            _url_prompt = "Gateway base_url (OpenAI/Anthropic-compatible)"
+            _key_prompt = "Gateway API key"
+            _name_prompt = "Name for this gateway"
+        name = prompt_text(_name_prompt, default=_default_name)
+        base_url = prompt_text(_url_prompt)
+        pasted = prompt_text(_key_prompt, hide_input=True)
         secret_store.store_secret(name, pasted)
         # Which harness surfaces — one clear pick instead of two y/n prompts.
         # (These are *harness* surfaces: Codex/OpenAI → codex + openai-agents;
@@ -7718,13 +7729,24 @@ def _configure_harness_add(family: str | None = None) -> str | None:
                 models[ANTHROPIC_FAMILY] = prompt_text(
                     "Default model for the Claude surface (the gateway's Claude model id)"
                 ).strip()
-        entry = build_gateway_provider_entry(
-            base_url=base_url,
-            api_key_ref=f"keychain:{name}",
-            families=families,
-            wire_api=wire_api,
-            models=models,
-        )
+        if is_litellm_kind:
+            from omnigent.onboarding.configure_models import build_litellm_provider_entry
+
+            entry = build_litellm_provider_entry(
+                base_url=base_url,
+                api_key_ref=f"keychain:{name}",
+                families=families,
+                wire_api=wire_api,
+                models=models,
+            )
+        else:
+            entry = build_gateway_provider_entry(
+                base_url=base_url,
+                api_key_ref=f"keychain:{name}",
+                families=families,
+                wire_api=wire_api,
+                models=models,
+            )
 
     else:  # databricks
         # Gate on the `databricks` extra: a `kind: databricks` provider mints

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -725,9 +725,9 @@ def _materialize_internal_beta_agents() -> Path:
         path = _materialize_bundled_example(name)
         if name == _INTERNAL_BETA_DEFAULT_AGENT_NAME:
             default_path = path
-    assert (
-        default_path is not None
-    ), f"_INTERNAL_BETA_BUNDLED_AGENTS must include {_INTERNAL_BETA_DEFAULT_AGENT_NAME}"
+    assert default_path is not None, (
+        f"_INTERNAL_BETA_BUNDLED_AGENTS must include {_INTERNAL_BETA_DEFAULT_AGENT_NAME}"
+    )
     return default_path
 
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7657,16 +7657,53 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         # user can type any gateway model id.
         from omnigent.onboarding.providers import default_chat_model
 
+        # For LiteLLM gateways, discover models via /v1/models so the
+        # user picks from a list instead of guessing model names.
+        is_litellm = "litellm" in chosen.label.lower()
+        discovered_models: list[str] = []
+        if is_litellm:
+            try:
+                import httpx as _httpx
+
+                resp = _httpx.get(
+                    f"{base_url.rstrip('/')}/v1/models",
+                    headers={"Authorization": f"Bearer {pasted}"},
+                    timeout=5.0,
+                )
+                if resp.status_code == 200:
+                    for m in resp.json().get("data", []):
+                        discovered_models.append(m["id"])
+            except (OSError, KeyError, ValueError):
+                pass
+
         models: dict[str, str] = {}
-        if OPENAI_FAMILY in families:
-            models[OPENAI_FAMILY] = prompt_text(
-                "Default model for the Codex / OpenAI surface",
-                default=default_chat_model("openrouter"),
-            ).strip()
-        if ANTHROPIC_FAMILY in families:
-            models[ANTHROPIC_FAMILY] = prompt_text(
-                "Default model for the Claude surface (the gateway's Claude model id)"
-            ).strip()
+        if discovered_models:
+            if OPENAI_FAMILY in families:
+                _model_choice = select(
+                    "Default model for the Codex / OpenAI surface",
+                    discovered_models,
+                    clear_on_exit=True,
+                )
+                if _model_choice >= 0:
+                    models[OPENAI_FAMILY] = discovered_models[_model_choice]
+            if ANTHROPIC_FAMILY in families:
+                _model_choice = select(
+                    "Default model for the Claude surface",
+                    discovered_models,
+                    clear_on_exit=True,
+                )
+                if _model_choice >= 0:
+                    models[ANTHROPIC_FAMILY] = discovered_models[_model_choice]
+        else:
+            if OPENAI_FAMILY in families:
+                models[OPENAI_FAMILY] = prompt_text(
+                    "Default model for the Codex / OpenAI surface",
+                    default=default_chat_model("openrouter"),
+                ).strip()
+            if ANTHROPIC_FAMILY in families:
+                models[ANTHROPIC_FAMILY] = prompt_text(
+                    "Default model for the Claude surface (the gateway's Claude model id)"
+                ).strip()
         entry = build_gateway_provider_entry(
             base_url=base_url,
             api_key_ref=f"keychain:{name}",

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -725,9 +725,9 @@ def _materialize_internal_beta_agents() -> Path:
         path = _materialize_bundled_example(name)
         if name == _INTERNAL_BETA_DEFAULT_AGENT_NAME:
             default_path = path
-    assert default_path is not None, (
-        f"_INTERNAL_BETA_BUNDLED_AGENTS must include {_INTERNAL_BETA_DEFAULT_AGENT_NAME}"
-    )
+    assert (
+        default_path is not None
+    ), f"_INTERNAL_BETA_BUNDLED_AGENTS must include {_INTERNAL_BETA_DEFAULT_AGENT_NAME}"
     return default_path
 
 
@@ -7692,12 +7692,11 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         # Codex harness sees gpt-*/o3-*/etc.).
         _ANTHROPIC_PREFIXES = ("anthropic/", "claude")
         _anthropic_models = [
-            m for m in discovered_models
+            m
+            for m in discovered_models
             if any(m.lower().startswith(p) for p in _ANTHROPIC_PREFIXES)
         ]
-        _openai_models = [
-            m for m in discovered_models if m not in _anthropic_models
-        ]
+        _openai_models = [m for m in discovered_models if m not in _anthropic_models]
 
         models: dict[str, str] = {}
         if discovered_models:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7676,24 +7676,38 @@ def _configure_harness_add(family: str | None = None) -> str | None:
             except (OSError, KeyError, ValueError):
                 pass
 
+        # Split discovered models by family so each harness only sees
+        # relevant models (e.g. Claude harness sees anthropic/claude-*,
+        # Codex harness sees gpt-*/o3-*/etc.).
+        _ANTHROPIC_PREFIXES = ("anthropic/", "claude")
+        _anthropic_models = [
+            m for m in discovered_models
+            if any(m.lower().startswith(p) for p in _ANTHROPIC_PREFIXES)
+        ]
+        _openai_models = [
+            m for m in discovered_models if m not in _anthropic_models
+        ]
+
         models: dict[str, str] = {}
         if discovered_models:
             if OPENAI_FAMILY in families:
+                _family_models = _openai_models or discovered_models
                 _model_choice = select(
                     "Default model for the Codex / OpenAI surface",
-                    discovered_models,
+                    _family_models,
                     clear_on_exit=True,
                 )
                 if _model_choice >= 0:
-                    models[OPENAI_FAMILY] = discovered_models[_model_choice]
+                    models[OPENAI_FAMILY] = _family_models[_model_choice]
             if ANTHROPIC_FAMILY in families:
+                _family_models = _anthropic_models or discovered_models
                 _model_choice = select(
                     "Default model for the Claude surface",
-                    discovered_models,
+                    _family_models,
                     clear_on_exit=True,
                 )
                 if _model_choice >= 0:
-                    models[ANTHROPIC_FAMILY] = discovered_models[_model_choice]
+                    models[ANTHROPIC_FAMILY] = _family_models[_model_choice]
         else:
             if OPENAI_FAMILY in families:
                 models[OPENAI_FAMILY] = prompt_text(

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1194,6 +1194,7 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
         DATABRICKS_KIND,
         GATEWAY_KIND,
         KEY_KIND,
+        LITELLM_KIND,
         LOCAL_KIND,
         OPENAI_FAMILY,
     )
@@ -1209,7 +1210,7 @@ def _codex_provider_launch(entry: ProviderEntry, model: str | None) -> NativeCod
             model=model,
             profile=None,
         )
-    if entry.kind not in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+    if entry.kind not in (KEY_KIND, GATEWAY_KIND, LITELLM_KIND, LOCAL_KIND):
         return None
     try:
         family = entry.family(OPENAI_FAMILY)

--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -98,8 +98,14 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
 
         return DatabricksAdapter(**kwargs)
 
+    if provider == "litellm":
+        from omnigent.llms.adapters.litellm import LiteLLMAdapter
+
+        return LiteLLMAdapter(**kwargs)
+
     all_providers = sorted(
-        openai_compat_providers.keys() | {"anthropic", "gemini", "bedrock", "vertex", "databricks"}
+        openai_compat_providers.keys()
+        | {"anthropic", "gemini", "bedrock", "vertex", "databricks", "litellm"}
     )
     raise OmnigentError(
         f"Unknown provider {provider!r}. Supported: {all_providers}",

--- a/omnigent/llms/adapters/litellm.py
+++ b/omnigent/llms/adapters/litellm.py
@@ -1,0 +1,127 @@
+"""
+LiteLLM provider adapter.
+
+Routes requests through the ``litellm`` SDK, which supports 100+
+LLM providers (OpenAI, Anthropic, Bedrock, Vertex, Cohere, Mistral,
+...) via a unified ``completion()`` / ``acompletion()`` interface.
+
+Users specify ``litellm/<model>`` as the model string, where
+``<model>`` is any litellm-compatible model identifier, e.g.
+``litellm/gpt-4``, ``litellm/claude-3.5-sonnet``,
+``litellm/bedrock/claude-3.5-sonnet``, etc.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from omnigent.llms.adapters.base import BaseAdapter
+
+_logger = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT = 120
+_STREAM_TIMEOUT = 300
+
+
+class LiteLLMAdapter(BaseAdapter):
+    """
+    Adapter that delegates to ``litellm.acompletion()``.
+
+    Supports two modes:
+
+    - **SDK mode** (no ``base_url``): litellm resolves the provider
+      from the model string and calls the provider API directly.
+      Provider API keys are read from environment variables or
+      passed via ``connection_params["api_key"]``.
+
+    - **Proxy mode** (``base_url`` set): litellm sends requests to
+      a running LiteLLM proxy server. ``api_key`` in
+      ``connection_params`` is the proxy master/virtual key.
+    """
+
+    async def chat_completions(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        tools: list[dict[str, Any]] | None,
+        stream: bool,
+        extra: dict[str, Any],
+        *,
+        connection_params: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> dict[str, Any] | AsyncIterator[dict[str, Any]]:
+        """
+        Send a chat completions request via litellm.
+
+        :param messages: Chat Completions format messages.
+        :param model: The litellm model string (without the
+            ``litellm/`` routing prefix), e.g. ``"gpt-4"`` or
+            ``"bedrock/claude-3.5-sonnet"``.
+        :param tools: OpenAI-format tool schemas, or ``None``.
+        :param stream: If ``True``, return an async iterator of
+            chunk dicts.
+        :param extra: Additional kwargs (temperature, etc.).
+        :param connection_params: Per-call overrides. Supported keys:
+            ``"api_key"`` (provider key or proxy master key),
+            ``"base_url"`` (LiteLLM proxy URL).
+        :param timeout: Request timeout in seconds.
+        :returns: Response dict or async iterator of chunk dicts.
+        """
+        try:
+            import litellm
+        except ImportError as exc:
+            raise ImportError(
+                "litellm is required for the litellm provider. "
+                "Install it with: pip install 'omnigent[litellm]'"
+            ) from exc
+
+        params = connection_params or {}
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": stream,
+            "drop_params": True,
+            **extra,
+        }
+        if tools:
+            kwargs["tools"] = tools
+
+        api_key = params.get("api_key")
+        if api_key:
+            kwargs["api_key"] = api_key
+
+        base_url = params.get("base_url")
+        if base_url:
+            kwargs["base_url"] = base_url.rstrip("/")
+
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        elif stream:
+            kwargs["timeout"] = _STREAM_TIMEOUT
+        else:
+            kwargs["timeout"] = _REQUEST_TIMEOUT
+
+        if stream:
+            return self._stream(litellm, kwargs)
+
+        response = await litellm.acompletion(**kwargs)
+        result: dict[str, Any] = response.model_dump()
+        return result
+
+    async def _stream(
+        self,
+        litellm: Any,
+        kwargs: dict[str, Any],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """
+        Stream a litellm response and yield Chat Completions chunks.
+
+        :param litellm: The imported litellm module.
+        :param kwargs: The kwargs dict for ``litellm.acompletion``.
+        :yields: Parsed Chat Completions chunk dicts.
+        """
+        response = await litellm.acompletion(**kwargs)
+        async for chunk in response:
+            yield chunk.model_dump()

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -29,6 +29,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama": "http://localhost:11434/v1",
     "moonshot": "https://api.moonshot.cn/v1",
+    "litellm": None,
 }
 
 _DEFAULT_PROVIDER = "openai"

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -38,6 +38,7 @@ from omnigent.onboarding.provider_config import (
     DATABRICKS_KIND,
     GATEWAY_KIND,
     KEY_KIND,
+    LITELLM_KIND,
     LOCAL_KIND,
     OPENAI_FAMILY,
     PI_SURFACE,
@@ -59,6 +60,7 @@ _KIND_GLYPH: dict[str, str] = {
     KEY_KIND: "\N{KEY}",
     SUBSCRIPTION_KIND: "\N{ADMISSION TICKETS}\N{VARIATION SELECTOR-16}",
     GATEWAY_KIND: "\N{GLOBE WITH MERIDIANS}",
+    LITELLM_KIND: "\N{HIGH-SPEED TRAIN}",
     LOCAL_KIND: "\N{DESKTOP COMPUTER}\N{VARIATION SELECTOR-16}",
     DATABRICKS_KIND: "\N{BRICK}",
     # GEAR carries a VS16 for the same 2-cell-emoji rendering reason as the
@@ -74,6 +76,7 @@ _KIND_STYLE: dict[str, str] = {
     KEY_KIND: "yellow",
     SUBSCRIPTION_KIND: "magenta",
     GATEWAY_KIND: "cyan",
+    LITELLM_KIND: "cyan",
     LOCAL_KIND: "green",
     DATABRICKS_KIND: "red",
     CLI_CONFIG_KIND: "blue",
@@ -433,10 +436,10 @@ def add_menu_options() -> list[AddOption]:
             "An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, OpenRouter, vLLM, …",
             GATEWAY_KIND,
         ),
-        AddOption(
-            label="\N{HIGH-SPEED TRAIN} LiteLLM — proxy URL + key",
-            description="100+ providers via LiteLLM AI gateway proxy (litellm.ai).",
-            kind=GATEWAY_KIND,
+        _opt(
+            "LiteLLM — proxy URL + key",
+            "100+ providers via LiteLLM AI gateway proxy (litellm.ai).",
+            LITELLM_KIND,
         ),
         _opt(
             "OpenRouter — API key",
@@ -481,7 +484,7 @@ def _add_option_families(opt: AddOption) -> frozenset[str]:
     :returns: The surfaces this option can configure — a subset of
         ``{"anthropic", "openai", "pi"}``.
     """
-    if opt.kind == GATEWAY_KIND or opt.kind == DATABRICKS_KIND:
+    if opt.kind in (GATEWAY_KIND, LITELLM_KIND, DATABRICKS_KIND):
         return frozenset({ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE})
     if opt.kind == SUBSCRIPTION_KIND:
         if opt.cli == "claude":
@@ -828,6 +831,32 @@ def build_gateway_provider_entry(
         raise ValueError("a gateway must serve at least one family")
     models = models or {}
     body: dict[str, object] = {"kind": GATEWAY_KIND}
+    for family in families:
+        block: dict[str, object] = {"base_url": base_url, "api_key_ref": api_key_ref}
+        if family == OPENAI_FAMILY and wire_api is not None:
+            block["wire_api"] = wire_api
+        if models.get(family):
+            block["models"] = {"default": models[family]}
+        body[family] = block
+    return body
+
+
+def build_litellm_provider_entry(
+    base_url: str,
+    api_key_ref: str,
+    families: list[str],
+    wire_api: str | None = None,
+    models: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Build a ``kind: litellm`` provider entry body.
+
+    Identical to :func:`build_gateway_provider_entry` but stamped
+    with ``LITELLM_KIND`` so the UI renders the 🚅 glyph.
+    """
+    if not families:
+        raise ValueError("a litellm provider must serve at least one family")
+    models = models or {}
+    body: dict[str, object] = {"kind": LITELLM_KIND}
     for family in families:
         block: dict[str, object] = {"base_url": base_url, "api_key_ref": api_key_ref}
         if family == OPENAI_FAMILY and wire_api is not None:

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -147,6 +147,7 @@ _CATALOG_PROVIDER_FAMILY: dict[str, str] = {
     "mistral": OPENAI_FAMILY,
     "together_ai": OPENAI_FAMILY,
     "fireworks_ai": OPENAI_FAMILY,
+    "litellm": OPENAI_FAMILY,
 }
 
 
@@ -237,6 +238,7 @@ _PROVIDER_DISPLAY_NAME: dict[str, str] = {
     "mistral": "Mistral",
     "together_ai": "Together AI",
     "fireworks_ai": "Fireworks AI",
+    "litellm": "LiteLLM",
     "gemini": "Google Gemini",
     "google": "Google Gemini",
     "databricks": "Databricks",
@@ -430,6 +432,11 @@ def add_menu_options() -> list[AddOption]:
             "Gateway — custom base URL + key (e.g. OpenRouter)",
             "An OpenAI/Anthropic-compatible proxy: LiteLLM, Ollama, OpenRouter, vLLM, …",
             GATEWAY_KIND,
+        ),
+        AddOption(
+            label="\N{HIGH-SPEED TRAIN} LiteLLM — proxy URL + key",
+            description="100+ providers via LiteLLM AI gateway proxy (litellm.ai).",
+            kind=GATEWAY_KIND,
         ),
         _opt(
             "OpenRouter — API key",

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -87,6 +87,7 @@ _VALID_WIRE_API = (RESPONSES_WIRE_API, CHAT_WIRE_API)
 KEY_KIND = "key"
 SUBSCRIPTION_KIND = "subscription"
 GATEWAY_KIND = "gateway"
+LITELLM_KIND = "litellm"
 LOCAL_KIND = "local"
 DATABRICKS_KIND = "databricks"
 CLI_CONFIG_KIND = "cli-config"
@@ -94,6 +95,7 @@ _VALID_KINDS = (
     KEY_KIND,
     SUBSCRIPTION_KIND,
     GATEWAY_KIND,
+    LITELLM_KIND,
     LOCAL_KIND,
     DATABRICKS_KIND,
     CLI_CONFIG_KIND,
@@ -881,7 +883,7 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
         ``frozenset({"anthropic", "openai", "pi"})`` for a Databricks
         profile.
     """
-    if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+    if entry.kind in (KEY_KIND, GATEWAY_KIND, LITELLM_KIND, LOCAL_KIND):
         return frozenset(entry.families) | {PI_SURFACE}
     if entry.kind in (SUBSCRIPTION_KIND, CLI_CONFIG_KIND):
         if entry.cli == "claude":

--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -176,6 +176,7 @@ COMMON_PROVIDERS: list[str] = [
     "gemini",
     "vertex_ai",
     "azure",
+    "litellm",
     "xai",
     "mistral",
     "groq",
@@ -570,6 +571,27 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, dict[str, Any]]] = {
             ],
         },
     },
+    "litellm": {
+        "api_key": {
+            "display_name": "API Key",
+            "description": "Use LiteLLM API Key (proxy master key or provider API key)",
+            "default": True,
+            "fields": [
+                {
+                    "name": "api_key",
+                    "description": "LiteLLM API Key",
+                    "secret": True,
+                    "required": False,
+                },
+                {
+                    "name": "base_url",
+                    "description": "LiteLLM Proxy URL (e.g. http://localhost:4000)",
+                    "secret": False,
+                    "required": False,
+                },
+            ],
+        },
+    },
     "sagemaker": {
         "access_keys": {
             "display_name": "Access Keys",
@@ -609,6 +631,7 @@ _PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "gemini": "Google Gemini",
     "vertex_ai": "Google Vertex AI",
     "azure": "Azure OpenAI",
+    "litellm": "LiteLLM",
     "groq": "Groq",
     "databricks": "Databricks",
     "xai": "xAI",
@@ -667,6 +690,7 @@ PROVIDER_ENV_VARS: dict[str, str] = {
     "cerebras": "CEREBRAS_API_KEY",
     "sambanova": "SAMBANOVA_API_KEY",
     "novita": "NOVITA_API_KEY",
+    "litellm": "LITELLM_API_KEY",
 }
 
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -30,6 +30,7 @@ from omnigent.onboarding.provider_config import (
     DATABRICKS_KIND,
     GATEWAY_KIND,
     KEY_KIND,
+    LITELLM_KIND,
     LOCAL_KIND,
     OPENAI_FAMILY,
     PI_SURFACE,
@@ -200,7 +201,7 @@ def resolve_pi_native_provider(
             return None
         if entry.kind == DATABRICKS_KIND:
             return _databricks_pi_provider(entry, model=model)
-        if entry.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+        if entry.kind in (KEY_KIND, GATEWAY_KIND, LITELLM_KIND, LOCAL_KIND):
             return _inline_family_pi_provider(entry, model=model)
         # subscription / cli-config: a CLI's own login can't be reused outside
         # that CLI — let Pi use its own login.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ antigravity = ["google-antigravity>=0.1,<1"]
 # cursor` users need this extra (`omnigent[cursor]`). Was a baseline dependency;
 # now opt-in to keep the default install lean.
 cursor = ["cursor-sdk>=0.1.7"]
+litellm = ["litellm>=1.80.0,<1.87.0"]
 databricks = [
     # Floor matches what core code was tested against when the SDK was a
     # default dependency (it moved here from `dependencies` above).
@@ -514,6 +515,10 @@ ignore_missing_imports = true
 # a base dependency, so its imports are unresolved in the default env too.
 [[tool.mypy.overrides]]
 module = "openshell.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "litellm.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -533,6 +533,7 @@ def test_add_menu_options_ordering() -> None:
         "ChatGPT — subscription",
         "Claude — subscription (Pro/Max)",
         "Gateway — custom base URL + key (e.g. OpenRouter)",
+        "LiteLLM — proxy URL + key",
         "OpenRouter — API key",
         "Databricks — workspace",
         "Other provider — API key",
@@ -545,6 +546,7 @@ def test_add_menu_options_ordering() -> None:
         "OpenAI — API key",
         "ChatGPT — subscription",
         "Gateway — custom base URL + key (e.g. OpenRouter)",
+        "LiteLLM — proxy URL + key",
         "OpenRouter — API key",
         "Databricks — workspace",
         "Other provider — API key",
@@ -558,6 +560,7 @@ def test_add_menu_options_ordering() -> None:
         "Anthropic — API key",
         "Claude — subscription (Pro/Max)",
         "Gateway — custom base URL + key (e.g. OpenRouter)",
+        "LiteLLM — proxy URL + key",
         "Databricks — workspace",
     ]
 

--- a/tests/llms/test_litellm_adapter.py
+++ b/tests/llms/test_litellm_adapter.py
@@ -1,0 +1,433 @@
+"""Tests for llms.adapters.litellm -- SDK delegation and streaming."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnigent.llms.adapters.litellm import LiteLLMAdapter
+
+# ── Unit tests (mocked litellm) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_delegates_to_acompletion() -> None:
+    adapter = LiteLLMAdapter()
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "id": "chatcmpl-abc",
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+    with patch.dict("sys.modules", {"litellm": MagicMock()}):
+        import sys
+
+        mock_litellm = sys.modules["litellm"]
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        result = await adapter.chat_completions(
+            messages=[{"role": "user", "content": "Hi"}],
+            model="gpt-4o",
+            tools=None,
+            stream=False,
+            extra={"temperature": 0.7},
+            connection_params={
+                "api_key": "sk-test",
+                "base_url": "http://localhost:4000",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["model"] == "gpt-4o"
+    assert result["choices"][0]["message"]["content"] == "Hello!"
+
+    call_kwargs = mock_litellm.acompletion.call_args[1]
+    assert call_kwargs["model"] == "gpt-4o"
+    assert call_kwargs["api_key"] == "sk-test"
+    assert call_kwargs["base_url"] == "http://localhost:4000"
+    assert call_kwargs["drop_params"] is True
+    assert call_kwargs["temperature"] == 0.7
+    assert call_kwargs["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_tools_forwarded() -> None:
+    adapter = LiteLLMAdapter()
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "id": "chatcmpl-abc",
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": ""},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    with patch.dict("sys.modules", {"litellm": MagicMock()}):
+        import sys
+
+        mock_litellm = sys.modules["litellm"]
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        await adapter.chat_completions(
+            messages=[{"role": "user", "content": "Weather?"}],
+            model="gpt-4o",
+            tools=tools,
+            stream=False,
+            extra={},
+        )
+
+    call_kwargs = mock_litellm.acompletion.call_args[1]
+    assert call_kwargs["tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_streaming_yields_chunks() -> None:
+    adapter = LiteLLMAdapter()
+
+    chunk1 = MagicMock()
+    chunk1.model_dump.return_value = {
+        "id": "chatcmpl-abc",
+        "model": "gpt-4o",
+        "choices": [
+            {"index": 0, "delta": {"content": "Hello"}, "finish_reason": None},
+        ],
+    }
+
+    chunk2 = MagicMock()
+    chunk2.model_dump.return_value = {
+        "id": "chatcmpl-abc",
+        "model": "gpt-4o",
+        "choices": [
+            {"index": 0, "delta": {"content": " world"}, "finish_reason": "stop"},
+        ],
+    }
+
+    async def mock_acompletion(**_kwargs: Any) -> Any:
+        class MockStream:
+            def __aiter__(self) -> Any:
+                return self
+
+            async def __anext__(self) -> Any:
+                if not hasattr(self, "_items"):
+                    self._items = iter([chunk1, chunk2])
+                try:
+                    return next(self._items)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+
+        return MockStream()
+
+    with patch.dict("sys.modules", {"litellm": MagicMock()}):
+        import sys
+
+        mock_litellm = sys.modules["litellm"]
+        mock_litellm.acompletion = mock_acompletion
+
+        result = await adapter.chat_completions(
+            messages=[{"role": "user", "content": "Hi"}],
+            model="gpt-4o",
+            tools=None,
+            stream=True,
+            extra={},
+        )
+
+        chunks = []
+        async for c in result:  # type: ignore[union-attr]
+            chunks.append(c)
+
+    assert len(chunks) == 2
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+    assert chunks[1]["choices"][0]["delta"]["content"] == " world"
+
+
+@pytest.mark.asyncio
+async def test_import_error_raised_when_litellm_missing() -> None:
+    adapter = LiteLLMAdapter()
+
+    with patch.dict("sys.modules", {"litellm": None}):
+        with pytest.raises(ImportError, match="litellm is required"):
+            await adapter.chat_completions(
+                messages=[{"role": "user", "content": "Hi"}],
+                model="gpt-4o",
+                tools=None,
+                stream=False,
+                extra={},
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_string",
+    [
+        "gpt-4o",
+        "anthropic/claude-sonnet-4-6",
+        "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "vertex_ai/gemini-2.5-pro",
+        "groq/llama-3.3-70b-versatile",
+        "deepseek/deepseek-chat",
+        "together_ai/meta-llama/Llama-3-8b-chat-hf",
+        "ollama/llama3",
+    ],
+)
+async def test_any_model_string_forwarded(model_string: str) -> None:
+    adapter = LiteLLMAdapter()
+
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "id": "chatcmpl-abc",
+        "model": model_string,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    with patch.dict("sys.modules", {"litellm": MagicMock()}):
+        import sys
+
+        mock_litellm = sys.modules["litellm"]
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        await adapter.chat_completions(
+            messages=[{"role": "user", "content": "Hi"}],
+            model=model_string,
+            tools=None,
+            stream=False,
+            extra={},
+        )
+
+    call_kwargs = mock_litellm.acompletion.call_args[1]
+    assert call_kwargs["model"] == model_string
+
+
+# ── Registration ─────────────────────────────────────────
+
+
+def test_get_adapter_returns_litellm_adapter() -> None:
+    from omnigent.llms.adapters import clear_cache, get_adapter
+
+    clear_cache()
+    adapter = get_adapter("litellm")
+    assert isinstance(adapter, LiteLLMAdapter)
+
+
+def test_litellm_provider_config_has_auth_mode() -> None:
+    from omnigent.onboarding.providers import get_provider_config
+
+    config = get_provider_config("litellm")
+    assert config.default_mode == "api_key"
+    fields = {f.name for f in config.auth_modes[0].fields}
+    assert "api_key" in fields
+    assert "base_url" in fields
+
+
+def test_parse_model_string_litellm_nested_provider() -> None:
+    from omnigent.llms.routing import parse_model_string
+
+    routed = parse_model_string("litellm/anthropic/claude-sonnet-4-6")
+    assert routed.provider == "litellm"
+    assert routed.model == "anthropic/claude-sonnet-4-6"
+
+
+# ── Live tests (real litellm SDK, @pytest.mark.live) ─────
+# Require: pip install litellm, ANTHROPIC_FOUNDRY_API_KEY set
+
+
+def _skip_unless_litellm_installed() -> None:
+    pytest.importorskip("litellm", reason="litellm not installed")
+
+
+def _get_live_connection_params(provider: str = "anthropic") -> dict[str, str]:
+    import os
+
+    api_key = os.environ.get("ANTHROPIC_FOUNDRY_API_KEY")
+    if not api_key:
+        pytest.skip("ANTHROPIC_FOUNDRY_API_KEY not set")
+
+    if provider == "openai":
+        base_url = "https://amanrai-test-resource.openai.azure.com/openai/v1"
+    else:
+        base_url = os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL", "")
+        if base_url and not base_url.startswith("http"):
+            base_url = f"https://{base_url}"
+    return {"api_key": api_key, "base_url": base_url}
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_tool_calling() -> None:
+    """Tool/function calling produces a valid tool_calls response."""
+    _skip_unless_litellm_installed()
+    import json
+
+    params = _get_live_connection_params()
+    adapter = LiteLLMAdapter()
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather in a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {
+                            "type": "string",
+                            "description": "City name",
+                        },
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                        },
+                    },
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    result = await adapter.chat_completions(
+        messages=[{"role": "user", "content": "What is the weather in Tokyo?"}],
+        model="anthropic/claude-sonnet-4-6",
+        tools=tools,
+        stream=False,
+        extra={"max_tokens": 200},
+        connection_params=params,
+    )
+
+    choice = result["choices"][0]
+    assert choice["finish_reason"] in ("tool_calls", "stop")
+    if choice["finish_reason"] == "tool_calls":
+        tc = choice["message"]["tool_calls"][0]
+        assert tc["function"]["name"] == "get_weather"
+        args = json.loads(tc["function"]["arguments"])
+        assert "city" in args
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_streaming() -> None:
+    """Streaming produces multiple chunks with substantive content."""
+    _skip_unless_litellm_installed()
+    params = _get_live_connection_params()
+    adapter = LiteLLMAdapter()
+
+    result = await adapter.chat_completions(
+        messages=[
+            {
+                "role": "user",
+                "content": "Explain what an API gateway is in exactly 2 sentences.",
+            },
+        ],
+        model="anthropic/claude-sonnet-4-6",
+        tools=None,
+        stream=True,
+        extra={"max_tokens": 200},
+        connection_params=params,
+    )
+
+    chunks = []
+    full_content = ""
+    async for chunk in result:  # type: ignore[union-attr]
+        chunks.append(chunk)
+        delta = chunk.get("choices", [{}])[0].get("delta", {}).get("content")
+        if delta:
+            full_content += delta
+
+    assert len(chunks) >= 3
+    assert len(full_content) > 50
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_full_routing_pipeline() -> None:
+    """E2E: parse_model_string -> get_adapter -> chat_completions -> Response."""
+    _skip_unless_litellm_installed()
+    params = _get_live_connection_params()
+
+    from omnigent.llms._responses_to_chat import chat_response_to_response
+    from omnigent.llms.adapters import clear_cache, get_adapter
+    from omnigent.llms.routing import parse_model_string
+
+    clear_cache()
+    routed = parse_model_string("litellm/anthropic/claude-sonnet-4-6")
+    adapter = get_adapter(routed.provider)
+    assert isinstance(adapter, LiteLLMAdapter)
+
+    result = await adapter.chat_completions(
+        messages=[{"role": "user", "content": "Respond with exactly: LITELLM_OK"}],
+        model=routed.model,
+        tools=None,
+        stream=False,
+        extra={"max_tokens": 20},
+        connection_params=params,
+    )
+
+    response = chat_response_to_response(result)
+    assert response.output
+    assert response.model
+    assert response.output[0].content[0].text
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model,provider_key",
+    [
+        ("anthropic/claude-sonnet-4-6", "anthropic"),
+        ("openai/gpt-4o-mini", "openai"),
+        ("openai/gpt-4o", "openai"),
+        ("openai/gpt-4.1-mini", "openai"),
+    ],
+)
+async def test_live_any_model_string(model: str, provider_key: str) -> None:
+    """Same adapter handles arbitrary model strings across providers."""
+    _skip_unless_litellm_installed()
+    params = _get_live_connection_params(provider=provider_key)
+    adapter = LiteLLMAdapter()
+
+    result = await adapter.chat_completions(
+        messages=[{"role": "user", "content": "Say OK and nothing else."}],
+        model=model,
+        tools=None,
+        stream=False,
+        extra={"max_tokens": 10},
+        connection_params=params,
+    )
+
+    assert isinstance(result, dict)
+    assert result["choices"][0]["message"]["content"]

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,47 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1295,6 +1336,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
 [[package]]
@@ -1606,6 +1656,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1712,6 +1794,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1740,14 +1842,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -2100,6 +2202,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
     { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
     { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.86.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/b0/f9d77f086fd2eec69ff1b80083003134994d11e540206cd3a18ef29affbd/litellm-1.86.5.tar.gz", hash = "sha256:caadbedb3e894f5b5d940ca14bbc228f6d42d67876ac38252a52347acaddaaaa", size = 15385926, upload-time = "2026-06-11T02:50:22.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/03/baa73376a73146dc627a8d767f4542983782e6a22d3d2c4a1bf24e8e26ba/litellm-1.86.5-py3-none-any.whl", hash = "sha256:6842c1d10c561e7312dc5a6324d13efaebf53c82641c6530e0d969d3090bdc4d", size = 17020244, upload-time = "2026-06-11T02:50:16.335Z" },
 ]
 
 [[package]]
@@ -2791,6 +2916,9 @@ dev = [
 e2b = [
     { name = "e2b" },
 ]
+litellm = [
+    { name = "litellm" },
+]
 modal = [
     { name = "modal" },
 ]
@@ -2836,6 +2964,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0,<3" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "keyring", specifier = ">=24,<26" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80.0,<1.87.0" },
     { name = "mcp", specifier = ">=1.0,<2" },
     { name = "mlflow", marker = "extra == 'databricks'", specifier = ">=3,<4" },
     { name = "mlflow", marker = "extra == 'dev'", specifier = ">=3,<4" },
@@ -2885,7 +3014,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "cwsandbox", "e2b", "openshell", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "cwsandbox", "e2b", "openshell", "tracing", "agents-sdk", "antigravity", "cursor", "litellm", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"
@@ -4552,6 +4681,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4780,6 +4918,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4807,6 +4972,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/b3/36c8ecf72e8925200671613332db156d84b99b3aee742a41c1938ebb0808/tqdm-4.68.1.tar.gz", hash = "sha256:fc163d96b287bd031e1aa24421ce4411b25559bd0a1be4fe649bdaa4d2c02bf5", size = 171236, upload-time = "2026-06-05T17:23:15.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/aa/218a0eb34de1f753c83e4d0d1c8e7c4cef27f20dcb8342e024f63a80dc86/tqdm-4.68.1-py3-none-any.whl", hash = "sha256:fea4a90e4023f764914569f7802a297277c5ab1a66be5144143e142e1a4031d8", size = 78354, upload-time = "2026-06-05T17:23:13.654Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

Closes #875

## Summary

- Add [LiteLLM](https://github.com/BerriAI/litellm) as a first-class LLM provider, giving users access to 100+ LLM providers via a single adapter and a dedicated entry in `omnigent setup`
- Backend: new `LiteLLMAdapter` in `omnigent/llms/adapters/litellm.py` using `litellm.acompletion()` with `drop_params=True` for agent YAML specs (`model: litellm/<model>`)
- Frontend: dedicated `LITELLM_KIND` with 🚅 emoji in setup UI, auto-discovers models from the proxy's `/v1/models` endpoint and filters by harness family (Claude sees anthropic models, Codex sees GPT models)
- Optional dependency (`omnigent[litellm]`, pinned `>=1.80.0,<1.87.0`)

```
                    omnigent routing
                          │
            ┌─────────────┼─────────────┐
            │             │             │
       OpenAI        Anthropic      LiteLLM (new)
       Adapter        Adapter        Adapter
            │             │             │
            ▼             ▼             ▼
       OpenAI API   Anthropic    litellm.acompletion()
                      API               │
                               ┌────────┼────────┐
                               ▼        ▼        ▼
                            OpenAI  Anthropic  100+ more
                            Bedrock  Vertex    providers
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Commands run:

```bash
python -m ruff check omnigent/llms/adapters/litellm.py tests/llms/test_litellm_adapter.py
# All checks passed.

python -m py_compile omnigent/llms/adapters/litellm.py
python -m py_compile tests/llms/test_litellm_adapter.py
# No syntax errors.
```

Live integration tests run manually against Azure Foundry (4 models, 2 providers):

```
OK  anthropic/claude-sonnet-4-6  -> claude-sonnet-4-6
OK  openai/gpt-4o-mini          -> gpt-4o-mini-2024-07-18
OK  openai/gpt-4o               -> gpt-4o-2024-11-20
OK  openai/gpt-4.1-mini         -> gpt-4.1-mini-2025-04-14
```

Unit tests (`tests/llms/test_litellm_adapter.py`) cover delegation kwargs, tool forwarding, streaming chunks, `ImportError` path, 8 arbitrary model strings forwarded as-is, adapter registry, auth config, and nested routing.

Integration tests (`@pytest.mark.live`) cover tool calling, streaming, full routing pipeline, and multi-model multi-provider verification.

Manual verification: started LiteLLM proxy with 4 models (Claude + GPT), configured via `omnigent setup` -> 🚅 LiteLLM entry, confirmed models visible in harness model picker, chatted through proxy successfully.

E2E scenario exercised: started omnigent server with an agent YAML wired to a LiteLLM proxy (4 models), created a session via HTTP API, sent a message, polled until completion, verified the assistant response came back through the full server -> harness -> LiteLLM proxy -> provider chain:

```
1. Starting server on port 61520...
2. Server started
3. Session: conv_6e3f49bbd11f43e1b4593766720c5b5a
4. Message sent
5. Status: idle
6. Output: 'OK'
E2E TEST PASSED
```

## E2E video demo


https://github.com/user-attachments/assets/cfcd9700-973e-471d-9ee2-2028ae99ae81





