### PR TITLE
fix(hooks): retry transient 5xx/connect errors on policy evaluate POST

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -31,6 +31,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    post_evaluate_with_retry,
 )
 
 # Client-side budget for the permission-request long-poll to AP. Held
@@ -822,20 +823,10 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         return 0
 
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{url_component(session_id)}/policies/evaluate"
-    try:
-        with httpx.Client(
-            headers=headers, timeout=httpx.Timeout(_EVALUATE_POLICY_TIMEOUT_S)
-        ) as client:
-            resp = client.post(url, json=eval_request)
-            resp.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        print(
-            f"omnigent evaluate-policy hook: Omnigent returned {exc.response.status_code}",
-            file=sys.stderr,
-        )
-        return _fail_closed()
-    except httpx.HTTPError as exc:
-        print(f"omnigent evaluate-policy hook: Omnigent request failed: {exc}", file=sys.stderr)
+    resp = post_evaluate_with_retry(
+        url, headers, eval_request, _EVALUATE_POLICY_TIMEOUT_S, "evaluate-policy hook"
+    )
+    if resp is None:
         return _fail_closed()
     if not resp.content:
         print("omnigent evaluate-policy hook: empty Omnigent response", file=sys.stderr)

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -17,8 +17,6 @@ import sys
 import urllib.parse
 from pathlib import Path
 
-import httpx
-
 from omnigent.codex_native_bridge import (
     read_bridge_state,
     read_codex_config_model,
@@ -28,6 +26,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    post_evaluate_with_retry,
 )
 
 # Budget for the policy evaluation POST. Normally a quick
@@ -160,23 +159,10 @@ def _main_evaluate_policy(argv: list[str]) -> int:
 
     session_component = urllib.parse.quote(session_id, safe="")
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{session_component}/policies/evaluate"
-    try:
-        with httpx.Client(
-            headers=headers, timeout=httpx.Timeout(_EVALUATE_POLICY_TIMEOUT_S)
-        ) as client:
-            resp = client.post(url, json=eval_request)
-            resp.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        print(
-            f"omnigent codex evaluate-policy hook: Omnigent returned {exc.response.status_code}",
-            file=sys.stderr,
-        )
-        return _fail_closed()
-    except httpx.HTTPError as exc:
-        print(
-            f"omnigent codex evaluate-policy hook: Omnigent request failed: {exc}",
-            file=sys.stderr,
-        )
+    resp = post_evaluate_with_retry(
+        url, headers, eval_request, _EVALUATE_POLICY_TIMEOUT_S, "codex evaluate-policy hook"
+    )
+    if resp is None:
         return _fail_closed()
     if not resp.content:
         print("omnigent codex evaluate-policy hook: empty Omnigent response", file=sys.stderr)

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -21,6 +21,21 @@ model sees it).
 from __future__ import annotations
 
 import json
+import sys
+import time
+
+import httpx
+
+# How long to keep retrying transient 5xx / connect errors on the
+# policy evaluate POST before failing closed. Keeps the pre-execution
+# gate from blocking long on a sick server while still absorbing brief
+# DB hiccups on a hosted deployment.
+_EVALUATE_POLICY_RETRY_BUDGET_S = 30.0
+_EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S = 1.0
+_EVALUATE_POLICY_RETRY_MAX_BACKOFF_S = 10.0
+# Fast connect budget so an unreachable server fails into the retry
+# loop quickly rather than blocking on the day-long read timeout.
+_EVALUATE_POLICY_CONNECT_TIMEOUT_S = 5.0
 
 # Hook event names that gate tool execution and therefore carry policy
 # meaning. ``PreToolUse`` fires before the tool runs (can block);
@@ -269,3 +284,79 @@ def fail_closed_hook_output(hook_event: str) -> dict[str, object] | None:
             },
         }
     return None
+
+
+def post_evaluate_with_retry(
+    url: str,
+    headers: dict[str, str],
+    eval_request: dict[str, object],
+    read_timeout: float,
+    hook_label: str,
+) -> httpx.Response | None:
+    """
+    POST to the Omnigent policy evaluate endpoint, retrying on transient errors.
+
+    Retries on 5xx HTTP responses and connection-level errors
+    (:class:`httpx.ConnectError`, :class:`httpx.ConnectTimeout`) within
+    :data:`_EVALUATE_POLICY_RETRY_BUDGET_S`. Returns the successful response,
+    or ``None`` if the budget is exhausted or a non-retryable error occurs.
+
+    4xx responses are final — a bad request won't succeed on retry. Other
+    mid-stream errors (e.g. :class:`httpx.ReadTimeout`) are also not retried:
+    a read timeout can indicate a long-polling ASK gate being severed, and
+    retrying would open a new server-side elicitation, prompting the human
+    twice. The caller is responsible for fail-closed handling on ``None``.
+
+    :param url: Absolute URL of the evaluate endpoint.
+    :param headers: Auth headers for the Omnigent server.
+    :param eval_request: ``EvaluationRequest`` JSON body to POST.
+    :param read_timeout: Per-attempt read timeout in seconds. Should be
+        large (e.g. one day) to accommodate long-polling ASK gates.
+    :param hook_label: Diagnostic label used in stderr messages,
+        e.g. ``"evaluate-policy hook"`` or ``"codex evaluate-policy hook"``.
+    :returns: Successful :class:`httpx.Response`, or ``None`` when retries
+        are exhausted or the error is non-retryable.
+    """
+    deadline = time.monotonic() + _EVALUATE_POLICY_RETRY_BUDGET_S
+    backoff_s = _EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S
+    timeout = httpx.Timeout(read_timeout, connect=_EVALUATE_POLICY_CONNECT_TIMEOUT_S)
+    while True:
+        try:
+            with httpx.Client(headers=headers, timeout=timeout) as client:
+                resp = client.post(url, json=eval_request)
+                resp.raise_for_status()
+                return resp
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code < 500:
+                print(
+                    f"omnigent {hook_label}: Omnigent returned {exc.response.status_code}",
+                    file=sys.stderr,
+                )
+                return None
+            print(
+                f"omnigent {hook_label}: Omnigent returned {exc.response.status_code}; retrying",
+                file=sys.stderr,
+            )
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            print(
+                f"omnigent {hook_label}: Omnigent request failed; retrying: {exc}",
+                file=sys.stderr,
+            )
+        except httpx.HTTPError as exc:
+            # Other HTTP errors (ReadTimeout while a long ASK poll is in flight,
+            # etc.) are not retried — retrying a severed ASK would open a new
+            # elicitation and prompt the human twice.
+            print(
+                f"omnigent {hook_label}: Omnigent request failed: {exc}",
+                file=sys.stderr,
+            )
+            return None
+        if time.monotonic() + backoff_s >= deadline:
+            print(
+                f"omnigent {hook_label}: retry budget exhausted",
+                file=sys.stderr,
+            )
+            return None
+        # Two-step backoff; not worth a retry library in this dependency-light hook.
+        time.sleep(backoff_s)
+        backoff_s = min(backoff_s * 2, _EVALUATE_POLICY_RETRY_MAX_BACKOFF_S)

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from omnigent import claude_native_hook
+from omnigent import claude_native_hook, native_policy_hook
 from omnigent.claude_native_bridge import (
     build_hook_settings,
     prepare_bridge_dir,
@@ -1179,7 +1179,7 @@ def test_evaluate_policy_pre_tool_use_converts_and_returns_deny(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir(
         "conv_abc",
         bridge_id="bridge_shared",
@@ -1786,3 +1786,64 @@ def test_evaluate_policy_non_tool_call_phases_fail_open_on_error(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert captured.out == ""
+
+
+def test_evaluate_policy_retries_5xx_and_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    A transient 5xx from the policy server is retried and the eventual 200 is used.
+
+    Regression guard for DB-hosted deployments where brief server hiccups
+    previously caused a spurious fail-closed deny on every affected tool call.
+    """
+    call_count = 0
+
+    class _FlakyThenOkClient:
+        def __init__(self, *, headers: object, timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _FlakyThenOkClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: object = None) -> httpx.Response:
+            del json
+            nonlocal call_count
+            call_count += 1
+            req = httpx.Request("POST", url)
+            if call_count < 3:
+                return httpx.Response(503, text="upstream down", request=req)
+            return httpx.Response(
+                200,
+                text='{"result":"POLICY_ACTION_ALLOW"}',
+                request=req,
+            )
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    # Sleep is a no-op so retries are instant.
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _: None)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _FlakyThenOkClient)
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
+    write_active_session_id(bridge_dir, "conv_active")
+    build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    exit_code = claude_native_hook.main(["evaluate-policy", "--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # ALLOW verdict → no hook output (hook defers to Claude's own permission system).
+    assert captured.out == ""
+    # Two 503s then one 200 = 3 total attempts.
+    assert call_count == 3

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from omnigent import codex_native_hook
+from omnigent import codex_native_hook, native_policy_hook
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     codex_home_for_bridge_dir,
@@ -195,7 +195,7 @@ def test_pre_tool_use_converts_posts_and_returns_deny(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -247,7 +247,7 @@ def test_user_prompt_submit_converts_posts_and_blocks(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -293,7 +293,7 @@ def test_pre_tool_use_stamps_model_from_config(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -327,7 +327,7 @@ def test_pre_tool_use_stamps_harness_without_config_model(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -356,7 +356,7 @@ def test_missing_bridge_state_is_fail_open(
     """
     monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native")
     empty_dir = prepare_bridge_dir("bridge_no_state")
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _RaisesIfCalled)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RaisesIfCalled)
 
     exit_code = _run_hook(
         empty_dir,
@@ -381,7 +381,7 @@ def test_missing_policy_config_is_fail_open(
     local run with no Omnigent server), so there is nothing to enforce against.
     The hook returns 0 with no output and does not touch the network.
     """
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _RaisesIfCalled)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RaisesIfCalled)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -408,7 +408,8 @@ def test_pre_tool_use_fails_closed_when_verdict_unavailable(
     CLOSED (deny) instead of "no opinion" — the bypass reported in #536.
     """
     write_policy_hook_config(bridge_dir, ap_server_url="http://127.0.0.1:8787", ap_auth_headers={})
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", make_failing_client(mode))
+    monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", make_failing_client(mode))
 
     exit_code = _run_hook(
         bridge_dir,
@@ -453,7 +454,8 @@ def test_non_tool_call_phases_fail_open_on_error(
     runner-side ``FAIL_CLOSED_PHASES`` (PR #163).
     """
     write_policy_hook_config(bridge_dir, ap_server_url="http://127.0.0.1:8787", ap_auth_headers={})
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", make_failing_client("connect_error"))
+    monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", make_failing_client("connect_error"))
 
     exit_code = _run_hook(bridge_dir, payload, monkeypatch)
 


### PR DESCRIPTION
## Summary

- Adds `post_evaluate_with_retry()` to `native_policy_hook` (shared by both claude and codex hooks): retries 5xx and `ConnectError`/`ConnectTimeout` within a 30s budget with exponential backoff (1s → 10s cap)
- Non-retryable errors (4xx, `ReadTimeout`) still fail immediately — `ReadTimeout` in particular may be a severed long-poll ASK gate; retrying would open a new server-side elicitation and prompt the human twice
- Moves `httpx.Client` out of the per-hook modules into the shared helper; tests now patch `native_policy_hook.httpx` instead of per-hook module attrs

## Root cause

Intermittent `"Omnigent policy evaluation unavailable; failing closed for this tool call."` denies on a DB-hosted server were caused by transient 5xx responses from `POST /v1/sessions/{id}/policies/evaluate` — likely brief DB connection pool exhaustion — hitting a zero-retry path that immediately failed closed.

## Test plan

- [ ] Existing fail-closed tests (`test_evaluate_policy_pre_tool_use_fails_closed_when_verdict_unavailable`, `test_pre_tool_use_fails_closed_when_verdict_unavailable`) pass with `_EVALUATE_POLICY_RETRY_BUDGET_S=0` (no sleep)
- [ ] New `test_evaluate_policy_retries_5xx_and_succeeds`: flaky client returns 503 twice then 200; asserts 3 total calls and no deny output
- [ ] `python -m pytest tests/test_native_policy_hook.py tests/test_claude_native_hook.py tests/test_codex_native_hook.py` — 63 passed

This pull request and its description were written by Isaac.