### PR TITLE
Feat/side by side sessions

### DIFF
--- a/ap-web/src/App.tsx
+++ b/ap-web/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { Route, Routes } from "react-router-dom";
 import { ChatPage } from "@/pages/ChatPage";
+import { ComparePage } from "@/pages/ComparePage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
@@ -119,6 +120,7 @@ function App({ basename }: AppProps = {}) {
         <Route element={<AppShell />}>
           <Route path={prefix || "/"} element={<ChatPage />} />
           <Route path={`${prefix}/c/:conversationId`} element={<ChatPage />} />
+          <Route path={`${prefix}/compare`} element={<ComparePage />} />
           <Route path={`${prefix}/inbox`} element={<InboxPage />} />
           {info.accounts_enabled && (
             <>

--- a/ap-web/src/components/blocks/ApprovalCard.tsx
+++ b/ap-web/src/components/blocks/ApprovalCard.tsx
@@ -49,7 +49,7 @@ import {
   parseAskUserQuestionPreview,
 } from "@/lib/askUserQuestion";
 import { formatPreview } from "@/lib/previewFormat";
-import { useChatStore } from "@/store/chatStore";
+import { useScopedChatStore } from "@/store/chatStore";
 import { AskUserQuestionForm, type AskUserQuestionAnswers } from "./AskUserQuestionForm";
 import { ExitPlanModeReview } from "./ExitPlanModeReview";
 
@@ -161,10 +161,14 @@ export function ApprovalCard({
   allowAllEdits,
   onSubmit,
 }: ApprovalCardProps) {
+  // Scope the default submitter to THIS pane's session so approving a card in
+  // one side-by-side pane never resolves another pane's elicitation. The Inbox
+  // still overrides via `onSubmit` for cards outside the chat store entirely.
+  const scopedChat = useScopedChatStore();
   const submit: SubmitApprovalFn =
     onSubmit ??
     ((id, action, content) => {
-      void useChatStore.getState().submitApproval(id, action, content);
+      void scopedChat.getState().submitApproval(id, action, content);
     });
   const submitBinary = (action: "accept" | "decline") => {
     submit(elicitationId, action);

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -91,6 +91,7 @@ import {
   type PendingInitialPrompt,
   type PendingUserMessage,
   useChatStore,
+  useScopedChatStore,
 } from "@/store/chatStore";
 import { useSession } from "@/hooks/useSession";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
@@ -384,8 +385,30 @@ const sessionDrafts = loadDraftsFromStorage();
  * and triggers `switchTo` when the URL changes. The store owns the
  * items fetch (no useConversationItems here).
  */
-export function ChatPage() {
+export interface ChatPageProps {
+  /**
+   * When set, this ChatPage instance renders as a side-by-side PANE bound to
+   * this session id instead of the URL's conversation. The pane's whole
+   * subtree is wrapped in a `ChatSessionScopeContext` by `MultiSessionGrid`,
+   * so store reads/imperatives resolve to this session automatically.
+   */
+  paneSessionId?: string;
+  /** Pane mode: render lean pane chrome (own header + close) and skip the
+   *  route-only behaviors (URL sync, initial-prompt auto-send, dialogs). */
+  embedded?: boolean;
+  /** Close control for the pane header (pane mode only). */
+  onClose?: () => void;
+}
+
+export function ChatPage({ paneSessionId, embedded = false, onClose }: ChatPageProps = {}) {
   const { conversationId: urlConvId } = useParams<{ conversationId: string }>();
+  // The session this instance shows: the pane's id when embedded, else the URL.
+  // On the route the two are identical, so route behavior is unchanged.
+  const sessionId = paneSessionId ?? urlConvId ?? null;
+  // Imperative store access scoped to THIS pane (or the active session on the
+  // route) — pane sends/stops must target their own session, not the global
+  // active one. Reactive `useChatStore((s) => …)` reads scope via context.
+  const scopedChat = useScopedChatStore();
   const navigate = useNavigate();
   // Optional first message handed off by the landing composer through the
   // shared chatStore (keyed by conversation id), not router state — router state
@@ -436,7 +459,10 @@ export function ChatPage() {
   // Clear the "unseen messages" sidebar dot for the conversation the
   // user is currently viewing. Re-fires when conversations refresh
   // (every 4 s) so messages arriving while viewing are marked seen.
-  useMarkConversationSeen(urlConvId, conversations?.find((c) => c.id === urlConvId)?.updated_at);
+  useMarkConversationSeen(
+    sessionId ?? undefined,
+    conversations?.find((c) => c.id === sessionId)?.updated_at,
+  );
 
   // Sync the store's active conversation to the URL. Single source of
   // truth: URL is what's "current"; store mirrors it. The effect is
@@ -449,8 +475,11 @@ export function ChatPage() {
   // intentionally don't await it here. The store's `loadingConversation` flag
   // drives the loading UI below; `conversationLoadError` drives the error UI.
   useEffect(() => {
+    // Panes own their bind lifecycle via MultiSessionGrid (acquire/release);
+    // only the single-session route mirrors the URL into the active session.
+    if (embedded) return;
     void useChatStore.getState().switchTo(urlConvId ?? null);
-  }, [urlConvId]);
+  }, [urlConvId, embedded]);
 
   // Pull the first message the landing composer stashed for this conversation,
   // if any. Read-once (consume deletes), so a refresh/back can't replay
@@ -491,8 +520,8 @@ export function ChatPage() {
   // Read runner liveness from the app-level batch poller (see
   // RunnerHealthProvider). `undefined` = not yet polled — the indicator
   // stays hidden until the first poll for this session resolves.
-  const runnerOnline = useSessionRunnerOnline(urlConvId);
-  useRefreshSessionStateOnRunnerOnline(urlConvId, runnerOnline);
+  const runnerOnline = useSessionRunnerOnline(sessionId ?? undefined);
+  useRefreshSessionStateOnRunnerOnline(sessionId ?? undefined, runnerOnline);
   // OR'd into "Working…" so cross-client turns surface a shimmer.
   const sessionStatus = useChatStore((s) => s.sessionStatus);
   const loadingConversation = useChatStore((s) => s.loadingConversation);
@@ -504,7 +533,7 @@ export function ChatPage() {
   // agent object for the active session. Drives the picker's
   // name/description; the same react-query cache also feeds the header
   // info icon (AgentInfoButton) its tools & policies.
-  const { data: boundAgentBySession } = useSessionAgent(urlConvId ?? null);
+  const { data: boundAgentBySession } = useSessionAgent(sessionId);
   const hasMoreHistory = useChatStore((s) => s.hasMoreHistory);
   const loadingMoreHistory = useChatStore((s) => s.loadingMoreHistory);
 
@@ -654,7 +683,7 @@ export function ChatPage() {
   // Must be declared BEFORE the early-return guards below — otherwise
   // the hook is skipped on renders that hit the loading/error branches,
   // tripping React's "rendered fewer hooks than expected".
-  const { session: activeSession, isLoading: sessionLoading } = useSession(urlConvId ?? null);
+  const { session: activeSession, isLoading: sessionLoading } = useSession(sessionId);
 
   // Hoisted above the guards; the turn-start/turn-end ["session", id] invalidations refresh it (no new polling).
   const activeSessionLabels = activeSession?.labels;
@@ -672,7 +701,7 @@ export function ChatPage() {
   const subAgentLabel = subAgentComposerLabel(activeSession);
 
   // Hoisted above the early-return guards so the title-update effect can read them.
-  const activeConv = urlConvId ? conversations?.find((c) => c.id === urlConvId) : null;
+  const activeConv = sessionId ? conversations?.find((c) => c.id === sessionId) : null;
 
   // `isWorking` gates the parent's OWN turn (Stop/Interrupt) and must NOT
   // include child-session activity. `showsWorking` is display-only (tab title
@@ -707,7 +736,7 @@ export function ChatPage() {
   const viewerId = getCurrentAuthorId();
   const sessionOwner = activeConv?.owner ?? null;
   const viewerOwnsSession = sessionOwner !== null && sessionOwner === viewerId;
-  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? (urlConvId ?? null) : null);
+  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? sessionId : null);
   const isSessionShared = isSessionSharedWithOthers(sessionOwner, viewerId, ownerGrants);
 
   // The open session's derived liveness — the single signal the chat
@@ -727,7 +756,7 @@ export function ChatPage() {
   // session misclassifies as `local_stranded` and shows the wrong reconnect
   // path. See `livenessRowFromSession`.
   const livenessRow = activeConv ?? livenessRowFromSession(activeSession);
-  const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {
+  const liveness = useSessionLiveness(sessionId ?? undefined, livenessRow, {
     turnActive: status === "streaming",
   });
 
@@ -753,11 +782,13 @@ export function ChatPage() {
   const selectedModel = useChatStore((s) => s.selectedModel);
   const llmModel = useChatStore((s) => s.llmModel);
 
-  // Loading + error gates for `/c/:id` hydration.
-  if (urlConvId) {
+  // Loading + error gates for `/c/:id` hydration. Panes skip the full-page
+  // placeholder/error and render their own frame (the transcript shows the
+  // loading state), so a hydrating pane still has its header + close control.
+  if (sessionId && !embedded) {
     if (loadingConversation) return <HydratingPlaceholder />;
     if (conversationLoadError) {
-      return <ConversationLoadError conversationId={urlConvId} error={conversationLoadError} />;
+      return <ConversationLoadError conversationId={sessionId} error={conversationLoadError} />;
     }
   }
 
@@ -792,7 +823,7 @@ export function ChatPage() {
       setReconnectDialogOpen(true);
       return;
     }
-    void useChatStore.getState().send(text, agentId, files, {
+    void scopedChat.getState().send(text, agentId, files, {
       onConversationCreated: (newId) => {
         // Eager URL update: the moment the server tells us this
         // conversation's id, promote `/` → `/c/:newId`. Replace (not
@@ -815,7 +846,7 @@ export function ChatPage() {
       setReconnectDialogOpen(true);
       return;
     }
-    void useChatStore.getState().sendSlashCommand(name, args, agentId, {
+    void scopedChat.getState().sendSlashCommand(name, args, agentId, {
       onConversationCreated: (newId) => {
         navigate(`/c/${newId}`, { replace: true });
       },
@@ -823,7 +854,7 @@ export function ChatPage() {
   }
 
   function onStop() {
-    useChatStore.getState().stop();
+    scopedChat.getState().stop();
   }
 
   // Sub-agent (child) sessions aren't returned by the sidebar list, so
@@ -867,7 +898,7 @@ export function ChatPage() {
 
   const mainAgent = (
     <MainAgentSurface
-      conversationId={urlConvId ?? null}
+      conversationId={sessionId}
       bubbles={bubbles}
       status={status}
       isWorking={isWorking}
@@ -905,6 +936,43 @@ export function ChatPage() {
       subAgentLabel={subAgentLabel}
     />
   );
+
+  // Side-by-side pane: a self-contained interactive chat view bound to its own
+  // session — own header (title + close), transcript, composer — without the
+  // route-only chrome (workspace rail, dialogs, landing screen). The pane's
+  // subtree already reads/drives THIS session via the scope context provided
+  // by MultiSessionGrid, so the reused transcript + composer stay isolated.
+  if (embedded) {
+    const paneTitle =
+      activeConv?.title ?? activeSession?.title ?? boundAgentName ?? subAgentLabel ?? "Session";
+    return (
+      <section
+        data-testid="session-pane"
+        data-session-id={sessionId ?? ""}
+        aria-label={`Session: ${paneTitle}`}
+        className="flex h-full min-h-0 min-w-0 flex-col"
+      >
+        <header className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3">
+          <span className="min-w-0 flex-1 truncate text-sm font-medium" title={paneTitle}>
+            {paneTitle}
+          </span>
+          {onClose && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close pane"
+              data-testid="session-pane-close"
+              onClick={onClose}
+            >
+              <XIcon className="size-4" />
+            </Button>
+          )}
+        </header>
+        <div className="relative flex min-h-0 flex-1 flex-col">{mainAgent}</div>
+      </section>
+    );
+  }
 
   // On `/` (no conversation), the composer would let the user POST a
   // first message and silently create a session — but sessions are
@@ -1630,6 +1698,9 @@ export function HistoryAutoLoader({
   const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
     scrollRef: React.RefObject<HTMLElement>;
   };
+  // Scope older-history paging to THIS pane's session (or the active session
+  // on the route), never the global active store.
+  const scopedChat = useScopedChatStore();
 
   // Preserve scroll position when items are prepended after a scroll-up
   // fetch. Snapshot scrollHeight before the call; restore the offset in a
@@ -1639,8 +1710,8 @@ export function HistoryAutoLoader({
     if (!hasMoreHistory || loadingMoreHistory) return;
     const el = ctx.scrollRef?.current;
     if (el) prevScrollHeightRef.current = el.scrollHeight;
-    void useChatStore.getState().loadMoreHistory();
-  }, [ctx.scrollRef, hasMoreHistory, loadingMoreHistory]);
+    void scopedChat.getState().loadMoreHistory();
+  }, [ctx.scrollRef, hasMoreHistory, loadingMoreHistory, scopedChat]);
 
   useLayoutEffect(() => {
     const el = ctx.scrollRef?.current;
@@ -1673,9 +1744,9 @@ export function HistoryAutoLoader({
     const el = ctx.scrollRef?.current;
     if (!el || !hasMoreHistory || loadingMoreHistory) return;
     if (el.scrollHeight <= el.clientHeight) {
-      void useChatStore.getState().loadMoreHistory();
+      void scopedChat.getState().loadMoreHistory();
     }
-  }, [ctx.scrollRef, hasMoreHistory, loadingMoreHistory]);
+  }, [ctx.scrollRef, hasMoreHistory, loadingMoreHistory, scopedChat]);
 
   // Re-check on mount and whenever a fetch settles (loadingMoreHistory flips
   // back to false): if content still doesn't overflow, the callback pages again.
@@ -1768,6 +1839,8 @@ export function JumpToTopButton({
   scroller: ConversationScroller | null;
   hasMoreHistory: boolean;
 }) {
+  // Exhaustive "jump to top" paging targets THIS pane's session.
+  const scopedChat = useScopedChatStore();
   const [atTop, setAtTop] = useState(true);
   const [hovering, setHovering] = useState(false);
   const [jumping, setJumping] = useState(false);
@@ -1856,8 +1929,8 @@ export function JumpToTopButton({
       // history or on error. The rAF wait yields a frame for the prepend to
       // commit and for the in-flight flag to settle between pages. The
       // iteration cap is a backstop against a server that never reports done.
-      for (let i = 0; i < 1000 && useChatStore.getState().hasMoreHistory; i++) {
-        await useChatStore.getState().loadMoreHistory();
+      for (let i = 0; i < 1000 && scopedChat.getState().hasMoreHistory; i++) {
+        await scopedChat.getState().loadMoreHistory();
         // Keep the lock released — a prepend that briefly lands us near the
         // bottom can otherwise re-arm it via the library's scroll handler.
         state.isAtBottom = false;
@@ -1880,7 +1953,7 @@ export function JumpToTopButton({
     } finally {
       setJumping(false);
     }
-  }, [scroller]);
+  }, [scroller, scopedChat]);
 
   return (
     <div
@@ -2934,6 +3007,9 @@ export function Composer({
   costRoutingEligible = false,
   subAgentLabel = null,
 }: ComposerProps) {
+  // Slash commands and model/effort/plan toggles act on THIS pane's session
+  // (or the active session on the route), never the global active store.
+  const scopedChat = useScopedChatStore();
   const [value, setValue] = useState("");
   const [files, setFiles] = useState<File[]>([]);
   const [commandError, setCommandError] = useState<string | null>(null);
@@ -3067,7 +3143,7 @@ export function Composer({
     setCommandError(null);
     setPlanModeBusy(true);
     try {
-      await useChatStore.getState().setCodexPlanMode(!codexPlanMode);
+      await scopedChat.getState().setCodexPlanMode(!codexPlanMode);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setCommandError(`Could not ${codexPlanMode ? "exit" : "enter"} Plan mode: ${message}`);
@@ -3107,7 +3183,7 @@ export function Composer({
         dirtyRef.current = true;
         setValue("");
         setCommandError(null);
-        void useChatStore
+        void scopedChat
           .getState()
           .compact()
           .catch((err: unknown) => {
@@ -3125,7 +3201,7 @@ export function Composer({
         dirtyRef.current = true;
         setValue("");
         setCommandError(null);
-        void useChatStore
+        void scopedChat
           .getState()
           .setEffort(level)
           .catch((err: unknown) => {
@@ -3140,7 +3216,7 @@ export function Composer({
         if (!showModel) return false;
         const target = arg.trim();
         if (!target) {
-          const { sessionModelOverride, llmModel } = useChatStore.getState();
+          const { sessionModelOverride, llmModel } = scopedChat.getState();
           const current = sessionModelOverride
             ? `${sessionModelOverride} (override)`
             : (llmModel ?? "agent default");
@@ -3156,7 +3232,7 @@ export function Composer({
         // Confirmation is a durable `[System: model changed to X]` note the
         // server appends to the transcript (see _persist_model_change_note) —
         // not a transient composer hint. Surface only failures inline here.
-        void useChatStore
+        void scopedChat
           .getState()
           .setModel(clear ? null : target)
           .catch((err: unknown) => {
@@ -3165,7 +3241,7 @@ export function Composer({
         return true;
       }
       case "/context": {
-        const state = useChatStore.getState();
+        const state = scopedChat.getState();
         const { contextWindow, llmModel, sessionModelOverride, tokensUsed, blocks } = state;
         const lines: string[] = [];
         if (sessionModelOverride) lines.push(`Model: ${sessionModelOverride} (override)`);
@@ -3714,7 +3790,7 @@ export function Composer({
               <IntelligentModelControl
                 value={costControlModeOverride}
                 onChange={(mode) =>
-                  void useChatStore
+                  void scopedChat
                     .getState()
                     .setCostControlMode(mode)
                     .catch(() => {})
@@ -4119,6 +4195,8 @@ function AgentPicker({
   }, [openNonce]);
 
   const hasAgents = !!agents && agents.length > 0;
+  // Model/effort selections from the dropdown apply to THIS pane's session.
+  const scopedChat = useScopedChatStore();
   const selectedEffort = useChatStore((s) => s.selectedEffort);
   const selectedModel = useChatStore((s) => s.selectedModel);
   const llmModel = useChatStore((s) => s.llmModel);
@@ -4233,7 +4311,7 @@ function AgentPicker({
                   data-model-id={m.id}
                   data-active={isActive ? "true" : undefined}
                   onSelect={() =>
-                    void useChatStore
+                    void scopedChat
                       .getState()
                       .setModel(m.id)
                       .catch(() => {})
@@ -4264,7 +4342,7 @@ function AgentPicker({
                 data-effort-level={level}
                 data-active={selectedEffort === level ? "true" : undefined}
                 onSelect={() =>
-                  void useChatStore
+                  void scopedChat
                     .getState()
                     .setEffort(level)
                     .catch(() => {})

--- a/ap-web/src/pages/ComparePage.tsx
+++ b/ap-web/src/pages/ComparePage.tsx
@@ -1,0 +1,54 @@
+// `/compare?sessions=a,b,c` — the side-by-side multi-session view. Renders the
+// selected sessions as live, independently interactive panes. Entered from the
+// sidebar's "Open side-by-side" bulk action; the session list lives in the URL
+// so the view is shareable and survives a refresh.
+
+import { useCallback, useEffect, useMemo } from "react";
+import { useNavigate, useSearchParams } from "@/lib/routing";
+import { MultiSessionGrid } from "@/shell/MultiSessionGrid";
+
+/** Parse + de-duplicate the `?sessions=` list, preserving left-to-right order. */
+function parseSessionIds(raw: string | null): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const part of (raw ?? "").split(",")) {
+    const id = part.trim();
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+export function ComparePage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const sessionIds = useMemo(() => parseSessionIds(searchParams.get("sessions")), [searchParams]);
+
+  // Side-by-side needs at least two sessions. With one, fall back to the normal
+  // single-session route; with none, the landing page.
+  useEffect(() => {
+    if (sessionIds.length === 0) navigate("/", { replace: true });
+    else if (sessionIds.length === 1) navigate(`/c/${sessionIds[0]}`, { replace: true });
+  }, [sessionIds, navigate]);
+
+  const closeSession = useCallback(
+    (id: string) => {
+      const next = sessionIds.filter((s) => s !== id);
+      if (next.length >= 2) {
+        setSearchParams({ sessions: next.join(",") }, { replace: true });
+      } else if (next.length === 1) {
+        navigate(`/c/${next[0]}`, { replace: true });
+      } else {
+        navigate("/", { replace: true });
+      }
+    },
+    [sessionIds, navigate, setSearchParams],
+  );
+
+  // While the redirect effect settles (fewer than two sessions), render nothing.
+  if (sessionIds.length < 2) return null;
+
+  return <MultiSessionGrid sessionIds={sessionIds} onCloseSession={closeSession} />;
+}

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Outlet, useParams, useSearchParams } from "@/lib/routing";
+import { Outlet, useLocation, useParams, useSearchParams } from "@/lib/routing";
 import { useConversations } from "@/hooks/useConversations";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { useApproveHotkey } from "@/hooks/useApproveHotkey";
@@ -110,6 +110,12 @@ export function AppShell() {
   // Read early: the conversationId scopes the per-session workspace state
   // (rail open/width/tab/open files) used throughout this component.
   const { conversationId } = useParams<{ conversationId: string }>();
+  // The side-by-side view (/compare) has no single active conversation and each
+  // pane brings its own header, so the shell's absolute ChatHeader overlay is
+  // both redundant and would cover the panes' top controls (their close
+  // buttons). Suppress it there; the rest of the chrome already self-gates on
+  // `conversationId` (undefined on /compare).
+  const isComparePage = useLocation().pathname.endsWith("/compare");
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -977,75 +983,78 @@ export function AppShell() {
                   panelOpen && !terminalFirst && "md:hidden",
                 )}
               >
-                <ChatHeader
-                  sidebarOpen={sidebarOpen}
-                  onOpenSidebar={() => setSidebarOpen(true)}
-                  isChildSession={isChildSession}
-                  parentSessionId={activeSession?.parentSessionId}
-                  conversationId={conversationId}
-                  boundAgent={boundAgent}
-                  canShare={canShare}
-                  onShare={() => setShareOpen(true)}
-                  hasAgentInfo={hasAgentInfo}
-                  onAgentInfo={() => setAgentInfoOpen(true)}
-                  hasHeaderMenu={hasHeaderMenu}
-                  showFilesPanel={showFilesPanel}
-                  hasRailContent={hasRailContent}
-                  rightPanelOpen={rightPanelOpen}
-                  onToggleRightPanel={() => {
-                    const next = !rightPanelOpen;
-                    if (conversationId) writeSessionWorkspaceState(conversationId, { open: next });
-                    if (next) {
-                      // Reopening lands back on the file remembered in per-session
-                      // state, so re-add ?file= to keep the URL shareable — mirroring
-                      // how the scope-sync effect re-adds ?view= on reopen. diff and
-                      // comment are URL-only ephemerals (not remembered), so they
-                      // intentionally don't rehydrate. Imperative (not an effect) to
-                      // avoid the FileViewer diff-sync race documented in that effect.
-                      if (selectedFilePath) {
-                        setSearchParams(
-                          (prev) => {
-                            const params = new URLSearchParams(prev);
-                            params.set("file", selectedFilePath);
-                            return params;
-                          },
-                          { replace: true },
-                        );
+                {!isComparePage && (
+                  <ChatHeader
+                    sidebarOpen={sidebarOpen}
+                    onOpenSidebar={() => setSidebarOpen(true)}
+                    isChildSession={isChildSession}
+                    parentSessionId={activeSession?.parentSessionId}
+                    conversationId={conversationId}
+                    boundAgent={boundAgent}
+                    canShare={canShare}
+                    onShare={() => setShareOpen(true)}
+                    hasAgentInfo={hasAgentInfo}
+                    onAgentInfo={() => setAgentInfoOpen(true)}
+                    hasHeaderMenu={hasHeaderMenu}
+                    showFilesPanel={showFilesPanel}
+                    hasRailContent={hasRailContent}
+                    rightPanelOpen={rightPanelOpen}
+                    onToggleRightPanel={() => {
+                      const next = !rightPanelOpen;
+                      if (conversationId)
+                        writeSessionWorkspaceState(conversationId, { open: next });
+                      if (next) {
+                        // Reopening lands back on the file remembered in per-session
+                        // state, so re-add ?file= to keep the URL shareable — mirroring
+                        // how the scope-sync effect re-adds ?view= on reopen. diff and
+                        // comment are URL-only ephemerals (not remembered), so they
+                        // intentionally don't rehydrate. Imperative (not an effect) to
+                        // avoid the FileViewer diff-sync race documented in that effect.
+                        if (selectedFilePath) {
+                          setSearchParams(
+                            (prev) => {
+                              const params = new URLSearchParams(prev);
+                              params.set("file", selectedFilePath);
+                              return params;
+                            },
+                            { replace: true },
+                          );
+                        }
+                      } else {
+                        // Collapsing the rail hides the workspace, so strip the deep-
+                        // link params that point into it (file/diff/comment) — otherwise
+                        // the URL advertises a file that isn't shown and a reload would
+                        // re-open the rail. (?view= is dropped by the scope-sync effect,
+                        // which is gated on rightPanelOpen.)
+                        clearFileViewerUrl();
                       }
-                    } else {
-                      // Collapsing the rail hides the workspace, so strip the deep-
-                      // link params that point into it (file/diff/comment) — otherwise
-                      // the URL advertises a file that isn't shown and a reload would
-                      // re-open the rail. (?view= is dropped by the scope-sync effect,
-                      // which is gated on rightPanelOpen.)
-                      clearFileViewerUrl();
-                    }
-                    setRightPanelOpen(next);
-                  }}
-                  mobileMenu={{
-                    fileViewerOpen,
-                    panelOpen,
-                    terminalFirst,
-                    executionLogsOpen,
-                    filesPanelOpen,
-                    subagentsPanelOpen,
-                    todosPanelOpen,
-                    hideTerminalsTab,
-                    terminalsLength: railTerminals.length,
-                    isClaudeNative,
-                    todosCompleted,
-                    todosTotal: todos.length,
-                    debugMode,
-                    changedCount,
-                    subagentsWorking,
-                    agentCount,
-                    onOpenFiles: openFilesPanel,
-                    onOpenFirstTerminal: openFirstTerminal,
-                    onOpenSubagents: openSubagentsPanel,
-                    onOpenTodos: openTodosPanel,
-                    onOpenMainExecutionLog: openMainExecutionLog,
-                  }}
-                />
+                      setRightPanelOpen(next);
+                    }}
+                    mobileMenu={{
+                      fileViewerOpen,
+                      panelOpen,
+                      terminalFirst,
+                      executionLogsOpen,
+                      filesPanelOpen,
+                      subagentsPanelOpen,
+                      todosPanelOpen,
+                      hideTerminalsTab,
+                      terminalsLength: railTerminals.length,
+                      isClaudeNative,
+                      todosCompleted,
+                      todosTotal: todos.length,
+                      debugMode,
+                      changedCount,
+                      subagentsWorking,
+                      agentCount,
+                      onOpenFiles: openFilesPanel,
+                      onOpenFirstTerminal: openFirstTerminal,
+                      onOpenSubagents: openSubagentsPanel,
+                      onOpenTodos: openTodosPanel,
+                      onOpenMainExecutionLog: openMainExecutionLog,
+                    }}
+                  />
+                )}
                 <main className="relative flex min-h-0 min-w-0 flex-1 flex-col">
                   <Outlet />
                 </main>

--- a/ap-web/src/shell/MultiSessionGrid.tsx
+++ b/ap-web/src/shell/MultiSessionGrid.tsx
@@ -1,0 +1,59 @@
+// Side-by-side multi-session grid: renders one self-contained, fully
+// interactive chat pane per session so an engineer can watch and drive several
+// agents in parallel. Each pane binds its OWN live SSE stream (acquire on
+// mount, release on unmount — aborting only that session's stream) and reads /
+// drives its own session via the `ChatSessionScopeContext`, so the panes are
+// truly isolated rather than snapshots of one active session.
+
+import { useEffect } from "react";
+import { ChatPage } from "@/pages/ChatPage";
+import { acquireSession, ChatSessionScopeContext, releaseSession } from "@/store/chatStore";
+
+/** Minimum readable pane width before the grid switches to horizontal scroll. */
+const PANE_MIN_WIDTH_PX = 360;
+
+/**
+ * One pane: owns its session's bind lifecycle (lazy per pane — the stream
+ * binds when this pane mounts/visible and aborts when it unmounts) and scopes
+ * the reused ChatPage to its session.
+ */
+function SessionPane({ sessionId, onClose }: { sessionId: string; onClose: () => void }) {
+  useEffect(() => {
+    acquireSession(sessionId);
+    return () => releaseSession(sessionId);
+  }, [sessionId]);
+
+  return (
+    <ChatSessionScopeContext.Provider value={sessionId}>
+      <ChatPage paneSessionId={sessionId} embedded onClose={onClose} />
+    </ChatSessionScopeContext.Provider>
+  );
+}
+
+export interface MultiSessionGridProps {
+  /** Sessions to show side by side, left to right. */
+  sessionIds: string[];
+  /** Remove one pane (its session's stream is released on unmount). */
+  onCloseSession: (sessionId: string) => void;
+}
+
+/**
+ * Unbounded horizontal row of panes. Panes share width evenly while they fit
+ * (`flex-1`); once they'd shrink below {@link PANE_MIN_WIDTH_PX} the row
+ * overflows and scrolls horizontally instead.
+ */
+export function MultiSessionGrid({ sessionIds, onCloseSession }: MultiSessionGridProps) {
+  return (
+    <div data-testid="multi-session-grid" className="flex min-h-0 min-w-0 flex-1 overflow-x-auto">
+      {sessionIds.map((id) => (
+        <div
+          key={id}
+          className="flex min-h-0 flex-1 flex-col border-r border-border last:border-r-0"
+          style={{ minWidth: `${PANE_MIN_WIDTH_PX}px` }}
+        >
+          <SessionPane sessionId={id} onClose={() => onCloseSession(id)} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   CheckIcon,
   ChevronRightIcon,
   CircleStopIcon,
+  Columns2Icon,
   GitBranchIcon,
   InboxIcon,
   ListChecksIcon,
@@ -1641,6 +1642,20 @@ function BulkActionBar({
 
         {count > 0 && (
           <div className="hidden items-center gap-1.5 px-2 md:flex">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-xs"
+              disabled={selectedConversations.length < 2}
+              onClick={() =>
+                navigate(`/compare?sessions=${selectedConversations.map((c) => c.id).join(",")}`)
+              }
+              data-testid="open-side-by-side"
+            >
+              <Columns2Icon className="size-3" />
+              Open side-by-side
+            </Button>
             {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
               <Button
                 type="button"

--- a/ap-web/src/store/chatStore.test.ts
+++ b/ap-web/src/store/chatStore.test.ts
@@ -45,10 +45,13 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
+  acquireSession,
   consumePendingInitialPrompt,
+  getChatSessionStore,
   handleSessionEvent,
   initChatStore,
   pumpStreamEvents,
+  releaseSession,
   setPendingInitialPrompt,
   startStreamPump,
   useChatStore,
@@ -346,14 +349,14 @@ beforeEach(() => {
   sessionCostControlOverrides = new Map();
   sessionLabels = new Map();
   initChatStore(client);
+  // initChatStore (above) tears down the per-session registry, clears the
+  // module-level pending stash, and resets the facade to a fresh draft store —
+  // so a stash entry or bound session left by one test can't leak into the
+  // next. This reset just re-asserts the draft store's defaults explicitly.
   useChatStore.setState({
     conversationId: null,
     blocks: [],
     pendingUserMessages: [],
-    // Reset the per-conversation stash too, or a stash entry left by one
-    // navigation test leaks into the next (the entry survives switchTo by
-    // design — that's the whole point — so beforeEach must clear it).
-    pendingByConversation: {},
     activeResponse: null,
     status: "idle",
     sessionStatus: "idle",
@@ -1369,7 +1372,12 @@ describe("chatStore — switchTo", () => {
       },
       content: [{ type: "input_text", text: "preserved" }],
     };
-    useChatStore.setState({ conversationId: "conv_abc", blocks: [block] });
+    // Bind conv_abc as the active session, then re-switch to it: the same-id
+    // guard must short-circuit before any re-fetch.
+    seedSession("conv_abc");
+    await useChatStore.getState().switchTo("conv_abc");
+    useChatStore.setState({ blocks: [block] });
+    fetchMock.mockClear();
 
     await useChatStore.getState().switchTo("conv_abc");
 
@@ -1381,19 +1389,30 @@ describe("chatStore — switchTo", () => {
   });
 
   it("aborts the in-flight stream's controller when switching conversations", async () => {
-    const controller = new AbortController();
-    useChatStore.setState({
-      conversationId: "conv_abc",
-      abortController: controller,
+    // Keep conv_abc's stream open (a pushable sink that never closes) so its
+    // pump — and the controller it owns — stays live until we switch away.
+    const sink = pushableStream();
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/conv_abc\/stream$/.test(url)) {
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      return defaultFetchHandler(input, init);
     });
+    seedSession("conv_abc");
     seedSession("conv_def");
+    await useChatStore.getState().switchTo("conv_abc");
+    // The live bind owns a controller; switching away must abort exactly it.
+    const controller = useChatStore.getState().abortController;
+    expect(controller).not.toBeNull();
 
     await useChatStore.getState().switchTo("conv_def");
 
-    expect(controller.signal.aborted).toBe(true);
+    expect(controller!.signal.aborted).toBe(true);
     // The NEW bind creates a fresh controller; that one stays for the
     // lifetime of the new session's stream.
     expect(useChatStore.getState().conversationId).toBe("conv_def");
+    sink.error();
   });
 
   it("switching to null clears state without opening a stream", async () => {
@@ -1409,13 +1428,16 @@ describe("chatStore — switchTo", () => {
       },
       content: [{ type: "input_text", text: "x" }],
     };
+    // Be on a real conversation with in-flight state, then return to `/`.
+    seedSession("conv_abc");
+    await useChatStore.getState().switchTo("conv_abc");
     useChatStore.setState({
-      conversationId: "conv_abc",
       blocks: [block],
       pendingUserMessages: [
         { tempId: "pend_unacked", content: [{ type: "input_text", text: "still waiting" }] },
       ],
     });
+    fetchMock.mockClear();
 
     await useChatStore.getState().switchTo(null);
 
@@ -1427,6 +1449,7 @@ describe("chatStore — switchTo", () => {
     // ghost bubble from the conv they just left.
     expect(state.pendingUserMessages).toEqual([]);
     expect(state.loadingConversation).toBe(false);
+    // switchTo(null) itself opens no stream (the landing page has no session).
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -6068,7 +6091,6 @@ describe("chatStore — startStreamPump reconnect loop", () => {
 
   it("drops a stale reconcile/re-hydrate after a switch-away-and-back mid-backfill", async () => {
     const preGap = Array.from({ length: 30 }, (_, i) => gapUser("spre", i));
-    const windowItems = preGap.slice(-SESSION_HISTORY_PAGE_SIZE);
     seedSession("conv_stale", preGap);
     seedSession("conv_other", []);
     // Route /stream opens to sinks AND hold reconcile's first backfill page.
@@ -6088,17 +6110,13 @@ describe("chatStore — startStreamPump reconnect loop", () => {
       }
       return defaultFetchHandler(input, init);
     });
-    const controller = new AbortController();
-    useChatStore.setState({
-      conversationId: "conv_stale",
-      abortController: controller,
-      blocks: itemsToBlocks(windowItems),
-      hasMoreHistory: true,
-      oldestItemId: windowItems[0]!.id,
-    });
 
-    const loop = startStreamPump("conv_stale", controller, setState, getState);
+    // Bind conv_stale through the real switchTo path so its stream + controller
+    // are owned by `bindStream` (and aborted on switch-away), rather than a
+    // hand-injected controller the registry never sees.
+    const bind = useChatStore.getState().switchTo("conv_stale");
     await drainAsync();
+    await bind;
     expect(sinks).toHaveLength(1);
 
     // 100 gap items: if the stale backfill resumed, it would outrun the
@@ -6110,8 +6128,9 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // Sync gate: reconcile is parked on its first deferred backfill page.
     expect(releaseBackfill).not.toBeNull();
 
-    // The user leaves and comes back: the revisit hydrates a FRESH window
-    // (the newest 20 gap items) and then scrolls one page up.
+    // The user leaves and comes back: switch-away aborts the live stream; the
+    // revisit re-binds a FRESH window (the newest 20 gap items), bumps the
+    // history generation, and then scrolls one page up.
     const away = useChatStore.getState().switchTo("conv_other");
     await drainAsync(5);
     await away;
@@ -6124,8 +6143,9 @@ describe("chatStore — startStreamPump reconnect loop", () => {
       gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
     );
 
-    // The stale page resolves: the conversation id matches again, so only
-    // the generation guard separates it from the new window.
+    // The stale page resolves: the conversation id matches again (the cached
+    // store was re-bound), so only the generation guard separates it from the
+    // new window.
     releaseBackfill!();
     await drainAsync();
 
@@ -6147,10 +6167,9 @@ describe("chatStore — startStreamPump reconnect loop", () => {
       gap.slice(-3 * SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
     );
 
-    // Unpark the orphaned pump so the awaited loop can exit.
-    sinks[1]!.error();
+    // Unpark every orphaned pump so dangling reconnect loops can exit.
+    for (const sink of sinks) sink.error();
     await drainAsync(2);
-    await loop;
   });
 
   it("re-hydrate keeps pending elicitation and synthetic error blocks in the tail", async () => {
@@ -7188,5 +7207,131 @@ describe("chatStore — policy deny renders once", () => {
     expect(
       await run({ delta: "[Denied by policy: over budget]", message_id: "deny_abc", index: 0 }),
     ).toBe(1);
+  });
+});
+
+describe("chatStore — per-session isolation (side-by-side)", () => {
+  type PumpSetter = Parameters<typeof pumpStreamEvents>[3];
+  type PumpGetter = Parameters<typeof pumpStreamEvents>[4];
+  const textDelta = (marker: string): string =>
+    sse("response.output_text.delta", { delta: `${marker.repeat(34)} ` });
+
+  it("(a) streams two concurrent sessions into independent slices", async () => {
+    // Two sessions, each pumped from its own SSE body. A chunk delivered to
+    // one must land ONLY in that session's store — never bleed across.
+    const storeA = getChatSessionStore("conv_iso_a");
+    const storeB = getChatSessionStore("conv_iso_b");
+    storeA.setState({ conversationId: "conv_iso_a", blocks: [] });
+    storeB.setState({ conversationId: "conv_iso_b", blocks: [] });
+    const sinkA = pushableStream();
+    const sinkB = pushableStream();
+    const ctrlA = new AbortController();
+    const ctrlB = new AbortController();
+    void pumpStreamEvents(
+      "conv_iso_a",
+      sinkA.stream,
+      ctrlA,
+      storeA.setState as unknown as PumpSetter,
+      storeA.getState as unknown as PumpGetter,
+    );
+    void pumpStreamEvents(
+      "conv_iso_b",
+      sinkB.stream,
+      ctrlB,
+      storeB.setState as unknown as PumpSetter,
+      storeB.getState as unknown as PumpGetter,
+    );
+
+    // Stream a response into A only (first content flushes synchronously).
+    sinkA.push(sse("response.created", { id: "resp_a", status: "in_progress", output: [] }));
+    sinkA.push(textDelta("A"));
+    await tick();
+
+    expect(storeA.getState().blocks.some((b) => b.type === "text_chunk")).toBe(true);
+    // B's slice is untouched by A's stream.
+    expect(storeB.getState().blocks).toEqual([]);
+
+    // Now stream into B; A's slice does not change.
+    const aLen = storeA.getState().blocks.length;
+    sinkB.push(sse("response.created", { id: "resp_b", status: "in_progress", output: [] }));
+    sinkB.push(textDelta("B"));
+    await tick();
+
+    expect(storeB.getState().blocks.some((b) => b.type === "text_chunk")).toBe(true);
+    expect(storeA.getState().blocks.length).toBe(aLen);
+
+    ctrlA.abort();
+    ctrlB.abort();
+    sinkA.error();
+    sinkB.error();
+  });
+
+  it("(b) per-session send queues do not cross-talk", async () => {
+    // Hold session A's POST open; session B's resolves normally. If the send
+    // chains were shared, B would block behind A's stalled POST.
+    let releaseA: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/conv_q_a\/events$/.test(url) && init?.method === "POST") {
+        return new Promise<Response>((resolve) => {
+          releaseA = () => resolve(mockResponse({ queued: true, item_id: "ci_a" }));
+        }) as unknown as Response;
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const storeA = getChatSessionStore("conv_q_a");
+    const storeB = getChatSessionStore("conv_q_b");
+    storeA.setState({ conversationId: "conv_q_a", abortController: new AbortController() });
+    storeB.setState({ conversationId: "conv_q_b", abortController: new AbortController() });
+
+    // A's send hangs on its held-open POST; B's send completes independently.
+    const aSend = storeA.getState().send("from A", "agent_xyz");
+    await storeB.getState().send("from B", "agent_xyz");
+
+    // B settled (its optimistic bubble is marked posted) without waiting for A.
+    expect(storeB.getState().pendingUserMessages).toHaveLength(1);
+    expect(storeB.getState().pendingUserMessages.every((p) => p.posted === true)).toBe(true);
+    // A is still in flight — its bubble has not settled.
+    expect(storeA.getState().pendingUserMessages.some((p) => p.posted !== true)).toBe(true);
+
+    releaseA!();
+    await aSend;
+    expect(storeA.getState().pendingUserMessages.every((p) => p.posted === true)).toBe(true);
+  });
+
+  it("(c) releasing a pane aborts ONLY that session's stream", async () => {
+    const sinks: Record<string, StreamSink> = {};
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const m = url.match(/\/v1\/sessions\/([^/]+)\/stream$/);
+      if (m) {
+        const sink = pushableStream();
+        sinks[m[1]!] = sink;
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    seedSession("conv_pane_a");
+    seedSession("conv_pane_b");
+
+    // Two panes, each holding a ref → each binds its own live stream.
+    await acquireSession("conv_pane_a");
+    await acquireSession("conv_pane_b");
+    await tick();
+    const ctrlA = getChatSessionStore("conv_pane_a").getState().abortController;
+    const ctrlB = getChatSessionStore("conv_pane_b").getState().abortController;
+    expect(ctrlA).not.toBeNull();
+    expect(ctrlB).not.toBeNull();
+
+    // Close pane A: ONLY A's stream aborts; B keeps streaming.
+    releaseSession("conv_pane_a");
+    expect(ctrlA!.signal.aborted).toBe(true);
+    expect(ctrlB!.signal.aborted).toBe(false);
+    expect(getChatSessionStore("conv_pane_b").getState().abortController).toBe(ctrlB);
+
+    releaseSession("conv_pane_b");
+    expect(ctrlB!.signal.aborted).toBe(true);
+    sinks["conv_pane_a"]?.error();
+    sinks["conv_pane_b"]?.error();
   });
 });

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -43,7 +43,7 @@
 //     deduping by item id.
 
 import type { InfiniteData, QueryClient } from "@tanstack/react-query";
-import { create } from "zustand";
+import { createStore, useStore, type StoreApi } from "zustand";
 import type {
   AnyBlock,
   ElicitationBlock,
@@ -145,7 +145,7 @@ export interface PendingUserMessage {
 
 /**
  * A conversation's in-flight optimistic bubbles, stashed so they survive
- * in-app navigation. See {@link ChatState.pendingByConversation}.
+ * in-app navigation. See the module-level {@link pendingStash}.
  */
 export interface StashedPending {
   /**
@@ -171,6 +171,37 @@ export interface StashedPending {
   committedTexts: string[];
 }
 
+/**
+ * Cross-session stash of in-flight optimistic bubbles, keyed by conversation
+ * id, so a send whose POST hasn't settled survives the teardown of its
+ * session's store on navigate-away and is restored when that session is bound
+ * again (`bindStream`). Module-level — NOT per-store state — because the whole
+ * point is to outlive a single session store: when a pane (or the
+ * single-session route) releases a session, its store is disposed, and this
+ * map is where the unsettled bubble waits to be re-seeded.
+ *
+ * Scope: ONLY this client's own sends whose POST hasn't settled (`pend_` temp
+ * ids, `posted` unset). Settled / server-owned bubbles are re-served by the
+ * snapshot's `pending_inputs`; stashing them is what stranded the
+ * stuck-forever pending bubble, so `send` prunes an entry the moment its POST
+ * settles. See {@link StashedPending}.
+ */
+const pendingStash = new Map<string, StashedPending>();
+
+/**
+ * Drop one optimistic bubble (by temp id) from a conversation's stash entry,
+ * deleting the entry entirely once empty. Called when a send settles, is
+ * denied, or fails — the server now owns (or will never own) that message, so
+ * the stash must not resurrect it on navigate-back.
+ */
+function prunePendingStash(sessionId: string, tempId: string): void {
+  const entry = pendingStash.get(sessionId);
+  if (entry === undefined) return;
+  const messages = entry.messages.filter((p) => p.tempId !== tempId);
+  if (messages.length === 0) pendingStash.delete(sessionId);
+  else pendingStash.set(sessionId, { ...entry, messages });
+}
+
 export interface ChatState {
   // Reactive — subscribed to by UI components.
   conversationId: string | null;
@@ -188,28 +219,6 @@ export interface ChatState {
   blocks: AnyBlock[];
   /** User messages POSTed but not yet acked via session.input.consumed. */
   pendingUserMessages: PendingUserMessage[];
-  /**
-   * In-flight optimistic bubbles stashed per conversation so they survive
-   * in-app navigation (`switchTo`), keyed by conversation id.
-   *
-   * Scope: ONLY sends whose POST hasn't settled (`posted` unset). Until
-   * the POST returns, the message exists nowhere on the server — on a
-   * cold-starting runner the POST is held open for the whole ensure
-   * probe, before `pending_inputs.record()` runs — so navigating away
-   * and back in that window would otherwise drop the user's message
-   * entirely. Once the POST settles the server is the source of
-   * truth: the navigate-back snapshot re-seeds the bubble from
-   * `pending_inputs` while it's still queued, and shows it committed
-   * once the round-trip lands. Stashing a settled bubble is what made
-   * the stuck-forever pending message possible (committed while away +
-   * consumed event missed + image-only content the text dedupe can't
-   * match), so `send` prunes an entry from here the moment its POST
-   * settles. `bindStream` dedupes a restored bubble against committed
-   * messages that are NEW since the bubble was stashed (the round-trip
-   * can outrun the POST response — see
-   * {@link StashedPending.committedTexts}). Pruned to non-empty entries.
-   */
-  pendingByConversation: Record<string, StashedPending>;
   /** Lifecycle of the most recent send. `null` when idle pre-send. */
   activeResponse: ActiveResponse | null;
   /**
@@ -510,14 +519,10 @@ export interface ChatState {
 }
 
 let queryClient: QueryClient | null = null;
+// Monotonic temp-id counter for optimistic bubbles. Global on purpose: a
+// `pend_<n>` id must be unique across ALL sessions so a bubble stashed for
+// one session can never collide with another's when restored.
 let pendingSeq = 0;
-// Tail of the send chain. Each `send` waits on the previous send's network
-// work before issuing its own POST, so rapid-fire messages reach the server
-// in submission order. Concurrent `fetch` POSTs have no ordering guarantee,
-// which otherwise lets the server accept messages out of order. Module-level
-// (one active chat at a time); the chain only ever resolves, never rejects.
-let sendChain: Promise<void> = Promise.resolve();
-let flashTimer: ReturnType<typeof setTimeout> | null = null;
 const workspaceInvalidationTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 // Must match the @keyframes user-msg-flash duration in index.css.
@@ -565,6 +570,17 @@ export function initChatStore(client: QueryClient): void {
     clearTimeout(timer);
   }
   workspaceInvalidationTimers.clear();
+  // Tear down any bound session stores. Idempotent at app boot (registry
+  // empty) and the teardown a test's `beforeEach` relies on: abort every live
+  // pump, drop every store, and reset the facade to a clean draft so one
+  // test's sessions can't leak into the next.
+  for (const entry of sessionRegistry.values()) {
+    entry.store.getState().abortController?.abort();
+  }
+  sessionRegistry.clear();
+  pendingStash.clear();
+  draftStore = createStore<ChatState>(chatSessionInitializer);
+  activeSessionStore.setState({ id: null });
   queryClient = client;
 }
 
@@ -668,717 +684,874 @@ export function consumePendingInitialPrompt(conversationId: string): PendingInit
   return prompt;
 }
 
-export const useChatStore = create<ChatState>((set, get) => ({
-  conversationId: null,
-  blocks: [],
-  pendingUserMessages: [],
-  pendingByConversation: {},
-  activeResponse: null,
-  interruptedResponseIds: [],
-  status: "idle",
-  sessionStatus: "idle",
-  isNativeTerminalSession: false,
-  boundAgentId: null,
-  boundAgentName: null,
-  loadingConversation: false,
-  conversationLoadError: null,
-  selectedEffort: loadPickerPref(PICKER_PREF_EFFORT_KEY),
-  selectedModel: loadPickerPref(PICKER_PREF_MODEL_KEY),
-  sessionModelOverride: null,
-  costControlModeOverride: null,
-  codexPlanMode: false,
-  hasMoreHistory: false,
-  loadingMoreHistory: false,
-  oldestItemId: null,
-  flashItemId: null,
-  llmModel: null,
-  sessionHarness: null,
-  contextWindow: null,
-  tokensUsed: null,
-  sessionCostUsd: null,
-  sessionUsageByModel: null,
-  gitBranch: null,
-  todos: [],
-  skills: [],
-  codexModelOptions: [],
-  terminalPending: false,
-  viewers: [],
-  sandboxStatus: null,
-  abortController: null,
-  historyGeneration: 0,
+/**
+ * Build one session's store contents (state + actions). Instantiated once per
+ * session via `createStore(chatSessionInitializer)` in the registry below, so
+ * every session owns its own `blocks`, `activeResponse`, `abortController`,
+ * SSE pump, and send queue — concurrent sessions never share streaming state.
+ *
+ * The two per-session mutable bits that used to be module-level singletons
+ * live here as closure locals so they can't cross-talk between sessions:
+ *   - `sendChain` serializes a single session's sends in submission order
+ *     (rapid-fire messages reach the server ordered) without delaying or being
+ *     delayed by any OTHER session's sends. The chain only ever resolves.
+ *   - `flashTimer` debounces the bubble-flash highlight for THIS session, so
+ *     flashing a message in one pane can't cancel another pane's flash.
+ */
+function chatSessionInitializer(set: Setter, get: Getter): ChatState {
+  let sendChain: Promise<void> = Promise.resolve();
+  let flashTimer: ReturnType<typeof setTimeout> | null = null;
+  return {
+    conversationId: null,
+    blocks: [],
+    pendingUserMessages: [],
+    activeResponse: null,
+    interruptedResponseIds: [],
+    status: "idle",
+    sessionStatus: "idle",
+    isNativeTerminalSession: false,
+    boundAgentId: null,
+    boundAgentName: null,
+    loadingConversation: false,
+    conversationLoadError: null,
+    selectedEffort: loadPickerPref(PICKER_PREF_EFFORT_KEY),
+    selectedModel: loadPickerPref(PICKER_PREF_MODEL_KEY),
+    sessionModelOverride: null,
+    costControlModeOverride: null,
+    codexPlanMode: false,
+    hasMoreHistory: false,
+    loadingMoreHistory: false,
+    oldestItemId: null,
+    flashItemId: null,
+    llmModel: null,
+    sessionHarness: null,
+    contextWindow: null,
+    tokensUsed: null,
+    sessionCostUsd: null,
+    sessionUsageByModel: null,
+    gitBranch: null,
+    todos: [],
+    skills: [],
+    codexModelOptions: [],
+    terminalPending: false,
+    viewers: [],
+    sandboxStatus: null,
+    abortController: null,
+    historyGeneration: 0,
 
-  send: async (text, agentId, files, opts) => {
-    if (!agentId) {
-      throw new Error("chatStore.send: no agentId");
-    }
-    // Sending while a response is already streaming is allowed — the
-    // session API queues item-typed events and the server delivers them
-    // into the running task's inbox. Keep `activeResponse` untouched in
-    // that case so the in-flight bubble keeps its "streaming" lifecycle
-    // until its own `response.completed` arrives.
-    const alreadyStreaming = get().status === "streaming";
-    if (!alreadyStreaming) {
-      set({ status: "streaming", activeResponse: null });
-    }
-
-    // Push to `pendingUserMessages` BEFORE the POST so the bubble
-    // renders immediately AND so `session.input.consumed` finds an
-    // entry to promote even if the SSE event races ahead of the POST
-    // response (separate TCP connections; either can resolve first).
-    // FIFO promotion in the consumed handler matches this pending
-    // entry to the eventual server item id.
-    pendingSeq += 1;
-    const tempId = `pend_${pendingSeq}`;
-    const pendingFileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
-      const filename = file.name || "image.png";
-      return file.type.startsWith("image/")
-        ? { type: "input_image" as const, file_id: `pending:${filename}`, filename }
-        : { type: "input_file" as const, file_id: `pending:${filename}`, filename };
-    });
-    const content: MessageContentBlock[] = [
-      ...pendingFileBlocks,
-      ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
-    ];
-    const selfAuthor = getCurrentAuthorId();
-    set((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        { tempId, content, ...(selfAuthor !== null ? { author: selfAuthor } : {}) },
-      ],
-    }));
-
-    // Pin the destination before joining the send chain: a stalled prior
-    // send can delay this POST past a session switch, and resolving the
-    // target afterward would leak the message into the now-active session.
-    const submitConversationId = get().conversationId;
-
-    // Take our place in the send chain: wait for the prior send's network
-    // work, then hand off to the next via `releaseSend` in the finally
-    // below. This serializes POSTs in submission order without delaying the
-    // optimistic bubble rendered above. `priorSend` only ever resolves.
-    const priorSend = sendChain;
-    let releaseSend: () => void = () => {};
-    sendChain = new Promise<void>((resolve) => {
-      releaseSend = resolve;
-    });
-
-    // The session this send actually posts to, once resolved. Read in the
-    // catch to decide whether a failure may touch the active session's UI.
-    let postedSessionId: string | null = null;
-
-    try {
-      await priorSend;
-      const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
-      postedSessionId = sessionId;
-
-      // Upload any attached files and build the real content blocks with
-      // server-assigned file_ids. For images use input_image; for all
-      // other types use input_file. Plain text (if any) appended last.
-      const fileBlocks: ContentBlock[] = [];
-      if (files && files.length > 0) {
-        for (const file of files) {
-          const uploaded = await uploadFile(sessionId, file);
-          if (file.type.startsWith("image/")) {
-            fileBlocks.push({
-              type: "input_image",
-              file_id: uploaded.id,
-              filename: uploaded.filename,
-            });
-          } else {
-            fileBlocks.push({
-              type: "input_file",
-              file_id: uploaded.id,
-              filename: uploaded.filename,
-            });
-          }
-        }
+    send: async (text, agentId, files, opts) => {
+      if (!agentId) {
+        throw new Error("chatStore.send: no agentId");
       }
-      const serverContent: ContentBlock[] = [
-        ...fileBlocks,
+      // Sending while a response is already streaming is allowed — the
+      // session API queues item-typed events and the server delivers them
+      // into the running task's inbox. Keep `activeResponse` untouched in
+      // that case so the in-flight bubble keeps its "streaming" lifecycle
+      // until its own `response.completed` arrives.
+      const alreadyStreaming = get().status === "streaming";
+      if (!alreadyStreaming) {
+        set({ status: "streaming", activeResponse: null });
+      }
+
+      // Push to `pendingUserMessages` BEFORE the POST so the bubble
+      // renders immediately AND so `session.input.consumed` finds an
+      // entry to promote even if the SSE event races ahead of the POST
+      // response (separate TCP connections; either can resolve first).
+      // FIFO promotion in the consumed handler matches this pending
+      // entry to the eventual server item id.
+      pendingSeq += 1;
+      const tempId = `pend_${pendingSeq}`;
+      const pendingFileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
+        const filename = file.name || "image.png";
+        return file.type.startsWith("image/")
+          ? { type: "input_image" as const, file_id: `pending:${filename}`, filename }
+          : { type: "input_file" as const, file_id: `pending:${filename}`, filename };
+      });
+      const content: MessageContentBlock[] = [
+        ...pendingFileBlocks,
         ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
       ];
+      const selfAuthor = getCurrentAuthorId();
+      set((s) => ({
+        pendingUserMessages: [
+          ...s.pendingUserMessages,
+          { tempId, content, ...(selfAuthor !== null ? { author: selfAuthor } : {}) },
+        ],
+      }));
 
-      // Promote "pending:<filename>" to real file_ids. Claude-native's
-      // session.input.consumed is text-only (transcript round-trip
-      // drops input_image blocks), so the consumed handler falls back
-      // to the pending file blocks — they must already carry real ids.
-      if (fileBlocks.length > 0) {
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.map((p) =>
-            p.tempId === tempId ? { ...p, content: serverContent } : p,
-          ),
-        }));
-      }
+      // Pin the destination before joining the send chain: a stalled prior
+      // send can delay this POST past a session switch, and resolving the
+      // target afterward would leak the message into the now-active session.
+      const submitConversationId = get().conversationId;
 
-      const postResult = await postEvent(sessionId, {
-        type: "message",
-        data: {
-          role: "user",
-          content: serverContent,
-        },
+      // Take our place in the send chain: wait for the prior send's network
+      // work, then hand off to the next via `releaseSend` in the finally
+      // below. This serializes POSTs in submission order without delaying the
+      // optimistic bubble rendered above. `priorSend` only ever resolves.
+      const priorSend = sendChain;
+      let releaseSend: () => void = () => {};
+      sendChain = new Promise<void>((resolve) => {
+        releaseSend = resolve;
       });
-      // Policy denied the input — the server returned immediately
-      // without starting a turn or persisting the user message, so
-      // no session.input.consumed will reconcile this exact optimistic
-      // bubble. Settle local state from the POST response instead of
-      // depending on the live stream being connected.
-      if (postResult.denied) {
-        set((s) => {
+
+      // The session this send actually posts to, once resolved. Read in the
+      // catch to decide whether a failure may touch the active session's UI.
+      let postedSessionId: string | null = null;
+
+      try {
+        await priorSend;
+        const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
+        postedSessionId = sessionId;
+
+        // Upload any attached files and build the real content blocks with
+        // server-assigned file_ids. For images use input_image; for all
+        // other types use input_file. Plain text (if any) appended last.
+        const fileBlocks: ContentBlock[] = [];
+        if (files && files.length > 0) {
+          for (const file of files) {
+            const uploaded = await uploadFile(sessionId, file);
+            if (file.type.startsWith("image/")) {
+              fileBlocks.push({
+                type: "input_image",
+                file_id: uploaded.id,
+                filename: uploaded.filename,
+              });
+            } else {
+              fileBlocks.push({
+                type: "input_file",
+                file_id: uploaded.id,
+                filename: uploaded.filename,
+              });
+            }
+          }
+        }
+        const serverContent: ContentBlock[] = [
+          ...fileBlocks,
+          ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
+        ];
+
+        // Promote "pending:<filename>" to real file_ids. Claude-native's
+        // session.input.consumed is text-only (transcript round-trip
+        // drops input_image blocks), so the consumed handler falls back
+        // to the pending file blocks — they must already carry real ids.
+        if (fileBlocks.length > 0) {
+          set((s) => ({
+            pendingUserMessages: s.pendingUserMessages.map((p) =>
+              p.tempId === tempId ? { ...p, content: serverContent } : p,
+            ),
+          }));
+        }
+
+        const postResult = await postEvent(sessionId, {
+          type: "message",
+          data: {
+            role: "user",
+            content: serverContent,
+          },
+        });
+        // Policy denied the input — the server returned immediately
+        // without starting a turn or persisting the user message, so
+        // no session.input.consumed will reconcile this exact optimistic
+        // bubble. Settle local state from the POST response instead of
+        // depending on the live stream being connected.
+        if (postResult.denied) {
           // The stash copy rolls back even when the user has navigated
           // away — that's exactly when the entry lives there, and a
           // denied send has no server-side record to ever reconcile it.
-          const patch: Partial<ChatState> = {
-            pendingByConversation: removeFromPendingStash(
-              s.pendingByConversation,
-              sessionId,
-              tempId,
+          prunePendingStash(sessionId, tempId);
+          set((s) => {
+            if (s.conversationId !== sessionId) return {};
+            const patch: Partial<ChatState> = {
+              pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+            };
+            if (!alreadyStreaming) {
+              patch.status = "idle";
+              patch.sessionStatus = "idle";
+            }
+            return patch;
+          });
+        } else {
+          // POST accepted: the server can now account for this message
+          // (native: pending_inputs replay until the round-trip commits
+          // it; non-native: already persisted). Mark the live bubble
+          // settled and drop any stash copy so navigation defers to the
+          // server instead of resurrecting a client copy the server may
+          // have since resolved — the stuck-pending-bubble bug. The live
+          // bubble itself keeps rendering until its consumed event pops
+          // it; only the navigation-survival policy changes here.
+          prunePendingStash(sessionId, tempId);
+          set((s) => ({
+            pendingUserMessages: s.pendingUserMessages.map((p) =>
+              p.tempId === tempId ? { ...p, posted: true } : p,
             ),
-          };
-          if (s.conversationId !== sessionId) return patch;
-          patch.pendingUserMessages = s.pendingUserMessages.filter((p) => p.tempId !== tempId);
+          }));
+        }
+        // Note: native-terminal messages return a `pending_id`, but the
+        // optimistic bubble deliberately keeps its client temp id as its
+        // stable React key — swapping it to the server id mid-send forces
+        // a bubble remount (a visible flink). The eventual
+        // `session.input.consumed` clears this bubble by FIFO order (its
+        // `clearedPendingId` matches only snapshot-hydrated bubbles, which
+        // already carry the server id); see the consumed handler.
+        // Refresh the sidebar without waiting for the 4 s `useConversations`
+        // poll — picks up server-side title auto-gen and any runner_id /
+        // status transitions that happen during the turn.
+        queryClient?.invalidateQueries({ queryKey: ["conversations"] });
+      } catch (err) {
+        const { message, code } = describeSendFailure(err);
+        // The stash copy rolls back unconditionally: a failed send has no
+        // server-side record, so a bubble stashed by a mid-POST
+        // navigate-away would otherwise strand as forever-pending on
+        // navigate-back (nothing can ever reconcile it).
+        const stashSessionId = postedSessionId ?? submitConversationId;
+        if (stashSessionId !== null) {
+          prunePendingStash(stashSessionId, tempId);
+        }
+        // A queued send can target a session the user has since switched away
+        // from (submit-time pin). Only roll back the bubble and settle status
+        // when that session is still active — otherwise the failure would
+        // clobber the now-active session's UI. When the throw came from
+        // session setup itself (postedSessionId never resolved), settle
+        // unconditionally: that failure belongs to the active context.
+        if (postedSessionId === null || get().conversationId === postedSessionId) {
+          // Roll back the optimistic bubble — no server idle will fire.
+          set((s) => ({
+            pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+          }));
           if (!alreadyStreaming) {
-            patch.status = "idle";
-            patch.sessionStatus = "idle";
+            if (get().activeResponse !== null) {
+              // A response bubble already exists (the turn started, then failed)
+              // — mark it failed so the error rides on that bubble.
+              finalizeActive(set, "failed", message, null);
+            } else {
+              // No response bubble to carry the failure — the turn never started
+              // (e.g. the runner never came online, so POST /events 503'd). Append
+              // a standalone error block so the user sees WHY nothing happened
+              // instead of being left on a silent, empty composer.
+              set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
+            }
+            set({ status: "idle" });
           }
-          return patch;
-        });
-      } else {
-        // POST accepted: the server can now account for this message
-        // (native: pending_inputs replay until the round-trip commits
-        // it; non-native: already persisted). Mark the live bubble
-        // settled and drop any stash copy so navigation defers to the
-        // server instead of resurrecting a client copy the server may
-        // have since resolved — the stuck-pending-bubble bug. The live
-        // bubble itself keeps rendering until its consumed event pops
-        // it; only the navigation-survival policy changes here.
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.map((p) =>
-            p.tempId === tempId ? { ...p, posted: true } : p,
-          ),
-          pendingByConversation: removeFromPendingStash(s.pendingByConversation, sessionId, tempId),
-        }));
+        }
+      } finally {
+        // Release the next queued send regardless of success/failure so one
+        // failed POST can't stall the chain forever.
+        releaseSend();
       }
-      // Note: native-terminal messages return a `pending_id`, but the
-      // optimistic bubble deliberately keeps its client temp id as its
-      // stable React key — swapping it to the server id mid-send forces
-      // a bubble remount (a visible flink). The eventual
-      // `session.input.consumed` clears this bubble by FIFO order (its
-      // `clearedPendingId` matches only snapshot-hydrated bubbles, which
-      // already carry the server id); see the consumed handler.
-      // Refresh the sidebar without waiting for the 4 s `useConversations`
-      // poll — picks up server-side title auto-gen and any runner_id /
-      // status transitions that happen during the turn.
-      queryClient?.invalidateQueries({ queryKey: ["conversations"] });
-    } catch (err) {
-      const { message, code } = describeSendFailure(err);
-      // The stash copy rolls back unconditionally: a failed send has no
-      // server-side record, so a bubble stashed by a mid-POST
-      // navigate-away would otherwise strand as forever-pending on
-      // navigate-back (nothing can ever reconcile it).
-      const stashSessionId = postedSessionId ?? submitConversationId;
-      if (stashSessionId !== null) {
-        set((s) => ({
-          pendingByConversation: removeFromPendingStash(
-            s.pendingByConversation,
-            stashSessionId,
+    },
+
+    sendSlashCommand: async (name, args, agentId, opts) => {
+      if (!agentId) {
+        throw new Error("chatStore.sendSlashCommand: no agentId");
+      }
+      // Mirror `send`'s lifecycle scaffolding (streaming flag + send-chain
+      // serialization) so a skill invocation behaves like any other turn.
+      const alreadyStreaming = get().status === "streaming";
+      if (!alreadyStreaming) {
+        set({ status: "streaming", activeResponse: null });
+      }
+      // Optimistic echo of the typed command, mirroring `send`. Without it
+      // the chat shows nothing until the server's `slash_command` receipt
+      // arrives over SSE — and on a fresh session that POST is held open
+      // while the host boots a runner and resolves the skill, so a
+      // skill-first session flashed the empty-chat state for seconds. The
+      // pump's `slash_command` case pops this FIFO entry the moment the
+      // receipt (and its synthesized `${id}:user` echo block) lands, so the
+      // optimistic bubble swaps for the committed one in the same flush.
+      pendingSeq += 1;
+      const tempId = `pend_${pendingSeq}`;
+      const commandText = args ? `/${name} ${args}` : `/${name}`;
+      const selfAuthor = getCurrentAuthorId();
+      set((s) => ({
+        pendingUserMessages: [
+          ...s.pendingUserMessages,
+          {
             tempId,
-          ),
-        }));
-      }
-      // A queued send can target a session the user has since switched away
-      // from (submit-time pin). Only roll back the bubble and settle status
-      // when that session is still active — otherwise the failure would
-      // clobber the now-active session's UI. When the throw came from
-      // session setup itself (postedSessionId never resolved), settle
-      // unconditionally: that failure belongs to the active context.
-      if (postedSessionId === null || get().conversationId === postedSessionId) {
-        // Roll back the optimistic bubble — no server idle will fire.
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
-        }));
-        if (!alreadyStreaming) {
-          if (get().activeResponse !== null) {
-            // A response bubble already exists (the turn started, then failed)
-            // — mark it failed so the error rides on that bubble.
-            finalizeActive(set, "failed", message, null);
-          } else {
-            // No response bubble to carry the failure — the turn never started
-            // (e.g. the runner never came online, so POST /events 503'd). Append
-            // a standalone error block so the user sees WHY nothing happened
-            // instead of being left on a silent, empty composer.
-            set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
-          }
+            content: [{ type: "input_text" as const, text: commandText }],
+            ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+          },
+        ],
+      }));
+
+      // Pin the destination at submit time — see `send` above for why a late
+      // resolve mis-routes to the session the user has since switched to.
+      const submitConversationId = get().conversationId;
+
+      const priorSend = sendChain;
+      let releaseSend: () => void = () => {};
+      sendChain = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+
+      // The session this command actually posts to, once resolved.
+      let postedSessionId: string | null = null;
+
+      try {
+        await priorSend;
+        const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
+        postedSessionId = sessionId;
+        // Same wire shape the REPL sends (repl/_repl.py). The server resolves
+        // the skill, persists a visible receipt + hidden `<skill>` meta
+        // message, and forwards the meta to the runner.
+        const postResult = await postEvent(sessionId, {
+          type: "slash_command",
+          data: { kind: "skill", name, arguments: args },
+        });
+        if (postResult.denied) {
+          // Denied commands publish no receipt, so nothing will pop the
+          // optimistic echo — roll it back here alongside the status
+          // settle. The stash copy rolls back even when the user has
+          // navigated away (that's when the entry lives there).
+          prunePendingStash(sessionId, tempId);
+          set((s) => {
+            if (s.conversationId !== sessionId) return {};
+            const patch: Partial<ChatState> = {
+              pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+            };
+            if (!alreadyStreaming) {
+              patch.status = "idle";
+              patch.sessionStatus = "idle";
+            }
+            return patch;
+          });
+        } else {
+          // POST accepted: the server persisted the visible receipt, so
+          // navigation can rely on the snapshot — mark the echo settled
+          // and drop any stash copy. Without this, an echo stashed by a
+          // mid-POST navigate-away strands forever: the receipt is a
+          // SlashCommandBlock, not a user message, so the navigate-back
+          // text dedupe can never match it, and no consumed event fires.
+          prunePendingStash(sessionId, tempId);
+          set((s) => ({
+            pendingUserMessages: s.pendingUserMessages.map((p) =>
+              p.tempId === tempId ? { ...p, posted: true } : p,
+            ),
+          }));
+        }
+        queryClient?.invalidateQueries({ queryKey: ["conversations"] });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // The stash copy rolls back unconditionally — a failed command has
+        // no server-side record to ever reconcile a stashed echo.
+        const stashSessionId = postedSessionId ?? submitConversationId;
+        if (stashSessionId !== null) {
+          prunePendingStash(stashSessionId, tempId);
+        }
+        // Only settle status when the failed command's session is still active
+        // — a queued send can target a session the user switched away from, and
+        // its failure must not reset the now-active session's UI. A throw from
+        // session setup itself (postedSessionId unresolved) settles the active
+        // context as before.
+        const stillActive = postedSessionId === null || get().conversationId === postedSessionId;
+        if (stillActive) {
+          // Roll back the optimistic echo — no receipt will reconcile it.
+          set((s) => ({
+            pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+          }));
+        }
+        if (stillActive && !alreadyStreaming) {
+          finalizeActive(set, "failed", message, null);
           set({ status: "idle" });
         }
+      } finally {
+        releaseSend();
       }
-    } finally {
-      // Release the next queued send regardless of success/failure so one
-      // failed POST can't stall the chain forever.
-      releaseSend();
-    }
-  },
+    },
 
-  sendSlashCommand: async (name, args, agentId, opts) => {
-    if (!agentId) {
-      throw new Error("chatStore.sendSlashCommand: no agentId");
-    }
-    // Mirror `send`'s lifecycle scaffolding (streaming flag + send-chain
-    // serialization) so a skill invocation behaves like any other turn.
-    const alreadyStreaming = get().status === "streaming";
-    if (!alreadyStreaming) {
-      set({ status: "streaming", activeResponse: null });
-    }
-    // Optimistic echo of the typed command, mirroring `send`. Without it
-    // the chat shows nothing until the server's `slash_command` receipt
-    // arrives over SSE — and on a fresh session that POST is held open
-    // while the host boots a runner and resolves the skill, so a
-    // skill-first session flashed the empty-chat state for seconds. The
-    // pump's `slash_command` case pops this FIFO entry the moment the
-    // receipt (and its synthesized `${id}:user` echo block) lands, so the
-    // optimistic bubble swaps for the committed one in the same flush.
-    pendingSeq += 1;
-    const tempId = `pend_${pendingSeq}`;
-    const commandText = args ? `/${name} ${args}` : `/${name}`;
-    const selfAuthor = getCurrentAuthorId();
-    set((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        {
-          tempId,
-          content: [{ type: "input_text" as const, text: commandText }],
-          ...(selfAuthor !== null ? { author: selfAuthor } : {}),
-        },
-      ],
-    }));
-
-    // Pin the destination at submit time — see `send` above for why a late
-    // resolve mis-routes to the session the user has since switched to.
-    const submitConversationId = get().conversationId;
-
-    const priorSend = sendChain;
-    let releaseSend: () => void = () => {};
-    sendChain = new Promise<void>((resolve) => {
-      releaseSend = resolve;
-    });
-
-    // The session this command actually posts to, once resolved.
-    let postedSessionId: string | null = null;
-
-    try {
-      await priorSend;
-      const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
-      postedSessionId = sessionId;
-      // Same wire shape the REPL sends (repl/_repl.py). The server resolves
-      // the skill, persists a visible receipt + hidden `<skill>` meta
-      // message, and forwards the meta to the runner.
-      const postResult = await postEvent(sessionId, {
-        type: "slash_command",
-        data: { kind: "skill", name, arguments: args },
+    stop: () => {
+      const sessionId = get().conversationId;
+      if (!sessionId) return;
+      // Fire-and-forget interrupt; the server emits session.interrupted
+      // + response.incomplete on the open stream, which the pump
+      // translates into the cancelled bubble decoration. We deliberately
+      // do NOT abort the local SSE stream — it remains open across
+      // turns; switchTo or tab unload is the only thing that tears it
+      // down.
+      void interruptSession(sessionId).catch(() => {
+        // Interrupt is best-effort. A network failure here means the
+        // user's cancel won't reach the server, but the local UI already
+        // reflects the user's stop request below.
       });
-      if (postResult.denied) {
-        // Denied commands publish no receipt, so nothing will pop the
-        // optimistic echo — roll it back here alongside the status
-        // settle. The stash copy rolls back even when the user has
-        // navigated away (that's when the entry lives there).
-        set((s) => {
-          const patch: Partial<ChatState> = {
-            pendingByConversation: removeFromPendingStash(
-              s.pendingByConversation,
-              sessionId,
-              tempId,
-            ),
-          };
-          if (s.conversationId !== sessionId) return patch;
-          patch.pendingUserMessages = s.pendingUserMessages.filter((p) => p.tempId !== tempId);
-          if (!alreadyStreaming) {
-            patch.status = "idle";
-            patch.sessionStatus = "idle";
-          }
-          return patch;
-        });
-      } else {
-        // POST accepted: the server persisted the visible receipt, so
-        // navigation can rely on the snapshot — mark the echo settled
-        // and drop any stash copy. Without this, an echo stashed by a
-        // mid-POST navigate-away strands forever: the receipt is a
-        // SlashCommandBlock, not a user message, so the navigate-back
-        // text dedupe can never match it, and no consumed event fires.
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.map((p) =>
-            p.tempId === tempId ? { ...p, posted: true } : p,
-          ),
-          pendingByConversation: removeFromPendingStash(s.pendingByConversation, sessionId, tempId),
-        }));
-      }
-      queryClient?.invalidateQueries({ queryKey: ["conversations"] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      // The stash copy rolls back unconditionally — a failed command has
-      // no server-side record to ever reconcile a stashed echo.
-      const stashSessionId = postedSessionId ?? submitConversationId;
-      if (stashSessionId !== null) {
-        set((s) => ({
-          pendingByConversation: removeFromPendingStash(
-            s.pendingByConversation,
-            stashSessionId,
-            tempId,
-          ),
-        }));
-      }
-      // Only settle status when the failed command's session is still active
-      // — a queued send can target a session the user switched away from, and
-      // its failure must not reset the now-active session's UI. A throw from
-      // session setup itself (postedSessionId unresolved) settles the active
-      // context as before.
-      const stillActive = postedSessionId === null || get().conversationId === postedSessionId;
-      if (stillActive) {
-        // Roll back the optimistic echo — no receipt will reconcile it.
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
-        }));
-      }
-      if (stillActive && !alreadyStreaming) {
-        finalizeActive(set, "failed", message, null);
-        set({ status: "idle" });
-      }
-    } finally {
-      releaseSend();
-    }
-  },
-
-  stop: () => {
-    const sessionId = get().conversationId;
-    if (!sessionId) return;
-    // Fire-and-forget interrupt; the server emits session.interrupted
-    // + response.incomplete on the open stream, which the pump
-    // translates into the cancelled bubble decoration. We deliberately
-    // do NOT abort the local SSE stream — it remains open across
-    // turns; switchTo or tab unload is the only thing that tears it
-    // down.
-    void interruptSession(sessionId).catch(() => {
-      // Interrupt is best-effort. A network failure here means the
-      // user's cancel won't reach the server, but the local UI already
-      // reflects the user's stop request below.
-    });
-    set((s) => {
-      if (s.conversationId !== sessionId) return {};
-      const patch: Partial<ChatState> = {
-        pendingUserMessages: [],
-        status: "idle",
-        sessionStatus: "idle",
-      };
-      if (s.activeResponse?.state === "streaming") {
-        patch.activeResponse = {
-          ...s.activeResponse,
-          state: "cancelled",
-          error: null,
+      set((s) => {
+        if (s.conversationId !== sessionId) return {};
+        const patch: Partial<ChatState> = {
+          pendingUserMessages: [],
+          status: "idle",
+          sessionStatus: "idle",
         };
-      }
-      return patch;
-    });
-    // Optimistic, unbacked write: unlike the session.status SSE caller, no
-    // server event backs this, so a poll that interleaves while the turn is
-    // genuinely still running may briefly revert the sidebar dot — the helper's
-    // "never fights the poller" contract doesn't hold here. Self-corrects on the
-    // real idle event.
-    patchConversationStatusInCache(sessionId, "idle");
-    // Mirror the session.status handler: a sub-agent's row lives in its parent's
-    // child-sessions list, not the sidebar, so refresh the rail in lockstep.
-    const snapshot = queryClient?.getQueryData<Session>(["session", sessionId]);
-    if (snapshot?.parentSessionId) {
-      queryClient?.invalidateQueries({
-        queryKey: childSessionsQueryKey(snapshot.parentSessionId),
-      });
-    }
-  },
-
-  switchTo: async (conversationId) => {
-    if (get().conversationId === conversationId) return;
-
-    // Abort the prior session's stream. The reader loop in
-    // bindStream's pump unwinds via AbortError and stops applying
-    // events to state.blocks.
-    get().abortController?.abort();
-
-    set((s) => {
-      // Stash the OUTGOING conversation's still-in-flight optimistic
-      // bubbles and restore the INCOMING one's. Until a send's POST
-      // settles, the message exists nowhere on the server (a
-      // cold-starting runner holds the POST open before
-      // pending_inputs.record() runs), so wiping pendingUserMessages
-      // here (as a cold load must) would drop the user's message
-      // entirely on navigate-away. The stash bridges exactly
-      // that window and nothing more. Pruned to non-empty so the map
-      // doesn't accrete stale keys; a restored bubble is reconciled
-      // against the server snapshot in bindStream.
-      const pendingByConversation = { ...s.pendingByConversation };
-      if (s.conversationId !== null) {
-        // Stash only THIS client's own UNSETTLED bubbles — client temp
-        // ids (`pend_<n>`, set by send) whose POST hasn't returned.
-        // Everything else is server-owned and re-seeded by the
-        // navigate-back snapshot: snapshot-replayed / foreign bubbles
-        // (server `pending_<hex>` ids) come back via pending_inputs, and
-        // settled own sends (`posted`) come back via pending_inputs while
-        // queued or as committed items once their round-trip lands.
-        // Stashing a settled bubble is what stranded image-only messages
-        // forever (committed while away + consumed event missed → no
-        // pending_inputs entry left, no text for the dedupe to match).
-        const own = s.pendingUserMessages.filter(
-          (p) => p.tempId.startsWith("pend_") && p.posted !== true,
-        );
-        if (own.length > 0) {
-          // Capture the committed user texts present NOW as the dedup
-          // baseline: on navigate-back only committed messages new since this
-          // moment count as the persisted copy of a stashed bubble (see
-          // StashedPending.committedTexts).
-          pendingByConversation[s.conversationId] = {
-            messages: own,
-            committedTexts: committedUserTextsOf(s.blocks),
+        if (s.activeResponse?.state === "streaming") {
+          patch.activeResponse = {
+            ...s.activeResponse,
+            state: "cancelled",
+            error: null,
           };
-        } else {
-          delete pendingByConversation[s.conversationId];
         }
+        return patch;
+      });
+      // Optimistic, unbacked write: unlike the session.status SSE caller, no
+      // server event backs this, so a poll that interleaves while the turn is
+      // genuinely still running may briefly revert the sidebar dot — the helper's
+      // "never fights the poller" contract doesn't hold here. Self-corrects on the
+      // real idle event.
+      patchConversationStatusInCache(sessionId, "idle");
+      // Mirror the session.status handler: a sub-agent's row lives in its parent's
+      // child-sessions list, not the sidebar, so refresh the rail in lockstep.
+      const snapshot = queryClient?.getQueryData<Session>(["session", sessionId]);
+      if (snapshot?.parentSessionId) {
+        queryClient?.invalidateQueries({
+          queryKey: childSessionsQueryKey(snapshot.parentSessionId),
+        });
       }
-      return {
-        pendingByConversation,
-        conversationId,
-        // Cleared here, so a different session's in-flight preview blocks
-        // (``live:*``) never bleed across.
-        blocks: [],
-        pendingUserMessages:
-          conversationId !== null ? (pendingByConversation[conversationId]?.messages ?? []) : [],
-        activeResponse: null,
-        interruptedResponseIds: [],
-        status: "idle",
-        sessionStatus: "idle",
-        isNativeTerminalSession: false,
-        boundAgentId: null,
-        boundAgentName: null,
-        loadingConversation: conversationId !== null,
-        conversationLoadError: null,
-        hasMoreHistory: false,
-        loadingMoreHistory: false,
-        oldestItemId: null,
-        llmModel: null,
-        sessionHarness: null,
-        // ``selectedEffort`` / ``selectedModel`` are sticky user picks —
-        // not reset here so a CLI-created new chat inherits them.
-        // ``sessionModelOverride`` and the cost switch ARE session-scoped,
-        // so they reset with the session and re-hydrate from the snapshot.
-        sessionModelOverride: null,
-        costControlModeOverride: null,
-        codexPlanMode: false,
-        contextWindow: null,
-        tokensUsed: null,
-        sessionCostUsd: null,
-        sessionUsageByModel: null,
-        gitBranch: null,
-        todos: [],
-        skills: [],
-        codexModelOptions: [],
-        terminalPending: false,
-        viewers: [],
-        sandboxStatus: null,
-        abortController: null,
-        historyGeneration: s.historyGeneration + 1,
-      };
-    });
+    },
 
-    if (conversationId === null) return;
-    // hydratePending: this is a cold load / navigation. When no bubble was
-    // restored from the stash above, replay the snapshot's un-consumed
-    // native messages; when one was, bindStream dedupes it against the
-    // committed snapshot. Reconnect/rebind paths pass false so they never
-    // overwrite the live optimistic bubbles (which would flink).
-    await bindStream(conversationId, set, get, true);
-  },
+    // `switchTo` is the single-session route's "make this the active session"
+    // entry point. It is intentionally a thin delegate to the registry-level
+    // `facadeSwitchTo`: in the per-session-store model there is no in-place
+    // reset to do — moving to another session means releasing the prior store
+    // (which aborts its stream and stashes its unsettled bubbles) and acquiring
+    // a fresh one for the target (which binds + hydrates). See `facadeSwitchTo`.
+    switchTo: (conversationId) => facadeSwitchTo(conversationId),
 
-  submitApproval: async (elicitationId, action, content) => {
-    const sessionId = get().conversationId;
-    if (!sessionId) return;
-    const targetSessionId =
-      get().blocks.find(
-        (b): b is ElicitationBlock => b.type === "elicitation" && b.elicitationId === elicitationId,
-      )?.targetSessionId ?? sessionId;
-    // Optimistically flip the matching elicitation block to
-    // "responded" so the buttons disappear immediately. No server
-    // event confirms the approval — the agent just resumes (or
-    // refuses) and emits its next stream events, so this local
-    // update is the entire UX of "I clicked accept".
-    //
-    // ``content`` rides through the response field so multi-choice
-    // cards (AskUserQuestion) can render the selected label rather
-    // than a generic "Approved" pill.
-    const responseValue: ElicitationBlock["response"] =
-      content === undefined ? { action } : { action, content };
-    set((s) => ({
-      blocks: s.blocks.map((b) =>
-        b.type === "elicitation" && b.elicitationId === elicitationId
-          ? { ...b, status: "responded", response: responseValue }
-          : b,
-      ),
-    }));
-    try {
-      await approveElicitation(
-        targetSessionId,
-        elicitationId,
-        content === undefined ? { action } : { action, content },
-      );
-    } catch {
-      // Roll back to pending so the user can retry. Surfacing the
-      // error is a future affordance — for now, the buttons
-      // reappear and the user can try again.
+    submitApproval: async (elicitationId, action, content) => {
+      const sessionId = get().conversationId;
+      if (!sessionId) return;
+      const targetSessionId =
+        get().blocks.find(
+          (b): b is ElicitationBlock =>
+            b.type === "elicitation" && b.elicitationId === elicitationId,
+        )?.targetSessionId ?? sessionId;
+      // Optimistically flip the matching elicitation block to
+      // "responded" so the buttons disappear immediately. No server
+      // event confirms the approval — the agent just resumes (or
+      // refuses) and emits its next stream events, so this local
+      // update is the entire UX of "I clicked accept".
+      //
+      // ``content`` rides through the response field so multi-choice
+      // cards (AskUserQuestion) can render the selected label rather
+      // than a generic "Approved" pill.
+      const responseValue: ElicitationBlock["response"] =
+        content === undefined ? { action } : { action, content };
       set((s) => ({
         blocks: s.blocks.map((b) =>
           b.type === "elicitation" && b.elicitationId === elicitationId
-            ? { ...b, status: "pending", response: null }
+            ? { ...b, status: "responded", response: responseValue }
             : b,
         ),
       }));
-    }
-  },
-
-  flashUserMessage: (itemId) => {
-    if (flashTimer !== null) clearTimeout(flashTimer);
-    set({ flashItemId: itemId });
-    flashTimer = setTimeout(() => {
-      flashTimer = null;
-      set({ flashItemId: null });
-    }, FLASH_DURATION_MS);
-  },
-
-  compact: async () => {
-    const { conversationId } = get();
-    if (!conversationId) return;
-    await postEvent(conversationId, { type: "compact", data: {} });
-  },
-
-  refreshSessionState: async (conversationId) => {
-    const id = conversationId ?? get().conversationId;
-    if (!id) return;
-    await refetchRunnerBackedSessionState(id, {
-      refreshState: true,
-      applyBindingPatch: true,
-    });
-  },
-
-  setEffort: async (effort) => {
-    set({ selectedEffort: effort });
-    savePickerPref(PICKER_PREF_EFFORT_KEY, effort);
-    const { conversationId } = get();
-    if (conversationId) {
-      if (queryClient === null) {
-        throw new Error("chatStore.setEffort: queryClient not initialized");
-      }
-      const session = await queryClient.fetchQuery({
-        queryKey: ["session", conversationId],
-        queryFn: () => getSessionSlim(conversationId),
-        staleTime: Infinity,
-        retry: false,
-      });
-      if (!supportsEffortControl(session)) return;
-      await updateSession(conversationId, { reasoningEffort: effort });
-    }
-  },
-
-  setModel: async (model) => {
-    // `selectedModel` is the sticky pick; `sessionModelOverride` is this
-    // session's applied override. An explicit `/model` sets both.
-    set({ selectedModel: model, sessionModelOverride: model });
-    savePickerPref(PICKER_PREF_MODEL_KEY, model);
-    const { conversationId } = get();
-    if (conversationId) {
-      const session = await updateSession(conversationId, { modelOverride: model });
-      // Server-canonical may differ from the optimistic write (e.g.
-      // when a clear alias was sent) — refresh local state to match.
-      const canonical = session.modelOverride ?? null;
-      set({ selectedModel: canonical, sessionModelOverride: canonical });
-      savePickerPref(PICKER_PREF_MODEL_KEY, canonical);
-    }
-  },
-
-  setCostControlMode: async (mode) => {
-    const { conversationId } = get();
-    if (!conversationId) return;
-    const previous = get().costControlModeOverride;
-    // Optimistic flip so the pill responds instantly; the PATCH
-    // response (or the rollback below) is the settled truth.
-    set({ costControlModeOverride: mode });
-    try {
-      const session = await updateSession(conversationId, { costControlModeOverride: mode });
-      if (get().conversationId !== conversationId) return;
-      set({ costControlModeOverride: session.costControlModeOverride ?? null });
-    } catch (err) {
-      // Roll back so the pill doesn't claim a state the server never persisted.
-      if (get().conversationId === conversationId) {
-        set({ costControlModeOverride: previous });
-      }
-      throw err;
-    }
-  },
-
-  setCodexPlanMode: async (enabled) => {
-    const { conversationId } = get();
-    if (!conversationId) return;
-    const previous = get().codexPlanMode;
-    set({ codexPlanMode: enabled });
-    try {
-      const session = await updateSession(conversationId, { codexPlanMode: enabled });
-      if (get().conversationId !== conversationId) return;
-      set({ codexPlanMode: codexPlanModeFromSession(session) });
-    } catch (err) {
-      if (get().conversationId === conversationId) {
-        set({ codexPlanMode: previous });
-      }
-      throw err;
-    }
-  },
-
-  loadMoreHistory: async () => {
-    const { conversationId, oldestItemId, loadingMoreHistory, hasMoreHistory, historyGeneration } =
-      get();
-    if (!conversationId || !oldestItemId || loadingMoreHistory || !hasMoreHistory) return;
-    set({ loadingMoreHistory: true });
-    // Drop the result if the window was reset while this page was in flight
-    // (navigate away-and-back, rebind hydration, reconnect re-hydrate): the
-    // page is cursor-relative to the OLD window, and prepending it into the
-    // new one would invert order or rewind the cursor past a silent gap.
-    const stale = (): boolean =>
-      get().conversationId !== conversationId || get().historyGeneration !== historyGeneration;
-    try {
-      const { items, hasMore } = await fetchSessionItemsPage(conversationId, {
-        olderThan: oldestItemId,
-      });
-      if (stale()) return;
-      const newBlocks = itemsToBlocks(items);
-      set((state) => {
-        // Rebind hydration resets the cursor to the fresh window's top while
-        // keeping scrolled-up blocks, so an older page can overlap — dedupe.
-        const seen = new Set(
-          state.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
+      try {
+        await approveElicitation(
+          targetSessionId,
+          elicitationId,
+          content === undefined ? { action } : { action, content },
         );
-        const unique = newBlocks.filter((b) => !b.ctx.itemId || !seen.has(b.ctx.itemId));
-        return {
-          blocks: [...unique, ...state.blocks],
-          hasMoreHistory: hasMore,
-          oldestItemId: items[0]?.id ?? state.oldestItemId,
-          loadingMoreHistory: false,
-        };
+      } catch {
+        // Roll back to pending so the user can retry. Surfacing the
+        // error is a future affordance — for now, the buttons
+        // reappear and the user can try again.
+        set((s) => ({
+          blocks: s.blocks.map((b) =>
+            b.type === "elicitation" && b.elicitationId === elicitationId
+              ? { ...b, status: "pending", response: null }
+              : b,
+          ),
+        }));
+      }
+    },
+
+    flashUserMessage: (itemId) => {
+      if (flashTimer !== null) clearTimeout(flashTimer);
+      set({ flashItemId: itemId });
+      flashTimer = setTimeout(() => {
+        flashTimer = null;
+        set({ flashItemId: null });
+      }, FLASH_DURATION_MS);
+    },
+
+    compact: async () => {
+      const { conversationId } = get();
+      if (!conversationId) return;
+      await postEvent(conversationId, { type: "compact", data: {} });
+    },
+
+    refreshSessionState: async (conversationId) => {
+      const id = conversationId ?? get().conversationId;
+      if (!id) return;
+      await refetchRunnerBackedSessionState(id, set, get, {
+        refreshState: true,
+        applyBindingPatch: true,
       });
-    } catch {
-      // A stale failure must not disable scroll-up on the NEW window.
-      if (stale()) return;
-      // Disable further fetches on error — a persistent server failure
-      // would otherwise re-trigger the scroll listener on every scroll event.
-      set({ loadingMoreHistory: false, hasMoreHistory: false });
-    }
-  },
-}));
+    },
+
+    setEffort: async (effort) => {
+      set({ selectedEffort: effort });
+      savePickerPref(PICKER_PREF_EFFORT_KEY, effort);
+      const { conversationId } = get();
+      if (conversationId) {
+        if (queryClient === null) {
+          throw new Error("chatStore.setEffort: queryClient not initialized");
+        }
+        const session = await queryClient.fetchQuery({
+          queryKey: ["session", conversationId],
+          queryFn: () => getSessionSlim(conversationId),
+          staleTime: Infinity,
+          retry: false,
+        });
+        if (!supportsEffortControl(session)) return;
+        await updateSession(conversationId, { reasoningEffort: effort });
+      }
+    },
+
+    setModel: async (model) => {
+      // `selectedModel` is the sticky pick; `sessionModelOverride` is this
+      // session's applied override. An explicit `/model` sets both.
+      set({ selectedModel: model, sessionModelOverride: model });
+      savePickerPref(PICKER_PREF_MODEL_KEY, model);
+      const { conversationId } = get();
+      if (conversationId) {
+        const session = await updateSession(conversationId, { modelOverride: model });
+        // Server-canonical may differ from the optimistic write (e.g.
+        // when a clear alias was sent) — refresh local state to match.
+        const canonical = session.modelOverride ?? null;
+        set({ selectedModel: canonical, sessionModelOverride: canonical });
+        savePickerPref(PICKER_PREF_MODEL_KEY, canonical);
+      }
+    },
+
+    setCostControlMode: async (mode) => {
+      const { conversationId } = get();
+      if (!conversationId) return;
+      const previous = get().costControlModeOverride;
+      // Optimistic flip so the pill responds instantly; the PATCH
+      // response (or the rollback below) is the settled truth.
+      set({ costControlModeOverride: mode });
+      try {
+        const session = await updateSession(conversationId, { costControlModeOverride: mode });
+        if (get().conversationId !== conversationId) return;
+        set({ costControlModeOverride: session.costControlModeOverride ?? null });
+      } catch (err) {
+        // Roll back so the pill doesn't claim a state the server never persisted.
+        if (get().conversationId === conversationId) {
+          set({ costControlModeOverride: previous });
+        }
+        throw err;
+      }
+    },
+
+    setCodexPlanMode: async (enabled) => {
+      const { conversationId } = get();
+      if (!conversationId) return;
+      const previous = get().codexPlanMode;
+      set({ codexPlanMode: enabled });
+      try {
+        const session = await updateSession(conversationId, { codexPlanMode: enabled });
+        if (get().conversationId !== conversationId) return;
+        set({ codexPlanMode: codexPlanModeFromSession(session) });
+      } catch (err) {
+        if (get().conversationId === conversationId) {
+          set({ codexPlanMode: previous });
+        }
+        throw err;
+      }
+    },
+
+    loadMoreHistory: async () => {
+      const {
+        conversationId,
+        oldestItemId,
+        loadingMoreHistory,
+        hasMoreHistory,
+        historyGeneration,
+      } = get();
+      if (!conversationId || !oldestItemId || loadingMoreHistory || !hasMoreHistory) return;
+      set({ loadingMoreHistory: true });
+      // Drop the result if the window was reset while this page was in flight
+      // (navigate away-and-back, rebind hydration, reconnect re-hydrate): the
+      // page is cursor-relative to the OLD window, and prepending it into the
+      // new one would invert order or rewind the cursor past a silent gap.
+      const stale = (): boolean =>
+        get().conversationId !== conversationId || get().historyGeneration !== historyGeneration;
+      try {
+        const { items, hasMore } = await fetchSessionItemsPage(conversationId, {
+          olderThan: oldestItemId,
+        });
+        if (stale()) return;
+        const newBlocks = itemsToBlocks(items);
+        set((state) => {
+          // Rebind hydration resets the cursor to the fresh window's top while
+          // keeping scrolled-up blocks, so an older page can overlap — dedupe.
+          const seen = new Set(
+            state.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
+          );
+          const unique = newBlocks.filter((b) => !b.ctx.itemId || !seen.has(b.ctx.itemId));
+          return {
+            blocks: [...unique, ...state.blocks],
+            hasMoreHistory: hasMore,
+            oldestItemId: items[0]?.id ?? state.oldestItemId,
+            loadingMoreHistory: false,
+          };
+        });
+      } catch {
+        // A stale failure must not disable scroll-up on the NEW window.
+        if (stale()) return;
+        // Disable further fetches on error — a persistent server failure
+        // would otherwise re-trigger the scroll listener on every scroll event.
+        set({ loadingMoreHistory: false, hasMoreHistory: false });
+      }
+    },
+  };
+}
+
+// ── Per-session store registry + active-session facade ─────────────
+//
+// One vanilla store per session id, created lazily and reference-counted.
+// Refs come from two places: the single-session route (via `switchTo`) holds
+// one ref on the active session; each open side-by-side pane holds one ref on
+// its own session. When the last ref is released the session's SSE stream is
+// aborted and its store dropped — so unbinding a pane tears down ONLY that
+// session's stream, never another's. This is what makes concurrent panes
+// truly isolated: independent stores, independent subscriptions, independent
+// pumps and send queues.
+
+interface SessionEntry {
+  store: StoreApi<ChatState>;
+  refs: number;
+  /** True once `bindStream` has been kicked off for this entry. */
+  bound: boolean;
+}
+
+const sessionRegistry = new Map<string, SessionEntry>();
+
+/**
+ * The landing / "no conversation yet" store (conversationId null). Replaced
+ * with a fresh instance whenever its first `send` promotes it into a real
+ * session (`promoteDraftToSession`) or the route returns to `/`, so the
+ * landing page always starts clean.
+ */
+let draftStore: StoreApi<ChatState> = createStore<ChatState>(chatSessionInitializer);
+
+/**
+ * Which session the backward-compatible `useChatStore` facade points at. A
+ * tiny store of its own so the facade hook re-subscribes to the new session's
+ * store the instant the active session changes.
+ */
+const activeSessionStore = createStore<{ id: string | null }>(() => ({ id: null }));
+function getActiveSessionId(): string | null {
+  return activeSessionStore.getState().id;
+}
+function setActiveSessionId(id: string | null): void {
+  if (activeSessionStore.getState().id !== id) activeSessionStore.setState({ id });
+}
+
+/**
+ * Return the store for a session id, creating an UNBOUND entry on demand.
+ * Safe to call during render (pure allocation + memoization); binding the SSE
+ * stream is a separate, explicit step owned by `acquireSession`.
+ */
+function ensureSessionStore(id: string | null): StoreApi<ChatState> {
+  if (id === null) return draftStore;
+  let entry = sessionRegistry.get(id);
+  if (entry === undefined) {
+    entry = { store: createStore<ChatState>(chatSessionInitializer), refs: 0, bound: false };
+    sessionRegistry.set(id, entry);
+  }
+  return entry.store;
+}
+
+/** The store the facade currently proxies (active session, or the draft). */
+function activeStore(): StoreApi<ChatState> {
+  return ensureSessionStore(getActiveSessionId());
+}
+
+/**
+ * The cross-session sticky picker prefs (model + reasoning effort). They are
+ * a single user preference, not per-session state, so a freshly-created
+ * session store inherits the currently-active value rather than only the
+ * localStorage default — preserving the single-store behavior where these
+ * survive a `switchTo` untouched (and where `bindStream` reads them to decide
+ * a native sticky handoff).
+ */
+type StickyPicks = Pick<ChatState, "selectedEffort" | "selectedModel">;
+
+function stickyPicksOf(store: StoreApi<ChatState>): StickyPicks {
+  const s = store.getState();
+  return { selectedEffort: s.selectedEffort, selectedModel: s.selectedModel };
+}
+
+/**
+ * Bind a session entry's SSE stream once, seeding any stashed optimistic
+ * bubbles (so a navigate-away-mid-send message reappears on return) and the
+ * inherited sticky picks first.
+ */
+function bindSessionEntry(
+  id: string,
+  entry: SessionEntry,
+  sticky?: StickyPicks,
+): Promise<void> | undefined {
+  if (entry.bound) return undefined;
+  entry.bound = true;
+  const set = entry.store.setState;
+  const get = entry.store.getState;
+  // Reset the transient fields `bindStream` does NOT overwrite before it
+  // re-hydrates. A store is reused across release→re-acquire (cached, not
+  // destroyed, so an in-flight `send` keeps resolving against it), so a
+  // re-bind must start from a clean slate — otherwise stale blocks/active
+  // response from the prior visit would leak in (and `bindStream` prepends to
+  // `state.blocks`). For a brand-new store these are already the defaults.
+  set({
+    conversationId: id,
+    blocks: [],
+    activeResponse: null,
+    interruptedResponseIds: [],
+    status: "idle",
+    sessionStatus: "idle",
+    conversationLoadError: null,
+    flashItemId: null,
+    viewers: [],
+    loadingConversation: true,
+    // Restore any optimistic bubble stashed when this session was last
+    // released; `bindStream` reconciles it against the snapshot.
+    pendingUserMessages: pendingStash.get(id)?.messages ?? [],
+    ...(sticky ?? {}),
+  });
+  return bindStream(id, set, get, true);
+}
+
+/**
+ * Take a reference on a session, creating + binding its store on first
+ * acquire. Returns the bind promise on first bind (so `switchTo` can await
+ * hydration), else undefined. Panes ignore the return and bind lazily on
+ * mount; the single-session route awaits it via `facadeSwitchTo`, which seeds
+ * the inherited sticky picks.
+ */
+export function acquireSession(id: string, sticky?: StickyPicks): Promise<void> | undefined {
+  ensureSessionStore(id);
+  const entry = sessionRegistry.get(id)!;
+  entry.refs += 1;
+  return bindSessionEntry(id, entry, sticky);
+}
+
+/**
+ * Release a reference on a session. On the last release, stash this client's
+ * still-unsettled optimistic bubbles (so they survive to the next bind), abort
+ * THIS session's SSE stream, and mark the entry unbound. No other session is
+ * touched — so unbinding one pane never disturbs another's stream.
+ *
+ * The store object is KEPT (not deleted): an in-flight `send` captured its
+ * set/get, so disposing it mid-POST would strand the settle (the `posted`
+ * flag + stash prune) on a dead store. Caching it lets a navigate-back
+ * re-acquire the SAME store; `bindSessionEntry` resets it on re-bind.
+ */
+export function releaseSession(id: string): void {
+  const entry = sessionRegistry.get(id);
+  if (entry === undefined) return;
+  entry.refs -= 1;
+  if (entry.refs > 0) return;
+  const state = entry.store.getState();
+  // Stash only own unsettled bubbles (`pend_` ids, POST not settled) with the
+  // current committed texts as the dedup baseline — mirrors the old switchTo
+  // stash. Everything else is re-served by the snapshot's pending_inputs.
+  const own = state.pendingUserMessages.filter(
+    (p) => p.tempId.startsWith("pend_") && p.posted !== true,
+  );
+  if (own.length > 0) {
+    pendingStash.set(id, { messages: own, committedTexts: committedUserTextsOf(state.blocks) });
+  } else {
+    pendingStash.delete(id);
+  }
+  state.abortController?.abort();
+  entry.bound = false;
+}
+
+/**
+ * Promote the draft store into a real session the instant its first `send`
+ * creates one. Re-keys the draft under the new id (its in-flight bind + POST
+ * stay attached) and mints a fresh draft for the landing page, then points the
+ * active facade at the new session — so the subsequent URL-driven
+ * `switchTo(newId)` is a no-op (active already === newId), exactly like the
+ * old same-id self-skip. The `refs: 1` stands in for the single-session
+ * route's ref, balanced when the route later switches away.
+ */
+function promoteDraftToSession(newId: string): void {
+  const promoted = draftStore;
+  draftStore = createStore<ChatState>(chatSessionInitializer);
+  sessionRegistry.set(newId, { store: promoted, refs: 1, bound: true });
+  setActiveSessionId(newId);
+}
+
+/**
+ * Registry-level session switch for the single-session route. Acquires the
+ * target (binding + hydrating on first acquire), points the facade at it, and
+ * releases the prior active session's route ref (tearing it down if no pane
+ * holds it). Awaits the target's first hydration so callers that await
+ * `switchTo` still observe a hydrated store.
+ */
+async function facadeSwitchTo(conversationId: string | null): Promise<void> {
+  const prev = getActiveSessionId();
+  if (prev === conversationId) return;
+  // Sticky picker prefs are a single user preference, not per-session state —
+  // carry them from the session we're leaving so a new chat (or a freshly
+  // bound session) inherits them, exactly as the old single store did.
+  const sticky = stickyPicksOf(ensureSessionStore(prev));
+  if (conversationId === null) {
+    // Landing page: hand out a fresh draft so a value from a prior promotion
+    // can never show through, then release the session we left.
+    draftStore = createStore<ChatState>(chatSessionInitializer);
+    draftStore.setState(sticky);
+    setActiveSessionId(null);
+    if (prev !== null) releaseSession(prev);
+    return;
+  }
+  const bindPromise = acquireSession(conversationId, sticky);
+  setActiveSessionId(conversationId);
+  if (prev !== null) releaseSession(prev);
+  await bindPromise;
+}
+
+/**
+ * Subscribe to one session's slice. The explicit-id public API behind the
+ * side-by-side panes; pass `null` for the landing/draft store.
+ */
+export function useChatSession<T>(sessionId: string | null, selector: (s: ChatState) => T): T {
+  return useStore(ensureSessionStore(sessionId), selector);
+}
+
+/** Imperative access to a session's store api (for action calls in panes). */
+export function getChatSessionStore(sessionId: string | null): StoreApi<ChatState> {
+  return ensureSessionStore(sessionId);
+}
+
+/**
+ * Backward-compatible facade over the ACTIVE session's store. Existing
+ * single-session call sites — `useChatStore((s) => s.x)`,
+ * `useChatStore.getState().send(...)`, `useChatStore.setState(...)` — keep
+ * working unchanged; they all resolve against whichever session `switchTo`
+ * last made active (the draft store when none).
+ */
+function useChatStoreHook<T>(selector: (s: ChatState) => T): T {
+  const id = useStore(activeSessionStore, (s) => s.id);
+  return useStore(ensureSessionStore(id), selector);
+}
+
+export const useChatStore = Object.assign(useChatStoreHook, {
+  getState: (): ChatState => activeStore().getState(),
+  setState: ((...args: Parameters<StoreApi<ChatState>["setState"]>) =>
+    activeStore().setState(...args)) as StoreApi<ChatState>["setState"],
+  getInitialState: (): ChatState => activeStore().getInitialState(),
+  subscribe: ((...args: Parameters<StoreApi<ChatState>["subscribe"]>) =>
+    activeStore().subscribe(...args)) as StoreApi<ChatState>["subscribe"],
+});
 
 // ── Internal helpers ─────────────────────────────────────
 
 type Setter = (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void;
 type Getter = () => ChatState;
+
+// Setter/getter bound to the ACTIVE session's store, used as defaults so the
+// exported `handleSessionEvent(event)` keeps working for direct unit tests
+// (and any single-session caller) while the production pump passes the
+// concrete per-session set/get.
+const facadeSetter: Setter = (partial) => useChatStore.setState(partial);
+const facadeGetter: Getter = () => useChatStore.getState();
 
 type NativeModelFamily = "claude" | "codex";
 
@@ -1478,6 +1651,12 @@ async function ensureBoundSession(
       boundAgentName: session.agentName,
       loadingConversation: true,
     });
+    // A brand-new session is only ever created from the draft store (the
+    // landing page is the one place `conversationId` is null). Re-key the
+    // draft under the new id BEFORE `onConversationCreated` navigates, so the
+    // resulting `switchTo(newId)` self-skips instead of spinning up a second
+    // store for the same session.
+    promoteDraftToSession(sessionId);
     opts?.onConversationCreated?.(sessionId);
     queryClient?.invalidateQueries({ queryKey: ["conversations"] });
     await bindStream(sessionId, set, get);
@@ -1532,7 +1711,7 @@ function pendingElicitationBlocksFromSnapshot(session: Session): AnyBlock[] {
  *
  * @param id - Conversation/session id to reconcile.
  */
-async function reconcilePendingElicitations(id: string): Promise<void> {
+async function reconcilePendingElicitations(id: string, set: Setter, get: Getter): Promise<void> {
   if (queryClient === null) return;
   let session: Session;
   try {
@@ -1545,13 +1724,13 @@ async function reconcilePendingElicitations(id: string): Promise<void> {
   } catch {
     return;
   }
-  if (useChatStore.getState().conversationId !== id) return;
+  if (get().conversationId !== id) return;
   const stillPending = new Set(
     (session.pendingElicitations ?? [])
       .map((e) => (typeof e.elicitation_id === "string" ? e.elicitation_id : null))
       .filter((x): x is string => x !== null),
   );
-  useChatStore.setState((s) => {
+  set((s) => {
     let changed = false;
     const blocks = s.blocks.map((b) => {
       if (
@@ -1644,7 +1823,7 @@ function sessionBindingPatch(
  *
  * @param id - Conversation/session id whose binding changed.
  */
-async function refreshSessionBinding(id: string): Promise<void> {
+async function refreshSessionBinding(id: string, set: Setter, get: Getter): Promise<void> {
   if (queryClient === null) return;
   let session: Session;
   try {
@@ -1657,8 +1836,8 @@ async function refreshSessionBinding(id: string): Promise<void> {
   } catch {
     return;
   }
-  if (useChatStore.getState().conversationId !== id) return;
-  useChatStore.setState(sessionBindingPatch(session));
+  if (get().conversationId !== id) return;
+  set(sessionBindingPatch(session));
 }
 
 /**
@@ -1694,7 +1873,7 @@ async function bindStream(
   // the stream unbinds (abort), so it never leaks across conversations.
   if (typeof document !== "undefined") {
     const onVisible = (): void => {
-      if (document.visibilityState === "visible") void reconcilePendingElicitations(id);
+      if (document.visibilityState === "visible") void reconcilePendingElicitations(id, set, get);
     };
     document.addEventListener("visibilitychange", onVisible);
     controller.signal.addEventListener("abort", () => {
@@ -1888,7 +2067,7 @@ async function bindStream(
       // "disappears then reappears" report).
       const dedupePending = hydratePending && candidatePending.length > 0;
       const committedUserTexts = dedupePending ? committedUserTextsOf(allBlocks) : [];
-      const stashBaseline = state.pendingByConversation[id]?.committedTexts ?? [];
+      const stashBaseline = pendingStash.get(id)?.committedTexts ?? [];
       const countEndsWith = (texts: string[], suffix: string): number =>
         texts.reduce((n, c) => (c.endsWith(suffix) ? n + 1 : n), 0);
       const snapshotPending: PendingUserMessage[] = dedupePending
@@ -1899,23 +2078,20 @@ async function bindStream(
             return countEndsWith(committedUserTexts, text) <= baseline;
           })
         : candidatePending;
-      // Keep the stash consistent with what survived dedupe on cold load: a
-      // restored bubble whose message committed while away is now dropped, so
-      // prune it from the stash too (else it lingers until the next
-      // switch-away). Only this client's own bubbles (``pend_`` ids) belong
-      // in the stash — foreign entries are re-served by pending_inputs. Reset
-      // the baseline to the now-current committed texts so a subsequent
+      // Keep the module stash consistent with what survived dedupe on cold
+      // load: a restored bubble whose message committed while away is now
+      // dropped, so prune it from the stash too (else it lingers until the
+      // next switch-away). Only this client's own bubbles (``pend_`` ids)
+      // belong in the stash — foreign entries are re-served by pending_inputs.
+      // Reset the baseline to the now-current committed texts so a subsequent
       // navigate-away/back compares against history as it stands after this
       // bind.
-      const prunedStash = hydratePending
-        ? (() => {
-            const own = snapshotPending.filter((p) => p.tempId.startsWith("pend_"));
-            const next = { ...state.pendingByConversation };
-            if (own.length > 0) next[id] = { messages: own, committedTexts: committedUserTexts };
-            else delete next[id];
-            return next;
-          })()
-        : state.pendingByConversation;
+      if (hydratePending) {
+        const own = snapshotPending.filter((p) => p.tempId.startsWith("pend_"));
+        if (own.length > 0)
+          pendingStash.set(id, { messages: own, committedTexts: committedUserTexts });
+        else pendingStash.delete(id);
+      }
       const syntheticError: ErrorBlock | null =
         session.status === "failed" && session.lastTaskError != null && !hasErrorBlock
           ? {
@@ -1930,7 +2106,6 @@ async function bindStream(
         ...bindingPatch,
         blocks: syntheticError !== null ? [...allBlocks, syntheticError] : allBlocks,
         pendingUserMessages: snapshotPending,
-        pendingByConversation: prunedStash,
         loadingConversation: false,
         hasMoreHistory: page.hasMore,
         oldestItemId,
@@ -2389,22 +2564,6 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
   });
 }
 
-// ── Presence idle reporting ─────────────────────────────────────────
-// The stream GET's `idle` query param is the entire client→server
-// presence uplink (no dedicated endpoint), so an idle flip is delivered
-// by recycling the live stream attempt — the same abort-and-reopen the
-// ingress already forces every ~5 minutes. The tracker aborts only the
-// per-attempt controller; the outer controller (teardown) stays live.
-let presenceAttemptController: AbortController | null = null;
-const presenceIdle = createPresenceIdleTracker({
-  onFlip: () => presenceAttemptController?.abort(),
-});
-if (typeof document !== "undefined") {
-  document.addEventListener("visibilitychange", () =>
-    presenceIdle.handleVisibilityChange(document.hidden),
-  );
-}
-
 /**
  * Own the session SSE stream for the lifetime of a bound conversation,
  * reconnecting transparently across drops.
@@ -2439,6 +2598,23 @@ export async function startStreamPump(
   // established stream — failed opens leave it false so a recovered first
   // connect is still treated as initial, not a reconnect.
   let hasConnected = false;
+  // Per-pump presence idle tracking. Local (not module-level) so concurrent
+  // session pumps — e.g. side-by-side panes — each recycle ONLY their own
+  // connection on an idle flip, never another session's. The stream GET's
+  // `idle` query param is the entire client→server presence uplink, so a flip
+  // is delivered by aborting the current attempt and reopening with the new
+  // flag — the same abort-and-reopen the ingress already forces every ~5 min.
+  let presenceAttempt: AbortController | null = null;
+  const presenceIdle = createPresenceIdleTracker({
+    onFlip: () => presenceAttempt?.abort(),
+  });
+  const onVisibility = (): void => presenceIdle.handleVisibilityChange(document.hidden);
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibility);
+    // Seed from current visibility so a stream bound while the tab is already
+    // hidden still reports idle once the dwell elapses.
+    presenceIdle.handleVisibilityChange(document.hidden);
+  }
   // A reconnect loop is inherently sequential — open → pump → reconnect —
   // so its awaits cannot be parallelized; no-await-in-loop doesn't apply.
   /* eslint-disable no-await-in-loop */
@@ -2459,7 +2635,7 @@ export async function startStreamPump(
       const attempt = new AbortController();
       const onOuterAbort = () => attempt.abort();
       controller.signal.addEventListener("abort", onOuterAbort);
-      presenceAttemptController = attempt;
+      presenceAttempt = attempt;
       try {
         const idle = presenceIdle.idleNow();
         let streamRes: Response;
@@ -2521,12 +2697,15 @@ export async function startStreamPump(
         if (reason !== "dropped") break;
       } finally {
         controller.signal.removeEventListener("abort", onOuterAbort);
-        if (presenceAttemptController === attempt) {
-          presenceAttemptController = null;
+        if (presenceAttempt === attempt) {
+          presenceAttempt = null;
         }
       }
     }
   } finally {
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibility);
+    }
     if (get().abortController === controller) {
       set({ abortController: null });
     }
@@ -2809,7 +2988,7 @@ export async function pumpStreamEvents(
   // Per-message high-water chunk index, for delta duplicate suppression.
   const liveLastIndex = new Map<string, number>();
   const events = tapLiveDeltas(
-    tapSessionEvents(rawEvents),
+    tapSessionEvents(rawEvents, set, get),
     id,
     retiredLiveMessages,
     liveLastIndex,
@@ -3173,9 +3352,11 @@ interface RefetchRunnerBackedSessionStateOptions {
  */
 async function refetchRunnerBackedSessionState(
   conversationId: string,
+  set: Setter,
+  get: Getter,
   options: RefetchRunnerBackedSessionStateOptions = {},
 ): Promise<void> {
-  if (useChatStore.getState().conversationId !== conversationId) return;
+  if (get().conversationId !== conversationId) return;
   let session: Session;
   try {
     if (queryClient !== null) {
@@ -3196,8 +3377,8 @@ async function refetchRunnerBackedSessionState(
   // Re-check after the await — the user may have switched conversations
   // while the request was in flight; applying now would leak another
   // session's capabilities into the open composer.
-  if (useChatStore.getState().conversationId !== conversationId) return;
-  useChatStore.setState(
+  if (get().conversationId !== conversationId) return;
+  set(
     options.applyBindingPatch === true
       ? sessionBindingPatch(session)
       : {
@@ -3262,31 +3443,6 @@ function contentKeyOf(content: MessageContentBlock[]): string {
 }
 
 /**
- * Drop one optimistic entry from a conversation's navigation stash.
- *
- * Called when that entry's POST settles — accepted, denied, or failed.
- * From that point the server owns the message's fate (accepted native:
- * replayed via `pending_inputs` until committed; accepted non-native:
- * already persisted; denied/failed: gone), so a lingering stash copy
- * could only resurrect a bubble the server can no longer account for —
- * the stuck-forever pending message. No-op when the entry isn't
- * stashed (the common case: the user never navigated away mid-POST).
- */
-function removeFromPendingStash(
-  stash: Record<string, StashedPending>,
-  conversationId: string,
-  tempId: string,
-): Record<string, StashedPending> {
-  const entry = stash[conversationId];
-  if (!entry || !entry.messages.some((p) => p.tempId === tempId)) return stash;
-  const messages = entry.messages.filter((p) => p.tempId !== tempId);
-  const next = { ...stash };
-  if (messages.length > 0) next[conversationId] = { ...entry, messages };
-  else delete next[conversationId];
-  return next;
-}
-
-/**
  * Apply store side effects for a `session.*` SSE event.
  *
  * Exported for direct unit testing — production code reaches this
@@ -3297,7 +3453,11 @@ function removeFromPendingStash(
  *
  * No-op for events outside the `session.*` family.
  */
-export function handleSessionEvent(event: StreamEvent): void {
+export function handleSessionEvent(
+  event: StreamEvent,
+  set: Setter = facadeSetter,
+  get: Getter = facadeGetter,
+): void {
   switch (event.type) {
     case "response_completed":
       // Prefer contextTokens (last sub-call total) for the context ring — on
@@ -3308,27 +3468,27 @@ export function handleSessionEvent(event: StreamEvent): void {
       if (event.response.usage != null) {
         const ringTokens = event.response.usage.contextTokens ?? event.response.usage.totalTokens;
         if (ringTokens != null) {
-          useChatStore.setState({ tokensUsed: ringTokens });
+          set({ tokensUsed: ringTokens });
         }
       }
       return;
     case "session_todos":
       // Replace the todo list entirely — each event carries the full
       // current list, not a diff.
-      useChatStore.setState({ todos: event.todos });
+      set({ todos: event.todos });
       return;
     case "session_terminal_pending":
       // Toggle the Terminal-pill spinner. The runner sets pending=true
       // before auto-creating the terminal and clears it once the
       // terminal lands or auto-create fails.
-      useChatStore.setState({ terminalPending: event.pending });
+      set({ terminalPending: event.pending });
       return;
     case "session_sandbox_status":
       // Advance the managed-sandbox provisioning indicator. `ready`
       // clears it — from then on the session looks like any
       // host-bound session; `failed` retains the reason so the page
       // explains why the sandbox never came up.
-      useChatStore.setState({
+      set({
         sandboxStatus: event.stage === "ready" ? null : { stage: event.stage, error: event.error },
       });
       return;
@@ -3356,7 +3516,7 @@ export function handleSessionEvent(event: StreamEvent): void {
         patch.sessionUsageByModel = event.usageByModel;
       }
       if (Object.keys(patch).length > 0) {
-        useChatStore.setState(patch);
+        set(patch);
       }
       return;
     }
@@ -3368,7 +3528,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // terminal switch is a per-session choice, not a new default).
       // Guard by conversation id so a late frame from a switched-away
       // stream cannot overwrite the model for the currently-open session.
-      useChatStore.setState((s) =>
+      set((s) =>
         s.conversationId === event.conversationId
           ? { selectedModel: event.model, sessionModelOverride: event.model }
           : {},
@@ -3380,7 +3540,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // reasoning_effort, so reload restores the same value.
       // Guard by conversation id so a late event from a previous session
       // cannot overwrite the effort picker for the currently-open one.
-      useChatStore.setState((s) =>
+      set((s) =>
         s.conversationId === event.conversationId ? { selectedEffort: event.reasoningEffort } : {},
       );
       return;
@@ -3388,7 +3548,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // A Codex /plan switch made in either the web UI or native TUI.
       // Guard by conversation id so a late frame from an aborted stream
       // cannot paint Plan mode onto the newly-opened conversation.
-      useChatStore.setState((s) =>
+      set((s) =>
         s.conversationId === event.conversationId ? { codexPlanMode: event.mode === "plan" } : {},
       );
       return;
@@ -3397,9 +3557,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // complete viewer list, so there is no join/leave ordering to
       // get wrong. Guarded by conversation id so a late frame from a
       // switched-away stream can't paint another session's viewers.
-      useChatStore.setState((s) =>
-        s.conversationId === event.conversationId ? { viewers: event.viewers } : {},
-      );
+      set((s) => (s.conversationId === event.conversationId ? { viewers: event.viewers } : {}));
       return;
     case "session_agent_changed":
       // The session's bound agent was switched in place (switch-agent
@@ -3409,12 +3567,12 @@ export function handleSessionEvent(event: StreamEvent): void {
       // lifecycle) from a fresh snapshot — the event is the only signal
       // an in-place switch produces; the URL doesn't change, so the
       // switchTo/bindStream path never re-runs.
-      useChatStore.setState((s) =>
+      set((s) =>
         s.conversationId === event.conversationId
           ? { boundAgentId: event.agentId, boundAgentName: event.agentName }
           : {},
       );
-      void refreshSessionBinding(event.conversationId);
+      void refreshSessionBinding(event.conversationId, set, get);
       // Refresh the header's agent card and the sidebar row for every
       // connected client (the switching client's dialog already does
       // this for itself; observers only learn about it here).
@@ -3447,13 +3605,13 @@ export function handleSessionEvent(event: StreamEvent): void {
       // estimate so the ring reflects the reduced context without waiting
       // for the next LLM response.completed event.
       if (event.totalTokens != null) {
-        useChatStore.setState({ tokensUsed: event.totalTokens });
+        set({ tokensUsed: event.totalTokens });
       }
       return;
     case "compaction_failed":
       // Compaction failed — history is unchanged. Remove the compaction_loading
       // block so the "Compacting…" shimmer disappears without leaving a marker.
-      useChatStore.setState((s) => {
+      set((s) => {
         const idx = [...s.blocks].reverse().findIndex((b) => b.type === "compaction_loading");
         if (idx === -1) return {};
         const realIdx = s.blocks.length - 1 - idx;
@@ -3465,15 +3623,15 @@ export function handleSessionEvent(event: StreamEvent): void {
       // server won't emit session.input.consumed for denied inputs, so
       // it would otherwise linger in the transcript). The "Working…"
       // indicator is driven by session.status, not this.
-      useChatStore.setState({
+      set({
         pendingUserMessages: [],
       });
       return;
     case "session_status": {
       // Captured BEFORE the patch below adopts event.responseId, so a
       // running/waiting status carrying an unseen id marks a new turn.
-      const prevResponseId = useChatStore.getState().activeResponse?.responseId;
-      useChatStore.setState((s) => {
+      const prevResponseId = get().activeResponse?.responseId;
+      set((s) => {
         if (
           event.status === "idle" &&
           event.responseId === undefined &&
@@ -3603,7 +3761,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       //      the drop and strand the bubble as a duplicate.
       //   3. No pending entry — render the event payload as a fresh
       //      committed bubble (TUI-typed message, or another client).
-      useChatStore.setState((s) => {
+      set((s) => {
         if (hasCommittedItem(s.blocks, event.itemId)) return {};
 
         // 1. Drop by id when the server names the drained entry.
@@ -3677,7 +3835,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // until refresh. Pop the FIFO head here to ack the local
       // send; non-empty guard so observing clients (with no pending
       // bubble) just render the block.
-      useChatStore.setState((s) => {
+      set((s) => {
         if (s.pendingUserMessages.length === 0) return {};
         const [, ...rest] = s.pendingUserMessages;
         return { pendingUserMessages: rest };
@@ -3691,14 +3849,14 @@ export function handleSessionEvent(event: StreamEvent): void {
       // becomes a no-op when it sees the existing terminal state.
       if (event.responseId !== undefined) {
         const interruptedResponseId = event.responseId;
-        useChatStore.setState((s) => {
+        set((s) => {
           if (s.interruptedResponseIds.includes(interruptedResponseId)) return {};
           return {
             interruptedResponseIds: [...s.interruptedResponseIds, interruptedResponseId],
           };
         });
       }
-      finalizeCurrentActive("cancelled", event.responseId);
+      finalizeActive(set, "cancelled", null, event.responseId);
       return;
     case "session_created":
       // Sub-agent spawn signal. Invalidate the parent's child-sessions
@@ -3753,13 +3911,13 @@ export function handleSessionEvent(event: StreamEvent): void {
       // the first moment the slash-command menu can be filled. Refetch
       // the now-warm snapshot and apply its `skills`. Fire and forget —
       // refetchRunnerBackedSessionState self-guards against a stale apply.
-      void refetchRunnerBackedSessionState(event.conversationId);
+      void refetchRunnerBackedSessionState(event.conversationId, set, get);
       return;
     case "session_model_options":
       // Codex app-server `model/list` just resolved. Refetch the
       // cache-warmed snapshot and apply `codexModelOptions`; the picker
       // derives both model rows and effort levels from that catalog.
-      void refetchRunnerBackedSessionState(event.conversationId);
+      void refetchRunnerBackedSessionState(event.conversationId, set, get);
       return;
     case "tool_result":
       // Tool results are not a reliable correlation signal for
@@ -3775,7 +3933,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // Match by id, not first-pending — the `pending` guard keeps
       // a user-delivered verdict from being overwritten by a later
       // duplicate-resolve.
-      useChatStore.setState((s) => {
+      set((s) => {
         const matchIdx = s.blocks.findIndex(
           (b) =>
             b.type === "elicitation" &&
@@ -3966,26 +4124,15 @@ function applyChildSessionUpdated(
   queryClient.setQueryData<ChildSessionInfo[]>(key, next);
 }
 
-async function* tapSessionEvents(events: AsyncIterable<StreamEvent>): AsyncIterable<StreamEvent> {
+async function* tapSessionEvents(
+  events: AsyncIterable<StreamEvent>,
+  set: Setter,
+  get: Getter,
+): AsyncIterable<StreamEvent> {
   for await (const event of events) {
-    handleSessionEvent(event);
+    handleSessionEvent(event, set, get);
     yield event;
   }
-}
-
-/**
- * Force the store's `activeResponse` into a terminal state without
- * needing a closure-scoped setter. Mirrors `finalizeActive` but
- * works from the module-scope `handleSessionEvent` boundary.
- */
-function finalizeCurrentActive(state: ActiveResponse["state"], responseIdOverride?: string): void {
-  useChatStore.setState((s) => {
-    if (s.activeResponse === null && responseIdOverride === undefined) return {};
-    const responseId = s.activeResponse?.responseId ?? responseIdOverride ?? "";
-    return {
-      activeResponse: { responseId, state, error: null },
-    };
-  });
 }
 
 /**

--- a/ap-web/src/store/chatStore.ts
+++ b/ap-web/src/store/chatStore.ts
@@ -42,6 +42,7 @@
 //     stream, fetches the items snapshot, and merges into blocks
 //     deduping by item id.
 
+import { createContext, useContext } from "react";
 import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 import { createStore, useStore, type StoreApi } from "zustand";
 import type {
@@ -1521,14 +1522,40 @@ export function getChatSessionStore(sessionId: string | null): StoreApi<ChatStat
 }
 
 /**
- * Backward-compatible facade over the ACTIVE session's store. Existing
- * single-session call sites — `useChatStore((s) => s.x)`,
- * `useChatStore.getState().send(...)`, `useChatStore.setState(...)` — keep
- * working unchanged; they all resolve against whichever session `switchTo`
- * last made active (the draft store when none).
+ * When set by a side-by-side pane, redirects the `useChatStore` HOOK reads (and
+ * scoped imperative access) to a specific session id instead of the global
+ * active session — so each pane shows and drives its OWN session. `undefined`
+ * (no provider — e.g. the single-session route) falls back to the active
+ * session, leaving that path observably unchanged. A `null` value scopes to
+ * the landing/draft store.
+ */
+export const ChatSessionScopeContext = createContext<string | null | undefined>(undefined);
+
+/** The session id the current subtree is scoped to (pane scope, or active). */
+export function useScopedSessionId(): string | null {
+  const scopeId = useContext(ChatSessionScopeContext);
+  const activeId = useStore(activeSessionStore, (s) => s.id);
+  return scopeId === undefined ? activeId : scopeId;
+}
+
+/**
+ * Store api for the current scope — for imperative action calls
+ * (`useScopedChatStore().getState().send(...)`) inside a pane or the route.
+ */
+export function useScopedChatStore(): StoreApi<ChatState> {
+  return ensureSessionStore(useScopedSessionId());
+}
+
+/**
+ * Backward-compatible, scope-aware facade over the chat store. Reactive reads
+ * `useChatStore((s) => s.x)` resolve to the nearest pane scope when one is
+ * provided, else the active session — so existing single-session call sites are
+ * unchanged while a pane's subtree automatically reads its OWN session. The
+ * static `getState()`/`setState()` always target the active session; pane
+ * imperative calls use `useScopedChatStore()` instead.
  */
 function useChatStoreHook<T>(selector: (s: ChatState) => T): T {
-  const id = useStore(activeSessionStore, (s) => s.id);
+  const id = useScopedSessionId();
   return useStore(ensureSessionStore(id), selector);
 }
 

--- a/tests/e2e_ui/sessions/test_side_by_side.py
+++ b/tests/e2e_ui/sessions/test_side_by_side.py
@@ -1,0 +1,95 @@
+"""E2E: the side-by-side multi-session view streams and accepts input per pane.
+
+Covers ``/compare?sessions=a,b`` — ``ap-web``'s ``ComparePage`` +
+``MultiSessionGrid`` + the embedded ``ChatPage`` pane mode (and the per-session
+chat-store registry under it). A developer opens several sessions at once and
+watches/drives them in parallel rather than clicking between them.
+
+The property under test is ISOLATION: each pane binds its OWN SSE stream and
+POSTs to its OWN session. So the test opens two panes, sends distinct prompts
+into each, and asserts each pane shows only its own user + assistant bubbles —
+never the other's. Then it closes one pane and confirms it is removed while the
+remaining session stays live (with two sessions, closing one falls back to the
+single-session route, re-binding the kept session from its own cached store).
+
+Selectors mirror the rest of ``tests/e2e_ui``: the pane is found by
+``data-testid="session-pane"`` + ``data-session-id``; within it, the composer
+by placeholder, Send by its accessible name, message bubbles by
+``data-testid="message-bubble"`` + ``data-role``, and the pane's close control
+by ``data-testid="session-pane-close"``.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+_COMPOSER = "Ask the agent anything…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_USER = '[data-testid="message-bubble"][data-role="user"]'
+
+
+def _pane(page: Page, session_id: str) -> Locator:
+    """The pane bound to *session_id* (a ``MultiSessionGrid`` child)."""
+    return page.locator(f'[data-testid="session-pane"][data-session-id="{session_id}"]')
+
+
+def _send_into(pane: Locator, text: str) -> None:
+    """Type *text* into THIS pane's composer and click its Send button."""
+    composer = pane.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible()
+    composer.fill(text)
+    pane.get_by_role("button", name="Send", exact=True).click()
+
+
+# Real-LLM nondeterminism only matters when e2e-ui.yml runs against a live
+# model; against the default mock LLM this is deterministic. Mirrors the
+# multi-turn chat test's retry posture.
+@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)
+def test_side_by_side_panes_stream_send_and_close(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Open two sessions side by side, send into each, then close one."""
+    base_url, session_a, session_b = seeded_session_pair
+    page.goto(f"{base_url}/compare?sessions={session_a},{session_b}")
+
+    # Both panes mount, each bound to its own session.
+    pane_a = _pane(page, session_a)
+    pane_b = _pane(page, session_b)
+    expect(pane_a).to_be_visible(timeout=30_000)
+    expect(pane_b).to_be_visible(timeout=30_000)
+    expect(page.locator('[data-testid="session-pane"]')).to_have_count(2)
+
+    token_a = f"alpha-{uuid.uuid4().hex[:8]}"
+    token_b = f"beta-{uuid.uuid4().hex[:8]}"
+
+    # Send a distinct prompt into each pane, independently.
+    _send_into(pane_a, f"Reply with one short word. My tag is {token_a}.")
+    _send_into(pane_b, f"Reply with one short word. My tag is {token_b}.")
+
+    # Each pane shows ONLY its own user message — proof the send routed to the
+    # right session and the panes don't cross-talk.
+    expect(pane_a.locator(_USER, has_text=token_a)).to_have_count(1, timeout=15_000)
+    expect(pane_b.locator(_USER, has_text=token_b)).to_have_count(1, timeout=15_000)
+    expect(pane_a.locator(_USER, has_text=token_b)).to_have_count(0)
+    expect(pane_b.locator(_USER, has_text=token_a)).to_have_count(0)
+
+    # Both panes stream an assistant response in parallel (not snapshots).
+    expect(pane_a.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
+    expect(pane_a.locator(_ASSISTANT).first).to_have_text(re.compile(r"\S"), timeout=60_000)
+    expect(pane_b.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
+    expect(pane_b.locator(_ASSISTANT).first).to_have_text(re.compile(r"\S"), timeout=60_000)
+
+    # Close pane A. It is removed; with one session left the view falls back to
+    # the single-session route, and the kept session's transcript survives
+    # (re-bound from its own cached store) — its user message is still on screen.
+    pane_a.get_by_test_id("session-pane-close").click()
+    expect(_pane(page, session_a)).to_have_count(0, timeout=10_000)
+    expect(page).to_have_url(re.compile(rf"/c/{re.escape(session_b)}"))
+    expect(page.locator(_USER, has_text=token_b)).to_be_visible(timeout=15_000)
+    # The kept session stays interactive.
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible()


### PR DESCRIPTION
## Related issue

Closes #888

## Summary

Adds a **side-by-side multi-session view** so an engineer can watch and drive several agent sessions in parallel instead of clicking between them.

- **Store: singleton → per-session registry.** `ap-web/src/store/chatStore.ts` no longer holds one global session; it builds one store per session, each owning its own `blocks`, `activeResponse`, `abortController`, SSE pump, and send queue. `useChatStore` + `getState().switchTo(id)` are preserved as a facade over the *active* session, so the single-session route is observably unchanged. New API: `useChatSession(sessionId, selector)`, `acquireSession`/`releaseSession`.
- **Panes: prop-driven ChatPage.** `ChatPage` gains an `embedded` pane mode (own header + close, transcript, composer; no workspace/dialog chrome) and a `ChatSessionScopeContext` that scopes its reactive reads *and* imperative calls (send/stop/approve/pickers) to that pane's session.
- **Layout + entry.** A new `/compare?sessions=a,b,c` route renders a `MultiSessionGrid` at the AppShell main seam (panes share width, then horizontal-scroll below a min readable width); each pane binds its own stream lazily and aborts only its own on close. The sidebar's existing multi-select gets an **"Open side-by-side"** bulk action.

### ELI5

The chat UI could only show one conversation at a time because all the live streaming state lived in a single shared store. This splits it into one independent store per session, so the UI can open several sessions as live, fully-interactive panes at once — each streaming and accepting input on its own, without stepping on each other. The normal one-session view behaves exactly as before.

```
BEFORE — one global store, one live session
  useChatStore (singleton) ──switchTo(id)──► [ blocks · pump · sendQ · abort ]
                                              (only the active session is live)

AFTER — registry of per-session stores; each pane drives its own
  sessionRegistry
   ├─ A → [ blocks · pump · sendQ · abort ]  ◄── Pane A  (live)
   ├─ B → [ blocks · pump · sendQ · abort ]  ◄── Pane B  (live)
   └─ C → [ blocks · pump · sendQ · abort ]  ◄── Pane C  (live)

  /c/:id    → ChatPage          (useChatStore facade → active session: unchanged)
  /compare  → MultiSessionGrid  → [ Pane A | Pane B | Pane C ]  (scoped per session)
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

**Unit (Vitest) — `cd ap-web && npm run test`: 2880 passed, 0 regressions.**
- `src/store/chatStore.test.ts` (226 cases) was adapted to the new model — single-session *behavior* preserved, not the `switchTo` refs verbatim — and extended with the three isolation cases that are the crux of the feature: (a) two concurrent sessions stream into independent slices, (b) per-session send queues don't cross-talk (a stalled POST on A doesn't block B), and (c) releasing a pane aborts only that session's stream.
- The full suite passing (incl. the existing AppShell/ChatPage/ApprovalCard tests) is the regression net for the backward-compatible single-session path.

**E2E (Playwright) — new `tests/e2e_ui/sessions/test_side_by_side.py`.** Scenario, via the `seeded_session_pair` fixture: open `/compare?sessions=a,b` → assert both `session-pane`s mount → send a distinct prompt into each pane independently and assert each pane shows **only its own** user + assistant bubble (no cross-talk) → close one pane and assert it's removed while the kept session stays live. This is the coverage for the **E2E UI Required** check.

**Manual / local verification.** Ran the E2E against a live server + real browser locally — `uv run pytest tests/e2e_ui/sessions/test_side_by_side.py --browser-channel chrome` → **1 passed** (Ubuntu 26.04 is newer than Playwright 1.60's bundled chromium, so the system Chrome channel is used locally; CI uses the bundled browser with no flag). This run also surfaced and fixed a real bug: the shell's absolute `ChatHeader` overlay covered the panes' close controls on `/compare`, so it's now suppressed there.

**Other gates:** `npm run type-check` clean, `npm run build` succeeds, `npm run lint` adds no new findings (the pre-existing baseline is unchanged).