### PR TITLE
feat(cli): show running sub-agents in the bottom toolbar

### DIFF
--- a/designs/CLI_SUBAGENT_STATUSBAR.md
+++ b/designs/CLI_SUBAGENT_STATUSBAR.md
@@ -1,0 +1,130 @@
+# Design: surface running sub-agents in the Omnigent CLI status bar
+
+Status: **DRAFT for review** (red-team in progress). Author: Isaac (with Ruslan).
+
+## Problem
+
+When an orchestrator agent (e.g. `polly`) dispatches sub-agents, the CLI shows
+only "dispatched … / finished" — there is no live indication that work is
+happening in the background. Today you can only watch sub-agents run in the
+**web UI**. We want a minimal, always-visible cue in the CLI so the user is
+aware of background work, without polluting the transcript.
+
+## Confirmed: the CLI already runs sub-agents in parallel
+
+- Emitting multiple `sys_session_send` tool-calls in one LLM response dispatches
+  children **concurrently** (`omnigent/tools/builtins/spawn.py:129-131`).
+- The runner tracks each child live: `_SubagentWorkEntry`
+  (`omnigent/runner/app.py:3671-3709`) carries `agent`, `title`, `status`
+  (`launching`→`running`→`completed`/`failed`/`cancelled`), `created_at`,
+  `completed_at`; `list_subagent_work(parent)` returns them sorted.
+- The server defines `session.child_session.updated`
+  (`omnigent/server/schemas.py:3262-3285`, summary `:558-665`) and
+  `session.created` (`:2483`), both members of the `ServerStreamEvent` union
+  the CLI already parses (`sdks/python-client/omnigent_client/_sessions.py`).
+
+So the only gap is the **CLI surface**.
+
+## Design
+
+### What the user sees
+
+A compact segment in the existing bottom toolbar, shown only when ≥1 child is
+active (ephemeral — never written to scrollback):
+
+```
+omnigent · streaming… 5s   ⇡2 sub-agents · researcher 12s · coder 8s   ● 31%  state: running ⠹
+```
+
+- `⇡N sub-agents` (singular `⇡1 sub-agent`); up to 2 named children oldest-first
+  as `{label} {elapsed}`; `+K` when more than 2 are active.
+- `⚠` prefix when any child is **blocked on input**
+  (`pending_elicitations_count > 0`) — the highest-value signal.
+- **Width-budgeted**: computed after the existing segments against remaining
+  width; degrades to `⇡N sub-agents`, then to nothing. Never wraps.
+
+### Data source — consume events already on the wire (RESOLVED: events are live)
+
+**Confirmed in code:** the runner fans out each child status/preview delta onto
+the parent's **live** stream as `session.child_session.updated`
+(`_fan_out_child_delta_to_parent`, `omnigent/runner/app.py:4792`), coalescing on
+busy/status edges — *not* only in the connect snapshot. The CLI's
+`_render_session_event` already receives these (the `_sessions.py` parser
+includes `SessionChildSessionUpdatedEvent`); it simply ignored them. So the MVP
+is **purely event-driven — no polling, no new API.**
+
+The `child` payload is a **partial** dict (only changed fields), so the reducer
+**merges** per `child_session_id`:
+
+- **Active** = `busy` OR `current_task_status ∈ {launching, queued,
+  in_progress}`. **Removed** when terminal (`completed`/`failed`/`cancelled`).
+- **Elapsed** uses a **client-side `time.monotonic()` first-seen** time (not the
+  server `created_at` epoch) — skew-free and always ≥ 0.
+
+### Update / clear lifecycle
+
+- `host.apply_child_session_update(child_id, child)` folds each delta into the
+  registry and repaints (mirrors `update_context_usage`).
+- The 10fps ticker is extended (`… or self._subagents`) so elapsed keeps ticking
+  while children run **even after the parent's turn goes idle**.
+- **Correction vs the first draft: do NOT clear on parent idle.** Sub-agents
+  keep running in the background after the orchestrator's turn ends (that's the
+  point), so the active set is driven *purely* by child terminal events; a
+  missed terminal self-corrects on the next reconnect snapshot.
+  `clear_subagents()` exists for session reset.
+
+### Change points (as implemented)
+
+- `sdks/ui/omnigent_ui_sdk/terminal/_host.py`: `_subagents` +
+  `_subagent_state` registry fields; module-level pure helpers
+  `_format_elapsed_short`, `_format_subagent_segment`, `_reduce_subagent_event`;
+  `apply_child_session_update()` and `clear_subagents()` methods; the segment
+  wired into `build_toolbar()` (width-budgeted); the ticker condition extended
+  (`… or self._subagents`).
+- `omnigent/repl/_repl.py`: in `_render_session_event`, handle
+  `SessionChildSessionUpdatedEvent` → `host.apply_child_session_update(...)`.
+
+### Test seams (unit-tested)
+
+1. **`_format_subagent_segment`**: singular/plural, oldest-first, `+K`, `⚠`,
+   width-budget degradation, empty.
+2. **`_format_elapsed_short`**: `8s`/`2m`/`1h`, never negative.
+3. **`_reduce_subagent_event`**: add on running, merge partial deltas (preserve
+   label + start), drop on terminal, `launching`-without-`busy`, label fallback.
+
+## MVP scope / non-goals
+
+- IN: count + ≤2 named children + elapsed + blocked-on-input flag in the toolbar.
+- OUT (later): interleaving each child's actual tool calls/output; a full
+  multi-child panel; reconnect reconciliation fetch.
+
+## Alternatives considered
+
+- **Append-only inline status lines**: simpler to render, but clutters the
+  transcript and is noisier; rejected for the toolbar (ephemeral, cleaner).
+- **In-place live block**: prettier, but fights the streaming output for the
+  cursor and is hard to test; rejected for MVP.
+
+## Risks / decisions (resolved during implementation)
+
+1. **Live child events** — RESOLVED: pushed live by the runner (above); purely
+   event-driven, no polling, no new API.
+2. **`created_at` clock skew** — avoided: elapsed uses the client
+   `time.monotonic()` first-seen time, not the server epoch.
+3. **Clear on parent idle** — corrected: do NOT clear on idle (children outlive
+   the turn); the set is driven by child terminal events.
+4. **Terminal compatibility** — the toolbar already uses Unicode (`─`, `●`, the
+   braille spinner), so `⇡ ⚠ ·` are consistent with existing assumptions; the
+   segment is width-budgeted and degrades to nothing rather than wrapping.
+5. **Reconnect / missed terminal** — a stale child self-corrects on the next
+   connect snapshot (which re-sends child summaries). Accepted for MVP.
+6. **Nested sub-agents / many children / cancellation** — handled generically:
+   any `session.child_session.updated` for an active child shows; cancellation
+   is a terminal status; `+K` collapses many children.
+
+## Verification note
+
+The pure helpers (formatter, elapsed, reducer) are unit-tested. The visual
+toolbar integration (placement, width budgeting against the live stream) is
+best confirmed by running an orchestrator (`omnigent run examples/polly`) and
+watching a multi-sub-agent turn — recommended before merge.

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2836,6 +2836,9 @@ async def run_repl(
             SessionAgentChangedEvent as _AgentChangedEv,
         )
         from omnigent.server.schemas import (
+            SessionChildSessionUpdatedEvent as _ChildEv,
+        )
+        from omnigent.server.schemas import (
             SessionInputConsumedEvent as _SICEv,
         )
         from omnigent.server.schemas import (
@@ -2845,6 +2848,16 @@ async def run_repl(
         tape_entry = None
         if _event_tape is not None:
             tape_entry = _event_tape.record_raw(event, path="sessions")
+
+        # Live sub-agent (child session) status → the bottom-toolbar segment,
+        # so the user sees background sub-agents running. The runner fans these
+        # deltas out onto the parent stream as session.child_session.updated;
+        # sub-agents keep running after the parent's turn goes idle, so the
+        # segment is driven purely by these deltas (added while running,
+        # dropped on terminal), not by the parent's turn boundary.
+        if isinstance(event, _ChildEv):
+            host.apply_child_session_update(event.child_session_id, event.child)
+            return
 
         if isinstance(event, _StatusEv):
             if tape_entry is not None:

--- a/sdks/ui/omnigent_ui_sdk/terminal/_host.py
+++ b/sdks/ui/omnigent_ui_sdk/terminal/_host.py
@@ -200,6 +200,108 @@ _SPINNER_FRAMES: tuple[str, ...] = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "�
 # calls don't dominate the event loop.
 _SPINNER_TICK_SECONDS: float = 0.1
 
+# ── Running sub-agents toolbar segment ────────────────
+# Surfaces background sub-agents an orchestrator dispatched (via
+# ``sys_session_send``) so the user is aware work is happening — even after
+# the parent's turn goes idle while children keep running. Driven entirely by
+# the live ``session.child_session.updated`` deltas the runner fans out onto
+# the parent stream. The pure helpers below keep the formatting and the event
+# reduction unit-testable without constructing a host.
+
+# How many child names to show before collapsing the rest into ``+K``.
+_SUBAGENT_NAMES_SHOWN: int = 2
+
+
+def _format_elapsed_short(seconds: float) -> str:
+    """Compact elapsed string: ``8s`` / ``2m`` / ``1h`` (floored, never < 0)."""
+    secs = max(0, int(seconds))
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    return f"{secs // 3600}h"
+
+
+def _format_subagent_segment(
+    subagents: dict[str, tuple[str, float, bool]],
+    *,
+    budget: int,
+    now: float,
+) -> str:
+    """Format the running-sub-agents toolbar segment within ``budget`` columns.
+
+    :param subagents: Active children, ``child_id -> (label, started_monotonic,
+        awaiting_input)``.
+    :param budget: Maximum columns the segment may occupy.
+    :param now: Current ``time.monotonic()`` (passed in for testability).
+    :returns: e.g. ``" ⇡2 sub-agents · researcher 12s · coder 8s "`` —
+        degrading to ``" ⇡2 sub-agents "`` then ``""`` as ``budget`` shrinks,
+        and ``""`` when there are no active children.
+    """
+    if not subagents:
+        return ""
+    count = len(subagents)
+    noun = "sub-agent" if count == 1 else "sub-agents"
+    warn = "⚠ " if any(awaiting for _, _, awaiting in subagents.values()) else ""
+    # Oldest-first, so the longest-running children lead.
+    ordered = sorted(subagents.values(), key=lambda entry: entry[1])
+    shown = ordered[:_SUBAGENT_NAMES_SHOWN]
+    tails = [f"{label} {_format_elapsed_short(now - started)}" for label, started, _ in shown]
+    tail = " · ".join(tails)
+    extra = count - len(shown)
+    if extra > 0:
+        tail = f"{tail} +{extra}"
+    full = f" {warn}⇡{count} {noun} · {tail} "
+    if len(full) <= budget:
+        return full
+    compact = f" {warn}⇡{count} {noun} "
+    if len(compact) <= budget:
+        return compact
+    return ""
+
+
+def _reduce_subagent_event(
+    state: dict[str, dict[str, object]],
+    active: dict[str, tuple[str, float, bool]],
+    *,
+    child_id: str,
+    child: dict[str, object],
+    now: float,
+) -> None:
+    """Fold one ``session.child_session.updated`` delta into the registry.
+
+    Mutates ``state`` (the per-child merge cache, since the runner sends
+    PARTIAL deltas) and ``active`` (``child_id -> (label, started, awaiting)``
+    for currently-running children). A child is active while ``busy`` or its
+    task is ``launching`` / ``queued`` / ``in_progress``; it is dropped once
+    terminal (``completed`` / ``failed`` / ``cancelled``). The start time is
+    captured the first time a child is seen active and preserved across later
+    deltas, so its elapsed counter is stable (and clock-skew-free — it uses
+    the client monotonic clock, not the server ``created_at`` epoch).
+
+    :param state: Per-child merge cache, carried across deltas.
+    :param active: The active-children registry, updated in place.
+    :param child_id: The child session id from the event.
+    :param child: The PARTIAL child summary (only changed fields present).
+    :param now: Current ``time.monotonic()`` for a newly-seen child's start.
+    """
+    merged = state.setdefault(child_id, {})
+    merged.update({key: value for key, value in child.items() if value is not None})
+    busy = bool(merged.get("busy"))
+    task_status = merged.get("current_task_status")
+    is_active = busy or task_status in ("launching", "queued", "in_progress")
+    is_terminal = not busy and task_status in ("completed", "failed", "cancelled")
+    if is_terminal or not is_active:
+        active.pop(child_id, None)
+        if is_terminal:
+            state.pop(child_id, None)
+        return
+    label = merged.get("tool") or merged.get("session_name") or merged.get("title") or "sub-agent"
+    awaiting = bool(merged.get("pending_elicitations_count"))
+    started = active[child_id][1] if child_id in active else now
+    active[child_id] = (str(label), started, awaiting)
+
+
 # Window for the two-press Ctrl+C exit: first Ctrl+C with an
 # empty input arms the exit hint; a second Ctrl+C within this
 # many seconds actually exits. Longer than "immediate" so a
@@ -883,6 +985,14 @@ class TerminalHost:
         self._tokens_used: int | None = None
         self._context_window: int | None = None
 
+        # Running sub-agents shown in the bottom toolbar. ``_subagents`` maps
+        # child_id -> (label, started_monotonic, awaiting_input) for children
+        # currently running; ``_subagent_state`` is the per-child merge cache
+        # for the PARTIAL ``session.child_session.updated`` deltas the runner
+        # fans out. Both stay empty until the first such delta arrives.
+        self._subagents: dict[str, tuple[str, float, bool]] = {}
+        self._subagent_state: dict[str, dict[str, object]] = {}
+
         # Overlays registered via :meth:`add_overlay`. Populated
         # before :meth:`run` is invoked; the host wires each
         # overlay's trigger into the prompt's keybindings below,
@@ -1211,6 +1321,36 @@ class TerminalHost:
         with contextlib.suppress(RuntimeError):
             get_app().invalidate()
 
+    def apply_child_session_update(self, child_id: str, child: dict[str, object]) -> None:
+        """Fold a ``session.child_session.updated`` delta into the toolbar's
+        running-sub-agents segment, then repaint.
+
+        Called by the REPL for each child delta the runner fans out onto the
+        parent stream. Children are added while running and dropped once
+        terminal; see :func:`_reduce_subagent_event`.
+
+        :param child_id: The child session id from the event.
+        :param child: The PARTIAL child summary (only changed fields present).
+        """
+        import time as _time
+
+        _reduce_subagent_event(
+            self._subagent_state,
+            self._subagents,
+            child_id=child_id,
+            child=child,
+            now=_time.monotonic(),
+        )
+        with contextlib.suppress(RuntimeError):
+            get_app().invalidate()
+
+    def clear_subagents(self) -> None:
+        """Drop all tracked sub-agents (e.g. on a session reset) and repaint."""
+        self._subagents.clear()
+        self._subagent_state.clear()
+        with contextlib.suppress(RuntimeError):
+            get_app().invalidate()
+
     def set_theme(self, theme: TerminalTheme | str) -> None:
         """Switch prompt/status-bar colors for future TUI renders."""
         self.theme = get_theme(theme) if isinstance(theme, str) else theme
@@ -1516,7 +1656,7 @@ class TerminalHost:
               the toolbar responsive to late ``is_busy`` flips.
             """
             while True:
-                if self._stream_start is not None or self.is_busy:
+                if self._stream_start is not None or self.is_busy or self._subagents:
                     if self._prompt.app:
                         self._prompt.app.invalidate()
                     await asyncio.sleep(_SPINNER_TICK_SECONDS)
@@ -3064,16 +3204,23 @@ class TerminalHost:
             ring_segment = f" {ring_char} {pct:.0%} "
         state_segment = f" {state_badge} "
         width = _term_width()
-        bar_right = max(
-            0,
-            width
-            - 2
-            - len(parts)
-            - len(hints)
-            - len(counter_segment)
-            - len(ring_segment)
-            - len(state_segment),
+        # Running sub-agents segment, fitted into the space left after the
+        # fixed segments. It degrades (drops per-child names) then disappears
+        # rather than wrapping or displacing the core toolbar elements.
+        fixed = (
+            2
+            + len(parts)
+            + len(hints)
+            + len(counter_segment)
+            + len(ring_segment)
+            + len(state_segment)
         )
+        subagent_segment = _format_subagent_segment(
+            self._subagents,
+            budget=max(0, width - fixed),
+            now=_time.monotonic(),
+        )
+        bar_right = max(0, width - fixed - len(subagent_segment))
         segments: list[tuple[str, str]] = [
             ("class:bar", "──"),
             ("class:model-name", parts),
@@ -3083,6 +3230,8 @@ class TerminalHost:
             segments.append(("class:model-name", counter_segment))
         if ring_segment:
             segments.append(("class:model-name", ring_segment))
+        if subagent_segment:
+            segments.append(("class:bottom-toolbar.key", subagent_segment))
         segments.append(("class:bar", "─" * bar_right))
         segments.append(("class:model-name", state_segment))
         return FormattedText(segments)

--- a/tests/frontends/sdk/test_subagent_segment.py
+++ b/tests/frontends/sdk/test_subagent_segment.py
@@ -1,0 +1,178 @@
+"""Tests for the running-sub-agents bottom-toolbar segment.
+
+Covers the pure helpers behind the toolbar feature: the compact elapsed
+formatter, the width-budgeted segment formatter (singular/plural, oldest-first,
+``+K`` overflow, the ``⚠`` blocked-on-input flag, and graceful degradation),
+and the reducer that folds the runner's PARTIAL
+``session.child_session.updated`` deltas into the active-children registry.
+"""
+
+from __future__ import annotations
+
+from omnigent_ui_sdk.terminal._host import (
+    _format_elapsed_short,
+    _format_subagent_segment,
+    _reduce_subagent_event,
+)
+
+# ── elapsed formatter ────────────────────────────────
+
+
+def test_elapsed_seconds_minutes_hours() -> None:
+    """Scales s → m → h, flooring fractional seconds."""
+    assert _format_elapsed_short(0) == "0s"
+    assert _format_elapsed_short(8.9) == "8s"
+    assert _format_elapsed_short(65) == "1m"
+    assert _format_elapsed_short(3661) == "1h"
+
+
+def test_elapsed_never_negative() -> None:
+    """A negative delta (clock jitter) clamps to ``0s``, never ``-5s``."""
+    assert _format_elapsed_short(-5) == "0s"
+
+
+# ── segment formatter ────────────────────────────────
+
+
+def _active(
+    *entries: tuple[str, str, float, bool],
+) -> dict[str, tuple[str, float, bool]]:
+    """Build an active-children dict from ``(id, label, started, awaiting)``."""
+    return {cid: (label, started, awaiting) for cid, label, started, awaiting in entries}
+
+
+def test_segment_empty_is_blank() -> None:
+    """No active children → no segment."""
+    assert _format_subagent_segment({}, budget=80, now=100.0) == ""
+
+
+def test_segment_singular() -> None:
+    """One child uses the singular noun and shows its elapsed time."""
+    seg = _format_subagent_segment(
+        _active(("c1", "researcher", 90.0, False)), budget=80, now=100.0
+    )
+    assert seg == " ⇡1 sub-agent · researcher 10s "
+
+
+def test_segment_two_children_oldest_first() -> None:
+    """Two children are listed oldest-first (longest-running leads)."""
+    active = _active(("c1", "coder", 92.0, False), ("c2", "researcher", 88.0, False))
+    seg = _format_subagent_segment(active, budget=80, now=100.0)
+    assert seg == " ⇡2 sub-agents · researcher 12s · coder 8s "
+
+
+def test_segment_collapses_extra_with_plus_k() -> None:
+    """Beyond two names, the rest collapse into ``+K``."""
+    active = _active(
+        ("c1", "a", 90.0, False),
+        ("c2", "b", 91.0, False),
+        ("c3", "c", 92.0, False),
+        ("c4", "d", 93.0, False),
+    )
+    seg = _format_subagent_segment(active, budget=80, now=100.0)
+    assert seg == " ⇡4 sub-agents · a 10s · b 9s +2 "
+
+
+def test_segment_warn_prefix_when_awaiting_input() -> None:
+    """A child blocked on input (pending elicitation) flags the segment with ⚠."""
+    seg = _format_subagent_segment(_active(("c1", "researcher", 90.0, True)), budget=80, now=100.0)
+    assert seg == " ⚠ ⇡1 sub-agent · researcher 10s "
+
+
+def test_segment_degrades_to_compact_when_tight() -> None:
+    """When the full form won't fit, it drops the per-child names."""
+    active = _active(("c1", "researcher", 90.0, False), ("c2", "coder", 88.0, False))
+    compact = " ⇡2 sub-agents "
+    seg = _format_subagent_segment(active, budget=len(compact), now=100.0)
+    assert seg == compact
+
+
+def test_segment_disappears_when_no_room() -> None:
+    """With essentially no room, the segment vanishes rather than wrap."""
+    assert (
+        _format_subagent_segment(_active(("c1", "researcher", 90.0, False)), budget=3, now=100.0)
+        == ""
+    )
+
+
+# ── reducer ──────────────────────────────────────────
+
+
+def test_reduce_adds_running_child() -> None:
+    """A first ``busy`` delta adds the child with its label and start time."""
+    state: dict[str, dict[str, object]] = {}
+    active: dict[str, tuple[str, float, bool]] = {}
+    _reduce_subagent_event(
+        state,
+        active,
+        child_id="c1",
+        child={"busy": True, "current_task_status": "in_progress", "tool": "researcher"},
+        now=100.0,
+    )
+    assert active == {"c1": ("researcher", 100.0, False)}
+
+
+def test_reduce_merges_partial_and_preserves_start() -> None:
+    """A later partial delta (only the elicitation flag) merges without
+    losing the label or resetting the start time."""
+    state: dict[str, dict[str, object]] = {}
+    active: dict[str, tuple[str, float, bool]] = {}
+    _reduce_subagent_event(
+        state,
+        active,
+        child_id="c1",
+        child={"busy": True, "current_task_status": "in_progress", "tool": "researcher"},
+        now=100.0,
+    )
+    _reduce_subagent_event(
+        state, active, child_id="c1", child={"pending_elicitations_count": 1}, now=130.0
+    )
+    label, started, awaiting = active["c1"]
+    assert label == "researcher"  # preserved across the partial delta
+    assert started == 100.0  # first-seen start preserved (not bumped to 130)
+    assert awaiting is True
+
+
+def test_reduce_drops_on_terminal() -> None:
+    """A terminal delta removes the child and cleans the merge cache."""
+    state: dict[str, dict[str, object]] = {}
+    active: dict[str, tuple[str, float, bool]] = {}
+    _reduce_subagent_event(
+        state,
+        active,
+        child_id="c1",
+        child={"busy": True, "current_task_status": "in_progress", "tool": "x"},
+        now=100.0,
+    )
+    _reduce_subagent_event(
+        state,
+        active,
+        child_id="c1",
+        child={"busy": False, "current_task_status": "completed"},
+        now=140.0,
+    )
+    assert active == {}
+    assert state == {}
+
+
+def test_reduce_active_when_launching_without_busy() -> None:
+    """A ``launching`` task status counts as active even before ``busy``."""
+    state: dict[str, dict[str, object]] = {}
+    active: dict[str, tuple[str, float, bool]] = {}
+    _reduce_subagent_event(
+        state,
+        active,
+        child_id="c1",
+        child={"current_task_status": "launching", "session_name": "explorer"},
+        now=100.0,
+    )
+    assert "c1" in active
+    assert active["c1"][0] == "explorer"
+
+
+def test_reduce_label_fallback() -> None:
+    """With no tool/session_name/title, the label falls back to 'sub-agent'."""
+    state: dict[str, dict[str, object]] = {}
+    active: dict[str, tuple[str, float, bool]] = {}
+    _reduce_subagent_event(state, active, child_id="c1", child={"busy": True}, now=100.0)
+    assert active["c1"][0] == "sub-agent"


### PR DESCRIPTION
## What

A compact, ephemeral bottom-toolbar segment showing sub-agents an orchestrator (e.g. `polly`) is running:

```
omnigent · streaming… 5s   ⇡2 sub-agents · researcher 12s · coder 8s   ● 31%  state: running ⠹
```

- `⇡N sub-agent(s)` + up to 2 named children (oldest-first) with live elapsed; `+K` for more; `⚠` when a child is **blocked on input** (`pending_elicitations_count > 0`).
- **Width-budgeted** — degrades to `⇡N sub-agents`, then to nothing; never wraps or displaces the existing toolbar.
- Keeps ticking **after the parent's turn goes idle**, since sub-agents keep running in the background.

## Why

Today the CLI shows only "dispatched / finished" for sub-agents — you had to open the **web UI** to see background work happening. This surfaces it in the terminal so you're aware N agents are running and roughly how long they've been at it.

## How

**Purely event-driven — no polling, no new server API.** The runner already fans out each child status/preview delta onto the parent's live stream as `session.child_session.updated` (`_fan_out_child_delta_to_parent`, `runner/app.py`), and the CLI already parses these — it simply ignored them.

- `_host.py`: `_subagents`/`_subagent_state` registry; pure helpers `_format_subagent_segment`, `_format_elapsed_short`, `_reduce_subagent_event`; `apply_child_session_update()`/`clear_subagents()`; the segment wired into `build_toolbar()`; the ticker extended so elapsed keeps animating while children run.
- `_repl.py`: `_render_session_event` feeds `SessionChildSessionUpdatedEvent` → `host.apply_child_session_update(...)`.

Design choices (documented in `designs/CLI_SUBAGENT_STATUSBAR.md`):
- **Elapsed uses a client `time.monotonic()` first-seen time** — skew-free vs the server `created_at` epoch.
- The `child` payload is a **partial** delta, so the reducer **merges** per child id.
- **Not cleared on parent-idle** — children outlive the orchestrator's turn; the set is driven purely by child terminal events (a missed terminal self-corrects on the next connect snapshot).

## Tests

- 14 new unit tests in `tests/frontends/sdk/test_subagent_segment.py` (formatter: singular/plural, oldest-first, `+K`, `⚠`, width-budget degradation; elapsed scaling; reducer: add-on-running, partial-merge preserving label+start, drop-on-terminal, launching-without-busy, label fallback).
- `ruff check` / `ruff format --check` clean; **843 passed** across `tests/frontends/sdk` + `tests/repl` (no regressions).

## Pre-merge note

The pure logic is unit-tested. The **visual** toolbar integration (placement/width against the live stream) is best confirmed by running `omnigent run examples/polly` on a real multi-sub-agent turn.

This pull request and its description were written by Isaac.
