### PR TITLE
docs(polly): focus cross-review on critical issues, security, and UX

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -292,12 +292,14 @@ jobs:
           ```
 
           ## Instructions
-          Review the diff against the PR description. Report:
-          1. **Blocking issues** — bugs, security problems, correctness errors, data loss risks.
-          2. **Security analysis** — carefully check the security implications of the changes. Look for injection vulnerabilities (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.
-          3. **Non-blocking suggestions** — style, naming, performance, test coverage gaps.
-          4. **Summary** — one-paragraph overall assessment.
+          Review the diff against the PR description. Focus on what actually matters:
+          1. **Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.
+          2. **Security vulnerabilities** — injection (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.
+          3. **UX regressions** — changes that make a feature unusable, misleading, or visibly broken for end users.
+          4. **Non-blocking notes** — design concerns or edge cases worth flagging (brief).
+          5. **Summary** — one-paragraph overall assessment.
 
+          Do NOT comment on code style, formatting, naming conventions, or other cosmetic issues — omit them entirely.
           Be concise. Do not restate the diff. Focus on what matters.
 
           IMPORTANT: Your output will be posted directly as a PR comment. Output

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -292,12 +292,11 @@ jobs:
           ```
 
           ## Instructions
-          Review the diff against the PR description. Focus on what actually matters:
+          Review the diff against the PR description. Report:
           1. **Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.
           2. **Security vulnerabilities** — injection (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.
-          3. **UX regressions** — changes that make a feature unusable, misleading, or visibly broken for end users.
-          4. **Non-blocking notes** — design concerns or edge cases worth flagging (brief).
-          5. **Summary** — one-paragraph overall assessment.
+          3. **Non-blocking notes** — design concerns or edge cases worth flagging (brief).
+          4. **Summary** — one-paragraph overall assessment.
 
           Do NOT comment on code style, formatting, naming conventions, or other cosmetic issues — omit them entirely.
           Be concise. Do not restate the diff. Focus on what matters.

--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -21,8 +21,15 @@ anyone needs to read through.
    `review-auth-refactor`, never the raw vendor name:
    `sys_session_send(agent="claude_code"|"codex"|"pi", title="review-<task_slug>",
    args={purpose: "review", input: "<the diff> + <the acceptance contract>.
-   Review ONLY against the contract. Report blocking / non-blocking /
-   suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
+   Review ONLY against the contract. Focus your review on:
+   1. BLOCKING — correctness bugs, security vulnerabilities (injection, auth bypass,
+      data exposure, etc.), broken contracts, missing error handling on failure paths,
+      and UX regressions that make a feature unusable or misleading.
+   2. NON-BLOCKING — design concerns, edge cases worth noting.
+   3. SUGGESTIONS — minor improvements.
+   Do NOT flag code style, formatting, naming conventions, or other cosmetic issues —
+   those are not worth review bandwidth. Report blocking / non-blocking / suggestions.
+   Do not edit code."})`. Give it the diff as text — do NOT point
    it at the implementer's worktree. Fetch the diff and emit the
    `sys_session_send` call in the SAME turn you decide to review — never end a
    turn having only announced "I'll load cross-review and fetch the diff" with
@@ -54,6 +61,9 @@ anyone needs to read through.
   human at the plan gate.
 - Give the reviewer ONLY the diff + contract — never the implementer's
   transcript or worktree. The cross-vendor independence is the whole point.
+- The reviewer's mandate is critical issues only: security vulnerabilities, correctness
+  bugs, contract violations, and UX regressions. Code style, formatting, and naming
+  are explicitly out of scope — do not include them in the report.
 - Review is a coding sub-agent (`claude_code`/`codex`/`pi`) dispatched with
   `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
   reports issues and never edits; only the implementer opens a PR, so a stray

--- a/examples/polly/skills/cross-review/SKILL.md
+++ b/examples/polly/skills/cross-review/SKILL.md
@@ -21,15 +21,8 @@ anyone needs to read through.
    `review-auth-refactor`, never the raw vendor name:
    `sys_session_send(agent="claude_code"|"codex"|"pi", title="review-<task_slug>",
    args={purpose: "review", input: "<the diff> + <the acceptance contract>.
-   Review ONLY against the contract. Focus your review on:
-   1. BLOCKING — correctness bugs, security vulnerabilities (injection, auth bypass,
-      data exposure, etc.), broken contracts, missing error handling on failure paths,
-      and UX regressions that make a feature unusable or misleading.
-   2. NON-BLOCKING — design concerns, edge cases worth noting.
-   3. SUGGESTIONS — minor improvements.
-   Do NOT flag code style, formatting, naming conventions, or other cosmetic issues —
-   those are not worth review bandwidth. Report blocking / non-blocking / suggestions.
-   Do not edit code."})`. Give it the diff as text — do NOT point
+   Review ONLY against the contract. Report blocking / non-blocking /
+   suggestions. Do not edit code."})`. Give it the diff as text — do NOT point
    it at the implementer's worktree. Fetch the diff and emit the
    `sys_session_send` call in the SAME turn you decide to review — never end a
    turn having only announced "I'll load cross-review and fetch the diff" with
@@ -61,9 +54,6 @@ anyone needs to read through.
   human at the plan gate.
 - Give the reviewer ONLY the diff + contract — never the implementer's
   transcript or worktree. The cross-vendor independence is the whole point.
-- The reviewer's mandate is critical issues only: security vulnerabilities, correctness
-  bugs, contract violations, and UX regressions. Code style, formatting, and naming
-  are explicitly out of scope — do not include them in the report.
 - Review is a coding sub-agent (`claude_code`/`codex`/`pi`) dispatched with
   `purpose: "review"` — a DIFFERENT vendor from the one that built the diff. It
   reports issues and never edits; only the implementer opens a PR, so a stray


### PR DESCRIPTION
## Summary
- Updates the `cross-review` skill prompt to prioritize security vulnerabilities, correctness bugs, contract violations, and UX regressions as blocking issues
- Explicitly excludes code style, formatting, and naming from review scope
- Adds a Notes bullet reinforcing the narrowed mandate

## Test plan
- [ ] Verify the cross-review skill still loads correctly in a polly run
- [ ] Confirm a reviewer sub-agent dispatched via the skill no longer flags style/naming issues

Replaces #912 (rebased cleanly on main).

This pull request and its description were written by Isaac.