### PR TITLE
feat(harnesses): add Databricks Genie Spaces harness

### DIFF
--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -157,10 +157,18 @@ the workspace.
 Responses API** (`POST /api/2.0/genie/agents/{space_id}/responses`) and streamed
 back over SSE as each step of the turn completes — whole items, not
 token-by-token deltas. Genie's planning arrives as reasoning and each SQL query
-it runs shows up as a tool call while the turn is still running; the report text
-lands when Genie finishes writing it, with result rows re-rendered as Markdown
-tables (capped at 50 rows). Follow-up turns continue the same Genie
-conversation.
+it runs surfaces as a tool card while the turn is still running — Genie executes
+that SQL itself and Omnigent only observes it, so it is not a tool call Omnigent
+serves: it is not subject to `TOOL_CALL` policy gating and emits no usage toward
+cost budgets. The report text lands when Genie finishes writing it, with result
+rows re-rendered as Markdown tables (capped at 50 rows).
+
+Follow-up turns continue the same Genie conversation. That continuity is
+server-side, keyed by a `conversation_id` the running harness process holds in
+memory: it is never persisted, and the harness declares resume `NONE`. A restart
+— or resuming a saved session — therefore starts a fresh, contextless Genie
+conversation, since only the latest user message is forwarded and earlier turns
+are not replayed.
 
 Genie Agent mode is a Databricks **Beta** API gated on a workspace preview
 toggle. Until a workspace admin turns it on, the endpoint answers 404
@@ -201,7 +209,13 @@ the credentials the Databricks SDK resolves from your profile — every request
 carries a freshly minted bearer token, so a long turn survives OAuth token
 expiry — not through the Databricks AI gateway. It also dispatches no Omnigent
 tools: the space runs its own SQL, so those calls are surfaced as observations.
-See [`examples/genie`](../examples/genie).
+
+That makes **tools attached to a `databricks-genie` agent inert**. A `tools:`
+block — or an MCP server wired to the agent — parses and connects without
+complaint, but the harness reports no tool-calling support and forwards only the
+latest user message to Genie, so the tools are silently discarded. If you need
+tool composition, point a tool-calling harness at the Genie MCP server instead
+of using this harness. See [`examples/genie`](../examples/genie).
 
 CLI flags such as `--harness` and `--model` can override or supply missing
 executor values for a run. Databricks credentials come from the spec's

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -153,10 +153,18 @@ the workspace.
 
 `harness: databricks-genie` (alias `genie`) registers a remote Databricks
 **AI/BI Genie space** as the agent's harness (`pip install
-"omnigent[databricks]"`). Each turn is forwarded to the Genie space, which
-answers natural-language questions over your curated data; the response carries
-Genie's summary, the SQL it generated, and the result rows. Follow-up turns
-continue the same Genie conversation.
+"omnigent[databricks]"`). Each turn is posted to the space's Genie **Agent-mode
+Responses API** (`POST /api/2.0/genie/agents/{space_id}/responses`) and streamed
+back over SSE as each step of the turn completes — whole items, not
+token-by-token deltas. Genie's planning arrives as reasoning and each SQL query
+it runs shows up as a tool call while the turn is still running; the report text
+lands when Genie finishes writing it, with result rows re-rendered as Markdown
+tables (capped at 50 rows). Follow-up turns continue the same Genie
+conversation.
+
+Genie Agent mode is a Databricks **Beta** API gated on a workspace preview
+toggle. Until a workspace admin turns it on, the endpoint answers 404
+`FEATURE_DISABLED` and the turn fails saying exactly that.
 
 A Genie space is the conversational unit, so its **space id** is carried in
 `executor.model`. Authentication reuses the Databricks CLI: run
@@ -172,15 +180,34 @@ executor:
     profile: DEFAULT             # ~/.databrickscfg profile; omit to use defaults
 ```
 
-Unlike the gateway-backed harnesses, Genie talks to the workspace through the
-databricks-sdk `WorkspaceClient`, not the Databricks AI gateway, and it dispatches
-no Omnigent tools — the space queries its own data directly. See
-[`examples/genie`](../examples/genie).
+Two Genie-specific knobs:
+
+- **`enable_viz`** (default `false`) asks Genie to attach visualizations to its
+  answer; left off, the field is omitted from the request entirely. It is read
+  from `executor.config`, so it belongs in a bundle spec such as
+  [`examples/genie/config.yaml`](../examples/genie/config.yaml) — the
+  single-file format above has no `config:` block. For a single-file spec, set
+  `HARNESS_DATABRICKS_GENIE_ENABLE_VIZ=true` in the environment instead.
+- **`HARNESS_DATABRICKS_GENIE_TIMEOUT`** overrides the per-turn HTTP deadline in
+  seconds (default `900`), which has to cover Genie planning, running real
+  warehouse queries, and writing its report.
+
+Unlike the gateway-backed harnesses, Genie talks to the workspace directly with
+the credentials the Databricks SDK resolves from your profile — every request
+carries a freshly minted bearer token, so a long turn survives OAuth token
+expiry — not through the Databricks AI gateway. It also dispatches no Omnigent
+tools: the space runs its own SQL, so those calls are surfaced as observations.
+See [`examples/genie`](../examples/genie).
 
 CLI flags such as `--harness` and `--model` can override or supply missing
 executor values for a run. Databricks credentials come from the spec's
 `executor.auth` block or your `omnigent setup` provider config — there is
-no profile flag.
+no profile flag. `databricks-genie` is the exception on the provider half: it
+takes the profile from the spec alone (`executor.auth.profile`, or the legacy
+`executor.profile` / `executor.config.profile`), so a default provider from
+`omnigent setup` does not apply to it; with no profile in the spec it falls back
+to the Databricks SDK's own resolution (`DATABRICKS_CONFIG_PROFILE` env var /
+`[DEFAULT]` section).
 
 ## Qwen Code
 

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -187,10 +187,14 @@ Two Genie-specific knobs:
   from `executor.config`, so it belongs in a bundle spec such as
   [`examples/genie/config.yaml`](../examples/genie/config.yaml) — the
   single-file format above has no `config:` block. For a single-file spec, set
-  `HARNESS_DATABRICKS_GENIE_ENABLE_VIZ=true` in the environment instead.
-- **`HARNESS_DATABRICKS_GENIE_TIMEOUT`** overrides the per-turn HTTP deadline in
-  seconds (default `900`), which has to cover Genie planning, running real
-  warehouse queries, and writing its report.
+  `HARNESS_DATABRICKS_GENIE_ENABLE_VIZ=true` in the environment instead. The
+  chart itself renders in the Genie room — follow the citation link in the
+  answer; Omnigent's own output stays text and tables.
+- **`HARNESS_DATABRICKS_GENIE_TIMEOUT`** overrides the stream idle timeout in
+  seconds (default `900`). It bounds each silent gap in the streamed response —
+  one long warehouse query is a single gap — not the turn's total length. The
+  harness subprocess's idle watchdog (`HARNESS_TURN_TIMEOUT_S`) is sized just
+  above it automatically unless you set that variable yourself.
 
 Unlike the gateway-backed harnesses, Genie talks to the workspace directly with
 the credentials the Databricks SDK resolves from your profile — every request

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -55,7 +55,7 @@ of the agent YAML.
 
 ```yaml
 executor:
-  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, ...
+  harness: claude-sdk        # claude-sdk, openai-agents, codex, cursor, kiro-native, pi, antigravity, qwen, kimi, copilot, hermes, databricks-genie, ...
   model: databricks-claude-opus-4-7
   auth:
     type: databricks
@@ -148,6 +148,34 @@ declares no `executor.auth` block. To route through a gateway, either set
 shell, declare a key/gateway provider in `~/.omnigent/config.yaml`, or use
 `executor.auth: {type: databricks, profile: …}` and let Omnigent resolve
 the workspace.
+
+### Databricks Genie Spaces
+
+`harness: databricks-genie` (alias `genie`) registers a remote Databricks
+**AI/BI Genie space** as the agent's harness (`pip install
+"omnigent[databricks]"`). Each turn is forwarded to the Genie space, which
+answers natural-language questions over your curated data; the response carries
+Genie's summary, the SQL it generated, and the result rows. Follow-up turns
+continue the same Genie conversation.
+
+A Genie space is the conversational unit, so its **space id** is carried in
+`executor.model`. Authentication reuses the Databricks CLI: run
+`databricks auth login --host <workspace>` once (writes `~/.databrickscfg`), then
+name the profile under `executor.auth`.
+
+```yaml
+executor:
+  harness: databricks-genie      # alias: genie
+  model: "01ef…"                 # the Genie space id (from the room URL)
+  auth:
+    type: databricks
+    profile: DEFAULT             # ~/.databrickscfg profile; omit to use defaults
+```
+
+Unlike the gateway-backed harnesses, Genie talks to the workspace through the
+databricks-sdk `WorkspaceClient`, not the Databricks AI gateway, and it dispatches
+no Omnigent tools — the space queries its own data directly. See
+[`examples/genie`](../examples/genie).
 
 CLI flags such as `--harness` and `--model` can override or supply missing
 executor values for a run. Databricks credentials come from the spec's

--- a/examples/genie/README.md
+++ b/examples/genie/README.md
@@ -1,0 +1,50 @@
+# Sales Genie
+
+An Omnigent agent that registers a remote **Databricks AI/BI Genie space** as
+its harness. Each turn is forwarded to the Genie space, which answers
+natural-language questions over your curated data and returns a text summary,
+the SQL it generated, and the result rows.
+
+## Prerequisites
+
+1. **Install the Databricks extra** (provides `databricks-sdk`):
+
+   ```bash
+   uv tool install --force "omnigent[databricks]"
+   ```
+
+2. **Authenticate with the Databricks CLI** — this writes OAuth/PAT credentials
+   into `~/.databrickscfg`, which the harness reads (refreshing OAuth tokens
+   transparently):
+
+   ```bash
+   databricks auth login --host https://<your-workspace>.databricks.com
+   ```
+
+3. **A Genie space** you can query. Find its id in the Genie room URL:
+   `https://<workspace>/genie/rooms/<SPACE_ID>`.
+
+## Configure
+
+Edit [`config.yaml`](config.yaml):
+
+- `executor.model` — your Genie **space id** (the space is the conversational
+  unit, so it is carried in `model`).
+- `executor.auth.profile` — the Databricks profile name from `~/.databrickscfg`.
+  Drop the `auth:` block to use the default resolution
+  (`DATABRICKS_CONFIG_PROFILE` env var / `[DEFAULT]` section).
+
+## Run
+
+```bash
+omnigent run examples/genie -p "What were total sales by region last quarter?"
+```
+
+Or interactively:
+
+```bash
+omnigent run examples/genie
+```
+
+Follow-up questions in the same session continue the same Genie conversation,
+so you can refine ("now break that down by month") without repeating context.

--- a/examples/genie/README.md
+++ b/examples/genie/README.md
@@ -8,17 +8,26 @@ items, not token-by-token deltas — so the work is visible while it happens
 rather than only at the end:
 
 - Genie's planning arrives as **reasoning** while the turn is still running.
-- Each **SQL query it runs** appears as a tool call *during* the turn, with the
-  query's output attached when it finishes.
+- Each **SQL query it runs** surfaces *during* the turn as a tool card, with the
+  query's output attached when it finishes. Genie runs that SQL itself and
+  Omnigent only observes it — it is not a tool call Omnigent serves.
 - The **report text** lands when Genie finishes writing it, with result rows
   re-rendered as Markdown tables (capped at 50 rows) from Genie's
   machine-readable `columns` / `preview_rows` metadata — Databricks documents
   Genie's own Markdown as unstable.
 
 Genie executes its SQL itself, so those calls are observations: this harness
-dispatches no Omnigent tools. The Genie space also carries its own instructions,
-so the `prompt` in [`config.yaml`](config.yaml) documents the agent rather than
-being sent to Genie.
+dispatches no Omnigent tools. Because Omnigent never serves them, they are not
+subject to `TOOL_CALL` policy gating and emit no usage toward cost budgets. The
+Genie space also carries its own instructions, so the `prompt` in
+[`config.yaml`](config.yaml) documents the agent rather than being sent to Genie.
+
+For the same reason, **tools attached to a `databricks-genie` agent are inert**.
+A `tools:` block — or an MCP server wired to the agent — parses and connects
+without complaint, but the harness reports no tool-calling support and forwards
+only the latest user message to Genie, so the tools are silently discarded. If
+you need tool composition, point a tool-calling harness (`claude-sdk`, `codex`,
+…) at the Genie MCP server instead of using this harness.
 
 ## Prerequisites
 
@@ -81,9 +90,12 @@ omnigent run examples/genie
 ```
 
 Follow-up questions in the same session continue the same Genie conversation, so
-you can refine ("now break that down by month") without repeating context. The
-conversation id is held by the running harness process, so a new process starts
-a fresh Genie conversation.
+you can refine ("now break that down by month") without repeating context. That
+context lives server-side in Databricks, keyed by a `conversation_id` the
+running harness process holds in memory — it is never persisted, and the harness
+declares resume `NONE`. Restarting Omnigent (or resuming a saved session) starts
+a fresh, contextless Genie conversation: only the latest user message is
+forwarded, so earlier turns are not replayed.
 
 If a turn fails with `RESOURCE_CONFLICT` (HTTP 409), the conversation still has
 a turn in progress — wait for it to finish before sending the next message.

--- a/examples/genie/README.md
+++ b/examples/genie/README.md
@@ -55,13 +55,15 @@ Edit [`config.yaml`](config.yaml):
   (`DATABRICKS_CONFIG_PROFILE` env var / `[DEFAULT]` section).
 - `executor.config.enable_viz` — set to `true` to ask Genie to attach
   visualizations to its answer. Defaults to `false`, and when off the field is
-  omitted from the request entirely.
+  omitted from the request entirely. The chart itself renders in the Genie
+  room — follow the citation link in the answer; Omnigent's own output stays
+  text and tables.
 
 ## Environment variables
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `HARNESS_DATABRICKS_GENIE_TIMEOUT` | `900` | Per-turn HTTP deadline in seconds for the streamed response — it has to cover planning, real warehouse queries, and the written report. A malformed value falls back to the default. |
+| `HARNESS_DATABRICKS_GENIE_TIMEOUT` | `900` | Stream idle timeout in seconds — bounds each silent gap in the streamed response (one long warehouse query is a single gap), not the turn's total length. A malformed value falls back to the default. |
 | `HARNESS_DATABRICKS_GENIE_ENABLE_VIZ` | unset (off) | `true` / `1` turns the visualization opt-in on. `executor.config.enable_viz` sets this for you; set it in the shell for specs that have no `config:` block. |
 | `HARNESS_DATABRICKS_GENIE_MODEL` | — | The space id. Omnigent sets it from `executor.model`, which wins over any value already in your shell. |
 | `HARNESS_DATABRICKS_GENIE_PROFILE` | — | The `~/.databrickscfg` profile. Omnigent sets it from `executor.auth.profile`, which wins over any value already in your shell. |

--- a/examples/genie/README.md
+++ b/examples/genie/README.md
@@ -1,9 +1,24 @@
 # Sales Genie
 
 An Omnigent agent that registers a remote **Databricks AI/BI Genie space** as
-its harness. Each turn is forwarded to the Genie space, which answers
-natural-language questions over your curated data and returns a text summary,
-the SQL it generated, and the result rows.
+its harness. Each turn is posted to the space's Genie **Agent-mode Responses
+API** (`POST /api/2.0/genie/agents/{space_id}/responses`) and streamed back over
+SSE. The stream carries each step of the turn as Genie finishes it — whole
+items, not token-by-token deltas — so the work is visible while it happens
+rather than only at the end:
+
+- Genie's planning arrives as **reasoning** while the turn is still running.
+- Each **SQL query it runs** appears as a tool call *during* the turn, with the
+  query's output attached when it finishes.
+- The **report text** lands when Genie finishes writing it, with result rows
+  re-rendered as Markdown tables (capped at 50 rows) from Genie's
+  machine-readable `columns` / `preview_rows` metadata — Databricks documents
+  Genie's own Markdown as unstable.
+
+Genie executes its SQL itself, so those calls are observations: this harness
+dispatches no Omnigent tools. The Genie space also carries its own instructions,
+so the `prompt` in [`config.yaml`](config.yaml) documents the agent rather than
+being sent to Genie.
 
 ## Prerequisites
 
@@ -14,8 +29,9 @@ the SQL it generated, and the result rows.
    ```
 
 2. **Authenticate with the Databricks CLI** — this writes OAuth/PAT credentials
-   into `~/.databrickscfg`, which the harness reads (refreshing OAuth tokens
-   transparently):
+   into `~/.databrickscfg`, which the harness reads. Every request to Genie
+   carries a freshly minted bearer token, so a long turn survives OAuth
+   access-token expiry:
 
    ```bash
    databricks auth login --host https://<your-workspace>.databricks.com
@@ -23,6 +39,10 @@ the SQL it generated, and the result rows.
 
 3. **A Genie space** you can query. Find its id in the Genie room URL:
    `https://<workspace>/genie/rooms/<SPACE_ID>`.
+
+4. **Genie Agent mode enabled for the workspace.** These APIs are **Beta** and
+   gated behind a preview toggle a workspace admin has to turn on. Without it,
+   every turn fails with a 404 `FEATURE_DISABLED` error saying so.
 
 ## Configure
 
@@ -33,6 +53,18 @@ Edit [`config.yaml`](config.yaml):
 - `executor.auth.profile` — the Databricks profile name from `~/.databrickscfg`.
   Drop the `auth:` block to use the default resolution
   (`DATABRICKS_CONFIG_PROFILE` env var / `[DEFAULT]` section).
+- `executor.config.enable_viz` — set to `true` to ask Genie to attach
+  visualizations to its answer. Defaults to `false`, and when off the field is
+  omitted from the request entirely.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HARNESS_DATABRICKS_GENIE_TIMEOUT` | `900` | Per-turn HTTP deadline in seconds for the streamed response — it has to cover planning, real warehouse queries, and the written report. A malformed value falls back to the default. |
+| `HARNESS_DATABRICKS_GENIE_ENABLE_VIZ` | unset (off) | `true` / `1` turns the visualization opt-in on. `executor.config.enable_viz` sets this for you; set it in the shell for specs that have no `config:` block. |
+| `HARNESS_DATABRICKS_GENIE_MODEL` | — | The space id. Omnigent sets it from `executor.model`, which wins over any value already in your shell. |
+| `HARNESS_DATABRICKS_GENIE_PROFILE` | — | The `~/.databrickscfg` profile. Omnigent sets it from `executor.auth.profile`, which wins over any value already in your shell. |
 
 ## Run
 
@@ -46,5 +78,10 @@ Or interactively:
 omnigent run examples/genie
 ```
 
-Follow-up questions in the same session continue the same Genie conversation,
-so you can refine ("now break that down by month") without repeating context.
+Follow-up questions in the same session continue the same Genie conversation, so
+you can refine ("now break that down by month") without repeating context. The
+conversation id is held by the running harness process, so a new process starts
+a fresh Genie conversation.
+
+If a turn fails with `RESOURCE_CONFLICT` (HTTP 409), the conversation still has
+a turn in progress — wait for it to finish before sending the next message.

--- a/examples/genie/config.yaml
+++ b/examples/genie/config.yaml
@@ -1,0 +1,47 @@
+# Sales Genie — an Omnigent agent backed by a Databricks Genie space.
+#
+# This agent forwards each question to a remote Databricks AI/BI Genie space,
+# which answers natural-language questions over your curated data (returning a
+# text summary plus the SQL it generated and the result rows).
+#
+# Quick start:
+#
+#   1. Install the Databricks extra (provides databricks-sdk):
+#        uv tool install --force "omnigent[databricks]"
+#
+#   2. Authenticate with the Databricks CLI (writes ~/.databrickscfg):
+#        databricks auth login --host https://<your-workspace>.databricks.com
+#
+#   3. Put your Genie space id in `executor.model` and your profile name in
+#      `executor.auth.profile` below, then run:
+#        omnigent run examples/genie -p "What were total sales by region last quarter?"
+#
+# Find a space id in the Genie UI URL:
+#   https://<workspace>/genie/rooms/<SPACE_ID>
+
+spec_version: 1
+name: sales_genie
+description: >-
+  Answers questions over your data by conversing with a remote Databricks
+  Genie space (natural language → SQL), returning a summary, the generated
+  query, and the result rows.
+
+# The Genie space carries its own instructions, so this prompt is not sent to
+# Genie; it documents the agent's purpose.
+prompt: A data analyst backed by a Databricks Genie space.
+
+executor:
+  type: omnigent
+  config:
+    # Register the remote Genie space as this agent's harness.
+    harness: databricks-genie
+  # The Genie space id is the conversational unit, so it is carried in `model`.
+  # Replace with your space id (from the Genie room URL).
+  model: "REPLACE_WITH_GENIE_SPACE_ID"
+  # Auth via a Databricks CLI profile from ~/.databrickscfg
+  # (`databricks auth login` / `databricks configure`). Replace `DEFAULT` with
+  # your profile name, or drop the `auth:` block to use the default resolution
+  # (DATABRICKS_CONFIG_PROFILE env / [DEFAULT] section).
+  auth:
+    type: databricks
+    profile: DEFAULT

--- a/examples/genie/config.yaml
+++ b/examples/genie/config.yaml
@@ -1,8 +1,12 @@
 # Sales Genie — an Omnigent agent backed by a Databricks Genie space.
 #
 # This agent forwards each question to a remote Databricks AI/BI Genie space,
-# which answers natural-language questions over your curated data (returning a
-# text summary plus the SQL it generated and the result rows).
+# which answers natural-language questions over your curated data. The turn runs
+# on Genie's Agent-mode Responses API and streams back over SSE, so you see its
+# reasoning and the SQL it runs while the answer is still being written.
+#
+# Genie Agent mode is a Databricks Beta API: a workspace admin has to enable the
+# preview, or the turn fails with 404 FEATURE_DISABLED.
 #
 # Quick start:
 #
@@ -23,8 +27,8 @@ spec_version: 1
 name: sales_genie
 description: >-
   Answers questions over your data by conversing with a remote Databricks
-  Genie space (natural language → SQL), returning a summary, the generated
-  query, and the result rows.
+  Genie space (natural language → SQL), streaming its reasoning, the queries
+  it runs, and the final report with the result rows.
 
 # The Genie space carries its own instructions, so this prompt is not sent to
 # Genie; it documents the agent's purpose.
@@ -35,6 +39,9 @@ executor:
   config:
     # Register the remote Genie space as this agent's harness.
     harness: databricks-genie
+    # Ask Genie to attach visualizations to its answer. Off by default — when
+    # false (or absent) the request omits the field entirely.
+    # enable_viz: false
   # The Genie space id is the conversational unit, so it is carried in `model`.
   # Replace with your space id (from the Genie room URL).
   model: "REPLACE_WITH_GENIE_SPACE_ID"

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5755,7 +5755,7 @@ def session_import(input_path: str, title: str | None, server: str | None) -> No
 # into a materialized copy of the spec before the server starts.
 _HARNESS_CHOICES_HELP = (
     "'claude' (alias for 'claude-sdk'), 'claude-sdk', 'codex', "
-    "'cursor', 'kimi', "
+    "'cursor', 'genie' (alias for 'databricks-genie'), 'kimi', "
     "'openai-agents', 'open-responses', 'pi', 'antigravity', 'qwen', 'goose', or 'copilot'"
 )
 _HARNESS_HELP = f"Harness to use for a local agent: {_HARNESS_CHOICES_HELP}."

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -625,19 +625,23 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         streaming=True,
     ),
     # Genie streams each turn's reasoning, SQL, and report over the Agent-mode
-    # Responses API — DatabricksGenieExecutor.supports_streaming() returns True.
-    # It does not override interrupt_session(), so interrupt stays False. The
-    # conversation id it threads across turns lives on the executor instance and
-    # is not rehydrated on resume, hence COLD_ONLY.
+    # Responses API — DatabricksGenieExecutor.supports_streaming() returns True
+    # (progressively, as whole output items rather than token deltas).
+    # interrupt_session() closes the live response stream, so a cancelled turn
+    # unblocks immediately instead of waiting out a warehouse query — hence
+    # interrupt True. Continuity lives only in the in-process conversation id
+    # and only the latest user message is forwarded (no transcript replay), so
+    # a restarted harness process starts a fresh, contextless Genie
+    # conversation — hence resume NONE.
     "databricks-genie": _C(
         _IM.SDK_IN_PROCESS,
         _EL.NONE,
-        _RS.COLD_ONLY,
+        _RS.NONE,
         _EF.NONE,
         _MF.MULTI,
         _AU.OWN_AUTH,
         subagents=False,
-        interrupt=False,
+        interrupt=True,
         streaming=True,
     ),
     # open-responses is resolved via an alternate path, but its executor
@@ -814,6 +818,9 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         # openai-agents is intentionally omitted from the picker catalog: it
         # stays a valid harness for YAML specs (and the credential-free
         # integration mock LLM), but is no longer offered as a UI pick.
+        # databricks-genie is deliberately not a picker row either: an agent
+        # needs a Genie space id and a Databricks profile the create dialog
+        # cannot collect, so it stays YAML/CLI-configured.
         "pi": "Pi",
     },
     capabilities=_BUILTIN_CAPABILITIES,

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -624,9 +624,9 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         interrupt=True,
         streaming=True,
     ),
-    # Genie answers each turn with one complete message over the databricks-sdk
-    # Genie API — DatabricksGenieExecutor.supports_streaming() returns False and
-    # it does not override interrupt_session(), so both are declared False. The
+    # Genie streams each turn's reasoning, SQL, and report over the Agent-mode
+    # Responses API — DatabricksGenieExecutor.supports_streaming() returns True.
+    # It does not override interrupt_session(), so interrupt stays False. The
     # conversation id it threads across turns lives on the executor instance and
     # is not rehydrated on resume, hence COLD_ONLY.
     "databricks-genie": _C(
@@ -638,7 +638,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _AU.OWN_AUTH,
         subagents=False,
         interrupt=False,
-        streaming=False,
+        streaming=True,
     ),
     # open-responses is resolved via an alternate path, but its executor
     # (omnigent/inner/open_responses_sdk.py) is concrete: interrupt_session()

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -624,6 +624,22 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         interrupt=True,
         streaming=True,
     ),
+    # Genie answers each turn with one complete message over the databricks-sdk
+    # Genie API — DatabricksGenieExecutor.supports_streaming() returns False and
+    # it does not override interrupt_session(), so both are declared False. The
+    # conversation id it threads across turns lives on the executor instance and
+    # is not rehydrated on resume, hence COLD_ONLY.
+    "databricks-genie": _C(
+        _IM.SDK_IN_PROCESS,
+        _EL.NONE,
+        _RS.COLD_ONLY,
+        _EF.NONE,
+        _MF.MULTI,
+        _AU.OWN_AUTH,
+        subagents=False,
+        interrupt=False,
+        streaming=False,
+    ),
     # open-responses is resolved via an alternate path, but its executor
     # (omnigent/inner/open_responses_sdk.py) is concrete: interrupt_session()
     # closes the active stream and returns True, supports_streaming() is True,
@@ -657,6 +673,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "copilot",
             "cursor",
             "cursor-native",
+            "databricks-genie",
             "goose",
             "goose-native",
             "hermes",
@@ -684,6 +701,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "copilot": "omnigent.inner.copilot_harness",
         "cursor": "omnigent.inner.cursor_harness",
         "cursor-native": "omnigent.inner.cursor_native_harness",
+        "databricks-genie": "omnigent.inner.databricks_genie_harness",
         "goose": "omnigent.inner.goose_harness",
         "goose-native": "omnigent.inner.goose_native_harness",
         "hermes": "omnigent.inner.hermes_harness",
@@ -701,6 +719,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
     aliases={
         "agy": "antigravity",
         "claude": "claude-sdk",
+        "genie": "databricks-genie",
         "github-copilot": "copilot",
         "google-antigravity": "antigravity",
         "kimi-code": "kimi",
@@ -763,6 +782,8 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "codex": "HARNESS_CODEX_MODEL",
         "copilot": "HARNESS_COPILOT_MODEL",
         "cursor": "HARNESS_CURSOR_MODEL",
+        # Genie carries the space id (not a model name) in ``executor.model``.
+        "databricks-genie": "HARNESS_DATABRICKS_GENIE_MODEL",
         "goose": "HARNESS_GOOSE_MODEL",
         "kimi": "HARNESS_KIMI_MODEL",
         "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",

--- a/omnigent/inner/databricks_genie_executor.py
+++ b/omnigent/inner/databricks_genie_executor.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+import re
+from collections.abc import AsyncIterator, Sequence
 from datetime import timedelta
 
 from omnigent.inner.executor import (
@@ -104,18 +105,34 @@ def _latest_user_text(messages: list[Message]) -> str:
     return ""
 
 
+def _md_cell(value: object) -> str:
+    """Sanitize a value for one GitHub-Flavored-Markdown table cell.
+
+    Collapses internal whitespace (so a multi-line review stays on a single
+    table row instead of shattering the layout) and escapes pipes (so a value
+    containing ``|`` doesn't open a spurious column).
+
+    :param value: A raw cell value; ``None`` renders as an empty cell.
+    :returns: A single-line, pipe-safe cell string.
+    """
+    text = "" if value is None else str(value)
+    return re.sub(r"\s+", " ", text).strip().replace("|", r"\|")
+
+
 def _render_statement(statement: object) -> str:
-    """Render a SQL ``StatementResponse`` as a compact text table.
+    """Render a SQL ``StatementResponse`` as a GitHub-Flavored-Markdown table.
 
     Reads column names from ``statement.manifest.schema.columns[*].name`` and
     rows from ``statement.result.data_array`` (Genie returns cell values as
-    strings). Rows beyond :data:`_MAX_RESULT_ROWS` are summarized rather than
-    printed.
+    strings), emitting a ``| col | col |`` header, a ``| --- | --- |`` delimiter
+    row, and one ``| ... |`` line per row — the form the web UI renders as an
+    HTML table. Cells are sanitized via :func:`_md_cell`; rows beyond
+    :data:`_MAX_RESULT_ROWS` are summarized rather than printed.
 
     :param statement: A ``databricks.sdk.service.sql.StatementResponse`` (or any
         object exposing the same ``manifest`` / ``result`` shape).
-    :returns: A ``"Result (N rows):\\n<header>\\n<rows>"`` block, or ``""`` when
-        the statement carries no rows.
+    :returns: A ``"Result (N rows):\\n\\n<markdown table>"`` block, or ``""``
+        when the statement carries no rows.
     """
     data = getattr(statement, "result", None)
     rows = getattr(data, "data_array", None) if data is not None else None
@@ -126,19 +143,24 @@ def _render_statement(statement: object) -> str:
     schema = getattr(manifest, "schema", None) if manifest is not None else None
     columns = [str(getattr(col, "name", "")) for col in (getattr(schema, "columns", None) or [])]
 
-    lines: list[str] = []
-    if columns:
-        lines.append(" | ".join(columns))
     shown = rows[:_MAX_RESULT_ROWS]
-    for row in shown:
-        lines.append(" | ".join("" if cell is None else str(cell) for cell in row))
-    omitted = len(rows) - len(shown)
-    if omitted > 0:
-        lines.append(f"… ({omitted} more row{'s' if omitted != 1 else ''})")
+    width = max(len(columns), max(len(row) for row in shown))
+    headers = [columns[i] if i < len(columns) else f"col{i + 1}" for i in range(width)]
+
+    def _row(cells: Sequence[object]) -> str:
+        padded = (_md_cell(cells[i]) if i < len(cells) else "" for i in range(width))
+        return "| " + " | ".join(padded) + " |"
+
+    table = [_row(headers), "| " + " | ".join(["---"] * width) + " |"]
+    table.extend(_row(row) for row in shown)
 
     total = len(rows)
-    header = f"Result ({total} row{'s' if total != 1 else ''}):"
-    return header + "\n" + "\n".join(lines)
+    block = f"Result ({total} row{'s' if total != 1 else ''}):\n\n" + "\n".join(table)
+
+    omitted = total - len(shown)
+    if omitted > 0:
+        block += f"\n\n… ({omitted} more row{'s' if omitted != 1 else ''})"
+    return block
 
 
 class DatabricksGenieExecutor(Executor):
@@ -256,15 +278,15 @@ class DatabricksGenieExecutor(Executor):
         description = getattr(query, "description", None)
         sql = getattr(query, "query", None)
 
-        lines: list[str] = [f'Generated SQL ("{title}"):' if title else "Generated SQL:"]
+        blocks: list[str] = [f'Generated SQL ("{title}"):' if title else "Generated SQL:"]
         if description:
-            lines.append(str(description))
+            blocks.append(str(description))
         if sql:
-            lines.append(str(sql))
+            blocks.append(f"```sql\n{sql}\n```")
         table = self._fetch_statement_table(client, getattr(query, "statement_id", None))
         if table:
-            lines.append(table)
-        return "\n".join(lines)
+            blocks.append(table)
+        return "\n\n".join(blocks)
 
     def _format_message(self, client: object, message: object) -> str:
         """Assemble the turn's response text from a ``GenieMessage``.

--- a/omnigent/inner/databricks_genie_executor.py
+++ b/omnigent/inner/databricks_genie_executor.py
@@ -1,0 +1,355 @@
+"""
+``harness: databricks-genie`` executor.
+
+Drives a remote Databricks **AI/BI Genie space** over the Genie Conversation
+API exposed by the ``databricks-sdk`` (``WorkspaceClient.genie``). Each Omnigent
+turn maps to one Genie message: the first turn starts a conversation, later
+turns continue it (Genie keeps the conversation state server-side, keyed by a
+conversation id this executor remembers between turns).
+
+Genie answers natural-language questions over the space's curated data. A turn's
+response carries Genie's text summary plus — when Genie runs SQL — the generated
+query and a rendering of its result rows.
+
+Auth reuses the Databricks CLI: ``databricks auth login`` writes OAuth/PAT
+credentials into ``~/.databrickscfg``; ``WorkspaceClient(profile=...)`` consumes
+them and refreshes OAuth tokens transparently. The Genie space id is carried in
+``executor.model`` (a Genie space is the conversational unit, so it maps onto
+"model") and the profile in ``executor.auth`` / ``executor.profile``; the
+:mod:`omnigent.inner.databricks_genie_harness` wrap passes both to this executor.
+
+The SDK's ``*_and_wait`` helpers are blocking, so each call runs in a worker
+thread via :func:`asyncio.to_thread` to keep the event loop responsive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from datetime import timedelta
+
+from omnigent.inner.executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    TextChunk,
+    ToolSpec,
+    TurnComplete,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Display guard: cap the number of result rows rendered inline so a large query
+# result doesn't blow up the turn's response payload. Genie truncates upstream
+# too; this is a belt-and-braces bound on what we echo back.
+_MAX_RESULT_ROWS = 50
+
+# Default deadline handed to Genie's blocking ``*_and_wait`` helpers. Comfortably
+# under Omnigent's per-turn ceiling while leaving room for a real warehouse query.
+_DEFAULT_TIMEOUT_SECONDS = 300.0
+
+
+class DatabricksGenieError(Exception):
+    """Raised for databricks-genie setup / response failures.
+
+    Carries an actionable, human-readable message (missing SDK + install hint,
+    or a failed Genie message). :meth:`DatabricksGenieExecutor.run_turn`
+    converts it — and any other exception raised while talking to Genie — into
+    an :class:`~omnigent.inner.executor.ExecutorError` turn event.
+    """
+
+
+def _extract_text(msg: Message) -> str:
+    """Return the plain text of a single message dict.
+
+    Handles both string ``content`` and a list of multimodal parts (joining the
+    ``text`` of each ``{"type": "text", "text": ...}`` block), mirroring the
+    peer executors' message handling.
+
+    :param msg: An executor-facing message dict, e.g.
+        ``{"role": "user", "content": "hi"}``.
+    :returns: The message's text, or ``""`` when it carries none.
+    """
+    content = msg.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return " ".join(parts)
+    return str(content)
+
+
+def _latest_user_text(messages: list[Message]) -> str:
+    """Return the text of the most recent ``user`` message.
+
+    Genie maintains its own conversation history server-side, so only the latest
+    user turn is forwarded; prior turns are already known to the Genie space.
+
+    :param messages: The turn's message history (oldest first).
+    :returns: The latest user message's text, or ``""`` when there is none.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return _extract_text(msg)
+    return ""
+
+
+def _render_statement(statement: object) -> str:
+    """Render a SQL ``StatementResponse`` as a compact text table.
+
+    Reads column names from ``statement.manifest.schema.columns[*].name`` and
+    rows from ``statement.result.data_array`` (Genie returns cell values as
+    strings). Rows beyond :data:`_MAX_RESULT_ROWS` are summarized rather than
+    printed.
+
+    :param statement: A ``databricks.sdk.service.sql.StatementResponse`` (or any
+        object exposing the same ``manifest`` / ``result`` shape).
+    :returns: A ``"Result (N rows):\\n<header>\\n<rows>"`` block, or ``""`` when
+        the statement carries no rows.
+    """
+    data = getattr(statement, "result", None)
+    rows = getattr(data, "data_array", None) if data is not None else None
+    if not rows:
+        return ""
+
+    manifest = getattr(statement, "manifest", None)
+    schema = getattr(manifest, "schema", None) if manifest is not None else None
+    columns = [str(getattr(col, "name", "")) for col in (getattr(schema, "columns", None) or [])]
+
+    lines: list[str] = []
+    if columns:
+        lines.append(" | ".join(columns))
+    shown = rows[:_MAX_RESULT_ROWS]
+    for row in shown:
+        lines.append(" | ".join("" if cell is None else str(cell) for cell in row))
+    omitted = len(rows) - len(shown)
+    if omitted > 0:
+        lines.append(f"… ({omitted} more row{'s' if omitted != 1 else ''})")
+
+    total = len(rows)
+    header = f"Result ({total} row{'s' if total != 1 else ''}):"
+    return header + "\n" + "\n".join(lines)
+
+
+class DatabricksGenieExecutor(Executor):
+    """Executor that drives a Databricks Genie space over the Genie API.
+
+    :param space_id: The Genie space id to converse with (from
+        ``executor.model``). When unset, :meth:`run_turn` yields an
+        :class:`ExecutorError` instructing the user to set it.
+    :param profile: The Databricks profile from ``~/.databrickscfg`` used to
+        build the workspace client. ``None`` lets the SDK use its own resolution
+        order (``DATABRICKS_CONFIG_PROFILE`` env / ``DEFAULT`` section).
+    :param workspace_client: An injected ``WorkspaceClient`` (tests pass a fake).
+        When ``None``, one is built lazily on the first turn so a missing
+        ``databricks-sdk`` install surfaces as a turn error, not a boot crash.
+    :param timeout_seconds: Deadline handed to Genie's blocking
+        ``*_and_wait`` helpers.
+    """
+
+    def __init__(
+        self,
+        *,
+        space_id: str | None,
+        profile: str | None = None,
+        workspace_client: object | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._space_id = space_id
+        self._profile = profile
+        self._client = workspace_client
+        self._timeout_seconds = timeout_seconds
+        # Set on the first turn that reaches Genie; subsequent turns continue
+        # this conversation instead of starting a new one.
+        self._conversation_id: str | None = None
+
+    def supports_streaming(self) -> bool:
+        """Genie returns a complete answer per message — there is no token stream."""
+        return False
+
+    def supports_tool_calling(self) -> bool:
+        """Genie has no Omnigent-dispatched tools; it queries the space directly."""
+        return False
+
+    def _ensure_client(self) -> object:
+        """Return the workspace client, building one lazily on first use.
+
+        :returns: The (possibly newly constructed) ``WorkspaceClient``.
+        :raises DatabricksGenieError: When ``databricks-sdk`` is not installed.
+        """
+        if self._client is not None:
+            return self._client
+        try:
+            from databricks.sdk import WorkspaceClient
+        except ImportError as exc:
+            from omnigent.onboarding.databricks_config import DATABRICKS_EXTRA_INSTALL_HINT
+
+            raise DatabricksGenieError(
+                "the databricks-sdk package is required for the databricks-genie "
+                f"harness but is not installed. {DATABRICKS_EXTRA_INSTALL_HINT}"
+            ) from exc
+        self._client = WorkspaceClient(profile=self._profile)
+        return self._client
+
+    def _send(self, client: object, space_id: str, content: str) -> object:
+        """Send *content* to Genie, starting or continuing the conversation.
+
+        :param client: The workspace client whose ``.genie`` API is called.
+        :param space_id: The Genie space id.
+        :param content: The user's natural-language message.
+        :returns: The resolved ``GenieMessage``.
+        """
+        genie = client.genie  # type: ignore[attr-defined]  # untyped databricks-sdk
+        timeout = timedelta(seconds=self._timeout_seconds)
+        if self._conversation_id is None:
+            return genie.start_conversation_and_wait(space_id, content, timeout=timeout)
+        return genie.create_message_and_wait(
+            space_id, self._conversation_id, content, timeout=timeout
+        )
+
+    def _fetch_statement_table(self, client: object, statement_id: object) -> str:
+        """Fetch and render the executed query's result rows, best-effort.
+
+        A result-fetch failure (e.g. the result expired) must not sink the turn —
+        Genie's text answer is still useful — so this swallows errors and returns
+        ``""`` after logging.
+
+        :param client: The workspace client.
+        :param statement_id: The executed query's statement id (from the query
+            attachment). ``None`` / empty → no table.
+        :returns: A rendered result table, or ``""`` when unavailable.
+        """
+        if not statement_id:
+            return ""
+        try:
+            statement = client.statement_execution.get_statement(  # type: ignore[attr-defined]
+                statement_id
+            )
+        except Exception as exc:  # noqa: BLE001 — result is optional; never fail the turn
+            _logger.debug("databricks-genie: could not fetch query result: %s", exc)
+            return ""
+        return _render_statement(statement)
+
+    def _format_query(self, client: object, query: object) -> str:
+        """Render a Genie query attachment: title/description + SQL + result rows.
+
+        The executed query's rows are fetched via the SQL Statement Execution
+        API keyed by the attachment's ``statement_id`` — Genie's
+        ``get_message_query_result`` returns the row metadata but not the inline
+        rows, whereas ``statement_execution.get_statement`` returns them.
+
+        :param client: The workspace client (for fetching the result).
+        :param query: The ``GenieQueryAttachment`` to render.
+        :returns: A multi-line block describing the generated query and its data.
+        """
+        title = getattr(query, "title", None)
+        description = getattr(query, "description", None)
+        sql = getattr(query, "query", None)
+
+        lines: list[str] = [f'Generated SQL ("{title}"):' if title else "Generated SQL:"]
+        if description:
+            lines.append(str(description))
+        if sql:
+            lines.append(str(sql))
+        table = self._fetch_statement_table(client, getattr(query, "statement_id", None))
+        if table:
+            lines.append(table)
+        return "\n".join(lines)
+
+    def _format_message(self, client: object, message: object) -> str:
+        """Assemble the turn's response text from a ``GenieMessage``.
+
+        Concatenates each attachment's text summary and rendered query (with
+        result rows). Falls back to the message's own ``content`` when Genie
+        returns no attachments.
+
+        :param client: The workspace client.
+        :param message: The resolved ``GenieMessage``.
+        :returns: The combined response text (possibly ``""``).
+        """
+        parts: list[str] = []
+        for att in getattr(message, "attachments", None) or []:
+            text = getattr(att, "text", None)
+            content = getattr(text, "content", None) if text is not None else None
+            if content:
+                parts.append(str(content))
+            query = getattr(att, "query", None)
+            if query is not None:
+                parts.append(self._format_query(client, query))
+
+        if not parts:
+            content = getattr(message, "content", None)
+            if content:
+                parts.append(str(content))
+        return "\n\n".join(part for part in parts if part)
+
+    def _run_genie_turn(self, client: object, space_id: str, prompt: str) -> str:
+        """Blocking: send the prompt and format the response.
+
+        Runs inside :func:`asyncio.to_thread`. Genie's ``*_and_wait`` helpers
+        raise (``OperationFailed`` / ``TimeoutError``) when a message does not
+        reach ``COMPLETED``, so failures arrive as the exception
+        :meth:`run_turn` turns into an :class:`ExecutorError` — this method only
+        handles the success path. The conversation id is recorded so the next
+        turn continues the same conversation.
+
+        :param client: The workspace client.
+        :param space_id: The Genie space id.
+        :param prompt: The user's natural-language message.
+        :returns: The formatted response text.
+        """
+        message = self._send(client, space_id, prompt)
+        conversation_id = getattr(message, "conversation_id", None)
+        if conversation_id:
+            self._conversation_id = conversation_id
+        return self._format_message(client, message)
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],  # noqa: ARG002 — Genie has no Omnigent-dispatched tools
+        system_prompt: str,  # noqa: ARG002 — the Genie space carries its own instructions
+        config: ExecutorConfig | None = None,  # noqa: ARG002 — space id comes from __init__
+    ) -> AsyncIterator[ExecutorEvent]:
+        """Run one Genie turn and yield its events.
+
+        Yields an :class:`ExecutorError` (and stops) when no space id is
+        configured, there is no user message, or talking to Genie fails;
+        otherwise yields a :class:`TextChunk` with the response followed by a
+        :class:`TurnComplete`.
+        """
+        space_id = self._space_id
+        if not space_id:
+            yield ExecutorError(
+                message=(
+                    "no Genie space id configured for the databricks-genie harness; "
+                    "set executor.model to the Genie space id in the agent spec."
+                )
+            )
+            return
+
+        prompt = _latest_user_text(messages)
+        if not prompt.strip():
+            yield ExecutorError(message="databricks-genie: no user message to send to Genie.")
+            return
+
+        try:
+            client = self._ensure_client()
+            response = await asyncio.to_thread(self._run_genie_turn, client, space_id, prompt)
+        except Exception as exc:  # noqa: BLE001 — any SDK/auth/Genie error becomes a turn error
+            yield ExecutorError(message=f"databricks-genie request failed: {exc}")
+            return
+
+        if response:
+            yield TextChunk(text=response)
+        yield TurnComplete(response=response)

--- a/omnigent/inner/databricks_genie_executor.py
+++ b/omnigent/inner/databricks_genie_executor.py
@@ -43,6 +43,7 @@ import asyncio
 import json
 import logging
 import re
+import threading
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
@@ -61,6 +62,7 @@ from omnigent.inner.executor import (
     ToolCallStatus,
     ToolSpec,
     TurnComplete,
+    _close_stream_quietly,
     iterate_blocking_stream,
 )
 
@@ -74,9 +76,9 @@ _logger = logging.getLogger(__name__)
 # too; this is a belt-and-braces bound on what we echo back.
 _MAX_RESULT_ROWS = 50
 
-# HTTP deadline for the streamed response. An Agent-mode turn plans, runs real
-# warehouse queries, and writes a report, so this is generous while still
-# bounding a wedged stream.
+# Idle timeout for the streamed response: bounds each silent gap between
+# stream chunks — one warehouse query can be a single long gap — not the
+# turn's total duration. Generous, while still bounding a wedged stream.
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
 # Responses API model slug for a Genie agent; which agent is selected by the
@@ -156,14 +158,16 @@ def _md_cell(value: object) -> str:
     """Sanitize a value for one GitHub-Flavored-Markdown table cell.
 
     Collapses internal whitespace (so a multi-line review stays on a single
-    table row instead of shattering the layout) and escapes pipes (so a value
-    containing ``|`` doesn't open a spurious column).
+    table row instead of shattering the layout) and escapes backslashes and
+    pipes (so a value containing ``|`` — or ``\\|``, which would otherwise
+    become an escaped backslash before a live delimiter — doesn't open a
+    spurious column).
 
     :param value: A raw cell value; ``None`` renders as an empty cell.
     :returns: A single-line, pipe-safe cell string.
     """
     text = "" if value is None else str(value)
-    return re.sub(r"\s+", " ", text).strip().replace("|", r"\|")
+    return re.sub(r"\s+", " ", text).strip().replace("\\", "\\\\").replace("|", r"\|")
 
 
 def _get(node: object, name: str) -> object:
@@ -217,7 +221,9 @@ def _render_table(metadata: object) -> str:
     Emits a ``| col | col |`` header, a ``| --- | --- |`` delimiter row, and one
     ``| ... |`` line per row — the form the web UI renders as an HTML table.
     Cells are sanitized via :func:`_md_cell`; rows beyond
-    :data:`_MAX_RESULT_ROWS` are summarized rather than printed.
+    :data:`_MAX_RESULT_ROWS` — and rows Genie already previewed away upstream,
+    per ``total_row_count`` — are summarized rather than printed, so a partial
+    preview is never presented as the complete result.
 
     :param metadata: The ``output_text`` part's ``metadata`` blob, carrying
         ``columns`` and ``preview_rows``.
@@ -244,7 +250,11 @@ def _render_table(metadata: object) -> str:
     table = [_line([_md_cell(label) for label in labels]), _line(["---"] * width)]
     table.extend(_line(cells) for cells in shown)
 
-    omitted = len(rows) - len(shown)
+    # ``preview_rows`` is itself a preview: ``total_row_count`` counts the full
+    # query result, so the footer owns both our cap and Genie's upstream one.
+    total = _get(metadata, "total_row_count")
+    row_count = max(len(rows), total) if isinstance(total, int) else len(rows)
+    omitted = row_count - len(shown)
     if omitted > 0:
         table.append(f"\n… ({omitted} more row{'s' if omitted != 1 else ''})")
     return "\n".join(table)
@@ -308,7 +318,7 @@ def _reasoning_text(item: object) -> str:
     for key in ("content", "summary"):
         value = _get(item, key)
         if isinstance(value, str):
-            if value:
+            if value.strip():
                 return value
             continue
         parts = [
@@ -316,9 +326,26 @@ def _reasoning_text(item: object) -> str:
             for part in _as_sequence(value)
         ]
         joined = "\n".join(part for part in parts if part)
-        if joined:
+        if joined.strip():
             return joined
     return _get_str(item, "text")
+
+
+def _output_payload(output: object) -> object:
+    """Return a ``function_call_output``'s payload, flattened to text when parts.
+
+    The wire carries ``output`` as either a string or a list of content parts;
+    a parts list is joined into its text so the result renders as the query
+    result rather than a parts dump. Anything else — including a raw dict —
+    passes through verbatim.
+    """
+    if isinstance(output, str):
+        return output
+    parts = [
+        part if isinstance(part, str) else _get_str(part, "text") for part in _as_sequence(output)
+    ]
+    joined = "".join(part for part in parts if part)
+    return joined if joined else output
 
 
 def _parse_arguments(raw: object) -> ToolArgs:
@@ -434,7 +461,7 @@ class _CallPairing:
         self._awaiting.remove(call_id)
         return ToolCallComplete(
             name=_get_str(item, "name") or self._names[call_id],
-            result=_get(item, "output"),
+            result=_output_payload(_get(item, "output")),
             metadata={"call_id": call_id},
         )
 
@@ -466,7 +493,11 @@ def _item_events(item: object, pairing: _CallPairing) -> Iterator[ExecutorEvent]
     item_type = _get_str(item, "type")
     if item_type == "reasoning":
         reasoning = _reasoning_text(item)
-        if reasoning:
+        if reasoning.strip():
+            # Anchor each item as its own reasoning block — Genie plans before
+            # every SQL call, and consecutive items would otherwise run
+            # together downstream (mirrors the claude-sdk whole-block path).
+            yield ReasoningChunk(delta="", event_type="reasoning_started")
             yield ReasoningChunk(delta=reasoning, event_type="reasoning_text")
     elif item_type == "function_call":
         yield pairing.request(item)
@@ -493,7 +524,8 @@ class DatabricksGenieExecutor(Executor):
         ``None``, one is built lazily on the first turn so a missing
         ``databricks-sdk`` install — or an expired login — surfaces as a turn
         error, not a boot crash.
-    :param timeout_seconds: HTTP deadline for the streamed response.
+    :param timeout_seconds: Idle timeout bounding each silent gap in the
+        streamed response (not the turn's total duration).
     :param enable_viz: Whether to ask Genie to attach visualizations to its
         answer. Off by default, and the field is omitted from the request
         entirely when off.
@@ -514,11 +546,18 @@ class DatabricksGenieExecutor(Executor):
         # Set only for a client this executor built; an injected one belongs to
         # its caller, so :meth:`close` must not close it.
         self._http_client: httpx.Client | None = None
+        # Guards the lazy build: a turn cancelled mid-construction can overlap
+        # the next turn's ``to_thread`` worker, and an unguarded check-then-set
+        # would leak the losing worker's connection pool.
+        self._client_lock = threading.Lock()
         self._timeout_seconds = timeout_seconds
         self._enable_viz = enable_viz
         # Captured from the first ``response.created``; later turns continue
         # that conversation instead of starting a new one.
         self._conversation_id: str | None = None
+        # The turn's live SSE stream; :meth:`interrupt_session` closes it to
+        # unblock the reader thread instead of waiting out a warehouse query.
+        self._active_stream: Iterator[object] | None = None
 
     def supports_streaming(self) -> bool:
         """Agent-mode responses stream reasoning, SQL, and report text over SSE."""
@@ -542,48 +581,51 @@ class DatabricksGenieExecutor(Executor):
         :returns: The (possibly newly constructed) ``OpenAI`` client.
         :raises DatabricksGenieError: When ``databricks-sdk`` is not installed.
         """
-        if self._client is not None:
+        with self._client_lock:
+            if self._client is not None:
+                return self._client
+
+            import httpx
+            from openai import OpenAI
+
+            from omnigent.inner.databricks_executor import _resolve_databricks_auth
+            from omnigent.inner.open_responses_sdk import _OPENAI_KEY_PLACEHOLDER
+
+            try:
+                auth, host = _resolve_databricks_auth(self._profile)
+            except ImportError as exc:
+                from omnigent.onboarding.databricks_config import DATABRICKS_EXTRA_INSTALL_HINT
+
+                raise DatabricksGenieError(
+                    "the databricks-sdk package is required for the databricks-genie "
+                    "harness but is not installed; it ships in the omnigent[databricks] "
+                    f"extra. {DATABRICKS_EXTRA_INSTALL_HINT}"
+                ) from exc
+
+            http_client = httpx.Client(auth=auth)
+            try:
+                self._client = OpenAI(
+                    base_url=f"{host.rstrip('/')}/api/2.0/genie/agents/{agent_id}",
+                    # The bearer token rides on the httpx auth hook, which
+                    # re-mints it per request so a turn outliving the OAuth
+                    # token still works; the key is only the placeholder the
+                    # SDK insists on.
+                    api_key=_OPENAI_KEY_PLACEHOLDER,
+                    http_client=http_client,
+                    timeout=self._timeout_seconds,
+                    # The SDK's default retry set includes 409, which here
+                    # means "a response is already being generated for this
+                    # conversation" — never retryable, so retrying only delays
+                    # an actionable error.
+                    max_retries=0,
+                )
+            except Exception:
+                # Nothing else holds this client yet, so it would leak its
+                # connection pool if the constructor rejected our arguments.
+                http_client.close()
+                raise
+            self._http_client = http_client
             return self._client
-
-        import httpx
-        from openai import OpenAI
-
-        from omnigent.inner.databricks_executor import _resolve_databricks_auth
-        from omnigent.inner.open_responses_sdk import _OPENAI_KEY_PLACEHOLDER
-
-        try:
-            auth, host = _resolve_databricks_auth(self._profile)
-        except ImportError as exc:
-            from omnigent.onboarding.databricks_config import DATABRICKS_EXTRA_INSTALL_HINT
-
-            raise DatabricksGenieError(
-                "the databricks-sdk package is required for the databricks-genie "
-                "harness but is not installed; it ships in the omnigent[databricks] "
-                f"extra. {DATABRICKS_EXTRA_INSTALL_HINT}"
-            ) from exc
-
-        http_client = httpx.Client(auth=auth)
-        try:
-            self._client = OpenAI(
-                base_url=f"{host.rstrip('/')}/api/2.0/genie/agents/{agent_id}",
-                # The bearer token rides on the httpx auth hook, which re-mints
-                # it per request so a turn outliving the OAuth token still
-                # works; the key is only the placeholder the SDK insists on.
-                api_key=_OPENAI_KEY_PLACEHOLDER,
-                http_client=http_client,
-                timeout=self._timeout_seconds,
-                # The SDK's default retry set includes 409, which here means "a
-                # response is already being generated for this conversation" —
-                # never retryable, so retrying only delays an actionable error.
-                max_retries=0,
-            )
-        except Exception:
-            # Nothing else holds this client yet, so it would leak its
-            # connection pool if the constructor rejected our arguments.
-            http_client.close()
-            raise
-        self._http_client = http_client
-        return self._client
 
     async def close(self) -> None:
         """Close the httpx client backing the Responses client, if we built one.
@@ -630,7 +672,26 @@ class DatabricksGenieExecutor(Executor):
         if extra_body:
             kwargs["extra_body"] = extra_body
         stream = client.responses.create(**kwargs)  # type: ignore[attr-defined]  # duck-typed client
-        return cast("Iterator[object]", stream)
+        # Recorded here, in the worker thread, so a cancel landing between the
+        # POST returning and run_turn resuming can still close the stream.
+        self._active_stream = cast("Iterator[object]", stream)
+        return self._active_stream
+
+    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002 — one conversation per executor instance
+        """Close the live response stream so a cancelled turn unblocks now.
+
+        Genie streams only whole output items, so a cancelled turn would
+        otherwise stay parked until the next item arrives — mid-query, that is
+        minutes away. Closing errors the reader thread's blocked iteration,
+        which ends :meth:`run_turn` with cancellations and one
+        :class:`ExecutorError` (surfaced as ``response.cancelled`` upstream).
+        Best-effort and idempotent, mirroring the databricks executor.
+        """
+        stream = self._active_stream
+        if stream is None:
+            return False
+        await asyncio.to_thread(_close_stream_quietly, stream)
+        return True
 
     def _capture_conversation_id(self, event: object) -> None:
         """Remember the conversation Genie opened, for the next turn's request."""
@@ -678,8 +739,9 @@ class DatabricksGenieExecutor(Executor):
         or a single :class:`ExecutorError`, never both. Only
         ``response.completed`` ends a turn successfully: a stream that stops
         without it delivered a partial answer, which must not be reported as a
-        finished one. Any SQL call still awaiting its output is cancelled first,
-        so the turn leaves no card rendering as in progress.
+        finished one. On every terminal path, any SQL call still awaiting its
+        output is cancelled before the terminal event, so no turn — failed or
+        successful — leaves a card rendering as in progress.
 
         :param stream: The response's blocking SSE iterator.
         """
@@ -718,9 +780,12 @@ class DatabricksGenieExecutor(Executor):
 
         if error is None and not completed:
             error = _TRUNCATED_STREAM_MESSAGE
+        # Every terminal path cancels first: a call Genie never answered —
+        # even on a completed response — would otherwise leave its SQL card
+        # rendering as in progress forever.
+        for cancelled in pairing.cancel_awaiting():
+            yield cancelled
         if error is not None:
-            for cancelled in pairing.cancel_awaiting():
-                yield cancelled
             yield ExecutorError(message=error)
             return
 
@@ -772,5 +837,8 @@ class DatabricksGenieExecutor(Executor):
             yield ExecutorError(message=self._request_failure(exc))
             return
 
-        async for event in self._stream_events(stream):
-            yield event
+        try:
+            async for event in self._stream_events(stream):
+                yield event
+        finally:
+            self._active_stream = None

--- a/omnigent/inner/databricks_genie_executor.py
+++ b/omnigent/inner/databricks_genie_executor.py
@@ -1,34 +1,51 @@
 """
 ``harness: databricks-genie`` executor.
 
-Drives a remote Databricks **AI/BI Genie space** over the Genie Conversation
-API exposed by the ``databricks-sdk`` (``WorkspaceClient.genie``). Each Omnigent
-turn maps to one Genie message: the first turn starts a conversation, later
-turns continue it (Genie keeps the conversation state server-side, keyed by a
-conversation id this executor remembers between turns).
+Drives a remote Databricks **AI/BI Genie space** in Agent mode over the Genie
+Responses API (``POST /api/2.0/genie/agents/{agent_id}/responses``). The
+endpoint is OpenAI-shaped, so it is driven with the core ``openai`` client
+pointed at the agent's base URL. Genie keeps the conversation server-side, so
+each Omnigent turn posts exactly one user message and continues the
+conversation via the id captured from the previous turn's ``response.created``
+event.
 
-Genie answers natural-language questions over the space's curated data. A turn's
-response carries Genie's text summary plus — when Genie runs SQL — the generated
-query and a rendering of its result rows.
+The response's streamed output items become Omnigent events: Genie's planning
+becomes :class:`~omnigent.inner.executor.ReasoningChunk`, each SQL query it runs
+becomes a :class:`~omnigent.inner.executor.ToolCallRequest` /
+:class:`~omnigent.inner.executor.ToolCallComplete` pair (Genie executes them
+itself — Omnigent only observes), and the final report becomes
+:class:`~omnigent.inner.executor.TextChunk` text. Query results are re-rendered
+from the machine-readable ``columns`` / ``preview_rows`` metadata rather than
+Genie's own Markdown, which Databricks documents as unstable across requests.
 
 Auth reuses the Databricks CLI: ``databricks auth login`` writes OAuth/PAT
-credentials into ``~/.databrickscfg``; ``WorkspaceClient(profile=...)`` consumes
-them and refreshes OAuth tokens transparently. The Genie space id is carried in
-``executor.model`` (a Genie space is the conversational unit, so it maps onto
-"model") and the profile in ``executor.auth`` / ``executor.profile``; the
-:mod:`omnigent.inner.databricks_genie_harness` wrap passes both to this executor.
+credentials into the CLI config file (path in ``docs/AGENT_YAML_SPEC.md``), and
+:func:`~omnigent.inner.databricks_executor._resolve_databricks_auth` turns the
+profile into an httpx auth hook that re-mints the bearer token on every
+request, so a long turn survives OAuth access-token expiry. The Genie agent id
+is the space id carried in ``executor.model`` (a Genie space is the
+conversational unit, so it maps onto "model") and the profile in
+``executor.auth`` / ``executor.profile``; the
+:mod:`omnigent.inner.databricks_genie_harness` wrap passes both to this
+executor.
 
-The SDK's ``*_and_wait`` helpers are blocking, so each call runs in a worker
-thread via :func:`asyncio.to_thread` to keep the event loop responsive.
+Agent mode is a Databricks **Beta** API gated on a workspace preview toggle;
+without it the endpoint answers 404 ``FEATURE_DISABLED``.
+
+The client's SSE iterator is blocking, so it is consumed on a worker thread via
+:func:`~omnigent.inner.executor.iterate_blocking_stream` to keep the event loop
+responsive.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
-from collections.abc import AsyncIterator, Sequence
-from datetime import timedelta
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
 
 from omnigent.inner.executor import (
     Executor,
@@ -36,30 +53,60 @@ from omnigent.inner.executor import (
     ExecutorError,
     ExecutorEvent,
     Message,
+    ReasoningChunk,
     TextChunk,
+    ToolArgs,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
     ToolSpec,
     TurnComplete,
+    iterate_blocking_stream,
 )
+
+if TYPE_CHECKING:
+    import httpx
 
 _logger = logging.getLogger(__name__)
 
 # Display guard: cap the number of result rows rendered inline so a large query
-# result doesn't blow up the turn's response payload. Genie truncates upstream
+# result doesn't blow up the turn's response payload. Genie previews upstream
 # too; this is a belt-and-braces bound on what we echo back.
 _MAX_RESULT_ROWS = 50
 
-# Default deadline handed to Genie's blocking ``*_and_wait`` helpers. Comfortably
-# under Omnigent's per-turn ceiling while leaving room for a real warehouse query.
-_DEFAULT_TIMEOUT_SECONDS = 300.0
+# HTTP deadline for the streamed response. An Agent-mode turn plans, runs real
+# warehouse queries, and writes a report, so this is generous while still
+# bounding a wedged stream.
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+# Responses API model slug for a Genie agent; which agent is selected by the
+# space id in the base URL, not by this value.
+_GENIE_AGENT_MODEL = "genie-agent"
+
+# Name reported for the SQL calls Genie runs itself, when an item omits one.
+_GENIE_TOOL_NAME = "execute_sql"
+
+# ``output_text`` metadata status marking a result Genie could not fetch — its
+# own text is then the only thing left to show.
+_FETCH_FAILED_STATUS = "fetch_failed"
+
+# ``response.completed`` is the only event that ends a turn successfully. A
+# stream that stops without one — an idle proxy, a connection closed mid-report
+# — carries a partial answer that must not be presented as a finished turn.
+_TRUNCATED_STREAM_MESSAGE = (
+    "databricks-genie: the response stream ended before Genie completed the turn; "
+    "any text already streamed is partial."
+)
 
 
 class DatabricksGenieError(Exception):
-    """Raised for databricks-genie setup / response failures.
+    """Raised for databricks-genie setup failures.
 
-    Carries an actionable, human-readable message (missing SDK + install hint,
-    or a failed Genie message). :meth:`DatabricksGenieExecutor.run_turn`
-    converts it — and any other exception raised while talking to Genie — into
-    an :class:`~omnigent.inner.executor.ExecutorError` turn event.
+    Carries an actionable, human-readable message (currently a missing
+    ``databricks-sdk`` install plus its install hint).
+    :meth:`DatabricksGenieExecutor.run_turn` converts it — and any other
+    exception raised while talking to Genie — into an
+    :class:`~omnigent.inner.executor.ExecutorError` turn event.
     """
 
 
@@ -119,64 +166,337 @@ def _md_cell(value: object) -> str:
     return re.sub(r"\s+", " ", text).strip().replace("|", r"\|")
 
 
-def _render_statement(statement: object) -> str:
-    """Render a SQL ``StatementResponse`` as a GitHub-Flavored-Markdown table.
+def _get(node: object, name: str) -> object:
+    """Read *name* off one node of a streamed response.
 
-    Reads column names from ``statement.manifest.schema.columns[*].name`` and
-    rows from ``statement.result.data_array`` (Genie returns cell values as
-    strings), emitting a ``| col | col |`` header, a ``| --- | --- |`` delimiter
-    row, and one ``| ... |`` line per row — the form the web UI renders as an
-    HTML table. Cells are sanitized via :func:`_md_cell`; rows beyond
+    Genie's Beta fields are unknown to the OpenAI SDK's models, so a node is
+    either a parsed model (attribute access) or the raw dict the SDK left
+    unvalidated (key access).
+
+    :param node: A stream event, output item, content part, or metadata blob.
+    :param name: The field to read.
+    :returns: The field's value, or ``None`` when the node carries none.
+    """
+    if isinstance(node, Mapping):
+        return node.get(name)
+    return getattr(node, name, None)
+
+
+def _get_str(node: object, name: str) -> str:
+    """Read *name* off *node*, or ``""`` when it is absent or not text."""
+    value = _get(node, name)
+    return value if isinstance(value, str) else ""
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    """Return *value* as a sequence of nodes, or empty when it is not a list."""
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return value
+    return ()
+
+
+def _column_names(columns: object) -> list[str]:
+    """Return the result table's labels from Genie's ``columns`` metadata."""
+    return [
+        col if isinstance(col, str) else _get_str(col, "name") for col in _as_sequence(columns)
+    ]
+
+
+def _row_cells(row: object, headers: Sequence[str]) -> list[str]:
+    """Return one preview row's sanitized cells, ordered by *headers* when keyed."""
+    if isinstance(row, Mapping):
+        return [_md_cell(row.get(name)) for name in headers]
+    if isinstance(row, Sequence) and not isinstance(row, (str, bytes)):
+        return [_md_cell(value) for value in row]
+    return [_md_cell(row)]
+
+
+def _render_table(metadata: object) -> str:
+    """Render a result chunk's metadata as a GitHub-Flavored-Markdown table.
+
+    Emits a ``| col | col |`` header, a ``| --- | --- |`` delimiter row, and one
+    ``| ... |`` line per row — the form the web UI renders as an HTML table.
+    Cells are sanitized via :func:`_md_cell`; rows beyond
     :data:`_MAX_RESULT_ROWS` are summarized rather than printed.
 
-    :param statement: A ``databricks.sdk.service.sql.StatementResponse`` (or any
-        object exposing the same ``manifest`` / ``result`` shape).
-    :returns: A ``"Result (N rows):\\n\\n<markdown table>"`` block, or ``""``
-        when the statement carries no rows.
+    :param metadata: The ``output_text`` part's ``metadata`` blob, carrying
+        ``columns`` and ``preview_rows``.
+    :returns: The Markdown table, or ``""`` when the metadata carries no rows.
     """
-    data = getattr(statement, "result", None)
-    rows = getattr(data, "data_array", None) if data is not None else None
+    rows = _as_sequence(_get(metadata, "preview_rows"))
     if not rows:
         return ""
 
-    manifest = getattr(statement, "manifest", None)
-    schema = getattr(manifest, "schema", None) if manifest is not None else None
-    columns = [str(getattr(col, "name", "")) for col in (getattr(schema, "columns", None) or [])]
+    headers = _column_names(_get(metadata, "columns"))
+    if not headers and isinstance(rows[0], Mapping):
+        # Keyed rows with no column metadata still know their own labels;
+        # without this they would render as a table of empty cells.
+        headers = [str(key) for key in rows[0]]
+    shown = [_row_cells(row, headers) for row in rows[:_MAX_RESULT_ROWS]]
+    width = max(len(headers), max(len(cells) for cells in shown))
+    if not width:
+        return ""
+    labels = [headers[i] if i < len(headers) else f"col{i + 1}" for i in range(width)]
 
-    shown = rows[:_MAX_RESULT_ROWS]
-    width = max(len(columns), max(len(row) for row in shown))
-    headers = [columns[i] if i < len(columns) else f"col{i + 1}" for i in range(width)]
+    def _line(cells: Sequence[str]) -> str:
+        return "| " + " | ".join(cells[i] if i < len(cells) else "" for i in range(width)) + " |"
 
-    def _row(cells: Sequence[object]) -> str:
-        padded = (_md_cell(cells[i]) if i < len(cells) else "" for i in range(width))
-        return "| " + " | ".join(padded) + " |"
+    table = [_line([_md_cell(label) for label in labels]), _line(["---"] * width)]
+    table.extend(_line(cells) for cells in shown)
 
-    table = [_row(headers), "| " + " | ".join(["---"] * width) + " |"]
-    table.extend(_row(row) for row in shown)
-
-    total = len(rows)
-    block = f"Result ({total} row{'s' if total != 1 else ''}):\n\n" + "\n".join(table)
-
-    omitted = total - len(shown)
+    omitted = len(rows) - len(shown)
     if omitted > 0:
-        block += f"\n\n… ({omitted} more row{'s' if omitted != 1 else ''})"
-    return block
+        table.append(f"\n… ({omitted} more row{'s' if omitted != 1 else ''})")
+    return "\n".join(table)
+
+
+def _content_text(part: object) -> str:
+    """Render one ``output_text`` content part of an assistant message.
+
+    A query result arrives as model-written Markdown *plus* the stable
+    ``columns`` / ``preview_rows`` metadata; re-rendering from the metadata
+    keeps the row cap and pipe escaping ours. A part with no metadata — or one
+    Genie marks :data:`_FETCH_FAILED_STATUS` — has only its own text to show.
+
+    :param part: The content part.
+    :returns: The text to emit for this part.
+    """
+    text = _get_str(part, "text")
+    metadata = _get(part, "metadata")
+    if metadata is None or _get_str(metadata, "status") == _FETCH_FAILED_STATUS:
+        return text
+    return _render_table(metadata) or text
+
+
+def _block_separator(previous: str) -> str:
+    """Return the newlines that open a fresh Markdown block after *previous*.
+
+    Genie ships prose and result tables as separate chunks; a table glued onto
+    the end of a sentence is not a table to any Markdown renderer. Callers put
+    this separator *inside* the next chunk, so concatenating every emitted
+    :class:`TextChunk` still reproduces ``TurnComplete.response`` exactly.
+
+    :param previous: The text emitted immediately before, or ``""`` when this
+        is the turn's first chunk.
+    :returns: ``""``, ``"\\n"``, or ``"\\n\\n"``.
+    """
+    if not previous:
+        return ""
+    trailing = len(previous) - len(previous.rstrip("\n"))
+    return "\n" * max(0, 2 - trailing)
+
+
+def _message_texts(item: object) -> list[str]:
+    """Return the rendered ``output_text`` parts of one assistant message item."""
+    texts: list[str] = []
+    for part in _as_sequence(_get(item, "content")):
+        part_type = _get_str(part, "type")
+        if part_type and part_type != "output_text":
+            continue
+        rendered = _content_text(part)
+        if rendered:
+            texts.append(rendered)
+    return texts
+
+
+def _reasoning_text(item: object) -> str:
+    """Return a reasoning item's text, whichever field Genie carries it in.
+
+    Each field may hold the text directly or a list of parts, so both shapes are
+    read; anything else falls through to the next field.
+    """
+    for key in ("content", "summary"):
+        value = _get(item, key)
+        if isinstance(value, str):
+            if value:
+                return value
+            continue
+        parts = [
+            part if isinstance(part, str) else _get_str(part, "text")
+            for part in _as_sequence(value)
+        ]
+        joined = "\n".join(part for part in parts if part)
+        if joined:
+            return joined
+    return _get_str(item, "text")
+
+
+def _parse_arguments(raw: object) -> ToolArgs:
+    """Parse a ``function_call.arguments`` payload.
+
+    Databricks documents these keys as unstable, so anything that is not a JSON
+    object is preserved under ``"raw"`` rather than reshaped into an assumed
+    schema.
+
+    :param raw: The item's ``arguments`` field.
+    :returns: The call's arguments as a JSON-shaped dict.
+    """
+    if raw is None or raw == "":
+        return {}
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    if not isinstance(raw, str):
+        return {"raw": raw}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {"raw": raw}
+    return parsed if isinstance(parsed, dict) else {"raw": parsed}
+
+
+def _failure_message(event: object) -> str:
+    """Describe a terminal ``response.failed`` / ``error`` stream event.
+
+    :param event: The stream event; its error carries ``type``, ``code``, and
+        ``message``, and the event itself is the fallback carrier.
+    :returns: A message naming every field the event supplied.
+    """
+    error = _get(_get(event, "response"), "error") or _get(event, "error") or event
+    labelled = [
+        f"{label}={value}"
+        for label, value in (("type", _get_str(error, "type")), ("code", _get_str(error, "code")))
+        if value
+    ]
+    detail = f" [{', '.join(labelled)}]" if labelled else ""
+    return (
+        f"databricks-genie: Genie reported a failed response{detail}: "
+        f"{_get_str(error, 'message') or error}"
+    )
+
+
+def _incomplete_message(event: object) -> str:
+    """Describe a terminal ``response.incomplete`` stream event.
+
+    :param event: The stream event; ``incomplete_details.reason`` names why
+        Genie stopped early when it carries one.
+    :returns: A message naming the reason Genie gave, when it gave one.
+    """
+    details = _get(_get(event, "response"), "incomplete_details") or _get(
+        event, "incomplete_details"
+    )
+    reason = _get_str(details, "reason") or _get_str(details, "type")
+    detail = f" (reason={reason})" if reason else ""
+    return (
+        f"databricks-genie: Genie ended the response before it was complete{detail}; "
+        "any text already streamed is partial."
+    )
+
+
+@dataclass
+class _CallPairing:
+    """Correlates Genie's ``function_call`` items with their outputs.
+
+    Downstream consumers pair a completion to its request strictly by
+    ``call_id`` and drop uncorrelated ones, so ids are synthesized when Genie
+    omits them, and an id-less output takes the oldest call still awaiting one.
+    An output naming a call that is unknown — or already completed — is dropped
+    rather than emitted against someone else's id.
+    """
+
+    _names: dict[str, str] = field(default_factory=dict)
+    _awaiting: list[str] = field(default_factory=list)
+
+    def request(self, item: object) -> ToolCallRequest:
+        """Record a ``function_call`` item and return its observed-call event."""
+        call_id = (
+            _get_str(item, "call_id")
+            or _get_str(item, "id")
+            or f"genie_call_{len(self._names) + 1}"
+        )
+        name = _get_str(item, "name") or _GENIE_TOOL_NAME
+        self._names[call_id] = name
+        self._awaiting.append(call_id)
+        return ToolCallRequest(
+            name=name,
+            args=_parse_arguments(_get(item, "arguments")),
+            metadata={"call_id": call_id},
+        )
+
+    def complete(self, item: object) -> ToolCallComplete | None:
+        """Return the completion event for a ``function_call_output`` item.
+
+        :param item: The output item.
+        :returns: The paired completion, or ``None`` when no call is awaiting
+            this output — such an event would render as a result card with no
+            call to attach to, or a second card on a call already finished.
+        """
+        call_id = _get_str(item, "call_id")
+        if not call_id:
+            # Genie streams outputs in call order, so an id-less one belongs to
+            # the oldest call that has not been completed yet.
+            call_id = self._awaiting[0] if self._awaiting else ""
+        if call_id not in self._awaiting:
+            _logger.debug(
+                "databricks-genie: dropping function_call_output with no call awaiting it (%r)",
+                call_id,
+            )
+            return None
+        self._awaiting.remove(call_id)
+        return ToolCallComplete(
+            name=_get_str(item, "name") or self._names[call_id],
+            result=_get(item, "output"),
+            metadata={"call_id": call_id},
+        )
+
+    def cancel_awaiting(self) -> list[ToolCallComplete]:
+        """Return a CANCELLED completion for every call still awaiting output.
+
+        A turn that ends before Genie reports a query's result would otherwise
+        leave that SQL card rendering as permanently in progress.
+        """
+        cancelled = [
+            ToolCallComplete(
+                name=self._names[call_id],
+                status=ToolCallStatus.CANCELLED,
+                metadata={"call_id": call_id},
+            )
+            for call_id in self._awaiting
+        ]
+        self._awaiting.clear()
+        return cancelled
+
+
+def _item_events(item: object, pairing: _CallPairing) -> Iterator[ExecutorEvent]:
+    """Map one completed output item onto its executor events.
+
+    :param item: The item carried by ``response.output_item.done``.
+    :param pairing: The turn's call correlation state.
+    :returns: The events this item produces, in order.
+    """
+    item_type = _get_str(item, "type")
+    if item_type == "reasoning":
+        reasoning = _reasoning_text(item)
+        if reasoning:
+            yield ReasoningChunk(delta=reasoning, event_type="reasoning_text")
+    elif item_type == "function_call":
+        yield pairing.request(item)
+    elif item_type == "function_call_output":
+        completion = pairing.complete(item)
+        if completion is not None:
+            yield completion
+    elif item_type == "message":
+        for chunk in _message_texts(item):
+            yield TextChunk(text=chunk)
 
 
 class DatabricksGenieExecutor(Executor):
-    """Executor that drives a Databricks Genie space over the Genie API.
+    """Executor that drives a Databricks Genie space over the Genie Responses API.
 
-    :param space_id: The Genie space id to converse with (from
-        ``executor.model``). When unset, :meth:`run_turn` yields an
-        :class:`ExecutorError` instructing the user to set it.
+    :param space_id: The Genie space id — the same value as its Agent-mode
+        agent id — to converse with (from ``executor.model``). When unset,
+        :meth:`run_turn` yields an :class:`ExecutorError` instructing the user
+        to set it.
     :param profile: The Databricks profile from ``~/.databrickscfg`` used to
-        build the workspace client. ``None`` lets the SDK use its own resolution
-        order (``DATABRICKS_CONFIG_PROFILE`` env / ``DEFAULT`` section).
-    :param workspace_client: An injected ``WorkspaceClient`` (tests pass a fake).
-        When ``None``, one is built lazily on the first turn so a missing
-        ``databricks-sdk`` install surfaces as a turn error, not a boot crash.
-    :param timeout_seconds: Deadline handed to Genie's blocking
-        ``*_and_wait`` helpers.
+        authenticate. ``None`` lets the SDK use its own resolution order
+        (``DATABRICKS_CONFIG_PROFILE`` env / ``DEFAULT`` section).
+    :param client: An injected ``OpenAI`` client (tests pass a fake). When
+        ``None``, one is built lazily on the first turn so a missing
+        ``databricks-sdk`` install — or an expired login — surfaces as a turn
+        error, not a boot crash.
+    :param timeout_seconds: HTTP deadline for the streamed response.
+    :param enable_viz: Whether to ask Genie to attach visualizations to its
+        answer. Off by default, and the field is omitted from the request
+        entirely when off.
     """
 
     def __init__(
@@ -184,171 +504,248 @@ class DatabricksGenieExecutor(Executor):
         *,
         space_id: str | None,
         profile: str | None = None,
-        workspace_client: object | None = None,
+        client: object | None = None,
         timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        enable_viz: bool = False,
     ) -> None:
         self._space_id = space_id
         self._profile = profile
-        self._client = workspace_client
+        self._client = client
+        # Set only for a client this executor built; an injected one belongs to
+        # its caller, so :meth:`close` must not close it.
+        self._http_client: httpx.Client | None = None
         self._timeout_seconds = timeout_seconds
-        # Set on the first turn that reaches Genie; subsequent turns continue
-        # this conversation instead of starting a new one.
+        self._enable_viz = enable_viz
+        # Captured from the first ``response.created``; later turns continue
+        # that conversation instead of starting a new one.
         self._conversation_id: str | None = None
 
     def supports_streaming(self) -> bool:
-        """Genie returns a complete answer per message — there is no token stream."""
-        return False
+        """Agent-mode responses stream reasoning, SQL, and report text over SSE."""
+        return True
 
     def supports_tool_calling(self) -> bool:
         """Genie has no Omnigent-dispatched tools; it queries the space directly."""
         return False
 
-    def _ensure_client(self) -> object:
-        """Return the workspace client, building one lazily on first use.
+    def handles_tools_internally(self) -> bool:
+        """Genie runs its own SQL, so its calls are observations, not requests."""
+        return True
 
-        :returns: The (possibly newly constructed) ``WorkspaceClient``.
+    def _ensure_client(self, agent_id: str) -> object:
+        """Blocking: return the Responses client, building one lazily on first use.
+
+        Resolving credentials reads the Databricks CLI config file and mints an
+        OAuth token over HTTP, so callers run this off the event loop.
+
+        :param agent_id: The Genie agent (space) id the base URL targets.
+        :returns: The (possibly newly constructed) ``OpenAI`` client.
         :raises DatabricksGenieError: When ``databricks-sdk`` is not installed.
         """
         if self._client is not None:
             return self._client
+
+        import httpx
+        from openai import OpenAI
+
+        from omnigent.inner.databricks_executor import _resolve_databricks_auth
+        from omnigent.inner.open_responses_sdk import _OPENAI_KEY_PLACEHOLDER
+
         try:
-            from databricks.sdk import WorkspaceClient
+            auth, host = _resolve_databricks_auth(self._profile)
         except ImportError as exc:
             from omnigent.onboarding.databricks_config import DATABRICKS_EXTRA_INSTALL_HINT
 
             raise DatabricksGenieError(
                 "the databricks-sdk package is required for the databricks-genie "
-                f"harness but is not installed. {DATABRICKS_EXTRA_INSTALL_HINT}"
+                "harness but is not installed; it ships in the omnigent[databricks] "
+                f"extra. {DATABRICKS_EXTRA_INSTALL_HINT}"
             ) from exc
-        self._client = WorkspaceClient(profile=self._profile)
+
+        http_client = httpx.Client(auth=auth)
+        try:
+            self._client = OpenAI(
+                base_url=f"{host.rstrip('/')}/api/2.0/genie/agents/{agent_id}",
+                # The bearer token rides on the httpx auth hook, which re-mints
+                # it per request so a turn outliving the OAuth token still
+                # works; the key is only the placeholder the SDK insists on.
+                api_key=_OPENAI_KEY_PLACEHOLDER,
+                http_client=http_client,
+                timeout=self._timeout_seconds,
+                # The SDK's default retry set includes 409, which here means "a
+                # response is already being generated for this conversation" —
+                # never retryable, so retrying only delays an actionable error.
+                max_retries=0,
+            )
+        except Exception:
+            # Nothing else holds this client yet, so it would leak its
+            # connection pool if the constructor rejected our arguments.
+            http_client.close()
+            raise
+        self._http_client = http_client
         return self._client
 
-    def _send(self, client: object, space_id: str, content: str) -> object:
-        """Send *content* to Genie, starting or continuing the conversation.
+    async def close(self) -> None:
+        """Close the httpx client backing the Responses client, if we built one.
 
-        :param client: The workspace client whose ``.genie`` API is called.
-        :param space_id: The Genie space id.
-        :param content: The user's natural-language message.
-        :returns: The resolved ``GenieMessage``.
+        The adapter calls this at harness shutdown. A caller-injected client is
+        left alone (it belongs to whoever passed it in), a second call is a
+        no-op, and closing runs off the event loop because it is blocking.
         """
-        genie = client.genie  # type: ignore[attr-defined]  # untyped databricks-sdk
-        timeout = timedelta(seconds=self._timeout_seconds)
-        if self._conversation_id is None:
-            return genie.start_conversation_and_wait(space_id, content, timeout=timeout)
-        return genie.create_message_and_wait(
-            space_id, self._conversation_id, content, timeout=timeout
-        )
+        http_client = self._http_client
+        if http_client is None:
+            return
+        self._http_client = None
+        self._client = None
+        await asyncio.to_thread(http_client.close)
 
-    def _fetch_statement_table(self, client: object, statement_id: object) -> str:
-        """Fetch and render the executed query's result rows, best-effort.
+    def _create_stream(self, client: object, prompt: str) -> Iterator[object]:
+        """Blocking: post the turn and return the response's SSE iterator.
 
-        A result-fetch failure (e.g. the result expired) must not sink the turn —
-        Genie's text answer is still useful — so this swallows errors and returns
-        ``""`` after logging.
+        Genie keeps the conversation server-side, so ``input`` carries exactly
+        one user message — continuity comes from ``conversation_id``, never from
+        replayed history.
 
-        :param client: The workspace client.
-        :param statement_id: The executed query's statement id (from the query
-            attachment). ``None`` / empty → no table.
-        :returns: A rendered result table, or ``""`` when unavailable.
-        """
-        if not statement_id:
-            return ""
-        try:
-            statement = client.statement_execution.get_statement(  # type: ignore[attr-defined]
-                statement_id
-            )
-        except Exception as exc:  # noqa: BLE001 — result is optional; never fail the turn
-            _logger.debug("databricks-genie: could not fetch query result: %s", exc)
-            return ""
-        return _render_statement(statement)
-
-    def _format_query(self, client: object, query: object) -> str:
-        """Render a Genie query attachment: title/description + SQL + result rows.
-
-        The executed query's rows are fetched via the SQL Statement Execution
-        API keyed by the attachment's ``statement_id`` — Genie's
-        ``get_message_query_result`` returns the row metadata but not the inline
-        rows, whereas ``statement_execution.get_statement`` returns them.
-
-        :param client: The workspace client (for fetching the result).
-        :param query: The ``GenieQueryAttachment`` to render.
-        :returns: A multi-line block describing the generated query and its data.
-        """
-        title = getattr(query, "title", None)
-        description = getattr(query, "description", None)
-        sql = getattr(query, "query", None)
-
-        blocks: list[str] = [f'Generated SQL ("{title}"):' if title else "Generated SQL:"]
-        if description:
-            blocks.append(str(description))
-        if sql:
-            blocks.append(f"```sql\n{sql}\n```")
-        table = self._fetch_statement_table(client, getattr(query, "statement_id", None))
-        if table:
-            blocks.append(table)
-        return "\n\n".join(blocks)
-
-    def _format_message(self, client: object, message: object) -> str:
-        """Assemble the turn's response text from a ``GenieMessage``.
-
-        Concatenates each attachment's text summary and rendered query (with
-        result rows). Falls back to the message's own ``content`` when Genie
-        returns no attachments.
-
-        :param client: The workspace client.
-        :param message: The resolved ``GenieMessage``.
-        :returns: The combined response text (possibly ``""``).
-        """
-        parts: list[str] = []
-        for att in getattr(message, "attachments", None) or []:
-            text = getattr(att, "text", None)
-            content = getattr(text, "content", None) if text is not None else None
-            if content:
-                parts.append(str(content))
-            query = getattr(att, "query", None)
-            if query is not None:
-                parts.append(self._format_query(client, query))
-
-        if not parts:
-            content = getattr(message, "content", None)
-            if content:
-                parts.append(str(content))
-        return "\n\n".join(part for part in parts if part)
-
-    def _run_genie_turn(self, client: object, space_id: str, prompt: str) -> str:
-        """Blocking: send the prompt and format the response.
-
-        Runs inside :func:`asyncio.to_thread`. Genie's ``*_and_wait`` helpers
-        raise (``OperationFailed`` / ``TimeoutError``) when a message does not
-        reach ``COMPLETED``, so failures arrive as the exception
-        :meth:`run_turn` turns into an :class:`ExecutorError` — this method only
-        handles the success path. The conversation id is recorded so the next
-        turn continues the same conversation.
-
-        :param client: The workspace client.
-        :param space_id: The Genie space id.
+        :param client: The Responses client.
         :param prompt: The user's natural-language message.
-        :returns: The formatted response text.
+        :returns: The stream of response events.
         """
-        message = self._send(client, space_id, prompt)
-        conversation_id = getattr(message, "conversation_id", None)
+        extra_body: dict[str, object] = {}
+        if self._conversation_id:
+            extra_body["conversation_id"] = self._conversation_id
+        if self._enable_viz:
+            extra_body["enable_viz"] = True
+
+        kwargs: dict[str, object] = {
+            "model": _GENIE_AGENT_MODEL,
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": prompt}],
+                }
+            ],
+            "stream": True,
+        }
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+        stream = client.responses.create(**kwargs)  # type: ignore[attr-defined]  # duck-typed client
+        return cast("Iterator[object]", stream)
+
+    def _capture_conversation_id(self, event: object) -> None:
+        """Remember the conversation Genie opened, for the next turn's request."""
+        conversation_id = _get_str(_get(event, "response"), "conversation_id") or _get_str(
+            event, "conversation_id"
+        )
         if conversation_id:
             self._conversation_id = conversation_id
-        return self._format_message(client, message)
+
+    def _request_failure(self, exc: Exception) -> str:
+        """Turn a failure from the Genie endpoint into an actionable message.
+
+        Agent mode answers 404 ``FEATURE_DISABLED`` until the workspace enables
+        the Beta preview, and 409 ``RESOURCE_CONFLICT`` while another turn of
+        the same conversation is still running. Both are user-fixable, unlike a
+        generic transport error.
+
+        :param exc: The exception raised while opening or reading the stream.
+        :returns: The message for the turn's :class:`ExecutorError`.
+        """
+        if isinstance(exc, DatabricksGenieError):
+            # Already a self-describing setup message; don't bury it in a prefix.
+            return str(exc)
+        status = getattr(exc, "status_code", None)
+        detail = str(exc)
+        if status == 404 and "FEATURE_DISABLED" in detail:
+            return (
+                "databricks-genie: the Genie Agent-mode APIs are Beta and are not enabled "
+                "for this workspace; ask a workspace admin to turn on the Genie agent "
+                f"preview, then retry. ({detail})"
+            )
+        if status == 409:
+            named = f" {self._conversation_id}" if self._conversation_id else ""
+            return (
+                f"databricks-genie: the Genie conversation{named} already has a turn in "
+                f"progress; wait for it to finish before sending another message. ({detail})"
+            )
+        return f"databricks-genie request failed: {exc}"
+
+    async def _stream_events(self, stream: Iterator[object]) -> AsyncIterator[ExecutorEvent]:
+        """Map one response's streamed items onto executor events.
+
+        Ends with either a :class:`TurnComplete` carrying every text chunk
+        concatenated — downstream policy prefers it over the streamed deltas —
+        or a single :class:`ExecutorError`, never both. Only
+        ``response.completed`` ends a turn successfully: a stream that stops
+        without it delivered a partial answer, which must not be reported as a
+        finished one. Any SQL call still awaiting its output is cancelled first,
+        so the turn leaves no card rendering as in progress.
+
+        :param stream: The response's blocking SSE iterator.
+        """
+        text: list[str] = []
+        pairing = _CallPairing()
+        completed = False
+        error: str | None = None
+        try:
+            async for event in iterate_blocking_stream(stream):
+                event_type = _get_str(event, "type")
+                if event_type == "response.created":
+                    self._capture_conversation_id(event)
+                elif event_type == "response.completed":
+                    # Read the id here too: if Genie ever omits it from
+                    # ``response.created``, the next turn would silently open a
+                    # new conversation instead of continuing this one.
+                    self._capture_conversation_id(event)
+                    completed = True
+                    break
+                elif event_type in ("response.failed", "error"):
+                    error = _failure_message(event)
+                    break
+                elif event_type == "response.incomplete":
+                    error = _incomplete_message(event)
+                    break
+                elif event_type == "response.output_item.done":
+                    for item_event in _item_events(_get(event, "item"), pairing):
+                        if not isinstance(item_event, TextChunk):
+                            yield item_event
+                            continue
+                        chunk = _block_separator(text[-1] if text else "") + item_event.text
+                        text.append(chunk)
+                        yield TextChunk(text=chunk)
+        except Exception as exc:  # noqa: BLE001 — stream boundary surfaces any error as a turn error
+            error = self._request_failure(exc)
+
+        if error is None and not completed:
+            error = _TRUNCATED_STREAM_MESSAGE
+        if error is not None:
+            for cancelled in pairing.cancel_awaiting():
+                yield cancelled
+            yield ExecutorError(message=error)
+            return
+
+        yield TurnComplete(response="".join(text))
 
     async def run_turn(
         self,
         messages: list[Message],
-        tools: list[ToolSpec],  # noqa: ARG002 — Genie has no Omnigent-dispatched tools
+        tools: list[ToolSpec],  # noqa: ARG002 — Genie runs its own SQL; no Omnigent tools
         system_prompt: str,  # noqa: ARG002 — the Genie space carries its own instructions
         config: ExecutorConfig | None = None,  # noqa: ARG002 — space id comes from __init__
     ) -> AsyncIterator[ExecutorEvent]:
         """Run one Genie turn and yield its events.
 
-        Yields an :class:`ExecutorError` (and stops) when no space id is
-        configured, there is no user message, or talking to Genie fails;
-        otherwise yields a :class:`TextChunk` with the response followed by a
-        :class:`TurnComplete`.
+        Yields a single :class:`ExecutorError` — and nothing else — when no
+        space id is configured, there is no user message, or the turn fails
+        before the stream opens (credential resolution or the opening POST).
+
+        Once the stream is open, yields the response's reasoning, observed SQL
+        calls, and report text as they arrive, followed by either a
+        :class:`TurnComplete` carrying the full answer or — when the stream
+        fails or ends without ``response.completed`` — a cancellation for each
+        in-flight SQL call and a final :class:`ExecutorError`. A mid-stream
+        failure therefore does not suppress the events already emitted, so
+        callers must not treat an :class:`ExecutorError` as "nothing happened".
         """
         space_id = self._space_id
         if not space_id:
@@ -366,12 +763,14 @@ class DatabricksGenieExecutor(Executor):
             return
 
         try:
-            client = self._ensure_client()
-            response = await asyncio.to_thread(self._run_genie_turn, client, space_id, prompt)
-        except Exception as exc:  # noqa: BLE001 — any SDK/auth/Genie error becomes a turn error
-            yield ExecutorError(message=f"databricks-genie request failed: {exc}")
+            # Both steps block: building the client resolves credentials (file
+            # I/O plus an OAuth token mint) and creating the stream posts the
+            # turn, so neither may run on the event loop.
+            client = await asyncio.to_thread(self._ensure_client, space_id)
+            stream = await asyncio.to_thread(self._create_stream, client, prompt)
+        except Exception as exc:  # noqa: BLE001 — any setup/auth/HTTP error becomes a turn error
+            yield ExecutorError(message=self._request_failure(exc))
             return
 
-        if response:
-            yield TextChunk(text=response)
-        yield TurnComplete(response=response)
+        async for event in self._stream_events(stream):
+            yield event

--- a/omnigent/inner/databricks_genie_harness.py
+++ b/omnigent/inner/databricks_genie_harness.py
@@ -1,0 +1,87 @@
+"""
+``harness: databricks-genie`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"databricks-genie"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Wraps a :class:`omnigent.inner.databricks_genie_executor.DatabricksGenieExecutor`,
+which converses with a remote Databricks Genie space over the Genie Conversation
+API. Mirrors the cursor wrap's env-var config flow.
+
+Env vars read at startup (set by
+:func:`omnigent.runtime.workflow._build_databricks_genie_spawn_env`):
+
+- ``HARNESS_DATABRICKS_GENIE_MODEL``: the Genie space id (carried in
+  ``executor.model``). ``None`` surfaces as a turn error telling the user to set
+  it.
+- ``HARNESS_DATABRICKS_GENIE_PROFILE``: the Databricks profile from
+  ``~/.databrickscfg`` used to authenticate the workspace client. ``None`` lets
+  the SDK use its own resolution order.
+- ``HARNESS_DATABRICKS_GENIE_TIMEOUT``: optional per-turn deadline (seconds,
+  float) handed to Genie's blocking ``*_and_wait`` helpers. Malformed values
+  fall back to the executor default.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import FastAPI
+
+from omnigent.inner.databricks_genie_executor import (
+    _DEFAULT_TIMEOUT_SECONDS,
+    DatabricksGenieExecutor,
+)
+from omnigent.inner.executor import Executor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+_ENV_MODEL = "HARNESS_DATABRICKS_GENIE_MODEL"
+_ENV_PROFILE = "HARNESS_DATABRICKS_GENIE_PROFILE"
+_ENV_TIMEOUT = "HARNESS_DATABRICKS_GENIE_TIMEOUT"
+
+
+def _resolve_timeout() -> float:
+    """Resolve the per-turn timeout from :data:`_ENV_TIMEOUT`.
+
+    :returns: The parsed timeout in seconds, or
+        :data:`~omnigent.inner.databricks_genie_executor._DEFAULT_TIMEOUT_SECONDS`
+        when the env var is unset or malformed.
+    """
+    raw = os.environ.get(_ENV_TIMEOUT, "").strip()
+    if not raw:
+        return _DEFAULT_TIMEOUT_SECONDS
+    try:
+        return float(raw)
+    except ValueError:
+        _logger.warning(
+            "%s is not a valid float (%r); falling back to %s seconds",
+            _ENV_TIMEOUT,
+            raw,
+            _DEFAULT_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_TIMEOUT_SECONDS
+
+
+def _build_databricks_genie_executor() -> Executor:
+    """Construct a :class:`DatabricksGenieExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first turn, so a missing
+    ``databricks-sdk`` install surfaces as a request-time error rather than an
+    app-boot crash.
+    """
+    return DatabricksGenieExecutor(
+        space_id=os.environ.get(_ENV_MODEL) or None,
+        profile=os.environ.get(_ENV_PROFILE) or None,
+        timeout_seconds=_resolve_timeout(),
+    )
+
+
+def create_app() -> FastAPI:
+    """Build the databricks-genie harness's FastAPI app (required entry point)."""
+    adapter = ExecutorAdapter(executor_factory=_build_databricks_genie_executor)
+    return adapter.build()

--- a/omnigent/inner/databricks_genie_harness.py
+++ b/omnigent/inner/databricks_genie_harness.py
@@ -10,7 +10,8 @@ Wraps a :class:`omnigent.inner.databricks_genie_executor.DatabricksGenieExecutor
 which converses with a remote Databricks Genie space in Agent mode over the
 Genie Responses API. Mirrors the cursor wrap's env-var config flow.
 
-Env vars read at startup. Three are spec-driven — set by
+Env vars read when the adapter builds the executor — lazily, on the first
+turn. Three are spec-driven — set by
 :func:`omnigent.runtime.workflow._build_databricks_genie_spawn_env`:
 
 - ``HARNESS_DATABRICKS_GENIE_MODEL``: the Genie space id (carried in
@@ -21,14 +22,16 @@ Env vars read at startup. Three are spec-driven — set by
   resolution order.
 - ``HARNESS_DATABRICKS_GENIE_ENABLE_VIZ``: optional opt-in asking Genie to
   attach visualizations to its answer, from ``executor.config["enable_viz"]``.
-  Off unless set to ``"true"``/``"1"``.
+  Off unless set (case-insensitively) to ``"true"``/``"True"``/``"1"`` — the
+  spawn-env builder exports a YAML ``true`` as the string ``"True"``.
 
 The remaining one has no spec surface — the spawn-env builder never exports it,
 so it is read from the ambient environment the harness subprocess inherits:
 
-- ``HARNESS_DATABRICKS_GENIE_TIMEOUT``: optional per-turn deadline (seconds,
-  float) applied to the streamed response. Values that are not a positive,
-  finite number fall back to the executor default.
+- ``HARNESS_DATABRICKS_GENIE_TIMEOUT``: optional idle timeout (seconds, float)
+  bounding each silent gap in the streamed response — not the turn's total
+  length. Values that are not a positive, finite number fall back to the
+  executor default.
 """
 
 from __future__ import annotations
@@ -59,7 +62,7 @@ _TRUTHY = frozenset({"true", "1"})
 
 
 def _resolve_timeout() -> float:
-    """Resolve the per-turn timeout from :data:`_ENV_TIMEOUT`.
+    """Resolve the stream idle timeout from :data:`_ENV_TIMEOUT`.
 
     Only a positive, finite number of seconds is a usable HTTP deadline —
     ``0``, a negative, ``nan``, and ``inf`` all parse as floats but would either

--- a/omnigent/inner/databricks_genie_harness.py
+++ b/omnigent/inner/databricks_genie_harness.py
@@ -7,26 +7,34 @@ resolves ``"databricks-genie"`` to this module via
 :data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
 
 Wraps a :class:`omnigent.inner.databricks_genie_executor.DatabricksGenieExecutor`,
-which converses with a remote Databricks Genie space over the Genie Conversation
-API. Mirrors the cursor wrap's env-var config flow.
+which converses with a remote Databricks Genie space in Agent mode over the
+Genie Responses API. Mirrors the cursor wrap's env-var config flow.
 
-Env vars read at startup (set by
-:func:`omnigent.runtime.workflow._build_databricks_genie_spawn_env`):
+Env vars read at startup. Three are spec-driven — set by
+:func:`omnigent.runtime.workflow._build_databricks_genie_spawn_env`:
 
 - ``HARNESS_DATABRICKS_GENIE_MODEL``: the Genie space id (carried in
   ``executor.model``). ``None`` surfaces as a turn error telling the user to set
   it.
 - ``HARNESS_DATABRICKS_GENIE_PROFILE``: the Databricks profile from
-  ``~/.databrickscfg`` used to authenticate the workspace client. ``None`` lets
-  the SDK use its own resolution order.
+  ``~/.databrickscfg`` used to authenticate. ``None`` lets the SDK use its own
+  resolution order.
+- ``HARNESS_DATABRICKS_GENIE_ENABLE_VIZ``: optional opt-in asking Genie to
+  attach visualizations to its answer, from ``executor.config["enable_viz"]``.
+  Off unless set to ``"true"``/``"1"``.
+
+The remaining one has no spec surface — the spawn-env builder never exports it,
+so it is read from the ambient environment the harness subprocess inherits:
+
 - ``HARNESS_DATABRICKS_GENIE_TIMEOUT``: optional per-turn deadline (seconds,
-  float) handed to Genie's blocking ``*_and_wait`` helpers. Malformed values
-  fall back to the executor default.
+  float) applied to the streamed response. Values that are not a positive,
+  finite number fall back to the executor default.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 import os
 
 from fastapi import FastAPI
@@ -43,20 +51,29 @@ _logger = logging.getLogger(__name__)
 _ENV_MODEL = "HARNESS_DATABRICKS_GENIE_MODEL"
 _ENV_PROFILE = "HARNESS_DATABRICKS_GENIE_PROFILE"
 _ENV_TIMEOUT = "HARNESS_DATABRICKS_GENIE_TIMEOUT"
+_ENV_ENABLE_VIZ = "HARNESS_DATABRICKS_GENIE_ENABLE_VIZ"
+
+# ``executor.config`` scalars reach the harness stringified, so a YAML ``true``
+# arrives as ``"True"``; accept the spellings a user could plausibly write.
+_TRUTHY = frozenset({"true", "1"})
 
 
 def _resolve_timeout() -> float:
     """Resolve the per-turn timeout from :data:`_ENV_TIMEOUT`.
 
+    Only a positive, finite number of seconds is a usable HTTP deadline —
+    ``0``, a negative, ``nan``, and ``inf`` all parse as floats but would either
+    fail every request or never bound a wedged stream.
+
     :returns: The parsed timeout in seconds, or
         :data:`~omnigent.inner.databricks_genie_executor._DEFAULT_TIMEOUT_SECONDS`
-        when the env var is unset or malformed.
+        when the env var is unset or does not name a positive, finite number.
     """
     raw = os.environ.get(_ENV_TIMEOUT, "").strip()
     if not raw:
         return _DEFAULT_TIMEOUT_SECONDS
     try:
-        return float(raw)
+        timeout = float(raw)
     except ValueError:
         _logger.warning(
             "%s is not a valid float (%r); falling back to %s seconds",
@@ -65,6 +82,24 @@ def _resolve_timeout() -> float:
             _DEFAULT_TIMEOUT_SECONDS,
         )
         return _DEFAULT_TIMEOUT_SECONDS
+    if not math.isfinite(timeout) or timeout <= 0:
+        _logger.warning(
+            "%s must be a positive, finite number of seconds (%r); falling back to %s seconds",
+            _ENV_TIMEOUT,
+            raw,
+            _DEFAULT_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_TIMEOUT_SECONDS
+    return timeout
+
+
+def _resolve_enable_viz() -> bool:
+    """Resolve the visualization opt-in from :data:`_ENV_ENABLE_VIZ`.
+
+    :returns: ``True`` for ``"true"``/``"True"``/``"1"``; ``False`` when the
+        env var is unset or holds anything else.
+    """
+    return os.environ.get(_ENV_ENABLE_VIZ, "").strip().lower() in _TRUTHY
 
 
 def _build_databricks_genie_executor() -> Executor:
@@ -78,6 +113,7 @@ def _build_databricks_genie_executor() -> Executor:
         space_id=os.environ.get(_ENV_MODEL) or None,
         profile=os.environ.get(_ENV_PROFILE) or None,
         timeout_seconds=_resolve_timeout(),
+        enable_viz=_resolve_enable_viz(),
     )
 
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -74,7 +74,7 @@ from omnigent.onboarding.provider_config import (
 _logger = logging.getLogger(__name__)
 
 _SDK_HARNESSES: frozenset[str] = frozenset(
-    {"claude-sdk", "openai-agents", "openai-agents-sdk", "antigravity"}
+    {"claude-sdk", "openai-agents", "openai-agents-sdk", "antigravity", "databricks-genie"}
 )
 
 # Families whose CLIs authenticate via file-based credentials rather than a CLI

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8635,6 +8635,7 @@ def _build_spawn_env_from_spec(
             _build_codex_spawn_env,
             _build_copilot_spawn_env,
             _build_cursor_spawn_env,
+            _build_databricks_genie_spawn_env,
             _build_goose_spawn_env,
             _build_kimi_spawn_env,
             _build_openai_agents_sdk_spawn_env,
@@ -8664,6 +8665,8 @@ def _build_spawn_env_from_spec(
             env = _build_acp_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "copilot":
             env = _build_copilot_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
+        elif harness == "databricks-genie":
+            env = _build_databricks_genie_spawn_env(effective_spec)
         else:
             builder_path = spawn_env_builders().get(harness)
             if builder_path is not None:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1921,6 +1921,8 @@ def _build_databricks_genie_spawn_env(spec: AgentSpec) -> dict[str, str]:
       ``HARNESS_DATABRICKS_GENIE_PROFILE``
     - ``executor.config["enable_viz"]`` (Genie's visualization opt-in) →
       ``HARNESS_DATABRICKS_GENIE_ENABLE_VIZ``
+    - ``HARNESS_TURN_TIMEOUT_S`` (the scaffold idle watchdog), sized above the
+      stream idle timeout unless the ambient environment already sets it
 
     Genie reaches the workspace with Databricks-CLI / OAuth / PAT credentials
     resolved by the databricks-sdk, NOT the Databricks AI gateway — so, like
@@ -1941,8 +1943,9 @@ def _build_databricks_genie_spawn_env(spec: AgentSpec) -> dict[str, str]:
     if isinstance(auth, DatabricksAuth):
         profile = auth.profile or None
     else:
-        # Legacy path: executor.config["profile"] or executor.profile.
-        profile = spec.executor.config.get("profile") or spec.executor.profile or None
+        # Legacy path: executor.profile then executor.config["profile"], the
+        # same order as _resolve_provider_for_build.
+        profile = spec.executor.profile or spec.executor.config.get("profile") or None
     if profile:
         env["HARNESS_DATABRICKS_GENIE_PROFILE"] = profile
 
@@ -1951,6 +1954,16 @@ def _build_databricks_genie_spawn_env(spec: AgentSpec) -> dict[str, str]:
     enable_viz = spec.executor.config.get("enable_viz")
     if enable_viz is not None:
         env["HARNESS_DATABRICKS_GENIE_ENABLE_VIZ"] = str(enable_viz)
+
+    # A Genie turn is silent while a warehouse query runs — the stream carries
+    # only completed items — so size the scaffold idle watchdog above the
+    # executor's stream idle timeout; the HTTP read then fails first, with an
+    # actionable databricks-genie message instead of a "wedged LLM" one.
+    # Ambient env wins, per the shared env > config > default precedence.
+    if "HARNESS_TURN_TIMEOUT_S" not in os.environ:
+        from omnigent.inner.databricks_genie_harness import _resolve_timeout
+
+        env["HARNESS_TURN_TIMEOUT_S"] = str(_resolve_timeout() + 60.0)
     return env
 
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1919,9 +1919,11 @@ def _build_databricks_genie_spawn_env(spec: AgentSpec) -> dict[str, str]:
     - the Databricks profile (``executor.auth: {type: databricks, profile}`` or
       the legacy ``executor.profile`` / ``executor.config["profile"]``) →
       ``HARNESS_DATABRICKS_GENIE_PROFILE``
+    - ``executor.config["enable_viz"]`` (Genie's visualization opt-in) →
+      ``HARNESS_DATABRICKS_GENIE_ENABLE_VIZ``
 
-    Genie reaches the workspace via the databricks-sdk ``WorkspaceClient``
-    (Databricks-CLI / OAuth / PAT auth), NOT the Databricks AI gateway — so, like
+    Genie reaches the workspace with Databricks-CLI / OAuth / PAT credentials
+    resolved by the databricks-sdk, NOT the Databricks AI gateway — so, like
     cursor, it is intentionally absent from :data:`AgentHarnessType` and the
     gateway / ucode dicts above, and there is no base-URL / gateway resolution
     here.
@@ -1943,6 +1945,12 @@ def _build_databricks_genie_spawn_env(spec: AgentSpec) -> dict[str, str]:
         profile = spec.executor.config.get("profile") or spec.executor.profile or None
     if profile:
         env["HARNESS_DATABRICKS_GENIE_PROFILE"] = profile
+
+    # ``executor.config`` scalars reach the harness stringified, so a YAML
+    # ``true`` lands here as ``"True"`` and the wrap parses it back to a bool.
+    enable_viz = spec.executor.config.get("enable_viz")
+    if enable_viz is not None:
+        env["HARNESS_DATABRICKS_GENIE_ENABLE_VIZ"] = str(enable_viz)
     return env
 
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1910,6 +1910,42 @@ def _build_kimi_spawn_env(
     return env
 
 
+def _build_databricks_genie_spawn_env(spec: AgentSpec) -> dict[str, str]:
+    """
+    Map ``spec.executor`` fields → the ``HARNESS_DATABRICKS_GENIE_*`` env vars
+    the databricks-genie harness wrap reads.
+
+    - ``executor.model`` (the Genie space id) → ``HARNESS_DATABRICKS_GENIE_MODEL``
+    - the Databricks profile (``executor.auth: {type: databricks, profile}`` or
+      the legacy ``executor.profile`` / ``executor.config["profile"]``) →
+      ``HARNESS_DATABRICKS_GENIE_PROFILE``
+
+    Genie reaches the workspace via the databricks-sdk ``WorkspaceClient``
+    (Databricks-CLI / OAuth / PAT auth), NOT the Databricks AI gateway — so, like
+    cursor, it is intentionally absent from :data:`AgentHarnessType` and the
+    gateway / ucode dicts above, and there is no base-URL / gateway resolution
+    here.
+
+    :param spec: The agent spec.
+    :returns: Env-var overrides for the harness subprocess; may be empty (the
+        wrap then surfaces a "no space id configured" turn error).
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_DATABRICKS_GENIE_MODEL"] = model
+
+    auth = spec.executor.auth
+    if isinstance(auth, DatabricksAuth):
+        profile = auth.profile or None
+    else:
+        # Legacy path: executor.config["profile"] or executor.profile.
+        profile = spec.executor.config.get("profile") or spec.executor.profile or None
+    if profile:
+        env["HARNESS_DATABRICKS_GENIE_PROFILE"] = profile
+    return env
+
+
 def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
     """
     Map ``spec.executor`` fields → the ``HARNESS_ANTIGRAVITY_*`` env vars the

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -98,6 +98,7 @@ OMNIGENT_HARNESSES = frozenset(
         "kimi",
         "kimi-native",
         "cursor-native",
+        "databricks-genie",
         "kiro-native",
         "goose",
         "goose-native",
@@ -130,6 +131,7 @@ OMNIGENT_HARNESS_ALIASES = frozenset(
         "native-hermes",
         "github-copilot",
         "native-kimi",
+        "genie",
     }
 )
 _OMNIGENT_ACCEPTED_HARNESSES = OMNIGENT_HARNESSES | OMNIGENT_HARNESS_ALIASES

--- a/tests/e2e/omnigent/test_example_genie.py
+++ b/tests/e2e/omnigent/test_example_genie.py
@@ -1,0 +1,63 @@
+"""Structural test for the Databricks Genie example (examples/genie).
+
+Genie is a single-agent recipe that registers a remote Databricks AI/BI Genie
+space as the agent itself, over the ``databricks-genie`` harness. Pure
+spec-load — no LLM, no credentials, no live workspace. The live gate for the
+harness is ``test_per_harness_databricks_genie.py`` (which drives a real Genie
+space via CLI overrides); this file pins the shipped bundle's spec shape and
+the exact fields ``_build_databricks_genie_spawn_env`` consumes from it.
+
+What breaks if this fails:
+- the bundle stops parsing under a spec-schema change (users following the
+  README quick start get a parse error),
+- the harness id, space-id placeholder, or auth block drifts away from what
+  the docs tell users to edit,
+- the spawn-env builder stops resolving the bundle's fields into the
+  ``HARNESS_DATABRICKS_GENIE_*`` env vars the harness wrap reads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runtime.workflow import _build_databricks_genie_spawn_env
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec, DatabricksAuth
+
+# tests/e2e/omnigent/test_example_genie.py -> repo root is 3 parents up.
+_GENIE_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "genie"
+
+_SPACE_ID_PLACEHOLDER = "REPLACE_WITH_GENIE_SPACE_ID"
+
+
+@pytest.fixture(scope="module")
+def genie_spec() -> AgentSpec:
+    """Load and validate the genie bundle once for the module."""
+    return load(_GENIE_BUNDLE, expand_env=False)
+
+
+def test_genie_name_harness_and_space_id(genie_spec: AgentSpec) -> None:
+    """
+    The agent runs on the databricks-genie harness with the space id carried in
+    ``executor.model`` — the placeholder the README quick start tells users to
+    replace with their Genie room's id.
+    """
+    assert genie_spec.name == "sales_genie"
+    assert genie_spec.executor.config.get("harness") == "databricks-genie"
+    assert genie_spec.executor.model == _SPACE_ID_PLACEHOLDER
+
+
+def test_genie_auth_is_a_databricks_profile(genie_spec: AgentSpec) -> None:
+    """Auth is a Databricks CLI profile — the only credential path Genie has."""
+    assert genie_spec.executor.auth == DatabricksAuth(profile="DEFAULT")
+
+
+def test_genie_bundle_resolves_through_the_spawn_env_builder(
+    genie_spec: AgentSpec,
+) -> None:
+    """The bundle's fields land in the env vars the harness wrap reads."""
+    env = _build_databricks_genie_spawn_env(genie_spec)
+    assert env["HARNESS_DATABRICKS_GENIE_MODEL"] == _SPACE_ID_PLACEHOLDER
+    assert env["HARNESS_DATABRICKS_GENIE_PROFILE"] == "DEFAULT"

--- a/tests/e2e/omnigent/test_examples_coverage_sync.py
+++ b/tests/e2e/omnigent/test_examples_coverage_sync.py
@@ -198,6 +198,11 @@ _ALT_COVERED: frozenset[str] = frozenset(
         # test_switch_agent_native_e2e.py, test_sessions_fork_e2e.py).
         "sdk-chat-builtin",
         "sandbox-deps-os-env",
+        # examples/genie is covered by test_per_harness_databricks_genie.py —
+        # the harness-named live characterization test that runs the example
+        # against a real Genie space (skipped when the workspace creds are
+        # absent), so there is no separate test_example_genie.py.
+        "genie",
     }
 )
 

--- a/tests/e2e/omnigent/test_examples_coverage_sync.py
+++ b/tests/e2e/omnigent/test_examples_coverage_sync.py
@@ -198,11 +198,6 @@ _ALT_COVERED: frozenset[str] = frozenset(
         # test_switch_agent_native_e2e.py, test_sessions_fork_e2e.py).
         "sdk-chat-builtin",
         "sandbox-deps-os-env",
-        # examples/genie is covered by test_per_harness_databricks_genie.py —
-        # the harness-named live characterization test that runs the example
-        # against a real Genie space (skipped when the workspace creds are
-        # absent), so there is no separate test_example_genie.py.
-        "genie",
     }
 )
 

--- a/tests/e2e/omnigent/test_per_harness_databricks_genie.py
+++ b/tests/e2e/omnigent/test_per_harness_databricks_genie.py
@@ -1,0 +1,105 @@
+"""Per-harness live characterization test — databricks-genie harness, one-shot.
+
+Runs ``omnigent run hello_world.yaml --harness databricks-genie --model
+<space_id> -p "..."`` as a real subprocess and asserts structural invariants
+(exit 0, a non-trivial assistant reply). This is the end-to-end gate for the
+databricks-genie harness: CLI parse → spec materialize → spawn the
+``databricks-genie`` harness subprocess →
+:class:`~omnigent.inner.databricks_genie_executor.DatabricksGenieExecutor`
+driving a remote Genie space over the ``databricks-sdk`` Genie API →
+``TurnComplete`` → the ``-p`` one-shot printer.
+
+**Prerequisites (skipped when absent):**
+- The ``databricks-sdk`` package installed (the ``databricks`` extra).
+- ``OMNIGENT_GENIE_SPACE_ID`` set to a real Genie space id.
+- A resolvable Databricks credential — typically ``databricks auth login``
+  having written ``~/.databrickscfg`` (optionally named via
+  ``OMNIGENT_GENIE_PROFILE`` → ``DATABRICKS_CONFIG_PROFILE``).
+
+**Why this test cannot use the mock LLM server:** Genie is a proprietary
+Databricks conversational API reached through ``WorkspaceClient.genie``; it does
+not honour ``OPENAI_BASE_URL``. The harness can only be exercised against a real
+workspace, so the test **skips** (rather than fails) when the prerequisites are
+absent so the e2e shards stay green; it runs for real wherever they are present.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HARNESS = "databricks-genie"
+_PROMPT = "Give me a one-sentence summary of what this space can answer."
+
+# Minimum assistant-text length proving a genuine Genie reply (not empty/error).
+_MIN_ASSISTANT_CHARS = 4
+
+# Genie cold-starts a conversation and may run a warehouse query; allow headroom.
+_RUN_TIMEOUT_SEC = 300
+
+
+def test_per_harness_databricks_genie_one_shot(
+    omnigent_python: Path,
+    omnigent_repo_root: Path,
+) -> None:
+    """``omnigent run ... --harness databricks-genie --model <space> -p <q>`` works.
+
+    :param omnigent_python: Interpreter with omnigent installed and importable.
+    :param omnigent_repo_root: Cwd for the subprocess so the YAML spec resolves.
+    """
+    if importlib.util.find_spec("databricks.sdk") is None:
+        pytest.skip(
+            "databricks-genie prerequisite missing: the 'databricks-sdk' package is "
+            "not installed (install the 'databricks' extra)."
+        )
+    space_id = os.environ.get("OMNIGENT_GENIE_SPACE_ID", "").strip()
+    if not space_id:
+        pytest.skip(
+            "databricks-genie prerequisite missing: OMNIGENT_GENIE_SPACE_ID is not set. "
+            "Set it to a real Genie space id (and authenticate via 'databricks auth "
+            "login') to run this live gate."
+        )
+
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+
+    env = dict(os.environ)
+    profile = os.environ.get("OMNIGENT_GENIE_PROFILE", "").strip()
+    if profile:
+        env["DATABRICKS_CONFIG_PROFILE"] = profile
+
+    result = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(yaml_path),
+            "--harness",
+            _HARNESS,
+            "--model",
+            space_id,
+            "-p",
+            _PROMPT,
+            "--no-log",
+            "--no-session",
+        ],
+        env=env,
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+    assistant_text = result.stdout.strip()
+    assert result.returncode == 0, (
+        f"databricks-genie run exited {result.returncode}.\n\n"
+        f"stdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    assert len(assistant_text) >= _MIN_ASSISTANT_CHARS, (
+        f"databricks-genie assistant text shorter than {_MIN_ASSISTANT_CHARS} chars; "
+        f"got {assistant_text!r}\n\nstderr:\n{result.stderr!r}"
+    )

--- a/tests/e2e/omnigent/test_per_harness_databricks_genie.py
+++ b/tests/e2e/omnigent/test_per_harness_databricks_genie.py
@@ -66,7 +66,7 @@ def test_per_harness_databricks_genie_one_shot(
 
     yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
 
-    env = dict(os.environ)
+    env = os.environ.copy()
     profile = os.environ.get("OMNIGENT_GENIE_PROFILE", "").strip()
     if profile:
         env["DATABRICKS_CONFIG_PROFILE"] = profile

--- a/tests/e2e/omnigent/test_per_harness_databricks_genie.py
+++ b/tests/e2e/omnigent/test_per_harness_databricks_genie.py
@@ -6,21 +6,28 @@ Runs ``omnigent run hello_world.yaml --harness databricks-genie --model
 databricks-genie harness: CLI parse → spec materialize → spawn the
 ``databricks-genie`` harness subprocess →
 :class:`~omnigent.inner.databricks_genie_executor.DatabricksGenieExecutor`
-driving a remote Genie space over the ``databricks-sdk`` Genie API →
-``TurnComplete`` → the ``-p`` one-shot printer.
+streaming a remote Genie space over the Agent-mode Responses API
+(``POST /api/2.0/genie/agents/{agent_id}/responses``) → ``TurnComplete`` → the
+``-p`` one-shot printer.
 
 **Prerequisites (skipped when absent):**
-- The ``databricks-sdk`` package installed (the ``databricks`` extra).
+- The ``databricks-sdk`` package installed (the ``databricks`` extra) — it
+  resolves the workspace credentials the request's bearer auth refreshes.
 - ``OMNIGENT_GENIE_SPACE_ID`` set to a real Genie space id.
 - A resolvable Databricks credential — typically ``databricks auth login``
   having written ``~/.databrickscfg`` (optionally named via
   ``OMNIGENT_GENIE_PROFILE`` → ``DATABRICKS_CONFIG_PROFILE``).
+- The workspace preview toggle for Genie **Agent mode** enabled. The APIs are
+  Beta; without it the endpoint answers 404 ``FEATURE_DISABLED``. This one
+  cannot be detected up front — it only shows up as a failed run — so a run
+  that reports it is skipped rather than failed (see below).
 
-**Why this test cannot use the mock LLM server:** Genie is a proprietary
-Databricks conversational API reached through ``WorkspaceClient.genie``; it does
-not honour ``OPENAI_BASE_URL``. The harness can only be exercised against a real
-workspace, so the test **skips** (rather than fails) when the prerequisites are
-absent so the e2e shards stay green; it runs for real wherever they are present.
+**Why this test cannot use the mock LLM server:** the Genie Responses endpoint
+is OpenAI-shaped but lives at a workspace-specific Databricks URL derived from
+the resolved credentials, so it does not honour ``OPENAI_BASE_URL``. The harness
+can only be exercised against a real workspace, so the test **skips** (rather
+than fails) when the prerequisites are absent so the e2e shards stay green; it
+runs for real wherever they are present.
 """
 
 from __future__ import annotations
@@ -38,8 +45,19 @@ _PROMPT = "Give me a one-sentence summary of what this space can answer."
 # Minimum assistant-text length proving a genuine Genie reply (not empty/error).
 _MIN_ASSISTANT_CHARS = 4
 
-# Genie cold-starts a conversation and may run a warehouse query; allow headroom.
-_RUN_TIMEOUT_SEC = 300
+# Outlast the executor's own per-turn deadline (900s) plus process startup, so a
+# slow warehouse query surfaces as the executor's actionable error rather than a
+# truncated subprocess.
+_RUN_TIMEOUT_SEC = 960
+
+# Substrings in a failed run that mean "the environment isn't ready", not "the
+# harness is broken" — the workspace preview toggle for Agent mode (Beta) is off,
+# or no Databricks credential could be minted. Neither is detectable up front.
+_UNAVAILABLE_MARKERS = (
+    "FEATURE_DISABLED",
+    "Agent-mode APIs are Beta",
+    "Databricks authentication failed",
+)
 
 
 def test_per_harness_databricks_genie_one_shot(
@@ -54,7 +72,8 @@ def test_per_harness_databricks_genie_one_shot(
     if importlib.util.find_spec("databricks.sdk") is None:
         pytest.skip(
             "databricks-genie prerequisite missing: the 'databricks-sdk' package is "
-            "not installed (install the 'databricks' extra)."
+            "not installed (install the 'databricks' extra), so no workspace "
+            "credential can be resolved for the Responses request."
         )
     space_id = os.environ.get("OMNIGENT_GENIE_SPACE_ID", "").strip()
     if not space_id:
@@ -93,6 +112,16 @@ def test_per_harness_databricks_genie_one_shot(
         text=True,
         timeout=_RUN_TIMEOUT_SEC,
     )
+
+    if result.returncode != 0:
+        combined = f"{result.stdout}\n{result.stderr}"
+        marker = next((m for m in _UNAVAILABLE_MARKERS if m in combined), None)
+        if marker is not None:
+            pytest.skip(
+                f"databricks-genie prerequisite missing: the run reported {marker!r}. "
+                "Enable the workspace preview for Genie Agent mode (Beta) and "
+                "authenticate via 'databricks auth login' to run this live gate."
+            )
 
     assistant_text = result.stdout.strip()
     assert result.returncode == 0, (

--- a/tests/e2e/omnigent/test_per_harness_databricks_genie.py
+++ b/tests/e2e/omnigent/test_per_harness_databricks_genie.py
@@ -45,9 +45,9 @@ _PROMPT = "Give me a one-sentence summary of what this space can answer."
 # Minimum assistant-text length proving a genuine Genie reply (not empty/error).
 _MIN_ASSISTANT_CHARS = 4
 
-# Outlast the executor's own per-turn deadline (900s) plus process startup, so a
-# slow warehouse query surfaces as the executor's actionable error rather than a
-# truncated subprocess.
+# Outlast the executor's stream idle timeout (900s of wire silence) plus process
+# startup, so a wedged stream surfaces as the executor's actionable error rather
+# than a truncated subprocess.
 _RUN_TIMEOUT_SEC = 960
 
 # Substrings in a failed run that mean "the environment isn't ready", not "the
@@ -69,7 +69,13 @@ def test_per_harness_databricks_genie_one_shot(
     :param omnigent_python: Interpreter with omnigent installed and importable.
     :param omnigent_repo_root: Cwd for the subprocess so the YAML spec resolves.
     """
-    if importlib.util.find_spec("databricks.sdk") is None:
+    try:
+        # find_spec("databricks.sdk") imports the parent package first, so a
+        # machine without the extra raises here rather than returning None.
+        databricks_sdk_missing = importlib.util.find_spec("databricks.sdk") is None
+    except ModuleNotFoundError:
+        databricks_sdk_missing = True
+    if databricks_sdk_missing:
         pytest.skip(
             "databricks-genie prerequisite missing: the 'databricks-sdk' package is "
             "not installed (install the 'databricks' extra), so no workspace "

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -225,6 +225,19 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     ``omnigent run --harness hermes-native``, AND it wraps the ``hermes`` CLI
     binary. Its coverage is the dedicated hermes-native bridge/executor/forwarder/
     approval-mirror unit tests.
+
+    ``databricks-genie`` is excluded for the same reason as ``cursor`` /
+    ``copilot``: it is an SDK harness that drives a live Databricks workspace
+    rather than the shared gateway/profile probe wiring this matrix drives. A
+    round-trip needs a real Genie space id in ``executor.model``, workspace
+    credentials the Databricks SDK can resolve, and the workspace-admin Beta
+    preview toggle for Genie Agent mode — without that toggle every turn fails
+    with a 404 ``FEATURE_DISABLED``. Its live round-trip is covered by the
+    skip-gated ``tests/e2e/omnigent/test_per_harness_databricks_genie.py``.
+
+    (The ``genie`` alias needs no exclusion: it is registered in
+    ``_HARNESS_MODULES`` but not in ``OMNIGENT_HARNESSES``, so the intersection
+    above never yields it.)
     """
     expected_live_harnesses = set(OMNIGENT_HARNESSES).intersection(_HARNESS_MODULES) - {
         "acp",
@@ -246,5 +259,6 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
         "kimi-native",
         "hermes",
         "hermes-native",
+        "databricks-genie",
     }
     assert {probe.harness for probe in HARNESS_PROBES} == expected_live_harnesses

--- a/tests/inner/test_databricks_genie_executor.py
+++ b/tests/inner/test_databricks_genie_executor.py
@@ -21,6 +21,7 @@ from omnigent.inner.databricks_genie_executor import (
     DatabricksGenieExecutor,
     _extract_text,
     _latest_user_text,
+    _md_cell,
     _render_statement,
 )
 from omnigent.inner.executor import (
@@ -225,12 +226,15 @@ def test_query_answer_includes_sql_and_result_rows() -> None:
     assert "Here is the breakdown." in response
     assert 'Generated SQL ("By region"):' in response
     assert "totals per region" in response
-    assert "SELECT region, count(*) n FROM s GROUP BY region" in response
+    # SQL is wrapped in a fenced code block.
+    assert "```sql\nSELECT region, count(*) n FROM s GROUP BY region\n```" in response
+    # The result is a valid GFM table: header, delimiter, then data rows.
     assert "Result (2 rows):" in response
-    assert "region | n" in response
-    assert "EMEA | 1200" in response
-    # None cell rendered as empty string.
-    assert "APAC | " in response
+    assert "| region | n |" in response
+    assert "| --- | --- |" in response
+    assert "| EMEA | 1200 |" in response
+    # None cell rendered as an empty cell.
+    assert "| APAC |  |" in response
     # The result is fetched via the Statement Execution API by statement id.
     assert stmt_exec.get_calls == ["stmt-region"]
 
@@ -473,8 +477,23 @@ def test_latest_user_text_handles_multimodal_parts() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _render_statement (pure helper) — table edge cases
+# _md_cell / _render_statement (pure helpers) — table formatting
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, ""),  # None → empty cell
+        ("plain", "plain"),  # passthrough
+        ("a\nb\tc  d", "a b c d"),  # newline/tab/double-space collapse to single spaces
+        ("  trim  ", "trim"),  # leading/trailing whitespace stripped
+        ("a|b", r"a\|b"),  # pipe escaped so it doesn't open a column
+        (1200, "1200"),  # non-str coerced via str()
+    ],
+)
+def test_md_cell(value: object, expected: str) -> None:
+    assert _md_cell(value) == expected
 
 
 def test_render_statement_no_rows_returns_empty() -> None:
@@ -482,13 +501,45 @@ def test_render_statement_no_rows_returns_empty() -> None:
     assert _render_statement(FakeStatementResponse(result=None)) == ""
 
 
-def test_render_statement_without_columns_renders_rows_only() -> None:
+def test_render_statement_without_columns_synthesizes_headers() -> None:
+    """With no schema, generic ``col1, col2`` headers keep the table valid GFM."""
     stmt = FakeStatementResponse(
         manifest=None,
         result=FakeResultData(data_array=[["a", "b"]]),
     )
     rendered = _render_statement(stmt)
-    assert rendered == "Result (1 row):\na | b"
+    assert rendered == "Result (1 row):\n\n| col1 | col2 |\n| --- | --- |\n| a | b |"
+
+
+def test_render_statement_emits_valid_gfm_table() -> None:
+    """Header row, delimiter row, blank-line separation, and pipe-bounded cells."""
+    stmt = FakeStatementResponse(
+        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("region"), FakeColumn("n")])),
+        result=FakeResultData(data_array=[["EMEA", "1200"]]),
+    )
+    assert _render_statement(stmt) == (
+        "Result (1 row):\n\n| region | n |\n| --- | --- |\n| EMEA | 1200 |"
+    )
+
+
+def test_render_statement_pads_ragged_rows() -> None:
+    """A row shorter than the column count is padded with empty cells."""
+    stmt = FakeStatementResponse(
+        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("a"), FakeColumn("b")])),
+        result=FakeResultData(data_array=[["x"]]),
+    )
+    assert _render_statement(stmt) == "Result (1 row):\n\n| a | b |\n| --- | --- |\n| x |  |"
+
+
+def test_render_statement_sanitizes_multiline_cells() -> None:
+    """A multi-line / pipe-bearing cell is collapsed to one row so the table holds."""
+    stmt = FakeStatementResponse(
+        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("review")])),
+        result=FakeResultData(data_array=[["line one\nline two | tail"]]),
+    )
+    assert _render_statement(stmt) == (
+        "Result (1 row):\n\n| review |\n| --- |\n| line one line two \\| tail |"
+    )
 
 
 def test_render_statement_truncates_beyond_cap() -> None:
@@ -500,8 +551,10 @@ def test_render_statement_truncates_beyond_cap() -> None:
     rendered = _render_statement(stmt)
     assert "Result (55 rows):" in rendered
     assert "… (5 more rows)" in rendered
-    # 1 header line + 1 column line + 50 rows + 1 omitted line.
-    assert rendered.count("\n") == 1 + 1 + 50
+    assert "| --- |" in rendered
+    # Exactly the first 50 rows are shown; row index 50+ is summarized away.
+    assert "| 49 |" in rendered
+    assert "| 50 |" not in rendered
 
 
 def test_render_statement_single_omitted_row_is_singular() -> None:

--- a/tests/inner/test_databricks_genie_executor.py
+++ b/tests/inner/test_databricks_genie_executor.py
@@ -1,0 +1,554 @@
+"""Tests for :class:`DatabricksGenieExecutor` with a fake Genie client.
+
+The executor talks to a Databricks Genie space via ``WorkspaceClient.genie``. A
+small set of fakes mirror the ``databricks-sdk`` shapes the executor reads
+(``GenieMessage`` / ``GenieAttachment`` / ``StatementResponse``), so every branch
+is exercised without the SDK or a live workspace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from omnigent.inner.databricks_genie_executor import (
+    DatabricksGenieError,
+    DatabricksGenieExecutor,
+    _extract_text,
+    _latest_user_text,
+    _render_statement,
+)
+from omnigent.inner.executor import (
+    ExecutorError,
+    TextChunk,
+    TurnComplete,
+)
+
+
+def _run(coro: Any) -> Any:
+    """Drive a coroutine to completion on a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Fakes mirroring the databricks-sdk Genie shapes the executor reads
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTextAttachment:
+    content: str | None = None
+
+
+@dataclass
+class FakeQueryAttachment:
+    title: str | None = None
+    description: str | None = None
+    query: str | None = None
+    statement_id: str | None = "stmt-1"
+
+
+@dataclass
+class FakeAttachment:
+    text: FakeTextAttachment | None = None
+    query: FakeQueryAttachment | None = None
+
+
+@dataclass
+class FakeMessage:
+    """Stand-in for ``GenieMessage``."""
+
+    conversation_id: str | None = "conv-1"
+    message_id: str | None = "msg-1"
+    content: str | None = None
+    attachments: list[FakeAttachment] | None = None
+
+
+@dataclass
+class FakeColumn:
+    name: str = ""
+
+
+@dataclass
+class FakeSchema:
+    columns: list[FakeColumn] = field(default_factory=list)
+
+
+@dataclass
+class FakeManifest:
+    schema: FakeSchema | None = None
+
+
+@dataclass
+class FakeResultData:
+    data_array: list[list[Any]] | None = None
+
+
+@dataclass
+class FakeStatementResponse:
+    manifest: FakeManifest | None = None
+    result: FakeResultData | None = None
+
+
+class FakeGenie:
+    """Mimics ``WorkspaceClient.genie``, scripting one message per call."""
+
+    def __init__(
+        self,
+        message: FakeMessage,
+        *,
+        raise_on_send: Exception | None = None,
+    ) -> None:
+        self._message = message
+        self._raise_on_send = raise_on_send
+        self.start_calls: list[tuple[str, str]] = []
+        self.create_calls: list[tuple[str, str, str]] = []
+
+    def start_conversation_and_wait(
+        self, space_id: str, content: str, timeout: Any = None
+    ) -> FakeMessage:
+        self.start_calls.append((space_id, content))
+        if self._raise_on_send is not None:
+            raise self._raise_on_send
+        return self._message
+
+    def create_message_and_wait(
+        self, space_id: str, conversation_id: str, content: str, timeout: Any = None
+    ) -> FakeMessage:
+        self.create_calls.append((space_id, conversation_id, content))
+        if self._raise_on_send is not None:
+            raise self._raise_on_send
+        return self._message
+
+
+class FakeStatementExecution:
+    """Mimics ``WorkspaceClient.statement_execution`` for result-row fetches."""
+
+    def __init__(
+        self,
+        statement: FakeStatementResponse | None = None,
+        *,
+        raise_on_get: Exception | None = None,
+    ) -> None:
+        self._statement = statement
+        self._raise_on_get = raise_on_get
+        self.get_calls: list[object] = []
+
+    def get_statement(self, statement_id: object) -> FakeStatementResponse | None:
+        self.get_calls.append(statement_id)
+        if self._raise_on_get is not None:
+            raise self._raise_on_get
+        return self._statement
+
+
+class FakeWorkspaceClient:
+    def __init__(
+        self, genie: FakeGenie, statement_execution: FakeStatementExecution | None = None
+    ) -> None:
+        self.genie = genie
+        self.statement_execution = statement_execution or FakeStatementExecution()
+
+
+def _user(text: str) -> dict[str, Any]:
+    return {"role": "user", "content": text}
+
+
+def _events(executor: DatabricksGenieExecutor, messages: list[dict[str, Any]]) -> list[Any]:
+    async def _collect() -> list[Any]:
+        return [e async for e in executor.run_turn(messages, [], "SYS")]
+
+    return _run(_collect())
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_text_only_answer_starts_conversation() -> None:
+    """A text-only Genie answer streams one TextChunk + TurnComplete."""
+    genie = FakeGenie(
+        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="42 sales"))])
+    )
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    events = _events(executor, [_user("how many sales?")])
+
+    texts = [e.text for e in events if isinstance(e, TextChunk)]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert texts == ["42 sales"]
+    assert len(completes) == 1 and completes[0].response == "42 sales"
+    # First turn → start_conversation, not create_message.
+    assert genie.start_calls == [("sp", "how many sales?")]
+    assert genie.create_calls == []
+
+
+def test_query_answer_includes_sql_and_result_rows() -> None:
+    """A query attachment renders title + SQL + the fetched result table."""
+    statement = FakeStatementResponse(
+        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("region"), FakeColumn("n")])),
+        result=FakeResultData(data_array=[["EMEA", "1200"], ["APAC", None]]),
+    )
+    genie = FakeGenie(
+        FakeMessage(
+            attachments=[
+                FakeAttachment(text=FakeTextAttachment(content="Here is the breakdown.")),
+                FakeAttachment(
+                    query=FakeQueryAttachment(
+                        title="By region",
+                        description="totals per region",
+                        query="SELECT region, count(*) n FROM s GROUP BY region",
+                        statement_id="stmt-region",
+                    )
+                ),
+            ]
+        ),
+    )
+    stmt_exec = FakeStatementExecution(statement)
+    executor = DatabricksGenieExecutor(
+        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
+    )
+
+    events = _events(executor, [_user("breakdown by region")])
+    response = next(e.response for e in events if isinstance(e, TurnComplete))
+
+    assert "Here is the breakdown." in response
+    assert 'Generated SQL ("By region"):' in response
+    assert "totals per region" in response
+    assert "SELECT region, count(*) n FROM s GROUP BY region" in response
+    assert "Result (2 rows):" in response
+    assert "region | n" in response
+    assert "EMEA | 1200" in response
+    # None cell rendered as empty string.
+    assert "APAC | " in response
+    # The result is fetched via the Statement Execution API by statement id.
+    assert stmt_exec.get_calls == ["stmt-region"]
+
+
+def test_follow_up_turn_continues_conversation() -> None:
+    """The second turn reuses the stored conversation id via create_message."""
+    genie = FakeGenie(
+        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="ok"))])
+    )
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    _events(executor, [_user("first")])
+    _events(executor, [_user("second")])
+
+    assert genie.start_calls == [("sp", "first")]
+    assert genie.create_calls == [("sp", "conv-1", "second")]
+
+
+def test_message_content_fallback_when_no_attachments() -> None:
+    """With no attachments, the message's own content is used as the answer."""
+    genie = FakeGenie(FakeMessage(attachments=[], content="bare answer"))
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    events = _events(executor, [_user("q")])
+    assert next(e.response for e in events if isinstance(e, TurnComplete)) == "bare answer"
+
+
+def test_empty_answer_emits_turn_complete_without_text_chunk() -> None:
+    """An empty response yields only TurnComplete (no empty TextChunk)."""
+    genie = FakeGenie(FakeMessage(attachments=[], content=None))
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    events = _events(executor, [_user("q")])
+    assert [type(e).__name__ for e in events] == ["TurnComplete"]
+    assert events[0].response == ""
+
+
+# ---------------------------------------------------------------------------
+# Error / guard paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_space_id_errors() -> None:
+    """No space id → an actionable ExecutorError, no SDK call."""
+    genie = FakeGenie(FakeMessage())
+    executor = DatabricksGenieExecutor(space_id=None, workspace_client=FakeWorkspaceClient(genie))
+
+    events = _events(executor, [_user("q")])
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "executor.model" in events[0].message
+    assert genie.start_calls == []
+
+
+def test_empty_user_message_errors() -> None:
+    """A blank/absent user message → ExecutorError before any SDK call."""
+    genie = FakeGenie(FakeMessage())
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    events = _events(executor, [_user("   ")])
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "no user message" in events[0].message
+    assert genie.start_calls == []
+
+
+def test_send_exception_becomes_executor_error() -> None:
+    """An SDK error during send (e.g. Genie message FAILED / timed out — the SDK's
+    ``*_and_wait`` raises ``OperationFailed`` — or auth failure) becomes an ExecutorError."""
+    genie = FakeGenie(FakeMessage(), raise_on_send=RuntimeError("workspace down"))
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    events = _events(executor, [_user("q")])
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "workspace down" in events[0].message
+
+
+def test_query_result_fetch_failure_is_best_effort() -> None:
+    """A result-fetch failure drops the table but keeps the SQL/text answer."""
+    genie = FakeGenie(
+        FakeMessage(
+            attachments=[
+                FakeAttachment(query=FakeQueryAttachment(query="SELECT 1")),
+            ]
+        ),
+    )
+    stmt_exec = FakeStatementExecution(raise_on_get=RuntimeError("result expired"))
+    executor = DatabricksGenieExecutor(
+        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
+    )
+
+    events = _events(executor, [_user("q")])
+    response = next(e.response for e in events if isinstance(e, TurnComplete))
+    assert "Generated SQL:" in response
+    assert "SELECT 1" in response
+    assert "Result (" not in response
+
+
+def test_query_attachment_without_sql_renders_description_only() -> None:
+    """A query attachment with a description but no SQL omits the SQL line."""
+    genie = FakeGenie(
+        FakeMessage(
+            attachments=[
+                FakeAttachment(query=FakeQueryAttachment(description="just a note", query=None))
+            ]
+        )
+    )
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+    response = next(
+        e.response for e in _events(executor, [_user("q")]) if isinstance(e, TurnComplete)
+    )
+    assert "Generated SQL:" in response
+    assert "just a note" in response
+
+
+def test_message_without_conversation_id_does_not_thread() -> None:
+    """A message lacking a conversation id leaves the next turn starting fresh."""
+    genie = FakeGenie(
+        FakeMessage(
+            conversation_id=None,
+            attachments=[FakeAttachment(text=FakeTextAttachment(content="ok"))],
+        )
+    )
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    _events(executor, [_user("first")])
+    _events(executor, [_user("second")])
+
+    # No conversation id was recorded, so both turns start a new conversation.
+    assert genie.start_calls == [("sp", "first"), ("sp", "second")]
+    assert genie.create_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Lazy client construction (databricks-sdk import)
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_client_built_from_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no injected client, a WorkspaceClient is built from the SDK once."""
+    genie = FakeGenie(
+        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="hi"))])
+    )
+    constructed: list[dict[str, Any]] = []
+
+    def _client_factory(**kwargs: Any) -> FakeWorkspaceClient:
+        constructed.append(kwargs)
+        return FakeWorkspaceClient(genie)
+
+    fake_sdk = types.ModuleType("databricks.sdk")
+    fake_sdk.WorkspaceClient = _client_factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "databricks.sdk", fake_sdk)
+
+    executor = DatabricksGenieExecutor(space_id="sp", profile="dev")
+    events = _events(executor, [_user("q")])
+
+    assert next(e.response for e in events if isinstance(e, TurnComplete)) == "hi"
+    # Built exactly once, with the configured profile, then reused.
+    assert constructed == [{"profile": "dev"}]
+    _events(executor, [_user("again")])
+    assert len(constructed) == 1
+
+
+def test_missing_sdk_errors_with_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing databricks-sdk surfaces an ExecutorError with an install hint."""
+
+    real_import = __import__
+
+    def _no_databricks_sdk(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "databricks.sdk":
+            raise ImportError("No module named 'databricks.sdk'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "databricks.sdk", raising=False)
+    monkeypatch.setattr("builtins.__import__", _no_databricks_sdk)
+
+    executor = DatabricksGenieExecutor(space_id="sp")
+    events = _events(executor, [_user("q")])
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "databricks-sdk" in events[0].message
+    assert "omnigent[databricks]" in events[0].message
+
+
+# ---------------------------------------------------------------------------
+# Capability flags & message extraction
+# ---------------------------------------------------------------------------
+
+
+def test_capability_flags() -> None:
+    executor = DatabricksGenieExecutor(space_id="sp")
+    assert executor.supports_streaming() is False
+    assert executor.supports_tool_calling() is False
+
+
+def test_extract_text_edge_cases() -> None:
+    """``_extract_text`` covers absent, string, multimodal, and non-text content."""
+    assert _extract_text({"role": "user"}) == ""  # no content key → None
+    assert _extract_text({"content": None}) == ""
+    assert _extract_text({"content": "plain"}) == "plain"
+    assert _extract_text({"content": [{"type": "text", "text": "a"}, {"no": "text"}]}) == "a"
+    # A non-dict element in the parts list is skipped, not coerced.
+    assert _extract_text({"content": ["skip-me", {"type": "text", "text": "a"}]}) == "a"
+    # Non-str / non-list content falls back to str().
+    assert _extract_text({"content": 123}) == "123"
+
+
+def test_latest_user_text_no_user_message_returns_empty() -> None:
+    """With no user-role message, the latest-user lookup yields ``""``."""
+    assert _latest_user_text([{"role": "assistant", "content": "hi"}]) == ""
+    assert _latest_user_text([]) == ""
+
+
+def test_run_turn_with_no_user_role_errors() -> None:
+    """A history with no user message → the empty-prompt guard fires."""
+    genie = FakeGenie(FakeMessage())
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+    events = _events(executor, [{"role": "assistant", "content": "hello"}])
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "no user message" in events[0].message
+
+
+def test_latest_user_text_handles_multimodal_parts() -> None:
+    """The latest user message wins, and list-of-parts content is joined."""
+    genie = FakeGenie(
+        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="ok"))])
+    )
+    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+
+    messages = [
+        {"role": "user", "content": "old"},
+        {"role": "assistant", "content": "ignored"},
+        {"role": "user", "content": [{"type": "text", "text": "hello"}, {"type": "image"}]},
+    ]
+    _events(executor, messages)
+    assert genie.start_calls == [("sp", "hello")]
+
+
+# ---------------------------------------------------------------------------
+# _render_statement (pure helper) — table edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_render_statement_no_rows_returns_empty() -> None:
+    assert _render_statement(FakeStatementResponse(result=FakeResultData(data_array=[]))) == ""
+    assert _render_statement(FakeStatementResponse(result=None)) == ""
+
+
+def test_render_statement_without_columns_renders_rows_only() -> None:
+    stmt = FakeStatementResponse(
+        manifest=None,
+        result=FakeResultData(data_array=[["a", "b"]]),
+    )
+    rendered = _render_statement(stmt)
+    assert rendered == "Result (1 row):\na | b"
+
+
+def test_render_statement_truncates_beyond_cap() -> None:
+    rows = [[str(i)] for i in range(55)]
+    stmt = FakeStatementResponse(
+        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("i")])),
+        result=FakeResultData(data_array=rows),
+    )
+    rendered = _render_statement(stmt)
+    assert "Result (55 rows):" in rendered
+    assert "… (5 more rows)" in rendered
+    # 1 header line + 1 column line + 50 rows + 1 omitted line.
+    assert rendered.count("\n") == 1 + 1 + 50
+
+
+def test_render_statement_single_omitted_row_is_singular() -> None:
+    rows = [[str(i)] for i in range(51)]
+    stmt = FakeStatementResponse(
+        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("i")])),
+        result=FakeResultData(data_array=rows),
+    )
+    assert "… (1 more row)" in _render_statement(stmt)
+
+
+def test_statement_with_no_rows_renders_no_table() -> None:
+    """A statement that resolves with no rows renders the SQL but no table."""
+    genie = FakeGenie(
+        FakeMessage(attachments=[FakeAttachment(query=FakeQueryAttachment(query="SELECT 1"))]),
+    )
+    stmt_exec = FakeStatementExecution(
+        FakeStatementResponse(result=FakeResultData(data_array=None))
+    )
+    executor = DatabricksGenieExecutor(
+        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
+    )
+    events = _events(executor, [_user("q")])
+    response = next(e.response for e in events if isinstance(e, TurnComplete))
+    assert "SELECT 1" in response
+    assert "Result (" not in response
+
+
+def test_query_with_missing_statement_id_skips_result_fetch() -> None:
+    """No statement id → the result table is skipped without an SDK call."""
+    genie = FakeGenie(
+        FakeMessage(
+            attachments=[
+                FakeAttachment(query=FakeQueryAttachment(query="SELECT 1", statement_id=None))
+            ],
+        )
+    )
+    stmt_exec = FakeStatementExecution()
+    executor = DatabricksGenieExecutor(
+        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
+    )
+    events = _events(executor, [_user("q")])
+    response = next(e.response for e in events if isinstance(e, TurnComplete))
+    assert "SELECT 1" in response
+    assert stmt_exec.get_calls == []
+
+
+def test_genie_error_str() -> None:
+    """The custom error type carries its message (used in ExecutorError text)."""
+    assert "boom" in str(DatabricksGenieError("boom"))

--- a/tests/inner/test_databricks_genie_executor.py
+++ b/tests/inner/test_databricks_genie_executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -31,6 +32,7 @@ from omnigent.inner.databricks_genie_executor import (
     _extract_text,
     _latest_user_text,
     _md_cell,
+    _output_payload,
     _parse_arguments,
     _reasoning_text,
     _render_table,
@@ -230,12 +232,15 @@ def test_first_turn_maps_every_item_kind_to_its_event() -> None:
 
     assert [type(e).__name__ for e in events] == [
         "ReasoningChunk",
+        "ReasoningChunk",
         "ToolCallRequest",
         "ToolCallComplete",
         "TextChunk",
         "TurnComplete",
     ]
-    reasoning = next(e for e in events if isinstance(e, ReasoningChunk))
+    anchor, reasoning = (e for e in events if isinstance(e, ReasoningChunk))
+    assert anchor.delta == ""
+    assert anchor.event_type == "reasoning_started"
     assert reasoning.delta == "Plan it."
     assert reasoning.event_type == "reasoning_text"
     assert _response(events) == "One row."
@@ -313,6 +318,45 @@ def test_conversation_id_is_captured_from_response_completed() -> None:
 
     assert "conversation_id" not in client.responses.calls[0].get("extra_body", {})
     assert client.responses.calls[1]["extra_body"]["conversation_id"] == "conv-late"
+
+
+def test_each_reasoning_item_opens_its_own_block() -> None:
+    """Genie plans before every SQL call; adjacent items must not run together.
+
+    The ``reasoning_started`` anchor before each item's text is what lets the
+    web reducer separate consecutive blocks instead of gluing sentences.
+    """
+    client = FakeClient(
+        [
+            _item_done(FakeReasoningItem(content=[{"text": "Check the tables."}])),
+            _item_done(FakeReasoningItem(content=[{"text": "Aggregate by region."}])),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    reasoning = [e for e in events if isinstance(e, ReasoningChunk)]
+    assert [(e.event_type, e.delta) for e in reasoning] == [
+        ("reasoning_started", ""),
+        ("reasoning_text", "Check the tables."),
+        ("reasoning_started", ""),
+        ("reasoning_text", "Aggregate by region."),
+    ]
+
+
+def test_whitespace_only_reasoning_emits_no_chunk() -> None:
+    """A formatting-artifact item must not open a visually empty reasoning block."""
+    client = FakeClient(
+        [
+            _item_done(FakeReasoningItem(content=[{"text": "  \n"}])),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["TurnComplete"]
 
 
 def test_enable_viz_is_sent_only_when_enabled() -> None:
@@ -688,6 +732,59 @@ def test_parse_arguments_never_silently_drops_a_present_value(
     assert _parse_arguments(raw) == expected
 
 
+def test_call_with_item_id_but_no_call_id_correlates_by_that_id() -> None:
+    """The wire's ``id`` is the fallback correlation key when ``call_id`` is absent."""
+    client = FakeClient(
+        [
+            _item_done({"type": "function_call", "id": "fc_9", "arguments": "{}"}),
+            _item_done({"type": "function_call_output", "call_id": "fc_9", "output": "ok"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    request = next(e for e in events if isinstance(e, ToolCallRequest))
+    completion = next(e for e in events if isinstance(e, ToolCallComplete))
+    assert request.metadata["call_id"] == "fc_9"
+    assert completion.metadata["call_id"] == "fc_9"
+    assert completion.result == "ok"
+
+
+def test_list_shaped_output_flattens_to_its_text() -> None:
+    """A parts-list ``output`` renders as the query result, not a parts dump."""
+    client = FakeClient(
+        [
+            _item_done(FakeFunctionCallItem(call_id="c1")),
+            _item_done(
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": [
+                        {"type": "input_text", "text": "42 "},
+                        {"type": "input_text", "text": "rows"},
+                    ],
+                }
+            ),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    completion = next(e for e in events if isinstance(e, ToolCallComplete))
+    assert completion.result == "42 rows"
+
+
+def test_output_payload_keeps_text_less_values_verbatim() -> None:
+    """A payload with no extractable text (or a raw dict) passes through untouched."""
+    image_parts = [{"type": "input_image", "image_url": "u"}]
+    assert _output_payload(image_parts) is image_parts
+    raw = {"rows": 2}
+    assert _output_payload(raw) is raw
+    assert _output_payload("already text") == "already text"
+
+
 # ---------------------------------------------------------------------------
 # I/O matrix: failures and guard rails
 # ---------------------------------------------------------------------------
@@ -800,6 +897,29 @@ def test_resolved_sql_call_is_not_cancelled_when_the_stream_truncates() -> None:
     completions = [e for e in events if isinstance(e, ToolCallComplete)]
     assert [e.status for e in completions] == [ToolCallStatus.SUCCESS]
     assert [type(e).__name__ for e in events][-1] == "ExecutorError"
+
+
+def test_unresolved_sql_call_is_cancelled_when_the_turn_completes() -> None:
+    """Success must not strand a card either: an unanswered call is cancelled
+    before ``TurnComplete``, or its SQL card would spin forever on a turn that
+    looks perfectly healthy."""
+    client = FakeClient(
+        [
+            _item_done(FakeFunctionCallItem(call_id="call_x")),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == [
+        "ToolCallRequest",
+        "ToolCallComplete",
+        "TurnComplete",
+    ]
+    cancelled = events[1]
+    assert cancelled.status is ToolCallStatus.CANCELLED
+    assert cancelled.metadata["call_id"] == "call_x"
 
 
 def test_feature_disabled_404_points_at_the_beta_preview() -> None:
@@ -916,6 +1036,42 @@ def test_unknown_event_types_are_ignored() -> None:
     assert [type(e).__name__ for e in events] == ["TextChunk", "TurnComplete"]
 
 
+def test_unknown_item_types_are_dropped_without_breaking_the_turn() -> None:
+    """An unmapped output item — a viz item under ``enable_viz`` is today's
+    occupant of this branch — is skipped; the rest of the turn stays intact."""
+    client = FakeClient(
+        [
+            _item_done({"type": "visualization", "spec": {"chart": "bar"}}),
+            _item_done(_text_item(FakeTextPart(text="report"))),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client, enable_viz=True))
+
+    assert [type(e).__name__ for e in events] == ["TextChunk", "TurnComplete"]
+    assert _response(events) == "report"
+
+
+def test_non_output_text_parts_are_skipped() -> None:
+    """A message part that is not ``output_text`` (e.g. a refusal) is not report text."""
+    client = FakeClient(
+        [
+            _item_done(
+                _text_item(
+                    FakeTextPart(text="shown"),
+                    FakeTextPart(text="hidden", type="refusal"),
+                )
+            ),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert _texts(events) == ["shown"]
+
+
 # ---------------------------------------------------------------------------
 # Lazy client construction
 # ---------------------------------------------------------------------------
@@ -972,7 +1128,7 @@ def test_lazy_client_never_snapshots_a_token(_stub_databricks_auth: _FakeAuth) -
         client.close()
 
 
-def test_lazy_client_applies_the_turn_timeout_and_disables_retries(
+def test_lazy_client_applies_the_stream_idle_timeout_and_disables_retries(
     _stub_databricks_auth: _FakeAuth,
 ) -> None:
     """Genie's 409 is in the SDK's default retry set but is never retryable."""
@@ -1081,6 +1237,150 @@ def test_missing_databricks_sdk_names_the_package_and_the_extra(
     assert isinstance(events[0], ExecutorError)
     assert "databricks-sdk" in events[0].message
     assert "omnigent[databricks]" in events[0].message
+    # The setup message is self-describing and must NOT be buried behind the
+    # generic "databricks-genie request failed:" prefix.
+    assert events[0].message.startswith("the databricks-sdk package is required")
+
+
+def test_concurrent_first_turns_build_exactly_one_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two workers racing the lazy build share one client; no pool leaks.
+
+    A cancelled first turn can overlap the next turn's ``to_thread`` worker, so
+    the check-then-build must be atomic — the loser of an unguarded race would
+    leak its httpx connection pool for the process lifetime.
+    """
+    auth = _FakeAuth()
+
+    def _slow_resolve(profile: Any = None, **_: Any) -> tuple[Any, str]:
+        time.sleep(0.2)
+        return auth, "https://ws.example.com/"
+
+    monkeypatch.setattr(databricks_executor, "_resolve_databricks_auth", _slow_resolve)
+    built: list[httpx.Client] = []
+
+    class _CountingClient(httpx.Client):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            built.append(self)
+
+    monkeypatch.setattr(httpx, "Client", _CountingClient)
+    executor = DatabricksGenieExecutor(space_id="sp")
+
+    results: list[object] = []
+    threads = [
+        threading.Thread(target=lambda: results.append(executor._ensure_client("sp")))
+        for _ in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    try:
+        assert len(built) == 1
+        assert len(results) == 2
+        assert results[0] is results[1]
+    finally:
+        _run(executor.close())
+    assert all(client.is_closed for client in built)
+
+
+# ---------------------------------------------------------------------------
+# Interrupt: closing the live stream unblocks a cancelled turn
+# ---------------------------------------------------------------------------
+
+
+class _BlockingClosableStream:
+    """Iterator that replays a prefix, then blocks until :meth:`close`."""
+
+    def __init__(self, prefix: list[Any]) -> None:
+        self._items = iter(prefix)
+        self._unblock = threading.Event()
+        self.closed = False
+
+    def __iter__(self) -> _BlockingClosableStream:
+        return self
+
+    def __next__(self) -> Any:
+        for item in self._items:
+            return item
+        self._unblock.wait(timeout=5.0)
+        raise RuntimeError("stream closed" if self.closed else "stream never closed")
+
+    def close(self) -> None:
+        self.closed = True
+        self._unblock.set()
+
+
+def test_interrupt_session_with_no_active_stream_returns_false() -> None:
+    """Nothing in flight → nothing to interrupt."""
+    executor = DatabricksGenieExecutor(space_id="sp", client=FakeClient([_completed()]))
+    assert _run(executor.interrupt_session("k")) is False
+
+
+def test_interrupt_session_mid_stream_closes_the_stream_and_unblocks_the_turn() -> None:
+    """Closing the stream ends a turn parked mid-query with cancellations + one error."""
+    stream = _BlockingClosableStream(
+        [_created("conv-1"), _item_done(FakeFunctionCallItem(call_id="c1"))]
+    )
+    executor = DatabricksGenieExecutor(space_id="sp", client=FakeClient(stream))
+
+    async def _scenario() -> list[Any]:
+        events: list[Any] = []
+
+        async def _consume() -> None:
+            async for event in executor.run_turn([_user("q")], [], "SYS"):
+                events.append(event)
+
+        task = asyncio.ensure_future(_consume())
+        while not events:  # wait until the SQL call surfaced, then interrupt
+            await asyncio.sleep(0.01)
+        assert await executor.interrupt_session("k") is True
+        await asyncio.wait_for(task, timeout=5.0)
+        return events
+
+    events = _run(_scenario())
+
+    assert stream.closed
+    assert [type(e).__name__ for e in events] == [
+        "ToolCallRequest",
+        "ToolCallComplete",
+        "ExecutorError",
+    ]
+    assert events[1].status is ToolCallStatus.CANCELLED
+    assert events[1].metadata["call_id"] == "c1"
+
+
+def test_interrupt_session_twice_is_safe_and_clears_after_the_turn() -> None:
+    """Double interrupt is idempotent; a finished turn leaves nothing to close."""
+    stream = _BlockingClosableStream([_created("conv-1")])
+    executor = DatabricksGenieExecutor(space_id="sp", client=FakeClient(stream))
+
+    async def _scenario() -> None:
+        events: list[Any] = []
+
+        async def _consume() -> None:
+            async for event in executor.run_turn([_user("q")], [], "SYS"):
+                events.append(event)
+
+        task = asyncio.ensure_future(_consume())
+        while executor._active_stream is None:
+            await asyncio.sleep(0.01)
+        assert await executor.interrupt_session("k") is True
+        assert await executor.interrupt_session("k") is True
+        await asyncio.wait_for(task, timeout=5.0)
+        assert await executor.interrupt_session("k") is False
+
+    _run(_scenario())
+
+
+def test_interrupt_session_tolerates_a_stream_without_close() -> None:
+    """A close-less iterator (the test fakes' shape) must not make interrupt raise."""
+    executor = DatabricksGenieExecutor(space_id="sp", client=FakeClient([]))
+    executor._active_stream = iter([])
+    assert _run(executor.interrupt_session("k")) is True
 
 
 # ---------------------------------------------------------------------------
@@ -1127,6 +1427,8 @@ def test_latest_user_text_no_user_message_returns_empty() -> None:
         ({"content": [{"text": "a"}, {"text": "b"}]}, "a\nb"),  # list of parts
         ({"content": ["a", "b"]}, "a\nb"),  # list of bare strings
         ({"content": "", "summary": "fallback"}, "fallback"),  # empty → next field
+        ({"content": "  ", "summary": "fallback"}, "fallback"),  # whitespace-only too
+        ({"content": ["  "], "summary": "fallback"}, "fallback"),  # …and as parts
         ({"content": [], "text": "last resort"}, "last resort"),  # neither field → ``text``
         ({}, ""),  # nothing to show
     ],
@@ -1159,6 +1461,10 @@ def test_latest_user_text_takes_the_last_user_turn_and_joins_parts() -> None:
         ("a\nb\tc  d", "a b c d"),  # newline/tab/double-space collapse to single spaces
         ("  trim  ", "trim"),  # leading/trailing whitespace stripped
         ("a|b", r"a\|b"),  # pipe escaped so it doesn't open a column
+        # A pre-escaped pipe would otherwise become ``\\|`` — an escaped
+        # backslash before a LIVE delimiter — so backslashes escape first.
+        ("a\\|b", "a\\\\\\|b"),
+        ("C:\\*.txt", "C:\\\\*.txt"),  # a lone backslash is doubled, not swallowed
         (1200, "1200"),  # non-str coerced via str()
     ],
 )
@@ -1233,3 +1539,41 @@ def test_render_table_truncates_beyond_the_row_cap() -> None:
 def test_render_table_single_omitted_row_is_singular() -> None:
     rows = [[str(i)] for i in range(_MAX_RESULT_ROWS + 1)]
     assert "… (1 more row)" in _render_table({"columns": ["i"], "preview_rows": rows})
+
+
+def test_render_table_reports_rows_genie_previewed_away_upstream() -> None:
+    """``preview_rows`` is itself a preview: ``total_row_count`` counts the full
+    result, so a 2-row preview of a 12,000-row result must say so."""
+    metadata = {
+        "columns": ["customer"],
+        "preview_rows": [["Acme"], ["Globex"]],
+        "total_row_count": 12000,
+    }
+    assert "… (11998 more rows)" in _render_table(metadata)
+
+
+def test_render_table_with_total_matching_the_preview_adds_no_footer() -> None:
+    """A complete preview (the common case on the wire) stays footer-free."""
+    metadata = {
+        "columns": ["customer"],
+        "preview_rows": [["Acme"], ["Globex"]],
+        "total_row_count": 2,
+    }
+    assert "more row" not in _render_table(metadata)
+
+
+def test_render_table_combines_upstream_total_with_the_local_cap() -> None:
+    """Local capping and upstream truncation fold into one honest footer."""
+    rows = [[str(i)] for i in range(_MAX_RESULT_ROWS + 5)]
+    rendered = _render_table({"columns": ["i"], "preview_rows": rows, "total_row_count": 100})
+    assert f"… ({100 - _MAX_RESULT_ROWS} more rows)" in rendered
+
+
+def test_render_table_ignores_a_malformed_total_row_count() -> None:
+    """A non-int total (Beta wire drift) falls back to counting preview rows."""
+    metadata = {
+        "columns": ["c"],
+        "preview_rows": [["v"]],
+        "total_row_count": "not-a-number",
+    }
+    assert "more row" not in _render_table(metadata)

--- a/tests/inner/test_databricks_genie_executor.py
+++ b/tests/inner/test_databricks_genie_executor.py
@@ -1,34 +1,50 @@
-"""Tests for :class:`DatabricksGenieExecutor` with a fake Genie client.
+"""Tests for :class:`DatabricksGenieExecutor` with a fake Responses client.
 
-The executor talks to a Databricks Genie space via ``WorkspaceClient.genie``. A
-small set of fakes mirror the ``databricks-sdk`` shapes the executor reads
-(``GenieMessage`` / ``GenieAttachment`` / ``StatementResponse``), so every branch
-is exercised without the SDK or a live workspace.
+The executor drives a Genie space in Agent mode over the Genie Responses API.
+A small set of fakes mirror the streamed shapes it reads — ``response.created``,
+``response.output_item.done`` items, ``response.failed``, ``response.completed``
+— so every branch is exercised without the OpenAI SDK, the Databricks SDK, or a
+live workspace.
+
+Two node shapes matter and both are covered: parsed models (attribute access)
+and raw dicts (key access). Genie's Agent mode is Beta and free to ship fields
+and item variants the installed SDK does not model, which it then leaves
+unvalidated, so the executor reads either shape deliberately.
 """
 
 from __future__ import annotations
 
 import asyncio
 import sys
-import types
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
+import httpx
 import pytest
 
+from omnigent.inner import databricks_executor
 from omnigent.inner.databricks_genie_executor import (
-    DatabricksGenieError,
+    _MAX_RESULT_ROWS,
     DatabricksGenieExecutor,
+    _block_separator,
     _extract_text,
     _latest_user_text,
     _md_cell,
-    _render_statement,
+    _parse_arguments,
+    _reasoning_text,
+    _render_table,
 )
 from omnigent.inner.executor import (
     ExecutorError,
+    ReasoningChunk,
     TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
     TurnComplete,
 )
+from omnigent.inner.open_responses_sdk import _OPENAI_KEY_PLACEHOLDER
 
 
 def _run(coro: Any) -> Any:
@@ -42,378 +58,1024 @@ def _run(coro: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Fakes mirroring the databricks-sdk Genie shapes the executor reads
+# Fakes mirroring the streamed Responses shapes the executor reads
 # ---------------------------------------------------------------------------
 
 
 @dataclass
-class FakeTextAttachment:
-    content: str | None = None
+class FakeError:
+    """Stand-in for the ``error`` object on a failed response."""
+
+    type: str = ""
+    code: str = ""
+    message: str = ""
 
 
 @dataclass
-class FakeQueryAttachment:
-    title: str | None = None
-    description: str | None = None
-    query: str | None = None
-    statement_id: str | None = "stmt-1"
+class FakeResponseInfo:
+    """Stand-in for the ``response`` object carried by lifecycle events."""
+
+    conversation_id: str | None = None
+    error: FakeError | None = None
+    incomplete_details: Any = None
 
 
 @dataclass
-class FakeAttachment:
-    text: FakeTextAttachment | None = None
-    query: FakeQueryAttachment | None = None
+class FakeEvent:
+    """Stand-in for one streamed SSE event."""
+
+    type: str
+    item: Any = None
+    response: FakeResponseInfo | None = None
 
 
 @dataclass
-class FakeMessage:
-    """Stand-in for ``GenieMessage``."""
+class FakeTextPart:
+    """``output_text`` content part; ``metadata`` carries Genie's result table."""
 
-    conversation_id: str | None = "conv-1"
-    message_id: str | None = "msg-1"
-    content: str | None = None
-    attachments: list[FakeAttachment] | None = None
-
-
-@dataclass
-class FakeColumn:
-    name: str = ""
+    text: str
+    type: str = "output_text"
+    metadata: Any = None
 
 
 @dataclass
-class FakeSchema:
-    columns: list[FakeColumn] = field(default_factory=list)
+class FakeMessageItem:
+    content: list[Any] = field(default_factory=list)
+    type: str = "message"
 
 
 @dataclass
-class FakeManifest:
-    schema: FakeSchema | None = None
+class FakeReasoningItem:
+    content: list[Any] = field(default_factory=list)
+    summary: list[Any] = field(default_factory=list)
+    type: str = "reasoning"
 
 
 @dataclass
-class FakeResultData:
-    data_array: list[list[Any]] | None = None
+class FakeFunctionCallItem:
+    name: str = "execute_sql"
+    arguments: str = "{}"
+    call_id: str = "call_1"
+    id: str = "fc_1"
+    type: str = "function_call"
 
 
-@dataclass
-class FakeStatementResponse:
-    manifest: FakeManifest | None = None
-    result: FakeResultData | None = None
+class FakeResponses:
+    """Stands in for ``client.responses``: records kwargs, replays a script.
+
+    ``error`` is public so a test can arm a failure between turns (the 409
+    "another turn is in progress" case only makes sense on a second call).
+    """
+
+    def __init__(self, events: Any = (), *, error: Exception | None = None) -> None:
+        self.events = events
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+        self.last_kwargs: dict[str, Any] = {}
+
+    def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        self.last_kwargs = kwargs
+        if self.error is not None:
+            raise self.error
+        return iter(self.events)
 
 
-class FakeGenie:
-    """Mimics ``WorkspaceClient.genie``, scripting one message per call."""
-
-    def __init__(
-        self,
-        message: FakeMessage,
-        *,
-        raise_on_send: Exception | None = None,
-    ) -> None:
-        self._message = message
-        self._raise_on_send = raise_on_send
-        self.start_calls: list[tuple[str, str]] = []
-        self.create_calls: list[tuple[str, str, str]] = []
-
-    def start_conversation_and_wait(
-        self, space_id: str, content: str, timeout: Any = None
-    ) -> FakeMessage:
-        self.start_calls.append((space_id, content))
-        if self._raise_on_send is not None:
-            raise self._raise_on_send
-        return self._message
-
-    def create_message_and_wait(
-        self, space_id: str, conversation_id: str, content: str, timeout: Any = None
-    ) -> FakeMessage:
-        self.create_calls.append((space_id, conversation_id, content))
-        if self._raise_on_send is not None:
-            raise self._raise_on_send
-        return self._message
+class FakeClient:
+    def __init__(self, events: Any = (), *, error: Exception | None = None) -> None:
+        self.responses = FakeResponses(events, error=error)
 
 
-class FakeStatementExecution:
-    """Mimics ``WorkspaceClient.statement_execution`` for result-row fetches."""
+class _Status4xx(Exception):
+    """Exception shaped like an OpenAI ``APIStatusError`` (carries a status code)."""
 
-    def __init__(
-        self,
-        statement: FakeStatementResponse | None = None,
-        *,
-        raise_on_get: Exception | None = None,
-    ) -> None:
-        self._statement = statement
-        self._raise_on_get = raise_on_get
-        self.get_calls: list[object] = []
-
-    def get_statement(self, statement_id: object) -> FakeStatementResponse | None:
-        self.get_calls.append(statement_id)
-        if self._raise_on_get is not None:
-            raise self._raise_on_get
-        return self._statement
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
-class FakeWorkspaceClient:
-    def __init__(
-        self, genie: FakeGenie, statement_execution: FakeStatementExecution | None = None
-    ) -> None:
-        self.genie = genie
-        self.statement_execution = statement_execution or FakeStatementExecution()
+def _created(conversation_id: str | None = None) -> FakeEvent:
+    return FakeEvent("response.created", response=FakeResponseInfo(conversation_id))
+
+
+def _item_done(item: Any) -> FakeEvent:
+    return FakeEvent("response.output_item.done", item=item)
+
+
+def _completed(conversation_id: str | None = None) -> FakeEvent:
+    return FakeEvent("response.completed", response=FakeResponseInfo(conversation_id))
+
+
+def _failed(**error: str) -> FakeEvent:
+    return FakeEvent("response.failed", response=FakeResponseInfo(error=FakeError(**error)))
+
+
+def _incomplete(reason: str | None = None) -> FakeEvent:
+    details = {"reason": reason} if reason is not None else None
+    return FakeEvent("response.incomplete", response=FakeResponseInfo(incomplete_details=details))
+
+
+def _error_event(**fields: str) -> dict[str, Any]:
+    """A bare ``error`` event — no ``response`` wrapper, fields at the top level."""
+    return {"type": "error", **fields}
+
+
+def _text_item(*parts: FakeTextPart) -> FakeMessageItem:
+    return FakeMessageItem(content=list(parts))
 
 
 def _user(text: str) -> dict[str, Any]:
     return {"role": "user", "content": text}
 
 
-def _events(executor: DatabricksGenieExecutor, messages: list[dict[str, Any]]) -> list[Any]:
+def _events(
+    executor: DatabricksGenieExecutor, messages: list[dict[str, Any]] | None = None
+) -> list[Any]:
     async def _collect() -> list[Any]:
-        return [e async for e in executor.run_turn(messages, [], "SYS")]
+        return [e async for e in executor.run_turn(messages or [_user("q")], [], "SYS")]
 
     return _run(_collect())
 
 
+def _texts(events: list[Any]) -> list[str]:
+    return [e.text for e in events if isinstance(e, TextChunk)]
+
+
+def _response(events: list[Any]) -> str | None:
+    return next(e.response for e in events if isinstance(e, TurnComplete))
+
+
 # ---------------------------------------------------------------------------
-# Happy paths
+# I/O matrix: first turn, follow-up turn, request shape
 # ---------------------------------------------------------------------------
 
 
-def test_text_only_answer_starts_conversation() -> None:
-    """A text-only Genie answer streams one TextChunk + TurnComplete."""
-    genie = FakeGenie(
-        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="42 sales"))])
+def test_first_turn_maps_every_item_kind_to_its_event() -> None:
+    """Reasoning, SQL, and report items become the matching executor events."""
+    client = FakeClient(
+        [
+            _created("conv-1"),
+            _item_done(
+                FakeReasoningItem(content=[{"type": "reasoning_text", "text": "Plan it."}])
+            ),
+            _item_done(FakeFunctionCallItem(arguments='{"query": "SELECT 1"}')),
+            _item_done({"type": "function_call_output", "call_id": "call_1", "output": "[[1]]"}),
+            _item_done(_text_item(FakeTextPart(text="One row."))),
+            _completed(),
+        ]
     )
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
 
-    events = _events(executor, [_user("how many sales?")])
+    events = _events(executor)
 
-    texts = [e.text for e in events if isinstance(e, TextChunk)]
-    completes = [e for e in events if isinstance(e, TurnComplete)]
-    assert texts == ["42 sales"]
-    assert len(completes) == 1 and completes[0].response == "42 sales"
-    # First turn → start_conversation, not create_message.
-    assert genie.start_calls == [("sp", "how many sales?")]
-    assert genie.create_calls == []
-
-
-def test_query_answer_includes_sql_and_result_rows() -> None:
-    """A query attachment renders title + SQL + the fetched result table."""
-    statement = FakeStatementResponse(
-        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("region"), FakeColumn("n")])),
-        result=FakeResultData(data_array=[["EMEA", "1200"], ["APAC", None]]),
-    )
-    genie = FakeGenie(
-        FakeMessage(
-            attachments=[
-                FakeAttachment(text=FakeTextAttachment(content="Here is the breakdown.")),
-                FakeAttachment(
-                    query=FakeQueryAttachment(
-                        title="By region",
-                        description="totals per region",
-                        query="SELECT region, count(*) n FROM s GROUP BY region",
-                        statement_id="stmt-region",
-                    )
-                ),
-            ]
-        ),
-    )
-    stmt_exec = FakeStatementExecution(statement)
-    executor = DatabricksGenieExecutor(
-        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
-    )
-
-    events = _events(executor, [_user("breakdown by region")])
-    response = next(e.response for e in events if isinstance(e, TurnComplete))
-
-    assert "Here is the breakdown." in response
-    assert 'Generated SQL ("By region"):' in response
-    assert "totals per region" in response
-    # SQL is wrapped in a fenced code block.
-    assert "```sql\nSELECT region, count(*) n FROM s GROUP BY region\n```" in response
-    # The result is a valid GFM table: header, delimiter, then data rows.
-    assert "Result (2 rows):" in response
-    assert "| region | n |" in response
-    assert "| --- | --- |" in response
-    assert "| EMEA | 1200 |" in response
-    # None cell rendered as an empty cell.
-    assert "| APAC |  |" in response
-    # The result is fetched via the Statement Execution API by statement id.
-    assert stmt_exec.get_calls == ["stmt-region"]
+    assert [type(e).__name__ for e in events] == [
+        "ReasoningChunk",
+        "ToolCallRequest",
+        "ToolCallComplete",
+        "TextChunk",
+        "TurnComplete",
+    ]
+    reasoning = next(e for e in events if isinstance(e, ReasoningChunk))
+    assert reasoning.delta == "Plan it."
+    assert reasoning.event_type == "reasoning_text"
+    assert _response(events) == "One row."
 
 
-def test_follow_up_turn_continues_conversation() -> None:
-    """The second turn reuses the stored conversation id via create_message."""
-    genie = FakeGenie(
-        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="ok"))])
-    )
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+def test_first_turn_request_omits_conversation_id() -> None:
+    """With no stored id, the request body carries no ``conversation_id``."""
+    client = FakeClient([_created("conv-1"), _completed()])
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
+
+    _events(executor, [_user("how many sales?")])
+
+    kwargs = client.responses.last_kwargs
+    assert kwargs["model"] == "genie-agent"
+    assert kwargs["stream"] is True
+    assert kwargs["input"] == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "how many sales?"}],
+        }
+    ]
+    assert "conversation_id" not in kwargs.get("extra_body", {})
+
+
+def test_follow_up_turn_sends_the_captured_conversation_id() -> None:
+    """The id from ``response.created`` is sent on the next turn's request."""
+    client = FakeClient([_created("conv-42"), _completed()])
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
 
     _events(executor, [_user("first")])
     _events(executor, [_user("second")])
 
-    assert genie.start_calls == [("sp", "first")]
-    assert genie.create_calls == [("sp", "conv-1", "second")]
+    assert "conversation_id" not in client.responses.calls[0].get("extra_body", {})
+    assert client.responses.calls[1]["extra_body"]["conversation_id"] == "conv-42"
 
 
-def test_message_content_fallback_when_no_attachments() -> None:
-    """With no attachments, the message's own content is used as the answer."""
-    genie = FakeGenie(FakeMessage(attachments=[], content="bare answer"))
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+def test_input_carries_only_the_latest_user_message() -> None:
+    """Genie owns the history, so prior turns are never replayed into ``input``."""
+    client = FakeClient([_created("conv-1"), _completed()])
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
 
-    events = _events(executor, [_user("q")])
-    assert next(e.response for e in events if isinstance(e, TurnComplete)) == "bare answer"
+    _events(
+        executor,
+        [
+            _user("old question"),
+            {"role": "assistant", "content": "old answer"},
+            _user("new question"),
+        ],
+    )
+
+    sent = client.responses.last_kwargs["input"]
+    assert len(sent) == 1
+    assert sent[0]["content"] == [{"type": "input_text", "text": "new question"}]
 
 
-def test_empty_answer_emits_turn_complete_without_text_chunk() -> None:
-    """An empty response yields only TurnComplete (no empty TextChunk)."""
-    genie = FakeGenie(FakeMessage(attachments=[], content=None))
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+def test_response_without_conversation_id_leaves_the_next_turn_fresh() -> None:
+    """No id in ``response.created`` → the follow-up starts a new conversation."""
+    client = FakeClient([_created(None), _completed()])
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
 
-    events = _events(executor, [_user("q")])
+    _events(executor, [_user("first")])
+    _events(executor, [_user("second")])
+
+    assert all("conversation_id" not in c.get("extra_body", {}) for c in client.responses.calls)
+
+
+def test_conversation_id_is_captured_from_response_completed() -> None:
+    """Genie may name the conversation only at the end; the next turn still continues it."""
+    client = FakeClient([_created(None), _completed("conv-late")])
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
+
+    _events(executor, [_user("first")])
+    _events(executor, [_user("second")])
+
+    assert "conversation_id" not in client.responses.calls[0].get("extra_body", {})
+    assert client.responses.calls[1]["extra_body"]["conversation_id"] == "conv-late"
+
+
+def test_enable_viz_is_sent_only_when_enabled() -> None:
+    """``enable_viz`` reaches ``extra_body`` as a real bool, and only when on."""
+    on = FakeClient([_completed()])
+    _events(DatabricksGenieExecutor(space_id="sp", client=on, enable_viz=True))
+    assert on.responses.last_kwargs["extra_body"] == {"enable_viz": True}
+
+    off = FakeClient([_completed()])
+    _events(DatabricksGenieExecutor(space_id="sp", client=off, enable_viz=False))
+    assert "enable_viz" not in off.responses.last_kwargs.get("extra_body", {})
+
+
+# ---------------------------------------------------------------------------
+# I/O matrix: table chunks
+# ---------------------------------------------------------------------------
+
+
+def test_table_chunk_is_re_rendered_from_metadata() -> None:
+    """A result chunk renders from ``columns``/``preview_rows``, not its Markdown."""
+    client = FakeClient(
+        [
+            _item_done(
+                _text_item(
+                    FakeTextPart(
+                        text="| unstable | model markdown |",
+                        metadata={
+                            "columns": [{"name": "region"}, {"name": "n"}],
+                            "preview_rows": [["EMEA", "1200"]],
+                        },
+                    )
+                )
+            ),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert _texts(events) == ["| region | n |\n| --- | --- |\n| EMEA | 1200 |"]
+    assert "unstable" not in (_response(events) or "")
+
+
+def test_table_chunk_without_metadata_emits_the_raw_text() -> None:
+    """No metadata → Genie's own text is all there is, so it passes through."""
+    client = FakeClient([_item_done(_text_item(FakeTextPart(text="just prose"))), _completed()])
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+    assert _texts(events) == ["just prose"]
+
+
+def test_fetch_failed_metadata_emits_the_raw_text() -> None:
+    """``status: fetch_failed`` disqualifies the rows even when some are present.
+
+    The stale preview below would otherwise render, so the raw text winning is
+    the status check doing its job — not the empty-metadata fallback.
+    """
+    client = FakeClient(
+        [
+            _item_done(
+                _text_item(
+                    FakeTextPart(
+                        text="Result unavailable.",
+                        metadata={
+                            "status": "fetch_failed",
+                            "columns": ["stale"],
+                            "preview_rows": [["do not render"]],
+                        },
+                    )
+                )
+            ),
+            _completed(),
+        ]
+    )
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+    assert _texts(events) == ["Result unavailable."]
+
+
+def test_metadata_without_rows_falls_back_to_the_raw_text() -> None:
+    """Metadata that renders nothing must not blank out the chunk."""
+    client = FakeClient(
+        [
+            _item_done(
+                _text_item(
+                    FakeTextPart(text="no rows", metadata={"columns": [{"name": "a"}]}),
+                )
+            ),
+            _completed(),
+        ]
+    )
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+    assert _texts(events) == ["no rows"]
+
+
+# ---------------------------------------------------------------------------
+# Separator: report parts must open their own Markdown block
+# ---------------------------------------------------------------------------
+
+
+def test_table_part_after_prose_starts_a_fresh_markdown_block() -> None:
+    """A table glued to the end of a sentence is not a table to any renderer."""
+    client = FakeClient(
+        [
+            _item_done(
+                _text_item(
+                    FakeTextPart(text="Here are your top customers [1](u)."),
+                    FakeTextPart(
+                        text="| ignored |",
+                        metadata={
+                            "columns": ["customer"],
+                            "preview_rows": [["Acme"]],
+                        },
+                    ),
+                )
+            ),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    chunks = _texts(events)
+    assert chunks[1].startswith("\n\n| customer |")
+    assert (
+        _response(events)
+        == "Here are your top customers [1](u).\n\n| customer |\n| --- |\n| Acme |"
+    )
+
+
+def test_part_already_ending_in_a_newline_gains_exactly_one() -> None:
+    """Topping up to a blank line must not produce three consecutive newlines."""
+    client = FakeClient(
+        [
+            _item_done(_text_item(FakeTextPart(text="first line\n"), FakeTextPart(text="second"))),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert _texts(events) == ["first line\n", "\nsecond"]
+    assert _response(events) == "first line\n\nsecond"
+
+
+def test_separator_spans_separate_message_items() -> None:
+    """Parts split across two message items are separated just the same."""
+    client = FakeClient(
+        [
+            _item_done(_text_item(FakeTextPart(text="prose"))),
+            _item_done(_text_item(FakeTextPart(text="more"))),
+            _completed(),
+        ]
+    )
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+    assert _texts(events) == ["prose", "\n\nmore"]
+
+
+@pytest.mark.parametrize(
+    ("previous", "expected"),
+    [
+        ("", ""),  # first chunk of the turn — nothing to separate from
+        ("prose", "\n\n"),  # no trailing newline → open a blank line
+        ("prose\n", "\n"),  # one already there → top up to two
+        ("prose\n\n", ""),  # already a blank line → add nothing
+        ("prose\n\n\n", ""),  # more than enough → never trim
+    ],
+)
+def test_block_separator(previous: str, expected: str) -> None:
+    assert _block_separator(previous) == expected
+
+
+def test_turn_complete_equals_the_concatenated_text_chunks() -> None:
+    """The load-bearing invariant: policy reads TurnComplete, the UI reads chunks."""
+    client = FakeClient(
+        [
+            _item_done(_text_item(FakeTextPart(text="alpha"))),
+            _item_done(
+                _text_item(
+                    FakeTextPart(text="beta\n"),
+                    FakeTextPart(
+                        text="| md |",
+                        metadata={"columns": ["c"], "preview_rows": [["v"]]},
+                    ),
+                )
+            ),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert _response(events) == "".join(_texts(events))
+
+
+# ---------------------------------------------------------------------------
+# I/O matrix: tool-call correlation
+# ---------------------------------------------------------------------------
+
+
+def test_call_and_output_share_one_non_empty_call_id() -> None:
+    """The adapter pairs strictly by ``call_id``; an unpaired event is dropped."""
+    client = FakeClient(
+        [
+            _item_done(
+                FakeFunctionCallItem(call_id="call_abc", arguments='{"query": "SELECT 1"}')
+            ),
+            _item_done({"type": "function_call_output", "call_id": "call_abc", "output": "ok"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    request = next(e for e in events if isinstance(e, ToolCallRequest))
+    complete = next(e for e in events if isinstance(e, ToolCallComplete))
+    assert request.metadata["call_id"] == complete.metadata["call_id"] == "call_abc"
+    assert request.name == complete.name == "execute_sql"
+    assert request.args == {"query": "SELECT 1"}
+    assert complete.result == "ok"
+
+
+def test_function_call_output_arriving_as_a_raw_dict_still_correlates() -> None:
+    """A raw-dict item correlates exactly like a parsed model does.
+
+    Agent mode is Beta and may stream item variants the installed SDK does not
+    model, which arrive unvalidated as plain dicts; key access must work exactly
+    like attribute access or those SQL calls render as perpetual in-progress
+    cards.
+    """
+    client = FakeClient(
+        [
+            _item_done(
+                {"type": "function_call", "call_id": "c9", "name": "run_sql", "arguments": "{}"}
+            ),
+            _item_done({"type": "function_call_output", "call_id": "c9", "output": {"rows": 2}}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    request = next(e for e in events if isinstance(e, ToolCallRequest))
+    complete = next(e for e in events if isinstance(e, ToolCallComplete))
+    assert request.metadata["call_id"] == complete.metadata["call_id"] == "c9"
+    assert request.name == complete.name == "run_sql"
+    assert complete.result == {"rows": 2}
+
+
+def test_id_less_call_and_output_are_paired_by_position() -> None:
+    """Genie may omit ids; a synthesized one still has to be shared and non-empty."""
+    client = FakeClient(
+        [
+            _item_done({"type": "function_call", "arguments": "{}"}),
+            _item_done({"type": "function_call_output", "output": "ok"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    request = next(e for e in events if isinstance(e, ToolCallRequest))
+    complete = next(e for e in events if isinstance(e, ToolCallComplete))
+    assert request.metadata["call_id"]
+    assert request.metadata["call_id"] == complete.metadata["call_id"]
+    # No name on either item → the observed-SQL default.
+    assert request.name == "execute_sql"
+
+
+def test_mixed_explicit_and_id_less_outputs_each_complete_their_own_call() -> None:
+    """An id-less output takes the oldest call still awaiting one, not the next by index.
+
+    Genie answers the second call first here; positional pairing that counted
+    every output would hand the id-less one to that same call twice and leave
+    the first call hanging.
+    """
+    client = FakeClient(
+        [
+            _item_done({"type": "function_call", "arguments": "{}"}),  # id-less → synthesized
+            _item_done({"type": "function_call", "call_id": "b", "arguments": "{}"}),
+            _item_done({"type": "function_call_output", "call_id": "b", "output": "second"}),
+            _item_done({"type": "function_call_output", "output": "first"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    requests = [e for e in events if isinstance(e, ToolCallRequest)]
+    completions = [e for e in events if isinstance(e, ToolCallComplete)]
+    synthesized = requests[0].metadata["call_id"]
+    assert synthesized and synthesized != "b"
+    assert [e.metadata["call_id"] for e in completions] == ["b", synthesized]
+    assert [e.result for e in completions] == ["second", "first"]
+
+
+def test_output_naming_an_unknown_call_is_dropped() -> None:
+    """An id we never issued must not produce a completion against another call."""
+    client = FakeClient(
+        [
+            _item_done(FakeFunctionCallItem(call_id="known")),
+            _item_done({"type": "function_call_output", "call_id": "stranger", "output": "?"}),
+            _item_done({"type": "function_call_output", "call_id": "known", "output": "ok"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    completions = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert [e.metadata["call_id"] for e in completions] == ["known"]
+    assert completions[0].result == "ok"
+
+
+def test_second_output_for_a_finished_call_is_dropped() -> None:
+    """One call, one completion — a repeat would render a duplicate result card."""
+    client = FakeClient(
+        [
+            _item_done(FakeFunctionCallItem(call_id="c1")),
+            _item_done({"type": "function_call_output", "call_id": "c1", "output": "first"}),
+            _item_done({"type": "function_call_output", "call_id": "c1", "output": "again"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    completions = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert [e.result for e in completions] == ["first"]
+
+
+def test_uncorrelatable_output_is_dropped_not_ghost_emitted() -> None:
+    """An output with no id and no preceding call cannot pair, so it is dropped."""
+    client = FakeClient(
+        [
+            _item_done({"type": "function_call_output", "output": "orphan"}),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["TurnComplete"]
+
+
+def test_malformed_call_arguments_are_preserved_not_assumed() -> None:
+    """Genie documents ``arguments`` keys as unstable, so non-JSON is kept raw."""
+    client = FakeClient(
+        [_item_done(FakeFunctionCallItem(arguments="not json at all")), _completed()]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    request = next(e for e in events if isinstance(e, ToolCallRequest))
+    assert request.args == {"raw": "not json at all"}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, {}),  # absent → nothing to show
+        ("", {}),  # empty string → nothing to show
+        ({"query": "SELECT 1"}, {"query": "SELECT 1"}),  # already a mapping
+        ('{"query": "SELECT 1"}', {"query": "SELECT 1"}),  # JSON object
+        ('["SELECT 1"]', {"raw": ["SELECT 1"]}),  # JSON, but not an object
+        (["SELECT 1"], {"raw": ["SELECT 1"]}),  # already decoded, not an object
+        (7, {"raw": 7}),  # a scalar is still worth showing
+        (False, {"raw": False}),  # falsy but present
+    ],
+)
+def test_parse_arguments_never_silently_drops_a_present_value(
+    raw: object, expected: dict[str, Any]
+) -> None:
+    """Unstable ``arguments`` shapes are preserved under ``raw``, not discarded."""
+    assert _parse_arguments(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# I/O matrix: failures and guard rails
+# ---------------------------------------------------------------------------
+
+
+def test_response_failed_emits_one_error_and_no_turn_complete() -> None:
+    """A terminal failure names ``type``, ``code``, and ``message`` — and stops."""
+    client = FakeClient(
+        [
+            _created("conv-1"),
+            _failed(type="INVALID_STATE", code="RESOURCE_EXHAUSTED", message="warehouse is down"),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "type=INVALID_STATE" in events[0].message
+    assert "code=RESOURCE_EXHAUSTED" in events[0].message
+    assert "warehouse is down" in events[0].message
+
+
+def test_error_event_is_terminal_like_a_failed_response() -> None:
+    """A bare ``error`` event carries its fields at the top level, not under ``response``."""
+    client = FakeClient(
+        [
+            _created("conv-1"),
+            _error_event(code="INTERNAL_ERROR", message="genie exploded"),
+            _completed(),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["ExecutorError"]
+    assert "code=INTERNAL_ERROR" in events[0].message
+    assert "genie exploded" in events[0].message
+
+
+def test_response_incomplete_errors_and_names_the_reason() -> None:
+    """Genie stopping early is a failed turn, not a short answer."""
+    client = FakeClient(
+        [
+            _item_done(_text_item(FakeTextPart(text="half an answer"))),
+            _incomplete("max_output_tokens"),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["TextChunk", "ExecutorError"]
+    assert "max_output_tokens" in events[-1].message
+
+
+def test_response_incomplete_without_details_still_errors() -> None:
+    """No ``incomplete_details`` → still terminal, just without a named reason."""
+    client = FakeClient([_created("conv-1"), _incomplete()])
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["ExecutorError"]
+    assert "reason=" not in events[0].message
+
+
+def test_stream_ending_without_a_terminal_event_is_not_a_completed_turn() -> None:
+    """A dropped connection truncates the report; reporting success would hide that."""
+    client = FakeClient([_created("conv-1"), _item_done(_text_item(FakeTextPart(text="half")))])
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["TextChunk", "ExecutorError"]
+    assert "ended before Genie completed the turn" in events[-1].message
+
+
+def test_unresolved_sql_call_is_cancelled_when_the_turn_fails() -> None:
+    """An unanswered call would otherwise render as a permanent in-progress card."""
+    client = FakeClient(
+        [
+            _item_done(FakeFunctionCallItem(call_id="call_x")),
+            _failed(type="INTERNAL", code="X", message="boom"),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == [
+        "ToolCallRequest",
+        "ToolCallComplete",
+        "ExecutorError",
+    ]
+    cancelled = events[1]
+    assert cancelled.status is ToolCallStatus.CANCELLED
+    assert cancelled.metadata["call_id"] == "call_x"
+    assert cancelled.name == "execute_sql"
+
+
+def test_resolved_sql_call_is_not_cancelled_when_the_stream_truncates() -> None:
+    """Only calls still awaiting an output are cancelled — no duplicate cards."""
+    client = FakeClient(
+        [
+            _item_done(FakeFunctionCallItem(call_id="c1")),
+            _item_done({"type": "function_call_output", "call_id": "c1", "output": "ok"}),
+        ]
+    )
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    completions = [e for e in events if isinstance(e, ToolCallComplete)]
+    assert [e.status for e in completions] == [ToolCallStatus.SUCCESS]
+    assert [type(e).__name__ for e in events][-1] == "ExecutorError"
+
+
+def test_feature_disabled_404_points_at_the_beta_preview() -> None:
+    """Agent mode is Beta; a 404 FEATURE_DISABLED is a workspace toggle, not a bug."""
+    client = FakeClient(error=_Status4xx(404, "FEATURE_DISABLED: genie agents"))
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "Beta" in events[0].message
+    assert "preview" in events[0].message
+
+
+def test_plain_404_does_not_claim_the_preview_is_disabled() -> None:
+    """A 404 without FEATURE_DISABLED is a bad space id, so keep the generic text."""
+    client = FakeClient(error=_Status4xx(404, "space not found"))
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+    assert "Beta" not in events[0].message
+    assert "space not found" in events[0].message
+
+
+def test_conflict_409_names_the_in_progress_conversation() -> None:
+    """409 means the previous turn is still generating for this conversation."""
+    client = FakeClient([_created("conv-77"), _completed()])
+    executor = DatabricksGenieExecutor(space_id="sp", client=client)
+    _events(executor, [_user("first")])
+
+    client.responses.error = _Status4xx(409, "RESOURCE_CONFLICT")
+    events = _events(executor, [_user("second")])
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "conv-77" in events[0].message
+    assert "in progress" in events[0].message
+
+
+def test_stream_error_mid_turn_becomes_one_executor_error() -> None:
+    """A transport failure while reading the stream ends the turn cleanly."""
+
+    def _explode() -> Any:
+        yield _item_done(_text_item(FakeTextPart(text="partial")))
+        raise RuntimeError("connection reset")
+
+    client = FakeClient(_explode())
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["TextChunk", "ExecutorError"]
+    assert "connection reset" in events[-1].message
+
+
+def test_missing_space_id_errors_without_any_http_call() -> None:
+    """No space id → an actionable ExecutorError, and the endpoint is never hit."""
+    client = FakeClient([_completed()])
+
+    events = _events(DatabricksGenieExecutor(space_id=None, client=client))
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "executor.model" in events[0].message
+    assert client.responses.calls == []
+
+
+def test_blank_user_text_errors_without_any_http_call() -> None:
+    """A whitespace-only prompt is not worth a request."""
+    client = FakeClient([_completed()])
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client), [_user("   ")])
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "no user message" in events[0].message
+    assert client.responses.calls == []
+
+
+def test_history_without_a_user_message_errors_without_any_http_call() -> None:
+    """An assistant-only history hits the same guard."""
+    client = FakeClient([_completed()])
+
+    events = _events(
+        DatabricksGenieExecutor(space_id="sp", client=client),
+        [{"role": "assistant", "content": "hello"}],
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert client.responses.calls == []
+
+
+def test_empty_report_completes_with_an_empty_response() -> None:
+    """A stream with no text yields TurnComplete("") and no empty TextChunk."""
+    client = FakeClient([_created("conv-1"), _completed()])
+
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
     assert [type(e).__name__ for e in events] == ["TurnComplete"]
     assert events[0].response == ""
 
 
-# ---------------------------------------------------------------------------
-# Error / guard paths
-# ---------------------------------------------------------------------------
-
-
-def test_missing_space_id_errors() -> None:
-    """No space id → an actionable ExecutorError, no SDK call."""
-    genie = FakeGenie(FakeMessage())
-    executor = DatabricksGenieExecutor(space_id=None, workspace_client=FakeWorkspaceClient(genie))
-
-    events = _events(executor, [_user("q")])
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-    assert "executor.model" in events[0].message
-    assert genie.start_calls == []
-
-
-def test_empty_user_message_errors() -> None:
-    """A blank/absent user message → ExecutorError before any SDK call."""
-    genie = FakeGenie(FakeMessage())
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
-
-    events = _events(executor, [_user("   ")])
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-    assert "no user message" in events[0].message
-    assert genie.start_calls == []
-
-
-def test_send_exception_becomes_executor_error() -> None:
-    """An SDK error during send (e.g. Genie message FAILED / timed out — the SDK's
-    ``*_and_wait`` raises ``OperationFailed`` — or auth failure) becomes an ExecutorError."""
-    genie = FakeGenie(FakeMessage(), raise_on_send=RuntimeError("workspace down"))
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
-
-    events = _events(executor, [_user("q")])
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-    assert "workspace down" in events[0].message
-
-
-def test_query_result_fetch_failure_is_best_effort() -> None:
-    """A result-fetch failure drops the table but keeps the SQL/text answer."""
-    genie = FakeGenie(
-        FakeMessage(
-            attachments=[
-                FakeAttachment(query=FakeQueryAttachment(query="SELECT 1")),
-            ]
-        ),
-    )
-    stmt_exec = FakeStatementExecution(raise_on_get=RuntimeError("result expired"))
-    executor = DatabricksGenieExecutor(
-        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
+def test_unknown_event_types_are_ignored() -> None:
+    """Genie's Beta stream may carry events we do not map; they must not break it."""
+    client = FakeClient(
+        [
+            FakeEvent("response.in_progress"),
+            FakeEvent("response.output_item.added", item=FakeFunctionCallItem()),
+            _item_done(_text_item(FakeTextPart(text="done"))),
+            _completed(),
+        ]
     )
 
-    events = _events(executor, [_user("q")])
-    response = next(e.response for e in events if isinstance(e, TurnComplete))
-    assert "Generated SQL:" in response
-    assert "SELECT 1" in response
-    assert "Result (" not in response
+    events = _events(DatabricksGenieExecutor(space_id="sp", client=client))
+
+    assert [type(e).__name__ for e in events] == ["TextChunk", "TurnComplete"]
 
 
-def test_query_attachment_without_sql_renders_description_only() -> None:
-    """A query attachment with a description but no SQL omits the SQL line."""
-    genie = FakeGenie(
-        FakeMessage(
-            attachments=[
-                FakeAttachment(query=FakeQueryAttachment(description="just a note", query=None))
-            ]
+# ---------------------------------------------------------------------------
+# Lazy client construction
+# ---------------------------------------------------------------------------
+
+
+class _FakeAuth(httpx.Auth):
+    """Stand-in for the refreshing Databricks bearer auth."""
+
+    token = "dapi-secret-token"
+
+    def auth_flow(self, request: httpx.Request) -> Any:
+        request.headers["Authorization"] = f"Bearer {self.token}"
+        yield request
+
+
+@pytest.fixture
+def _stub_databricks_auth(monkeypatch: pytest.MonkeyPatch) -> _FakeAuth:
+    """Resolve Databricks credentials to a fake auth + host, with no I/O."""
+    auth = _FakeAuth()
+    monkeypatch.setattr(
+        databricks_executor,
+        "_resolve_databricks_auth",
+        lambda profile=None, **_: (auth, "https://ws.example.com/"),
+    )
+    return auth
+
+
+def test_lazy_client_is_built_once_and_reused(_stub_databricks_auth: _FakeAuth) -> None:
+    """The client is constructed on first use and shared by every later turn."""
+    executor = DatabricksGenieExecutor(space_id="space-1", profile="dev")
+
+    client = executor._ensure_client("space-1")
+    try:
+        assert executor._ensure_client("space-1") is client
+        assert str(client.base_url).rstrip("/") == (
+            "https://ws.example.com/api/2.0/genie/agents/space-1"
         )
-    )
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
-    response = next(
-        e.response for e in _events(executor, [_user("q")]) if isinstance(e, TurnComplete)
-    )
-    assert "Generated SQL:" in response
-    assert "just a note" in response
+    finally:
+        client.close()
 
 
-def test_message_without_conversation_id_does_not_thread() -> None:
-    """A message lacking a conversation id leaves the next turn starting fresh."""
-    genie = FakeGenie(
-        FakeMessage(
-            conversation_id=None,
-            attachments=[FakeAttachment(text=FakeTextAttachment(content="ok"))],
-        )
-    )
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
+def test_lazy_client_never_snapshots_a_token(_stub_databricks_auth: _FakeAuth) -> None:
+    """Auth rides the per-request httpx hook so OAuth refresh keeps working."""
+    executor = DatabricksGenieExecutor(space_id="space-1", profile="dev")
 
-    _events(executor, [_user("first")])
-    _events(executor, [_user("second")])
-
-    # No conversation id was recorded, so both turns start a new conversation.
-    assert genie.start_calls == [("sp", "first"), ("sp", "second")]
-    assert genie.create_calls == []
+    client = executor._ensure_client("space-1")
+    try:
+        assert client.api_key == _OPENAI_KEY_PLACEHOLDER
+        assert _FakeAuth.token not in str(client.api_key)
+        # ``_client`` is the OpenAI SDK's httpx client; the auth hook living
+        # there is what makes the token per-request rather than a snapshot.
+        assert client._client.auth is _stub_databricks_auth
+    finally:
+        client.close()
 
 
-# ---------------------------------------------------------------------------
-# Lazy client construction (databricks-sdk import)
-# ---------------------------------------------------------------------------
+def test_lazy_client_applies_the_turn_timeout_and_disables_retries(
+    _stub_databricks_auth: _FakeAuth,
+) -> None:
+    """Genie's 409 is in the SDK's default retry set but is never retryable."""
+    executor = DatabricksGenieExecutor(space_id="space-1", timeout_seconds=900.0)
+
+    client = executor._ensure_client("space-1")
+    try:
+        assert client.timeout == 900.0
+        assert client.max_retries == 0
+    finally:
+        client.close()
 
 
-def test_lazy_client_built_from_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no injected client, a WorkspaceClient is built from the SDK once."""
-    genie = FakeGenie(
-        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="hi"))])
-    )
-    constructed: list[dict[str, Any]] = []
+def test_close_closes_an_owned_client_and_is_safe_twice(_stub_databricks_auth: _FakeAuth) -> None:
+    """Harness shutdown must release the connection pool this executor opened."""
+    executor = DatabricksGenieExecutor(space_id="space-1")
+    http_client = executor._ensure_client("space-1")._client  # type: ignore[attr-defined]
 
-    def _client_factory(**kwargs: Any) -> FakeWorkspaceClient:
-        constructed.append(kwargs)
-        return FakeWorkspaceClient(genie)
+    _run(executor.close())
 
-    fake_sdk = types.ModuleType("databricks.sdk")
-    fake_sdk.WorkspaceClient = _client_factory  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "databricks.sdk", fake_sdk)
-
-    executor = DatabricksGenieExecutor(space_id="sp", profile="dev")
-    events = _events(executor, [_user("q")])
-
-    assert next(e.response for e in events if isinstance(e, TurnComplete)) == "hi"
-    # Built exactly once, with the configured profile, then reused.
-    assert constructed == [{"profile": "dev"}]
-    _events(executor, [_user("again")])
-    assert len(constructed) == 1
+    assert http_client.is_closed
+    assert executor._client is None
+    _run(executor.close())  # second call must not raise
 
 
-def test_missing_sdk_errors_with_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A missing databricks-sdk surfaces an ExecutorError with an install hint."""
+def test_close_leaves_an_injected_client_alone() -> None:
+    """A client we did not build belongs to its caller, so closing must not touch it."""
+    injected = FakeClient([_completed()])
+    executor = DatabricksGenieExecutor(space_id="sp", client=injected)
 
+    _run(executor.close())
+
+    assert executor._client is injected
+
+
+def test_close_without_ever_building_a_client_is_a_no_op() -> None:
+    """A turn-less executor still gets closed at shutdown."""
+    _run(DatabricksGenieExecutor(space_id="sp").close())
+
+
+def test_failed_client_construction_does_not_orphan_the_http_client(
+    _stub_databricks_auth: _FakeAuth,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing else holds the pool if the OpenAI constructor rejects our arguments."""
+    built: list[httpx.Client] = []
+    real_client = httpx.Client
+
+    def _record(**kwargs: Any) -> httpx.Client:
+        client = real_client(**kwargs)
+        built.append(client)
+        return client
+
+    def _reject(**_: Any) -> Any:
+        raise TypeError("unexpected keyword argument")
+
+    monkeypatch.setattr(httpx, "Client", _record)
+    monkeypatch.setattr("openai.OpenAI", _reject)
+
+    executor = DatabricksGenieExecutor(space_id="sp")
+    with pytest.raises(TypeError):
+        executor._ensure_client("sp")
+
+    assert [c.is_closed for c in built] == [True]
+    assert executor._http_client is None
+
+
+def test_client_construction_runs_off_the_event_loop() -> None:
+    """Credential resolution blocks (file I/O + a token mint), so it needs a thread."""
+    built_on: list[int] = []
+    executor = DatabricksGenieExecutor(space_id="sp")
+
+    def _record(agent_id: str) -> object:
+        built_on.append(threading.get_ident())
+        return FakeClient([_completed()])
+
+    executor._ensure_client = _record  # type: ignore[method-assign]
+
+    async def _collect() -> int:
+        async for _ in executor.run_turn([_user("q")], [], "SYS"):
+            pass
+        return threading.get_ident()
+
+    loop_thread = _run(_collect())
+
+    assert built_on and built_on[0] != loop_thread
+
+
+def test_missing_databricks_sdk_names_the_package_and_the_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the SDK there is no way to authenticate; say what to install."""
     real_import = __import__
 
     def _no_databricks_sdk(name: str, *args: Any, **kwargs: Any) -> Any:
-        if name == "databricks.sdk":
-            raise ImportError("No module named 'databricks.sdk'")
+        if name.startswith("databricks.sdk"):
+            raise ImportError(f"No module named {name!r}")
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.delitem(sys.modules, "databricks.sdk", raising=False)
+    monkeypatch.delitem(sys.modules, "databricks.sdk.config", raising=False)
     monkeypatch.setattr("builtins.__import__", _no_databricks_sdk)
 
-    executor = DatabricksGenieExecutor(space_id="sp")
-    events = _events(executor, [_user("q")])
+    events = _events(DatabricksGenieExecutor(space_id="sp"))
 
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
@@ -422,14 +1084,21 @@ def test_missing_sdk_errors_with_install_hint(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
-# Capability flags & message extraction
+# Capability flags
 # ---------------------------------------------------------------------------
 
 
 def test_capability_flags() -> None:
+    """Streaming is real; Genie runs its own SQL so Session must not re-dispatch."""
     executor = DatabricksGenieExecutor(space_id="sp")
-    assert executor.supports_streaming() is False
+    assert executor.supports_streaming() is True
     assert executor.supports_tool_calling() is False
+    assert executor.handles_tools_internally() is True
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: message extraction
+# ---------------------------------------------------------------------------
 
 
 def test_extract_text_edge_cases() -> None:
@@ -450,34 +1119,35 @@ def test_latest_user_text_no_user_message_returns_empty() -> None:
     assert _latest_user_text([]) == ""
 
 
-def test_run_turn_with_no_user_role_errors() -> None:
-    """A history with no user message → the empty-prompt guard fires."""
-    genie = FakeGenie(FakeMessage())
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
-    events = _events(executor, [{"role": "assistant", "content": "hello"}])
-    assert len(events) == 1
-    assert isinstance(events[0], ExecutorError)
-    assert "no user message" in events[0].message
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        ({"content": "Plan it."}, "Plan it."),  # text directly on ``content``
+        ({"summary": "Summarized."}, "Summarized."),  # …or on ``summary``
+        ({"content": [{"text": "a"}, {"text": "b"}]}, "a\nb"),  # list of parts
+        ({"content": ["a", "b"]}, "a\nb"),  # list of bare strings
+        ({"content": "", "summary": "fallback"}, "fallback"),  # empty → next field
+        ({"content": [], "text": "last resort"}, "last resort"),  # neither field → ``text``
+        ({}, ""),  # nothing to show
+    ],
+)
+def test_reasoning_text_reads_either_shape(item: dict[str, Any], expected: str) -> None:
+    """Genie may carry planning as a string or a list of parts; both must surface."""
+    assert _reasoning_text(item) == expected
 
 
-def test_latest_user_text_handles_multimodal_parts() -> None:
-    """The latest user message wins, and list-of-parts content is joined."""
-    genie = FakeGenie(
-        FakeMessage(attachments=[FakeAttachment(text=FakeTextAttachment(content="ok"))])
-    )
-    executor = DatabricksGenieExecutor(space_id="sp", workspace_client=FakeWorkspaceClient(genie))
-
+def test_latest_user_text_takes_the_last_user_turn_and_joins_parts() -> None:
+    """The newest user message wins, and list-of-parts content is joined."""
     messages = [
         {"role": "user", "content": "old"},
         {"role": "assistant", "content": "ignored"},
         {"role": "user", "content": [{"type": "text", "text": "hello"}, {"type": "image"}]},
     ]
-    _events(executor, messages)
-    assert genie.start_calls == [("sp", "hello")]
+    assert _latest_user_text(messages) == "hello"
 
 
 # ---------------------------------------------------------------------------
-# _md_cell / _render_statement (pure helpers) — table formatting
+# Pure helpers: table formatting
 # ---------------------------------------------------------------------------
 
 
@@ -496,112 +1166,70 @@ def test_md_cell(value: object, expected: str) -> None:
     assert _md_cell(value) == expected
 
 
-def test_render_statement_no_rows_returns_empty() -> None:
-    assert _render_statement(FakeStatementResponse(result=FakeResultData(data_array=[]))) == ""
-    assert _render_statement(FakeStatementResponse(result=None)) == ""
+def test_render_table_without_rows_returns_empty() -> None:
+    assert _render_table({"columns": ["a"], "preview_rows": []}) == ""
+    assert _render_table({"columns": ["a"]}) == ""
+    assert _render_table(None) == ""
 
 
-def test_render_statement_without_columns_synthesizes_headers() -> None:
-    """With no schema, generic ``col1, col2`` headers keep the table valid GFM."""
-    stmt = FakeStatementResponse(
-        manifest=None,
-        result=FakeResultData(data_array=[["a", "b"]]),
-    )
-    rendered = _render_statement(stmt)
-    assert rendered == "Result (1 row):\n\n| col1 | col2 |\n| --- | --- |\n| a | b |"
+def test_render_table_emits_valid_gfm() -> None:
+    """Header row, delimiter row, then one line per preview row."""
+    metadata = {
+        "columns": [{"name": "region"}, {"name": "n"}],
+        "preview_rows": [["EMEA", "1200"]],
+    }
+    assert _render_table(metadata) == "| region | n |\n| --- | --- |\n| EMEA | 1200 |"
 
 
-def test_render_statement_emits_valid_gfm_table() -> None:
-    """Header row, delimiter row, blank-line separation, and pipe-bounded cells."""
-    stmt = FakeStatementResponse(
-        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("region"), FakeColumn("n")])),
-        result=FakeResultData(data_array=[["EMEA", "1200"]]),
-    )
-    assert _render_statement(stmt) == (
-        "Result (1 row):\n\n| region | n |\n| --- | --- |\n| EMEA | 1200 |"
-    )
+def test_render_table_accepts_plain_string_columns() -> None:
+    """Genie may name columns as bare strings rather than objects."""
+    metadata = {"columns": ["a", "b"], "preview_rows": [["1", "2"]]}
+    assert _render_table(metadata) == "| a | b |\n| --- | --- |\n| 1 | 2 |"
 
 
-def test_render_statement_pads_ragged_rows() -> None:
+def test_render_table_accepts_keyed_rows() -> None:
+    """Rows keyed by column name are ordered by the header, not by dict order."""
+    metadata = {
+        "columns": ["first", "second"],
+        "preview_rows": [{"second": "B", "first": "A"}],
+    }
+    assert _render_table(metadata) == "| first | second |\n| --- | --- |\n| A | B |"
+
+
+def test_render_table_without_columns_synthesizes_headers() -> None:
+    """With no column metadata, generic ``col1, col2`` keeps the table valid GFM."""
+    metadata = {"preview_rows": [["a", "b"]]}
+    assert _render_table(metadata) == "| col1 | col2 |\n| --- | --- |\n| a | b |"
+
+
+def test_render_table_takes_headers_from_keyed_rows_when_columns_are_absent() -> None:
+    """Keyed rows know their own labels; without them the row renders as blanks."""
+    metadata = {"preview_rows": [{"region": "EMEA", "n": "3"}]}
+    assert _render_table(metadata) == "| region | n |\n| --- | --- |\n| EMEA | 3 |"
+
+
+def test_render_table_pads_ragged_rows() -> None:
     """A row shorter than the column count is padded with empty cells."""
-    stmt = FakeStatementResponse(
-        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("a"), FakeColumn("b")])),
-        result=FakeResultData(data_array=[["x"]]),
-    )
-    assert _render_statement(stmt) == "Result (1 row):\n\n| a | b |\n| --- | --- |\n| x |  |"
+    metadata = {"columns": ["a", "b"], "preview_rows": [["x"]]}
+    assert _render_table(metadata) == "| a | b |\n| --- | --- |\n| x |  |"
 
 
-def test_render_statement_sanitizes_multiline_cells() -> None:
-    """A multi-line / pipe-bearing cell is collapsed to one row so the table holds."""
-    stmt = FakeStatementResponse(
-        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("review")])),
-        result=FakeResultData(data_array=[["line one\nline two | tail"]]),
-    )
-    assert _render_statement(stmt) == (
-        "Result (1 row):\n\n| review |\n| --- |\n| line one line two \\| tail |"
-    )
+def test_render_table_sanitizes_multiline_and_piped_cells() -> None:
+    """A multi-line / pipe-bearing cell is collapsed so the table holds together."""
+    metadata = {"columns": ["review"], "preview_rows": [["line one\nline two | tail"]]}
+    assert _render_table(metadata) == "| review |\n| --- |\n| line one line two \\| tail |"
 
 
-def test_render_statement_truncates_beyond_cap() -> None:
-    rows = [[str(i)] for i in range(55)]
-    stmt = FakeStatementResponse(
-        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("i")])),
-        result=FakeResultData(data_array=rows),
-    )
-    rendered = _render_statement(stmt)
-    assert "Result (55 rows):" in rendered
+def test_render_table_truncates_beyond_the_row_cap() -> None:
+    """Genie previews upstream; this is our own bound on what we echo back."""
+    rows = [[str(i)] for i in range(_MAX_RESULT_ROWS + 5)]
+    rendered = _render_table({"columns": ["i"], "preview_rows": rows})
+
     assert "… (5 more rows)" in rendered
-    assert "| --- |" in rendered
-    # Exactly the first 50 rows are shown; row index 50+ is summarized away.
-    assert "| 49 |" in rendered
-    assert "| 50 |" not in rendered
+    assert f"| {_MAX_RESULT_ROWS - 1} |" in rendered
+    assert f"| {_MAX_RESULT_ROWS} |" not in rendered
 
 
-def test_render_statement_single_omitted_row_is_singular() -> None:
-    rows = [[str(i)] for i in range(51)]
-    stmt = FakeStatementResponse(
-        manifest=FakeManifest(schema=FakeSchema(columns=[FakeColumn("i")])),
-        result=FakeResultData(data_array=rows),
-    )
-    assert "… (1 more row)" in _render_statement(stmt)
-
-
-def test_statement_with_no_rows_renders_no_table() -> None:
-    """A statement that resolves with no rows renders the SQL but no table."""
-    genie = FakeGenie(
-        FakeMessage(attachments=[FakeAttachment(query=FakeQueryAttachment(query="SELECT 1"))]),
-    )
-    stmt_exec = FakeStatementExecution(
-        FakeStatementResponse(result=FakeResultData(data_array=None))
-    )
-    executor = DatabricksGenieExecutor(
-        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
-    )
-    events = _events(executor, [_user("q")])
-    response = next(e.response for e in events if isinstance(e, TurnComplete))
-    assert "SELECT 1" in response
-    assert "Result (" not in response
-
-
-def test_query_with_missing_statement_id_skips_result_fetch() -> None:
-    """No statement id → the result table is skipped without an SDK call."""
-    genie = FakeGenie(
-        FakeMessage(
-            attachments=[
-                FakeAttachment(query=FakeQueryAttachment(query="SELECT 1", statement_id=None))
-            ],
-        )
-    )
-    stmt_exec = FakeStatementExecution()
-    executor = DatabricksGenieExecutor(
-        space_id="sp", workspace_client=FakeWorkspaceClient(genie, stmt_exec)
-    )
-    events = _events(executor, [_user("q")])
-    response = next(e.response for e in events if isinstance(e, TurnComplete))
-    assert "SELECT 1" in response
-    assert stmt_exec.get_calls == []
-
-
-def test_genie_error_str() -> None:
-    """The custom error type carries its message (used in ExecutorError text)."""
-    assert "boom" in str(DatabricksGenieError("boom"))
+def test_render_table_single_omitted_row_is_singular() -> None:
+    rows = [[str(i)] for i in range(_MAX_RESULT_ROWS + 1)]
+    assert "… (1 more row)" in _render_table({"columns": ["i"], "preview_rows": rows})

--- a/tests/inner/test_databricks_genie_harness.py
+++ b/tests/inner/test_databricks_genie_harness.py
@@ -1,0 +1,85 @@
+"""Tests for the ``harness: databricks-genie`` wrap shape.
+
+Verifies the registry entry, FastAPI routes, and env-var-driven lazy executor
+construction. ``DatabricksGenieExecutor.__init__`` is mocked so the test runs
+without ``databricks-sdk`` or a live workspace.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner import databricks_genie_harness
+from omnigent.inner.databricks_genie_executor import _DEFAULT_TIMEOUT_SECONDS
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+
+
+def test_harness_module_registered_in_module_registry() -> None:
+    assert _HARNESS_MODULES.get("databricks-genie") == "omnigent.inner.databricks_genie_harness"
+
+
+def test_create_app_returns_fastapi_with_required_routes() -> None:
+    app = databricks_genie_harness.create_app()
+    paths = {route.path for route in app.routes}  # type: ignore[attr-defined]
+    assert "/health" in paths
+    assert "/v1/sessions/{conversation_id}/events" in paths
+
+
+def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_MODEL", "space-123")
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_PROFILE", "dev")
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "120")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.databricks_genie_harness.DatabricksGenieExecutor.__init__",
+        _fake_init,
+    ):
+        databricks_genie_harness._build_databricks_genie_executor()
+
+    assert captured["space_id"] == "space-123"
+    assert captured["profile"] == "dev"
+    assert captured["timeout_seconds"] == 120.0
+
+
+def test_executor_factory_unset_optional_env_passes_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "HARNESS_DATABRICKS_GENIE_MODEL",
+        "HARNESS_DATABRICKS_GENIE_PROFILE",
+        "HARNESS_DATABRICKS_GENIE_TIMEOUT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.databricks_genie_harness.DatabricksGenieExecutor.__init__",
+        _fake_init,
+    ):
+        databricks_genie_harness._build_databricks_genie_executor()
+
+    assert captured["space_id"] is None
+    assert captured["profile"] is None
+    assert captured["timeout_seconds"] == _DEFAULT_TIMEOUT_SECONDS
+
+
+def test_malformed_timeout_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "not-a-number")
+    assert databricks_genie_harness._resolve_timeout() == _DEFAULT_TIMEOUT_SECONDS
+
+
+def test_valid_timeout_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "45.5")
+    assert databricks_genie_harness._resolve_timeout() == 45.5

--- a/tests/inner/test_databricks_genie_harness.py
+++ b/tests/inner/test_databricks_genie_harness.py
@@ -28,10 +28,21 @@ def test_create_app_returns_fastapi_with_required_routes() -> None:
     assert "/v1/sessions/{conversation_id}/events" in paths
 
 
-def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_MODEL", "space-123")
-    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_PROFILE", "dev")
-    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "120")
+def _build_with_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str]) -> dict[str, Any]:
+    """Build the executor under *env* and return the kwargs it was given.
+
+    Every ``HARNESS_DATABRICKS_GENIE_*`` var absent from *env* is cleared, so a
+    developer's real shell can't leak into the expectations.
+    """
+    for var in (
+        "HARNESS_DATABRICKS_GENIE_MODEL",
+        "HARNESS_DATABRICKS_GENIE_PROFILE",
+        "HARNESS_DATABRICKS_GENIE_TIMEOUT",
+        "HARNESS_DATABRICKS_GENIE_ENABLE_VIZ",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
 
     captured: dict[str, Any] = {}
 
@@ -43,36 +54,40 @@ def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> Non
         _fake_init,
     ):
         databricks_genie_harness._build_databricks_genie_executor()
+    return captured
+
+
+def test_executor_factory_reads_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _build_with_env(
+        monkeypatch,
+        {
+            "HARNESS_DATABRICKS_GENIE_MODEL": "space-123",
+            "HARNESS_DATABRICKS_GENIE_PROFILE": "dev",
+            "HARNESS_DATABRICKS_GENIE_TIMEOUT": "120",
+            "HARNESS_DATABRICKS_GENIE_ENABLE_VIZ": "true",
+        },
+    )
 
     assert captured["space_id"] == "space-123"
     assert captured["profile"] == "dev"
     assert captured["timeout_seconds"] == 120.0
+    assert captured["enable_viz"] is True
 
 
 def test_executor_factory_unset_optional_env_passes_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for var in (
-        "HARNESS_DATABRICKS_GENIE_MODEL",
-        "HARNESS_DATABRICKS_GENIE_PROFILE",
-        "HARNESS_DATABRICKS_GENIE_TIMEOUT",
-    ):
-        monkeypatch.delenv(var, raising=False)
-
-    captured: dict[str, Any] = {}
-
-    def _fake_init(self: Any, **kwargs: Any) -> None:
-        captured.update(kwargs)
-
-    with patch(
-        "omnigent.inner.databricks_genie_harness.DatabricksGenieExecutor.__init__",
-        _fake_init,
-    ):
-        databricks_genie_harness._build_databricks_genie_executor()
+    captured = _build_with_env(monkeypatch, {})
 
     assert captured["space_id"] is None
     assert captured["profile"] is None
     assert captured["timeout_seconds"] == _DEFAULT_TIMEOUT_SECONDS
+    assert captured["enable_viz"] is False
+
+
+def test_default_timeout_leaves_room_for_a_real_warehouse_query() -> None:
+    """An Agent-mode turn plans, queries, and writes a report — 300s was too tight."""
+    assert _DEFAULT_TIMEOUT_SECONDS == 900.0
 
 
 def test_malformed_timeout_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -83,3 +98,50 @@ def test_malformed_timeout_falls_back_to_default(monkeypatch: pytest.MonkeyPatch
 def test_valid_timeout_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "45.5")
     assert databricks_genie_harness._resolve_timeout() == 45.5
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "0",  # every request would time out immediately
+        "0.0",
+        "-1",  # negative deadlines are not a deadline
+        "nan",  # parses as a float, but bounds nothing
+        "inf",  # a wedged stream would hang forever
+        "-inf",
+    ],
+)
+def test_unusable_timeout_falls_back_to_default(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    """Only a positive, finite number of seconds is a usable HTTP deadline."""
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", raw)
+    assert databricks_genie_harness._resolve_timeout() == _DEFAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # ``executor.config`` scalars arrive stringified, so a YAML ``true``
+        # reaches the wrap as ``"True"`` — the spelling that matters most.
+        ("True", True),
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("  true  ", True),
+        ("False", False),
+        ("false", False),
+        ("0", False),
+        ("", False),
+        # Not a boolean spelling we accept: stay off rather than guess.
+        ("yes", False),
+        ("nonsense", False),
+    ],
+)
+def test_enable_viz_env_parsing(monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool) -> None:
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_ENABLE_VIZ", raw)
+    assert databricks_genie_harness._resolve_enable_viz() is expected
+
+
+def test_enable_viz_defaults_off_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Visualizations are opt-in, so an unset var must not enable them."""
+    monkeypatch.delenv("HARNESS_DATABRICKS_GENIE_ENABLE_VIZ", raising=False)
+    assert databricks_genie_harness._resolve_enable_viz() is False

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -341,6 +341,9 @@ def test_configured_harness_map_covers_all_spellings(
         # Generic ACP harness — config-gated (≥1 agent in the acp: block), no CLI
         # binary of its own; the acp:<slug> picks are config-derived, not keyed here.
         "acp",
+        # Databricks Genie Spaces SDK harness + its short alias.
+        "databricks-genie",
+        "genie",
     }
     assert set(result) == expected_keys
 

--- a/tests/runtime/test_databricks_genie_spawn_env.py
+++ b/tests/runtime/test_databricks_genie_spawn_env.py
@@ -1,0 +1,99 @@
+"""
+Tests for ``_build_databricks_genie_spawn_env`` in ``omnigent/runtime/workflow.py``.
+
+The builder maps ``spec`` fields to the ``HARNESS_DATABRICKS_GENIE_*`` env vars
+the databricks-genie harness wrap reads at first-turn time: the Genie space id
+from ``executor.model`` and the Databricks profile from ``executor.auth``
+(``type: databricks``) or the legacy ``executor.profile`` /
+``executor.config["profile"]``. There is NO gateway / base-URL resolution.
+
+This is a unit test — no subprocess spawn. Mirrors ``test_cursor_spawn_env.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.runtime.workflow import _build_databricks_genie_spawn_env
+from omnigent.spec.types import (
+    AgentSpec,
+    ApiKeyAuth,
+    DatabricksAuth,
+    ExecutorSpec,
+    LLMConfig,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point OMNIGENT_CONFIG_HOME at an empty temp dir so the developer's real
+    ``~/.omnigent/config.yaml`` can't leak into resolution."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+
+def _make_spec(
+    *,
+    model: str | None = "space-xyz",
+    profile: str | None = None,
+    config_profile: str | None = None,
+    auth: ApiKeyAuth | DatabricksAuth | None = None,
+) -> AgentSpec:
+    """Build a minimal databricks-genie :class:`AgentSpec` for the tests."""
+    config: dict[str, object] = {"harness": "databricks-genie"}
+    if model is not None:
+        config["model"] = model
+    if config_profile is not None:
+        config["profile"] = config_profile
+    return AgentSpec(
+        spec_version=1,
+        name="test-genie",
+        instructions="You are a test agent.",
+        executor=ExecutorSpec(
+            type="omnigent", config=config, model=model, profile=profile, auth=auth
+        ),
+        llm=LLMConfig(model=model) if model is not None else None,
+    )
+
+
+def test_model_threads_into_space_id_env_var() -> None:
+    """``executor.model`` (the space id) → ``HARNESS_DATABRICKS_GENIE_MODEL``."""
+    env = _build_databricks_genie_spawn_env(_make_spec(model="space-xyz"))
+    assert env["HARNESS_DATABRICKS_GENIE_MODEL"] == "space-xyz"
+
+
+def test_no_model_produces_no_model_env_var() -> None:
+    """A spec with no model omits the space-id env var (surfaces as a turn error)."""
+    env = _build_databricks_genie_spawn_env(_make_spec(model=None))
+    assert "HARNESS_DATABRICKS_GENIE_MODEL" not in env
+
+
+def test_databricks_auth_profile_threads_into_env() -> None:
+    """``executor.auth: {type: databricks, profile}`` → the profile env var."""
+    env = _build_databricks_genie_spawn_env(_make_spec(auth=DatabricksAuth(profile="oss")))
+    assert env["HARNESS_DATABRICKS_GENIE_PROFILE"] == "oss"
+
+
+def test_legacy_executor_profile_threads_into_env() -> None:
+    """The legacy ``executor.profile`` shorthand still resolves the profile."""
+    env = _build_databricks_genie_spawn_env(_make_spec(profile="legacy"))
+    assert env["HARNESS_DATABRICKS_GENIE_PROFILE"] == "legacy"
+
+
+def test_legacy_config_profile_threads_into_env() -> None:
+    """The legacy ``executor.config["profile"]`` shorthand resolves the profile."""
+    env = _build_databricks_genie_spawn_env(_make_spec(config_profile="cfgprof"))
+    assert env["HARNESS_DATABRICKS_GENIE_PROFILE"] == "cfgprof"
+
+
+def test_no_profile_omits_profile_env_var() -> None:
+    """With no auth and no legacy profile, the profile env var is omitted."""
+    env = _build_databricks_genie_spawn_env(_make_spec())
+    assert "HARNESS_DATABRICKS_GENIE_PROFILE" not in env
+
+
+def test_api_key_auth_does_not_set_profile() -> None:
+    """A non-Databricks (api_key) auth has no profile; the env var is omitted."""
+    env = _build_databricks_genie_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="k")))
+    assert "HARNESS_DATABRICKS_GENIE_PROFILE" not in env

--- a/tests/runtime/test_databricks_genie_spawn_env.py
+++ b/tests/runtime/test_databricks_genie_spawn_env.py
@@ -3,9 +3,10 @@ Tests for ``_build_databricks_genie_spawn_env`` in ``omnigent/runtime/workflow.p
 
 The builder maps ``spec`` fields to the ``HARNESS_DATABRICKS_GENIE_*`` env vars
 the databricks-genie harness wrap reads at first-turn time: the Genie space id
-from ``executor.model`` and the Databricks profile from ``executor.auth``
+from ``executor.model``, the Databricks profile from ``executor.auth``
 (``type: databricks``) or the legacy ``executor.profile`` /
-``executor.config["profile"]``. There is NO gateway / base-URL resolution.
+``executor.config["profile"]``, and the visualization opt-in from
+``executor.config["enable_viz"]``. There is NO gateway / base-URL resolution.
 
 This is a unit test — no subprocess spawn. Mirrors ``test_cursor_spawn_env.py``.
 """
@@ -38,14 +39,22 @@ def _make_spec(
     model: str | None = "space-xyz",
     profile: str | None = None,
     config_profile: str | None = None,
+    enable_viz: str | None = None,
     auth: ApiKeyAuth | DatabricksAuth | None = None,
 ) -> AgentSpec:
-    """Build a minimal databricks-genie :class:`AgentSpec` for the tests."""
+    """Build a minimal databricks-genie :class:`AgentSpec` for the tests.
+
+    :param enable_viz: Value for ``executor.config["enable_viz"]``. The spec
+        parser stringifies config scalars, so a YAML ``true`` reaches the
+        builder as ``"True"`` — pass the string form the parser would produce.
+    """
     config: dict[str, object] = {"harness": "databricks-genie"}
     if model is not None:
         config["model"] = model
     if config_profile is not None:
         config["profile"] = config_profile
+    if enable_viz is not None:
+        config["enable_viz"] = enable_viz
     return AgentSpec(
         spec_version=1,
         name="test-genie",
@@ -97,3 +106,21 @@ def test_api_key_auth_does_not_set_profile() -> None:
     """A non-Databricks (api_key) auth has no profile; the env var is omitted."""
     env = _build_databricks_genie_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="k")))
     assert "HARNESS_DATABRICKS_GENIE_PROFILE" not in env
+
+
+def test_enable_viz_true_threads_into_env() -> None:
+    """``executor.config: {enable_viz: true}`` → the env var, as its string form."""
+    env = _build_databricks_genie_spawn_env(_make_spec(enable_viz="True"))
+    assert env["HARNESS_DATABRICKS_GENIE_ENABLE_VIZ"] == "True"
+
+
+def test_enable_viz_false_threads_into_env() -> None:
+    """An explicit ``false`` is still exported; the wrap parses it back to off."""
+    env = _build_databricks_genie_spawn_env(_make_spec(enable_viz="False"))
+    assert env["HARNESS_DATABRICKS_GENIE_ENABLE_VIZ"] == "False"
+
+
+def test_unset_enable_viz_omits_the_env_var() -> None:
+    """No key in ``executor.config`` → no env var at all, not an empty one."""
+    env = _build_databricks_genie_spawn_env(_make_spec())
+    assert "HARNESS_DATABRICKS_GENIE_ENABLE_VIZ" not in env

--- a/tests/runtime/test_databricks_genie_spawn_env.py
+++ b/tests/runtime/test_databricks_genie_spawn_env.py
@@ -6,7 +6,9 @@ the databricks-genie harness wrap reads at first-turn time: the Genie space id
 from ``executor.model``, the Databricks profile from ``executor.auth``
 (``type: databricks``) or the legacy ``executor.profile`` /
 ``executor.config["profile"]``, and the visualization opt-in from
-``executor.config["enable_viz"]``. There is NO gateway / base-URL resolution.
+``executor.config["enable_viz"]``. It also sizes the scaffold idle watchdog
+(``HARNESS_TURN_TIMEOUT_S``) above the stream idle timeout unless the ambient
+environment already sets it. There is NO gateway / base-URL resolution.
 
 This is a unit test — no subprocess spawn. Mirrors ``test_cursor_spawn_env.py``.
 """
@@ -124,3 +126,54 @@ def test_unset_enable_viz_omits_the_env_var() -> None:
     """No key in ``executor.config`` → no env var at all, not an empty one."""
     env = _build_databricks_genie_spawn_env(_make_spec())
     assert "HARNESS_DATABRICKS_GENIE_ENABLE_VIZ" not in env
+
+
+def test_executor_profile_wins_over_config_profile() -> None:
+    """Both legacy spellings set → ``executor.profile`` wins, matching
+    ``_resolve_provider_for_build``'s precedence."""
+    env = _build_databricks_genie_spawn_env(
+        _make_spec(profile="from-executor", config_profile="from-config")
+    )
+    assert env["HARNESS_DATABRICKS_GENIE_PROFILE"] == "from-executor"
+
+
+@pytest.fixture
+def _clear_watchdog_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip the ambient watchdog / genie-timeout vars so sizing is deterministic."""
+    monkeypatch.delenv("HARNESS_TURN_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", raising=False)
+
+
+def test_watchdog_sized_above_the_default_stream_idle_timeout(
+    _clear_watchdog_env: None,
+) -> None:
+    """With nothing configured, the watchdog sits one margin above the 900s default."""
+    env = _build_databricks_genie_spawn_env(_make_spec())
+    assert env["HARNESS_TURN_TIMEOUT_S"] == "960.0"
+
+
+def test_watchdog_sized_above_an_ambient_genie_timeout(
+    _clear_watchdog_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raised stream idle timeout raises the watchdog with it."""
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "1200")
+    env = _build_databricks_genie_spawn_env(_make_spec())
+    assert env["HARNESS_TURN_TIMEOUT_S"] == "1260.0"
+
+
+def test_ambient_watchdog_setting_wins(
+    _clear_watchdog_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator-set ``HARNESS_TURN_TIMEOUT_S`` is inherited, never overridden."""
+    monkeypatch.setenv("HARNESS_TURN_TIMEOUT_S", "300")
+    env = _build_databricks_genie_spawn_env(_make_spec())
+    assert "HARNESS_TURN_TIMEOUT_S" not in env
+
+
+def test_malformed_genie_timeout_falls_back_to_default_watchdog_sizing(
+    _clear_watchdog_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-positive genie timeout falls back to the default before sizing."""
+    monkeypatch.setenv("HARNESS_DATABRICKS_GENIE_TIMEOUT", "-5")
+    env = _build_databricks_genie_spawn_env(_make_spec())
+    assert env["HARNESS_TURN_TIMEOUT_S"] == "960.0"

--- a/tests/test_harness_aliases.py
+++ b/tests/test_harness_aliases.py
@@ -131,3 +131,15 @@ def test_native_terminal_name(harness: str | None, expected: str | None) -> None
     wrong pane or silently skip a harness.
     """
     assert native_terminal_name(harness) == expected
+
+
+def test_harness_choices_help_names_the_genie_harness() -> None:
+    """The ``--harness`` help string names both genie spellings.
+
+    ``--harness`` accepts any registered harness, so the help text is the only
+    place a CLI user discovers the id — an omission reads as "not runnable".
+    """
+    from omnigent.cli import _HARNESS_CHOICES_HELP
+
+    assert "databricks-genie" in _HARNESS_CHOICES_HELP
+    assert "'genie'" in _HARNESS_CHOICES_HELP

--- a/tests/test_harness_aliases.py
+++ b/tests/test_harness_aliases.py
@@ -30,6 +30,9 @@ from omnigent.spec._omnigent_compat import OMNIGENT_HARNESSES
         ("agy", "antigravity"),
         ("google-antigravity", "antigravity"),
         ("antigravity", "antigravity"),
+        # Databricks Genie Spaces harness: short alias → canonical id.
+        ("genie", "databricks-genie"),
+        ("databricks-genie", "databricks-genie"),
         # Unknown names return unchanged so callers keep their own errors.
         ("bogus", "bogus"),
         (None, None),
@@ -71,6 +74,9 @@ def test_canonicalize_harness(alias: str | None, canonical: str | None) -> None:
         ("claude", False),
         # cursor is a headless ACP harness, not a native CLI bridge.
         ("cursor", False),
+        # databricks-genie is an in-process SDK harness, not a native CLI bridge.
+        ("databricks-genie", False),
+        ("genie", False),
         ("some-unknown-harness", False),
         (None, False),
     ],

--- a/tests/test_harness_capabilities.py
+++ b/tests/test_harness_capabilities.py
@@ -302,3 +302,18 @@ def test_native_tui_harnesses_declare_shell_tool_provocation() -> None:
         assert capability.shell_tool_name, harness
         assert capability.shell_tool_prompt, harness
         assert "omnigent-bench-ok" in capability.shell_tool_prompt, harness
+
+
+def test_databricks_genie_declarations_match_the_executor() -> None:
+    """Genie's declared capabilities match what DatabricksGenieExecutor implements.
+
+    ``resume`` must stay NONE until the conversation id is persisted or history
+    is replayed (neither happens today: one user message per turn, id lives on
+    the in-process executor). ``interrupt`` is True because interrupt_session()
+    closes the live response stream; ``streaming`` is True because output items
+    arrive progressively over SSE.
+    """
+    caps = harness_capabilities()["databricks-genie"]
+    assert caps.resume is Resume.NONE
+    assert caps.interrupt is True
+    assert caps.streaming is True


### PR DESCRIPTION
## Problem or use case

Omnigent is a meta-harness over many agent backends (Claude, Codex, Pi, Cursor, Antigravity…), but there was no way to point an agent at a **Databricks AI/BI Genie space** — Databricks' governed natural-language-to-SQL interface over curated data. Teams that already curate Genie spaces want to drive them through the same Omnigent surface (CLI/REPL/web UI) and governance (policies, spend caps, approval gates) as every other agent, without re-implementing NL→SQL.

Concretely: *"Register a remote Databricks Genie space as another harness so `omnigent run my_genie_agent` answers data questions from that space."*

## Proposed solution

A new in-process SDK harness **`databricks-genie`** (alias **`genie`**) that streams turns over Genie's **Agent-mode Responses API**:

- The Genie **space id** is the conversational unit, so it rides in `executor.model` (it doubles as the Responses API's `agent_id`).
- **Auth reuses the Databricks CLI** — `databricks auth login` writes OAuth/PAT credentials to the CLI config file, and `_DatabricksBearerAuth` (already in `databricks_executor.py`) turns the profile into an httpx auth hook that **re-mints the bearer token on every request**, so long turns survive access-token expiry. The profile is named via `executor.auth: {type: databricks, profile: …}`.
- Each turn is `POST /api/2.0/genie/agents/{agent_id}/responses` with `stream=True`. The SSE items map onto native Omnigent events, so **reasoning and in-flight SQL surface while the turn runs** rather than after it.
- Multi-turn continuity uses the server-side `conversation_id` returned on the stream, not client-side message replay.

```yaml
executor:
  harness: databricks-genie      # alias: genie
  model: "01ef…"                 # the Genie space id (from the room URL)
  auth:
    type: databricks
    profile: DEFAULT             # CLI profile; omit for default resolution
  config:
    enable_viz: false            # optional; default off
```

### Genie SSE item → Omnigent event

| Genie output item | Omnigent event |
|---|---|
| `reasoning` | `ReasoningChunk(event_type="reasoning_text")` |
| `function_call` (Genie's own SQL) | `ToolCallRequest` |
| `function_call_output` | `ToolCallComplete`, correlated by `call_id` |
| `message` / `output_text` | `TextChunk` (table re-rendered from `metadata`) |
| `response.completed` | `TurnComplete` |
| `response.failed` / `response.incomplete` / truncated stream | `ExecutorError` (+ `CANCELLED` for any in-flight call) |

Genie executes its own SQL, so `handles_tools_internally()` is `True` — Omnigent **observes** the calls rather than serving them.

## Alternatives considered

**1. `databricks-openai` (the client the Databricks docs suggest) — rejected.** Verified against real wheel metadata, for three reasons:

- **Weight.** It *unconditionally* requires `unitycatalog-openai[databricks]` → `unitycatalog-ai[databricks]` → **`databricks-connect`** (a full Spark client), plus `py4j`, `grpcio-status`, `nest-asyncio` and three `unitycatalog-*` packages. The extra is not optional, so it can't be trimmed, and it would land in both the `databricks` extra and `all`.
- **Version trap.** `0.16`/`0.17` pull `databricks-ai-search`, which pins `protobuf<6` against our core `protobuf>=6,<7` — unsatisfiable. That strands us on `0.15.0`, whose constructor **accepts no `timeout` argument**, which this harness requires.
- **It adds nothing we need.** For an explicit `base_url` it is a `BearerAuth` wrapper plus FMAPI/Apps concerns — no header signing, no retry policy, no response translation.

Meanwhile `openai` is **already a core dependency**, and `omnigent/inner/databricks_executor.py` already implements the same refreshing bearer auth (`_DatabricksBearerAuth`, itself *"inspired by `databricks-ai-bridge`'s `BearerAuth`"*). Reusing it is consistent with a choice this codebase already made, refreshes per request, and **adds zero dependencies** — `pyproject.toml` and `uv.lock` are untouched by this PR.

**2. Trusting Genie's own Markdown tables — rejected.** `output_text` parts carry both model-written Markdown *and* structured `columns` / `preview_rows` / `total_row_count` metadata. Databricks documents the model-generated Markdown as **not stable across requests or API versions**, and names the structured form the machine-readable one. Re-rendering from `metadata` keeps the row cap and pipe/newline escaping ours rather than the model's, and makes truncation explicit.

**3. The Genie Conversation API (`WorkspaceClient.genie`) — superseded.** The original implementation used `start_conversation_and_wait` / `create_message_and_wait` and then re-fetched result rows through the SQL Statement Execution API. It cannot stream, cannot surface reasoning or in-flight SQL, and blocks for the whole turn — which for Genie can be minutes. The Responses API supplies rows inline as structured metadata, so the Statement-Execution round trip disappears.

**4. A custom MCP/function tool that calls Genie — rejected:** it bolts NL→SQL onto another harness rather than letting a Genie space *be* the agent, and wouldn't get first-class harness governance/model-routing.

**5. Carrying the space id in `executor.connection` / `executor.config` — rejected:** `omnigent/inner/loader.py`'s `_parse_executor_spec` only populates `model`/`harness`/`profile`/`auth`. `executor.model` is the only field reliably populated by both loaders, and a space *is* the conversational unit.

## Scope / acceptance criteria

- [x] `executor.harness: databricks-genie` (and alias `genie`) is accepted by spec validation and dispatched to a harness subprocess.
- [x] Space id via `executor.model`; auth via a Databricks CLI profile (`executor.auth`/`executor.profile`).
- [x] Turns stream over the Agent-mode Responses API: `supports_streaming()` is `True`, and reasoning / SQL / report text arrive as they are produced.
- [x] Result tables re-rendered from structured `metadata`, with the row cap and cell escaping owned by Omnigent.
- [x] Multi-turn continuity via the server-side `conversation_id`.
- [x] `enable_viz` configurable (bundle `executor.config` or env), default **off**.
- [x] Per-turn timeout configurable, default 900 s; non-finite / non-positive values rejected.
- [x] Missing `databricks-sdk` surfaces an actionable install hint; **no new dependency of any kind**.
- [x] Unit tests + a skip-gated e2e gate; docs + a runnable example.

---

## Related issue

Closes #905

## Summary

Adds a new in-process SDK harness **`databricks-genie`** (alias **`genie`**) that registers a remote **Databricks AI/BI Genie space** as an Omnigent agent, streaming each turn over Genie's **Agent-mode Responses API** (SSE). Reasoning, the SQL Genie writes and runs, and the final report all surface as native Omnigent events while the turn is in flight. Result tables are re-rendered from the response's structured `columns`/`preview_rows` metadata. Auth reuses a Databricks CLI profile through the repo's existing refreshing-bearer-auth helper, so **no new dependency is added** — `openai` and `databricks-sdk` were already present.

**ELI5:** A Genie space is a "chat with your data" room in Databricks. This lets an Omnigent agent *be* that room — you ask in English, and you watch Genie think, watch it write and run the SQL, and get the answer plus the table.

```mermaid
flowchart LR
  U[CLI / REPL / Web UI] -->|turn| S[Omnigent server]
  S -->|"spawn-env: space id + profile + enable_viz"| H["databricks-genie harness (subprocess)"]
  H --> X[DatabricksGenieExecutor]
  X -->|"OpenAI client + refreshing bearer auth"| G["POST /api/2.0/genie/agents/{id}/responses (SSE)"]
  G -->|"reasoning"| R[ReasoningChunk]
  G -->|"function_call / _output"| T["ToolCallRequest / ToolCallComplete"]
  G -->|"message + metadata"| C["TextChunk (table re-rendered)"]
  G -->|"response.completed"| D[TurnComplete]
  R --> S
  T --> S
  C --> S
  D --> S
  S --> U
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Existing tests cover this change
- [x] Manual verification completed — **see "Live-verified" below**

## Coverage rationale

**Unit tests — 149 passing across the three offline test files** (`--cov-branch`):

```
$ uv run pytest tests/inner/test_databricks_genie_executor.py \
    tests/inner/test_databricks_genie_harness.py \
    tests/runtime/test_databricks_genie_spawn_env.py \
    --cov=omnigent.inner.databricks_genie_executor \
    --cov=omnigent.inner.databricks_genie_harness \
    --cov-branch --cov-report=term-missing -q

Name                                          Stmts   Miss Branch BrPart  Cover
omnigent/inner/databricks_genie_executor.py     317      2    124      3    99%
omnigent/inner/databricks_genie_harness.py       34      0      4      0   100%
TOTAL                                           351      2    128      3    99%
149 passed
```

The 2 uncovered statements and 3 partial branches are defensive fallbacks in the table renderer (a bare-scalar preview row, a zero-width table); they are reachable only from payload shapes Genie is not documented to emit.

Tests assert real behaviour against fakes that mirror the SSE stream (modelled on the existing `test_open_responses_sdk.py` fakes), covering:

- every output-item kind → its exact `ExecutorEvent`, in order;
- `conversation_id` threading across turns, captured from both `response.created` and `response.completed`;
- `TurnComplete.response` byte-identical to the concatenation of every emitted `TextChunk`, separators included;
- **truncated stream** (ends with no terminal event) → `ExecutorError`, not a short answer reported as success;
- `response.failed` / `response.incomplete` (with reason), and HTTP 409 naming the in-progress conversation;
- `call_id` correlation including the mixed / id-less / unknown-id / `id`-fallback cases, and `CANCELLED` `ToolCallComplete` for calls still awaiting output on **every** terminal path — success included;
- **interrupt**: closing the live stream unblocks a parked turn with cancellations + one `ExecutorError`, is idempotent, tolerates close-less streams, and returns `False` with nothing in flight;
- client lifetime: built lazily once, **never snapshots a token**, racing first-turn workers share one client (no leaked pool), `close()` closes only a client we own and is safe twice;
- timeout validation (`0`, negative, `NaN`, `inf`, malformed → default), `enable_viz` env parsing incl. the `"True"` stringified-YAML form, and spawn-env watchdog sizing (default, raised, ambient-wins, malformed);
- reasoning: a `reasoning_started` anchor per item, whitespace-only items suppressed, whitespace `content` falling through to `summary`;
- table rendering: pipe/newline **and backslash** escaping, `None` cells, missing `columns`, row-cap truncation (singular/plural), and upstream truncation via `total_row_count` (incl. malformed values).

**E2E:** `tests/e2e/omnigent/test_per_harness_databricks_genie.py` runs `omnigent run … --harness databricks-genie` as a real subprocess; it `pytest.skip`s cleanly when `databricks-sdk` / `OMNIGENT_GENIE_SPACE_ID` are absent (gateway-bound, like the other per-harness e2e gates). `tests/e2e/omnigent/test_example_genie.py` structurally pins the shipped `examples/genie` bundle — it must parse under the real loader and resolve through the spawn-env builder, offline.

**No regressions in shared files:** `harness_plugins.py` and `runtime/workflow.py` are shared, so the broader suites were run too — **1,156 passed** across the runtime and harness-registry suites.

**Lint/type:** `pre-commit run --all-files` (ruff-format, ruff-check, pyrefly, repo lint rules, web/mobile checks) passes.

### ✅ Live-verified (2026-08-02, "Bakehouse Sales Starter Space", Agent-mode preview enabled)

The Responses-API path has now been verified against a real Genie space:

- **One-shot turn** — `omnigent run … --harness databricks-genie` answers with the report prose plus the table re-rendered from `columns`/`preview_rows` (exit 0); re-run green again after the round-2 fixes below.
- **Raw wire transcript** (`live-wire-transcript.txt` alongside this file) — the stream carries only `response.created` / `output_item.added` / `output_item.done` / `response.completed`: the whole-item design matches the wire exactly, and there are no token deltas to miss. `conversation_id` rides on both `created` and `completed`, as coded.
- **Metadata shape** — `columns` (name/type objects), `preview_rows` (positional string lists), `status`, `sql`, `total_row_count`: the re-renderer reads exactly the stable fields, and `total_row_count` now powers the upstream-truncation footer.
- **Multi-turn continuity** — turn 2 sent the captured `conversation_id`, got the same conversation back, and resolved an anaphoric follow-up ("And how many units was that, exactly?") from turn 1's context.
- **`enable_viz` on/off** — on-mode streams extra call pairs plus an empty viz text part, handled gracefully; the chart renders in the Genie room (citation link), which the docs now say.
- **`call_id` shapes** — UUID-hex with `id == call_id` on calls; outputs named `<call_id>_output` with `name=None`, exercising the executor's name-fallback on the real wire.

---

## Implementation map (reviewer guide)

**New files**

| File | Purpose |
|---|---|
| `omnigent/inner/databricks_genie_executor.py` (844) | `DatabricksGenieExecutor`: lazy `OpenAI` client over the Genie agent base URL with refreshing bearer auth, SSE item→event mapping, `metadata`-driven table rendering, terminal-event handling, `close()`, `interrupt_session()`. `supports_streaming()` → `True`; `handles_tools_internally()` → `True`. |
| `omnigent/inner/databricks_genie_harness.py` (126) | `create_app()` wrap + `HARNESS_DATABRICKS_GENIE_{MODEL,PROFILE,TIMEOUT,ENABLE_VIZ}` env config. |
| `examples/genie/{config.yaml,README.md}` | Runnable example (native bundle format). |
| `tests/inner/test_databricks_genie_executor.py`, `…_harness.py`, `tests/runtime/test_databricks_genie_spawn_env.py`, `tests/e2e/…_databricks_genie.py`, `tests/e2e/…/test_example_genie.py` | Coverage (149 offline + 3 structural bundle tests + 1 gated live e2e). |

**Registration** (mirrors the `cursor`/`antigravity` SDK-harness precedent; gateway/ucode/model-override sites are intentionally N/A, same as `cursor`):

- `omnigent/harness_plugins.py` — capabilities (**`streaming=True`, `interrupt=True`, `resume=NONE`**), module map, `genie` alias, model env key; the web-picker omission is documented in code (the create dialog collects neither a space id nor a profile)
- `omnigent/runtime/harnesses/__init__.py` — `_HARNESS_MODULES["databricks-genie"]`
- `omnigent/onboarding/harness_readiness.py` — added to `_SDK_HARNESSES`
- `omnigent/spec/_omnigent_compat.py` — `OMNIGENT_HARNESSES` + alias allowlist
- `omnigent/runtime/workflow.py` — `_build_databricks_genie_spawn_env(spec)` (model, profile, `enable_viz`, idle-watchdog sizing)
- `omnigent/runner/app.py` — dispatch branch in `_build_spawn_env_from_spec`
- `omnigent/cli.py` — `--harness` help names both spellings (drift-tested)
- `docs/AGENT_YAML_SPEC.md` — harness reference

**Notable design details**

- **Only `response.completed` ends a turn successfully.** A stream that stops without a terminal event — a proxy idle timeout, a cleanly closed connection — yields `ExecutorError`. Reporting a truncated answer as a complete one is the failure mode worth engineering against, because nothing looks wrong.
- **Every terminal path cancels unanswered SQL calls first** — success included — so no card can render as in-progress forever.
- **Interrupt closes the live stream.** Genie streams whole items with multi-minute silent gaps mid-query; without `interrupt_session()` a cancelled turn stayed parked until the next item. Closing the stream errors the reader thread and ends the turn immediately (mirrors `databricks_executor`).
- **The scaffold idle watchdog is sized above the stream idle timeout** in the spawn env (ambient setting wins), so whatever the harness-wide default happens to be, a long silent warehouse query still ends at the executor's actionable timeout rather than a generic "wedged LLM" kill. This matters when `HARNESS_DATABRICKS_GENIE_TIMEOUT` is raised toward Genie's 90-minute server limit, past the scaffold's own default.
- **`max_retries=0`.** The OpenAI SDK's default retry set includes **409**, which here means *"a response is already being generated for this conversation"* — never retryable; retrying only delays an actionable error.
- **Client construction runs off the event loop** — and behind a lock, so a cancelled turn's worker racing the next turn's cannot leak a connection pool. Resolving Databricks auth does blocking file I/O and, for OAuth profiles, a token-mint request.

## Known limitations

- **Genie Agent mode is Beta** and requires a workspace-admin preview opt-in; without it the API is unavailable.
- **`enable_viz` in *flat* single-file specs is silently dropped.** This is pre-existing `executor.config` parsing behaviour affecting every harness knob, not specific to this change; `docs/AGENT_YAML_SPEC.md` documents `enable_viz` as a **bundle** `executor.config` knob and gives the env var as the flat-format path. Tracked separately.
- **Interrupt cannot abort the server-side Genie turn** (no public cancel API). Cancel returns control immediately, but a follow-up sent while the abandoned turn is still generating server-side can 409 — the message names the conversation and says to wait.

## Independent verification (adversarial review)

Two fresh-context reviewers received **only the diff** — no design rationale — and produced 34 findings; 9 were fixed and the rest classified with reasons. The three that mattered:

| Finding | Fix |
|---|---|
| A stream ending without a terminal event was reported as **success**, producing a silently truncated answer indistinguishable from a complete one | Only `response.completed` completes a turn; `response.incomplete` handled with its reason |
| `_ensure_client` ran **blocking file I/O + an OAuth token mint on the event loop** on every first turn | Moved into the existing `asyncio.to_thread` boundary |
| `httpx.Client` was **never closed** — the `close()` hook existed and the adapter called it, but the executor never overrode it | `close()` implemented; closes only a client we own, safe to call twice |

Also fixed: `CANCELLED` `ToolCallComplete` so a failed turn can't leave a SQL card spinning; strict `call_id` correlation (an output naming an unknown call is dropped rather than attached to the wrong id); timeout env rejecting `0`/negative/`NaN`/`inf`; and three docstring/doc statements that contradicted the code.

Explicitly **rejected**, with reasons: an `asyncio` wall-clock timeout (Genie turns legitimately run to the documented 90-minute server limit), retry/`retryable` flags (see `max_retries=0` above), and changes to `_md_cell` (byte-identical to its pre-existing form — a latent escaping gap in inherited code, tracked separately rather than smuggled into this diff).

### Round 2 — three-reviewer sweep, adversarially verified, then live-tested (2026-08-02)

A second pass ran **three independent reviewers** — GPT-5.6 Sol (Blind Hunter, diff-only), Kimi K3 (Edge Case Hunter, diff-only), and a six-lens full-repo-context sweep — producing 50 raw findings. Every deduped cluster then went to a dedicated **refute-first verifier with repo access** (15 verifiers: 8 confirmed, 7 partial, 3 clusters rejected outright), and the survivors were fixed and re-verified against the live space. Raw reports sit alongside this file (`blind-hunter.md`, `edge-case-hunter.md`, `live-wire-transcript.txt`, `deferred-work.md`).

| Finding (how found) | Fix |
|---|---|
| A `function_call` whose output never arrived was cancelled on *failed* turns only — a **successful** turn could still strand an in-progress SQL card (found independently by 3 reviewers) | `cancel_awaiting()` runs on **every** terminal path, before the terminal event |
| **Cancel couldn't stop a turn**: no `interrupt_session` override, so a cancelled turn stayed parked until Genie's next output item — minutes, mid-query — and a follow-up 409'd | `interrupt_session()` closes the live SSE stream off-thread (mirrors `databricks_executor`); capability `interrupt` flipped to `True` |
| The scaffold's idle watchdog (240 s when this branch was cut) killed any turn silent longer than 4 minutes — i.e. any real warehouse query — as a "wedged LLM", making the documented 900 s knob unreachable. `main` has since raised that default to one hour (#6204), so the acute case is gone; the sizing still keeps the guarantee when the Genie timeout is raised past the scaffold default | Spawn env sizes `HARNESS_TURN_TIMEOUT_S` just above the stream idle timeout (an ambient setting wins), so the executor's actionable timeout fires first |
| An upstream-truncated preview rendered as a complete table — `total_row_count` (live-verified as a real metadata field) was never read | `_render_table` folds upstream truncation into the `(N more rows)` footer |
| `timeout` is an httpx **read-gap** bound, not the "per-turn deadline" the docs claimed | Reworded to stream-idle semantics in the docs, both module docstrings, and the e2e comment |
| A cancelled turn's lazy-build worker racing the next turn's could leak an httpx connection pool | `threading.Lock` around the check-and-build |
| Consecutive reasoning items glued into one run-on string downstream; whitespace-only items opened empty blocks and masked populated summaries | `reasoning_started` anchor per item (the claude-sdk whole-block pattern) + strip gates |
| `\|` inside a cell defeated the pipe escaping (escaped backslash + live delimiter → phantom column) | Backslashes escape before pipes |
| `Resume.COLD_ONLY` claimed transcript rebuild that never happens (one message per turn; conversation id lives in-process) | `Resume.NONE`, pinned by a capabilities test |
| Legacy profile precedence (`config["profile"]` before `executor.profile`) inverted `_resolve_provider_for_build` | Aligned profile-first, pinned by a both-set test |
| A list-shaped `function_call_output.output` (a documented SDK union arm) would render as a pydantic-repr dump | Flattened to its text; raw dicts still pass through verbatim |
| `find_spec("databricks.sdk")` **raises** instead of returning `None` when the parent package is absent — the e2e gate errored where it must skip | Guarded |
| `examples/genie/config.yaml` had zero test coverage behind a false coverage-sync allowlist claim | `test_example_genie.py` pins the bundle + its spawn-env resolution; the allowlist entry is gone |
| `omnigent run --harness` help never named the new harness | Both spellings added, with a drift test |

Also closed: four test gaps (unknown item types under `enable_viz`, refusal parts, the unburied missing-SDK message, `id`-fallback correlation), and the docs now say where an `enable_viz` chart actually renders (the Genie room, via the citation link — live-observed).

**Rejected, with reasons:** re-enabling SDK retries for 429/5xx (the spec forbids retry logic; the 409 mis-retry is the documented hazard); guards for duplicate/colliding `call_id`s (the live wire shows UUID-hex ids, and the proposed guard is provably worse on the very shape it targets); richer mid-stream top-level-`error` diagnostics (shape undocumented and unobserved; such a turn still fails with the real message); markdown-injection hardening and NULL-vs-empty-cell rendering (platform-level rendering policy / deliberate design, applying equally to all model-authored text); narrowing the e2e auth-skip marker (it fires only for environment-side credential failures — the regression paths it could theoretically mask are pinned by offline tests); a web-picker catalog row (deliberate curation, now documented in code: the create dialog cannot collect a space id or profile, so a picker row would mint broken agents). Pre-existing issues surfaced along the way went to `deferred-work.md` rather than into this diff.
