### PR TITLE
fix(claude-sdk): isolate host MCP servers by default so agent runs don't pop visible browser windows

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1111,6 +1111,7 @@ class ClaudeSDKExecutor(Executor):
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
         api_key_helper: str | None = None,
+        strict_mcp_config: bool = True,
     ) -> None:
         """Create a ClaudeSDKExecutor.
 
@@ -1184,6 +1185,29 @@ class ClaudeSDKExecutor(Executor):
                 Injected into ``_extra_env`` as
                 :data:`_CLAUDE_API_KEY_HELPER_ENV_KEY` so it reaches
                 the SDK's ``settings.apiKeyHelper`` option at turn time.
+            strict_mcp_config: When ``True`` (the default), pass
+                ``--strict-mcp-config`` to the Claude CLI so it uses ONLY
+                the MCP servers Omnigent declares (the in-process
+                ``omnigent`` SDK server) and IGNORES every MCP server the
+                CLI would otherwise auto-discover from the host: the
+                user's ``~/.claude.json`` / ``~/.claude/settings.json``,
+                a project ``.mcp.json``, and plugin-provided servers.
+                This is the safe default: a ``claude-sdk`` agent run must
+                NOT silently boot the operator's personal MCP servers as
+                a side effect of inheriting ``setting_sources=["user",
+                "project"]`` (which is needed for host skills / CLAUDE.md).
+                Without this guard, a host-configured server such as
+                ``chrome-devtools-mcp`` — which launches a VISIBLE Chrome
+                window by default (``--headless`` defaults to ``false``)
+                — pops real browser windows on the user's machine during
+                an otherwise headless agent turn. Set to ``False`` to opt
+                back in to host MCP-server inheritance (e.g. an operator
+                who deliberately wants the agent to reach their own
+                glean / jira / databricks MCP servers). ``--strict-mcp-
+                config`` affects ONLY MCP-server discovery; host skills
+                and CLAUDE.md still load via ``--setting-sources``, so
+                this default does not change the intended skill /
+                CLAUDE.md leak-through.
         """
         # Fail loud: a ``databricks-*`` model requires the gateway transport.
         if not gateway and model is not None and model.startswith("databricks-"):
@@ -1210,6 +1234,10 @@ class ClaudeSDKExecutor(Executor):
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter
+        # Isolate the agent from host-configured MCP servers by default.
+        # See the ``strict_mcp_config`` constructor arg for the full
+        # rationale (the visible-Chrome-window regression).
+        self._strict_mcp_config = strict_mcp_config
         # Write the bundle's plugin manifest now (idempotent) so that
         # ``--plugin-dir <bundle>`` produces clean
         # ``<agent-name>:<skill-name>`` labels in Claude's skill
@@ -2005,6 +2033,19 @@ class ClaudeSDKExecutor(Executor):
             "plugins": bundle_plugins,
             "extra_args": {"no-session-persistence": None},
             "max_buffer_size": 10 * 1024 * 1024,
+            # Gate host MCP-server inheritance. The CLI otherwise merges
+            # the SDK's ``--mcp-config`` (our in-process ``omnigent``
+            # server) WITH every MCP server it discovers from the host
+            # config (``~/.claude.json`` / ``~/.claude/settings.json``,
+            # project ``.mcp.json``, plugins) because ``setting_sources``
+            # resolves to ``["user", "project"]`` to load host skills /
+            # CLAUDE.md. ``--strict-mcp-config`` keeps the skill /
+            # CLAUDE.md inheritance but drops the silent MCP-server
+            # inheritance, so a host ``chrome-devtools-mcp`` (visible
+            # Chrome by default) no longer pops real browser windows
+            # mid-turn. Defaults on; an operator can opt back in to host
+            # MCP servers via ``strict_mcp_config=False``.
+            "strict_mcp_config": self._strict_mcp_config,
         }
         # Only forward ``setting_sources`` when explicitly set.
         # ``None`` lets the SDK apply its default

--- a/omnigent/inner/claude_sdk_harness.py
+++ b/omnigent/inner/claude_sdk_harness.py
@@ -80,6 +80,18 @@ Env vars read at startup:
   stable plugin name (so bundled skills show as
   ``<agent>:<skill>`` rather than the bundle's tmpdir
   basename).
+- ``HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG``: ``"0"`` / ``"false"``
+  / ``"no"`` to OPT OUT of MCP-server isolation and let the
+  Claude CLI inherit the host's MCP servers (the operator's
+  ``~/.claude.json`` / ``~/.claude/settings.json``, a project
+  ``.mcp.json``, plugin servers). Defaults to strict
+  (isolated): the harness passes ``--strict-mcp-config`` so an
+  agent run uses only Omnigent's own MCP server and does NOT
+  silently boot host servers as a side effect of the
+  ``setting_sources=["user","project"]`` it needs for host
+  skills / CLAUDE.md. The motivating regression: a host
+  ``chrome-devtools-mcp`` (visible Chrome by default) popped
+  real browser windows on the user's machine mid-turn.
 """
 
 from __future__ import annotations
@@ -113,6 +125,7 @@ _ENV_RETRY_POLICY = "HARNESS_CLAUDE_SDK_RETRY_POLICY"
 _ENV_SKILLS_FILTER = "HARNESS_CLAUDE_SDK_SKILLS_FILTER"
 _ENV_BUNDLE_DIR = "HARNESS_CLAUDE_SDK_BUNDLE_DIR"
 _ENV_AGENT_NAME = "HARNESS_CLAUDE_SDK_AGENT_NAME"
+_ENV_STRICT_MCP_CONFIG = "HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG"
 _ENV_GATEWAY_BASE_URL = "HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"
 _ENV_GATEWAY_AUTH_COMMAND = "HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND"
 _ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_CLAUDE_SDK_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
@@ -249,6 +262,29 @@ def _resolve_skills_filter() -> str | list[str]:
     return "all"
 
 
+def _resolve_strict_mcp_config() -> bool:
+    """
+    Resolve the inner-executor ``strict_mcp_config`` from env config.
+
+    Reads :data:`_ENV_STRICT_MCP_CONFIG`. Defaults to ``True``
+    (host MCP servers isolated) so an agent run never silently
+    boots the operator's personal MCP servers — see the
+    motivating visible-Chrome-window regression in the module
+    docstring. Only an explicit opt-out value (``"0"`` /
+    ``"false"`` / ``"no"``, case-insensitive) flips it to
+    ``False`` to restore host MCP-server inheritance; anything
+    else (including an unset var or an unrecognized value) keeps
+    the safe default.
+
+    :returns: ``True`` to pass ``--strict-mcp-config`` (isolate
+        host MCP servers), ``False`` to inherit them.
+    """
+    raw = os.environ.get(_ENV_STRICT_MCP_CONFIG, "").strip().lower()
+    if raw in ("0", "false", "no"):
+        return False
+    return True
+
+
 def _build_claude_sdk_executor() -> Executor:
     """
     Construct a :class:`ClaudeSDKExecutor` from env-var config.
@@ -287,6 +323,7 @@ def _build_claude_sdk_executor() -> Executor:
         agent_name=agent_name,
         skills_filter=_resolve_skills_filter(),
         api_key_helper=os.environ.get(_ENV_API_KEY_HELPER) or None,
+        strict_mcp_config=_resolve_strict_mcp_config(),
     )
 
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -672,6 +672,70 @@ class TestConstructor(unittest.TestCase):
 
         _run(_t())
 
+    def test_strict_mcp_config_defaults_on(self):
+        """Default executor isolates host MCP servers via ``strict_mcp_config``.
+
+        The regression this guards: a host-configured MCP server such as
+        ``chrome-devtools-mcp`` (visible Chrome by default) was being
+        launched mid-turn because the CLI inherits host MCP servers
+        whenever ``setting_sources`` resolves to ``["user", "project"]``
+        (which it must, to load host skills / CLAUDE.md). Passing
+        ``--strict-mcp-config`` keeps the skill / CLAUDE.md inheritance
+        but drops the silent MCP-server inheritance, so the default must
+        reach the SDK options as ``True``.
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        async def _t():
+            executor = ClaudeSDKExecutor(gateway=False, model="claude-opus-4-7")
+            captured: dict[str, object] = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["strict"] = getattr(options, "strict_mcp_config", None)
+                raise RuntimeError("stop after options built")
+
+            with patch.object(
+                executor,
+                "_get_or_create_client",
+                side_effect=fake_get_or_create_client,
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            self.assertIs(captured["strict"], True)
+
+        _run(_t())
+
+    def test_strict_mcp_config_opt_out(self):
+        """``strict_mcp_config=False`` restores host MCP-server inheritance."""
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        async def _t():
+            executor = ClaudeSDKExecutor(
+                gateway=False,
+                model="claude-opus-4-7",
+                strict_mcp_config=False,
+            )
+            captured: dict[str, object] = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["strict"] = getattr(options, "strict_mcp_config", None)
+                raise RuntimeError("stop after options built")
+
+            with patch.object(
+                executor,
+                "_get_or_create_client",
+                side_effect=fake_get_or_create_client,
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            self.assertIs(captured["strict"], False)
+
+        _run(_t())
+
     def test_force_close_client_uses_process_tree_termination(self):
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
 

--- a/tests/inner/test_claude_sdk_harness.py
+++ b/tests/inner/test_claude_sdk_harness.py
@@ -387,6 +387,78 @@ def test_skills_filter_env_var_malformed_json_falls_back_to_all(
     assert captured["skills_filter"] == "all"
 
 
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        # Explicit opt-out values flip isolation off (case-insensitive).
+        ("0", False),
+        ("false", False),
+        ("False", False),
+        ("no", False),
+        ("NO", False),
+        # Anything else keeps the safe default (isolated).
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("", True),
+        ("garbage", True),
+    ],
+)
+def test_strict_mcp_config_env_var_parsing(
+    raw_value: str,
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG`` only opts OUT on explicit
+    falsey values; everything else stays isolated.
+
+    Isolation is the safe default: a ``claude-sdk`` run must not
+    silently boot the operator's host MCP servers (the visible-Chrome
+    regression). Only a deliberate ``0`` / ``false`` / ``no`` lets the
+    agent inherit host MCP servers, so an unset or unrecognized value
+    must NOT accidentally disable the guard.
+    """
+    monkeypatch.setenv("HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG", raw_value)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.claude_sdk_harness.ClaudeSDKExecutor.__init__",
+        _fake_init,
+    ):
+        claude_sdk_harness._build_claude_sdk_executor()
+
+    assert captured["strict_mcp_config"] is expected
+
+
+def test_strict_mcp_config_env_var_missing_defaults_to_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset ``HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG`` isolates host
+    MCP servers.
+
+    Legacy deployments that don't yet ship the env var must get the
+    safe behavior automatically — the whole point of the fix is that
+    no opt-in is required to stop host servers (like a visible
+    ``chrome-devtools-mcp``) from launching.
+    """
+    monkeypatch.delenv("HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG", raising=False)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.claude_sdk_harness.ClaudeSDKExecutor.__init__",
+        _fake_init,
+    ):
+        claude_sdk_harness._build_claude_sdk_executor()
+
+    assert captured["strict_mcp_config"] is True
+
+
 def test_bundle_dir_and_agent_name_env_vars_thread_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

Running a research question in the Omnigent CLI (a `claude-sdk` brain) popped **visible Chrome windows** on the user's machine — Chrome showed "Chrome is being controlled by automated test software" and navigated to DuckDuckGo/result pages. The model was calling `mcp__chrome-devtools__navigate_page`, `new_page`, `take_snapshot`, `evaluate_script`, `list_pages`. The user never asked for a real browser to be hijacked.

## Root cause

Omnigent ships no browser tooling of its own. The tools come from a host-configured **`chrome-devtools-mcp`** MCP server. The `claude-sdk` harness must inherit `setting_sources=["user","project"]` so the Claude CLI loads host **skills** and **CLAUDE.md** (`skills="all"` → SDK auto-defaults `setting_sources` to `["user","project"]`). But Omnigent never passed `--strict-mcp-config`, so the CLI **also** merged in every MCP server it discovered from the host config (`~/.claude.json`, `~/.claude/settings.json`, project `.mcp.json`, plugins) and launched them inside its subprocess.

`chrome-devtools-mcp` defaults `--headless` to `false`, so with a real `--userDataDir` it opens a **visible** Chrome window. That is why an otherwise-headless agent turn popped real browser windows.

Relevant code: `omnigent/inner/claude_sdk_executor.py` builds `ClaudeAgentOptions` without `strict_mcp_config`; the SDK transport (`claude_agent_sdk/_internal/transport/subprocess_cli.py`) emits `--setting-sources=user,project` and, absent `--strict-mcp-config`, lets the CLI inherit host MCP servers.

## Fix

Default `ClaudeSDKExecutor.strict_mcp_config=True` so the harness passes `--strict-mcp-config`: the agent uses **only** Omnigent's own in-process `omnigent` MCP server and ignores host MCP servers. `--strict-mcp-config` affects MCP-server discovery **only** — host skills and CLAUDE.md still load via `--setting-sources`, so the intended skill/CLAUDE.md inheritance is unchanged.

Operators who deliberately want the agent to reach their own host MCP servers (glean/jira/databricks/etc.) can opt back in with `HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG=0` (also accepts `false`/`no`, case-insensitive). The opt-out is unset by default, so legacy/AP deployments get the safe behavior with no runtime change.

## Tests

- `tests/inner/test_claude_sdk_executor.py`: `strict_mcp_config` defaults to `True` on the built SDK options, and `strict_mcp_config=False` flows through.
- `tests/inner/test_claude_sdk_harness.py`: `HARNESS_CLAUDE_SDK_STRICT_MCP_CONFIG` parsing (only explicit `0`/`false`/`no` opt out; unset/garbage stay isolated).

`uv run --extra dev ruff check`, `ruff format --check`, and `pytest tests/inner/test_claude_sdk_executor.py tests/inner/test_claude_sdk_harness.py` (132 passed) all pass.

This pull request and its description were written by Isaac.