### PR TITLE
test(repl-e2e): per-test mock isolation via content-routed queues (#523) [alt to #893]

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -264,6 +264,7 @@ def configure_mock_llm(
     responses: list[dict[str, Any]],
     *,
     key: str = "default",
+    match: str | None = None,
 ) -> None:
     """
     Configure a keyed response queue on the mock LLM server.
@@ -283,6 +284,16 @@ def configure_mock_llm(
         configure_mock_llm(url, [{"text": "LGTM"}],
                            key="mock-reviewer")
 
+    Pass *match* to route by request CONTENT instead of model: the queue
+    serves any request whose ``role="user"`` input contains the token.
+    This lets a test claim its own queue by the unique message it sends,
+    so a stray/late request from another test can't draw from it — the
+    fix for the #523 cross-test contamination flake without per-test
+    mock servers::
+
+        configure_mock_llm(url, [...], match="mangosteen-tr")
+        # and the test does child.send("mangosteen-tr ...")
+
     :param mock_llm_server_url: Mock server URL or ``None``.
     :param responses: List of response configs. Keys:
         ``text``, ``tool_calls``, ``block``, ``stream``,
@@ -290,12 +301,23 @@ def configure_mock_llm(
     :param key: Queue key — typically the model name baked into the
         agent spec. Defaults to ``"default"`` (matches any model
         not assigned to a more specific queue).
+    :param match: Optional content-routing token. When set, the queue is
+        selected if this token appears in the request's user input,
+        regardless of ``model``. Use a deliberately-unique token (the
+        message the test sends). Also used as the queue *key* when *key*
+        is left at its default, so each match-routed queue is distinct.
     """
     if mock_llm_server_url is None:
         return
+    payload: dict[str, Any] = {
+        "key": match if (match is not None and key == "default") else key,
+        "responses": responses,
+    }
+    if match is not None:
+        payload["match"] = match
     resp = httpx.post(
         f"{mock_llm_server_url}/mock/configure",
-        json={"key": key, "responses": responses},
+        json=payload,
         timeout=5.0,
     )
     resp.raise_for_status()

--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -1607,7 +1607,16 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
     worker_reply = "worker-reply-render-marker"
     parent_summary = "parent-summary-render-marker"
     reset_mock_llm(mock_llm_server_url)
-    # Parent queue (model gpt-4o): spawn toolworker, then summarize.
+    # Both queues are content-routed on DISTINCT, mutually-non-substring
+    # tokens so parent and sub-agent calls split correctly AND neither
+    # queue is reachable by model fallback (closes the gpt-4o / gpt-4o-mini
+    # contamination vectors entirely — #523 isolation):
+    #   - "statool-parent" appears ONLY in the root user message, so the
+    #     parent's calls (and its post-spawn continuation) route here. The
+    #     delegated-task token lives in a function_call, not user content,
+    #     so it never leaks into the parent's user text.
+    #   - "statool-worker" appears ONLY in the task delegated to the
+    #     toolworker, so the sub-agent's calls route to its own queue.
     configure_mock_llm(
         mock_llm_server_url,
         [
@@ -1617,7 +1626,11 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
                         "call_id": "sa1",
                         "name": "sys_session_send",
                         "arguments": json.dumps(
-                            {"agent": "toolworker", "title": "t", "args": "return the word durian"}
+                            {
+                                "agent": "toolworker",
+                                "title": "t",
+                                "args": "return the word durian statool-worker",
+                            }
                         ),
                     }
                 ]
@@ -1626,16 +1639,9 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
             {"text": "(spare)"},
             {"text": "(spare)"},
         ],
-        # Content-route the PARENT queue on a token that appears ONLY in
-        # the root user message — not in the delegated task the
-        # sub-agent receives ("return the word durian") — so the parent's
-        # calls hit this queue while the toolworker's calls fall through
-        # to its own model-keyed queue below. Dropping the "gpt-4o" model
-        # key also means a stray gpt-4o request from another test no
-        # longer lands here via model fallback (#523 isolation).
-        match="subagent-tool",
+        match="statool-parent",
     )
-    # Toolworker queue (model gpt-4o-mini): call echo, then reply.
+    # Toolworker queue — content-routed on the delegated-task token.
     configure_mock_llm(
         mock_llm_server_url,
         [
@@ -1652,7 +1658,7 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
             {"text": "(spare)"},
             {"text": "(spare)"},
         ],
-        key="gpt-4o-mini",
+        match="statool-worker",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -1669,7 +1675,7 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
             timeout=90,
             welcome_pattern="e2e.subagent.tool.gate",
         )
-        child.send("return the word durian subagent-tool" + "\r")
+        child.send("return the word durian statool-parent" + "\r")
         # Deterministic content-marker sync: the parent's summary text
         # renders only after the sub-agent ran echo end-to-end and its
         # result landed in the inbox. Keying on the marker (not the

--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -451,7 +451,9 @@ def test_repl_single_approval_allows_llm_response(
     multiple ``⚠ approval required`` banners. Counting on
     the ANSI-stripped buffer is the regression guard.
     """
-    _configure_mock_text(mock_llm_server_url, ["Hi there! How can I help you today?"], match="approve-llm-resp")
+    _configure_mock_text(
+        mock_llm_server_url, ["Hi there! How can I help you today?"], match="approve-llm-resp"
+    )
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_ASK_DEMO_DIR)],

--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -189,7 +189,9 @@ def repl_env(
     return env
 
 
-def _configure_mock_text(mock_llm_server_url: str, texts: list[str]) -> None:
+def _configure_mock_text(
+    mock_llm_server_url: str, texts: list[str], *, match: str | None = None
+) -> None:
     """
     Pre-load the mock LLM server with simple text responses.
 
@@ -201,11 +203,17 @@ def _configure_mock_text(mock_llm_server_url: str, texts: list[str]) -> None:
     :param mock_llm_server_url: Mock server base URL.
     :param texts: Ordered list of response texts the mock should
         return, one per LLM call.
+    :param match: Optional content-routing token (the unique user
+        message this test sends). When set, these responses are served
+        only to requests whose user input contains the token, isolating
+        this test's queue from a stray/late request fired by another
+        test on the shared mock (#523 cross-test contamination).
     """
     reset_mock_llm(mock_llm_server_url)
     configure_mock_llm(
         mock_llm_server_url,
         [{"text": t} for t in texts],
+        match=match,
     )
 
 
@@ -213,6 +221,8 @@ def _configure_mock_tool_then_text(
     mock_llm_server_url: str,
     tool_calls: list[dict[str, str]],
     follow_up_text: str,
+    *,
+    match: str | None = None,
 ) -> None:
     """
     Configure a tool-call response followed by a text response.
@@ -225,6 +235,11 @@ def _configure_mock_tool_then_text(
     :param tool_calls: Tool call dicts (``call_id``, ``name``,
         ``arguments``).
     :param follow_up_text: Text for the second LLM call.
+    :param match: Optional content-routing token (the unique user
+        message this test sends). When set, these responses are served
+        only to requests whose user input contains the token, isolating
+        this test's queue from a stray/late request fired by another
+        test on the shared mock (#523 cross-test contamination).
     """
     reset_mock_llm(mock_llm_server_url)
     configure_mock_llm(
@@ -233,6 +248,7 @@ def _configure_mock_tool_then_text(
             {"tool_calls": tool_calls},
             {"text": follow_up_text},
         ],
+        match=match,
     )
 
 
@@ -243,6 +259,7 @@ def _configure_mock_subagent_spawn(
     *,
     sub_agent_responses: list[dict[str, Any]],
     parent_summary: str,
+    match: str | None = None,
 ) -> None:
     """
     Configure a parent→sub-agent→parent mock LLM exchange.
@@ -268,6 +285,12 @@ def _configure_mock_subagent_spawn(
     :param sub_agent_responses: Response dicts the sub-agent's own
         LLM call(s) consume, in order.
     :param parent_summary: Parent's final text response.
+    :param match: Optional content-routing token. Works here only
+        because the sub-agent is delegated *message* — so both the
+        parent (user message) and the sub-agent (delegated task) carry
+        the token, and the single ordered queue serves both in order
+        while a stray request from another test (no token) cannot draw
+        from it (#523 isolation).
     """
     reset_mock_llm(mock_llm_server_url)
     spawn = {
@@ -288,6 +311,7 @@ def _configure_mock_subagent_spawn(
             {"text": "(spare)"},
             {"text": "(spare)"},
         ],
+        match=match,
     )
 
 
@@ -427,7 +451,7 @@ def test_repl_single_approval_allows_llm_response(
     multiple ``⚠ approval required`` banners. Counting on
     the ANSI-stripped buffer is the regression guard.
     """
-    _configure_mock_text(mock_llm_server_url, ["Hi there! How can I help you today?"])
+    _configure_mock_text(mock_llm_server_url, ["Hi there! How can I help you today?"], match="approve-llm-resp")
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_ASK_DEMO_DIR)],
@@ -443,7 +467,7 @@ def test_repl_single_approval_allows_llm_response(
         # Send the user message and wait for the approval
         # banner. 'approval required' is the human-readable
         # header emitted by the REPL's _make_approval_prompt.
-        child.send("Hello" + "\r")
+        child.send("Hello approve-llm-resp" + "\r")
         child.expect("approval required", timeout=30)
         # The preview line should echo what we just typed —
         # confirms the server-side INPUT-phase eval and the
@@ -523,7 +547,7 @@ def test_repl_refusal_shows_deny_sentinel(
     """
     # No LLM call expected on refuse — configure a dummy response
     # so the mock doesn't 500 if the server unexpectedly calls it.
-    _configure_mock_text(mock_llm_server_url, ["should not appear"])
+    _configure_mock_text(mock_llm_server_url, ["should not appear"], match="deny-sentinel")
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_ASK_DEMO_DIR)],
@@ -536,7 +560,7 @@ def test_repl_refusal_shows_deny_sentinel(
     try:
         _wait_for_prompt_ready(child, timeout=60)
 
-        child.send("Hello" + "\r")
+        child.send("Hello deny-sentinel" + "\r")
         child.expect("approval required", timeout=30)
         child.expect("Hello", timeout=5)
 
@@ -586,6 +610,7 @@ def test_repl_two_turns_fires_one_approval_per_turn(
             "Hello! Nice to meet you.",
             "Sure thing, got it!",
         ],
+        match="two-turns-guard",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -600,7 +625,7 @@ def test_repl_two_turns_fires_one_approval_per_turn(
         _wait_for_prompt_ready(child, timeout=60)
 
         # Turn 1: approve, wait for reply.
-        child.send("Hello" + "\r")
+        child.send("Hello two-turns-guard" + "\r")
         child.expect("approval required", timeout=30)
         child.send("y" + "\r")
         child.expect("approved", timeout=5)
@@ -700,6 +725,7 @@ def test_repl_approve_always_caches_for_later_turns(
             "Hello there!",
             "Following up as requested.",
         ],
+        match="approve-cache",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -714,7 +740,7 @@ def test_repl_approve_always_caches_for_later_turns(
         _wait_for_prompt_ready(child, timeout=60)
 
         # Turn 1: approve always.
-        child.send("Hello" + "\r")
+        child.send("Hello approve-cache" + "\r")
         child.expect("approval required", timeout=30)
         child.send("a" + "\r")
         # Echo line confirms the REPL parsed "a" as
@@ -800,6 +826,7 @@ def test_repl_tool_call_approval_allows_tool_to_run(
             }
         ],
         follow_up,
+        match="testing123",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -876,6 +903,7 @@ def test_repl_tool_call_refusal_blocks_tool(
             }
         ],
         follow_up,
+        match="testing456",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -971,9 +999,10 @@ def test_repl_subagent_ask_does_not_tunnel_banner_to_root(
     _configure_mock_subagent_spawn(
         mock_llm_server_url,
         "worker",
-        "say hello",
+        "say hello subagent-ask",
         sub_agent_responses=[{"text": worker_reply}],
         parent_summary="Parent summarized the worker.",
+        match="subagent-ask",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -990,7 +1019,7 @@ def test_repl_subagent_ask_does_not_tunnel_banner_to_root(
             timeout=90,
             welcome_pattern="e2e.subagent.gate",
         )
-        child.send("say hello" + "\r")
+        child.send("say hello subagent-ask" + "\r")
         # The full turn — spawn, sub-agent run, inbox collect, parent
         # summary — completes without ever parking on a banner.
         _wait_for_turn_complete(child, timeout=90)
@@ -1069,6 +1098,7 @@ def test_repl_label_driven_ask_approves(
             "Got it, banana trigger noted.",
             "Continuing as requested.",
         ],
+        match="label-approve",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -1087,7 +1117,7 @@ def test_repl_label_driven_ask_approves(
         )
         # Turn 1: trigger taint — no ASK fires this turn
         # (condition checks the pre-evaluation snapshot).
-        child.send("hello BANANA_TRIGGER" + "\r")
+        child.send("hello BANANA_TRIGGER label-approve" + "\r")
         # The LLM still replies normally. Wait for turn end.
         _wait_for_turn_complete(child, timeout=45)
         turn_one = child.before or ""
@@ -1149,6 +1179,7 @@ def test_repl_label_driven_ask_refuse_shows_sentinel(
             "Banana trigger received.",
             "should not appear",
         ],
+        match="label-refuse",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -1166,7 +1197,7 @@ def test_repl_label_driven_ask_refuse_shows_sentinel(
             welcome_pattern="e2e.label.ask.gate",
         )
         # Turn 1: taint.
-        child.send("hi BANANA_TRIGGER" + "\r")
+        child.send("hi BANANA_TRIGGER label-refuse" + "\r")
         _wait_for_turn_complete(child, timeout=45)
         _read_pending(child, seconds=1.0)
 
@@ -1230,7 +1261,7 @@ def test_repl_output_ask_does_not_prompt_in_repl(
     "same fix applies to OUTPUT" follow-up there does not hold.)
     """
     reply = "output-passthrough-reply-marker"
-    _configure_mock_text(mock_llm_server_url, [reply])
+    _configure_mock_text(mock_llm_server_url, [reply], match="output-noprompt")
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_OUTPUT_GATE_DIR)],
@@ -1246,7 +1277,7 @@ def test_repl_output_ask_does_not_prompt_in_repl(
             timeout=60,
             welcome_pattern="e2e.output.gate",
         )
-        child.send("say hi" + "\r")
+        child.send("say hi output-noprompt" + "\r")
         # The reply renders without ever parking on a banner. Sync on the
         # reply marker (deterministic content) rather than the cosmetic
         # `· ready` idle-settle, which can race/not-render under CI load.
@@ -1293,7 +1324,7 @@ def test_repl_output_ask_passes_reply_through_no_sentinel(
     substituted. Verified live against the mock.)
     """
     reply = "output-verbatim-reply-marker"
-    _configure_mock_text(mock_llm_server_url, [reply])
+    _configure_mock_text(mock_llm_server_url, [reply], match="output-passthru")
     child = pexpect.spawn(
         ap_cli,
         ["run", str(_OUTPUT_GATE_DIR)],
@@ -1309,7 +1340,7 @@ def test_repl_output_ask_passes_reply_through_no_sentinel(
             timeout=60,
             welcome_pattern="e2e.output.gate",
         )
-        child.send("say hi" + "\r")
+        child.send("say hi output-passthru" + "\r")
         # The raw reply reaches the user verbatim (no DENY substitution).
         # Sync on the reply marker itself — its appearance IS the proof the
         # output passed through ungated.
@@ -1387,6 +1418,7 @@ def test_repl_tool_result_ask_does_not_prompt_in_repl(
             }
         ],
         follow_up,
+        match="pineapple",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -1474,6 +1506,7 @@ def test_repl_tool_result_ask_passes_output_through(
             }
         ],
         follow_up,
+        match="mangosteen",
     )
     child = pexpect.spawn(
         ap_cli,
@@ -1591,7 +1624,14 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
             {"text": "(spare)"},
             {"text": "(spare)"},
         ],
-        key="gpt-4o",
+        # Content-route the PARENT queue on a token that appears ONLY in
+        # the root user message — not in the delegated task the
+        # sub-agent receives ("return the word durian") — so the parent's
+        # calls hit this queue while the toolworker's calls fall through
+        # to its own model-keyed queue below. Dropping the "gpt-4o" model
+        # key also means a stray gpt-4o request from another test no
+        # longer lands here via model fallback (#523 isolation).
+        match="subagent-tool",
     )
     # Toolworker queue (model gpt-4o-mini): call echo, then reply.
     configure_mock_llm(
@@ -1627,7 +1667,7 @@ def test_repl_subagent_tool_call_ask_does_not_tunnel_banner_to_root(
             timeout=90,
             welcome_pattern="e2e.subagent.tool.gate",
         )
-        child.send("return the word durian" + "\r")
+        child.send("return the word durian subagent-tool" + "\r")
         # Deterministic content-marker sync: the parent's summary text
         # renders only after the sub-agent ran echo end-to-end and its
         # result landed in the inbox. Keying on the marker (not the

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -678,8 +678,10 @@ class MockState:
         if user_text:
             best: _ResponseQueue | None = None
             for queue in self.queues.values():
-                if queue.match and queue.match in user_text and (
-                    best is None or len(queue.match) > len(best.match or "")
+                if (
+                    queue.match
+                    and queue.match in user_text
+                    and (best is None or len(queue.match) > len(best.match or ""))
                 ):
                     best = queue
             if best is not None:

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -713,7 +713,6 @@ async def create_response(
     async with _state._lock:
         _state.request_count += 1
         _state.captured_requests.append(parsed)
-        model = parsed.get("model") if isinstance(parsed, dict) else None
         queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 
@@ -781,7 +780,6 @@ async def create_message(
     async with _state._lock:
         _state.request_count += 1
         _state.captured_requests.append(parsed)
-        model = parsed.get("model") if isinstance(parsed, dict) else None
         queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -616,12 +616,22 @@ class MockState:
 
     @staticmethod
     def _user_input_text(parsed: object) -> str:
-        """Concatenate the text of all ``role="user"`` items in the request input.
+        """Concatenate the text of all ``role="user"`` items in the request.
+
+        Endpoint-agnostic: reads BOTH the Responses-API ``input`` array
+        (``/v1/responses``) AND the ``messages`` array used by the
+        Anthropic Messages (``/v1/messages``) and OpenAI Chat
+        (``/v1/chat/completions``) endpoints — so content routing behaves
+        identically no matter which endpoint ``resolve_queue_for_request``
+        is called from, rather than silently degrading to model routing
+        for ``messages``-shaped requests.
 
         Scoped to user-role content deliberately — NOT the system prompt
-        (``instructions``) or tool outputs — so a content-routing token
-        only ever matches what the test itself typed, never incidental
-        words in a shared system prompt.
+        (``instructions`` / ``system``) or tool outputs — so a
+        content-routing token only ever matches what the test itself
+        typed, never incidental words in a shared system prompt. Content
+        may be a plain string or a list of ``{"type","text"}`` blocks
+        (both the Responses and Messages shapes), so both are walked.
 
         :param parsed: The parsed request body.
         :returns: Space-joined user message text (``""`` if none).
@@ -629,16 +639,20 @@ class MockState:
         if not isinstance(parsed, dict):
             return ""
         parts: list[str] = []
-        for item in parsed.get("input") or []:
-            if not isinstance(item, dict) or item.get("role") != "user":
-                continue
-            content = item.get("content")
-            if isinstance(content, str):
-                parts.append(content)
-            elif isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict):
-                        parts.append(str(block.get("text", "")))
+        # ``input`` (Responses API) and ``messages`` (Anthropic / Chat)
+        # are mutually exclusive in practice, but walk both so the helper
+        # is correct for every endpoint that routes through it.
+        for key in ("input", "messages"):
+            for item in parsed.get(key) or []:
+                if not isinstance(item, dict) or item.get("role") != "user":
+                    continue
+                content = item.get("content")
+                if isinstance(content, str):
+                    parts.append(content)
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict):
+                            parts.append(str(block.get("text", "")))
         return " ".join(parts)
 
     def resolve_queue_for_request(self, parsed: object) -> _ResponseQueue:
@@ -650,14 +664,26 @@ class MockState:
         ``model`` / ``"default"`` routing, so tests that don't opt in are
         unaffected.
 
+        When several match-queues are live at once (e.g. a sub-agent test
+        with distinct parent/worker queues), the LONGEST matching token
+        wins — deterministic regardless of dict order, and robust if one
+        token is a substring of another. Tests should still pick mutually
+        non-substring tokens; longest-match is a safety net, not a
+        license to overlap.
+
         :param parsed: The parsed request body.
         :returns: The selected response queue.
         """
         user_text = self._user_input_text(parsed)
         if user_text:
+            best: _ResponseQueue | None = None
             for queue in self.queues.values():
-                if queue.match and queue.match in user_text:
-                    return queue
+                if queue.match and queue.match in user_text and (
+                    best is None or len(queue.match) > len(best.match or "")
+                ):
+                    best = queue
+            if best is not None:
+                return best
         model = parsed.get("model") if isinstance(parsed, dict) else None
         return self.resolve_queue(model)
 

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -548,6 +548,15 @@ class _ResponseQueue:
         self.responses: list[QueuedResponse] = []
         self.index: int = 0
         self.fallback: QueuedResponse | None = None
+        # Optional content-routing token. When set, a request is served
+        # from this queue if the token appears in the request's
+        # role="user" input text — regardless of the request's ``model``.
+        # Lets each test claim its own queue by the (unique) message it
+        # sends, so a stray/late request from another test (which carries
+        # a different user message) can't draw from this test's queue —
+        # the #523 cross-test contamination, fixed without per-test
+        # servers. ``None`` preserves the default model/"default" routing.
+        self.match: str | None = None
 
     def next(self) -> QueuedResponse:
         """Consume the next response, or return the fallback / default."""
@@ -560,9 +569,10 @@ class _ResponseQueue:
         return QueuedResponse()
 
     def reset(self) -> None:
-        """Clear the regular queue; the fallback is preserved."""
+        """Clear the regular queue + content-routing token; fallback is preserved."""
         self.responses.clear()
         self.index = 0
+        self.match = None
 
 
 class MockState:
@@ -603,6 +613,53 @@ class MockState:
         # requests to unknown models share the same instance.
         self.queues[_DEFAULT_KEY] = _ResponseQueue()
         return self.queues[_DEFAULT_KEY]
+
+    @staticmethod
+    def _user_input_text(parsed: object) -> str:
+        """Concatenate the text of all ``role="user"`` items in the request input.
+
+        Scoped to user-role content deliberately — NOT the system prompt
+        (``instructions``) or tool outputs — so a content-routing token
+        only ever matches what the test itself typed, never incidental
+        words in a shared system prompt.
+
+        :param parsed: The parsed request body.
+        :returns: Space-joined user message text (``""`` if none).
+        """
+        if not isinstance(parsed, dict):
+            return ""
+        parts: list[str] = []
+        for item in parsed.get("input") or []:
+            if not isinstance(item, dict) or item.get("role") != "user":
+                continue
+            content = item.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        parts.append(str(block.get("text", "")))
+        return " ".join(parts)
+
+    def resolve_queue_for_request(self, parsed: object) -> _ResponseQueue:
+        """Pick the queue for a request: content-routed queues first, then model/default.
+
+        A queue with a ``match`` token wins if that token appears in the
+        request's user input — this is how a test claims its own queue by
+        the unique message it sends. Otherwise falls back to the existing
+        ``model`` / ``"default"`` routing, so tests that don't opt in are
+        unaffected.
+
+        :param parsed: The parsed request body.
+        :returns: The selected response queue.
+        """
+        user_text = self._user_input_text(parsed)
+        if user_text:
+            for queue in self.queues.values():
+                if queue.match and queue.match in user_text:
+                    return queue
+        model = parsed.get("model") if isinstance(parsed, dict) else None
+        return self.resolve_queue(model)
 
     def reset(self) -> None:
         """Clear all state (queues, captured requests, gates).
@@ -657,7 +714,7 @@ async def create_response(
         _state.request_count += 1
         _state.captured_requests.append(parsed)
         model = parsed.get("model") if isinstance(parsed, dict) else None
-        queue = _state.resolve_queue(model)
+        queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 
     # Error response
@@ -725,7 +782,7 @@ async def create_message(
         _state.request_count += 1
         _state.captured_requests.append(parsed)
         model = parsed.get("model") if isinstance(parsed, dict) else None
-        queue = _state.resolve_queue(model)
+        queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 
     if qr.error is not None:
@@ -775,7 +832,7 @@ async def create_chat_completion(
         _state.request_count += 1
         _state.captured_requests.append(parsed)
         model = parsed.get("model") if isinstance(parsed, dict) else None
-        queue = _state.resolve_queue(model)
+        queue = _state.resolve_queue_for_request(parsed)
         qr = queue.next()
 
     if qr.error is not None:
@@ -870,17 +927,27 @@ async def configure(request: Request) -> dict[str, object]:
 
         {
             "key": "mock-model",          // optional, default "default"
+            "match": "mangosteen-tr",     // optional content-routing token
             "responses": [{"text": "..."}, ...]
         }
+
+    When ``match`` is set, a request is served from this queue if the
+    token appears in the request's ``role="user"`` input text, regardless
+    of the request's ``model`` — so a test can claim its own queue by the
+    unique message it sends (per-test isolation against cross-test
+    contamination). Omitting ``match`` keeps the default model/"default"
+    routing.
 
     Multiple calls with different keys accumulate queues; use
     ``POST /mock/reset`` to clear all keys.
     """
     body = await request.json()
     key = body.get("key", _DEFAULT_KEY)
+    match = body.get("match")
     async with _state._lock:
         queue = _state.get_queue(key)
         queue.reset()
+        queue.match = match
         for entry in body.get("responses", []):
             queue.responses.append(
                 QueuedResponse(


### PR DESCRIPTION
**Alternative to #893** for the same #523 cross-test contamination flake — fixes it at the mock-queue layer instead of the process layer, so there's **no runtime cost**. Open both; pick one.

## Problem (same as #893)

`test_repl_tool_result_ask_passes_output_through` flakes with `assert 'echo: mangosteen' in ''`. Proven from the original failing run: the mock's captured request was a **foreign** body (`"hi BANANA_TRIGGER"` from another test), not this test's `"mangosteen"`. A prior test's leaked `omnigent run` server fires a late LLM call into the **session-shared** mock and consumes the next test's queued `tool_calls`, so the turn gets the follow-up text, `echo` never runs, and `function_call_output` is empty.

The queue is shared because **every fixture uses `model: gpt-4o`** → the mock's single `"default"` queue → it can't tell whose request is whose.

## Fix: route the mock by request **content**, not just model

A queue can carry an optional `match` token. `resolve_queue_for_request` serves a request from a queue whose token appears in the request's `role:"user"` input (scoped to user content — *not* the system prompt or tool outputs), falling back to today's model/`"default"` routing when none match. Each test claims its own queue with **the unique message it already sends**, so a stray request from another test (different message) can never draw from it.

**Nothing is added to the request body** — the mock only *reads* the existing user message.

- `mock_llm_server.py`: `_ResponseQueue.match`, `_user_input_text`, `resolve_queue_for_request`; `/mock/configure` accepts `match`.
- `conftest.configure_mock_llm`: optional `match=`.
- test file: all 14 tests opt in via `match=<their unique message>`.

Subtleties handled:
- **Multi-turn** tests work because turn-1's message persists in later turns' input history.
- **Sub-agent** tests carry the token into the delegated task so parent + sub-agent calls both route; `subagent-tool` routes its parent queue on a token present **only** in the root user message (not the delegated task the worker sees), so the worker still falls through to its own model-keyed queue.

Backward-compatible: queues without `match` behave exactly as today.

## Verification

- Full file **14/14**.
- Runtime **193s ≈ main baseline** — server is still reused, so **no per-test-server regression** (contrast #893's ~+46%).
- Deterministic unit tests: a stray foreign request cannot draw from a `match` queue; backward-compat + follow-up-call routing confirmed.

## #893 vs this PR

| | #893 (per-test servers) | this PR (content-routed queues) |
|---|---|---|
| Isolation | process/port (fixture-agnostic) | mock-queue (per-test) |
| Runtime | ~+46% on this file | ~baseline |
| Surface | 2 files | 3 files (mock + conftest + 14 one-arg call-sites) |
| Caveat | fresh server per test | each test needs a unique user-message token |
