### PR TITLE
fix(e2e): isolate per-model mock queues to fix parallel sub-agent race

### DIFF
--- a/tests/_fixtures/agents/named-sub-agent-test/named-sub-agent-test.yaml
+++ b/tests/_fixtures/agents/named-sub-agent-test/named-sub-agent-test.yaml
@@ -42,7 +42,7 @@ tools:
     type: agent
     description: Test-fixture sub-agent. Returns RESEARCHER_PHASE4_OK.
     executor:
-      model: gpt-5.4
+      model: gpt-5.4-named-researcher
     prompt: |
       You are the test-fixture researcher sub-agent for Phase 4
       E2E. Whatever the user asks, your reply MUST contain
@@ -55,7 +55,7 @@ tools:
     type: agent
     description: Test-fixture sub-agent. Returns SUMMARIZER_PHASE4_OK.
     executor:
-      model: gpt-5.4
+      model: gpt-5.4-named-summarizer
     prompt: |
       You are the test-fixture summarizer sub-agent for Phase 4
       E2E. Whatever the user asks, your reply MUST contain

--- a/tests/e2e/test_named_sub_agent_persistence.py
+++ b/tests/e2e/test_named_sub_agent_persistence.py
@@ -79,6 +79,13 @@ pytestmark = pytest.mark.timeout(600, method="signal")
 _FIXTURES_DIR = Path(__file__).resolve().parents[1] / "_fixtures" / "agents"
 _NAMED_FIXTURE = _FIXTURES_DIR / "named-sub-agent-test"
 
+# Mock queue keys — must match the model names in named-sub-agent-test.yaml.
+# Each agent has its own key so their LLM calls consume from separate queues
+# and cannot race when researcher and summarizer run in parallel.
+_PARENT_MODEL = "gpt-5.4"
+_RESEARCHER_MODEL = "gpt-5.4-named-researcher"
+_SUMMARIZER_MODEL = "gpt-5.4-named-summarizer"
+
 
 # ─── Mock-LLM helpers ──────────────────────────────────────
 
@@ -143,6 +150,7 @@ def _configure_spawn_flow(
     mock_url: str | None,
     *,
     agent: str = "researcher",
+    child_model: str = _RESEARCHER_MODEL,
     title: str = "auth",
     child_args: str = "What are common auth patterns?",
     child_marker: str = "RESEARCHER_PHASE4_OK",
@@ -150,16 +158,20 @@ def _configure_spawn_flow(
 ) -> None:
     """Configure mock queues for a single spawn-and-autowake flow.
 
-    Queues four responses on the ``"default"`` key:
+    Queues responses on per-model keys so the parent and child never
+    race for the same queue slot:
 
-    1. Parent dispatch: ``sys_session_send`` tool call.
-    2. Parent after tool result: text acknowledging dispatch.
-    3. Child turn: text containing *child_marker*.
-    4. Parent auto-wake continuation: text quoting the marker.
+    Parent key (``_PARENT_MODEL``):
+      1. Dispatch: ``sys_session_send`` tool call.
+      2. After tool result: text acknowledging dispatch.
+      3. Auto-wake continuation: text quoting the marker.
+
+    Child key (*child_model*):
+      1. Child turn: text containing *child_marker*.
 
     The parent's harness makes TWO LLM calls per tool dispatch: one that
-    returns the tool_call, then another after the runner supplies the tool
-    result. Both consume from the same queue.
+    returns the tool_call, then another after the runner supplies the
+    tool result.
     """
     if parent_reply is None:
         parent_reply = f"The sub-agent returned: {child_marker}"
@@ -172,10 +184,14 @@ def _configure_spawn_flow(
                 ],
             },
             {"text": f"Dispatched {agent}, waiting for result."},
-            {"text": f"Research complete. {child_marker}"},
             {"text": parent_reply},
         ],
-        key="default",
+        key=_PARENT_MODEL,
+    )
+    configure_mock_llm(
+        mock_url,
+        [{"text": f"Research complete. {child_marker}"}],
+        key=child_model,
     )
 
 
@@ -394,6 +410,8 @@ def test_ambient_hint_steers_followup_to_send_e2e(
     but NOT the LLM's ability to read the hint.
     """
     reset_mock_llm(mock_llm_server_url)
+    # Parent LLM calls on the parent model key (6 total across 2 turns):
+    # turn 1: dispatch, after-tool, auto-wake; turn 2: dispatch, after-tool, auto-wake.
     configure_mock_llm(
         mock_llm_server_url,
         [
@@ -407,8 +425,6 @@ def test_ambient_hint_steers_followup_to_send_e2e(
             },
             # Turn 1: parent after tool result
             {"text": "Dispatched researcher, waiting."},
-            # Turn 1: child responds
-            {"text": "Foundations investigated. RESEARCHER_PHASE4_OK"},
             # Turn 1: parent auto-wake
             {"text": "Researcher returned: RESEARCHER_PHASE4_OK"},
             # Turn 2: parent continues (mock returns the right tool call)
@@ -421,12 +437,21 @@ def test_ambient_hint_steers_followup_to_send_e2e(
             },
             # Turn 2: parent after tool result
             {"text": "Dispatched continuation, waiting."},
-            # Turn 2: child responds
-            {"text": "Continued investigation. RESEARCHER_PHASE4_OK"},
             # Turn 2: parent auto-wake
             {"text": "Continuation result: RESEARCHER_PHASE4_OK"},
         ],
-        key="default",
+        key=_PARENT_MODEL,
+    )
+    # Researcher child LLM calls on the researcher model key (2 total across 2 turns).
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            # Turn 1: child responds
+            {"text": "Foundations investigated. RESEARCHER_PHASE4_OK"},
+            # Turn 2: child responds
+            {"text": "Continued investigation. RESEARCHER_PHASE4_OK"},
+        ],
+        key=_RESEARCHER_MODEL,
     )
 
     # Turn 1: spawn with explicit name + topic. Wait for the result so
@@ -487,6 +512,8 @@ def test_parallel_named_sub_agents_e2e(
     proving each child ran independently.
     """
     reset_mock_llm(mock_llm_server_url)
+    # Each agent gets its own model-keyed queue so their LLM calls never
+    # race against the parent's auto-wake call on a shared queue.
     configure_mock_llm(
         mock_llm_server_url,
         [
@@ -499,10 +526,6 @@ def test_parallel_named_sub_agents_e2e(
             },
             # Parent after tool results
             {"text": "Dispatched both, waiting."},
-            # Researcher child responds
-            {"text": "Topic A research. RESEARCHER_PHASE4_OK"},
-            # Summarizer child responds
-            {"text": "Topic B summary. SUMMARIZER_PHASE4_OK"},
             # Parent auto-wake continuation (reads inbox with both results)
             {
                 "text": (
@@ -510,7 +533,17 @@ def test_parallel_named_sub_agents_e2e(
                 ),
             },
         ],
-        key="default",
+        key=_PARENT_MODEL,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Topic A research. RESEARCHER_PHASE4_OK"}],
+        key=_RESEARCHER_MODEL,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Topic B summary. SUMMARIZER_PHASE4_OK"}],
+        key=_SUMMARIZER_MODEL,
     )
 
     _body, session_id = _run_turn(
@@ -542,8 +575,8 @@ def test_cross_parent_named_isolation_e2e(
     history. The partial unique index is per-parent.
     """
     reset_mock_llm(mock_llm_server_url)
-    # Two sequential spawn flows — 4 responses per conv (tool_call +
-    # text after tool result + child + auto-wake) = 8 total.
+    # Two sequential spawn flows with per-model queues so each agent's
+    # LLM calls consume from their own stream.
     configure_mock_llm(
         mock_llm_server_url,
         [
@@ -559,8 +592,6 @@ def test_cross_parent_named_isolation_e2e(
             },
             # Conv A: parent after tool result
             {"text": "Dispatched researcher for project A."},
-            # Conv A: child responds
-            {"text": "Project A auth. RESEARCHER_PHASE4_OK"},
             # Conv A: parent auto-wake
             {"text": "Researcher returned: RESEARCHER_PHASE4_OK"},
             # Conv B: parent dispatches
@@ -575,12 +606,20 @@ def test_cross_parent_named_isolation_e2e(
             },
             # Conv B: parent after tool result
             {"text": "Dispatched researcher for project B."},
-            # Conv B: child responds
-            {"text": "Project B auth. RESEARCHER_PHASE4_OK"},
             # Conv B: parent auto-wake
             {"text": "Researcher returned: RESEARCHER_PHASE4_OK"},
         ],
-        key="default",
+        key=_PARENT_MODEL,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            # Conv A: child responds
+            {"text": "Project A auth. RESEARCHER_PHASE4_OK"},
+            # Conv B: child responds
+            {"text": "Project B auth. RESEARCHER_PHASE4_OK"},
+        ],
+        key=_RESEARCHER_MODEL,
     )
 
     # Conversation A (fresh session).


### PR DESCRIPTION
## Summary

- `test_parallel_named_sub_agents_e2e` was flaky because all three agents (parent, researcher, summarizer) used `model: gpt-5.4` in the fixture YAML, routing all LLM calls to the same shared mock queue.
- When researcher completed first and triggered the parent's auto-wake, the auto-wake LLM call raced against summarizer's LLM call for the next queue slot — the wrong agent consumed the wrong response, so the expected markers never appeared.
- Fix: give researcher and summarizer distinct model names (`gpt-5.4-named-researcher`, `gpt-5.4-named-summarizer`) in the fixture YAML, and configure per-model mock LLM queues in all affected tests so each agent's calls consume from their own isolated stream.

## What changed

- **`tests/_fixtures/agents/named-sub-agent-test/named-sub-agent-test.yaml`**: researcher uses `gpt-5.4-named-researcher`, summarizer uses `gpt-5.4-named-summarizer` (were both `gpt-5.4`).
- **`tests/e2e/test_named_sub_agent_persistence.py`**: added `_PARENT_MODEL`, `_RESEARCHER_MODEL`, `_SUMMARIZER_MODEL` constants; updated `_configure_spawn_flow` and all four tests to use per-model `configure_mock_llm` calls instead of a single `key="default"` queue.

## Test plan

- [ ] Run `pytest tests/e2e/test_named_sub_agent_persistence.py --profile oss -v` — all tests pass, including `test_parallel_named_sub_agents_e2e`.
- [ ] Confirm no other tests reference `gpt-5.4` model names for researcher/summarizer sub-agents.

This pull request and its description were written by Isaac.