### PR TITLE
test: fix claude-sdk no-agent harness against the mock; un-quarantine (#523)

### DIFF
--- a/tests/e2e/omnigent/_pexpect_harness.py
+++ b/tests/e2e/omnigent/_pexpect_harness.py
@@ -25,6 +25,7 @@ shared infrastructure.
 from __future__ import annotations
 
 import atexit
+import contextlib
 import re
 import shutil
 from collections.abc import Mapping
@@ -385,21 +386,28 @@ def clean_exit(child: pexpect.spawn, *, timeout: float) -> None:
         ``app.exit()`` — all of which can take a few seconds on
         shutdown.
     """
-    child.sendcontrol("d")
     try:
-        child.expect(pexpect.EOF, timeout=timeout)
-    except pexpect.TIMEOUT:
-        # Clear any half-rendered prompt contents before submitting
-        # the explicit exit command. If the Ctrl+D timeout happened
-        # after the process actually exited, the expect below will see
-        # EOF immediately.
-        child.send("\x15")
-        submit_prompt(child, "/quit")
+        child.sendcontrol("d")
         try:
             child.expect(pexpect.EOF, timeout=timeout)
         except pexpect.TIMEOUT:
-            # Both graceful gestures stalled. The functional assertions
-            # are already done; don't let a slow teardown fail the run.
+            # Clear any half-rendered prompt contents before submitting
+            # the explicit exit command. If the Ctrl+D timeout happened
+            # after the process actually exited, the expect below will see
+            # EOF immediately.
+            child.send("\x15")
+            submit_prompt(child, "/quit")
+            try:
+                child.expect(pexpect.EOF, timeout=timeout)
+            except pexpect.TIMEOUT:
+                # Both graceful gestures stalled. The functional assertions
+                # are already done; don't let a slow teardown fail the run.
+                child.close(force=True)
+                return
+        child.close()
+    except OSError:
+        # Child already exited (closed PTY → [Errno 5] on the exit gesture);
+        # a headless one-shot like ``claude -p`` self-terminates after
+        # replying. Assertions ran before teardown, so treat as a clean exit.
+        with contextlib.suppress(Exception):
             child.close(force=True)
-            return
-    child.close()

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -75,18 +75,31 @@ def test_run_harness_without_agent_live_repl_round_trip(
     marker = f"{probe.marker}_RUN_HARNESS_WITHOUT_AGENT"
     prompt = _PROMPT_TEMPLATE.format(marker=marker)
 
+    # claude-code issues a warmup/title call before the turn that consumes one
+    # queued response, so the turn call needs another; queue a few markers.
+    responses = [{"text": marker}] * (4 if probe.harness == "claude-sdk" else 1)
     configure_mock_llm(
         mock_llm_server_url,
-        [{"text": marker}],
+        responses,
         key=model,
     )
+
+    # claude-sdk speaks the Anthropic wire, not OPENAI_*. Point it at the mock
+    # and pass a static gateway token via ANTHROPIC_AUTH_TOKEN (Authorization:
+    # Bearer) -- the docs-sanctioned custom-gateway auth. ANTHROPIC_API_KEY
+    # (x-api-key) would trigger claude-code's external-key validation, which
+    # the mock cannot satisfy ("Invalid API key").
+    env = dict(mock_credentials_env)
+    if probe.harness == "claude-sdk":
+        env["ANTHROPIC_BASE_URL"] = mock_llm_server_url
+        env["ANTHROPIC_AUTH_TOKEN"] = "mock-key"
 
     child = spawn_omnigent_run(
         omnigent_python=omnigent_python,
         yaml_path=None,
         model=model,
         harness=probe.harness,
-        env=mock_credentials_env,
+        env=env,
         cwd=omnigent_repo_root,
         timeout=_SPAWN_TIMEOUT,
         initial_prompt=prompt,

--- a/tests/known_failures.yaml
+++ b/tests/known_failures.yaml
@@ -26,10 +26,4 @@
 #
 # Note: entries here apply to every pytest invocation. If you
 # want to debug a skipped test locally, comment out its block.
-skips:
-
-  - id: tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_without_agent_live_repl_round_trip[claude-sdk]
-    reason: "Hangs >180s in CI -> xdist worker crash even on the mock LLM (#796 migration): the claude-sdk native claude-code CLI calls auth/metadata endpoints the mock server does not serve, so its headless -p turn never completes. Distinct from the stale-glyph fix that greened the openai-agents/codex rows; claude-sdk is mock-incompatible and should be excluded from the mock matrix (or the mock taught to serve the claude-code endpoints). Not the old live-gateway hang (that was removed by the mock migration)."
-    issue: 523
-    cluster: mock-claude-sdk-cli-unsupported
-    mode: skip
+skips: []


### PR DESCRIPTION
## Summary

Fixes and **un-quarantines** the last quarantined test, `harness_without_agent_live_repl_round_trip[claude-sdk]` — using the official Claude Code gateway docs.

### Root cause

The test gave claude-code no Anthropic credential, so in CI's fresh env it printed **"Not logged in · Please run /login"** and exited. Setting a raw `ANTHROPIC_API_KEY` only changed the failure to **"Invalid API key"** — claude-code's external-key validation (`x-api-key`) can't be satisfied by the mock. Per the [LLM gateway docs](https://code.claude.com/docs/en/llm-gateway), the custom-gateway method is **`ANTHROPIC_AUTH_TOKEN`** (`Authorization: Bearer`), which claude-code uses *without* external-key validation. With `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` pointed at the mock, claude-code authenticates and reaches it. claude-code also issues a warmup call before the turn that consumes one queued response, so the queue needs a couple of markers.

### Changes

- **test**: for claude-sdk, set `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` (mock) and queue the marker a few times.
- **`clean_exit`**: tolerate a self-exited child — claude's headless one-shot closes its PTY before `Ctrl+D`, raising `OSError [Errno 5]` in teardown *after* assertions passed. Wrapped the exit gestures (no change for harnesses that exit normally; verified `inline_tool_streaming` still passes).
- **`known_failures.yaml`**: removed the claude-sdk entry (now passes).

### Verification

- Passes locally (claude-code 2.1.179; routes to the mock via `ANTHROPIC_AUTH_TOKEN`, not the dev's subscription login).
- 30× CI flake-stress (link in a comment) — the real test, since CI is unauthenticated.

Follow-up PR will delete the now-empty `known_failures.yaml`.

This pull request and its description were written by Isaac.
