### PR TITLE
fix(onboarding): normalize pasted Databricks workspace URL to scheme://host

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7714,6 +7714,7 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         # it never happens on a bare `run`, so a user who only wants their
         # own provider is never routed through Databricks unexpectedly.
         from omnigent.onboarding.configure_models import family_label
+        from omnigent.onboarding.databricks_config import normalize_workspace_url
         from omnigent.onboarding.interactive import clear_screen
         from omnigent.onboarding.setup import login_databricks_workspace
         from omnigent.onboarding.ucode_setup import (
@@ -7735,7 +7736,17 @@ def _configure_harness_add(family: str | None = None) -> str | None:
             return None
         if not workspace_url.startswith(("http://", "https://")):
             workspace_url = f"https://{workspace_url}"
-        workspace_url = workspace_url.rstrip("/")
+        # Reduce to scheme://host. Users paste the URL from a browser address
+        # bar, whose `/browse?o=...` path breaks both the saved profile host
+        # and `ucode configure` (the Databricks CLI keys OAuth tokens by host,
+        # so a path-laden value yields "no access token").
+        normalized_workspace_url = normalize_workspace_url(workspace_url)
+        if normalized_workspace_url != workspace_url.rstrip("/"):
+            console.print(
+                f"  [dim]Using {normalized_workspace_url} — ignored the extra "
+                "path from the pasted URL.[/dim]"
+            )
+        workspace_url = normalized_workspace_url
 
         # 1. Authenticate the workspace (returns the ~/.databrickscfg profile
         #    name) and 2. run `ucode configure` against it for model serving —

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -6,10 +6,39 @@ import configparser
 import importlib.util
 import logging
 from pathlib import Path
+from urllib.parse import urlparse
 
 _logger = logging.getLogger(__name__)
 
 _DATABRICKSCFG_PATH = Path.home() / ".databrickscfg"
+
+
+def normalize_workspace_url(raw: str) -> str:
+    """Reduce a Databricks workspace URL to its bare ``scheme://host`` origin.
+
+    Users routinely paste the URL straight from a browser address bar, which
+    carries a path and query the workspace host does not — e.g.
+    ``https://my-ws.cloud.databricks.com/browse?o=1234567890``. Both the
+    ``~/.databrickscfg`` profile host and ``ucode configure --workspaces``
+    need the bare origin: the Databricks CLI keys its OAuth token cache by
+    host, so a path-laden value resolves to "no access token" and
+    ``ucode configure`` then exits non-zero.
+
+    :param raw: A workspace URL, possibly carrying a path/query/fragment
+        and/or a trailing slash, e.g.
+        ``"https://my-ws.cloud.databricks.com/browse?o=1"``.
+    :returns: ``scheme://host`` with no path, query, fragment, or trailing
+        slash (e.g. ``"https://my-ws.cloud.databricks.com"``). When *raw* has
+        no parseable scheme+host (e.g. a bare ``"host/path"`` with no scheme),
+        the input is returned trimmed of surrounding whitespace and a trailing
+        slash — matching the prior ``rstrip("/")`` behavior so callers that
+        pre-add a scheme never regress.
+    """
+    parsed = urlparse(raw.strip())
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return raw.strip().rstrip("/")
+
 
 # The install command surfaced wherever a Databricks flow is gated on the
 # `databricks` extra (the add-provider menu, `setup --internal-beta`).

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -546,8 +546,10 @@ def login_databricks_workspace(workspace_url: str, *, console: Console | None = 
     import click
     from rich.console import Console
 
+    from omnigent.onboarding.databricks_config import normalize_workspace_url
+
     console = console or Console()
-    workspace_url = workspace_url.rstrip("/")
+    workspace_url = normalize_workspace_url(workspace_url)
     cli = find_databricks_cli()
     if cli is None:
         installer = (

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 
 import click
 
+from omnigent.onboarding.databricks_config import normalize_workspace_url
 from omnigent.onboarding.ucode_state import read_ucode_state
 
 _UCODE_AGENT_NAMES: tuple[str, ...] = ("claude", "codex", "pi")
@@ -62,7 +63,7 @@ def build_ucode_configure_command(
         *ucode_command,
         "configure",
         "--workspaces",
-        ",".join(workspace_url.rstrip("/") for workspace_url in workspace_urls),
+        ",".join(normalize_workspace_url(url) for url in workspace_urls),
         "--agents",
         ",".join(agents),
     ]

--- a/tests/onboarding/test_databricks_config.py
+++ b/tests/onboarding/test_databricks_config.py
@@ -6,9 +6,12 @@ import configparser
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from omnigent.onboarding.databricks_config import (
     databricks_sdk_installed,
     get_workspace_url_for_profile,
+    normalize_workspace_url,
 )
 
 _WORKSPACE_URL = "https://example.databricks.com"
@@ -124,3 +127,44 @@ def test_databricks_sdk_installed_true_in_dev_env() -> None:
     Databricks extra is missing even on installs that have it.
     """
     assert databricks_sdk_installed() is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # The reported foot-gun: the URL copied from a browser address bar.
+        (
+            "https://my-ws.cloud.databricks.com/browse?o=1234567890",
+            "https://my-ws.cloud.databricks.com",
+        ),
+        # Path with no query.
+        (
+            "https://my-ws.cloud.databricks.com/explore/data",
+            "https://my-ws.cloud.databricks.com",
+        ),
+        # Fragment is dropped too.
+        (
+            "https://my-ws.cloud.databricks.com/#/setting/account",
+            "https://my-ws.cloud.databricks.com",
+        ),
+        # Surrounding whitespace is trimmed before parsing.
+        (
+            "  https://my-ws.cloud.databricks.com/browse  ",
+            "https://my-ws.cloud.databricks.com",
+        ),
+        # Pre-existing trailing-slash case still collapses.
+        ("https://my-ws.cloud.databricks.com/", "https://my-ws.cloud.databricks.com"),
+        # Already an origin — returned unchanged.
+        ("https://my-ws.cloud.databricks.com", "https://my-ws.cloud.databricks.com"),
+    ],
+)
+def test_normalize_workspace_url_reduces_to_origin(raw: str, expected: str) -> None:
+    """A pasted workspace URL is reduced to its bare ``scheme://host`` origin."""
+    assert normalize_workspace_url(raw) == expected
+
+
+def test_normalize_workspace_url_scheme_less_input_only_strips_trailing_slash() -> None:
+    """Without a scheme there is no netloc to isolate, so the result matches the
+    prior ``rstrip("/")`` behavior — the wizard pre-adds ``https://`` before
+    calling, so a scheme is present in practice."""
+    assert normalize_workspace_url("my-ws.cloud.databricks.com/") == "my-ws.cloud.databricks.com"

--- a/tests/onboarding/test_ucode_setup.py
+++ b/tests/onboarding/test_ucode_setup.py
@@ -214,3 +214,22 @@ def test_configure_ucode_for_workspace_raises_on_nonzero_exit() -> None:
         pytest.raises(ClickException, match="exited with code 3"),
     ):
         configure_ucode_for_workspace("https://example.cloud.databricks.com")
+
+
+def test_build_ucode_configure_command_normalizes_pasted_url() -> None:
+    """A browser-pasted workspace URL is reduced to scheme://host in the
+    ``--workspaces`` argument, so ``ucode configure`` never receives the
+    ``/browse?o=...`` path the Databricks CLI cannot tokenize."""
+    argv = build_ucode_configure_command(
+        ["ucode"],
+        workspace_urls=["https://example.cloud.databricks.com/browse?o=42"],
+        agents=["claude"],
+    )
+    assert argv == [
+        "ucode",
+        "configure",
+        "--workspaces",
+        "https://example.cloud.databricks.com",
+        "--agents",
+        "claude",
+    ]


### PR DESCRIPTION
## Problem

In the `omnigent setup` → **Databricks — workspace** flow, the entered workspace URL is only stripped of a trailing slash. Pasting the URL straight from a browser address bar — the natural thing to do — carries a path/query, e.g.:

```
https://my-ws.cloud.databricks.com/browse?o=1234567890
```

That full string is then (a) saved as the `~/.databrickscfg` profile host and (b) passed to `ucode configure --workspaces`. The Databricks CLI keys its OAuth token cache by host, so a path-laden value resolves to **no access token** and `ucode configure` exits non-zero:

```
ERROR Databricks CLI returned no access token for https://…/browse?o=1234567890. Run `databricks auth login` to re-authenticate.
Error: `ucode configure` exited with code 1; see the command output above for details.
```

The profile *name* was already derived via `urlparse(...).netloc`, so only the host string was left un-normalized.

## Fix

Add a small shared helper `normalize_workspace_url()` in `onboarding/databricks_config.py` that reduces the URL to its bare `scheme://host` origin (dropping any path/query/fragment; falling back to the prior `rstrip("/")` for scheme-less input so nothing regresses). Apply it:

- at the wizard capture point (`cli.py`), with a one-line notice when a path was dropped, and
- at the two downstream chokepoints — `login_databricks_workspace()` and the `ucode configure` command builder — for defense in depth.

## Testing

- `ruff check` and `ruff format --check`: clean
- `pytest tests/onboarding`: **501 passed**, including new parametrized `normalize_workspace_url` cases and a `build_ucode_configure_command` normalization case.

This pull request and its description were written by Isaac.
