### PR TITLE
feat(runner): honor a host-level Claude Code wrapper command (OMNIGENT_CLAUDE_NATIVE_COMMAND)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -282,6 +282,12 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # Testing knob: override the context window size for compaction
         # trigger threshold. Not a secret — a plain integer.
         "AP_CONTEXT_WINDOW_OVERRIDE",
+        # Host-level Claude Code wrapper command (e.g. Databricks' ``isaac``,
+        # ``dbexec repo run isaac``). The native runner launches this instead
+        # of bare ``claude`` when set; see runner.app._resolve_claude_native_command.
+        # A command string naming a host-local executable, not a secret —
+        # must reach the host-spawned runner or the override has no effect.
+        "OMNIGENT_CLAUDE_NATIVE_COMMAND",
     }
 )
 # Locale family (``LC_ALL``, ``LC_CTYPE``, …) — allowed by prefix.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -91,11 +91,21 @@ _logger = logging.getLogger(__name__)
 # remote path resolves credentials from provider config and otherwise launches
 # bare ``claude``.
 #
-# The value is a shell token string (shlex-split into argv); only argv[0] must
-# be on the runner host's PATH. The wrapper must forward the trailing
-# ``claude`` args/env Omnigent appends (bundle ``--plugin-dir``, permission
-# hooks, the session bridge), or the session won't bind to the web UI.
-# Propagated host -> runner via ``_RUNNER_ENV_ALLOWLIST``.
+# The value is a shell token string (shlex-split into argv); ``argv[0]`` is the
+# executable — a bare name resolved on the runner host's PATH, or an absolute /
+# relative path. The wrapper must forward the trailing ``claude`` args/env
+# Omnigent appends (bundle ``--plugin-dir``, permission hooks, the session
+# bridge), or the session won't bind to the web UI. Propagated host -> runner
+# via ``_RUNNER_ENV_ALLOWLIST``.
+#
+# Resolution is a best-effort *pre-check* against the runner process's PATH. For
+# the host-spawned terminal it launches (``os_env.type == "caller_process"``)
+# the launch shares that PATH, so the check is accurate. It is NOT a guarantee
+# across every launch environment: if a sandboxed launch (e.g. ``linux_bwrap``)
+# can't see an executable the runner PATH resolved, the override is still used
+# and terminal creation fails there rather than falling back to ``claude``. The
+# fallback covers misconfiguration the runner can observe (unset / malformed /
+# not on its own PATH), not sandbox-visibility mismatches.
 _CLAUDE_NATIVE_COMMAND_ENV_VAR = "OMNIGENT_CLAUDE_NATIVE_COMMAND"
 
 
@@ -103,11 +113,12 @@ def _resolve_claude_native_command() -> list[str]:
     """Resolve the Claude Code launch command for the host-spawned runner.
 
     Reads :data:`_CLAUDE_NATIVE_COMMAND_ENV_VAR`. When it names a wrapper
-    resolvable on the runner host's PATH, returns its argv so the runner
-    launches the wrapper instead of bare ``claude``. Falls back to
-    ``["claude"]`` — the historical remote-path behavior — when the var is
-    unset, empty, malformed, or its executable is not found, logging why so a
-    misconfiguration is visible rather than silent.
+    resolvable on the runner process's PATH (a best-effort pre-check — see the
+    module-level note on sandbox-visibility limits), returns its argv so the
+    runner launches the wrapper instead of bare ``claude``. Falls back to
+    ``["claude"]`` when the var is unset/empty (the normal default, no warning),
+    or — with a warning — when it is malformed or its executable is not found on
+    the runner PATH.
 
     :returns: argv whose head is the executable and whose tail is the
         wrapper's fixed leading args (e.g. ``["dbexec", "repo", "run",
@@ -118,11 +129,17 @@ def _resolve_claude_native_command() -> list[str]:
         return ["claude"]
     try:
         argv = shlex.split(raw)
-    except ValueError:
-        argv = []
+    except ValueError as exc:
+        _logger.warning(
+            "%s=%r could not be parsed as a command (%s); launching 'claude' directly.",
+            _CLAUDE_NATIVE_COMMAND_ENV_VAR,
+            raw,
+            exc,
+        )
+        return ["claude"]
     if not argv:
         _logger.warning(
-            "%s=%r is not a valid command; launching 'claude' directly.",
+            "%s=%r is empty after parsing; launching 'claude' directly.",
             _CLAUDE_NATIVE_COMMAND_ENV_VAR,
             raw,
         )
@@ -137,6 +154,27 @@ def _resolve_claude_native_command() -> list[str]:
         return ["claude"]
     _logger.info("Claude native command override active: launching via %s", argv)
     return argv
+
+
+def _compose_native_launch(
+    native_command: list[str], claude_args: list[str]
+) -> tuple[str, list[str]]:
+    """Assemble the terminal ``(command, args)`` for a (wrapper, claude) pair.
+
+    The wrapper argv leads and the ``claude`` args follow, so a wrapper like
+    ``["dbexec", "repo", "run", "isaac"]`` runs as
+    ``dbexec repo run isaac <claude args>``. Ordering matters: Omnigent's
+    appended args (bundle ``--plugin-dir``, permission hooks, the session
+    bridge) must reach Claude intact for the session to bind, and the wrapper
+    must come first so it, not Claude, is the process the runner launches. With
+    the no-override default (``["claude"]``) this yields ``("claude", claude_args)``.
+
+    :param native_command: Resolved wrapper argv (head is the executable);
+        ``["claude"]`` when no override is configured.
+    :param claude_args: The fully-resolved ``claude`` CLI args to forward.
+    :returns: ``(command, args)`` for the terminal launch.
+    """
+    return native_command[0], [*native_command[1:], *claude_args]
 
 
 def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
@@ -2540,14 +2578,17 @@ async def _auto_create_claude_terminal(
     # its config/auth on top while still forwarding the ``claude`` args
     # Omnigent appends; unset/unresolvable falls back to bare ``claude``.
     native_command = _resolve_claude_native_command()
+    native_terminal_command, native_terminal_args = _compose_native_launch(
+        native_command, list(claude_args)
+    )
     env_spec = TerminalEnvSpec(
         os_env=OSEnvSpec(
             type="caller_process",
             cwd=workspace,
             sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
         ),
-        command=native_command[0],
-        args=[*native_command[1:], *claude_args],
+        command=native_terminal_command,
+        args=native_terminal_args,
         # Tool Search env plus ucode gateway env (ANTHROPIC_BASE_URL
         # etc.) when derived. Empty provider config still forces
         # ENABLE_TOOL_SEARCH=true so MCP schemas are loaded on demand.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -15,6 +15,8 @@ import json
 import logging
 import mimetypes
 import os
+import shlex
+import shutil
 import sys
 import tempfile
 import time
@@ -76,6 +78,65 @@ from omnigent.tools.builtins.load_skill import (
 )
 
 _logger = logging.getLogger(__name__)
+
+
+# Host-level override for the Claude Code executable the native runner
+# launches. Set it to a transparent wrapper that preserves Claude Code's CLI
+# interface (forwards the args + env it is given, then exec's ``claude``) —
+# e.g. Databricks' ``isaac`` launcher, invoked as ``dbexec repo run isaac``,
+# which layers managed settings, MCP client config, model/account routing,
+# and plugin management on top of upstream Claude Code. Auth and that config
+# are the wrapper's responsibility, not Omnigent's, so this is the only way a
+# host-spawned (``--server``) session can run through such a wrapper: the
+# remote path resolves credentials from provider config and otherwise launches
+# bare ``claude``.
+#
+# The value is a shell token string (shlex-split into argv); only argv[0] must
+# be on the runner host's PATH. The wrapper must forward the trailing
+# ``claude`` args/env Omnigent appends (bundle ``--plugin-dir``, permission
+# hooks, the session bridge), or the session won't bind to the web UI.
+# Propagated host -> runner via ``_RUNNER_ENV_ALLOWLIST``.
+_CLAUDE_NATIVE_COMMAND_ENV_VAR = "OMNIGENT_CLAUDE_NATIVE_COMMAND"
+
+
+def _resolve_claude_native_command() -> list[str]:
+    """Resolve the Claude Code launch command for the host-spawned runner.
+
+    Reads :data:`_CLAUDE_NATIVE_COMMAND_ENV_VAR`. When it names a wrapper
+    resolvable on the runner host's PATH, returns its argv so the runner
+    launches the wrapper instead of bare ``claude``. Falls back to
+    ``["claude"]`` — the historical remote-path behavior — when the var is
+    unset, empty, malformed, or its executable is not found, logging why so a
+    misconfiguration is visible rather than silent.
+
+    :returns: argv whose head is the executable and whose tail is the
+        wrapper's fixed leading args (e.g. ``["dbexec", "repo", "run",
+        "isaac"]``). The caller appends the resolved ``claude`` args.
+    """
+    raw = os.environ.get(_CLAUDE_NATIVE_COMMAND_ENV_VAR, "").strip()
+    if not raw:
+        return ["claude"]
+    try:
+        argv = shlex.split(raw)
+    except ValueError:
+        argv = []
+    if not argv:
+        _logger.warning(
+            "%s=%r is not a valid command; launching 'claude' directly.",
+            _CLAUDE_NATIVE_COMMAND_ENV_VAR,
+            raw,
+        )
+        return ["claude"]
+    if shutil.which(argv[0]) is None:
+        _logger.warning(
+            "%s=%r: %r not found on the runner host PATH; launching 'claude' directly.",
+            _CLAUDE_NATIVE_COMMAND_ENV_VAR,
+            raw,
+            argv[0],
+        )
+        return ["claude"]
+    _logger.info("Claude native command override active: launching via %s", argv)
+    return argv
 
 
 def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
@@ -2474,14 +2535,19 @@ async def _auto_create_claude_terminal(
     # and ``parent_os_env`` below, launch_terminal falls back to
     # _default_sandbox_for_platform (linux_bwrap), overriding the YAML config.
     agent_os_env = _agent_os_env_from_spec(agent_spec)
+    # Optional host-level wrapper (e.g. Databricks' ``isaac``). When set, the
+    # runner launches ``<wrapper argv> <claude args>`` so the wrapper layers
+    # its config/auth on top while still forwarding the ``claude`` args
+    # Omnigent appends; unset/unresolvable falls back to bare ``claude``.
+    native_command = _resolve_claude_native_command()
     env_spec = TerminalEnvSpec(
         os_env=OSEnvSpec(
             type="caller_process",
             cwd=workspace,
             sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
         ),
-        command="claude",
-        args=list(claude_args),
+        command=native_command[0],
+        args=[*native_command[1:], *claude_args],
         # Tool Search env plus ucode gateway env (ANTHROPIC_BASE_URL
         # etc.) when derived. Empty provider config still forces
         # ENABLE_TOOL_SEARCH=true so MCP schemas are loaded on demand.

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -17,6 +17,7 @@ import pytest
 from omnigent.runner.app import (
     _CLAUDE_NATIVE_COMMAND_ENV_VAR,
     _build_claude_native_base_args,
+    _compose_native_launch,
     _resolve_claude_native_command,
 )
 
@@ -185,3 +186,31 @@ class TestResolveClaudeNativeCommand:
         # swallow it and fall back rather than crash the launch.
         monkeypatch.setenv(_CLAUDE_NATIVE_COMMAND_ENV_VAR, 'isaac "unterminated')
         assert _resolve_claude_native_command() == ["claude"]
+
+
+class TestComposeNativeLaunch:
+    """Terminal (command, args) assembly for a (wrapper, claude-args) pair.
+
+    The wrapper argv must lead and the Claude args must follow intact — that
+    ordering is what keeps Omnigent's appended args (bundle --plugin-dir,
+    permission hooks, the session bridge) reaching Claude so the session binds.
+    A silent reorder or drop here would break the integration without failing
+    the resolver's own tests.
+    """
+
+    def test_no_override_runs_claude_with_args_unchanged(self):
+        assert _compose_native_launch(["claude"], ["--foo", "--bar"]) == (
+            "claude",
+            ["--foo", "--bar"],
+        )
+
+    def test_wrapper_leads_and_claude_args_follow_in_order(self):
+        assert _compose_native_launch(
+            ["dbexec", "repo", "run", "isaac"], ["--plugin-dir", "/b", "--resume", "x"]
+        ) == ("dbexec", ["repo", "run", "isaac", "--plugin-dir", "/b", "--resume", "x"])
+
+    def test_no_claude_args(self):
+        assert _compose_native_launch(["dbexec", "repo", "run", "isaac"], []) == (
+            "dbexec",
+            ["repo", "run", "isaac"],
+        )

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.runner.app import _build_claude_native_base_args
+from omnigent.runner.app import (
+    _CLAUDE_NATIVE_COMMAND_ENV_VAR,
+    _build_claude_native_base_args,
+    _resolve_claude_native_command,
+)
 
 
 @pytest.mark.parametrize(
@@ -139,3 +143,45 @@ def test_build_claude_native_base_args_resume_prefix(
         )
         == expected
     )
+
+
+class TestResolveClaudeNativeCommand:
+    """Host-level Claude Code wrapper resolution for the native runner.
+
+    ``_resolve_claude_native_command`` reads ``OMNIGENT_CLAUDE_NATIVE_COMMAND``
+    and decides what the host-spawned runner launches: the configured wrapper
+    (so e.g. Databricks' ``isaac`` layers its config/auth on top of Claude
+    Code), or bare ``claude`` when the var is unset/empty/malformed or its
+    executable is missing on the runner host. The fallback must be silent-safe
+    (never raise) so a misconfigured host still launches Claude.
+    """
+
+    def test_unset_falls_back_to_claude(self, monkeypatch):
+        monkeypatch.delenv(_CLAUDE_NATIVE_COMMAND_ENV_VAR, raising=False)
+        assert _resolve_claude_native_command() == ["claude"]
+
+    def test_blank_falls_back_to_claude(self, monkeypatch):
+        monkeypatch.setenv(_CLAUDE_NATIVE_COMMAND_ENV_VAR, "   ")
+        assert _resolve_claude_native_command() == ["claude"]
+
+    def test_multi_token_wrapper_split_into_argv(self, monkeypatch):
+        # The Databricks case: a multi-token launcher. Only argv[0] is
+        # checked against PATH; the trailing tokens are the wrapper's fixed
+        # leading args, preserved in order for the caller to prepend.
+        monkeypatch.setenv(_CLAUDE_NATIVE_COMMAND_ENV_VAR, "dbexec repo run isaac")
+        monkeypatch.setattr(
+            "omnigent.runner.app.shutil.which",
+            lambda exe: "/usr/local/bin/dbexec" if exe == "dbexec" else None,
+        )
+        assert _resolve_claude_native_command() == ["dbexec", "repo", "run", "isaac"]
+
+    def test_missing_executable_falls_back_to_claude(self, monkeypatch):
+        monkeypatch.setenv(_CLAUDE_NATIVE_COMMAND_ENV_VAR, "isaac")
+        monkeypatch.setattr("omnigent.runner.app.shutil.which", lambda exe: None)
+        assert _resolve_claude_native_command() == ["claude"]
+
+    def test_malformed_quoting_falls_back_to_claude(self, monkeypatch):
+        # Unbalanced quotes make shlex.split raise; the resolver must
+        # swallow it and fall back rather than crash the launch.
+        monkeypatch.setenv(_CLAUDE_NATIVE_COMMAND_ENV_VAR, 'isaac "unterminated')
+        assert _resolve_claude_native_command() == ["claude"]


### PR DESCRIPTION
## Related issue

N/A — small, self-contained runner enhancement; filing directly as a PR.

## Summary

The host-spawned (`--server`) native Claude path hard-codes `command="claude"` in `_auto_create_claude_terminal`, so a session launched through a registered host always runs bare Claude Code. `omni claude --command` only takes effect on the *local* path; the remote/runner path ignores it by design (the daemon-spawned runner launches the executable itself).

That blocks running Claude Code through a wrapper on the host — concretely Databricks' `isaac` launcher (`dbexec repo run isaac`), which layers managed settings, MCP client config, model/account routing, and plugin management on top of upstream Claude Code. These are not things Omnigent's provider config substitutes (provider config covers auth/model only), so today a host session loses all of it and falls back to bare subscription `claude`.

This adds an opt-in, host-level knob:

- The runner reads `OMNIGENT_CLAUDE_NATIVE_COMMAND`. When it names a wrapper resolvable on the runner host's PATH, it launches `<wrapper argv> <claude args>` instead of bare `claude`.
- The wrapper is a property of the **runner host** (where the binary lives), so a host-level env var — not a per-session client flag — is the right granularity, and it keeps the runner authoritative: it validates the command on its *own* PATH and falls back to `claude` (logging why) when the var is unset, empty, malformed, or not found.
- Propagated host → runner via the existing `_RUNNER_ENV_ALLOWLIST` (it's a host-local command string, not a secret).

Contract (same as the local `--command` flag): the wrapper must forward the trailing `claude` args/env Omnigent appends (bundle `--plugin-dir`, permission hooks, the session bridge) so the session still binds to the web UI.

### ELI5

When you start Claude through a "host", Omnigent always ran plain `claude`. Some shops wrap `claude` in their own launcher that sets things up first. This lets the host say "launch Claude via this wrapper instead", and if the wrapper isn't there, it just runs `claude` like before.

## Relationship to #484 (`omni claude --command`)

Complement to #484, not a replacement. #484 added `--command` and wired it through the **local** path (`_run_with_local_server`). The **remote/host** path (`_run_with_remote_server`, which `--server` always takes) ignores `--command` by design — the daemon-spawned runner launches Claude itself and derives config from provider config, so it takes "neither `command` nor `claude_config`".

Reusing `--command` on the remote path is *possible* but not the right fit:

- It would require persisting a per-session `command` as a first-class session field (DB column + store + server schema + route), the way `terminal_launch_args` is — a multi-layer change plus a server redeploy — whereas the host-spawned runner needs no client round-trip to know its own host's wrapper.
- More fundamentally, the wrapper must exist on the **runner host**, which may not be the machine that ran `omni claude` (the remote path is built so the runner can be elsewhere). A per-invocation client flag is the wrong carrier for something that is a property of the runner host; a client could name a wrapper the runner host does not have.

So the split is by granularity, matching where the binary lives:

- `--command` (#484): per-invocation wrapper for the **local** path.
- `OMNIGENT_CLAUDE_NATIVE_COMMAND` (this PR): host-level wrapper for the **remote/host** path — validated on the runner's own PATH, falling back to `claude`.

Both honor the same contract: a transparent wrapper preserving Claude Code's CLI interface.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Unit: added `TestResolveClaudeNativeCommand` in `tests/runner/test_app_claude_native_launch_args.py` covering the resolver's branches — unset → `claude`; blank → `claude`; multi-token wrapper split to argv (`dbexec repo run isaac`, only argv[0] PATH-checked); missing executable → `claude`; malformed quoting → `claude` (never raises).

Commands run:

- `OMNIGENT_SKIP_WEB_UI=true uv run --extra dev pytest tests/runner/test_app_claude_native_launch_args.py` → 16 passed
- `... pytest tests/runner/test_app_sessions_native.py` → 193 passed (no regression)
- `ruff check` / `ruff format --check` on changed files → clean

Manual E2E on a real Databricks host (reproduced across two independent sessions): started `omni host --server <app-url>` with `OMNIGENT_CLAUDE_NATIVE_COMMAND="dbexec repo run isaac"`, then launched a session via the `--server` path. Confirmed:

- Runner log showed `tmux launch requested: command=dbexec args_count=9` (previously `command=claude`); the terminal stayed `running=True` with no `terminal_registered_but_not_running` / 60s-timeout loop; the session posted events (`POST /sessions/.../events 202`) and produced an Omnigent web-UI URL — i.e. the wrapper forwarded Omnigent's bundle/hook/bridge args to Claude and the session bound to the UI.
- Claude Code came up as "Claude Enterprise" (Databricks auth via the wrapper) and was interactively usable.

No automated E2E added: exercising the wrapper-forwarding path requires a real Databricks host (`dbexec`/isaac); the launch-command assembly is unit-covered and the default (`claude`) path is unchanged.

This pull request and its description were written by Isaac.
