### PR TITLE
chore(chat-ui): pin CDN assets and add Sub-resource Integrity

### DIFF
--- a/omnigent/inner/static/chat.html
+++ b/omnigent/inner/static/chat.html
@@ -4,11 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Omnigent Chat</title>
-<!-- Markdown + syntax highlighting + HTML sanitization from CDN -->
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark.min.css">
-<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
+<!-- Markdown + syntax highlighting + HTML sanitization from CDN.
+     Versions are pinned and protected with Subresource Integrity (SRI):
+     the browser refuses to run a file whose hash doesn't match, so a
+     compromised/swapped CDN asset can't inject code. Bumping a version
+     requires regenerating the matching integrity hash. -->
+<script src="https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.min.js" integrity="sha512-7W46WS6vPCNlOKFEEO1KksrE1R2BfdQoBF9vUTz+mlGqaYrNNDDBqIe+Ckd1alkxeVr0A8M3ISkA34kc+hFGjQ==" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.11/dist/purify.min.js" integrity="sha512-lBPWWUhZJjVB3av+jFeCwgle3o8VaQIQu867R9fZh4HlNdPl/9/jeGVayR4BEV635JFXnVecK52KIBEu7UH9Ug==" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css" integrity="sha512-rO+olRTkcf304DQBxSWxln8JXCzTHlKnIdnMUwYvQa9/Jd4cQaNkItIUj6Z4nvW1dqK0SKXLbn9h4KwZTNtAyw==" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js" integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw==" crossorigin="anonymous"></script>
 <style>
 :root {
   --bg: #f8f9fa; --fg: #1a1a2e; --muted: #f0f0f0; --muted-fg: #6b7280;


### PR DESCRIPTION
… integrity hashes + crossorigin="anonymous" to all four CDN tags. The browser now refuses to execute any asset whose hash doesn't match, preventing a compromised or swapped CDN file from injecting code.

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Type of change, Test coverage, Coverage rationale).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Leave every checkbox in place. The PR Template check fails if required sections
  or checkbox rows are removed.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
still-open community PR already closes the same issue, the newer one may be
auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
chores/docs with no associated issue.
-->

Closes #

## Summary

Hardens the four jsDelivr CDN dependencies in `omnigent/inner/static/chat.html` against supply-chain tampering:

| Asset                  | Pinned version | Hash    |
| ---------------------- | -------------- | ------- |
| marked (UMD build)     | 18.0.5         | SHA-512 |
| DOMPurify              | 3.4.11         | SHA-512 |
| highlight.js theme CSS | 11.11.1        | SHA-512 |
| highlight.js JS        | 11.11.1        | SHA-512 |

Each tag now carries `integrity` + `crossorigin="anonymous"`, and versions are pinned exactly (SRI requires fixed bytes). If a CDN file is ever swapped or compromised, its hash won't match and the browser will refuse to load it.

Used the following to generate the integrity hashes https://srihash.org/ 

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

<!--
Describe the exact commands run and the coverage added/updated. If you did not
add or run tests, explain why the existing coverage is enough or why tests are
not applicable. For E2E-relevant changes, call out the E2E scenario exercised or
why no E2E coverage was added.
-->
