### PR TITLE
feat(repl): render schema fields as interactive terminal prompts

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -776,6 +776,11 @@ class _FieldInputState:
     def __init__(self) -> None:
         self._future: asyncio.Future[str] | None = None
         self._field_name: str | None = None
+        # Set by ``cancel`` so the field-collection loop can tell an
+        # abort (Esc on the turn) apart from an empty submit and stop
+        # prompting rather than advancing to — and re-prompting for —
+        # the next field after the turn is already gone.
+        self._aborted: bool = False
 
     @property
     def pending(self) -> bool:
@@ -785,7 +790,17 @@ class _FieldInputState:
     def field_name(self) -> str | None:
         return self._field_name
 
+    @property
+    def aborted(self) -> bool:
+        """:returns: ``True`` if collection was cancelled mid-prompt."""
+        return self._aborted
+
     def begin(self, field_name: str) -> asyncio.Future[str]:
+        # A fresh prompt is never pre-aborted. Cleared here (not in the
+        # collection loop) so the flag spans exactly one begin/await
+        # cycle: the loop reads it the instant the await returns, and
+        # the only await between fields IS this ``begin``.
+        self._aborted = False
         if self._future is not None and not self._future.done():
             self._future.set_result("")
         self._field_name = field_name
@@ -801,6 +816,7 @@ class _FieldInputState:
         return True
 
     def cancel(self) -> None:
+        self._aborted = True
         if self._future is not None and not self._future.done():
             self._future.set_result("")
         self._future = None
@@ -2214,7 +2230,14 @@ class _SessionsChatReplAdapter:
             if content is not None:
                 resolve_payload["content"] = content
             elif schema.get("properties"):
-                prompted = await self._prompt_schema_fields(schema)
+                # Never leave the elicitation unresolved: any failure
+                # while prompting (or a user abort) declines, so the
+                # agent turn doesn't hang waiting on a verdict that the
+                # background task would otherwise never POST.
+                try:
+                    prompted = await self._prompt_schema_fields(schema)
+                except Exception:  # noqa: BLE001
+                    prompted = None
                 if prompted is not None:
                     resolve_payload["content"] = prompted
                 else:
@@ -2247,7 +2270,7 @@ class _SessionsChatReplAdapter:
         Returns the filled content dict, or ``None`` if the interactive
         state is unavailable (e.g. no ``_field_input_state`` wired up).
         """
-        from rich.text import Text  # noqa: PLC0415
+        from rich.text import Text
 
         fis = self._field_input_state
         host = self._host
@@ -2278,7 +2301,9 @@ class _SessionsChatReplAdapter:
                 label_parts.append(f" — {description}")
             hint_parts: list[str] = []
             if one_of and isinstance(one_of, list):
-                opts = [str(o.get("const", "")) for o in one_of if isinstance(o, dict) and "const" in o]
+                opts = [
+                    str(o.get("const", "")) for o in one_of if isinstance(o, dict) and "const" in o
+                ]
                 if opts:
                     hint_parts.append("/".join(opts))
             elif enum_vals and isinstance(enum_vals, list):
@@ -2294,49 +2319,89 @@ class _SessionsChatReplAdapter:
             hint = ", ".join(hint_parts)
             label_parts.append(f" [{hint}]")
 
-            host.output(
-                Text.from_markup(
-                    f"   [{fmt.accent}]{''.join(label_parts)}[/{fmt.accent}]",
-                ),
-            )
+            # Render as plain styled text, NOT markup: the label embeds
+            # server-controlled schema text (description, enum values,
+            # key) that ``Text.from_markup`` would parse as Rich tags —
+            # a stray ``[`` silently mangles the line and an unbalanced
+            # one raises ``MarkupError``, which would crash this
+            # background task and hang the elicitation.
+            host.output(Text("   " + "".join(label_parts), style=fmt.accent))
 
-            raw = await fis.begin(key)
-
-            # Use default when the user submits empty input.
-            if not raw.strip():
-                if default is not None:
-                    content[key] = default
-                elif key not in required:
-                    continue
-                else:
-                    return None
-                continue
-
-            # Parse according to type.
-            val: str | int | float | bool | None = raw.strip()
-            if prop_type == "boolean":
-                val = val.lower() in ("true", "1", "yes", "y")  # type: ignore[union-attr]
-            elif prop_type == "integer":
-                try:
-                    val = int(val)  # type: ignore[arg-type]
-                except ValueError:
-                    return None
-            elif prop_type == "number":
-                try:
-                    val = float(val)  # type: ignore[arg-type]
-                except ValueError:
+            # Re-prompt the same field on bad input rather than discarding
+            # everything: a single typo on field N shouldn't decline the
+            # whole form. The user aborts the turn with Esc (→ ``aborted``).
+            while True:
+                raw = await fis.begin(key)
+                if fis.aborted:
                     return None
 
-            # Validate enum constraints.
-            if one_of and isinstance(one_of, list):
-                valid = [o.get("const") for o in one_of if isinstance(o, dict) and "const" in o]
-                if val not in valid:
-                    return None
-            elif enum_vals and isinstance(enum_vals, list):
-                if val not in enum_vals:
-                    return None
+                stripped = raw.strip()
+                if not stripped:
+                    if default is not None:
+                        content[key] = default
+                    elif key in required:
+                        host.output(
+                            Text(
+                                f"     ↳ {key} is required — enter a value (Esc cancels)",
+                                style=fmt.warning,
+                            ),
+                        )
+                        continue
+                    # Optional with no default: leave unset.
+                    break
 
-            content[key] = val
+                # Parse according to type.
+                val: str | int | float | bool = stripped
+                if prop_type == "boolean":
+                    val = stripped.lower() in ("true", "1", "yes", "y")
+                elif prop_type == "integer":
+                    try:
+                        val = int(stripped)
+                    except ValueError:
+                        host.output(
+                            Text(
+                                f"     ↳ expected a whole number, got {stripped!r}",
+                                style=fmt.warning,
+                            ),
+                        )
+                        continue
+                elif prop_type == "number":
+                    try:
+                        val = float(stripped)
+                    except ValueError:
+                        host.output(
+                            Text(
+                                f"     ↳ expected a number, got {stripped!r}",
+                                style=fmt.warning,
+                            ),
+                        )
+                        continue
+
+                # Validate enum constraints.
+                if one_of and isinstance(one_of, list):
+                    valid = [
+                        o.get("const") for o in one_of if isinstance(o, dict) and "const" in o
+                    ]
+                    if val not in valid:
+                        host.output(
+                            Text(
+                                f"     ↳ choose one of: {', '.join(str(v) for v in valid)}",
+                                style=fmt.warning,
+                            ),
+                        )
+                        continue
+                elif enum_vals and isinstance(enum_vals, list):
+                    if val not in enum_vals:
+                        host.output(
+                            Text(
+                                f"     ↳ choose one of: {', '.join(str(v) for v in enum_vals)}",
+                                style=fmt.warning,
+                            ),
+                        )
+                        continue
+
+                content[key] = val
+                break
 
         return content
 
@@ -3541,10 +3606,10 @@ async def run_repl(
         # current field's value before any other routing.
         if field_input_state.pending:
             field_name = field_input_state.field_name or "field"
+            # Plain styled text: ``field_name`` (server schema) and
+            # ``text`` (user input) must not be parsed as Rich markup.
             host.output(
-                Text.from_markup(
-                    f"   [{fmt.muted}]› {field_name}: {text}[/{fmt.muted}]",
-                ),
+                Text(f"   › {field_name}: {text}", style=fmt.muted),
             )
             field_input_state.resolve(text)
             return

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -765,6 +765,48 @@ class _ApprovalState:
         self._current_phase = None
 
 
+class _FieldInputState:
+    """Collect free-form field values one at a time via the main input loop.
+
+    Same future-based pattern as :class:`_ApprovalState` — no direct
+    ``input()`` calls so ``prompt_toolkit``'s ``patch_stdout`` is
+    never disrupted.
+    """
+
+    def __init__(self) -> None:
+        self._future: asyncio.Future[str] | None = None
+        self._field_name: str | None = None
+
+    @property
+    def pending(self) -> bool:
+        return self._future is not None and not self._future.done()
+
+    @property
+    def field_name(self) -> str | None:
+        return self._field_name
+
+    def begin(self, field_name: str) -> asyncio.Future[str]:
+        if self._future is not None and not self._future.done():
+            self._future.set_result("")
+        self._field_name = field_name
+        self._future = asyncio.get_running_loop().create_future()
+        return self._future
+
+    def resolve(self, text: str) -> bool:
+        if self._future is None or self._future.done():
+            return False
+        self._future.set_result(text)
+        self._future = None
+        self._field_name = None
+        return True
+
+    def cancel(self) -> None:
+        if self._future is not None and not self._future.done():
+            self._future.set_result("")
+        self._future = None
+        self._field_name = None
+
+
 def _build_elicitation_content_from_schema(
     schema: dict[str, object],
 ) -> dict[str, object] | None:
@@ -1080,6 +1122,9 @@ class _SessionsChatReplAdapter:
         on_session_start: Callable[[str], None] | None = None,
         harness: str | None = None,
         attach_only: bool = False,
+        field_input_state: _FieldInputState | None = None,
+        host: TerminalHost | None = None,
+        fmt: RichBlockFormatter | None = None,
     ) -> None:
         """
         Wire the adapter; do NOT issue any HTTP calls.
@@ -1122,12 +1167,19 @@ class _SessionsChatReplAdapter:
             never bind/recover a runner (turns post to the session's
             existing host-bound runner). Used by ``omnigent attach``.
             ``False`` (default) is the runner-owning ``run`` path.
+        :param field_input_state: Shared state for collecting schema
+            field values interactively via the main input loop.
+        :param host: Terminal output channel for rendering field prompts.
+        :param fmt: Formatter for styling field prompts.
         """
         self._client = client
         self._agent_id: str | None = None
         self._agent_name = agent_name
         self._tool_callables = tool_callables
         self._hooks = hooks or StreamHooks()
+        self._field_input_state = field_input_state
+        self._host = host
+        self._fmt = fmt
         self._session_id: str | None = session_id
         self._session_bundle = session_bundle
         self._session_bundle_filename = session_bundle_filename
@@ -2162,11 +2214,11 @@ class _SessionsChatReplAdapter:
             if content is not None:
                 resolve_payload["content"] = content
             elif schema.get("properties"):
-                # Schema has properties we can't auto-fill — the REPL
-                # can't render arbitrary forms. Decline and tell the
-                # user to use the web UI.
-                # TODO: render schema fields as terminal input prompts.
-                resolve_payload["action"] = "decline"
+                prompted = await self._prompt_schema_fields(schema)
+                if prompted is not None:
+                    resolve_payload["content"] = prompted
+                else:
+                    resolve_payload["action"] = "decline"
 
         try:
             # URL-based elicitation: deliver the verdict to the
@@ -2185,6 +2237,108 @@ class _SessionsChatReplAdapter:
                 # The harness already received the verdict — treat as no-op.
                 return
             raise
+
+    async def _prompt_schema_fields(
+        self,
+        schema: dict[str, object],
+    ) -> dict[str, str | int | float | bool | list[str] | None] | None:
+        """Prompt the user for each schema property via the main input loop.
+
+        Returns the filled content dict, or ``None`` if the interactive
+        state is unavailable (e.g. no ``_field_input_state`` wired up).
+        """
+        from rich.text import Text  # noqa: PLC0415
+
+        fis = self._field_input_state
+        host = self._host
+        fmt = self._fmt
+        if fis is None or host is None or fmt is None:
+            return None
+
+        properties = schema.get("properties")
+        if not properties or not isinstance(properties, dict):
+            return None
+
+        required = set(schema.get("required", []))  # type: ignore[arg-type]
+        content: dict[str, str | int | float | bool | list[str] | None] = {}
+
+        for key, prop in properties.items():
+            if not isinstance(prop, dict):
+                return None
+
+            prop_type = prop.get("type", "string")
+            description = prop.get("description", "")
+            default = prop.get("default")
+            enum_vals = prop.get("enum")
+            one_of = prop.get("oneOf")
+
+            # Build the prompt label.
+            label_parts: list[str] = [f"   {key}"]
+            if description:
+                label_parts.append(f" — {description}")
+            hint_parts: list[str] = []
+            if one_of and isinstance(one_of, list):
+                opts = [str(o.get("const", "")) for o in one_of if isinstance(o, dict) and "const" in o]
+                if opts:
+                    hint_parts.append("/".join(opts))
+            elif enum_vals and isinstance(enum_vals, list):
+                hint_parts.append("/".join(str(v) for v in enum_vals))
+            elif prop_type == "boolean":
+                hint_parts.append("true/false")
+            else:
+                hint_parts.append(str(prop_type))
+            if default is not None:
+                hint_parts.append(f"default: {default}")
+            if key not in required:
+                hint_parts.append("optional")
+            hint = ", ".join(hint_parts)
+            label_parts.append(f" [{hint}]")
+
+            host.output(
+                Text.from_markup(
+                    f"   [{fmt.accent}]{''.join(label_parts)}[/{fmt.accent}]",
+                ),
+            )
+
+            raw = await fis.begin(key)
+
+            # Use default when the user submits empty input.
+            if not raw.strip():
+                if default is not None:
+                    content[key] = default
+                elif key not in required:
+                    continue
+                else:
+                    return None
+                continue
+
+            # Parse according to type.
+            val: str | int | float | bool | None = raw.strip()
+            if prop_type == "boolean":
+                val = val.lower() in ("true", "1", "yes", "y")  # type: ignore[union-attr]
+            elif prop_type == "integer":
+                try:
+                    val = int(val)  # type: ignore[arg-type]
+                except ValueError:
+                    return None
+            elif prop_type == "number":
+                try:
+                    val = float(val)  # type: ignore[arg-type]
+                except ValueError:
+                    return None
+
+            # Validate enum constraints.
+            if one_of and isinstance(one_of, list):
+                valid = [o.get("const") for o in one_of if isinstance(o, dict) and "const" in o]
+                if val not in valid:
+                    return None
+            elif enum_vals and isinstance(enum_vals, list):
+                if val not in enum_vals:
+                    return None
+
+            content[key] = val
+
+        return content
 
     async def _unbind_runner_soft(self, session_id: str) -> None:
         """
@@ -2680,6 +2834,7 @@ async def run_repl(
     # normal prompt_toolkit input path avoids the stdin /
     # patch_stdout fight that a direct input() call produced.
     approval_state = _ApprovalState()
+    field_input_state = _FieldInputState()
     hooks = StreamHooks(
         on_elicitation_request=_make_elicitation_prompt(
             host, fmt, approval_state, server_url=server_url
@@ -2717,6 +2872,9 @@ async def run_repl(
         on_session_start=on_session_start,
         harness=harness,
         attach_only=attach_only,
+        field_input_state=field_input_state,
+        host=host,
+        fmt=fmt,
     )
     # Make per-invocation log paths visible to slash commands such as
     # /logs without broadening the slash-command dispatch signature.
@@ -3379,6 +3537,18 @@ async def run_repl(
     async def on_input(text: str, attachments: list[PendingAttachment] | None = None) -> None:
         nonlocal conversation_id, is_streaming
 
+        # Pending schema field input: consume this line as the
+        # current field's value before any other routing.
+        if field_input_state.pending:
+            field_name = field_input_state.field_name or "field"
+            host.output(
+                Text.from_markup(
+                    f"   [{fmt.muted}]› {field_name}: {text}[/{fmt.muted}]",
+                ),
+            )
+            field_input_state.resolve(text)
+            return
+
         # Pending policy approval: consume this input as the
         # verdict BEFORE slash-command / normal-send routing.
         # The hook is awaiting a future; resolving it wakes
@@ -3480,6 +3650,7 @@ async def run_repl(
             # hook's future doesn't leak waiting for a verdict
             # that will never come.
             approval_state.cancel()
+            field_input_state.cancel()
             # Best-effort — server may already have finished.
             with contextlib.suppress(Exception):
                 await asyncio.shield(session.cancel())

--- a/tests/repl/test_field_input_state.py
+++ b/tests/repl/test_field_input_state.py
@@ -1,0 +1,96 @@
+"""Tests for ``_FieldInputState`` in ``omnigent.repl._repl``.
+
+Covers the future-based field input collection used to prompt
+schema fields interactively in the REPL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from omnigent.repl._repl import _FieldInputState
+
+
+def test_not_pending_initially() -> None:
+    state = _FieldInputState()
+    assert not state.pending
+    assert state.field_name is None
+
+
+def test_begin_creates_pending_future() -> None:
+    state = _FieldInputState()
+    loop = asyncio.new_event_loop()
+    try:
+        fut = loop.run_until_complete(_begin(state, "name"))
+        assert state.pending
+        assert state.field_name == "name"
+        assert not fut.done()
+    finally:
+        loop.close()
+
+
+def test_resolve_completes_future() -> None:
+    state = _FieldInputState()
+
+    async def _run() -> str:
+        fut = state.begin("email")
+        assert state.pending
+        state.resolve("test@example.com")
+        return await fut
+
+    loop = asyncio.new_event_loop()
+    try:
+        result = loop.run_until_complete(_run())
+        assert result == "test@example.com"
+        assert not state.pending
+        assert state.field_name is None
+    finally:
+        loop.close()
+
+
+def test_resolve_returns_false_when_no_pending() -> None:
+    state = _FieldInputState()
+    assert not state.resolve("value")
+
+
+def test_cancel_resolves_with_empty_string() -> None:
+    state = _FieldInputState()
+
+    async def _run() -> str:
+        fut = state.begin("field")
+        state.cancel()
+        return await fut
+
+    loop = asyncio.new_event_loop()
+    try:
+        result = loop.run_until_complete(_run())
+        assert result == ""
+        assert not state.pending
+    finally:
+        loop.close()
+
+
+def test_begin_replaces_previous_future() -> None:
+    state = _FieldInputState()
+
+    async def _run() -> tuple[str, str]:
+        fut1 = state.begin("first")
+        fut2 = state.begin("second")
+        assert fut1.done()
+        assert await fut1 == ""
+        state.resolve("val2")
+        return await fut1, await fut2
+
+    loop = asyncio.new_event_loop()
+    try:
+        r1, r2 = loop.run_until_complete(_run())
+        assert r1 == ""
+        assert r2 == "val2"
+    finally:
+        loop.close()
+
+
+async def _begin(state: _FieldInputState, name: str) -> asyncio.Future[str]:
+    return state.begin(name)

--- a/tests/repl/test_field_input_state.py
+++ b/tests/repl/test_field_input_state.py
@@ -7,10 +7,9 @@ schema fields interactively in the REPL.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
-import pytest
-
-from omnigent.repl._repl import _FieldInputState
+from omnigent.repl._repl import _FieldInputState, _SessionsChatReplAdapter
 
 
 def test_not_pending_initially() -> None:
@@ -94,3 +93,215 @@ def test_begin_replaces_previous_future() -> None:
 
 async def _begin(state: _FieldInputState, name: str) -> asyncio.Future[str]:
     return state.begin(name)
+
+
+# --------------------------------------------------------------------------
+# Abort contract: cancel() must be distinguishable from an empty submit.
+# --------------------------------------------------------------------------
+
+
+def test_aborted_false_initially() -> None:
+    state = _FieldInputState()
+    assert not state.aborted
+
+
+def test_cancel_sets_aborted() -> None:
+    state = _FieldInputState()
+
+    async def _run() -> bool:
+        state.begin("field")
+        state.cancel()
+        return state.aborted
+
+    loop = asyncio.new_event_loop()
+    try:
+        assert loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+def test_begin_clears_aborted() -> None:
+    """A fresh prompt starts un-aborted even after a prior cancel."""
+    state = _FieldInputState()
+
+    async def _run() -> bool:
+        state.begin("a")
+        state.cancel()
+        assert state.aborted
+        state.begin("b")
+        return state.aborted
+
+    loop = asyncio.new_event_loop()
+    try:
+        assert not loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+# --------------------------------------------------------------------------
+# _prompt_schema_fields: parsing, validation, re-prompting, abort, markup.
+# --------------------------------------------------------------------------
+
+
+class _FakeHost:
+    """Records rendered output instead of writing to a terminal."""
+
+    def __init__(self) -> None:
+        self.outputs: list[Any] = []
+
+    def output(self, renderable: Any) -> None:
+        self.outputs.append(renderable)
+
+
+class _FakeFmt:
+    accent = "cyan"
+    muted = "grey50"
+    warning = "yellow"
+
+
+def _outputs_text(host: _FakeHost) -> str:
+    """Concatenate the ``.plain`` of every rendered Rich ``Text``."""
+    return "\n".join(getattr(o, "plain", str(o)) for o in host.outputs)
+
+
+async def _drive_prompt(
+    schema: dict[str, Any],
+    answers: list[str],
+    *,
+    abort_at: int | None = None,
+    state: _FieldInputState | None = None,
+) -> tuple[dict[str, Any] | None, _FakeHost]:
+    """Run ``_prompt_schema_fields`` feeding scripted user answers.
+
+    :param answers: Values fed in order each time a field is pending.
+    :param abort_at: 1-based prompt index at which to ``cancel()``
+        (simulating Esc) instead of resolving.
+    :param state: Optional pre-built state (``None`` builds a fresh one;
+        pass an adapter-detached run by leaving the adapter's state unset).
+    """
+    fis = state if state is not None else _FieldInputState()
+    host = _FakeHost()
+    adapter = _SessionsChatReplAdapter.__new__(_SessionsChatReplAdapter)
+    adapter._field_input_state = fis  # type: ignore[attr-defined]
+    adapter._host = host  # type: ignore[attr-defined]
+    adapter._fmt = _FakeFmt()  # type: ignore[attr-defined]
+
+    task = asyncio.create_task(adapter._prompt_schema_fields(schema))
+    answer_iter = iter(answers)
+    prompts = 0
+    guard = 0
+    while not task.done():
+        await asyncio.sleep(0)
+        guard += 1
+        assert guard < 200, "prompt loop did not converge"
+        if fis.pending:
+            prompts += 1
+            if abort_at is not None and prompts == abort_at:
+                fis.cancel()
+                continue
+            fis.resolve(next(answer_iter, ""))
+    result = await task
+    return result, host
+
+
+def _run(coro: Any) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def test_prompt_collects_string_and_integer() -> None:
+    schema = {
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name", "age"],
+    }
+    result, _ = _run(_drive_prompt(schema, ["alice", "42"]))
+    assert result == {"name": "alice", "age": 42}
+
+
+def test_prompt_boolean_parsing() -> None:
+    schema = {"properties": {"flag": {"type": "boolean"}}, "required": ["flag"]}
+    assert _run(_drive_prompt(schema, ["yes"]))[0] == {"flag": True}
+    assert _run(_drive_prompt(schema, ["nope"]))[0] == {"flag": False}
+
+
+def test_prompt_uses_default_on_empty() -> None:
+    schema = {"properties": {"verbose": {"type": "boolean", "default": False}}}
+    result, _ = _run(_drive_prompt(schema, [""]))
+    assert result == {"verbose": False}
+
+
+def test_prompt_skips_optional_on_empty() -> None:
+    schema = {"properties": {"note": {"type": "string"}}}
+    result, _ = _run(_drive_prompt(schema, [""]))
+    assert result == {}
+
+
+def test_prompt_required_empty_reprompts_then_accepts() -> None:
+    schema = {"properties": {"name": {"type": "string"}}, "required": ["name"]}
+    result, host = _run(_drive_prompt(schema, ["", "bob"]))
+    assert result == {"name": "bob"}
+    assert "required" in _outputs_text(host)
+
+
+def test_prompt_invalid_integer_reprompts() -> None:
+    schema = {"properties": {"age": {"type": "integer"}}, "required": ["age"]}
+    result, host = _run(_drive_prompt(schema, ["abc", "7"]))
+    assert result == {"age": 7}
+    assert "whole number" in _outputs_text(host)
+
+
+def test_prompt_enum_rejects_then_accepts() -> None:
+    schema = {
+        "properties": {"choice": {"type": "string", "enum": ["yes", "no"]}},
+        "required": ["choice"],
+    }
+    result, host = _run(_drive_prompt(schema, ["maybe", "yes"]))
+    assert result == {"choice": "yes"}
+    assert "choose one of" in _outputs_text(host)
+
+
+def test_prompt_one_of_const_rejects_then_accepts() -> None:
+    schema = {
+        "properties": {"mode": {"oneOf": [{"const": "a"}, {"const": "b"}]}},
+        "required": ["mode"],
+    }
+    result, _ = _run(_drive_prompt(schema, ["z", "b"]))
+    assert result == {"mode": "b"}
+
+
+def test_prompt_abort_returns_none() -> None:
+    """Esc mid-prompt declines the whole form rather than advancing."""
+    schema = {
+        "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+        "required": ["a", "b"],
+    }
+    result, _ = _run(_drive_prompt(schema, [], abort_at=1))
+    assert result is None
+
+
+def test_prompt_markup_in_schema_text_is_safe() -> None:
+    """Bracketed server text must not be parsed as Rich markup.
+
+    A description containing an unbalanced closing tag would raise
+    ``MarkupError`` under ``Text.from_markup`` and crash the prompt;
+    here it must render literally and collection must succeed.
+    """
+    schema = {
+        "properties": {"x": {"type": "string", "description": "use [bold] or [/red]"}},
+        "required": ["x"],
+    }
+    result, host = _run(_drive_prompt(schema, ["v"]))
+    assert result == {"x": "v"}
+    assert "[/red]" in _outputs_text(host)
+
+
+def test_prompt_returns_none_when_state_unavailable() -> None:
+    schema = {"properties": {"x": {"type": "string"}}}
+    adapter = _SessionsChatReplAdapter.__new__(_SessionsChatReplAdapter)
+    adapter._field_input_state = None  # type: ignore[attr-defined]
+    adapter._host = None  # type: ignore[attr-defined]
+    adapter._fmt = None  # type: ignore[attr-defined]
+    assert _run(adapter._prompt_schema_fields(schema)) is None


### PR DESCRIPTION
## Related issue

Closes #770

## Summary

When the REPL accepts an elicitation whose schema has fields that can't be auto-filled (free-form strings, numbers without defaults), it previously declined silently — forcing users to the web UI. This PR adds interactive terminal prompts for each schema field, using the same `asyncio.Future` pattern as the existing approval flow to avoid `prompt_toolkit`/`patch_stdout` conflicts.

- Added `_FieldInputState` class mirroring `_ApprovalState` for collecting raw text input field-by-field.
- Added `_prompt_schema_fields` method on `_SessionsChatReplAdapter` that renders styled prompts per field (type hints, enum options, defaults, optional markers), awaits user input, and parses/validates responses.
- Wired field input handling into the main input loop before the approval state check.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `tests/repl/test_field_input_state.py` with 6 unit tests covering `_FieldInputState`: initial state, begin/resolve cycle, resolve-when-empty, cancel semantics, and replacement of prior futures. Ran against existing `tests/repl/test_elicitation_schema.py` (15 tests) to verify no regressions — all 21 tests pass.

The interactive prompting flow (`_prompt_schema_fields`) is tightly coupled to the REPL's `TerminalHost` and `prompt_toolkit` session, making it difficult to unit-test without a full REPL harness. E2E coverage for the elicitation approval flow exists in `tests/e2e/test_repl_approval_e2e.py`; extending it to cover schema field prompting would require a server-side elicitation with a complex schema, which is best addressed in a follow-up.