### PR TITLE
ci: auto-assign 1 reviewer per PR instead of 2

### DIFF
--- a/.github/reviewers
+++ b/.github/reviewers
@@ -5,7 +5,7 @@
 # reviewers. All assignment is driven by .github/workflows/auto-assign-reviewer.yml,
 # which:
 #   - runs ONLY on fork PRs authored by a non-maintainer, and
-#   - assigns EXACTLY 2 load-balanced reviewers from the area(s) the PR touches
+#   - assigns EXACTLY 1 load-balanced reviewer from the area(s) the PR touches
 #     (falling back to the full set of handles in this file for unowned paths).
 # So the per-area lists below are the CANDIDATE pool per area, not "everyone gets
 # requested". This is routing only -- it does not gate merge (that stays

--- a/.github/workflows/auto-assign-reviewer.js
+++ b/.github/workflows/auto-assign-reviewer.js
@@ -1,4 +1,4 @@
-// Repo-level reviewer assignment: assign EXACTLY 2 load-balanced reviewers to
+// Repo-level reviewer assignment: assign EXACTLY 1 load-balanced reviewer to
 // FORK PRs authored by a NON-maintainer, preferring the owners of the area(s)
 // the PR touches.
 //
@@ -21,7 +21,7 @@
 // so a manually-added reviewer outside that set is left untouched.
 module.exports = async ({ github, context, core }) => {
   const fs = require("fs");
-  const TARGET = 2;
+  const TARGET = 1;
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
   if (!pr || pr.draft) {
@@ -130,8 +130,8 @@ module.exports = async ({ github, context, core }) => {
     return out;
   };
 
-  // Desired = 2 lowest-load from candidates; top up from the full pool if an
-  // area has fewer than 2 owners.
+  // Desired = 1 lowest-load from candidates; top up from the full pool if an
+  // area has fewer than 1 owner.
   let desired = takeLowest(candidates, TARGET);
   if (desired.length < TARGET) {
     const have = new Set(desired.map((u) => u.toLowerCase()).concat(author));
@@ -142,7 +142,7 @@ module.exports = async ({ github, context, core }) => {
 
   // --- Reconcile current requested reviewers to exactly `desired`. Normally
   // nothing is pre-requested, but on a reopened PR (or after a manual add) this
-  // keeps the set at the 2 balanced picks.
+  // keeps the set at the 1 balanced pick.
   const current = (pr.requested_reviewers || []).map((r) => r.login);
   const currentLc = new Set(current.map((c) => c.toLowerCase()));
   const toAdd = desired.filter((u) => !currentLc.has(u.toLowerCase()));

--- a/.github/workflows/auto-assign-reviewer.test.js
+++ b/.github/workflows/auto-assign-reviewer.test.js
@@ -52,35 +52,35 @@ function assert(name, cond, detail) {
 
 (async () => {
   // 1. inner PR: owners SabhyaC26,TomeHirata,dhruv0811,dbczumar. Loads make the
-  //    two lowest deterministic: dhruv0811(0), dbczumar(1) win.
+  //    single lowest deterministic: dhruv0811(0) wins.
   let r = await run({
     files: ["omnigent/inner/foo.py"],
     load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
   });
-  assert("inner picks 2 lowest-load owners", JSON.stringify(r.added) === JSON.stringify(["dbczumar", "dhruv0811"]), JSON.stringify(r));
+  assert("inner picks the lowest-load owner", JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]), JSON.stringify(r));
 
-  // 2. unowned path -> full pool; lowest two by load chosen.
+  // 2. unowned path -> full pool; lowest by load chosen.
   r = await run({
     files: ["README.md"],
     load: { PattaraS: 9, "serena-ruan": 9, dhruv0811: 9, TomeHirata: 9, SabhyaC26: 9,
             "daniellok-db": 9, hzub: 0, dbczumar: 1, fanzeyi: 9, "ckcuslife-source": 9,
             bbqiu: 9, Edwinhe03: 9 },
   });
-  assert("unowned -> 2 lowest from full pool", JSON.stringify(r.added) === JSON.stringify(["dbczumar", "hzub"]), JSON.stringify(r));
+  assert("unowned -> lowest from full pool", JSON.stringify(r.added) === JSON.stringify(["hzub"]), JSON.stringify(r));
 
-  // 3. db has only 2 owners (fanzeyi, SabhyaC26) -> both selected.
-  r = await run({ files: ["omnigent/db/x.py"], load: {} });
-  assert("db (2 owners) -> both", JSON.stringify(r.added) === JSON.stringify(["SabhyaC26", "fanzeyi"]), JSON.stringify(r));
+  // 3. db area (fanzeyi, SabhyaC26) -> the lower-load one selected.
+  r = await run({ files: ["omnigent/db/x.py"], load: { SabhyaC26: 1 } });
+  assert("db -> lowest-load owner", JSON.stringify(r.added) === JSON.stringify(["fanzeyi"]), JSON.stringify(r));
 
-  // 4. reconcile: all 4 inner owners already requested; keep 2 lowest-load,
-  //    remove the other 2.
+  // 4. reconcile: all 4 inner owners already requested; keep the lowest-load,
+  //    remove the other 3.
   r = await run({
     files: ["omnigent/inner/foo.py"],
     load: { SabhyaC26: 5, TomeHirata: 4, dhruv0811: 0, dbczumar: 1 },
     current: ["SabhyaC26", "TomeHirata", "dhruv0811", "dbczumar"],
   });
-  assert("reconcile removes the 2 highest-load already-requested",
-    JSON.stringify(r.removed) === JSON.stringify(["SabhyaC26", "TomeHirata"]) && r.added.length === 0,
+  assert("reconcile removes the 3 higher-load already-requested",
+    JSON.stringify(r.removed) === JSON.stringify(["SabhyaC26", "TomeHirata", "dbczumar"]) && r.added.length === 0,
     JSON.stringify(r));
 
   // 5. mixed current: a managed reviewer not in `desired` is removed, while an
@@ -93,26 +93,26 @@ function assert(name, cond, detail) {
   assert("mixed: managed removed, external preserved",
     r.removed.includes("SabhyaC26") &&
     !r.removed.includes("some-external-human") &&
-    JSON.stringify(r.added) === JSON.stringify(["dbczumar", "dhruv0811"]),
+    JSON.stringify(r.added) === JSON.stringify(["dhruv0811"]),
     JSON.stringify(r));
 
-  // 6. single-owner area (sandbox -> @SabhyaC26): tops up to 2 from the pool.
+  // 6. single-owner area (sandbox -> @SabhyaC26): the lone owner is selected.
   r = await run({
     files: ["omnigent/sandbox/x.py"],
     load: { SabhyaC26: 0, hzub: 0, dhruv0811: 9, dbczumar: 9, TomeHirata: 9, PattaraS: 9,
             "serena-ruan": 9, "daniellok-db": 9, fanzeyi: 9, "ckcuslife-source": 9, bbqiu: 9, Edwinhe03: 9 },
   });
-  assert("single-owner area tops up to 2",
-    r.added.length === 2 && r.added.includes("SabhyaC26"), JSON.stringify(r));
+  assert("single-owner area picks that owner",
+    JSON.stringify(r.added) === JSON.stringify(["SabhyaC26"]), JSON.stringify(r));
 
-  // 7. multi-area PR (inner + tools): candidate pool is the UNION; a tools-only
-  //    owner (PattaraS) and an inner owner (dhruv0811) can both be picked.
+  // 7. multi-area PR (inner + tools): candidate pool is the UNION; the lowest-load
+  //    across both areas wins -- here a tools-only owner (PattaraS).
   r = await run({
     files: ["omnigent/inner/a.py", "omnigent/tools/b.py"],
     load: { SabhyaC26: 9, TomeHirata: 9, dbczumar: 9, PattaraS: 0, dhruv0811: 1 },
   });
   assert("multi-area unions both areas' owners",
-    r.added.includes("PattaraS") && r.added.includes("dhruv0811") && r.added.length === 2,
+    JSON.stringify(r.added) === JSON.stringify(["PattaraS"]),
     JSON.stringify(r));
 
   // 8. scope guard: non-fork PR -> nothing assigned.

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,6 +1,6 @@
 name: Auto-assign Reviewer
 
-# Repo-level reviewer assignment: assign EXACTLY 2 load-balanced reviewers to
+# Repo-level reviewer assignment: assign EXACTLY 1 load-balanced reviewer to
 # FORK PRs authored by a non-maintainer, preferring the owners of the area(s) the
 # PR touches. No org team required. Ownership is read from .github/reviewers at
 # runtime -- a custom, non-magic path (NOT .github/CODEOWNERS), so GitHub's
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .github
           persist-credentials: false
-      - name: Assign 2 balanced reviewers from the .github/reviewers pool
+      - name: Assign 1 balanced reviewer from the .github/reviewers pool
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           retries: 3


### PR DESCRIPTION
## What

Reduce the fork-PR reviewer auto-assignment from **EXACTLY 2** to **EXACTLY 1** load-balanced reviewer.

## Why

Two auto-assigned reviewers per PR is more review load than needed; one balanced reviewer is sufficient for routing.

## Changes

- `.github/workflows/auto-assign-reviewer.js` — flip `TARGET` from `2` to `1` (the single source of truth) and update the header/inline comments.
- `.github/workflows/auto-assign-reviewer.yml` — update the header comment and step name.
- `.github/reviewers` — update the doc comment.
- `.github/workflows/auto-assign-reviewer.test.js` — update the selection-logic assertions to expect a single lowest-load pick (reconcile now removes 3 of 4 already-requested; single-owner / multi-area cases assert one pick). Scope-guard cases unchanged.

Behavior is otherwise unchanged: still fork-PRs-from-non-maintainers only, still picks the lowest open-review-load candidate from the area's owner pool (falling back to the full pool for unowned paths), with random tie-breaks.

## Testing

`node .github/workflows/auto-assign-reviewer.test.js` — all 9 assertions pass.