### PR TITLE
fix(cli): URL linkifier embeds SGR reset → "0m" leaks before every link

### DIFF
--- a/sdks/ui/omnigent_ui_sdk/terminal/_linkify.py
+++ b/sdks/ui/omnigent_ui_sdk/terminal/_linkify.py
@@ -35,11 +35,20 @@ import re
 #   - closing brackets / quotes / angle that commonly delimit URLs
 #     in prose ("(see https://example.com)", "<https://...>",
 #     '"https://..."').
+#   - ANY C0 control byte or DEL (``\x00-\x1f``, ``\x7f``) — critically the
+#     ESC (``\x1b``) that introduces an SGR/OSC escape. Rich renders an
+#     autolinked URL as ``\x1b[..m<url>\x1b[0m`` (styled + reset); without
+#     excluding ESC, the URL class swallows the trailing ``\x1b[0m`` reset
+#     and embeds it INSIDE the OSC 8 link target built below
+#     (``\x1b]8;;<url>\x1b[0m\x1b\\``), a malformed hyperlink that terminals
+#     render by leaking the reset's tail ``0m`` as visible text before the
+#     URL. Real URLs never contain raw control bytes (they are
+#     percent-encoded), so excluding them is always safe.
 # Trailing punctuation (``.,;:!?``) is stripped in the substitution
 # callback rather than excluded by the regex — e.g. "Visit
 # https://example.com." should fire OSC 8 over the URL but leave
 # the period after the close-OSC8.
-_URL = r"https?://[^\s\)\]\>\"'<]+"
+_URL = r"https?://[^\s\)\]\>\"'<\x00-\x1f\x7f]+"
 
 # Match a complete pre-existing OSC 8 hyperlink block so we don't
 # re-wrap a URL that was already linkified (some agent paths emit

--- a/tests/frontends/sdk/test_linkify.py
+++ b/tests/frontends/sdk/test_linkify.py
@@ -164,6 +164,29 @@ def test_linkify_composes_with_sgr_styling() -> None:
     assert out == f"\x1b[1mSee \x1b[0m{_wrap('https://example.com')}"
 
 
+def test_linkify_url_followed_by_trailing_sgr_reset() -> None:
+    """
+    A URL immediately followed by an SGR reset (``\\x1b[0m``) — exactly what
+    Rich emits for a styled/underlined autolink (``\\x1b[4;34m<url>\\x1b[0m``)
+    — must NOT swallow the reset into the URL.
+
+    Regression target (the "0m before the URL" bug): ``_URL`` did not exclude
+    ESC, so it matched ``https://example.com\\x1b[0m`` and embedded the reset
+    INSIDE the OSC 8 link target
+    (``\\x1b]8;;https://example.com\\x1b[0m\\x1b\\``) — a malformed hyperlink
+    that terminals render by leaking ``0m`` as visible text before the URL.
+    The URL must end at the ESC, leaving the reset OUTSIDE the link envelope.
+    """
+    inp = "open \x1b[4;38;5;33mhttps://example.com\x1b[0m done"
+    out = linkify_ansi(inp)
+    # URL wrapped cleanly; the styling prefix and the trailing reset are
+    # untouched and sit OUTSIDE the OSC 8 envelope.
+    assert out == f"open \x1b[4;38;5;33m{_wrap('https://example.com')}\x1b[0m done"
+    # The link target must be the bare URL — no escape bytes embedded in it.
+    assert f"{_OSC_OPEN}https://example.com{_OSC_CLOSE}" in out
+    assert f"{_OSC_OPEN}https://example.com\x1b[0m" not in out
+
+
 def test_linkify_no_urls_passes_through_unchanged() -> None:
     """
     Strings without any URLs are returned byte-identical. No


### PR DESCRIPTION
## Problem

In the interactive CLI/REPL, a literal **`0m`** appears immediately before **every** URL in rendered assistant output — e.g. `0mhttp://localhost:5173` instead of `http://localhost:5173`.

`0m` is the tail of an ANSI SGR reset (`\x1b[0m`). Root cause: the OSC‑8 linkifier's bare-URL regex

```python
_URL = r"https?://[^\s\)\]\>\"'<]+"
```

does **not** exclude the ESC byte (`\x1b`). Rich renders an autolinked URL with styling + reset (`\x1b[..m<url>\x1b[0m`), so the regex swallows the trailing `\x1b[0m` **into the URL** and embeds it inside the OSC‑8 link target:

```
\x1b]8;;http://localhost:5173\x1b[0m\x1b\\http://localhost:5173\x1b]8;;\x1b\\
                             ^^^^^^^ reset escape inside the link target → malformed
```

Terminals mis-parse that malformed hyperlink and leak the reset's tail `0m` as visible text before the URL.

## Fix

Exclude all C0 control bytes and DEL (`\x00-\x1f`, `\x7f`) from the URL character class:

```python
_URL = r"https?://[^\s\)\]\>\"'<\x00-\x1f\x7f]+"
```

The match now stops at the ESC, so the reset stays **outside** the OSC‑8 envelope and the hyperlink is well-formed. Real URLs never contain raw control bytes (they're percent-encoded), so this is always safe.

## Testing

- `ruff check` / `ruff format --check`: clean
- `pytest tests/frontends/sdk/test_linkify.py`: **17 passed**, including a new regression test for a URL followed by a trailing SGR reset (the exact Rich autolink shape — not covered before).
- Verified the rendered bytes: the OSC‑8 link target is now the bare URL, with the `\x1b[0m` reset after the closer.

This pull request and its description were written by Isaac.
