### PR TITLE
fix(hooks): retry transient 5xx/connect errors on policy evaluate POST

### DIFF
--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -21,6 +21,7 @@ model sees it).
 from __future__ import annotations
 
 import json
+import secrets
 import sys
 import time
 
@@ -301,11 +302,22 @@ def post_evaluate_with_retry(
     :data:`_EVALUATE_POLICY_RETRY_BUDGET_S`. Returns the successful response,
     or ``None`` if the budget is exhausted or a non-retryable error occurs.
 
+    A stable ``_omnigent_elicitation_id`` is minted once and stamped on
+    every attempt. When the server parks an ASK gate and the connection
+    drops (5xx or :class:`httpx.ConnectError`), the retry re-POSTs the
+    same id so the server re-attaches to the existing elicitation rather
+    than minting a new one — mirroring the ``_post_hook_with_reattach``
+    idiom used by the ``PermissionRequest`` hook. This prevents a
+    second approval card from appearing when the first was already
+    published before the error.
+
     4xx responses are final — a bad request won't succeed on retry. Other
     mid-stream errors (e.g. :class:`httpx.ReadTimeout`) are also not retried:
-    a read timeout can indicate a long-polling ASK gate being severed, and
-    retrying would open a new server-side elicitation, prompting the human
-    twice. The caller is responsible for fail-closed handling on ``None``.
+    a read timeout fires *after* the server received the request and may
+    mean the long-polling ASK gate was severed mid-wait; retrying with the
+    same id will re-park the existing elicitation (no duplicate card), but
+    the caller's fail-closed path is equivalent and simpler. The caller is
+    responsible for fail-closed handling on ``None``.
 
     :param url: Absolute URL of the evaluate endpoint.
     :param headers: Auth headers for the Omnigent server.
@@ -317,13 +329,19 @@ def post_evaluate_with_retry(
     :returns: Successful :class:`httpx.Response`, or ``None`` when retries
         are exhausted or the error is non-retryable.
     """
+    # Mint one stable id for the whole retry sequence. Each retry re-sends
+    # it so the server can re-park the SAME elicitation rather than opening
+    # a second approval card. The ``elicit_evaluate_`` namespace is validated
+    # server-side by ``_EVALUATE_HOOK_ELICITATION_ID_RE``.
+    elicitation_id = f"elicit_evaluate_{secrets.token_hex(16)}"
+    request_body = {**eval_request, "_omnigent_elicitation_id": elicitation_id}
     deadline = time.monotonic() + _EVALUATE_POLICY_RETRY_BUDGET_S
     backoff_s = _EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S
     timeout = httpx.Timeout(read_timeout, connect=_EVALUATE_POLICY_CONNECT_TIMEOUT_S)
     while True:
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
-                resp = client.post(url, json=eval_request)
+                resp = client.post(url, json=request_body)
                 resp.raise_for_status()
                 return resp
         except httpx.HTTPStatusError as exc:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -597,6 +597,10 @@ _HARNESS_ELICITATION_REPARK_GRACE_S = 10.0
 # Client-supplied re-attach ids, namespaced so they cannot collide
 # with Codex deterministic ids or server-minted ids.
 _CLAUDE_HOOK_ELICITATION_ID_RE = re.compile(r"^elicit_claude_[0-9a-f]{32}$")
+# Stable re-attach id for ``POST /policies/evaluate`` retries. Allows the
+# server to re-park the existing ASK elicitation rather than minting a new
+# approval card when a transient 5xx or connect-drop triggered a retry.
+_EVALUATE_HOOK_ELICITATION_ID_RE = re.compile(r"^elicit_evaluate_[0-9a-f]{32}$")
 
 # Cap on reaping a cancelled disconnect/terminal-resolved race task in
 # the harness-elicitation gate's cleanup. Reaping normally completes in
@@ -3644,6 +3648,7 @@ async def _hold_native_ask_gate(
     engine: PolicyEngine,
     result: PolicyResult,
     conversation_store: ConversationStore,
+    elicitation_id: str | None = None,
 ) -> bool:
     """
     Hold a server-side ASK gate until a human resolves it.
@@ -3686,6 +3691,13 @@ async def _hold_native_ask_gate(
         the reason, deciding_policy, and withheld set_labels.
     :param conversation_store: Store used to mirror child-session
         prompts into ancestor streams.
+    :param elicitation_id: Optional stable re-attach id from the
+        calling hook, e.g. ``"elicit_evaluate_abc123"``. When supplied,
+        ``_publish_and_wait_for_harness_elicitation`` re-attaches to the
+        existing parked elicitation rather than publishing a new card —
+        used by ``POST /policies/evaluate`` retries so a hook retry after
+        a transient 5xx / connect-drop does not prompt the human twice.
+        ``None`` mints a fresh id (the default for non-retry callers).
     :returns: ``True`` iff a human accepted; ``False`` on decline /
         cancel / timeout / disconnect (fail closed).
     """
@@ -3701,11 +3713,11 @@ async def _hold_native_ask_gate(
     )
     # Per-policy ``ask_timeout`` override wins over the spec-level default.
     timeout_s = float(resolve_ask_timeout(engine, result))
-    # Mint the id up front so we can also surface this ASK in the native
-    # terminal (a tmux popup) before parking on the web verdict; both
-    # surfaces resolve the same id, so whichever answers first releases the
-    # gate.
-    elicitation_id = f"elicit_{secrets.token_hex(16)}"
+    # Use the caller-supplied id when present (hook retries re-attach to
+    # the same elicitation); otherwise mint a fresh one so we can surface
+    # this ASK in the native terminal before parking on the web verdict.
+    if elicitation_id is None:
+        elicitation_id = f"elicit_{secrets.token_hex(16)}"
     _spawn_native_approval_popup_forward(
         session_id, elicitation_id, params.message, result.deciding_policy
     )
@@ -14254,6 +14266,20 @@ def create_sessions_router(
                 f"Expected one of {list(_PROTO_EVENT_TYPE_TO_PHASE)}.",
                 code=ErrorCode.INVALID_INPUT,
             )
+        # Optional stable re-attach id for hook retries. Validated but not
+        # required — absent on non-retrying callers (old hooks, direct API use).
+        raw_elicitation_id = payload.get("_omnigent_elicitation_id")
+        hook_elicitation_id: str | None = None
+        if raw_elicitation_id is not None:
+            if not isinstance(raw_elicitation_id, str) or not (
+                _EVALUATE_HOOK_ELICITATION_ID_RE.fullmatch(raw_elicitation_id)
+            ):
+                raise OmnigentError(
+                    "Policy evaluate '_omnigent_elicitation_id' must match "
+                    "'elicit_evaluate_' + 32 hex chars.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            hook_elicitation_id = raw_elicitation_id
         data = event.get("data") or {}
 
         conv = conversation_store.get_conversation(session_id)
@@ -14369,6 +14395,7 @@ def create_sessions_router(
                             engine=engine,
                             result=result,
                             conversation_store=conversation_store,
+                            elicitation_id=hook_elicitation_id,
                         )
                         verdict_body: dict[str, Any] = (
                             {"result": "POLICY_ACTION_ALLOW"}

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -791,6 +791,7 @@ async def test_concurrent_cost_asks_serialize_and_collapse_sibling(
         engine: Any,
         result: Any,
         conversation_store: Any,
+        elicitation_id: str | None = None,
     ) -> bool:
         """
         Stand-in for ``_hold_native_ask_gate`` that simulates accept.

--- a/tests/server/routes/test_sessions_policy.py
+++ b/tests/server/routes/test_sessions_policy.py
@@ -702,6 +702,7 @@ async def test_input_ask_approved_falls_through_to_allow():
         engine: Any,
         result: PolicyResult,
         conversation_store: Any,
+        elicitation_id: str | None = None,
     ) -> bool:
         """Stand in for the server-side approval park; simulate approve.
 
@@ -778,6 +779,7 @@ async def test_input_ask_declined_denies():
         engine: Any,
         result: PolicyResult,
         conversation_store: Any,
+        elicitation_id: str | None = None,
     ) -> bool:
         """Stand in for the server-side approval park; simulate decline.
 


### PR DESCRIPTION
## Summary

- Adds `post_evaluate_with_retry()` to `native_policy_hook` (shared by both claude and codex hooks): retries 5xx and `ConnectError`/`ConnectTimeout` within a 30s budget with exponential backoff (1s → 10s cap)
- Stamps a stable `_omnigent_elicitation_id` (`elicit_evaluate_` namespace) on every attempt — mirrors `_post_hook_with_reattach` so the server re-attaches to the existing ASK elicitation on retry rather than publishing a second approval card
- `_hold_native_ask_gate` accepts optional `elicitation_id` (defaults to `None` for all existing non-retry callers); `_EVALUATE_HOOK_ELICITATION_ID_RE` validates the client-supplied id server-side
- Non-retryable errors (4xx, `ReadTimeout`) still fail closed immediately
- Moves `httpx.Client` out of the per-hook modules into the shared helper; tests patch `native_policy_hook.httpx`

## Root cause

Intermittent `"Omnigent policy evaluation unavailable; failing closed for this tool call."` denies on a DB-hosted server were caused by transient 5xx responses from `POST /v1/sessions/{id}/policies/evaluate` — likely brief DB connection pool exhaustion — hitting a zero-retry path that immediately failed closed.

## Test plan

- [ ] `python -m pytest tests/test_native_policy_hook.py tests/test_claude_native_hook.py tests/test_codex_native_hook.py tests/server/integration/test_sessions_policy_evaluate.py tests/server/integration/test_sessions_policy_evaluate_read_only.py tests/server/routes/test_sessions_policy.py` — 101 passed
- [ ] Fail-closed tests use `_EVALUATE_POLICY_RETRY_BUDGET_S=0` (no sleep)
- [ ] New `test_evaluate_policy_retries_5xx_and_succeeds`: flaky client returns 503 twice then 200; asserts 3 total calls and no deny output

This pull request and its description were written by Isaac.