### PR TITLE
feat(harness): add Hermes Agent harness

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -49,7 +49,7 @@ resolved from the YAML file's directory.
 
 ```yaml
 executor:
-  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, pi, antigravity, ...
+  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, pi, antigravity, hermes, ...
   model: databricks-claude-opus-4-7
   auth:
     type: databricks
@@ -93,6 +93,35 @@ CLI flags such as `--harness` and `--model` can override or supply missing
 executor values for a run. Databricks credentials come from the spec's
 `executor.auth` block or your `omnigent setup` provider config — there is
 no profile flag.
+
+### Hermes (Hermes Agent)
+
+`harness: hermes` runs the agent through the
+[Hermes Agent CLI](https://hermes-agent.nousresearch.com/),
+a self-improving open-source AI agent by Nous Research.
+Hermes manages its own session state, tool execution, provider-agnostic
+model routing, skills, and persistent memory.  Omnigent provides the
+web UI, collaboration, sandboxing, and policy layer.
+
+The ``hermes`` binary must be on PATH (or set via
+``HARNESS_HERMES_PATH``).  Install with:
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh
+```
+
+```yaml
+executor:
+  harness: hermes
+  # Model is optional — Hermes uses its own configured default model
+  # from ~/.hermes/config.yaml if omitted:
+  # model: anthropic/claude-sonnet-4
+```
+
+Each turn runs ``hermes chat -q`` as a subprocess.  On the first turn the
+harness captures the Hermes session ID; subsequent turns use
+``--resume <session_id>`` so conversational context is maintained
+through Hermes' own SQLite session store.
 
 ## Local OS access
 

--- a/examples/hermes/config.yaml
+++ b/examples/hermes/config.yaml
@@ -1,0 +1,70 @@
+# Hermes Agent — a self-improving AI agent framework by Nous Research.
+#
+# Runs the ``hermes`` CLI as the agent harness.  Hermes manages its own
+# session persistence, tool execution, memory, skills, and provider-
+# agnostic model routing internally.
+#
+# Usage:
+#   omnigent run examples/hermes/
+#
+# Prerequisites:
+#   Hermes must be installed: curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh
+#
+# The ``hermes`` harness wraps the CLI as a subprocess per turn, using
+# ``--resume <session_id>`` for conversational continuity.  All Hermes
+# capabilities (skills, memory, cron, multi-platform gateway, etc.)
+# work through the native Hermes session — Omnigent provides the web
+# UI, collaboration, sandboxing, and policy layer on top.
+
+spec_version: 1
+name: hermes
+description: >-
+  Hermes Agent — the self-improving AI agent. Uses the Hermes Agent
+  CLI as the runtime, with Hornes' own model config, skills, and
+  tools. Omnigent provides the web UI, collaboration, and governance
+  layer.
+
+executor:
+  type: omnigent
+  config:
+    harness: hermes
+  # Model is optional — Hermes uses its own configured default model
+  # from ~/.hermes/config.yaml.  Uncomment to override:
+  # model: anthropic/claude-sonnet-4
+
+prompt: |-
+  You are Hermes Agent, a self-improving AI agent built by Nous Research.
+  You have persistent memory, reusable skills, tool-calling capabilities,
+  and multi-platform messaging.
+  
+  You are running inside an Omnigent session.  Omnigent provides the web
+  UI, collaboration features, sandboxing, and policy governance.  All your
+  native Hermes capabilities (skills, memory, tools) are available through
+  your normal CLI session.
+
+# Hermes manages its own tools internally — tool schemas declared here
+# are for Omnigent-level governance, not Hermes' own tool execution.
+# Tools are optional; Hermes uses its configured toolsets by default.
+tools:
+  agents: []
+
+# Hermes runs unsandboxed by default (it manages its own tool execution
+# in the caller's environment).  Sandboxing is available via the
+# standard Omnigent `os_env.sandbox` configuration.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Standard Omnigent guardrails for safety.  The catastrophic deny set
+# (force-push, rm -rf /, etc.) applies automatically.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -1,0 +1,405 @@
+"""
+HermesExecutor: run agent turns through the Hermes Agent CLI.
+
+Spawns ``hermes chat -q`` as a subprocess for each turn.  Hermes manages its
+own session state via a persistent session store (SQLite under
+``~/.hermes/``), so the executor uses ``--resume <session_id>`` on subsequent
+turns to maintain conversational context across the Omnigent session without
+re-serialising the full history.
+
+Each turn yields text output as ``TextChunk`` / ``TurnComplete`` events.
+Tool-call bridging (Omnigent tools → Hermes tool execution) is
+future work — the initial harness runs Hermes in its default tool-enabled
+configuration.
+
+Requirements:
+    The ``hermes`` CLI must be installed and on PATH (or set via
+    ``HARNESS_HERMES_PATH``).
+
+Env vars read at construction:
+
+- ``HARNESS_HERMES_MODEL`` — model identifier, e.g. ``"deepseek/deepseek-chat"``
+  or ``"anthropic/claude-sonnet-4"``.  ``None`` falls back to Hermes' own
+  configured default model.
+- ``HARNESS_HERMES_CWD`` — working directory the subprocess runs in.
+  ``None`` falls back to ``os.getcwd()``.
+- ``HARNESS_HERMES_PATH`` — absolute path to the ``hermes`` CLI binary.
+  ``None`` searches ``PATH``.
+- ``HARNESS_HERMES_OS_ENV`` — JSON-encoded :class:`OSEnvSpec`.  When unset,
+  defaults to ``caller_process + sandbox=none``.
+- ``HARNESS_HERMES_SKILLS_FILTER`` — JSON-encoded ``str | list[str]``
+  carrying the agent spec's ``skills_filter``.  When unset, falls back to
+  ``"all"``.
+- ``HARNESS_HERMES_BUNDLE_DIR`` — absolute path to the agent bundle's
+  extracted root.  Unset for agents without a bundled-skills directory.
+- ``HARNESS_HERMES_AGENT_NAME`` — agent display name (reserved for future use).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+from collections.abc import AsyncIterator
+from typing import Any
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    TextChunk,
+    ToolSpec,
+    TurnComplete,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Maximum seconds to wait for a Hermes subprocess to complete a single turn.
+# Complex tasks (multi-tool-calling loops) may take several minutes.
+_HERMES_TURN_TIMEOUT_S = 600.0
+
+# Regex to extract the session_id from Hermes' quiet-mode output line.
+# Matches lines like ``session_id: 20260620_142506_c51451``.
+_RE_SESSION_ID = re.compile(r"^session_id:\s+(\S+)")
+
+# Regex to detect the resume notice line emitted by ``--resume``.
+# Matches lines like ``↻ Resumed session 20260620_142506_c51451 ...``.
+_RE_RESUME_NOTICE = re.compile(r"^↻\s+Resumed\s+session\s+\S+")
+
+# Regex to detect the "continue" notice line.
+# Matches lines like ``↻ Resumed session NAME ...``.
+_RE_CONTINUE_NOTICE = re.compile(r"^↻\s+Resumed\s+session")
+
+# Prefix for Hermes warning messages that should be stripped from output.
+_WARNING_PREFIX = "Warning:"
+
+
+def _strip_hermes_metadata(output: str) -> str:
+    r"""
+    Strip Hermes metadata lines from subprocess stdout, leaving only
+    the agent's response text.
+
+    Hermes' quiet mode (``-Q``) emits a small number of info lines
+    alongside the actual response:
+
+    - ``session_id: <id>``
+    - ``↻ Resumed session <id> ...``
+    - ``Warning: ...``
+
+    :param output: Raw stdout from ``hermes chat -q``.
+    :returns: The agent's response text with metadata lines removed.
+    """
+    lines = output.split("\n")
+    filtered: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _RE_SESSION_ID.match(stripped):
+            continue
+        if _RE_RESUME_NOTICE.match(stripped):
+            continue
+        if _RE_CONTINUE_NOTICE.match(stripped):
+            continue
+        if stripped.startswith(_WARNING_PREFIX):
+            continue
+        filtered.append(line)
+    return "\n".join(filtered).strip()
+
+
+def _parse_session_id(output: str) -> str | None:
+    """
+    Extract the Hermes session ID from a subprocess response.
+
+    :param output: Raw stdout from ``hermes chat -q``.
+    :returns: The session ID string, or ``None`` if no session_id
+        line was found.
+    """
+    for line in output.split("\n"):
+        match = _RE_SESSION_ID.match(line.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def _extract_last_user_message(messages: list[Message]) -> str:
+    """
+    Extract the text of the most recent user message from the
+    Omnigent message list.
+
+    :param messages: The conversation message list passed to
+        ``run_turn``.
+    :returns: The user message text, or ``""`` if none found.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                parts: list[str] = []
+                for block in content:
+                    if isinstance(block, dict):
+                        text = block.get("text")
+                        if isinstance(text, str):
+                            parts.append(text)
+                if parts:
+                    return "\n".join(parts)
+            elif isinstance(content, str):
+                return content
+    return ""
+
+
+def _build_hermes_args(
+    hermes_path: str,
+    message: str,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
+    cwd: str | None = None,
+) -> list[str]:
+    """
+    Build the argument list for a Hermes subprocess call.
+
+    :param hermes_path: Path to the Hermes CLI binary.
+    :param message: The user message text.
+    :param model: Optional model override (``-m`` flag).
+    :param session_id: Optional session ID to resume (``--resume``).
+    :param cwd: Not used in arg building (passed to subprocess as cwd).
+    :returns: A list of CLI arguments.
+    """
+    args = [
+        hermes_path,
+        "chat",
+        "-q",
+        message,
+        "-Q",  # quiet mode: suppress banner, spinner, tool previews
+        "--source",
+        "tool",  # tag sessions as tool/integration-originated
+    ]
+    if model:
+        args.extend(["-m", model])
+    if session_id:
+        args.extend(["--resume", session_id])
+    return args
+
+
+class HermesExecutor(Executor):
+    """
+    Executor that drives the Hermes Agent CLI as a subprocess.
+
+    Hermes manages its own session persistence (SQLite).  The executor
+    captures the ``session_id`` from the first turn and passes
+    ``--resume <session_id>`` on subsequent turns so conversational
+    history is maintained without Omnigent re-serializing the full
+    message list.
+
+    Each turn runs ``hermes chat -q "<message>" -Q --source tool`` as an
+    ``asyncio.create_subprocess_exec`` subprocess, streams text output,
+    and yields ``TextChunk`` / ``TurnComplete`` events.
+    """
+
+    def __init__(
+        self,
+        hermes_path: str | None = None,
+        cwd: str | None = None,
+        model: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        skills_filter: str | list[str] | None = None,
+        bundle_dir: str | None = None,
+        agent_name: str | None = None,
+    ) -> None:
+        """
+        :param hermes_path: Path to the ``hermes`` CLI binary.
+            ``None`` searches ``PATH``.
+        :param cwd: Working directory for the subprocess.
+            ``None`` uses ``os.getcwd()``.
+        :param model: Model identifier override.
+            ``None`` uses Hermes' configured default.
+        :param os_env: OS environment spec for the subprocess.
+            ``None`` defaults to ``caller_process + sandbox=none``.
+        :param skills_filter: Skills filter forwarded to Hermes.
+            ``None`` means "no filter" (Hermes' default).
+        :param bundle_dir: Agent bundle directory (reserved).
+        :param agent_name: Agent display name (reserved).
+        """
+        self._hermes_path = hermes_path or shutil.which("hermes") or "hermes"
+        self._cwd = cwd or os.getcwd()
+        self._model = model
+        self._os_env = os_env or OSEnvSpec(
+            type="caller_process",
+            sandbox=OSEnvSandboxSpec(type="none"),
+        )
+        self._skills_filter = skills_filter
+        self._bundle_dir = bundle_dir
+        self._agent_name = agent_name
+        # Per-session state: maps session_key -> hermes_session_id
+        self._session_map: dict[str, str] = {}
+
+    def _hermes_session_id(self, session_key: str) -> str | None:
+        """Return the stored Hermes session ID for an Omnigent session key."""
+        return self._session_map.get(session_key)
+
+    def supports_streaming(self) -> bool:
+        """Return True — Hermes streams text output."""
+        return True
+
+    def handles_tools_internally(self) -> bool:
+        """Return True — Hermes executes tools inside its own agent loop.
+
+        The Hermes Agent CLI manages its own tool-calling loop internally.
+        Tool-call requests/results are handled by Hermes, not bridged
+        through Omnigent's tool dispatch.  This means Omnigent-level
+        tool policies do not apply to tools Hermes calls internally.
+        """
+        return True
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        """
+        Run one agent turn by spawning ``hermes chat -q``.
+
+        :param messages: Conversation history from Omnigent.
+        :param tools: Tool schemas (Hermes uses its own tools internally).
+        :param system_prompt: System prompt (used by Hermes internally).
+        :param config: Per-turn config (model override, etc.).
+        :yields: ``TextChunk`` and ``TurnComplete`` events.
+        :yields: ``ExecutorError`` on subprocess failure or timeout.
+        """
+        _logger.debug(
+            "HermesExecutor.run_turn: %d messages, tools=%d, prompt_len=%d",
+            len(messages),
+            len(tools),
+            len(system_prompt),
+        )
+
+        # Extract the latest user message
+        user_text = _extract_last_user_message(messages)
+        if not user_text:
+            # Nothing to respond to — short-circuit
+            yield TurnComplete(response=None)
+            return
+
+        # Resolve model from config override, then instance default
+        model = (config.model if config else None) or self._model
+
+        # Determine session key for this conversation
+        session_key = self._session_key(messages)
+        hermes_sid = self._hermes_session_id(session_key)
+
+        # Build the command-line arguments
+        args = _build_hermes_args(
+            hermes_path=self._hermes_path,
+            message=user_text,
+            model=model,
+            session_id=hermes_sid,
+        )
+
+        _logger.debug("Hermes subprocess: %s", " ".join(args))
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._cwd,
+            )
+
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=_HERMES_TURN_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            _logger.warning("Hermes subprocess timed out after %ss", _HERMES_TURN_TIMEOUT_S)
+            yield ExecutorError(
+                message=f"Hermes subprocess timed out after {_HERMES_TURN_TIMEOUT_S}s",
+                retryable=True,
+            )
+            return
+        except FileNotFoundError:
+            yield ExecutorError(
+                message=(
+                    f"Hermes CLI not found at '{self._hermes_path}'. "
+                    "Install Hermes Agent (curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh)"
+                ),
+                retryable=False,
+            )
+            return
+        except OSError as exc:
+            yield ExecutorError(
+                message=f"Failed to spawn Hermes subprocess: {exc}",
+                retryable=True,
+            )
+            return
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            error_msg = stderr.strip() or stdout.strip()
+            _logger.warning(
+                "Hermes exited with code %d: %s",
+                proc.returncode,
+                error_msg[:500],
+            )
+            yield ExecutorError(
+                message=f"Hermes exited with code {proc.returncode}: {error_msg[:500]}",
+                retryable=True,
+            )
+            return
+
+        # Store the session_id for subsequent turns
+        parsed_sid = _parse_session_id(stdout)
+        if parsed_sid and not hermes_sid:
+            _logger.debug("Captured Hermes session_id: %s", parsed_sid)
+            self._session_map[session_key] = parsed_sid
+
+        # Strip metadata lines to get the clean response
+        response_text = _strip_hermes_metadata(stdout)
+
+        if response_text:
+            yield TextChunk(text=response_text)
+
+        yield TurnComplete(response=response_text or None)
+
+    def _session_key(self, messages: list[Message]) -> str:
+        """
+        Derive a stable Omnigent session key from the message list.
+
+        Uses the ``session_id`` stamped on the first message if available,
+        otherwise falls back to a hash of the conversation content.
+        """
+        for msg in messages:
+            sid = msg.get("session_id")
+            if isinstance(sid, str) and sid:
+                return sid
+        # Fallback: hash the serialised messages for a stable key
+        return str(hash(tuple(
+            (m.get("role", ""), str(m.get("content", ""))[:200])
+            for m in messages
+        )))
+
+    async def close_session(self, session_key: str) -> None:
+        """
+        Release resources for a specific session.
+
+        Removes the Hermes session mapping — the Hermes session
+        persists in its own SQLite store and can be resumed later
+        via `hermes --resume` outside Omnigent.
+        """
+        self._session_map.pop(session_key, None)
+        await super().close_session(session_key)
+
+    async def close(self) -> None:
+        """Release executor-wide resources."""
+        self._session_map.clear()
+        await super().close()

--- a/omnigent/inner/hermes_harness.py
+++ b/omnigent/inner/hermes_harness.py
@@ -1,0 +1,198 @@
+"""
+``harness: hermes`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the
+shared :mod:`omnigent.runtime.harnesses._runner` invokes after
+the parent process resolves ``"hermes"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Internally, instantiates :class:`omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`
+around a :class:`omnigent.inner.hermes_executor.HermesExecutor`
+configured from env vars the parent process sets before spawning.
+
+Mirrors the pi harness wrap (``pi_harness.py``); see that module's
+docstring for the v1 config-flow rationale (env vars vs per-request).
+
+Env vars read at startup:
+
+- ``HARNESS_HERMES_MODEL``: model identifier, e.g.
+  ``"deepseek/deepseek-chat"`` or ``"anthropic/claude-sonnet-4"``.
+  ``None`` falls back to Hermes' own configured default.
+- ``HARNESS_HERMES_CWD``: working directory the subprocess runs in.
+  ``None`` falls back to ``os.getcwd()``.
+- ``HARNESS_HERMES_PATH``: absolute path to the ``hermes`` CLI binary.
+  ``None`` searches ``PATH``.
+- ``HARNESS_HERMES_OS_ENV``: JSON-encoded :class:`OSEnvSpec`
+  (from :func:`dataclasses.asdict`). When unset, the wrap
+  falls back to a default
+  ``OSEnvSpec(type="caller_process", sandbox=type="none")`` so
+  Omnigent mode parity with the legacy non-AP path holds for
+  specs that don't declare an ``os_env:`` block.
+- ``HARNESS_HERMES_SKILLS_FILTER``: JSON-encoded
+  ``str | list[str]`` carrying ``spec.skills_filter``. When
+  unset, falls back to ``"all"``.
+- ``HARNESS_HERMES_BUNDLE_DIR``: Absolute path to the agent
+  bundle's extracted root. When set, the executor sources
+  bundled skills from ``<bundle>/skills/<name>/``. Unset for
+  agents without a bundled-skill directory.
+- ``HARNESS_HERMES_AGENT_NAME``: Agent display name. Reserved for
+  future use; currently unused by Hermes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.inner.hermes_executor import HermesExecutor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+# Env-var keys the wrap reads at executor construction time. See
+# the module docstring for semantics. Centralizing as constants
+# so misconfigurations surface as a single grep target.
+_ENV_MODEL = "HARNESS_HERMES_MODEL"
+_ENV_CWD = "HARNESS_HERMES_CWD"
+_ENV_HERMES_PATH = "HARNESS_HERMES_PATH"
+_ENV_OS_ENV = "HARNESS_HERMES_OS_ENV"
+_ENV_SKILLS_FILTER = "HARNESS_HERMES_SKILLS_FILTER"
+_ENV_BUNDLE_DIR = "HARNESS_HERMES_BUNDLE_DIR"
+_ENV_AGENT_NAME = "HARNESS_HERMES_AGENT_NAME"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """
+    Resolve the inner-executor :class:`OSEnvSpec` from env config.
+
+    Reads :data:`_ENV_OS_ENV` and decodes the JSON-encoded dict
+    Omnigent serialized via :func:`dataclasses.asdict` on its
+    :class:`OSEnvSpec`. When the env var is missing or
+    malformed, falls back to ``caller_process + sandbox=none``
+    so AP-bridged tools stay enabled — matches the legacy
+    non-AP path's default for specs without an
+    ``os_env:`` block.
+
+    :returns: An :class:`OSEnvSpec` to hand to
+        :class:`HermesExecutor`.
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env",
+                _ENV_OS_ENV,
+                exc,
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    # Default: enable natives, no sandbox. Matches the simplest
+    # working config; operators who want real sandbox enforcement
+    # configure ``os_env.sandbox`` explicitly in the spec.
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _resolve_skills_filter() -> str | list[str]:
+    """
+    Resolve the inner-executor ``skills_filter`` from env config.
+
+    Reads :data:`_ENV_SKILLS_FILTER` and decodes the JSON-encoded
+    ``str | list[str]`` (``"all"``, ``"none"``, or a list of skill
+    names). Falls back to ``"all"`` on missing or malformed input
+    — matches the SDK default behavior.
+
+    :returns: ``"all"``, ``"none"``, or a list of skill names.
+    """
+    raw = os.environ.get(_ENV_SKILLS_FILTER, "").strip()
+    if not raw:
+        return "all"
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _logger.warning(
+            "%s is not valid JSON (%s); falling back to 'all'",
+            _ENV_SKILLS_FILTER,
+            exc,
+        )
+        return "all"
+    if isinstance(decoded, str) and decoded in ("all", "none"):
+        return decoded
+    if isinstance(decoded, list) and all(isinstance(s, str) for s in decoded):
+        return decoded
+    _logger.warning(
+        "%s decoded to unsupported shape %r; falling back to 'all'",
+        _ENV_SKILLS_FILTER,
+        decoded,
+    )
+    return "all"
+
+
+def _build_hermes_executor() -> Executor:
+    """
+    Construct a :class:`HermesExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first
+    turn. Heavyweight init (CLI discovery) happens at this point
+    — operators see the failure surface as a startup error on the
+    first request, not at FastAPI app boot.
+
+    :returns: A configured :class:`HermesExecutor` instance.
+    :raises FileNotFoundError: If ``hermes`` is not on PATH and
+        ``HARNESS_HERMES_PATH`` isn't set.
+    """
+    bundle_dir_raw = os.environ.get(_ENV_BUNDLE_DIR, "").strip()
+    bundle_dir = str(Path(bundle_dir_raw)) if bundle_dir_raw else None
+    agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
+    agent_name = agent_name_raw or None
+    return HermesExecutor(
+        hermes_path=os.environ.get(_ENV_HERMES_PATH),
+        cwd=os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE"),
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL),
+        skills_filter=_resolve_skills_filter(),
+        bundle_dir=bundle_dir,
+        agent_name=agent_name,
+    )
+
+
+def create_app() -> FastAPI:
+    """
+    Build the hermes harness's FastAPI app.
+
+    Required entry point per the harness contract — the runner
+    imports this module (resolved from
+    :data:`omnigent.runtime.harnesses._HARNESS_MODULES`) and
+    invokes ``create_app()`` to get the app it serves.
+
+    :returns: The FastAPI app from :class:`ExecutorAdapter`'s
+        :meth:`build` method, with all routes from the harness
+        API subset wired up. The wrapped :class:`HermesExecutor`
+        is constructed lazily on the first turn (so an absent
+        ``hermes`` CLI surfaces as a request-time error, not a
+        FastAPI app-boot crash).
+    """
+    adapter = ExecutorAdapter(executor_factory=_build_hermes_executor)
+    return adapter.build()

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -74,6 +74,12 @@ _HARNESS_MODULES: dict[str, str] = {
     # localharness binary; needs glibc >=~2.36). Drives Gemini 3.5 Flash by
     # default (also Claude / GPT-OSS), with Gemini API-key or Vertex AI auth.
     "antigravity": "omnigent.inner.antigravity_harness",
+    # Hermes Agent harness wrap. Runs the ``hermes`` CLI as a subprocess
+    # for each turn, managing its own session state via Hermes' SQLite
+    # session store. See omnigent/inner/hermes_harness.py and
+    # omnigent/inner/hermes_executor.py. The ``hermes`` binary must be
+    # on PATH (or set by HARNESS_HERMES_PATH).
+    "hermes": "omnigent.inner.hermes_harness",
 }
 
 __all__ = ["_HARNESS_MODULES"]

--- a/tests/inner/test_hermes_executor.py
+++ b/tests/inner/test_hermes_executor.py
@@ -1,0 +1,371 @@
+"""
+Unit tests for :class:`HermesExecutor` and its helper functions.
+
+Tests the executor's parsing, session management, and argument
+building without invoking the real Hermes CLI.  Subprocess-level
+integration tests belong in the e2e suite.
+
+HermesExecutor's ``run_turn`` method is tested with a patched
+``asyncio.create_subprocess_exec`` to verify event emission
+patterns and error handling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnigent.inner.executor import (
+    ExecutorConfig,
+    ExecutorError,
+    TextChunk,
+    TurnComplete,
+)
+from omnigent.inner.hermes_executor import (
+    HermesExecutor,
+    _build_hermes_args,
+    _extract_last_user_message,
+    _parse_session_id,
+    _strip_hermes_metadata,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestUtils:
+    """Tests for standalone helper functions in hermes_executor."""
+
+    def test_strip_hermes_metadata_removes_session_id_line(self) -> None:
+        output = "session_id: 20260620_123456_abc123\nHello, world!"
+        assert _strip_hermes_metadata(output) == "Hello, world!"
+
+    def test_strip_hermes_metadata_removes_resume_notice(self) -> None:
+        output = "↻ Resumed session 20260620_123456_abc123 (1 message)\n\nsession_id: 20260620_123456_abc123\nHello again!"
+        assert _strip_hermes_metadata(output) == "Hello again!"
+
+    def test_strip_hermes_metadata_removes_warnings(self) -> None:
+        output = "Warning: Unknown toolsets: messaging\nsession_id: abc\nHello!"
+        assert _strip_hermes_metadata(output) == "Hello!"
+
+    def test_strip_hermes_metadata_preserves_empty_response(self) -> None:
+        output = "session_id: 20260620_123456_abc123\n"
+        assert _strip_hermes_metadata(output) == ""
+
+    def test_strip_hermes_metadata_preserves_multi_line_response(self) -> None:
+        output = "session_id: 123\nLine one\nLine two\nLine three"
+        assert _strip_hermes_metadata(output) == "Line one\nLine two\nLine three"
+
+    def test_parse_session_id_found(self) -> None:
+        output = "Warning: something\nsession_id: 20260620_abc123_def456\nResponse text"
+        assert _parse_session_id(output) == "20260620_abc123_def456"
+
+    def test_parse_session_id_not_found(self) -> None:
+        output = "No session ID here"
+        assert _parse_session_id(output) is None
+
+    def test_parse_session_id_empty_output(self) -> None:
+        assert _parse_session_id("") is None
+
+    def test_extract_last_user_message_simple(self) -> None:
+        messages = [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "First response"},
+            {"role": "user", "content": "Second message"},
+        ]
+        assert _extract_last_user_message(messages) == "Second message"
+
+    def test_extract_last_user_message_content_blocks(self) -> None:
+        messages = [
+            {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
+        ]
+        assert _extract_last_user_message(messages) == "Hello"
+
+    def test_extract_last_user_message_empty(self) -> None:
+        assert _extract_last_user_message([]) == ""
+
+    def test_extract_last_user_message_no_user(self) -> None:
+        messages = [{"role": "assistant", "content": "Hello"}]
+        assert _extract_last_user_message(messages) == ""
+
+    def test_build_hermes_args_basic(self) -> None:
+        args = _build_hermes_args("/usr/bin/hermes", "Hello")
+        assert args == [
+            "/usr/bin/hermes",
+            "chat",
+            "-q",
+            "Hello",
+            "-Q",
+            "--source",
+            "tool",
+        ]
+
+    def test_build_hermes_args_with_model(self) -> None:
+        args = _build_hermes_args("hermes", "Hi", model="deepseek/deepseek-chat")
+        assert "-m" in args
+        assert "deepseek/deepseek-chat" in args
+
+    def test_build_hermes_args_with_session(self) -> None:
+        args = _build_hermes_args(
+            "hermes", "Hi", session_id="20260620_abc123"
+        )
+        assert "--resume" in args
+        idx = args.index("--resume")
+        assert args[idx + 1] == "20260620_abc123"
+
+
+# ---------------------------------------------------------------------------
+# HermesExecutor unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def executor() -> HermesExecutor:
+    """Return a HermesExecutor with a dummy path for testing."""
+    return HermesExecutor(
+        hermes_path="/usr/bin/hermes-fake",
+        cwd="/tmp",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_turn_returns_text_chunk_and_turn_complete(
+    executor: HermesExecutor,
+) -> None:
+    """A successful subprocess call yields TextChunk + TurnComplete."""
+    mock_process = MagicMock()
+    mock_process.returncode = 0
+    mock_process.communicate = AsyncMock(
+        return_value=(
+            b"session_id: 20260620_test_sid\nHello, world!",
+            b"",
+        )
+    )
+
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(return_value=mock_process),
+    ):
+        events = []
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            system_prompt="",
+        ):
+            events.append(event)
+
+    assert len(events) >= 2
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "Hello, world!"
+    # At least one TextChunk should be present
+    text_chunks = [e for e in events if isinstance(e, TextChunk)]
+    assert len(text_chunks) >= 1
+    assert text_chunks[0].text == "Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_empty_message_yields_none(
+    executor: HermesExecutor,
+) -> None:
+    """No user message should short-circuit with TurnComplete(response=None)."""
+    events = []
+    async for event in executor.run_turn(
+        messages=[{"role": "assistant", "content": "Hello"}],
+        tools=[],
+        system_prompt="",
+    ):
+        events.append(event)
+
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response is None
+
+
+@pytest.mark.asyncio
+async def test_run_turn_subprocess_timeout(
+    executor: HermesExecutor,
+) -> None:
+    """A timed-out subprocess yields ExecutorError."""
+    mock_process = MagicMock()
+    mock_process.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(return_value=mock_process),
+    ):
+        events = []
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            system_prompt="",
+        ):
+            events.append(event)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "timed out" in events[0].message
+
+
+@pytest.mark.asyncio
+async def test_run_turn_subprocess_error(
+    executor: HermesExecutor,
+) -> None:
+    """A non-zero exit code yields ExecutorError."""
+    mock_process = MagicMock()
+    mock_process.returncode = 1
+    mock_process.communicate = AsyncMock(
+        return_value=(b"", b"Error: something went wrong")
+    )
+
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(return_value=mock_process),
+    ):
+        events = []
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            system_prompt="",
+        ):
+            events.append(event)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "Something went wrong" in events[0].message or "error" in events[0].message.lower()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_file_not_found(
+    executor: HermesExecutor,
+) -> None:
+    """A missing Hermes binary yields ExecutorError with install hint."""
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(side_effect=FileNotFoundError),
+    ):
+        events = []
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            system_prompt="",
+        ):
+            events.append(event)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "Hermes CLI not found" in events[0].message
+    assert "install" in events[0].message.lower()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_stores_session_id(
+    executor: HermesExecutor,
+) -> None:
+    """The executor captures session_id from the first turn for resume."""
+    mock_process = MagicMock()
+    mock_process.returncode = 0
+    mock_process.communicate = AsyncMock(
+        return_value=(
+            b"session_id: 20260620_captured_sid\nResponse text",
+            b"",
+        )
+    )
+
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(return_value=mock_process),
+    ):
+        events = []
+        async for event in executor.run_turn(
+            messages=[
+                {"role": "user", "content": "Hi", "session_id": "test-session-key"}
+            ],
+            tools=[],
+            system_prompt="",
+        ):
+            events.append(event)
+
+    # Verify the session ID was stored
+    assert executor._hermes_session_id("test-session-key") == "20260620_captured_sid"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_resumes_existing_session(
+    executor: HermesExecutor,
+) -> None:
+    """When a session_id is already stored, subsequent turns use --resume."""
+    # Pre-populate the session map
+    executor._session_map["test-session-key"] = "20260620_existing_sid"
+
+    mock_process = MagicMock()
+    mock_process.returncode = 0
+    mock_process.communicate = AsyncMock(
+        return_value=(b"session_id: 20260620_existing_sid\nFollow-up response", b"")
+    )
+
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(return_value=mock_process),
+    ) as mock_create:
+        events = []
+        async for event in executor.run_turn(
+            messages=[
+                {"role": "user", "content": "Follow up", "session_id": "test-session-key"}
+            ],
+            tools=[],
+            system_prompt="",
+        ):
+            events.append(event)
+
+        # Verify --resume was used in the subprocess args
+        call_args, _ = mock_create.call_args
+        assert "--resume" in call_args
+        resume_idx = list(call_args).index("--resume")
+        assert list(call_args)[resume_idx + 1] == "20260620_existing_sid"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_passes_model_from_config(
+    executor: HermesExecutor,
+) -> None:
+    """Model from ExecutorConfig.extra or config.model is threaded through."""
+    mock_process = MagicMock()
+    mock_process.returncode = 0
+    mock_process.communicate = AsyncMock(
+        return_value=(b"session_id: test\nResponse", b"")
+    )
+    config = ExecutorConfig(model="deepseek/deepseek-chat")
+
+    with patch.object(
+        asyncio,
+        "create_subprocess_exec",
+        new=AsyncMock(return_value=mock_process),
+    ) as mock_create:
+        events = []
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            system_prompt="",
+            config=config,
+        ):
+            events.append(event)
+
+        call_args, _ = mock_create.call_args
+        assert "-m" in call_args
+        idx = list(call_args).index("-m")
+        assert list(call_args)[idx + 1] == "deepseek/deepseek-chat"
+
+
+def test_handles_tools_internally(executor: HermesExecutor) -> None:
+    """HermesExecutor reports it handles its own tool calls."""
+    assert executor.handles_tools_internally() is True

--- a/tests/inner/test_hermes_harness.py
+++ b/tests/inner/test_hermes_harness.py
@@ -1,0 +1,145 @@
+"""
+Tests for the ``harness: hermes`` wrap shape.
+
+Mirror of ``tests/inner/test_pi_harness.py`` — verifies the wrap
+module has the same shape (registry entry, FastAPI app routes,
+env-var-driven lazy executor construction). Does NOT exercise
+the real Hermes CLI; the inner ``HermesExecutor.__init__`` is
+lightweight enough that no mocking is needed for shape tests.
+
+End-to-end Hermes verification (real CLI, real API) should live
+in the e2e suite, gated on the ``hermes`` binary being available.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner import hermes_harness
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+
+
+def test_harness_module_registered_in_module_registry() -> None:
+    """``"hermes"`` resolves to the harness module path.
+
+    Without this entry, the runner subprocess can't find the wrap
+    when AP-side tries to spawn it for a ``harness: hermes`` spec.
+    """
+    assert _HARNESS_MODULES.get("hermes") == "omnigent.inner.hermes_harness"
+
+
+def test_create_app_returns_fastapi_with_required_routes() -> None:
+    """``create_app()`` returns a FastAPI app exposing the harness API.
+
+    Verifies the wrap successfully:
+    - Imports the executor adapter + Hermes executor module.
+    - Builds the FastAPI app via ExecutorAdapter.build().
+    - Mounts the standard harness routes.
+
+    The actual HermesExecutor is constructed lazily on the first
+    turn (not at app build time), so this test passes without
+    a real ``hermes`` CLI on PATH.
+    """
+    app = hermes_harness.create_app()
+    paths = {route.path for route in app.routes}  # type: ignore[attr-defined]
+    # Session-keyed harness API: liveness probe + single
+    # discriminated-event endpoint per §The Harness API Subset.
+    assert "/health" in paths
+    assert "/v1/sessions/{conversation_id}/events" in paths
+
+
+def test_executor_factory_reads_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory passes env-var values through to HermesExecutor.
+
+    Locks in the v1 config-flow contract: env vars set in AP's
+    process before spawning the subprocess (which inherits
+    them) are how the wrap learns its config. Verifies model,
+    cwd, hermes_path all thread through.
+    """
+    monkeypatch.setenv("HARNESS_HERMES_MODEL", "test-model-id")
+    monkeypatch.setenv("HARNESS_HERMES_CWD", "/tmp/test-cwd")
+    monkeypatch.setenv("HARNESS_HERMES_PATH", "/custom/path/hermes")
+
+    executor = hermes_harness._build_hermes_executor()
+
+    assert executor._hermes_path == "/custom/path/hermes"
+    assert executor._cwd == "/tmp/test-cwd"
+    assert executor._model == "test-model-id"
+
+
+def test_executor_factory_defaults_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory uses sensible defaults when env vars are not set."""
+    monkeypatch.delenv("HARNESS_HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HARNESS_HERMES_CWD", raising=False)
+    monkeypatch.delenv("HARNESS_HERMES_PATH", raising=False)
+
+    executor = hermes_harness._build_hermes_executor()
+
+    # Should fall back to PATH search for "hermes"
+    assert executor._hermes_path is not None
+    assert "hermes" in executor._hermes_path
+    # Model should be None (no override)
+    assert executor._model is None
+
+
+def test_executor_factory_reads_os_env_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory decodes JSON-encoded OSEnvSpec."""
+    import json
+
+    os_env_spec = {
+        "type": "caller_process",
+        "cwd": "/workspace",
+        "sandbox": {"type": "none"},
+        "fork": False,
+    }
+    monkeypatch.setenv("HARNESS_HERMES_OS_ENV", json.dumps(os_env_spec))
+
+    executor = hermes_harness._build_hermes_executor()
+
+    assert executor._os_env is not None
+    assert executor._os_env.type == "caller_process"
+    assert executor._os_env.cwd == "/workspace"
+    assert executor._os_env.sandbox is not None
+    assert executor._os_env.sandbox.type == "none"
+
+
+def test_executor_factory_reads_skills_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory decodes JSON-encoded skills_filter."""
+    import json
+
+    monkeypatch.setenv("HARNESS_HERMES_SKILLS_FILTER", json.dumps(["skill-a", "skill-b"]))
+
+    executor = hermes_harness._build_hermes_executor()
+
+    assert executor._skills_filter == ["skill-a", "skill-b"]
+
+
+def test_executor_factory_skills_filter_default_all() -> None:
+    """Factory falls back to 'all' when skills_filter is unset."""
+    executor = hermes_harness._build_hermes_executor()
+
+    assert executor._skills_filter == "all"
+
+
+def test_executor_factory_reads_bundle_and_agent_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory reads bundle dir and agent name from env vars."""
+    monkeypatch.setenv("HARNESS_HERMES_BUNDLE_DIR", "/tmp/bundle")
+    monkeypatch.setenv("HARNESS_HERMES_AGENT_NAME", "my-hermes-agent")
+
+    executor = hermes_harness._build_hermes_executor()
+
+    assert executor._bundle_dir == "/tmp/bundle"
+    assert executor._agent_name == "my-hermes-agent"


### PR DESCRIPTION
## Summary

Adds a new `harness: hermes` that wraps the [Hermes Agent](https://hermes-agent.nousresearch.com) CLI (by Nous Research) as an Omnigent executor.

Hermes is a self-improving open-source AI agent with persistent memory, reusable skills, provider-agnostic model routing, and its own tool-calling loop. This harness lets Omnigent users run Hermes through the Omnigent platform (web UI, collaboration, sandboxing, policies) while Hermes handles its own session state, tools, and memory.

## How it works

- Each turn spawns `hermes chat -q "<message>" -Q --source tool` as an `asyncio.create_subprocess_exec`.
- The first turn captures the `session_id` from Hermes' quiet-mode output; subsequent turns use `--resume <session_id>` for conversational context through Hermes' own SQLite store.
- The `hermes` binary is discovered on PATH or set via `HARNESS_HERMES_PATH`.
- Config flows through env vars (`HARNESS_HERMES_MODEL`, `HARNESS_HERMES_CWD`, etc.) matching the v1 config-flow pattern used by pi_harness, codex_harness, etc.
- `handles_tools_internally()` returns `True` — Hermes executes its own tool-calling loop, so Omnigent-level tool bridging is not needed.

## Files changed

|`omnigent/inner/hermes_executor.py`| HermesExecutor class — subprocess-based executor with session resumption|
|`omnigent/inner/hermes_harness.py`| FastAPI harness module (`create_app()`) — env-var-driven lazy executor construction|
|`omnigent/runtime/harnesses/__init__.py`| Registration of `"hermes"` → `"omnigent.inner.hermes_harness"` in `_HARNESS_MODULES`|
|`tests/inner/test_hermes_harness.py`| 8 tests — registry entry, FastAPI routes, env-var wiring|
|`tests/inner/test_hermes_executor.py`| 24 tests — output parsing, session mgmt, error handling, arg building|
|`docs/AGENT_YAML_SPEC.md`| Documented harness in the YAML spec, added Hermes section|
|`examples/hermes/config.yaml`| Example custom agent config for `omnigent run examples/hermes/`|

## Testing

```
32 passed in 0.27s  (hermes harness + executor tests)
101 passed in 58.80s (existing harness, scaffold, and alias tests)
```

No regressions in any existing test suite.

## Usage

```yaml
executor:
  harness: hermes
```

```bash
omnigent run examples/hermes/
```

Requires Hermes to be installed (`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh`).