### PR TITLE
test: fix mock /chat/completions tool_calls; un-quarantine yaml_agent_with_tools[pi] (#807)

### DIFF
--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -33,4 +33,3 @@ skips:
     issue: 523
     cluster: mock-claude-sdk-cli-unsupported
     mode: skip
-

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -34,8 +34,3 @@ skips:
     cluster: mock-claude-sdk-cli-unsupported
     mode: skip
 
-  - id: tests/e2e/omnigent/test_yaml_hello_world.py::test_yaml_agent_with_tools[pi]
-    reason: "pi harness does not complete the headless `-p` tool round-trip: it makes only ONE LLM request (receives the forced calculate tool_call) then exits 0 with empty stdout — the tool is never dispatched and no follow-up call is made. Distinct from #677 (stale stdout-marker expectation, fixed for the claude-sdk/codex/openai-agents rows). See #807 for the full diagnosis."
-    issue: 807
-    cluster: pi-headless-tool-roundtrip
-    mode: skip

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -790,6 +790,29 @@ async def create_chat_completion(
         await qr._gate.wait()
 
     text = qr.text if not qr.tool_calls else ""
+    # Render queued tool_calls in Chat Completions format (harnesses on the
+    # openai-completions wire — e.g. pi's gateway models.json — POST here, not
+    # /v1/responses). Without this, a tool_call response collapsed to empty
+    # content and the tool round-trip silently produced nothing.
+    cc_tool_calls = (
+        [
+            {
+                "id": tc.get("call_id", "call-mock"),
+                "type": "function",
+                "function": {
+                    "name": tc.get("name", ""),
+                    "arguments": tc.get("arguments", "{}"),
+                },
+            }
+            for tc in qr.tool_calls
+        ]
+        if qr.tool_calls
+        else None
+    )
+    finish_reason = "tool_calls" if cc_tool_calls else "stop"
+    cc_message: dict[str, object] = {"role": "assistant", "content": text or None}
+    if cc_tool_calls:
+        cc_message["tool_calls"] = cc_tool_calls
     resp_id = _response_id()
     body_json = {
         "id": f"chatcmpl-{resp_id}",
@@ -798,8 +821,8 @@ async def create_chat_completion(
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "assistant", "content": text},
-                "finish_reason": "stop",
+                "message": cc_message,
+                "finish_reason": finish_reason,
             }
         ],
         "usage": {
@@ -809,6 +832,9 @@ async def create_chat_completion(
         },
     }
     if parsed.get("stream"):
+        delta: dict[str, object] = {"role": "assistant", "content": text or None}
+        if cc_tool_calls:
+            delta["tool_calls"] = [{"index": i, **tc} for i, tc in enumerate(cc_tool_calls)]
         chunk = {
             "id": f"chatcmpl-{resp_id}",
             "object": "chat.completion.chunk",
@@ -816,8 +842,8 @@ async def create_chat_completion(
             "choices": [
                 {
                     "index": 0,
-                    "delta": {"role": "assistant", "content": text},
-                    "finish_reason": "stop",
+                    "delta": delta,
+                    "finish_reason": finish_reason,
                 }
             ],
         }


### PR DESCRIPTION
## Summary

Fixes #807 and un-quarantines `test_yaml_agent_with_tools[pi]`. The fix is in test infra (the mock LLM server), not the product — pi was behaving correctly.

## Root cause (traced)

The pi harness in gateway mode drives the LLM over the **openai-completions** wire, so it POSTs to the mock's `/v1/chat/completions`. But that endpoint **dropped `tool_calls` entirely**:

```python
text = qr.text if not qr.tool_calls else ""   # tool_call → "" content, NO tool_calls field
```

So pi received an empty assistant message, never dispatched the forced `calculate` tool, and the headless `-p` run produced empty stdout → the test's `TOOL_ROUNDTRIP_OK_7` sentinel never appeared. The other harnesses pass because they use `/v1/responses` (which *does* render tool_calls); pi is the only row on the chat-completions wire.

I confirmed end-to-end (via `PiExecutor` RPC tracing + mock instrumentation) that everything else was correct: the pi RPC turn ran, the model routed correctly (`model='mock-calc-pi'` matched the keyed queue), and the tool bridge registered — the mock just never implemented `tool_calls` for `/chat/completions`.

## Fix

Render queued `tool_calls` in Chat Completions format (`choices[].message.tool_calls` + `finish_reason="tool_calls"`) in both the non-streaming and streaming branches of the mock's `/v1/chat/completions` handler. Text-only responses are unchanged.

## Verification

- `test_yaml_agent_with_tools` passes for **all four harnesses (4/4)**, pi included — the mock change doesn't affect the `/v1/responses` harnesses.
- `[pi]` un-quarantined; passes by default.
- 30× CI flake-stress to follow (link in a comment).

This pull request and its description were written by Isaac.
