### PR TITLE
fix(native): retry policy evaluation on transient 5xx instead of failing closed

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -31,6 +31,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    post_policy_evaluation,
 )
 
 # Client-side budget for the permission-request long-poll to AP. Held
@@ -822,29 +823,14 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         return 0
 
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{url_component(session_id)}/policies/evaluate"
-    try:
-        with httpx.Client(
-            headers=headers, timeout=httpx.Timeout(_EVALUATE_POLICY_TIMEOUT_S)
-        ) as client:
-            resp = client.post(url, json=eval_request)
-            resp.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        print(
-            f"omnigent evaluate-policy hook: Omnigent returned {exc.response.status_code}",
-            file=sys.stderr,
-        )
-        return _fail_closed()
-    except httpx.HTTPError as exc:
-        print(f"omnigent evaluate-policy hook: Omnigent request failed: {exc}", file=sys.stderr)
-        return _fail_closed()
-    if not resp.content:
-        print("omnigent evaluate-policy hook: empty Omnigent response", file=sys.stderr)
-        return _fail_closed()
-
-    try:
-        eval_response = resp.json()
-    except json.JSONDecodeError:
-        print("omnigent evaluate-policy hook: malformed Omnigent response", file=sys.stderr)
+    eval_response = post_policy_evaluation(
+        url,
+        headers,
+        eval_request,
+        read_timeout_s=_EVALUATE_POLICY_TIMEOUT_S,
+        log_prefix="omnigent evaluate-policy hook",
+    )
+    if eval_response is None:
         return _fail_closed()
 
     hook_output = evaluation_response_to_hook_output(hook_event, eval_response)

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -17,8 +17,6 @@ import sys
 import urllib.parse
 from pathlib import Path
 
-import httpx
-
 from omnigent.codex_native_bridge import (
     read_bridge_state,
     read_codex_config_model,
@@ -28,6 +26,7 @@ from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    post_policy_evaluation,
 )
 
 # Budget for the policy evaluation POST. Normally a quick
@@ -160,35 +159,14 @@ def _main_evaluate_policy(argv: list[str]) -> int:
 
     session_component = urllib.parse.quote(session_id, safe="")
     url = f"{ap_server_url.rstrip('/')}/v1/sessions/{session_component}/policies/evaluate"
-    try:
-        with httpx.Client(
-            headers=headers, timeout=httpx.Timeout(_EVALUATE_POLICY_TIMEOUT_S)
-        ) as client:
-            resp = client.post(url, json=eval_request)
-            resp.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        print(
-            f"omnigent codex evaluate-policy hook: Omnigent returned {exc.response.status_code}",
-            file=sys.stderr,
-        )
-        return _fail_closed()
-    except httpx.HTTPError as exc:
-        print(
-            f"omnigent codex evaluate-policy hook: Omnigent request failed: {exc}",
-            file=sys.stderr,
-        )
-        return _fail_closed()
-    if not resp.content:
-        print("omnigent codex evaluate-policy hook: empty Omnigent response", file=sys.stderr)
-        return _fail_closed()
-
-    try:
-        eval_response = resp.json()
-    except json.JSONDecodeError:
-        print(
-            "omnigent codex evaluate-policy hook: malformed Omnigent response",
-            file=sys.stderr,
-        )
+    eval_response = post_policy_evaluation(
+        url,
+        headers,
+        eval_request,
+        read_timeout_s=_EVALUATE_POLICY_TIMEOUT_S,
+        log_prefix="omnigent codex evaluate-policy hook",
+    )
+    if eval_response is None:
         return _fail_closed()
 
     hook_output = evaluation_response_to_hook_output(hook_event, eval_response)

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -21,6 +21,10 @@ model sees it).
 from __future__ import annotations
 
 import json
+import sys
+import time
+
+import httpx
 
 # Hook event names that gate tool execution and therefore carry policy
 # meaning. ``PreToolUse`` fires before the tool runs (can block);
@@ -41,6 +45,118 @@ _USER_PROMPT_SUBMIT = "UserPromptSubmit"
 _EVAL_UNAVAILABLE_REASON = (
     "Omnigent policy evaluation unavailable; failing closed for this tool call."
 )
+
+# Bounded retry for the synchronous ``POST /policies/evaluate`` gate that
+# fronts every native tool call. A shared Omnigent server under load returns
+# intermittent 5xx, and the gate used to fail CLOSED on the *first* such
+# error — turning a momentary blip into a denied tool call (the user then
+# had to retry by hand). A couple of quick retries absorb those blips while
+# still failing closed when the server is genuinely down. Kept small and
+# fast: this runs inline before the tool, not as the day-long permission
+# long-poll.
+_EVALUATE_RETRY_MAX_ATTEMPTS = 3
+_EVALUATE_RETRY_INITIAL_BACKOFF_S = 0.25
+_EVALUATE_RETRY_MAX_BACKOFF_S = 2.0
+# Connect fast so an unreachable server drops into the retry/backoff loop
+# instead of inheriting the day-long read budget (that budget exists only
+# for a server-side ASK park, which happens *after* a successful connect).
+_EVALUATE_CONNECT_TIMEOUT_S = 30.0
+
+
+def post_policy_evaluation(
+    url: str,
+    headers: dict[str, str],
+    eval_request: dict[str, object],
+    *,
+    read_timeout_s: float,
+    log_prefix: str,
+) -> dict[str, object] | None:
+    """
+    POST one ``EvaluationRequest`` to ``/policies/evaluate`` with bounded retry.
+
+    Retries only the *safe* transient failures so a brief server blip no
+    longer hard-denies the tool call:
+
+    - **5xx** — the server errored before producing a verdict (overload /
+      crash), so no ASK gate has parked; a retry usually lands on a healthy
+      backend.
+    - **connect-phase failures** (``ConnectError`` / ``ConnectTimeout`` /
+      ``PoolTimeout``) — the request never reached the server, so nothing
+      parked; safe to retry.
+
+    Everything else is final (returns ``None`` so the caller fails closed):
+
+    - **4xx** — a deterministic rejection; retrying cannot change it.
+    - **read/write/protocol transport errors** — these can mean a long-poll
+      ASK park was severed mid-wait. Unlike the permission long-poll
+      (:func:`omnigent.claude_native_hook._post_hook_with_reattach`), this
+      path carries no stable elicitation id, so re-POSTing would re-park a
+      *duplicate* approval card. Fail closed instead of retrying.
+    - **empty / malformed / non-object body** — the server answered but the
+      verdict is unusable.
+
+    :param url: Absolute evaluate endpoint, e.g.
+        ``"http://127.0.0.1:8787/v1/sessions/conv_x/policies/evaluate"``.
+    :param headers: Outbound Omnigent auth headers.
+    :param eval_request: ``EvaluationRequest`` envelope to POST.
+    :param read_timeout_s: Read budget in seconds. Held at the day-long
+        ASK-park budget by callers; the connect phase uses the shorter
+        :data:`_EVALUATE_CONNECT_TIMEOUT_S` so unreachable servers fail fast.
+    :param log_prefix: Diagnostic prefix for stderr lines, e.g.
+        ``"omnigent evaluate-policy hook"``.
+    :returns: The parsed ``EvaluationResponse`` dict, or ``None`` when no
+        usable verdict could be obtained (caller fails closed).
+    """
+    timeout = httpx.Timeout(read_timeout_s, connect=_EVALUATE_CONNECT_TIMEOUT_S)
+    backoff_s = _EVALUATE_RETRY_INITIAL_BACKOFF_S
+    last_error = ""
+    for attempt in range(1, _EVALUATE_RETRY_MAX_ATTEMPTS + 1):
+        try:
+            with httpx.Client(headers=headers, timeout=timeout) as client:
+                resp = client.post(url, json=eval_request)
+                resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status < 500:
+                # Deterministic rejection — retrying won't help.
+                print(f"{log_prefix}: Omnigent returned {status}", file=sys.stderr)
+                return None
+            last_error = f"Omnigent returned {status}"
+        except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
+            last_error = f"Omnigent connect failed: {exc}"
+        except httpx.HTTPError as exc:
+            # Read/write/protocol error — may be a severed ASK park; do not
+            # retry (would risk a duplicate elicitation). Fail closed.
+            print(f"{log_prefix}: Omnigent request failed: {exc}", file=sys.stderr)
+            return None
+        else:
+            if not resp.content:
+                print(f"{log_prefix}: empty Omnigent response", file=sys.stderr)
+                return None
+            try:
+                parsed = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                print(f"{log_prefix}: malformed Omnigent response", file=sys.stderr)
+                return None
+            if not isinstance(parsed, dict):
+                print(f"{log_prefix}: unexpected Omnigent response shape", file=sys.stderr)
+                return None
+            return parsed
+        # Reached only on a retryable failure (5xx or connect-phase).
+        if attempt >= _EVALUATE_RETRY_MAX_ATTEMPTS:
+            print(
+                f"{log_prefix}: {last_error}; retries exhausted, failing closed",
+                file=sys.stderr,
+            )
+            return None
+        print(
+            f"{log_prefix}: {last_error}; retrying "
+            f"(attempt {attempt}/{_EVALUATE_RETRY_MAX_ATTEMPTS})",
+            file=sys.stderr,
+        )
+        time.sleep(backoff_s)
+        backoff_s = min(backoff_s * 2, _EVALUATE_RETRY_MAX_BACKOFF_S)
+    return None
 
 
 def hook_payload_to_evaluation_request(

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from omnigent import claude_native_hook
+from omnigent import claude_native_hook, native_policy_hook
 from omnigent.claude_native_bridge import (
     build_hook_settings,
     prepare_bridge_dir,
@@ -1729,6 +1729,8 @@ def test_evaluate_policy_pre_tool_use_fails_closed_when_verdict_unavailable(
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
     monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client(mode))
+    # connect_error / non_2xx (5xx) are retried; skip the backoff sleeps.
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
@@ -1776,6 +1778,8 @@ def test_evaluate_policy_non_tool_call_phases_fail_open_on_error(
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
     monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client("connect_error"))
+    # connect_error is retried; skip the backoff sleeps to keep the test fast.
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from omnigent import codex_native_hook
+from omnigent import codex_native_hook, native_policy_hook
 from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     codex_home_for_bridge_dir,
@@ -195,7 +195,7 @@ def test_pre_tool_use_converts_posts_and_returns_deny(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -247,7 +247,7 @@ def test_user_prompt_submit_converts_posts_and_blocks(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -293,7 +293,7 @@ def test_pre_tool_use_stamps_model_from_config(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -327,7 +327,7 @@ def test_pre_tool_use_stamps_harness_without_config_model(
         ap_server_url="http://127.0.0.1:8787",
         ap_auth_headers={"Authorization": "Bearer test-token"},
     )
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _DenyHttpxClient)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _DenyHttpxClient)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -356,7 +356,7 @@ def test_missing_bridge_state_is_fail_open(
     """
     monkeypatch.setattr("omnigent.codex_native_bridge._BRIDGE_ROOT", tmp_path / "codex-native")
     empty_dir = prepare_bridge_dir("bridge_no_state")
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _RaisesIfCalled)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RaisesIfCalled)
 
     exit_code = _run_hook(
         empty_dir,
@@ -381,7 +381,7 @@ def test_missing_policy_config_is_fail_open(
     local run with no Omnigent server), so there is nothing to enforce against.
     The hook returns 0 with no output and does not touch the network.
     """
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", _RaisesIfCalled)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RaisesIfCalled)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -408,7 +408,9 @@ def test_pre_tool_use_fails_closed_when_verdict_unavailable(
     CLOSED (deny) instead of "no opinion" — the bypass reported in #536.
     """
     write_policy_hook_config(bridge_dir, ap_server_url="http://127.0.0.1:8787", ap_auth_headers={})
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", make_failing_client(mode))
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", make_failing_client(mode))
+    # connect_error / non_2xx (5xx) are retried; skip the backoff sleeps.
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
 
     exit_code = _run_hook(
         bridge_dir,
@@ -453,7 +455,9 @@ def test_non_tool_call_phases_fail_open_on_error(
     runner-side ``FAIL_CLOSED_PHASES`` (PR #163).
     """
     write_policy_hook_config(bridge_dir, ap_server_url="http://127.0.0.1:8787", ap_auth_headers={})
-    monkeypatch.setattr(codex_native_hook.httpx, "Client", make_failing_client("connect_error"))
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", make_failing_client("connect_error"))
+    # connect_error is retried; skip the backoff sleeps to keep the test fast.
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
 
     exit_code = _run_hook(bridge_dir, payload, monkeypatch)
 

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -2,13 +2,221 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
+from omnigent import native_policy_hook
 from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
+    post_policy_evaluation,
 )
+
+
+def _scripted_client(outcomes: list[object], calls: list[str]) -> type:
+    """
+    Build an ``httpx.Client`` stub that replays a scripted POST sequence.
+
+    :param outcomes: One entry per expected POST. An :class:`Exception`
+        is raised; an ``(status, text)`` tuple is returned as an
+        :class:`httpx.Response`.
+    :param calls: List the stub appends each POST URL to, so a test can
+        assert how many attempts were made.
+    :returns: A class usable as a drop-in for :class:`httpx.Client`.
+    """
+
+    class _Client:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            outcome = outcomes[len(calls)]
+            calls.append(url)
+            if isinstance(outcome, Exception):
+                raise outcome
+            status, text = outcome  # type: ignore[misc]
+            return httpx.Response(status, text=text, request=httpx.Request("POST", url))
+
+    return _Client
+
+
+_ALLOW_BODY = '{"result":"POLICY_ACTION_ALLOW"}'
+
+
+def test_post_policy_evaluation_retries_5xx_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A transient 5xx is retried and the eventual verdict is returned.
+
+    This is the reported failure: a shared server returning intermittent
+    5xx under load used to fail closed on the FIRST error, hard-denying the
+    tool call. Two blips followed by a healthy response must now yield the
+    real verdict instead of a denial.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _scripted_client([(503, "down"), (502, "down"), (200, _ALLOW_BODY)], calls),
+    )
+
+    result = post_policy_evaluation(
+        "http://x/evaluate",
+        {},
+        {"event": {}},
+        read_timeout_s=1.0,
+        log_prefix="test",
+    )
+
+    assert result == {"result": "POLICY_ACTION_ALLOW"}
+    assert len(calls) == 3
+
+
+def test_post_policy_evaluation_retries_connect_error_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A connect-phase failure is retried (the request never reached the server).
+
+    A ``ConnectError`` means nothing was evaluated or parked server-side, so
+    re-POSTing is safe and absorbs a brief unreachable-server blip.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _scripted_client(
+            [
+                httpx.ConnectError("unreachable", request=httpx.Request("POST", "http://x")),
+                (200, _ALLOW_BODY),
+            ],
+            calls,
+        ),
+    )
+
+    result = post_policy_evaluation(
+        "http://x/evaluate", {}, {"event": {}}, read_timeout_s=1.0, log_prefix="test"
+    )
+
+    assert result == {"result": "POLICY_ACTION_ALLOW"}
+    assert len(calls) == 2
+
+
+def test_post_policy_evaluation_exhausts_retries_on_persistent_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A server that is genuinely down still fails closed after the retry budget.
+
+    The retry must not paper over a real outage: once attempts are exhausted
+    the helper returns ``None`` so the caller fails closed (deny).
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _scripted_client([(503, "down")] * 10, calls),
+    )
+
+    result = post_policy_evaluation(
+        "http://x/evaluate", {}, {"event": {}}, read_timeout_s=1.0, log_prefix="test"
+    )
+
+    assert result is None
+    assert len(calls) == native_policy_hook._EVALUATE_RETRY_MAX_ATTEMPTS
+
+
+def test_post_policy_evaluation_does_not_retry_4xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A 4xx is a deterministic rejection — return immediately, no retry.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _scripted_client([(403, "forbidden"), (200, _ALLOW_BODY)], calls),
+    )
+
+    result = post_policy_evaluation(
+        "http://x/evaluate", {}, {"event": {}}, read_timeout_s=1.0, log_prefix="test"
+    )
+
+    assert result is None
+    assert len(calls) == 1
+
+
+def test_post_policy_evaluation_does_not_retry_read_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A read-phase transport error is NOT retried.
+
+    A severed read can mean a long-poll ASK gate was parked server-side and
+    then cut; re-POSTing (this path carries no stable elicitation id) would
+    re-park a duplicate approval card. Fail closed instead.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _scripted_client(
+            [
+                httpx.ReadError("connection reset", request=httpx.Request("POST", "http://x")),
+                (200, _ALLOW_BODY),
+            ],
+            calls,
+        ),
+    )
+
+    result = post_policy_evaluation(
+        "http://x/evaluate", {}, {"event": {}}, read_timeout_s=1.0, log_prefix="test"
+    )
+
+    assert result is None
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("body", ["", "not json at all"])
+def test_post_policy_evaluation_fails_on_unusable_body(
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+) -> None:
+    """
+    A 2xx with an empty or malformed body fails closed without retrying.
+
+    The server answered, so the verdict is simply unusable — retrying would
+    not change a deterministic bad body.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        native_policy_hook.httpx,
+        "Client",
+        _scripted_client([(200, body), (200, _ALLOW_BODY)], calls),
+    )
+
+    result = post_policy_evaluation(
+        "http://x/evaluate", {}, {"event": {}}, read_timeout_s=1.0, log_prefix="test"
+    )
+
+    assert result is None
+    assert len(calls) == 1
 
 
 def test_pre_tool_use_maps_to_phase_tool_call() -> None:


### PR DESCRIPTION
## Problem

Reported via Slack: tool calls against the shared Omnigent server intermittently get hard-denied with `Omnigent policy evaluation unavailable; failing closed for this tool call.`, forcing the user to retry by hand (and eventually fall back to vanilla Claude Code).

**Root cause:** the native policy hooks (`claude_native_hook`, `codex_native_hook`) gate every tool call on a synchronous `POST /policies/evaluate`, and that POST was **not retried**. Any 5xx, connect failure, or transport error immediately failed **closed** (deny). On a shared, load-heavy server returning intermittent 5xx, a single momentary blip = one denied tool call.

The fail-closed-on-unreachable behavior itself is correct and intentional (#579 — before it, a transient outage silently let gated calls through). The gap is that it fired on the *first* error with no retry, unlike the sibling permission long-poll path which already retries via `_post_hook_with_reattach`.

## Change

Add a shared `post_policy_evaluation()` helper in `native_policy_hook.py` and route both native hooks through it. It retries **only the safe transient failures**:

| Failure | Behavior |
|---|---|
| **5xx** (server errored before producing a verdict — no ASK gate parked) | **Retry** (3 attempts, 0.25s→0.5s backoff) |
| **Connect-phase** (`ConnectError`/`ConnectTimeout`/`PoolTimeout` — request never reached the server) | **Retry** |
| **4xx** (deterministic rejection) | Fail closed immediately |
| **Read/write/protocol transport error** | Fail closed immediately |
| **Empty / malformed / non-dict body** | Fail closed immediately |

Read-phase transport errors are deliberately **not** retried: a severed read can mean an ASK gate parked server-side, and this path carries no stable elicitation id (unlike the permission long-poll), so a blind re-POST would risk a **duplicate approval card**.

A 30s connect timeout drops an unreachable server into the retry loop instead of inheriting the day-long read budget (which exists only for the server-side ASK park, after a successful connect). The #579 fail-closed-when-genuinely-down guarantee is preserved — retries just absorb brief blips first.

## Tests

- 7 new unit tests for the helper (`test_native_policy_hook.py`): retry-then-succeed on 5xx and connect-error, exhaustion → fail-closed, no-retry on 4xx / read-error / bad-body.
- Updated existing codex tests to patch `httpx` via `native_policy_hook` (the POST moved modules) and stubbed `sleep` in the retrying-mode tests.
- `test_native_policy_hook.py` (32), `test_claude_native_hook.py` + `test_codex_native_hook.py` (37) all pass; `ruff check` / `ruff format --check` clean.