### PR TITLE
fix(ap-web): always show bulk Delete button, grey when no selection

### DIFF
--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1568,59 +1568,60 @@ function BulkActionBar({
           >
             Clear
           </Button>
-          {count > 0 && (
-            <div className="flex items-center gap-1.5 md:hidden">
-              {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 gap-1.5 text-xs"
-                  disabled={isBusy}
-                  onClick={handleArchive}
-                >
-                  {bulkArchive.isPending ? (
-                    <Loader2Icon className="size-3 animate-spin" />
-                  ) : (
-                    <ArchiveIcon className="size-3" />
-                  )}
-                  Archive
-                </Button>
-              )}
-              {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 gap-1.5 text-xs"
-                  disabled={isBusy}
-                  onClick={handleUnarchive}
-                >
-                  {bulkArchive.isPending ? (
-                    <Loader2Icon className="size-3 animate-spin" />
-                  ) : (
-                    <ArchiveRestoreIcon className="size-3" />
-                  )}
-                  Unarchive
-                </Button>
-              )}
+          <div className="flex items-center gap-1.5 md:hidden">
+            {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
-                className="h-7 gap-1.5 text-xs text-destructive"
-                disabled={isBusy || ownedSelected.length === 0}
-                onClick={() => setConfirmDeleteOpen(true)}
+                className="h-7 gap-1.5 text-xs"
+                disabled={isBusy}
+                onClick={handleArchive}
               >
-                {bulkDelete.isPending ? (
+                {bulkArchive.isPending ? (
                   <Loader2Icon className="size-3 animate-spin" />
                 ) : (
-                  <Trash2Icon className="size-3" />
+                  <ArchiveIcon className="size-3" />
                 )}
-                Delete {ownedSelected.length > 0 ? ownedSelected.length : ""}
+                Archive
               </Button>
-            </div>
-          )}
+            )}
+            {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-xs"
+                disabled={isBusy}
+                onClick={handleUnarchive}
+              >
+                {bulkArchive.isPending ? (
+                  <Loader2Icon className="size-3 animate-spin" />
+                ) : (
+                  <ArchiveRestoreIcon className="size-3" />
+                )}
+                Unarchive
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className={cn(
+                "h-7 gap-1.5 text-xs",
+                ownedSelected.length > 0 && "text-destructive",
+              )}
+              disabled={isBusy || ownedSelected.length === 0}
+              onClick={() => setConfirmDeleteOpen(true)}
+            >
+              {bulkDelete.isPending ? (
+                <Loader2Icon className="size-3 animate-spin" />
+              ) : (
+                <Trash2Icon className="size-3" />
+              )}
+              Delete {ownedSelected.length > 0 ? ownedSelected.length : ""}
+            </Button>
+          </div>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -1639,62 +1640,63 @@ function BulkActionBar({
           </Tooltip>
         </div>
 
-        {count > 0 && (
-          <div className="hidden items-center gap-1.5 px-2 md:flex">
-            {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-xs"
-                disabled={isBusy}
-                onClick={handleArchive}
-                data-testid="bulk-archive"
-              >
-                {bulkArchive.isPending ? (
-                  <Loader2Icon className="size-3 animate-spin" />
-                ) : (
-                  <ArchiveIcon className="size-3" />
-                )}
-                Archive
-              </Button>
-            )}
-            {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-xs"
-                disabled={isBusy}
-                onClick={handleUnarchive}
-                data-testid="bulk-unarchive"
-              >
-                {bulkArchive.isPending ? (
-                  <Loader2Icon className="size-3 animate-spin" />
-                ) : (
-                  <ArchiveRestoreIcon className="size-3" />
-                )}
-                Unarchive
-              </Button>
-            )}
+        <div className="hidden items-center gap-1.5 px-2 md:flex">
+          {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
             <Button
               type="button"
               variant="outline"
               size="sm"
-              className="h-7 gap-1.5 text-xs text-destructive"
-              disabled={isBusy || ownedSelected.length === 0}
-              onClick={() => setConfirmDeleteOpen(true)}
-              data-testid="bulk-delete"
+              className="h-7 gap-1.5 text-xs"
+              disabled={isBusy}
+              onClick={handleArchive}
+              data-testid="bulk-archive"
             >
-              {bulkDelete.isPending ? (
+              {bulkArchive.isPending ? (
                 <Loader2Icon className="size-3 animate-spin" />
               ) : (
-                <Trash2Icon className="size-3" />
+                <ArchiveIcon className="size-3" />
               )}
-              Delete {ownedSelected.length > 0 ? ownedSelected.length : ""}
+              Archive
             </Button>
-          </div>
-        )}
+          )}
+          {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-xs"
+              disabled={isBusy}
+              onClick={handleUnarchive}
+              data-testid="bulk-unarchive"
+            >
+              {bulkArchive.isPending ? (
+                <Loader2Icon className="size-3 animate-spin" />
+              ) : (
+                <ArchiveRestoreIcon className="size-3" />
+              )}
+              Unarchive
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-7 gap-1.5 text-xs",
+              ownedSelected.length > 0 && "text-destructive",
+            )}
+            disabled={isBusy || ownedSelected.length === 0}
+            onClick={() => setConfirmDeleteOpen(true)}
+            data-testid="bulk-delete"
+          >
+            {bulkDelete.isPending ? (
+              <Loader2Icon className="size-3 animate-spin" />
+            ) : (
+              <Trash2Icon className="size-3" />
+            )}
+            Delete {ownedSelected.length > 0 ? ownedSelected.length : ""}
+          </Button>
+        </div>
 
         {(bulkArchive.isError || bulkDelete.isError) && (
           <p className="text-xs text-destructive" role="alert">

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -1607,10 +1607,7 @@ function BulkActionBar({
               type="button"
               variant="outline"
               size="sm"
-              className={cn(
-                "h-7 gap-1.5 text-xs",
-                ownedSelected.length > 0 && "text-destructive",
-              )}
+              className={cn("h-7 gap-1.5 text-xs", ownedSelected.length > 0 && "text-destructive")}
               disabled={isBusy || ownedSelected.length === 0}
               onClick={() => setConfirmDeleteOpen(true)}
             >
@@ -1681,10 +1678,7 @@ function BulkActionBar({
             type="button"
             variant="outline"
             size="sm"
-            className={cn(
-              "h-7 gap-1.5 text-xs",
-              ownedSelected.length > 0 && "text-destructive",
-            )}
+            className={cn("h-7 gap-1.5 text-xs", ownedSelected.length > 0 && "text-destructive")}
             disabled={isBusy || ownedSelected.length === 0}
             onClick={() => setConfirmDeleteOpen(true)}
             data-testid="bulk-delete"


### PR DESCRIPTION
## What

In the sidebar bulk-action toolbar, the **Delete** button (and the whole action row) used to be conditionally rendered only when `count > 0`, so the row appeared and disappeared as the selection changed.

This change always renders the Delete button so the row stays in place:

- The action-row containers (mobile `md:hidden` and desktop `md:flex`) are no longer wrapped in `{count > 0 && (…)}`.
- The Delete button is **always present**, `disabled` when no owned sessions are selected (it already had `disabled={isBusy || ownedSelected.length === 0}`).
- When disabled it now renders **grey** instead of faded-red — the `text-destructive` color is applied only when `ownedSelected.length > 0` (via `cn(...)`). It turns red with a count once a selection exists.
- **Archive / Unarchive** buttons stay conditional on their existing archive-group rules, so they only show when relevant.

## Before / After

Before: nothing selected -> empty toolbar (just "None selected" / Select all / Clear).
After: nothing selected -> Delete button visible but greyed-out and non-clickable.

## Testing

- `npm run build` passed
- `npm test` passed (2878 passed)
- `uv run pytest tests/e2e_ui/sessions/test_sidebar_bulk_actions.py` passed (4 passed)