### PR TITLE
Install the Claude CLI via Anthropic's native installer

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1351,13 +1351,13 @@ def _prompt_install_harness(family: str) -> bool:
     from omnigent.onboarding.configure_models import family_label
     from omnigent.onboarding.harness_install import (
         harness_cli_version,
-        harness_install_command,
+        harness_install_display,
         install_harness_cli,
     )
     from omnigent.onboarding.interactive import console, select
 
     label = family_label(family)
-    cmd = " ".join(harness_install_command(family))
+    cmd = harness_install_display(family)
     detected_version, range_str = harness_cli_version(family)
     if detected_version is None:
         prompt = f"{label}'s CLI is missing. Install it now?"
@@ -1375,7 +1375,7 @@ def _prompt_install_harness(family: str) -> bool:
             "I'll run it myself (show the command)",
         ],
         descriptions=[
-            f"Runs `{cmd}` (needs npm), then continues to credential setup.",
+            f"Runs `{cmd}`, then continues to credential setup.",
             "Return to the harness picker without installing.",
             "Print the command so you can install it yourself, then return.",
         ],
@@ -3407,6 +3407,7 @@ def _run_configure_harnesses_interactive() -> None:
         harness_cli_installed,
         harness_cli_logged_in,
         harness_install_command,
+        harness_install_display,
         harness_install_spec,
     )
     from omnigent.onboarding.interactive import select
@@ -3536,7 +3537,7 @@ def _run_configure_harnesses_interactive() -> None:
                 name,
                 _cli_absence_label(fam),
                 "missing",
-                _install_hint(" ".join(harness_install_command(fam))),
+                _install_hint(harness_install_display(fam)),
             )
         default = surface_default_provider(config, fam)
         if default is None:

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -148,6 +148,12 @@ HERMES_KEY = "hermes"
 
 _HERMES_INSTALL_HINT = "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
 
+# Anthropic recommends its native installer over ``npm install -g``: it writes
+# to a user-writable ``~/.local/bin`` and self-updates, so it sidesteps the
+# EACCES failure on a root-owned npm global prefix.
+# See https://code.claude.com/docs/en/setup#native-install-recommended
+_CLAUDE_INSTALL_HINT = "curl -fsSL https://claude.ai/install.sh | bash"
+
 
 # Keyed by harness family (Claude=anthropic, Codex=openai) plus the pi
 # fallback. Binaries/packages mirror ucode's ``TOOL_SPECS`` so the two tools
@@ -155,14 +161,20 @@ _HERMES_INSTALL_HINT = "curl -fsSL https://hermes-agent.nousresearch.com/install
 # subcommands (``claude auth login --claudeai`` / ``codex login``), so the user
 # can sign in to a subscription from ``configure harnesses`` directly.
 _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
+    # Claude ships a vendor installer, so like Hermes it carries an
+    # ``install_hint`` + ``install_command`` and no ``package``. ``package is
+    # None`` is what routes :func:`harness_setup_hint` and the runner's
+    # missing-CLI error to the installer instead of the npm command.
     ANTHROPIC_FAMILY: HarnessInstallSpec(
         "Claude",
         "claude",
-        "@anthropic-ai/claude-code",
+        package=None,
         login_args=("auth", "login", "--claudeai"),
         logout_args=("auth", "logout"),
         status_args=("auth", "status"),
         login_status_key="loggedIn",
+        install_hint=_CLAUDE_INSTALL_HINT,
+        install_command=("bash", "-c", _CLAUDE_INSTALL_HINT),
         # The native bridge injects Omnigent's MCP relay via `--mcp-config`;
         # that flag first shipped in Claude Code 0.2.75.
         min_version=_CLAUDE_MIN_VERSION,
@@ -897,8 +909,9 @@ def harness_install_command(key: str) -> list[str]:
 
     :param key: A harness family or :data:`PI_KEY`.
     :returns: The install command, e.g. ``["npm", "install", "-g",
-        "@anthropic-ai/claude-code"]`` or an explicitly configured vendor
-        installer command.
+        "@openai/codex"]`` or an explicitly configured vendor installer command,
+        wrapped as ``["bash", "-c", <script>]``. For the form to show a user,
+        see :func:`harness_install_display`.
     :raises KeyError: If *key* has no install spec (caller should gate on
         :func:`harness_install_spec`).
     :raises ValueError: If *key* has a spec but no npm ``package`` (a CLI
@@ -913,6 +926,26 @@ def harness_install_command(key: str) -> list[str]:
     if package is None:
         raise ValueError(f"{key!r} has no npm package; show its install_hint instead")
     return ["npm", "install", "-g", package]
+
+
+def harness_install_display(key: str) -> str:
+    """Return the install command in the form to show a user.
+
+    A vendor installer publishes the runnable one-liner in ``install_hint``,
+    while :func:`harness_install_command` wraps it as ``bash -c <script>`` for
+    ``subprocess``; showing that joined argv would print the wrapper for the
+    user to strip by hand. npm harnesses render from the argv as before.
+
+    :param key: A harness family or :data:`PI_KEY`.
+    :returns: e.g. ``"curl -fsSL https://claude.ai/install.sh | bash"``.
+    :raises KeyError: If *key* has no install spec.
+    :raises ValueError: If *key* has neither an ``install_hint`` nor a
+        ``package``.
+    """
+    spec = harness_install_spec(key)
+    if spec is not None and spec.install_hint:
+        return spec.install_hint
+    return " ".join(harness_install_command(key))
 
 
 class HarnessInstallResult(NamedTuple):

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -45,14 +45,13 @@ def _stub_cli_fallback_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.parametrize(
     "key,binary,package",
     [
-        (ANTHROPIC_FAMILY, "claude", "@anthropic-ai/claude-code"),
         (OPENAI_FAMILY, "codex", "@openai/codex"),
         (hi.PI_KEY, "pi", "@earendil-works/pi-coding-agent"),
         (hi.QWEN_KEY, "qwen", "@qwen-code/qwen-code"),
     ],
 )
 def test_install_spec_and_command(key: str, binary: str, package: str) -> None:
-    """Each known harness maps to the ucode-matching binary + npm package.
+    """Each npm-installed harness maps to the ucode-matching binary + package.
 
     A drift in binary/package (e.g. a wrong npm name) would install the wrong
     thing or check the wrong PATH entry — caught here.
@@ -62,6 +61,45 @@ def test_install_spec_and_command(key: str, binary: str, package: str) -> None:
     assert spec.binary == binary
     assert spec.package == package
     assert hi.harness_install_command(key) == ["npm", "install", "-g", package]
+
+
+def test_claude_installs_via_anthropic_native_installer() -> None:
+    """Claude ships via Anthropic's installer, not ``npm install -g``.
+
+    ``package`` must stay ``None``: that is the flag :func:`harness_setup_hint`
+    and the runner's missing-CLI error branch on to name the vendor installer.
+    """
+    spec = hi.harness_install_spec(ANTHROPIC_FAMILY)
+    assert spec is not None
+    assert spec.binary == "claude"
+    assert spec.package is None
+    assert spec.install_hint == "curl -fsSL https://claude.ai/install.sh | bash"
+    assert hi.harness_install_command(ANTHROPIC_FAMILY) == [
+        "bash",
+        "-c",
+        spec.install_hint,
+    ]
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        (ANTHROPIC_FAMILY, "curl -fsSL https://claude.ai/install.sh | bash"),
+        (OPENAI_FAMILY, "npm install -g @openai/codex"),
+    ],
+)
+def test_install_display_hides_the_bash_c_wrapper(key: str, expected: str) -> None:
+    """The command shown to a user is runnable as-is, without the ``bash -c``
+    wrapper :func:`harness_install_command` adds for ``subprocess``."""
+    assert hi.harness_install_display(key) == expected
+
+
+def test_claude_setup_hint_names_the_native_installer() -> None:
+    """A machine missing the claude CLI is pointed at the working installer."""
+    hint = hi.harness_setup_hint("claude-native")
+    assert "claude.ai/install.sh" in hint
+    assert "npm" not in hint
+    assert "claude auth login --claudeai" in hint
 
 
 def test_kimi_install_spec_is_login_only_no_npm() -> None:
@@ -304,10 +342,13 @@ def test_setup_hint_for_native_kiro_points_at_vendor_installer(harness: str) -> 
     assert "omni setup" not in hint
 
 
-@pytest.mark.parametrize("harness", ["claude-native", "codex", "pi", "claude-sdk", None])
+@pytest.mark.parametrize("harness", ["codex", "pi", "claude-sdk", None])
 def test_setup_hint_defaults_to_omnigent_setup(harness: str | None) -> None:
     """Harnesses whose CLI ``omni setup`` installs (npm CLIs) — and the
-    SDK / unknown / ``None`` cases — route to the ``omni setup`` hint."""
+    SDK / unknown / ``None`` cases — route to the ``omni setup`` hint.
+
+    ``claude-native`` is absent: it names Anthropic's installer instead.
+    """
     hint = hi.harness_setup_hint(harness)
     assert "omni setup" in hint
 
@@ -412,7 +453,7 @@ def test_install_harness_cli_requires_npm(monkeypatch: pytest.MonkeyPatch) -> No
         raise AssertionError("subprocess.run reached despite missing npm")
 
     monkeypatch.setattr(hi.subprocess, "run", _explode)
-    assert hi.install_harness_cli(ANTHROPIC_FAMILY) is False
+    assert hi.install_harness_cli(OPENAI_FAMILY) is False
 
 
 def test_try_install_harness_cli_missing_npm(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -427,9 +468,13 @@ def test_try_install_harness_cli_missing_npm(monkeypatch: pytest.MonkeyPatch) ->
         "run",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not shell out")),
     )
-    installed, reason = hi.try_install_harness_cli(ANTHROPIC_FAMILY)
+    installed, reason = hi.try_install_harness_cli(OPENAI_FAMILY)
     assert installed is False
     assert reason is not None and "npm" in reason
+    # Claude's installer is bash-based, so its reason names bash, not npm.
+    installed, reason = hi.try_install_harness_cli(ANTHROPIC_FAMILY)
+    assert installed is False
+    assert reason is not None and "bash" in reason
 
 
 def test_try_install_harness_cli_manual_only() -> None:


### PR DESCRIPTION
Fixes #890

## What & why

`omnigent setup` / `configure harnesses` installed the Claude CLI with
`npm install -g @anthropic-ai/claude-code`. On machines where npm's global
prefix is root-owned — the common default (`/usr/local`, or a system Node) —
this dies with an `EACCES` permission error during onboarding, and the reflex
`sudo npm install -g` is exactly what [Anthropic's docs warn
against](https://code.claude.com/docs/en/setup#install-with-npm) (root-owned
files in `$HOME`, security risk).

## Change

Per review feedback, rather than have Omnigent reason about npm's global prefix
and PATH, **Claude now installs via Anthropic's recommended native installer**:

    curl -fsSL https://claude.ai/install.sh | bash

It writes to a user-writable `~/.local/bin` and self-updates, so the permission
problem doesn't arise and Omnigent owns no npm global-prefix / PATH edge cases.

- **Claude → native installer**, both auto-run by `install_harness_cli` and shown
  in the setup menu / "run it yourself" hint.
- **Codex, Pi, Qwen, OpenCode → unchanged** `npm install -g` flow (no first-party
  native installer).
- The native installer needs `curl` + `bash`; if either is missing the
  auto-install declines and the menu shows the command to run by hand (no silent
  fallback to `npm install -g`).

## Implementation

- `omnigent/onboarding/harness_install.py`
  - New `native_install` field on `HarnessInstallSpec`; set on the Claude spec.
    When present it takes precedence over `package`.
  - `harness_install_command()` returns `["bash", "-c", <installer>]` for a
    native harness, else `["npm", "install", "-g", <package>]`.
  - New `harness_install_display()` renders the human-readable command (the bare
    `curl … | bash` one-liner, not the `bash -c` wrapper) for menus/hints.
  - `install_harness_cli()` runs the native installer (gating on `curl`/`bash`)
    for Claude, npm otherwise.
- `omnigent/cli.py` — `_prompt_install_harness` shows `harness_install_display`.
- `omnigent/onboarding/wizard.py` — Claude's "not found" install hint updated.

## Tests

`tests/onboarding/test_harness_install.py`:

- Claude → native installer command + display; never `npm install -g`.
- Codex/Pi/Qwen → bare `npm install -g` command + display (unchanged).
- `install_harness_cli` runs the native `curl … | bash` for Claude and resolves
  once the binary appears.
- Native install needs both `curl` and `bash` — either missing → declines
  without spawning (and no npm fallback).
- npm harnesses still short-circuit to `False` when `npm` is absent.

Verified locally: `tests/onboarding/` (577 passed), the cli install-prompt tests,
and `ruff check` / `ruff format --check` all pass. Branch rebased onto current
`main`.

Refs: https://code.claude.com/docs/en/setup#native-install-recommended