### PR TITLE
feat(server): strip configurable identity-header prefix for Google IAP

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -352,7 +352,7 @@ overrides this auto-selection.
 |---|---|---|
 | `accounts` (deploy default) | Standalone deploy, no external IdP: built-in username/password with first-user-is-admin bootstrap and UI-based invites. Opt in with `OMNIGENT_AUTH_ENABLED=1` (and no OIDC vars). | Set `OMNIGENT_ACCOUNTS_COOKIE_SECRET` (or let `bootstrap.sh` mint it) and `OMNIGENT_ACCOUNTS_BASE_URL` (public URL). On first boot, set the admin password via the web Create-admin form, the terminal prompt, or `--admin-password` / `OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD`. |
 | `oidc` | Standalone deploy with your own IdP: server handles the full login flow | Set `OMNIGENT_AUTH_ENABLED=1` and the `OMNIGENT_OIDC_*` env vars; the presence of `OMNIGENT_OIDC_ISSUER` selects OIDC (or pin `OMNIGENT_AUTH_PROVIDER=oidc`). Requires HTTPS (the session cookie uses the `__Host-` prefix). |
-| `header` | Behind an existing SSO proxy (oauth2-proxy, AWS ALB OIDC, Cloudflare Access, Tailscale Funnel, …) that injects an identity header | The default when `OMNIGENT_AUTH_ENABLED` is off; or pin `OMNIGENT_AUTH_PROVIDER=header`. Reads `X-Forwarded-Email` by default; set `OMNIGENT_AUTH_HEADER` for proxies that use another name (e.g. `Cf-Access-Authenticated-User-Email`). Proxy MUST strip any inbound copy of the header from clients. Missing headers are always rejected. |
+| `header` | Behind an existing SSO proxy (oauth2-proxy, AWS ALB OIDC, Cloudflare Access, Tailscale Funnel, …) that injects an identity header | The default when `OMNIGENT_AUTH_ENABLED` is off; or pin `OMNIGENT_AUTH_PROVIDER=header`. Reads `X-Forwarded-Email` by default; set `OMNIGENT_AUTH_HEADER` for proxies that use another name (e.g. `Cf-Access-Authenticated-User-Email`), and `OMNIGENT_AUTH_HEADER_STRIP_PREFIX=accounts.google.com:` for Google IAP. Proxy MUST strip any inbound copy of the header from clients. Missing headers are always rejected. |
 
 ### Single sign-on (OIDC)
 
@@ -425,6 +425,18 @@ authenticated email in `Cf-Access-Authenticated-User-Email`):
 ```dotenv
 OMNIGENT_AUTH_PROVIDER=header
 OMNIGENT_AUTH_HEADER=Cf-Access-Authenticated-User-Email
+```
+
+Some proxies namespace the identity they inject. **Google IAP** forwards the
+email in `X-Goog-Authenticated-User-Email` prefixed with `accounts.google.com:`
+(e.g. `accounts.google.com:user@example.com`). Set
+`OMNIGENT_AUTH_HEADER_STRIP_PREFIX` to drop that prefix and recover the bare
+email:
+
+```dotenv
+OMNIGENT_AUTH_PROVIDER=header
+OMNIGENT_AUTH_HEADER=X-Goog-Authenticated-User-Email
+OMNIGENT_AUTH_HEADER_STRIP_PREFIX=accounts.google.com:
 ```
 
 In header mode **the server trusts whatever that header says**. If no proxy

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -58,6 +58,10 @@ POSTGRES_PASSWORD=change-me-please
 #      X-Forwarded-Email by default; set OMNIGENT_AUTH_HEADER for
 #      proxies that use another name, e.g.
 #      Cf-Access-Authenticated-User-Email for Cloudflare Access.
+#      For proxies that namespace the value (Google IAP forwards
+#      X-Goog-Authenticated-User-Email as accounts.google.com:<email>)
+#      set OMNIGENT_AUTH_HEADER_STRIP_PREFIX=accounts.google.com: to
+#      recover the bare email.
 #
 # OMNIGENT_AUTH_ENABLED is the master switch (defaults to 1 in
 # docker-compose.yaml). Set it to 0 to disable auth entirely (header

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -200,6 +200,17 @@ OMNIGENT_AUTH_PROVIDER=header
 OMNIGENT_AUTH_HEADER=Cf-Access-Authenticated-User-Email
 ```
 
+Some proxies namespace the value they inject. Google IAP forwards the
+email in `X-Goog-Authenticated-User-Email` prefixed with
+`accounts.google.com:`; set `OMNIGENT_AUTH_HEADER_STRIP_PREFIX` to drop
+it and recover the bare email:
+
+```bash
+OMNIGENT_AUTH_PROVIDER=header
+OMNIGENT_AUTH_HEADER=X-Goog-Authenticated-User-Email
+OMNIGENT_AUTH_HEADER_STRIP_PREFIX=accounts.google.com:
+```
+
 **Security note:** in this mode the proxy is responsible for
 stripping any inbound copy of the identity header from the client
 request — otherwise any visitor can spoof an identity. The server
@@ -215,6 +226,7 @@ trusts whatever value reaches it.
 | `OMNIGENT_AUTH_ENABLED` | `1` (in compose) | Master auth switch. `1` → accounts (or oidc if `OMNIGENT_OIDC_ISSUER` is set); `0` → single-user local mode (every request is the shared `local` user — local dev only, never shared deploys). |
 | `OMNIGENT_AUTH_PROVIDER` | unset | Escape hatch to pin a mode explicitly: `header` / `accounts` / `oidc`. Overrides the `AUTH_ENABLED` auto-selection. |
 | `OMNIGENT_AUTH_HEADER` | `X-Forwarded-Email` | Header-mode only: name of the trusted identity header. Set for proxies that use another name, e.g. `Cf-Access-Authenticated-User-Email` (Cloudflare Access). |
+| `OMNIGENT_AUTH_HEADER_STRIP_PREFIX` | unset (strip nothing) | Header-mode only: prefix removed from the identity header value. Set to `accounts.google.com:` for Google IAP's `X-Goog-Authenticated-User-Email`. |
 | `OMNIGENT_OIDC_*` | unset | OIDC config — required in oidc mode (issuer set, or `AUTH_PROVIDER=oidc`). See `.env.example`. |
 | `PYPI_INDEX_URL` | `https://pypi.org/simple` | Build-time PyPI index — override only behind a corporate proxy. |
 

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -64,6 +64,15 @@ _LOCAL_SINGLE_USER_ENV = "OMNIGENT_LOCAL_SINGLE_USER"
 _AUTH_HEADER_ENV = "OMNIGENT_AUTH_HEADER"
 _DEFAULT_AUTH_HEADER = "X-Forwarded-Email"
 
+# Optional prefix stripped from the identity header value in header-auth
+# mode. Some trusted proxies namespace the identity they inject — most
+# notably Google IAP, whose ``X-Goog-Authenticated-User-Email`` carries an
+# ``accounts.google.com:`` prefix (value
+# ``accounts.google.com:user@example.com``). Stripping it yields the bare
+# email used everywhere else. Unset (the default) strips nothing. See
+# :func:`resolve_auth_header_strip_prefix`.
+_AUTH_HEADER_STRIP_PREFIX_ENV = "OMNIGENT_AUTH_HEADER_STRIP_PREFIX"
+
 LEVEL_READ = 1
 LEVEL_EDIT = 2
 LEVEL_MANAGE = 3
@@ -122,6 +131,26 @@ def resolve_auth_header() -> str:
     """
     raw = os.environ.get(_AUTH_HEADER_ENV, "").strip()
     return raw or _DEFAULT_AUTH_HEADER
+
+
+def resolve_auth_header_strip_prefix() -> str:
+    """Resolve the prefix stripped from the identity header value.
+
+    Reads ``OMNIGENT_AUTH_HEADER_STRIP_PREFIX`` and returns it
+    (surrounding whitespace trimmed), or ``""`` when unset or empty —
+    the default, meaning the header value is used as-is.
+
+    The motivating case is Google IAP: point
+    ``OMNIGENT_AUTH_HEADER=X-Goog-Authenticated-User-Email`` at IAP's
+    identity header and set
+    ``OMNIGENT_AUTH_HEADER_STRIP_PREFIX=accounts.google.com:`` so the
+    namespaced value ``accounts.google.com:user@example.com`` resolves to
+    the bare ``user@example.com``. Kept generic rather than IAP-specific
+    so any proxy that namespaces its identity header is supported.
+
+    :returns: The prefix to strip, or ``""`` to strip nothing.
+    """
+    return os.environ.get(_AUTH_HEADER_STRIP_PREFIX_ENV, "").strip()
 
 
 _auth_enabled_deprecation_warned = False
@@ -247,6 +276,14 @@ class UnifiedAuthProvider(AuthProvider):
         ``OMNIGENT_AUTH_HEADER`` at construction, falling back to
         ``X-Forwarded-Email`` (see :func:`resolve_auth_header`).
         Only consulted in header mode. Tests pass an explicit name.
+    :param header_strip_prefix: A prefix stripped from the identity
+        header value in header mode — e.g. ``accounts.google.com:`` so
+        Google IAP's ``accounts.google.com:user@example.com`` resolves
+        to the bare email. ``None`` (the default) resolves from
+        ``OMNIGENT_AUTH_HEADER_STRIP_PREFIX`` at construction, falling
+        back to ``""`` (strip nothing; see
+        :func:`resolve_auth_header_strip_prefix`). Only consulted in
+        header mode. Tests pass an explicit prefix.
     """
 
     def __init__(
@@ -256,6 +293,7 @@ class UnifiedAuthProvider(AuthProvider):
         accounts_config: AccountsConfig | None = None,
         local_single_user: bool | None = None,
         header_name: str | None = None,
+        header_strip_prefix: str | None = None,
     ) -> None:
         self._source = source
         self._oidc_config = oidc_config
@@ -264,6 +302,11 @@ class UnifiedAuthProvider(AuthProvider):
             local_single_user if local_single_user is not None else local_single_user_enabled()
         )
         self._header_name = header_name if header_name is not None else resolve_auth_header()
+        self._header_strip_prefix = (
+            header_strip_prefix
+            if header_strip_prefix is not None
+            else resolve_auth_header_strip_prefix()
+        )
         self._cookie_cache: dict[str, tuple[str, float]] = {}
 
     @property
@@ -376,6 +419,14 @@ class UnifiedAuthProvider(AuthProvider):
         by default, overridable via ``OMNIGENT_AUTH_HEADER`` — e.g.
         ``Cf-Access-Authenticated-User-Email`` for Cloudflare Access).
 
+        When :attr:`_header_strip_prefix` is set (from
+        ``OMNIGENT_AUTH_HEADER_STRIP_PREFIX``), it is removed from the
+        front of the header value first — e.g. Google IAP's
+        ``X-Goog-Authenticated-User-Email`` value
+        ``accounts.google.com:user@example.com`` becomes the bare
+        ``user@example.com``. A value that is only the prefix (empty
+        after stripping) is rejected, like a reserved name.
+
         When the header is present, its value is used as the identity
         (reserved names like ``"local"`` are rejected). When absent,
         the request is rejected (``None`` → 401): a missing or
@@ -397,7 +448,9 @@ class UnifiedAuthProvider(AuthProvider):
         """
         email = request.headers.get(self._header_name)
         if email:
-            if email in _RESERVED_USERS:
+            if self._header_strip_prefix:
+                email = email.removeprefix(self._header_strip_prefix)
+            if not email or email in _RESERVED_USERS:
                 return None
             return email
         if self._local_single_user:

--- a/tests/server/test_oidc.py
+++ b/tests/server/test_oidc.py
@@ -18,6 +18,7 @@ from omnigent.server.auth import (
     UnifiedAuthProvider,
     create_auth_provider,
     resolve_auth_header,
+    resolve_auth_header_strip_prefix,
 )
 from omnigent.server.oidc import (
     OIDCConfig,
@@ -319,6 +320,113 @@ def test_resolve_auth_header_defaults_to_x_forwarded_email(
     assert resolve_auth_header() == "X-Forwarded-Email"
     monkeypatch.setenv("OMNIGENT_AUTH_HEADER", "   ")
     assert resolve_auth_header() == "X-Forwarded-Email"
+
+
+# ── UnifiedAuthProvider (header source: Google IAP prefix strip) ──
+
+# Google IAP injects its identity in ``X-Goog-Authenticated-User-Email``
+# namespaced as ``accounts.google.com:<email>``. The configured strip
+# prefix turns that into the bare email used everywhere else.
+_IAP_HEADER = "X-Goog-Authenticated-User-Email"
+_IAP_PREFIX = "accounts.google.com:"
+
+
+def test_header_source_strips_configured_prefix() -> None:
+    """Google IAP: the ``accounts.google.com:`` prefix is stripped.
+
+    IAP forwards ``accounts.google.com:user@example.com``. Without
+    stripping, the identity would carry the namespace prefix and never
+    match the bare email used for ownership/sharing — so a deploy behind
+    IAP could not be addressed by its real identity at all.
+    """
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_name=_IAP_HEADER,
+        header_strip_prefix=_IAP_PREFIX,
+    )
+    request = _mock_request(headers={_IAP_HEADER: f"{_IAP_PREFIX}alice@example.com"})
+    assert provider.get_user_id(request) == "alice@example.com"
+
+
+def test_header_source_strip_prefix_absent_passes_value_through() -> None:
+    """A value lacking the prefix is used unchanged.
+
+    ``str.removeprefix`` is a no-op when the prefix is absent, so a
+    proxy value that is already bare still authenticates — the strip is
+    purely additive and never corrupts a non-namespaced identity.
+    """
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_name=_IAP_HEADER,
+        header_strip_prefix=_IAP_PREFIX,
+    )
+    request = _mock_request(headers={_IAP_HEADER: "alice@example.com"})
+    assert provider.get_user_id(request) == "alice@example.com"
+
+
+def test_header_source_rejects_value_that_is_only_the_prefix() -> None:
+    """A header carrying only the prefix (empty after strip) fails closed.
+
+    ``accounts.google.com:`` with no email is malformed; it must reject
+    (``None`` → 401), never authenticate as an empty-string identity
+    that requests could then share.
+    """
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_name=_IAP_HEADER,
+        header_strip_prefix=_IAP_PREFIX,
+        local_single_user=False,
+    )
+    request = _mock_request(headers={_IAP_HEADER: _IAP_PREFIX})
+    assert provider.get_user_id(request) is None
+
+
+def test_header_source_rejects_reserved_name_behind_prefix() -> None:
+    """Reserved-name rejection applies AFTER stripping.
+
+    Otherwise ``accounts.google.com:local`` would slip past the
+    reserved check (it isn't literally ``"local"``) and then strip down
+    to the reserved ``"local"`` sentinel — letting a client impersonate
+    it through the namespaced header.
+    """
+    provider = UnifiedAuthProvider(
+        source="header",
+        header_name=_IAP_HEADER,
+        header_strip_prefix=_IAP_PREFIX,
+    )
+    request = _mock_request(headers={_IAP_HEADER: f"{_IAP_PREFIX}local"})
+    assert provider.get_user_id(request) is None
+
+
+def test_header_source_resolves_strip_prefix_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``header_strip_prefix=None`` resolves from the env var.
+
+    The deploy path configures the prefix via
+    ``OMNIGENT_AUTH_HEADER_STRIP_PREFIX``, not a constructor argument —
+    this pins the env-resolution path IAP deployments rely on.
+    """
+    monkeypatch.setenv("OMNIGENT_AUTH_HEADER", _IAP_HEADER)
+    monkeypatch.setenv("OMNIGENT_AUTH_HEADER_STRIP_PREFIX", _IAP_PREFIX)
+    provider = UnifiedAuthProvider(source="header")
+    request = _mock_request(headers={_IAP_HEADER: f"{_IAP_PREFIX}alice@example.com"})
+    assert provider.get_user_id(request) == "alice@example.com"
+
+
+def test_resolve_auth_header_strip_prefix_defaults_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset/whitespace ``OMNIGENT_AUTH_HEADER_STRIP_PREFIX`` → ``""``.
+
+    The default must strip nothing so every existing header-mode deploy
+    (none of which set this) keeps passing the header value through
+    verbatim.
+    """
+    monkeypatch.delenv("OMNIGENT_AUTH_HEADER_STRIP_PREFIX", raising=False)
+    assert resolve_auth_header_strip_prefix() == ""
+    monkeypatch.setenv("OMNIGENT_AUTH_HEADER_STRIP_PREFIX", "   ")
+    assert resolve_auth_header_strip_prefix() == ""
 
 
 # ── UnifiedAuthProvider (oidc source) ────────────────────────────


### PR DESCRIPTION
## Related issue

N/A — follow-up to #884 (configurable `OMNIGENT_AUTH_HEADER`), requested in
review by @PattaraS to extend header-auth mode to Google IAP.

Closes #

## Summary

- Header-auth mode now honors **`OMNIGENT_AUTH_HEADER_STRIP_PREFIX`**, a prefix
  removed from the trusted identity header value before it's used as the user ID.
- Motivating case: **Google IAP** forwards the email in
  `X-Goog-Authenticated-User-Email` namespaced as
  `accounts.google.com:user@example.com`. Stripping the prefix recovers the bare
  `user@example.com` used everywhere else for ownership/sharing.
- Kept **generic** (not IAP-specific) so any proxy that namespaces its identity
  header is supported — same spirit as #884 keeping `OMNIGENT_AUTH_HEADER` generic.
- Reserved-name rejection runs **after** stripping, and a value that is only the
  prefix (empty after strip) **fails closed**. Default unset = strip nothing, so
  existing header-mode deploys are byte-for-byte unaffected.

> **Assumption:** header-auth mode already trusts the proxy — it uses whatever
> identity the proxy injects, relying on the operator to secure ingress (only the
> proxy can reach the backend) and strip any client-supplied copy of the header.
> This PR keeps that exact trust model; it only reshapes the trusted value (drops a
> known namespace prefix) and adds no new trust assumption. It is **not** JWT/IAP
> assertion verification — that would be a separate, larger change if stronger
> defense-in-depth is wanted.

### Flow

```
IAP  ──  X-Goog-Authenticated-User-Email: accounts.google.com:alice@x.com
                         │
       OMNIGENT_AUTH_HEADER ─────────┘  (which header to read)
       OMNIGENT_AUTH_HEADER_STRIP_PREFIX=accounts.google.com:
                         │  removeprefix → "alice@x.com"
                         ▼
         reserved-name / empty check  →  user id = alice@x.com
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added 6 unit tests in `tests/server/test_oidc.py` (header-source section) covering:
IAP happy-path strip, no-op when the prefix is absent, fail-closed when the value
is only the prefix, reserved-name rejection *behind* the prefix (the
privilege-escalation guard), env-var resolution, and the default-empty resolver.

Commands run:
- `pytest tests/server/test_oidc.py` → 48 passed
- `pytest tests/server/test_accounts.py tests/server/test_permissions.py tests/server/test_admin_list.py` → 146 passed (no regression in adjacent auth paths)
- `ruff check` + `ruff format --check` on changed files → clean
