### PR TITLE
feat(tools): implement ToolManager shutdown lifecycle

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -394,8 +394,8 @@ async def _execute_local_python_tool(
 ) -> str:
     if agent_spec is None:
         return f"Error: {tool_name} not in local dispatch table (no agent spec)"
+    manager = ToolManager(agent_spec, workdir=runner_workspace)
     try:
-        manager = ToolManager(agent_spec, workdir=runner_workspace)
         workspace = None
         if runner_workspace is not None and conversation_id is not None:
             workspace = runner_workspace / conversation_id
@@ -410,6 +410,8 @@ async def _execute_local_python_tool(
     except Exception as exc:
         _logger.exception("runner local Python tool dispatch failed for %s", tool_name)
         return f"Error: {type(exc).__name__}: {exc}"
+    finally:
+        manager.shutdown()
 
 
 # Cache of resolved callables keyed by dotted path. Avoids

--- a/omnigent/tools/base.py
+++ b/omnigent/tools/base.py
@@ -142,6 +142,16 @@ class Tool(abc.ABC):
         the child process. Default is a no-op.
         """
 
+    def shutdown(self) -> None:  # noqa: B027 — optional override hook; default is a no-op
+        """
+        Release resources held by this tool instance.
+
+        Called by :meth:`ToolManager.shutdown` during teardown.
+        Tools that hold subprocesses, file handles, or other
+        long-lived resources override this to clean up.
+        Default is a no-op.
+        """
+
     def is_async(self, arguments: str | None = None) -> bool:
         """
         Return ``True`` if this invocation runs in a background workflow.

--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -495,6 +495,10 @@ class LocalPythonTool(Tool):
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
 
+    def shutdown(self) -> None:
+        """Kill any remaining in-flight subprocesses on teardown."""
+        self.cancel()
+
 
 def _write_srt_settings_file(state_root: str) -> str:
     """Write a per-invocation srt settings file for stateful tools.

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -143,9 +143,8 @@ class ToolManager:
         self._srt_available = is_srt_available()
         self._uv_available = shutil.which("uv") is not None
         # Track the OS environment instance the spec opts into so
-        # ``shutdown`` (which we currently don't ship — TODO) can
-        # close it cleanly. ``None`` when the spec didn't declare
-        # ``os_env``.
+        # ``shutdown`` can close it cleanly. ``None`` when the spec
+        # didn't declare ``os_env``.
         self._os_env: OSEnvironment | None = None
         self._register_skill_tools()
         self._register_builtin_tools()
@@ -762,8 +761,33 @@ class ToolManager:
         self._started = True
 
     def shutdown(self) -> None:
-        """Idempotent teardown."""
+        """Idempotent teardown: close OS environment and shut down tools.
+
+        Closes the OS environment that was created during registration
+        (skipped when the environment was pre-resolved from the
+        ``SessionResourceRegistry`` — the registry owns that lifecycle).
+        Then calls ``shutdown()`` on every registered tool so
+        subprocess-backed tools can kill lingering child processes.
+
+        Safe to call multiple times; the second call is a no-op.
+        """
         self._started = False
+
+        os_env = self._os_env
+        if os_env is not None and self._pre_resolved_os_env is None:
+            self._os_env = None
+            try:
+                os_env.close()
+            except Exception:
+                _logger.warning("os_env.close() failed during shutdown", exc_info=True)
+
+        for tool in self._tools.values():
+            try:
+                tool.shutdown()
+            except Exception:
+                _logger.warning(
+                    "tool %s shutdown failed", tool.name(), exc_info=True
+                )
 
     def get_tool_names(self) -> list[str]:
         """

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -785,9 +785,7 @@ class ToolManager:
             try:
                 tool.shutdown()
             except Exception:
-                _logger.warning(
-                    "tool %s shutdown failed", tool.name(), exc_info=True
-                )
+                _logger.warning("tool %s shutdown failed", tool.name(), exc_info=True)
 
     def get_tool_names(self) -> list[str]:
         """

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -478,6 +478,83 @@ def test_shutdown_safe_without_start() -> None:
     mgr.shutdown()
 
 
+def test_shutdown_idempotent() -> None:
+    """Calling ``shutdown()`` twice does not raise."""
+    spec = _make_spec()
+    mgr = ToolManager(spec)
+    mgr.start()
+    mgr.shutdown()
+    mgr.shutdown()
+
+
+def test_shutdown_closes_os_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``shutdown()`` closes ``_os_env`` when it was self-created."""
+    spec = _make_spec()
+    mgr = ToolManager(spec)
+    mgr.start()
+
+    class _FakeOSEnv:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake_env = _FakeOSEnv()
+    mgr._os_env = fake_env  # type: ignore[assignment]
+    mgr._pre_resolved_os_env = None
+
+    mgr.shutdown()
+    assert fake_env.closed
+    assert mgr._os_env is None
+
+
+def test_shutdown_skips_pre_resolved_os_env() -> None:
+    """``shutdown()`` does NOT close a pre-resolved (shared) OS env."""
+    spec = _make_spec()
+
+    class _FakeOSEnv:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    shared_env = _FakeOSEnv()
+    mgr = ToolManager(spec, os_env=shared_env)  # type: ignore[arg-type]
+    mgr.start()
+    mgr.shutdown()
+    assert not shared_env.closed
+
+
+def test_shutdown_calls_tool_shutdown() -> None:
+    """``shutdown()`` calls ``shutdown()`` on every registered tool."""
+    from omnigent.tools.base import Tool
+
+    class _TrackingTool(Tool):
+        shut_down = False
+
+        @classmethod
+        def name(cls) -> str:
+            return "_tracking"
+
+        @classmethod
+        def description(cls) -> str:
+            return "test"
+
+        def get_schema(self) -> dict[str, Any]:
+            return {"type": "function", "function": {"name": "_tracking"}}
+
+        def shutdown(self) -> None:
+            self.shut_down = True
+
+    spec = _make_spec()
+    mgr = ToolManager(spec)
+    tracker = _TrackingTool()
+    mgr._tools["_tracking"] = tracker
+    mgr.start()
+    mgr.shutdown()
+    assert tracker.shut_down
+
+
 # ── Client-specified tools ────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A — addresses inline TODO at `omnigent/tools/manager.py:146`.

## Summary

- Add `Tool.shutdown()` optional override hook so tools holding long-lived resources (subprocesses, file handles) can clean up on teardown.
- Implement `ToolManager.shutdown()` to close self-created OS environments and call `shutdown()` on every registered tool, with per-item exception safety and idempotency.
- Guard the ephemeral `ToolManager` in `_execute_local_python_tool` with `try/finally` so resources are released even on dispatch errors.
- `LocalPythonTool.shutdown()` delegates to `cancel()` to kill lingering child processes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `pytest tests/tools/test_manager.py` — all 36 tests pass (4 new). New tests cover:

- `test_shutdown_idempotent` — double shutdown doesn't raise.
- `test_shutdown_closes_os_env` — self-created OS env is closed and nulled.
- `test_shutdown_skips_pre_resolved_os_env` — shared (registry-owned) env is left open.
- `test_shutdown_calls_tool_shutdown` — every registered tool's `shutdown()` is invoked.