### PR TITLE
fix(native-harness): route `run --harness <x>-native` to the native TUI wrapper, like `omni <x>`

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -1049,6 +1049,14 @@ def _redirect_native_resume_if_needed(
             progress=progress,
         )
         return True
+    if native_agent.key == "cursor":
+        _run_cursor_native_resume_redirect(
+            base_url=base_url,
+            conversation_id=conversation_id,
+            auto_open_conversation=auto_open_conversation,
+            progress=progress,
+        )
+        return True
     return False
 
 
@@ -1176,6 +1184,46 @@ def _run_pi_native_resume_redirect(
         server=base_url,
         session_id=conversation_id,
         pi_args=(),
+        auto_open_conversation=auto_open_conversation,
+    )
+
+
+def _run_cursor_native_resume_redirect(
+    *,
+    base_url: str,
+    conversation_id: str,
+    auto_open_conversation: bool,
+    progress: RunnerStartupProgress | None,
+) -> None:
+    """
+    Hand a cursor-native conversation back to ``omnigent cursor``.
+
+    The cursor-native session is driven by the ``cursor-agent`` TUI in a
+    runner-owned tmux pane, and the forwarder mirrors that transcript back
+    into the conversation. Resuming through the Omnigent REPL would instead
+    run an Omnigent turn per message (which persists its own user item) *and*
+    leave the forwarder mirroring the same message from the cursor store —
+    recording each user message twice. Redirecting to ``omnigent cursor``'s
+    direct tmux attach keeps the TUI the single source of turns.
+
+    :param base_url: Omnigent server base URL.
+    :param conversation_id: Omnigent conversation id.
+    :param auto_open_conversation: Browser-open preference for the wrapper.
+    :param progress: Optional Omnigent startup spinner to finish before redirect.
+    :returns: None.
+    """
+    _finish_native_redirect_progress(
+        progress=progress,
+        conversation_id=conversation_id,
+        wrapper_name="cursor-native",
+        native_command="cursor",
+    )
+    from omnigent.cursor_native import run_cursor_native
+
+    run_cursor_native(
+        server=base_url,
+        session_id=conversation_id,
+        cursor_args=(),
         auto_open_conversation=auto_open_conversation,
     )
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5006,10 +5006,14 @@ def _dispatch_native_terminal_harness(
         if active
     ]
     if unsupported:
+        # These are REPL-only options with no analog in the TUI — and the
+        # dedicated subcommand doesn't accept them either (it would treat them
+        # as passthrough args), so tell the user to drop them rather than
+        # redirect. ``--model`` and session selection (--resume/--continue) ARE
+        # honored here.
         raise click.ClickException(
-            f"`run --harness {harness}` launches the {native_agent.display_name} TUI "
-            f"directly and does not support {', '.join(unsupported)}. "
-            f"Use `omnigent {native_agent.terminal_name}` for those options."
+            f"`run --harness {harness}` launches the {native_agent.display_name} TUI directly; "
+            f"the REPL-only option(s) {', '.join(unsupported)} have no effect there — remove them."
         )
 
     server = _ensure_backend(server)
@@ -5027,6 +5031,13 @@ def _dispatch_native_terminal_harness(
             agent_name=native_agent.agent_name,
             headers=_remote_headers(server_url=server),
         )
+        # The user explicitly asked to continue; if there's nothing to continue,
+        # fail loud rather than silently starting fresh (matches the REPL's
+        # _resolve_resume_target behavior).
+        if session_id is None:
+            raise click.ClickException(
+                f"No prior conversation for agent {native_agent.agent_name!r}."
+            )
 
     common = {
         "server": server,

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4943,6 +4943,95 @@ def _build_resume_parts() -> list[str]:
     return parts
 
 
+def _dispatch_native_terminal_harness(
+    *,
+    harness: str,
+    server: str | None,
+    model: str | None,
+    prompt: str | None,
+    system_prompt: str | None,
+    resume_conversation_id: str | None,
+    resume_picker: bool,
+    resume_latest: bool,
+    fork_session_id: str | None,
+    ephemeral: bool,
+    auto_open_conversation: bool,
+) -> bool:
+    """
+    Launch a ``*-native`` terminal harness via its TUI wrapper directly.
+
+    ``run --harness cursor-native`` (and the claude/codex/pi equivalents)
+    must NOT go through the materialized-launcher REPL: that drives an
+    Omnigent turn per message — which persists its own user item — *while*
+    the harness forwarder mirrors the same message back from the TUI's
+    transcript, recording every user message twice. These harnesses are
+    terminal-mirror sessions whose turns originate in the TUI, so dispatch
+    straight to the native wrapper (the same code ``omnigent cursor`` /
+    ``omnigent claude`` / etc. run), keeping the TUI the single source of
+    turns. A top-level ``--model`` is forwarded as a passthrough CLI flag.
+
+    :param harness: The requested ``--harness`` value (canonical or alias).
+    :returns: ``True`` when *harness* is a native terminal harness and was
+        dispatched here; ``False`` when it is not one (caller continues).
+    """
+    from omnigent.native_coding_agents import native_coding_agent_for_harness
+
+    native_agent = native_coding_agent_for_harness(harness)
+    if native_agent is None:
+        return False
+
+    # The native TUI wrappers attach to a tmux pane; one-shot / ephemeral /
+    # fork / --continue have no analog there. Fail loud rather than silently
+    # ignore, and point at the dedicated subcommand for the full option set.
+    unsupported = [
+        flag
+        for flag, active in (
+            ("-p/--prompt", prompt is not None),
+            ("--system-prompt", system_prompt is not None),
+            ("--continue", resume_latest),
+            ("--fork", fork_session_id is not None),
+            ("--no-session", ephemeral),
+        )
+        if active
+    ]
+    if unsupported:
+        raise click.ClickException(
+            f"`run --harness {harness}` launches the {native_agent.display_name} TUI "
+            f"directly and does not support {', '.join(unsupported)}. "
+            f"Use `omnigent {native_agent.terminal_name}` for those options."
+        )
+
+    server = _ensure_backend(server)
+    passthrough = ("--model", model) if model else ()
+
+    common = {
+        "server": server,
+        "session_id": resume_conversation_id,
+        "resume_picker": resume_picker,
+        "auto_open_conversation": auto_open_conversation,
+    }
+    if native_agent.key == "claude":
+        from omnigent.claude_native import run_claude_native
+
+        run_claude_native(claude_args=passthrough, **common)
+    elif native_agent.key == "codex":
+        from omnigent.codex_native import run_codex_native
+
+        # Codex takes its model as a first-class arg, not a passthrough flag.
+        run_codex_native(codex_args=(), model=model, **common)
+    elif native_agent.key == "pi":
+        from omnigent.pi_native import run_pi_native
+
+        run_pi_native(pi_args=passthrough, **common)
+    elif native_agent.key == "cursor":
+        from omnigent.cursor_native import run_cursor_native
+
+        run_cursor_native(cursor_args=passthrough, **common)
+    else:  # pragma: no cover - new native agent added without a dispatch arm
+        raise click.ClickException(f"No native terminal launcher wired for harness {harness!r}.")
+    return True
+
+
 def _dispatch_run(
     *,
     target: str | None,
@@ -5086,6 +5175,24 @@ def _dispatch_run(
             return
         if harness is None:
             raise click.ClickException(_missing_run_agent_message())
+        # ``*-native`` terminal harnesses launch their own TUI wrapper instead of
+        # the materialized-launcher REPL — the REPL would double-record every
+        # user message (Omnigent turn + forwarder mirror). Returns False for
+        # non-native harnesses, which fall through to the launcher below.
+        if _dispatch_native_terminal_harness(
+            harness=harness,
+            server=server,
+            model=model,
+            prompt=prompt,
+            system_prompt=system_prompt,
+            resume_conversation_id=resume_conversation_id,
+            resume_picker=resume_picker,
+            resume_latest=resume_latest,
+            fork_session_id=fork_session_id,
+            ephemeral=ephemeral,
+            auto_open_conversation=auto_open_conversation,
+        ):
+            return
         if ephemeral:
             raise click.ClickException(
                 "--no-session requires an AGENT path; no-AGENT harness launch "

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4950,6 +4950,9 @@ def _dispatch_native_terminal_harness(
     model: str | None,
     prompt: str | None,
     system_prompt: str | None,
+    tools: str | None,
+    log: bool,
+    debug_events: bool,
     resume_conversation_id: str | None,
     resume_picker: bool,
     resume_latest: bool,
@@ -4970,6 +4973,10 @@ def _dispatch_native_terminal_harness(
     ``omnigent claude`` / etc. run), keeping the TUI the single source of
     turns. A top-level ``--model`` is forwarded as a passthrough CLI flag.
 
+    ``--continue`` is honored (not rejected): it resolves to this harness's
+    most-recent conversation and hands that off to the wrapper, matching the
+    pre-dispatch launcher behavior so it is not a silent resume regression.
+
     :param harness: The requested ``--harness`` value (canonical or alias).
     :returns: ``True`` when *harness* is a native terminal harness and was
         dispatched here; ``False`` when it is not one (caller continues).
@@ -4980,15 +4987,19 @@ def _dispatch_native_terminal_harness(
     if native_agent is None:
         return False
 
-    # The native TUI wrappers attach to a tmux pane; one-shot / ephemeral /
-    # fork / --continue have no analog there. Fail loud rather than silently
-    # ignore, and point at the dedicated subcommand for the full option set.
+    # The native TUI wrappers attach to a tmux pane and own their own turn
+    # loop, so REPL-only options have no analog there. Reject them loudly
+    # rather than silently dropping them, and point at the dedicated
+    # subcommand. (``--continue``/``--resume <id>``/``--resume`` picker ARE
+    # supported below — they map onto the wrapper's session selection.)
     unsupported = [
         flag
         for flag, active in (
             ("-p/--prompt", prompt is not None),
             ("--system-prompt", system_prompt is not None),
-            ("--continue", resume_latest),
+            ("--tools", tools is not None),
+            ("--log", log),
+            ("--debug-events", debug_events),
             ("--fork", fork_session_id is not None),
             ("--no-session", ephemeral),
         )
@@ -5004,9 +5015,22 @@ def _dispatch_native_terminal_harness(
     server = _ensure_backend(server)
     passthrough = ("--model", model) if model else ()
 
+    # Resolve --continue to a concrete conversation id (the wrappers take a
+    # session id / picker, not a "latest" flag). Precedence matches the REPL:
+    # an explicit id wins, then the picker, then --continue.
+    session_id = resume_conversation_id
+    if session_id is None and not resume_picker and resume_latest:
+        from omnigent.chat import _remote_headers, _resolve_latest_conversation_id
+
+        session_id = _resolve_latest_conversation_id(
+            base_url=server,
+            agent_name=native_agent.agent_name,
+            headers=_remote_headers(server_url=server),
+        )
+
     common = {
         "server": server,
-        "session_id": resume_conversation_id,
+        "session_id": session_id,
         "resume_picker": resume_picker,
         "auto_open_conversation": auto_open_conversation,
     }
@@ -5030,6 +5054,31 @@ def _dispatch_native_terminal_harness(
     else:  # pragma: no cover - new native agent added without a dispatch arm
         raise click.ClickException(f"No native terminal launcher wired for harness {harness!r}.")
     return True
+
+
+def _reject_agent_with_native_terminal_harness(harness: str) -> None:
+    """
+    Reject ``run AGENT --harness <x>-native``: native harnesses own their TUI.
+
+    A ``*-native`` harness mirrors an external CLI's own TUI; the agent spec's
+    prompt/tools are never consulted, and driving it through the REPL would
+    double-record every message (Omnigent turn + forwarder mirror). So an
+    explicit AGENT path combined with a native terminal harness has no coherent
+    meaning — fail loud and point at the dedicated subcommand.
+
+    :param harness: The requested ``--harness`` value (canonical or alias).
+    :raises click.ClickException: When *harness* is a native terminal harness.
+    """
+    from omnigent.native_coding_agents import native_coding_agent_for_harness
+
+    native_agent = native_coding_agent_for_harness(harness)
+    if native_agent is None:
+        return
+    raise click.ClickException(
+        f"`--harness {harness}` launches the {native_agent.display_name} TUI and "
+        f"ignores an AGENT spec; drop the AGENT path and run "
+        f"`omnigent {native_agent.terminal_name}` (or `run --harness {harness}`)."
+    )
 
 
 def _dispatch_run(
@@ -5185,6 +5234,9 @@ def _dispatch_run(
             model=model,
             prompt=prompt,
             system_prompt=system_prompt,
+            tools=tools,
+            log=log,
+            debug_events=debug_events,
             resume_conversation_id=resume_conversation_id,
             resume_picker=resume_picker,
             resume_latest=resume_latest,
@@ -5210,6 +5262,11 @@ def _dispatch_run(
         system_prompt = None
     elif harness is not None:
         _validate_harness(harness)
+        # A ``*-native`` harness IS its own TUI agent — pairing it with an AGENT
+        # spec is meaningless, and routing it through the REPL would double-record
+        # every message (Omnigent turn + forwarder mirror, same as the no-AGENT
+        # path above). Reject rather than silently launch the broken surface.
+        _reject_agent_with_native_terminal_harness(harness)
 
     if server is not None:
         if _is_server_url(target):

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -3640,3 +3640,94 @@ def test_env_auth_injection_applies_when_nothing_configured(
     # The bake carries the actual key value so the uploaded bundle is
     # self-contained for the secret-less runner.
     assert executor["auth"] == {"type": "api_key", "api_key": "sk-ambient-shell-key"}
+
+
+def test_redirect_native_resume_handles_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cursor-native resume hands off to ``omnigent cursor`` (direct attach).
+
+    Regression: without a cursor branch in ``_redirect_native_resume_if_needed``
+    the resume fell through to the Omnigent REPL, which drove an Omnigent turn
+    per message (persisting its own user item) *while* the cursor forwarder
+    mirrored the same message from the cursor store — recording each user
+    message twice. The redirect keeps the TUI the single source of turns.
+    """
+    from omnigent._wrapper_labels import CURSOR_NATIVE_WRAPPER_VALUE
+
+    monkeypatch.setattr(
+        chat_module,
+        "_wrapper_label_for_conversation",
+        lambda **_kw: CURSOR_NATIVE_WRAPPER_VALUE,
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_run_cursor_native(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("omnigent.cursor_native.run_cursor_native", _fake_run_cursor_native)
+
+    handled = chat_module._redirect_native_resume_if_needed(
+        base_url="https://example.com",
+        conversation_id="conv_abc123",
+        auto_open_conversation=True,
+    )
+
+    assert handled is True
+    assert captured == {
+        "server": "https://example.com",
+        "session_id": "conv_abc123",
+        "cursor_args": (),
+        "auto_open_conversation": True,
+    }
+
+
+def test_cursor_native_resume_never_drives_an_omnigent_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resuming a cursor-native conversation must not enter the turn-driving REPL.
+
+    This is the behavior that makes the user's message appear exactly once. The
+    duplicate had two sources: (1) the Omnigent turn the REPL drives, which
+    persists its own user item, and (2) the cursor forwarder mirroring the same
+    message back from the cursor store. ``_chat_with_server`` must short-circuit
+    on the wrapper redirect *before* either ``_run_repl`` or ``_run_one_shot``
+    is reached, so source (1) never happens and only the forwarder records the
+    turn.
+    """
+    from omnigent._wrapper_labels import CURSOR_NATIVE_WRAPPER_VALUE
+
+    monkeypatch.setattr(
+        chat_module,
+        "_wrapper_label_for_conversation",
+        lambda **_kw: CURSOR_NATIVE_WRAPPER_VALUE,
+    )
+    redirected: dict[str, object] = {}
+    monkeypatch.setattr(
+        "omnigent.cursor_native.run_cursor_native",
+        lambda **kwargs: redirected.update(kwargs),
+    )
+
+    def _fail_repl(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("_run_repl drove an Omnigent turn for a cursor-native resume")
+
+    def _fail_one_shot(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("_run_one_shot drove an Omnigent turn for a cursor-native resume")
+
+    monkeypatch.setattr(chat_module, "_run_repl", _fail_repl)
+    monkeypatch.setattr(chat_module, "_run_one_shot", _fail_one_shot)
+    # _pick_agent runs only on the non-redirect path; tripping it also signals
+    # the redirect failed to short-circuit.
+    monkeypatch.setattr(
+        chat_module,
+        "_pick_agent",
+        lambda *_a, **_k: pytest.fail("reached the non-redirect path"),
+    )
+
+    # Returns cleanly via the redirect; the AssertionError stubs above fire if
+    # it ever falls through to a turn-driving path.
+    chat_module._chat_with_server(
+        "https://example.com",
+        None,
+        resume_conversation_id="conv_abc123",
+    )
+
+    assert redirected["session_id"] == "conv_abc123"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -4378,6 +4379,32 @@ def test_ensure_sqlite_parent_dir_noop_for_memory_and_non_sqlite(tmp_path: Path)
     assert list(tmp_path.iterdir()) == []
 
 
+def _native_dispatch_kwargs(**overrides: object) -> dict[str, object]:
+    """Build ``_dispatch_native_terminal_harness`` kwargs with safe defaults.
+
+    Keeps the call sites focused on the one or two fields each test exercises,
+    and means a new parameter only updates this helper rather than every test.
+    """
+    base: dict[str, object] = {
+        "harness": "cursor-native",
+        "server": None,
+        "model": None,
+        "prompt": None,
+        "system_prompt": None,
+        "tools": None,
+        "log": False,
+        "debug_events": False,
+        "resume_conversation_id": None,
+        "resume_picker": False,
+        "resume_latest": False,
+        "fork_session_id": None,
+        "ephemeral": False,
+        "auto_open_conversation": False,
+    }
+    base.update(overrides)
+    return base
+
+
 def test_dispatch_native_terminal_harness_cursor_launches_wrapper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4398,17 +4425,11 @@ def test_dispatch_native_terminal_harness_cursor_launches_wrapper(
     )
 
     handled = _dispatch_native_terminal_harness(
-        harness="cursor-native",
-        server=None,
-        model="composer-2.5",
-        prompt=None,
-        system_prompt=None,
-        resume_conversation_id="conv_abc123",
-        resume_picker=False,
-        resume_latest=False,
-        fork_session_id=None,
-        ephemeral=False,
-        auto_open_conversation=True,
+        **_native_dispatch_kwargs(
+            model="composer-2.5",
+            resume_conversation_id="conv_abc123",
+            auto_open_conversation=True,
+        )
     )
 
     assert handled is True
@@ -4435,44 +4456,110 @@ def test_dispatch_native_terminal_harness_ignores_non_native(
 
     monkeypatch.setattr("omnigent.cli._ensure_backend", _must_not_run)
 
-    handled = _dispatch_native_terminal_harness(
-        harness="openai-agents",
-        server=None,
-        model=None,
-        prompt=None,
-        system_prompt=None,
-        resume_conversation_id=None,
-        resume_picker=False,
-        resume_latest=False,
-        fork_session_id=None,
-        ephemeral=False,
-        auto_open_conversation=False,
-    )
+    handled = _dispatch_native_terminal_harness(**_native_dispatch_kwargs(harness="openai-agents"))
 
     assert handled is False
 
 
+@pytest.mark.parametrize(
+    ("override", "expected_flag"),
+    [
+        ({"prompt": "hi"}, "-p/--prompt"),
+        ({"system_prompt": "be terse"}, "--system-prompt"),
+        ({"tools": "fs"}, "--tools"),
+        ({"log": True}, "--log"),
+        ({"debug_events": True}, "--debug-events"),
+        ({"fork_session_id": "conv_src"}, "--fork"),
+        ({"ephemeral": True}, "--no-session"),
+    ],
+)
 def test_dispatch_native_terminal_harness_rejects_unsupported_flags(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, override: dict[str, object], expected_flag: str
 ) -> None:
-    """One-shot / fork / --continue have no analog in the TUI wrapper — fail loud."""
+    """REPL-only flags have no analog in the TUI wrapper — fail loud, don't drop.
+
+    Covers Copilot's finding that ``--tools`` / ``--log`` / ``--debug-events``
+    were silently ignored on the native-harness path.
+    """
 
     def _must_not_run(_server: str | None) -> str:
         raise AssertionError("_ensure_backend called despite unsupported flags")
 
     monkeypatch.setattr("omnigent.cli._ensure_backend", _must_not_run)
 
-    with pytest.raises(ClickException, match="does not support -p/--prompt"):
-        _dispatch_native_terminal_harness(
+    with pytest.raises(ClickException, match=re.escape(f"does not support {expected_flag}")):
+        _dispatch_native_terminal_harness(**_native_dispatch_kwargs(**override))
+
+
+def test_dispatch_native_terminal_harness_continue_resumes_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--continue`` resolves the harness's latest conversation, not an error.
+
+    Regression guard for the resume path: before this, ``--continue`` was listed
+    as unsupported and raised. It must instead resolve the most-recent
+    ``cursor-native-ui`` conversation and hand that to the wrapper as the
+    session id.
+    """
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    seen: dict[str, object] = {}
+
+    def _fake_latest(*, base_url: str, agent_name: str, headers: object) -> str:
+        seen["base_url"] = base_url
+        seen["agent_name"] = agent_name
+        return "conv_latest"
+
+    monkeypatch.setattr("omnigent.chat._resolve_latest_conversation_id", _fake_latest)
+    monkeypatch.setattr("omnigent.chat._remote_headers", lambda **_kw: {})
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "omnigent.cursor_native.run_cursor_native",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    handled = _dispatch_native_terminal_harness(**_native_dispatch_kwargs(resume_latest=True))
+
+    assert handled is True
+    # Resolved against the cursor-native agent identity, then passed as session_id.
+    assert seen == {"base_url": "http://localhost:0", "agent_name": "cursor-native-ui"}
+    assert captured["session_id"] == "conv_latest"
+
+
+def test_dispatch_native_terminal_harness_explicit_id_skips_latest_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``--resume <id>`` wins over ``--continue`` (no latest lookup)."""
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+
+    def _must_not_lookup(**_kw: object) -> str:
+        raise AssertionError("latest-conversation lookup ran despite an explicit id")
+
+    monkeypatch.setattr("omnigent.chat._resolve_latest_conversation_id", _must_not_lookup)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "omnigent.cursor_native.run_cursor_native",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    _dispatch_native_terminal_harness(
+        **_native_dispatch_kwargs(resume_conversation_id="conv_explicit", resume_latest=True)
+    )
+
+    assert captured["session_id"] == "conv_explicit"
+
+
+def test_run_agent_with_native_terminal_harness_is_rejected() -> None:
+    """``run AGENT --harness cursor-native`` is rejected (the TUI is the agent).
+
+    The native TUI ignores the AGENT spec, and routing it through the REPL would
+    double-record every message — so the combination has no coherent meaning.
+    """
+    with pytest.raises(ClickException, match="ignores an AGENT spec"):
+        _dispatch_run(
+            target="examples/hello_world.yaml",
+            tools=None,
             harness="cursor-native",
-            server=None,
             model=None,
-            prompt="hello",
+            prompt=None,
             system_prompt=None,
-            resume_conversation_id=None,
-            resume_picker=False,
-            resume_latest=False,
-            fork_session_id=None,
-            ephemeral=False,
-            auto_open_conversation=False,
         )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -25,6 +25,7 @@ from omnigent.cli import (
     _announce_auto_configured_credentials,
     _bundle,
     _bundled_example_path,
+    _dispatch_native_terminal_harness,
     _dispatch_run,
     _ensure_sqlite_parent_dir,
     _expand_config_env_vars,
@@ -4375,3 +4376,103 @@ def test_ensure_sqlite_parent_dir_noop_for_memory_and_non_sqlite(tmp_path: Path)
     _ensure_sqlite_parent_dir("postgresql://user:pw@db.example.com:5432/omnigent")
 
     assert list(tmp_path.iterdir()) == []
+
+
+def test_dispatch_native_terminal_harness_cursor_launches_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run --harness cursor-native`` dispatches to the cursor TUI wrapper.
+
+    Regression for duplicate user messages: the materialized-launcher REPL
+    drove an Omnigent turn (which persists its own user item) on top of the
+    cursor forwarder mirroring the same message back, recording each message
+    twice. Native terminal harnesses must launch their wrapper directly so the
+    TUI is the single source of turns. A top-level ``--model`` is forwarded as a
+    passthrough ``--model`` flag.
+    """
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "omnigent.cursor_native.run_cursor_native",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    handled = _dispatch_native_terminal_harness(
+        harness="cursor-native",
+        server=None,
+        model="composer-2.5",
+        prompt=None,
+        system_prompt=None,
+        resume_conversation_id="conv_abc123",
+        resume_picker=False,
+        resume_latest=False,
+        fork_session_id=None,
+        ephemeral=False,
+        auto_open_conversation=True,
+    )
+
+    assert handled is True
+    assert captured == {
+        "server": "http://localhost:0",
+        "session_id": "conv_abc123",
+        "resume_picker": False,
+        "auto_open_conversation": True,
+        "cursor_args": ("--model", "composer-2.5"),
+    }
+
+
+def test_dispatch_native_terminal_harness_ignores_non_native(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-native harness returns False and never touches the backend.
+
+    The SDK harnesses (``cursor``, ``codex``, ``claude-sdk``, ...) must keep
+    falling through to the materialized-launcher REPL.
+    """
+
+    def _must_not_run(_server: str | None) -> str:
+        raise AssertionError("_ensure_backend called for a non-native harness")
+
+    monkeypatch.setattr("omnigent.cli._ensure_backend", _must_not_run)
+
+    handled = _dispatch_native_terminal_harness(
+        harness="openai-agents",
+        server=None,
+        model=None,
+        prompt=None,
+        system_prompt=None,
+        resume_conversation_id=None,
+        resume_picker=False,
+        resume_latest=False,
+        fork_session_id=None,
+        ephemeral=False,
+        auto_open_conversation=False,
+    )
+
+    assert handled is False
+
+
+def test_dispatch_native_terminal_harness_rejects_unsupported_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One-shot / fork / --continue have no analog in the TUI wrapper — fail loud."""
+
+    def _must_not_run(_server: str | None) -> str:
+        raise AssertionError("_ensure_backend called despite unsupported flags")
+
+    monkeypatch.setattr("omnigent.cli._ensure_backend", _must_not_run)
+
+    with pytest.raises(ClickException, match="does not support -p/--prompt"):
+        _dispatch_native_terminal_harness(
+            harness="cursor-native",
+            server=None,
+            model=None,
+            prompt="hello",
+            system_prompt=None,
+            resume_conversation_id=None,
+            resume_picker=False,
+            resume_latest=False,
+            fork_session_id=None,
+            ephemeral=False,
+            auto_open_conversation=False,
+        )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4487,8 +4487,11 @@ def test_dispatch_native_terminal_harness_rejects_unsupported_flags(
 
     monkeypatch.setattr("omnigent.cli._ensure_backend", _must_not_run)
 
-    with pytest.raises(ClickException, match=re.escape(f"does not support {expected_flag}")):
+    # The rejected flag is named in the error, and it's framed as "remove them"
+    # (not "use the subcommand" — the subcommand doesn't accept these either).
+    with pytest.raises(ClickException, match=re.escape(expected_flag)) as excinfo:
         _dispatch_native_terminal_harness(**_native_dispatch_kwargs(**override))
+    assert "remove them" in str(excinfo.value)
 
 
 def test_dispatch_native_terminal_harness_continue_resumes_latest(
@@ -4523,6 +4526,28 @@ def test_dispatch_native_terminal_harness_continue_resumes_latest(
     # Resolved against the cursor-native agent identity, then passed as session_id.
     assert seen == {"base_url": "http://localhost:0", "agent_name": "cursor-native-ui"}
     assert captured["session_id"] == "conv_latest"
+
+
+def test_dispatch_native_terminal_harness_continue_with_no_prior_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--continue`` with nothing to continue errors, not a silent fresh start.
+
+    The user explicitly asked to resume; passing the unresolved ``None`` through
+    as ``session_id`` would silently open a new session. Matches the REPL's
+    ``_resolve_resume_target`` "No prior conversation" behavior.
+    """
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.chat._resolve_latest_conversation_id", lambda **_kw: None)
+    monkeypatch.setattr("omnigent.chat._remote_headers", lambda **_kw: {})
+
+    def _must_not_launch(**_kw: object) -> None:
+        raise AssertionError("wrapper launched despite no conversation to continue")
+
+    monkeypatch.setattr("omnigent.cursor_native.run_cursor_native", _must_not_launch)
+
+    with pytest.raises(ClickException, match="No prior conversation"):
+        _dispatch_native_terminal_harness(**_native_dispatch_kwargs(resume_latest=True))
 
 
 def test_dispatch_native_terminal_harness_explicit_id_skips_latest_lookup(


### PR DESCRIPTION
## Core issue

`omni <x>` (e.g. `omnigent cursor`, `omnigent claude`) and `omni run --harness <x>-native` create the **same kind of session** — same wrapper label, same runner-owned tmux terminal, same transcript forwarder — but took **different paths**, so they behaved differently:

- `omni <x>` attaches the local TTY directly to the native TUI. The TUI owns the turn loop; the forwarder mirrors its transcript into the Omnigent conversation. **One writer.**
- `omni run --harness <x>-native` went through the generic materialized-launcher **Omnigent REPL**, which drove an Omnigent turn per message *on top of* that same TUI + forwarder.

A `*-native` harness isn't a normal `--harness` backend (an in-process library Omnigent drives). It's a **foreign, interactive CLI** (Claude Code, cursor-agent, codex, pi) that owns its own UI and turn loop — Omnigent can only inject keystrokes and scrape the transcript back. Putting the Omnigent REPL in front of it is a category error: if you want Omnigent to own the loop you'd use the SDK harness (`claude-sdk`, …), not the `-native` one.

The two commands minting the same session kind should behave the same. They didn't, and that mismatch is what this PR fixes.

## Symptom: duplicate user messages

Because the REPL path added a second writer, every user message was recorded twice:

1. **The Omnigent turn** persists your text as the turn's user item, then the native executor's `run_turn` injects it into the tmux pane and returns `TurnComplete(response=None)` → a user bubble with no reply.
2. **The forwarder** mirrors the same message back from the TUI transcript as an `external_conversation_item` (no server-side dedup) → the same message again, this time with the assistant reply.

Confirmed against the on-disk store that the TUI itself records the message once — the duplication was purely Omnigent counting it on both paths. (`--model` was incidental; the double-record is structural to the REPL path.) The forwarder mirroring user turns is *correct* for the direct-attach path, where it's the only writer and seeds the conversation/title.

## Fix

- **`omnigent/cli.py`** — `_dispatch_native_terminal_harness`, called from `_dispatch_run`'s no-AGENT branch. The four `*-native` harness ids (`cursor-native`, `claude-native`, `codex-native`, `pi-native`) now dispatch straight to their TUI wrapper — the same code `omni cursor` / `omni claude` / etc. run — so the TUI is the single source of turns. SDK harnesses (`cursor`, `codex`, `claude-sdk`, …) are untouched and still use the REPL. A top-level `--model` is forwarded as a passthrough flag (codex takes it as a first-class arg).
  - **Session selection is honored:** `--resume <id>`, `--resume` (picker), and `--continue` all map onto the wrapper's session selection. `--continue` resolves the harness's most-recent conversation (by native agent name, e.g. `cursor-native-ui`) so it is **not** a resume regression. Precedence matches the REPL: explicit id > picker > `--continue`.
  - **REPL-only options fail loud** (rather than being silently dropped): `-p`/`--system-prompt`/`--tools`/`--log`/`--debug-events`/`--fork`/`--no-session` raise and point at the dedicated subcommand. (Headless `-p` could later map to the native CLIs' print modes; not wired up yet.)
  - **`AGENT` + `--harness <x>-native` is rejected** — the native TUI ignores the AGENT spec, and routing it through the REPL would double-record. (Closes the fresh-AGENT-launch gap, not just the no-AGENT path.)
- **`omnigent/chat.py`** — added a `cursor` branch to `_redirect_native_resume_if_needed`, the complementary resume case: `omni run --resume <id>` on a labeled cursor-native session now hands off to `omnigent cursor`, matching the claude/codex/pi siblings that already had this branch.

## Behavior notes

- `omni run --harness <x>-native` (no resume flags) now starts a **fresh** session each run, like the dedicated subcommands, instead of silently auto-resuming the last one. Use `--continue` (latest) or `--resume <id>` / `--resume` (picker) to resume.
- `AGENT` + `--harness <x>-native` now errors instead of launching a broken double-recording REPL surface.

## Tests

- `tests/cli/test_cli.py` — a native harness dispatches to its wrapper with `--model` passthrough; `--continue` resolves the latest conversation; an explicit `--resume <id>` skips the latest lookup (precedence); non-native (SDK) harness returns `False` without touching the backend; `AGENT + native` is rejected; every REPL-only flag fails loud (parametrized).
- `tests/cli/test_chat.py` — the resume redirect dispatches to `run_cursor_native`; a cursor-native resume never enters the turn-driving REPL path (verified to fail without the fix).