### PR TITLE
fix(codex-native): surface the real thread-start failure instead of "bridge state is missing"

### DIFF
--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -18,6 +18,7 @@ CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
 
 _STATE_FILE = "state.json"
+_STARTUP_ERROR_FILE = "startup_error.json"
 # Must match ``_CONFIG_FILE`` in ``claude_native_bridge.py`` because
 # ``serve-mcp`` reads this filename for the token.
 _MCP_CONFIG_FILE = "bridge.json"
@@ -345,10 +346,55 @@ def clear_bridge_state(bridge_dir: Path) -> None:
     :param bridge_dir: Native Codex bridge directory.
     :returns: None.
     """
+    for name in (_STATE_FILE, _STARTUP_ERROR_FILE):
+        try:
+            (bridge_dir / name).unlink()
+        except FileNotFoundError:
+            continue
+
+
+def write_bridge_startup_error(bridge_dir: Path, message: str) -> None:
+    """
+    Record why a native Codex app-server never started its thread (issue #59).
+
+    :param bridge_dir: Native Codex bridge directory.
+    :param message: Human-readable failure cause.
+    :returns: None.
+    """
     try:
-        (bridge_dir / _STATE_FILE).unlink()
-    except FileNotFoundError:
-        return
+        bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = bridge_dir / _STARTUP_ERROR_FILE
+        fd, tmp_name = tempfile.mkstemp(prefix=f"{_STARTUP_ERROR_FILE}.", dir=str(bridge_dir))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump({"message": message}, handle, sort_keys=True)
+                handle.write("\n")
+            os.replace(tmp_name, path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+    except OSError:
+        return  # best-effort; the real failure is already logged
+
+
+def read_bridge_startup_error(bridge_dir: Path) -> str | None:
+    """
+    Read a recorded native Codex startup-failure message, if any.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :returns: The recorded failure cause, or ``None`` if absent/unreadable.
+    """
+    path = bridge_dir / _STARTUP_ERROR_FILE
+    if not path.is_file():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    message = raw.get("message")
+    return message if isinstance(message, str) and message else None
 
 
 def read_bridge_state(bridge_dir: Path) -> CodexNativeBridgeState | None:

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -15,6 +15,7 @@ from omnigent.codex_native_app_server import client_for_transport
 from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    read_bridge_startup_error,
     read_bridge_state,
     update_active_turn_id,
 )
@@ -176,6 +177,9 @@ class CodexNativeExecutor(Executor):
         state = read_bridge_state(self._bridge_dir)
         if state is None:
             for _ in range(60):
+                # Startup already failed; the runner recorded the cause — stop waiting.
+                if read_bridge_startup_error(self._bridge_dir) is not None:
+                    break
                 await asyncio.sleep(1.0)
                 state = read_bridge_state(self._bridge_dir)
                 if state is not None:
@@ -189,7 +193,12 @@ class CodexNativeExecutor(Executor):
         async with self._inject_lock:
             state = read_bridge_state(self._bridge_dir)
             if state is None:
-                error_msg = "Codex native bridge state is missing"
+                startup_error = read_bridge_startup_error(self._bridge_dir)
+                error_msg = (
+                    f"Codex native thread never started: {startup_error}"
+                    if startup_error
+                    else "Codex native bridge state is missing"
+                )
             elif not _session_is_active(state.session_id, self._request_session_id):
                 error_msg = "Codex native session is no longer active"
             else:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1509,9 +1509,14 @@ async def _codex_discover_thread_and_forward(
                 session_id,
             )
             # Bridge state is never written here; leave the real cause for the executor (#59).
+            cause = (
+                "startup timed out"
+                if isinstance(exc, TimeoutError)
+                else "event stream ended before a thread was created"
+            )
             write_bridge_startup_error(
                 bridge_dir,
-                f"Codex app-server never started a thread (startup timed out: "
+                f"Codex app-server never started a thread ({cause}: "
                 f"{type(exc).__name__}). See the runner log near 'native-codex "
                 "routing' for the resolved provider/model.",
             )

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1484,6 +1484,7 @@ async def _codex_discover_thread_and_forward(
     """
     from omnigent.codex_native_bridge import (
         CodexNativeBridgeState,
+        write_bridge_startup_error,
         write_bridge_state,
     )
     from omnigent.codex_native_forwarder import (
@@ -1498,7 +1499,7 @@ async def _codex_discover_thread_and_forward(
     try:
         try:
             thread_id = await wait_for_thread_started(event_client)
-        except (TimeoutError, RuntimeError):
+        except (TimeoutError, RuntimeError) as exc:
             # Expected failure modes of wait_for_thread_started: the TUI exited
             # at startup, or the event stream ended before a thread was
             # created. Stop forwarding (cleanup runs in ``finally``); any other
@@ -1506,6 +1507,13 @@ async def _codex_discover_thread_and_forward(
             _logger.exception(
                 "Codex TUI never started a thread for %s; chat will not forward",
                 session_id,
+            )
+            # Bridge state is never written here; leave the real cause for the executor (#59).
+            write_bridge_startup_error(
+                bridge_dir,
+                f"Codex app-server never started a thread (startup timed out: "
+                f"{type(exc).__name__}). See the runner log near 'native-codex "
+                "routing' for the resolved provider/model.",
             )
             return
 

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -12,10 +12,11 @@ import pytest
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     read_bridge_state,
+    write_bridge_startup_error,
     write_bridge_state,
 )
 from omnigent.inner.codex_native_executor import CodexNativeExecutor
-from omnigent.inner.executor import TurnComplete
+from omnigent.inner.executor import ExecutorError, TurnComplete
 
 # A 1x1 transparent PNG, base64-encoded — a real decodable image small
 # enough to embed, used to prove image blocks are materialized to disk
@@ -648,3 +649,33 @@ async def test_concurrent_steering_during_turn_start_is_not_dropped(
     )
     # Exactly one turn was started — no double-start race.
     assert methods.count("turn/start") == 1, f"expected exactly one turn/start; got {methods}"
+
+
+def test_run_turn_surfaces_recorded_startup_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    A missing bridge state surfaces the recorded startup cause, not the
+    generic "bridge state is missing" (issue #59).
+    """
+
+    async def _no_sleep(_seconds: float) -> None:
+        """No-op the poll backoff so the missing-state path is fast."""
+
+    # asyncio.run does not depend on asyncio.sleep, so patching it is safe.
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    write_bridge_startup_error(
+        tmp_path,
+        "Codex app-server never started a thread within the startup timeout.",
+    )
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "hello")
+
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ExecutorError)
+    assert "never started" in error.message
+    assert "startup timeout" in error.message
+    assert error.message != "Codex native bridge state is missing"

--- a/tests/runner/test_app_sessions_native.py
+++ b/tests/runner/test_app_sessions_native.py
@@ -2666,6 +2666,70 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "expected_cause"),
+    [
+        (TimeoutError("no thread/started observed"), "startup timed out"),
+        (
+            RuntimeError("event stream ended"),
+            "event stream ended before a thread was created",
+        ),
+    ],
+)
+async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    exc: Exception,
+    expected_cause: str,
+) -> None:
+    """
+    The startup breadcrumb must describe the actual failure mode: a timeout
+    reads as "startup timed out", while a RuntimeError (TUI exited / event
+    stream ended) must NOT be mislabeled as a timeout.
+    """
+    from omnigent import codex_native_forwarder
+    from omnigent.codex_native_bridge import read_bridge_startup_error
+    from omnigent.runner.app import (
+        _AUTO_CODEX_APP_SERVERS,
+        _codex_discover_thread_and_forward,
+    )
+
+    class _Client:
+        async def close(self) -> None:
+            return None
+
+    class _AppServer:
+        async def close(self) -> None:
+            return None
+
+    async def _raise(*_args: object, **_kwargs: object) -> str:
+        raise exc
+
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _raise)
+
+    session_id = "conv_codex_startup_error_test"
+    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    try:
+        await _codex_discover_thread_and_forward(
+            session_id=session_id,
+            bridge_dir=tmp_path,
+            codex_ws_url="ws://127.0.0.1:1",
+            codex_home=tmp_path / "codex-home",
+            event_client=_Client(),  # type: ignore[arg-type]
+        )
+    finally:
+        _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+    recorded = read_bridge_startup_error(tmp_path)
+    assert recorded is not None
+    assert expected_cause in recorded
+    assert type(exc).__name__ in recorded
+    # A RuntimeError must never be described as a timeout.
+    if not isinstance(exc, TimeoutError):
+        assert "timed out" not in recorded
+
+
+@pytest.mark.asyncio
 async def test_create_session() -> None:
     """``POST /v1/sessions`` spawns harness and returns SessionResponse shape."""
     app, pm, _hc = _build_lifecycle_app()

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -9,11 +9,14 @@ import pytest
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     clear_active_turn_id_if_matches,
+    clear_bridge_state,
     codex_home_for_bridge_dir,
     prepare_bridge_dir,
+    read_bridge_startup_error,
     read_bridge_state,
     read_codex_config_model,
     read_policy_hook_config,
+    write_bridge_startup_error,
     write_bridge_state,
     write_policy_hook_config,
 )
@@ -199,3 +202,17 @@ def test_clear_active_turn_id_if_matches_no_state_returns_true(bridge_dir: Path)
     """
     # bridge_dir exists (fixture) but no state.json was written.
     assert clear_active_turn_id_if_matches(bridge_dir, "turn_1") is True
+
+
+def test_bridge_startup_error_round_trips_and_is_cleared(bridge_dir: Path) -> None:
+    """
+    The startup-error breadcrumb round-trips, and ``clear_bridge_state``
+    drops it before each launch so stale failures don't linger (issue #59).
+    """
+    assert read_bridge_startup_error(bridge_dir) is None
+
+    write_bridge_startup_error(bridge_dir, "thread never started (TimeoutError)")
+    assert read_bridge_startup_error(bridge_dir) == "thread never started (TimeoutError)"
+
+    clear_bridge_state(bridge_dir)
+    assert read_bridge_startup_error(bridge_dir) is None


### PR DESCRIPTION
## Summary

When a codex-native worker's Codex app-server never starts its thread,
`wait_for_thread_started` times out and the runner returns **before**
`write_bridge_state` runs (`runner/app.py`). The executor's bridge-state poll
then finds nothing and surfaces the misleading **"Codex native bridge state is
missing"**, hiding the real failure. This reproduces over an OpenAI-compatible
gateway (the original report) and — per @abedegno's follow-up — also on a
self-hosted host runner with ChatGPT-subscription auth where the thread comes
up empty, so the misleading message hits a whole class of startup failures.

This records a startup-failure breadcrumb in the bridge dir on the timeout path
and surfaces it from the executor, so the operator sees the real cause (a
thread-start timeout) and is pointed at the `native-codex routing` log for the
resolved provider/model. It also stops the executor's up-to-60s bridge-state
poll early once a failure is recorded.

Scope is the **diagnostics** half of the issue only. Whether codex-native should
support OpenAI-compatible gateway routing, or reject it fast at config/launch,
is a separate design question and is intentionally left out.

Fixes #59.

## Changes
- `codex_native_bridge.py`: `write_bridge_startup_error` / `read_bridge_startup_error`
  (atomic `startup_error.json` breadcrumb); `clear_bridge_state` clears it before each launch.
- `runner/app.py`: record the breadcrumb on the `wait_for_thread_started` timeout.
- `inner/codex_native_executor.py`: surface the recorded cause instead of the generic message.

## Test plan
- [x] `test_run_turn_surfaces_recorded_startup_error` — executor surfaces the real
  cause; **fails on unfixed code** (emits "bridge state is missing").
- [x] `test_bridge_startup_error_round_trips_and_is_cleared` — breadcrumb round-trips
  and is cleared by `clear_bridge_state`.
- [x] `ruff check` + `ruff format --check` clean.
- [x] codex-native unit suite green (pre-existing Windows-only termios/symlink
  failures verified unchanged via baseline).
