### PR TITLE
Fix pi-native wire API configuration to respect wire_api: chat setting

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
+    CHAT_WIRE_API,
     DATABRICKS_KIND,
     GATEWAY_KIND,
     KEY_KIND,
@@ -138,10 +139,17 @@ def _inline_family_pi_provider(
     :returns: The Pi provider config, or ``None`` when no usable family with a
         base URL and credential is configured.
     """
-    for family_name, api in (("anthropic", "anthropic-messages"), ("openai", "openai-responses")):
+    for family_name in ("anthropic", "openai"):
         family = entry.family(family_name)
         if family is None or not family.base_url:
             continue
+        # Determine the API type based on family and wire_api setting.
+        if family_name == "anthropic":
+            api = "anthropic-messages"
+        elif family.wire_api == CHAT_WIRE_API:
+            api = "openai-completions"
+        else:
+            api = "openai-responses"
         # A static key (or $VAR) — Pi reads a literal/env apiKey directly; an
         # auth_command becomes a "!command" Pi resolves at request time.
         if family.api_key:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -282,10 +282,6 @@ def test_anthropic_family_ignores_wire_api() -> None:
     """The Anthropic family always uses anthropic-messages, ignoring wire_api.
 
     The wire_api setting is only meaningful for the OpenAI family.
-    Errors: (BLE001 — any resolution failure must not break launch
-    # The contract is "any resolution failure → fall back to Pi's
-    # own login", so the resolver must swallow it and return ``None`` rather than
-    # let the exception fail the Pi terminal launch.
     """
     config = {
         "providers": {

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -183,3 +183,128 @@ def test_provider_launch_returns_env_and_args(tmp_path: Path) -> None:
     assert env == {creds.PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
     assert args == ["--provider", "omnigent", "--model", "claude-sonnet-4-6"]
     assert (agent_dir / "models.json").exists()
+
+
+def test_openai_chat_wire_api_resolves_to_completions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An OpenAI family with wire_api: chat → openai-completions API.
+
+    This tests the fix for the DeepInfra bug where pi-native was ignoring
+    the wire_api setting and always using openai-responses. Providers like
+    DeepInfra implement Chat Completions (/v1/openai/chat/completions) but
+    not the Responses API (/v1/openai/responses returns 404).
+    """
+    # Set a fake API key in the environment for testing
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-deepinfra-key")
+
+    config = {
+        "providers": {
+            "deepinfra": {
+                "kind": "gateway",
+                "default": True,
+                "openai": {
+                    "base_url": "https://api.deepinfra.com/v1/openai",
+                    "api_key": "$OPENAI_API_KEY",
+                    "wire_api": "chat",
+                    "models": {"default": "zai-org/GLM-4.7"},
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(config_loader=lambda: config)
+    assert provider is not None
+    # wire_api: chat should resolve to openai-completions, not openai-responses
+    assert provider.api == "openai-completions", (
+        f"Expected openai-completions but got {provider.api} "
+        f"(wire_api:chat should use chat completions API, not responses)"
+    )
+    assert provider.base_url == "https://api.deepinfra.com/v1/openai"
+    assert provider.model == "zai-org/GLM-4.7"
+    assert provider.api_key == "sk-test-deepinfra-key"  # Resolved from environment
+    assert provider.auth_header is False
+
+
+def test_openai_responses_wire_api_default() -> None:
+    """An OpenAI family without wire_api (or wire_api: responses) → openai-responses API.
+
+    When wire_api is not set or set to "responses", the default behavior
+    should be to use the OpenAI Responses API.
+    """
+    config = {
+        "providers": {
+            "openai-gateway": {
+                "kind": "gateway",
+                "default": True,
+                "openai": {
+                    "base_url": "https://api.openai.com/v1",
+                    "api_key": "sk-test",
+                    "models": {"default": "gpt-4o"},
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(config_loader=lambda: config)
+    assert provider is not None
+    # Default (no wire_api) should use openai-responses
+    assert provider.api == "openai-responses"
+    assert provider.base_url == "https://api.openai.com/v1"
+    assert provider.model == "gpt-4o"
+
+
+def test_openai_responses_wire_api_explicit() -> None:
+    """An OpenAI family with wire_api: responses → openai-responses API.
+
+    When wire_api is explicitly set to "responses", it should use the
+    OpenAI Responses API.
+    """
+    config = {
+        "providers": {
+            "openai-gateway": {
+                "kind": "gateway",
+                "default": True,
+                "openai": {
+                    "base_url": "https://api.openai.com/v1",
+                    "api_key": "sk-test",
+                    "wire_api": "responses",
+                    "models": {"default": "gpt-4o"},
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(config_loader=lambda: config)
+    assert provider is not None
+    # Explicit wire_api: responses should use openai-responses
+    assert provider.api == "openai-responses"
+    assert provider.base_url == "https://api.openai.com/v1"
+    assert provider.model == "gpt-4o"
+
+
+def test_anthropic_family_ignores_wire_api() -> None:
+    """The Anthropic family always uses anthropic-messages, ignoring wire_api.
+
+    The wire_api setting is only meaningful for the OpenAI family.
+    Errors: (BLE001 — any resolution failure must not break launch
+    # The contract is "any resolution failure → fall back to Pi's
+    # own login", so the resolver must swallow it and return ``None`` rather than
+    # let the exception fail the Pi terminal launch.
+    """
+    config = {
+        "providers": {
+            "anthropic": {
+                "kind": "key",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "sk-test",
+                    "wire_api": "chat",  # Should be ignored for Anthropic
+                    "models": {"default": "claude-4"},
+                },
+            }
+        }
+    }
+    provider = creds.resolve_pi_native_provider(config_loader=lambda: config)
+    assert provider is not None
+    # Anthropic should always use anthropic-messages, not affected by wire_api
+    assert provider.api == "anthropic-messages"
+    assert provider.base_url == "https://api.anthropic.com"
+    assert provider.model == "claude-4"
+    assert provider.api_key == "sk-test"


### PR DESCRIPTION
The pi_native_credentials module was ignoring the wire_api configuration setting for OpenAI family providers, always defaulting to 'openai-responses' API instead of respecting 'wire_api: chat' which should use 'openai-completions'.

This causes HTTP 404 errors when using providers like DeepInfra that implement the Chat Completions API (/v1/openai/chat/completions) but not the Responses API (/v1/openai/responses).

Changes:
- Import CHAT_WIRE_API from provider_config
- Modify _inline_family_pi_provider() to determine API type based on family and wire_api setting:
  * anthropic family → always 'anthropic-messages'
  * openai family with wire_api: chat → 'openai-completions'
  * openai family without wire_api or wire_api: responses → 'openai-responses'

Add comprehensive tests:
- test_openai_chat_wire_api_resolves_to_completions
- test_openai_responses_wire_api_default
- test_openai_responses_wire_api_explicit
- test_anthropic_family_ignores_wire_api

Fixes: DeepInfra and other Chat Completions-only providers cannot be used
        with omnigent pi / pi-native wire API.

## Related issue

Closes #902

## Summary

This PR fixes a bug where `omnigent pi` (pi-native) was ignoring the `wire_api: chat` configuration setting for OpenAI family providers, causing HTTP 404 errors when using providers like DeepInfra that implement the Chat Completions API but not the Responses API.

## Problem

The `pi_native_credentials.py` module was hardcoding the OpenAI API type to `openai-responses` for all OpenAI family providers, ignoring the user's `wire_api` configuration. This caused:

- DeepInfra and similar providers to fail with HTTP 404 errors
- Session logs showing `"api":"openai-responses"` despite correct configuration
- `omnigent config list` showing correct provider configuration but not being used

## Solution

Modified `_inline_family_pi_provider()` in `omnigent/pi_native_credentials.py` to:

1. Import `CHAT_WIRE_API` constant from `provider_config`
2. Determine API type based on family and `wire_api` setting:
   - `anthropic` family → always `anthropic-messages`
   - `openai` family with `wire_api: chat` → `openai-completions`
   - `openai` family without `wire_api` or with `wire_api: responses` → `openai-responses`


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

All tests pass:
```bash
$ uv run pytest tests/test_pi_native_credentials.py -v
============================ 14 passed in 0.10s =============================
```

Also verified that all pi_native related tests pass:
```bash
$ uv run pytest tests/ -k "pi_native" --tb=short
==================== 36 passed, 10687 deselected in 30.60s =====================
```

## Expected upstream behavior

| `wire_api` (config) | Pi `api` (models.json) |
|---------------------|-------------------------|
| `chat` | `openai-completions` |
| `responses` (or unset default) | `openai-responses` |

This matches the behavior of other harness paths (codex, pi_executor) which already respect `wire_api`.

