### PR TITLE
chore(triage): teach issue triage about comp:tui (terminal UI / REPL / CLI)

### DIFF
--- a/.github/ISSUE_ASSIGNEES
+++ b/.github/ISSUE_ASSIGNEES
@@ -12,10 +12,10 @@
 # Used by the issue triage workflow for P0/P1 auto-assignment.
 bbqiu server,runner,harnesses,repr
 daniellok-db server,runner,harnesses,web-ui
-dhruv0811 server,runner,harnesses,repr,infra
+dhruv0811 server,runner,harnesses,repr,infra,tui
 fanzeyi server,runner,harnesses,repr
 PattaraS server,runner,harnesses,infra
-SabhyaC26 server,runner,harnesses,repr
-TomeHirata server,runner,harnesses,policies,infra
+SabhyaC26 server,runner,harnesses,repr,tui
+TomeHirata server,runner,harnesses,policies,infra,tui
 serena-ruan server,runner,harnesses,web-ui,infra
 hzub web-ui

--- a/.github/ISSUE_ASSIGNEES
+++ b/.github/ISSUE_ASSIGNEES
@@ -13,7 +13,7 @@
 bbqiu server,runner,harnesses,repr
 daniellok-db server,runner,harnesses,web-ui
 dhruv0811 server,runner,harnesses,repr,infra,tui
-fanzeyi server,runner,harnesses,repr
+fanzeyi server,runner,harnesses,repr,tui
 PattaraS server,runner,harnesses,infra
 SabhyaC26 server,runner,harnesses,repr,tui
 TomeHirata server,runner,harnesses,policies,infra,tui

--- a/.github/triage/config.yaml
+++ b/.github/triage/config.yaml
@@ -32,7 +32,7 @@ prompt: |
   ```
   {
     "type": "bug" | "enhancement" | "documentation" | null,
-    "components": ["comp:server" | "comp:runner" | "comp:repr" | "comp:web-ui" | "comp:policies" | "comp:harnesses" | "comp:infra"],
+    "components": ["comp:server" | "comp:runner" | "comp:repr" | "comp:web-ui" | "comp:tui" | "comp:policies" | "comp:harnesses" | "comp:infra"],
     "priority": "P0-critical" | "P1-high" | "P2-medium" | "P3-low" | null,
     "needs_info": true | false,
     "help_wanted": true | false,
@@ -58,6 +58,7 @@ prompt: |
   - `comp:runner` — the agent runner, execution engine
   - `comp:repr` — serialization, representation layer
   - `comp:web-ui` — the web frontend (ap-web)
+  - `comp:tui` — the terminal UI, REPL, and CLI
   - `comp:policies` — safety policies, guardrails
   - `comp:harnesses` — SDK harnesses (Claude, Cursor, Antigravity, etc.)
   - `comp:infra` — CI/CD, GitHub Actions workflows, Docker, deployment, packaging

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -356,7 +356,7 @@ jobs:
           ALLOWED_TYPES = {"bug", "enhancement", "documentation"}
           ALLOWED_COMPONENTS = {
               "comp:server", "comp:runner", "comp:repr",
-              "comp:web-ui", "comp:policies", "comp:harnesses", "comp:infra",
+              "comp:web-ui", "comp:tui", "comp:policies", "comp:harnesses", "comp:infra",
           }
           ALLOWED_PRIORITIES = {"P0-critical", "P1-high", "P2-medium", "P3-low"}
 


### PR DESCRIPTION
## What

Wires the **`comp:tui`** label (terminal UI / REPL / CLI — the peer to `comp:web-ui`) into the issue-triage automation. The label already exists on the repo, but the triage bot couldn't apply it and the `tui` domain had no owners, so terminal/CLI issues were uncategorized and never auto-assigned.

## Changes

| File | Change |
| --- | --- |
| `.github/triage/config.yaml` | Add `comp:tui` to the classifier's component **enum** and its **descriptions** ("the terminal UI, REPL, and CLI") so the bot can choose it. |
| `.github/workflows/issue-triage.yml` | Add `comp:tui` to `ALLOWED_COMPONENTS` so the validated label is actually applied. |
| `.github/ISSUE_ASSIGNEES` | Give the `tui` domain to `SabhyaC26`, `dhruv0811`, `TomeHirata`, and `fanzeyi`. |

## Why these owners

`SabhyaC26`, `dhruv0811`, and `TomeHirata` are the top contributors to the terminal surface (`omnigent/repl` + `cli.py`): 27, 21, and 8 commits respectively. `fanzeyi` (Zeyi "Rice" Fan) added at maintainer request. **Please confirm or adjust.**

## Verification

- YAML lints clean (workflow + triage config).
- Reproduced the workflow's own roster-parse + assignment logic: a `comp:tui` P0/P1 issue routes deterministically across the 4 owners (`issue_number % 4`).
- `comp:tui` confirmed present in the classifier enum, descriptions, and `ALLOWED_COMPONENTS`.

No label creation needed (`comp:tui` already exists). No existing issues are relabeled by this PR.