### PR TITLE
feat(pi-native): add TOOL_CALL policy enforcement

### DIFF
--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -53,7 +53,9 @@ class _PolicyServer:
             await self._server.wait_closed()
             self._server = None
 
-    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
         try:
             raw = await reader.readline()
             if not raw:
@@ -67,7 +69,9 @@ class _PolicyServer:
                 return
             token = request.get("token")
             if not isinstance(token, str) or not hmac.compare_digest(token, self.token):
-                writer.write(json.dumps({"id": request.get("id"), "error": "unauthorized"}).encode() + b"\n")
+                writer.write(
+                    json.dumps({"id": request.get("id"), "error": "unauthorized"}).encode() + b"\n"
+                )
                 await writer.drain()
                 return
             req_id = request.get("id")
@@ -90,9 +94,12 @@ class _PolicyServer:
             raw = self._policy_gate(name, args)
             resolved = await raw if asyncio.iscoroutine(raw) or asyncio.isfuture(raw) else raw
             if isinstance(resolved, dict):
-                return {"block": bool(resolved.get("block")), "reason": str(resolved.get("reason") or "")}
+                return {
+                    "block": bool(resolved.get("block")),
+                    "reason": str(resolved.get("reason") or ""),
+                }
             return {"block": False, "reason": ""}
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — fail-open; the verdict path must never wedge Pi
             logger.warning("Pi native policy eval failed for %r: %s", name, exc)
             return {"block": False, "reason": ""}
 

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
-import hmac
-import json
-import logging
 import os
-import secrets
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -25,83 +20,8 @@ from omnigent.inner.native_attachments import materialize_attachment
 from omnigent.pi_native_bridge import (
     PI_NATIVE_BRIDGE_DIR_ENV_VAR,
     PI_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
-    clear_policy_server_config,
     enqueue_user_message,
-    write_policy_server_config,
 )
-
-logger = logging.getLogger(__name__)
-
-
-class _PolicyServer:
-    """Minimal TCP server for TOOL_CALL policy evaluation from the Pi native extension."""
-
-    def __init__(self) -> None:
-        self._server: asyncio.Server | None = None
-        self.port: int = 0
-        self.token: str = secrets.token_urlsafe(32)
-        self._policy_gate: Any = None
-
-    async def start(self) -> int:
-        self._server = await asyncio.start_server(self._handle_client, "127.0.0.1", 0)
-        self.port = self._server.sockets[0].getsockname()[1]
-        return self.port
-
-    async def stop(self) -> None:
-        if self._server is not None:
-            self._server.close()
-            await self._server.wait_closed()
-            self._server = None
-
-    async def _handle_client(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        try:
-            raw = await reader.readline()
-            if not raw:
-                return
-            line = raw.decode("utf-8", errors="replace").strip()
-            if not line:
-                return
-            try:
-                request = json.loads(line)
-            except json.JSONDecodeError:
-                return
-            token = request.get("token")
-            if not isinstance(token, str) or not hmac.compare_digest(token, self.token):
-                writer.write(
-                    json.dumps({"id": request.get("id"), "error": "unauthorized"}).encode() + b"\n"
-                )
-                await writer.drain()
-                return
-            req_id = request.get("id")
-            tool_name = request.get("tool")
-            if not isinstance(req_id, str) or not isinstance(tool_name, str):
-                return
-            tool_args = request.get("args", {})
-            verdict = await self._evaluate_policy(tool_name, tool_args)
-            writer.write((json.dumps({"id": req_id, "verdict": verdict}) + "\n").encode())
-            await writer.drain()
-        except (asyncio.CancelledError, ConnectionError):
-            pass
-        finally:
-            writer.close()
-
-    async def _evaluate_policy(self, name: str, args: dict) -> dict:
-        if self._policy_gate is None:
-            return {"block": False, "reason": ""}
-        try:
-            raw = self._policy_gate(name, args)
-            resolved = await raw if asyncio.iscoroutine(raw) or asyncio.isfuture(raw) else raw
-            if isinstance(resolved, dict):
-                return {
-                    "block": bool(resolved.get("block")),
-                    "reason": str(resolved.get("reason") or ""),
-                }
-            return {"block": False, "reason": ""}
-        except Exception as exc:  # noqa: BLE001 — fail-open; the verdict path must never wedge Pi
-            logger.warning("Pi native policy eval failed for %r: %s", name, exc)
-            return {"block": False, "reason": ""}
 
 
 class PiNativeExecutor(Executor):
@@ -112,12 +32,20 @@ class PiNativeExecutor(Executor):
     the Omnigent Pi extension loaded. Each turn queues the latest user
     message into the bridge inbox; the extension consumes it and calls
     ``pi.sendUserMessage`` inside the TUI process.
+
+    Policy enforcement for native Pi tool calls is handled entirely by the
+    extension: on each ``tool_call`` event the extension POSTs to
+    ``POST /v1/sessions/{sessionId}/policies/evaluate`` using the server URL
+    and auth headers from its config file. This bypasses the turn-scoped
+    ``_policy_evaluator`` round-trip (which would fail because
+    ``_current_ctx`` is cleared before Pi ever processes the message) and
+    instead routes directly through the same session-level HTTP endpoint that
+    the Claude Code native hook uses.
     """
 
     def __init__(self, bridge_dir: Path | None = None) -> None:
         self._bridge_dir = bridge_dir or _bridge_dir_from_env()
         self._request_session_id = _request_session_id_from_env()
-        self._policy_server: _PolicyServer | None = None
 
     def supports_streaming(self) -> bool:
         """:returns: ``False`` because output is emitted by the Pi extension."""
@@ -143,43 +71,6 @@ class PiNativeExecutor(Executor):
         enqueue_user_message(self._bridge_dir, text)
         return True
 
-    async def _gate_native_tool(self, name: str, args: dict) -> dict:
-        evaluator = getattr(self, "_policy_evaluator", None)
-        if evaluator is None:
-            return {"block": False, "reason": ""}
-        verdict = await evaluator("PHASE_TOOL_CALL", {"name": name, "arguments": args})
-        if verdict.action == "POLICY_ACTION_DENY":
-            return {"block": True, "reason": verdict.reason or "blocked by policy"}
-        return {"block": False, "reason": ""}
-
-    async def _ensure_policy_server(self) -> None:
-        if self._policy_server is not None:
-            return
-        server = _PolicyServer()
-        await server.start()
-        server._policy_gate = self._gate_native_tool
-        self._policy_server = server
-        write_policy_server_config(self._bridge_dir, server.port, server.token)
-
-    async def close_session(self, session_key: str) -> None:
-        """
-        Stop the policy server and remove its config file.
-
-        :param session_key: Adapter session key. Unused.
-        """
-        del session_key
-        if self._policy_server is not None:
-            await self._policy_server.stop()
-            self._policy_server = None
-        clear_policy_server_config(self._bridge_dir)
-
-    async def close(self) -> None:
-        """Stop the policy server and remove its config file."""
-        if self._policy_server is not None:
-            await self._policy_server.stop()
-            self._policy_server = None
-        clear_policy_server_config(self._bridge_dir)
-
     async def run_turn(
         self,
         messages: list[Message],
@@ -200,7 +91,6 @@ class PiNativeExecutor(Executor):
             :class:`ExecutorError` when no user text can be sent.
         """
         del tools, system_prompt, config
-        await self._ensure_policy_server()
         text = _latest_user_text(messages, self._bridge_dir)
         if not text:
             yield ExecutorError(message="Pi native turn had no user text to send")

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import hmac
+import json
+import logging
 import os
+import secrets
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -20,8 +25,76 @@ from omnigent.inner.native_attachments import materialize_attachment
 from omnigent.pi_native_bridge import (
     PI_NATIVE_BRIDGE_DIR_ENV_VAR,
     PI_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    clear_policy_server_config,
     enqueue_user_message,
+    write_policy_server_config,
 )
+
+logger = logging.getLogger(__name__)
+
+
+class _PolicyServer:
+    """Minimal TCP server for TOOL_CALL policy evaluation from the Pi native extension."""
+
+    def __init__(self) -> None:
+        self._server: asyncio.Server | None = None
+        self.port: int = 0
+        self.token: str = secrets.token_urlsafe(32)
+        self._policy_gate: Any = None
+
+    async def start(self) -> int:
+        self._server = await asyncio.start_server(self._handle_client, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return self.port
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            raw = await reader.readline()
+            if not raw:
+                return
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line:
+                return
+            try:
+                request = json.loads(line)
+            except json.JSONDecodeError:
+                return
+            token = request.get("token")
+            if not isinstance(token, str) or not hmac.compare_digest(token, self.token):
+                writer.write(json.dumps({"id": request.get("id"), "error": "unauthorized"}).encode() + b"\n")
+                await writer.drain()
+                return
+            req_id = request.get("id")
+            tool_name = request.get("tool")
+            if not isinstance(req_id, str) or not isinstance(tool_name, str):
+                return
+            tool_args = request.get("args", {})
+            verdict = await self._evaluate_policy(tool_name, tool_args)
+            writer.write((json.dumps({"id": req_id, "verdict": verdict}) + "\n").encode())
+            await writer.drain()
+        except (asyncio.CancelledError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+
+    async def _evaluate_policy(self, name: str, args: dict) -> dict:
+        if self._policy_gate is None:
+            return {"block": False, "reason": ""}
+        try:
+            raw = self._policy_gate(name, args)
+            resolved = await raw if asyncio.iscoroutine(raw) or asyncio.isfuture(raw) else raw
+            if isinstance(resolved, dict):
+                return {"block": bool(resolved.get("block")), "reason": str(resolved.get("reason") or "")}
+            return {"block": False, "reason": ""}
+        except Exception as exc:
+            logger.warning("Pi native policy eval failed for %r: %s", name, exc)
+            return {"block": False, "reason": ""}
 
 
 class PiNativeExecutor(Executor):
@@ -37,6 +110,7 @@ class PiNativeExecutor(Executor):
     def __init__(self, bridge_dir: Path | None = None) -> None:
         self._bridge_dir = bridge_dir or _bridge_dir_from_env()
         self._request_session_id = _request_session_id_from_env()
+        self._policy_server: _PolicyServer | None = None
 
     def supports_streaming(self) -> bool:
         """:returns: ``False`` because output is emitted by the Pi extension."""
@@ -62,6 +136,43 @@ class PiNativeExecutor(Executor):
         enqueue_user_message(self._bridge_dir, text)
         return True
 
+    async def _gate_native_tool(self, name: str, args: dict) -> dict:
+        evaluator = getattr(self, "_policy_evaluator", None)
+        if evaluator is None:
+            return {"block": False, "reason": ""}
+        verdict = await evaluator("PHASE_TOOL_CALL", {"name": name, "arguments": args})
+        if verdict.action == "POLICY_ACTION_DENY":
+            return {"block": True, "reason": verdict.reason or "blocked by policy"}
+        return {"block": False, "reason": ""}
+
+    async def _ensure_policy_server(self) -> None:
+        if self._policy_server is not None:
+            return
+        server = _PolicyServer()
+        await server.start()
+        server._policy_gate = self._gate_native_tool
+        self._policy_server = server
+        write_policy_server_config(self._bridge_dir, server.port, server.token)
+
+    async def close_session(self, session_key: str) -> None:
+        """
+        Stop the policy server and remove its config file.
+
+        :param session_key: Adapter session key. Unused.
+        """
+        del session_key
+        if self._policy_server is not None:
+            await self._policy_server.stop()
+            self._policy_server = None
+        clear_policy_server_config(self._bridge_dir)
+
+    async def close(self) -> None:
+        """Stop the policy server and remove its config file."""
+        if self._policy_server is not None:
+            await self._policy_server.stop()
+            self._policy_server = None
+        clear_policy_server_config(self._bridge_dir)
+
     async def run_turn(
         self,
         messages: list[Message],
@@ -82,6 +193,7 @@ class PiNativeExecutor(Executor):
             :class:`ExecutorError` when no user text can be sent.
         """
         del tools, system_prompt, config
+        await self._ensure_policy_server()
         text = _latest_user_text(messages, self._bridge_dir)
         if not text:
             yield ExecutorError(message="Pi native turn had no user text to send")

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -227,25 +227,6 @@ def _extension_source() -> str:
     return resource.read_text(encoding="utf-8")
 
 
-_POLICY_SERVER_FILE = "policy_server.json"
-
-
-def policy_server_config_path(bridge_dir: Path) -> Path:
-    """Return the policy server config path for *bridge_dir*."""
-    return bridge_dir / _POLICY_SERVER_FILE
-
-
-def write_policy_server_config(bridge_dir: Path, port: int, token: str) -> None:
-    """Write policy server port and token to the bridge dir."""
-    _atomic_json(policy_server_config_path(bridge_dir), {"port": port, "token": token})
-
-
-def clear_policy_server_config(bridge_dir: Path) -> None:
-    """Remove the policy server config file."""
-    with contextlib.suppress(OSError):
-        policy_server_config_path(bridge_dir).unlink()
-
-
 def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
     try:

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -227,6 +227,25 @@ def _extension_source() -> str:
     return resource.read_text(encoding="utf-8")
 
 
+_POLICY_SERVER_FILE = "policy_server.json"
+
+
+def policy_server_config_path(bridge_dir: Path) -> Path:
+    """Return the policy server config path for *bridge_dir*."""
+    return bridge_dir / _POLICY_SERVER_FILE
+
+
+def write_policy_server_config(bridge_dir: Path, port: int, token: str) -> None:
+    """Write policy server port and token to the bridge dir."""
+    _atomic_json(policy_server_config_path(bridge_dir), {"port": port, "token": token})
+
+
+def clear_policy_server_config(bridge_dir: Path) -> None:
+    """Remove the policy server config file."""
+    with contextlib.suppress(OSError):
+        policy_server_config_path(bridge_dir).unlink()
+
+
 def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
     try:

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -12,53 +12,49 @@ function readConfig() {
   }
 }
 
-function readPolicyConfig(config) {
-  if (!config || !config.bridgeDir) return null;
-  const policyPath = path.join(config.bridgeDir, "policy_server.json");
+/**
+ * Evaluate a TOOL_CALL policy for a native Pi tool via the Omnigent server's
+ * session-level HTTP endpoint (POST /v1/sessions/{sessionId}/policies/evaluate).
+ *
+ * This is the same endpoint used by the Claude Code and Codex native hooks.
+ * It does NOT require an active Omnigent turn context on the harness side —
+ * the endpoint evaluates against the session's full policy set directly.
+ * Fail-open (null) on any transport or parse error so a transient server
+ * outage never wedges Pi mid-turn.
+ */
+async function evalNativePolicyHttp(config, toolName, args) {
+  if (
+    !config ||
+    !config.serverUrl ||
+    !config.sessionId ||
+    typeof fetch !== "function"
+  )
+    return null;
+  const url = `${config.serverUrl}/v1/sessions/${encodeURIComponent(config.sessionId)}/policies/evaluate`;
+  const body = JSON.stringify({
+    event: {
+      type: "PHASE_TOOL_CALL",
+      target: "",
+      data: { name: toolName, arguments: args },
+      context: {},
+    },
+  });
   try {
-    return JSON.parse(fs.readFileSync(policyPath, "utf8"));
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...(config.authHeaders || {}) },
+      body,
+    });
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    if (json.result === "POLICY_ACTION_DENY") {
+      return { block: true, reason: json.reason || "blocked by Omnigent policy" };
+    }
+    return { block: false, reason: "" };
   } catch (_err) {
+    // Keep Pi responsive if Omnigent is temporarily unavailable.
     return null;
   }
-}
-
-function evalNativePolicy(policyConfig, toolName, args) {
-  if (!policyConfig || !policyConfig.port || !policyConfig.token) {
-    return Promise.resolve(null);
-  }
-  const net = require("net");
-  return new Promise((resolve) => {
-    const client = net.createConnection(
-      { port: policyConfig.port, host: "127.0.0.1" },
-      () => {
-        const id = Math.random().toString(36).slice(2);
-        const frame = {
-          id,
-          token: policyConfig.token,
-          kind: "policy_eval",
-          tool: toolName,
-          args,
-        };
-        let buf = "";
-        client.on("data", (chunk) => {
-          buf += chunk.toString();
-          const nl = buf.indexOf("\n");
-          if (nl !== -1) {
-            client.end();
-            try {
-              const resp = JSON.parse(buf.slice(0, nl));
-              resolve(resp && resp.verdict ? resp.verdict : null);
-            } catch (_e) {
-              resolve(null);
-            }
-          }
-        });
-        client.on("error", () => resolve(null));
-        client.write(JSON.stringify(frame) + "\n");
-      },
-    );
-    client.on("error", () => resolve(null));
-  });
 }
 
 function textFromContent(content) {
@@ -580,19 +576,18 @@ module.exports = function (pi) {
     if (blocked) {
       return { block: true, reason: "Interrupted by user" };
     }
-    // Evaluate TOOL_CALL policy via the local policy server written by
-    // the Omnigent harness process. Fail-open (null) when the server is
-    // absent (e.g. single-process tests or a turn that hasn't started yet).
-    const policyConfig = readPolicyConfig(config);
-    if (policyConfig) {
-      const verdict = await evalNativePolicy(
-        policyConfig,
-        (event && event.toolName) || "",
-        (event && event.input) || {},
-      );
-      if (verdict && verdict.block) {
-        return { block: true, reason: verdict.reason || "blocked by Omnigent policy" };
-      }
+    // Evaluate TOOL_CALL policy via the Omnigent server's session-level HTTP
+    // endpoint. This works even after the harness turn has completed (which
+    // happens immediately for pi-native — just enqueue + TurnComplete), so
+    // the verdict is always evaluated against live session policies regardless
+    // of whether an Omnigent turn is currently in flight.
+    const verdict = await evalNativePolicyHttp(
+      config,
+      (event && event.toolName) || "",
+      (event && event.input) || {},
+    );
+    if (verdict && verdict.block) {
+      return { block: true, reason: verdict.reason || "blocked by Omnigent policy" };
     }
   });
 

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -12,6 +12,55 @@ function readConfig() {
   }
 }
 
+function readPolicyConfig(config) {
+  if (!config || !config.bridgeDir) return null;
+  const policyPath = path.join(config.bridgeDir, "policy_server.json");
+  try {
+    return JSON.parse(fs.readFileSync(policyPath, "utf8"));
+  } catch (_err) {
+    return null;
+  }
+}
+
+function evalNativePolicy(policyConfig, toolName, args) {
+  if (!policyConfig || !policyConfig.port || !policyConfig.token) {
+    return Promise.resolve(null);
+  }
+  const net = require("net");
+  return new Promise((resolve) => {
+    const client = net.createConnection(
+      { port: policyConfig.port, host: "127.0.0.1" },
+      () => {
+        const id = Math.random().toString(36).slice(2);
+        const frame = {
+          id,
+          token: policyConfig.token,
+          kind: "policy_eval",
+          tool: toolName,
+          args,
+        };
+        let buf = "";
+        client.on("data", (chunk) => {
+          buf += chunk.toString();
+          const nl = buf.indexOf("\n");
+          if (nl !== -1) {
+            client.end();
+            try {
+              const resp = JSON.parse(buf.slice(0, nl));
+              resolve(resp && resp.verdict ? resp.verdict : null);
+            } catch (_e) {
+              resolve(null);
+            }
+          }
+        });
+        client.on("error", () => resolve(null));
+        client.write(JSON.stringify(frame) + "\n");
+      },
+    );
+    client.on("error", () => resolve(null));
+  });
+}
+
 function textFromContent(content) {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
@@ -530,6 +579,20 @@ module.exports = function (pi) {
     );
     if (blocked) {
       return { block: true, reason: "Interrupted by user" };
+    }
+    // Evaluate TOOL_CALL policy via the local policy server written by
+    // the Omnigent harness process. Fail-open (null) when the server is
+    // absent (e.g. single-process tests or a turn that hasn't started yet).
+    const policyConfig = readPolicyConfig(config);
+    if (policyConfig) {
+      const verdict = await evalNativePolicy(
+        policyConfig,
+        (event && event.toolName) || "",
+        (event && event.input) || {},
+      );
+      if (verdict && verdict.block) {
+        return { block: true, reason: verdict.reason || "blocked by Omnigent policy" };
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds a `_PolicyServer` (minimal TCP server, policy-eval-only) to `PiNativeExecutor`, mirroring how `PiExecutor` uses `_ToolServer`'s `_policy_gate`
- The harness starts the server lazily on the first `run_turn` call and writes `port + token` to `{bridge_dir}/policy_server.json` so the already-running Pi extension can find it
- The native extension reads `policy_server.json` fresh on each `tool_call` event and calls `evalNativePolicy()` over TCP before allowing the tool — fail-open when the server file is absent (test / pre-turn paths)

## Test plan

- [ ] Pi native session: trigger a tool call that should be blocked by a TOOL_CALL policy — verify the tool is blocked with the expected reason
- [ ] Pi native session: trigger a tool call that is allowed — verify execution proceeds normally
- [ ] No policy server present (test/pre-turn path): verify tool calls are not blocked (fail-open)
- [ ] Session teardown: verify `policy_server.json` is removed from the bridge dir on `close_session` / `close`

This pull request and its description were written by Isaac.