### PR TITLE
feat(sandbox): add Declaw sandbox provider with full security-policy support

### DIFF
--- a/deploy/declaw/README.md
+++ b/deploy/declaw/README.md
@@ -1,0 +1,252 @@
+# Omnigent on Declaw
+
+[Declaw](https://declaw.ai) runs Omnigent hosts in secure cloud microVMs,
+two ways:
+
+- **CLI-launched**: `omnigent sandbox create` / `connect` provisions a
+  sandbox from your terminal, ships your local checkout into it, and
+  registers it as a host with your server.
+- **Server-managed**: the server provisions a sandbox automatically when a
+  session is created with `"host_type": "managed"` and terminates it when
+  the session is deleted.
+
+What sets Declaw apart from the other sandbox providers is that it is not
+just compute — it is a **security plane**. Every sandbox can be wrapped in a
+policy that redacts PII, defends against prompt injection, enforces a network
+egress allow/deny list, injects credentials from a vault (so secret values
+never enter the VM), applies custom OPA governance, and audits activity.
+That policy is configured entirely through Declaw's own config surface
+(below); Omnigent's local sandbox layer is not involved.
+
+> [!IMPORTANT]
+> **Declaw boots from a named *template*, not a registry image.** Like the
+> E2B launcher — and unlike Modal / Daytona / CoreWeave, which pull
+> `ghcr.io/omnigent-ai/omnigent-host` directly — Declaw starts a sandbox
+> from a template you build ahead of time (a one-time step, below). The
+> launcher's `template` field names *that template's alias*, not a
+> `ghcr.io/...` reference. This directory is **not** a server deploy target.
+
+## Prerequisites
+
+```bash
+pip install 'omnigent[declaw]'   # installs the declaw SDK extra
+```
+
+Create an API key in the [Declaw dashboard](https://declaw.ai) and make it
+available where the launcher runs — your shell for the CLI flow, the
+**server** process for managed sandboxes:
+
+```bash
+export DECLAW_API_KEY=declaw_…
+export DECLAW_DOMAIN=…           # optional; only for non-default deployments
+```
+
+## Build the host template (one time)
+
+Declaw builds a template from a Dockerfile. The Omnigent host image already
+bakes the full omnigent install plus git / tmux / curl, so the template
+Dockerfile layers nothing on top of the published image. Build it once and
+give it the alias `omnigent-host` (the default the launcher looks for):
+
+```python
+from declaw import Template, TemplateBase
+
+Template.build(
+    TemplateBase().from_dockerfile(
+        "FROM ghcr.io/omnigent-ai/omnigent-host:latest\n"
+    ),
+    alias="omnigent-host",
+)
+```
+
+`omnigent-host` is the default template alias the launcher resolves
+([`DEFAULT_DECLAW_TEMPLATE`](../../omnigent/onboarding/sandboxes/declaw.py)),
+so a deployment that uses that alias needs no further config. Use a different
+alias (or pin a `:sha-<short>` host image) and point the launcher at it with
+`sandbox.declaw.template` / `OMNIGENT_DECLAW_TEMPLATE`.
+
+To run your own host image, build the `host` target of
+[`deploy/docker/Dockerfile`](../docker/Dockerfile) (`--platform
+linux/amd64`), push it somewhere Declaw can pull from, and `FROM` that ref in
+the template Dockerfile instead. Rebuild the template whenever the host image
+changes (the CLI flow still overlays your *local* wheels on top per-sandbox,
+so day-to-day code changes don't need a template rebuild).
+
+## CLI-launched sandboxes
+
+Provision a sandbox and ship your local checkout into it:
+
+```bash
+omnigent sandbox create --provider declaw
+```
+
+This starts a sandbox from the `omnigent-host` template, builds wheels from
+your local checkout, and overlays them on top — so the sandbox runs *your*
+code. Then register it as a host with your server:
+
+```bash
+omnigent sandbox connect --provider declaw \
+  --sandbox-id <id-printed-by-create> \
+  --server https://your-host
+```
+
+`connect` runs `omnigent host` inside the sandbox and holds the connection
+open in your terminal — Ctrl-C detaches.
+
+> [!NOTE]
+> Declaw has no local→sandbox port forward, so the interactive in-sandbox App
+> OAuth step is skipped automatically (as on E2B / Modal / Daytona): use
+> Declaw with servers that don't require in-sandbox App auth, or authenticate
+> via injected credentials (below).
+
+To inject LLM/git credentials into a CLI-launched sandbox, set
+`OMNIGENT_DECLAW_SANDBOX_ENV` in your shell to a comma-separated list of
+variable names (e.g. `ANTHROPIC_API_KEY,GIT_TOKEN`) before running `create`.
+The default security posture is set with `OMNIGENT_DECLAW_SECURITY_MODE`
+(one of `strict` / `balanced` / `permissive` / `agentic-tool` /
+`data-egress-sensitive`; default `balanced`).
+
+## Server-managed sandboxes
+
+Add a `sandbox:` section to the server config (`omnigent server -c
+config.yaml`, or `<data_dir>/config.yaml`):
+
+```yaml
+sandbox:
+  provider: declaw
+  server_url: https://your-host    # public URL sandboxes dial back to
+```
+
+`server_url` must be reachable from Declaw's cloud — a public HTTPS URL, not
+`localhost`. Sessions created with `host_type: "managed"` then run on a fresh
+Declaw sandbox; the create returns immediately and provisioning happens in
+the background (including repository workspaces, the first-message
+rendezvous, and dead-sandbox relaunch).
+
+Optional `declaw:` settings:
+
+```yaml
+sandbox:
+  provider: declaw
+  server_url: https://your-host
+  declaw:
+    template: omnigent-host                 # template alias (default: omnigent-host)
+    env: [OPENAI_API_KEY, ANTHROPIC_API_KEY, GIT_TOKEN]
+    vault_refs:                             # see "Credentials" below
+      OPENAI_API_KEY: openai-prod
+    security:                               # see "Security policy" below
+      mode: balanced
+```
+
+## Security policy
+
+This is Declaw's distinguishing feature. Configure it under
+`sandbox.declaw.security`.
+
+**Secure-by-default.** Omit the `security` block entirely and every managed
+sandbox still gets a *balanced* policy: PII is redacted on egress, audit is
+on, and the injection-defense cascade is configured but scans no domains yet
+(injection scanning is opt-in per domain), so it never interferes with the
+agent's own model endpoint. Dial it up only when you need to.
+
+**Curated knobs.** The common controls are surfaced as named fields:
+
+```yaml
+sandbox:
+  provider: declaw
+  server_url: https://your-host
+  declaw:
+    security:
+      mode: balanced                      # injection posture: strict / balanced /
+                                          #   permissive / agentic-tool / data-egress-sensitive
+      agent_policy: >                      # what this agent may legitimately do; sharpens
+        Summarize fetched docs; never      #   the injection judge's task-vs-attack calls
+        exfiltrate repository secrets.
+      governance_pack: owasp-llm-top10     # an OPA governance pack to enforce
+      pii:
+        enabled: true
+        action: redact                     # redact / block / log_only
+      injection_defense:
+        enabled: true
+        action: block
+        domains: ["api.github.com"]        # opt-in: only these hosts are scanned
+      network:
+        allow: ["api.github.com", "*.pypi.org"]
+        deny: ["169.254.169.254"]          # e.g. block cloud metadata
+      audit:
+        enabled: true
+```
+
+**Escape hatch.** Anything not surfaced as a named knob is reachable through
+the raw custom-policy fields, so you are never limited to the curated set:
+
+```yaml
+    security:
+      policy_ref: "my-org-pack@v2"          # a published/bundled OPA policy
+      # — or inline Rego —
+      inline_rego: |
+        deny_command contains msg if {
+          input.action.command in {"curl", "wget"}
+          msg := "no ad-hoc network tools"
+        }
+```
+
+Fields you omit from a `security` block take Declaw's defaults (audit on,
+the rest off) — so omit the **whole** block for the balanced secure-by-default
+policy, and add a block when you want to drive specific controls.
+
+## Credentials for the sandbox (LLM keys, git tokens)
+
+Two mechanisms, usable together:
+
+- **`sandbox.declaw.env`** lists the **names** of variables to copy from the
+  **server's own environment** into every sandbox at provision time (passed
+  to `Sandbox.create(envs=…)`). Values never live in the config file — set
+  them where the server runs. A listed name that is not set in the server's
+  environment fails the launch loudly.
+
+  ```bash
+  export OPENAI_API_KEY=sk-…        # on the server
+  export GIT_TOKEN=github_pat_…     # private-repo clone/fetch/push
+  ```
+
+- **`sandbox.declaw.vault_refs`** maps an in-sandbox env var name to a secret
+  stored in the Declaw vault. The secret value is resolved by Declaw at
+  provision and **never enters the config file or the VM image** — the
+  Declaw-native, higher-assurance alternative to plaintext env passthrough.
+  Store the secret in the vault first, then reference it by name:
+
+  ```yaml
+  declaw:
+    vault_refs:
+      OPENAI_API_KEY: openai-prod      # ENV_VAR_NAME: vault-secret-name
+      GIT_TOKEN: github-bot
+  ```
+
+Managed launches never need credentials for the dial-back itself — the server
+injects a per-launch host token automatically.
+
+## Environment variable reference
+
+| Variable | Where it's read | Purpose |
+|---|---|---|
+| `DECLAW_API_KEY` | CLI machine / server | Declaw API credentials (required) |
+| `DECLAW_DOMAIN` | CLI machine / server | Declaw domain override (optional) |
+| `OMNIGENT_DECLAW_TEMPLATE` | CLI machine / server | Template alias to provision from (`sandbox.declaw.template` takes precedence; default `omnigent-host`) |
+| `OMNIGENT_DECLAW_SANDBOX_ENV` | CLI machine / server | Comma-separated env var names to inject (`sandbox.declaw.env` takes precedence for managed) |
+| `OMNIGENT_DECLAW_MAX_LIFETIME_S` | CLI machine / server | Requested sandbox lifetime in seconds (default 24 h) |
+| `OMNIGENT_DECLAW_SECURITY_MODE` | CLI machine | Secure-by-default injection posture for the CLI path (default `balanced`) |
+
+## Troubleshooting
+
+- **"Declaw sandbox creation failed: template '…' is unavailable"** — the host
+  image was never built into a Declaw template, or the alias doesn't match.
+  Run the [template build](#build-the-host-template-one-time) with alias
+  `omnigent-host` (or set `sandbox.declaw.template` to your alias).
+- **"managed host did not come online"** — the sandbox couldn't dial back to
+  `server_url`. Confirm it's a public HTTPS URL reachable from Declaw's cloud
+  (not `localhost`), and check the sandbox's host log.
+- **The agent's own model calls are being blocked** — an injection `domains`
+  entry is scanning your model endpoint. Injection scanning is opt-in per
+  domain; list only the untrusted hosts you want scanned, not the agent's
+  model endpoint.

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -67,6 +67,11 @@ _LAUNCHERS: dict[str, str] = {
     # `omnigent[e2b]` extra), imported lazily like modal/daytona.
     "e2b": "omnigent.onboarding.sandboxes.e2b:E2BSandboxLauncher",
     "openshell": "omnigent.onboarding.sandboxes.openshell:OpenShellSandboxLauncher",
+    # Declaw (https://declaw.ai) secure microVM sandboxes via the official
+    # `declaw` SDK (the `omnigent[declaw]` extra), imported lazily like the
+    # others. The only provider that attaches a security policy (PII /
+    # injection / network / vault / governance) at provision time.
+    "declaw": "omnigent.onboarding.sandboxes.declaw:DeclawSandboxLauncher",
 }
 
 

--- a/omnigent/onboarding/sandboxes/declaw.py
+++ b/omnigent/onboarding/sandboxes/declaw.py
@@ -1,0 +1,739 @@
+"""
+Declaw sandbox launcher.
+
+Implements :class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher`
+for `Declaw <https://declaw.ai>`_ secure microVM sandboxes on top of the
+official ``declaw`` Python SDK. Same posture as the E2B / Modal / Daytona
+/ CoreWeave launchers: the SDK is an optional dependency (``pip install
+'omnigent[declaw]'``) imported lazily, so the provider can be listed and
+the module probed without it.
+
+Supports both server-managed hosts (``host_type="managed"`` sessions) and
+the CLI bootstrap flow. The one unsupported primitive is
+``forward_local_port``: Declaw has no local→sandbox path, so the App OAuth
+flow doesn't apply — managed hosts authenticate with a server-minted
+launch token instead (same posture as E2B / CoreWeave).
+
+What sets this launcher apart from every other provider is that Declaw is
+not just compute — it is a **security plane**. :meth:`provision` attaches a
+Declaw ``SecurityPolicy`` (PII redaction, prompt-injection defense, network
+egress policy, credential vault, governance/OPA custom policy, audit) to the
+sandbox. That policy is built entirely from Declaw's own SDK config classes
+(:meth:`_build_security_policy`); Omnigent's local sandbox policy layer
+(``omnigent.inner``) is not involved.
+
+Notes that shape this launcher:
+
+- **Templates, not registry images.** Like E2B, Declaw boots from a named
+  *template* baked ahead of time, not an arbitrary ``ghcr.io/...`` image.
+  The Omnigent host image must be built into a Declaw template out-of-band
+  (see ``deploy/declaw/README.md``); :data:`DEFAULT_DECLAW_TEMPLATE` names
+  it. The wheel-overlay path (:meth:`wheel_install_command`) still applies
+  because the template is built FROM the prebaked host image.
+- **Secure-by-default.** With no ``security`` config, the sandbox gets a
+  *balanced* policy: PII redaction + audit on, the injection cascade
+  configured but scanning no domains yet (opt-in per domain), so it never
+  blocks the agent's own model endpoint. Operators dial it up via the
+  ``sandbox.declaw.security`` block (managed) or
+  :data:`SECURITY_MODE_ENV_VAR` (CLI).
+- **API-key auth.** ``DECLAW_API_KEY`` (and optional ``DECLAW_DOMAIN``) are
+  read from the CLI/server process environment by the SDK, 12-factor — like
+  the other providers' keys.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import shlex
+import threading
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import click
+
+from omnigent.inner import ui
+from omnigent.onboarding.sandboxes.base import (
+    RemoteCommandResult,
+    RemoteProcess,
+    SandboxLauncher,
+    host_image_wheel_install_command,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from declaw import Sandbox, SecurityPolicy
+    from declaw.sandbox_sync.commands.commands import Commands
+
+
+# ── Constants ──────────────────────────────────────────
+
+API_KEY_ENV_VAR: str = "DECLAW_API_KEY"
+"""Declaw API key, read from the CLI/server process environment by the SDK.
+An optional ``DECLAW_DOMAIN`` is read by the SDK the same way (12-factor)."""
+
+TEMPLATE_ENV_VAR: str = "OMNIGENT_DECLAW_TEMPLATE"
+"""Environment variable overriding :data:`DEFAULT_DECLAW_TEMPLATE` — the
+NAME of the Declaw template the Omnigent host image was built into (see
+``deploy/declaw/README.md``). NOT a registry image reference."""
+
+DEFAULT_DECLAW_TEMPLATE: str = "omnigent-host"
+"""Default Declaw template name — matches the ``--name`` the
+``deploy/declaw/README.md`` walkthrough builds the host template with."""
+
+SANDBOX_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_DECLAW_SANDBOX_ENV"
+"""Comma-separated server-process environment variable NAMES whose values
+are injected into every sandbox this launcher creates — typically the
+harness LLM credentials (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, …) and
+``GIT_TOKEN``. Names, not values: the values are read from the server's own
+environment at provision time, so secrets never live in config files. The
+server's managed-host config (``sandbox.declaw.env``) takes precedence when
+set. For secrets that must never enter the VM at all, use Declaw vault refs
+(``sandbox.declaw.vault_refs``) instead."""
+
+MAX_LIFETIME_ENV_VAR: str = "OMNIGENT_DECLAW_MAX_LIFETIME_S"
+"""Environment variable overriding the requested sandbox lifetime in
+seconds (default :data:`_DEFAULT_MAX_LIFETIME_S`, 24 h). Declaw caps the
+lifetime per tier; set this to your tier's maximum for long-lived hosts."""
+
+SECURITY_MODE_ENV_VAR: str = "OMNIGENT_DECLAW_SECURITY_MODE"
+"""Environment variable selecting the secure-by-default injection posture
+for the CLI bootstrap path (where there is no ``sandbox.declaw.security``
+block). One of ``strict`` / ``balanced`` / ``permissive`` / ``agentic-tool``
+/ ``data-egress-sensitive``. Default :data:`_DEFAULT_SECURITY_MODE`."""
+
+_DEFAULT_MAX_LIFETIME_S: int = 24 * 60 * 60
+# Token TTL slack: the managed launch token must outlive the sandbox so a
+# live sandbox can re-authenticate its tunnel across reconnects.
+_TOKEN_TTL_SLACK_S: int = 3600
+# Foreground-command cap. Declaw's commands.run defaults to 60 s; a wheel
+# install or git clone must not be killed mid-run, so run() raises it. The
+# managed `omnigent host` is detached via run_background (setsid nohup) and
+# is not bound by this.
+_RUN_TIMEOUT_S: int = 30 * 60
+_DEFAULT_SECURITY_MODE: str = "balanced"
+# The set of accepted `security` keys (mode / governance_pack / pii /
+# injection_defense / network / audit / … / policy_ref / inline_rego) is
+# validated structurally in server/managed_hosts.py; the launcher maps
+# whatever it receives, so it stays lenient here.
+
+
+def resolve_max_lifetime_s() -> int:
+    """
+    Resolve the requested sandbox lifetime in seconds.
+
+    :data:`MAX_LIFETIME_ENV_VAR` overrides the 24 h default.
+
+    :returns: The lifetime to request at sandbox creation.
+    :raises click.ClickException: When the env override is not a number.
+    """
+    raw = os.environ.get(MAX_LIFETIME_ENV_VAR)
+    if raw is None:
+        return _DEFAULT_MAX_LIFETIME_S
+    try:
+        return int(float(raw))
+    except ValueError as exc:
+        raise click.ClickException(f"{MAX_LIFETIME_ENV_VAR} must be a number of seconds") from exc
+
+
+def managed_token_ttl_s() -> int:
+    """
+    Launch-token TTL for the managed path, derived from (and always above)
+    the sandbox lifetime so the token outlives the sandbox across tunnel
+    reconnects.
+
+    :returns: The token lifetime in seconds.
+    """
+    return resolve_max_lifetime_s() + _TOKEN_TTL_SLACK_S
+
+
+def _ensure_sdk() -> None:
+    """
+    Verify the Declaw SDK is importable, with an install hint when not.
+
+    Called at the top of every launcher entry point because the SDK is an
+    optional dependency — the base ``omnigent`` install does not pull it in.
+
+    :raises click.ClickException: When the ``declaw`` package is not installed.
+    """
+    try:
+        import declaw  # noqa: F401  # presence probe only
+    except ImportError as exc:
+        raise click.ClickException(
+            "The Declaw SDK is required for the 'declaw' sandbox provider. "
+            "Install it with `pip install 'omnigent[declaw]'`, then set "
+            "DECLAW_API_KEY (and optionally DECLAW_DOMAIN)."
+        ) from exc
+
+
+def _echo_lines(stream: str, *, err: bool = False) -> None:
+    """
+    Echo a captured remote output stream line-by-line, dropping
+    pure-whitespace lines.
+
+    :param stream: Captured stdout or stderr from a remote command.
+    :param err: When ``True``, write to stderr.
+    """
+    for line in stream.splitlines():
+        if line.strip():
+            click.echo(line, err=err)
+
+
+def _as_mapping(value: object) -> dict[str, Any]:
+    """Return *value* as a plain dict when it is a mapping, else ``{}``."""
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _normalize_network(value: object) -> dict[str, Any]:
+    """
+    Normalize a ``security.network`` block to Declaw's ``NetworkPolicy`` shape.
+
+    Accepts the ergonomic ``allow`` / ``deny`` aliases (matching the
+    documented config) and maps them to Declaw's ``allow_out`` / ``deny_out``.
+    """
+    out = _as_mapping(value)
+    if "allow" in out and "allow_out" not in out:
+        out["allow_out"] = out.pop("allow")
+    if "deny" in out and "deny_out" not in out:
+        out["deny_out"] = out.pop("deny")
+    return out
+
+
+class _DeclawRemoteProcess(RemoteProcess):
+    """
+    Thread-backed :class:`RemoteProcess` over a Declaw streaming command.
+
+    Declaw's real-time output rides ``commands.run_stream`` (SSE), which
+    blocks the calling thread until the process exits while invoking
+    ``on_stdout`` / ``on_stderr`` per line. A worker thread drives it with
+    both callbacks feeding one queue — the queue is the combined-output
+    stream the :class:`RemoteProcess` contract wants.
+    """
+
+    def __init__(self, commands: Commands, command: str) -> None:
+        """
+        Wrap a streaming command.
+
+        :param commands: The sandbox's ``commands`` module.
+        :param command: Shell command to stream (already ``bash -lc`` wrapped).
+        """
+        self._commands = commands
+        self._command = command
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._returncode: int | None = None
+        self._error: BaseException | None = None
+        # Materialize the iterator once so repeated `lines` reads resume the
+        # same stream (the RemoteProcess contract).
+        self._line_iter: Iterator[str] = self._iter_lines()
+        self._thread = threading.Thread(
+            target=self._run, name="declaw-remote-process", daemon=True
+        )
+        self._thread.start()
+
+    @property
+    def lines(self) -> Iterator[str]:
+        """Iterator over the command's combined output lines (stable object)."""
+        return self._line_iter
+
+    def wait(self) -> int:
+        """
+        Block until the command finishes and return its exit code.
+
+        :returns: The command's exit code.
+        :raises click.ClickException: When the command failed to run at the
+            transport level.
+        """
+        self._thread.join()
+        if self._error is not None:
+            raise click.ClickException(str(self._error)) from self._error
+        return self._returncode if self._returncode is not None else 1
+
+    def close(self) -> None:
+        """
+        Best-effort teardown.
+
+        DEVIATION from the base contract: Declaw's real-time stream
+        (``run_stream`` over SSE) exposes no remote pid, so a still-running
+        process cannot be force-killed from here — it is reaped when the
+        sandbox is terminated. Unreachable for the App-OAuth flow (gated off
+        for Declaw via ``supports_local_port_forward=False``); for
+        :meth:`exec_foreground` (CLI connect) the user's Ctrl-C abandons the
+        daemon thread and the remote host stops with the sandbox. Mirrors the
+        CoreWeave launcher's documented deviation.
+        """
+
+    def _run(self) -> None:
+        """Drive the stream to completion, feeding output into the queue."""
+        try:
+            # timeout = the sandbox lifetime so a long-lived `omnigent host`
+            # isn't cut by the SDK's default 60 s per-command read timeout.
+            result = self._commands.run_stream(
+                self._command,
+                on_stdout=self._enqueue,
+                on_stderr=self._enqueue,
+                timeout=resolve_max_lifetime_s(),
+            )
+            self._returncode = result.exit_code
+        # Catch Exception (not BaseException) so KeyboardInterrupt/SystemExit
+        # still propagate; transport errors are surfaced through wait().
+        except Exception as exc:
+            self._error = exc
+        finally:
+            self._lines.put(None)
+
+    def _iter_lines(self) -> Iterator[str]:
+        """Yield queued output lines until the terminating sentinel."""
+        while True:
+            item = self._lines.get()
+            if item is None:
+                return
+            yield item
+
+    def _enqueue(self, text: str) -> None:
+        """Split a callback chunk into newline-terminated lines and queue them."""
+        for line in text.splitlines(keepends=True):
+            self._lines.put(line)
+        if text and not text.endswith(("\n", "\r")):
+            self._lines.put("\n")
+
+
+class DeclawSandboxLauncher(SandboxLauncher):
+    """
+    :class:`SandboxLauncher` for Declaw sandboxes, over the ``declaw`` SDK.
+
+    All transport rides the SDK: ``Sandbox.create`` / ``connect`` / ``kill``
+    for lifecycle, ``sandbox.commands.run`` for commands (a ``bash -lc``
+    wrap applies login PATH), ``sandbox.files.write`` for file shipping, and
+    ``commands.run_stream`` for the foreground attach. Handles are cached per
+    sandbox id to avoid a server round-trip on every primitive.
+    """
+
+    provider: ClassVar[str] = "declaw"
+    # Declaw exposes no local→sandbox path; managed hosts authenticate with
+    # the server-minted launch token instead of the App OAuth callback.
+    supports_local_port_forward: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        *,
+        template: str | None = None,
+        env: Sequence[str] | None = None,
+        security: Mapping[str, Any] | None = None,
+        vault_refs: Mapping[str, str] | None = None,
+    ) -> None:
+        """
+        Initialize the launcher.
+
+        :param template: Optional Declaw template NAME to provision sandboxes
+            from — the server's ``sandbox.declaw.template`` config. ``None``
+            resolves :data:`TEMPLATE_ENV_VAR` then :data:`DEFAULT_DECLAW_TEMPLATE`.
+        :param env: Optional names of server-process environment variables to
+            inject into every sandbox — the server's ``sandbox.declaw.env``
+            config. ``None`` resolves :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR`.
+        :param security: Optional Declaw security config (``sandbox.declaw.
+            security``) — a mapping of curated knobs (``mode``,
+            ``governance_pack``, ``pii``, ``injection_defense``, ``network``,
+            ``audit``, …) plus a ``policy_ref`` / ``inline_rego`` escape hatch.
+            ``None``/empty → the balanced secure-by-default policy.
+        :param vault_refs: Optional Declaw vault references
+            (``sandbox.declaw.vault_refs``) mapping an in-sandbox env var name
+            to a stored vault secret name — the secret value never enters the
+            VM. Used for harness LLM credentials (the Declaw-native alternative
+            to plaintext ``env`` passthrough).
+        """
+        self._template_ref = template
+        self._env_names = tuple(env) if env is not None else None
+        self._security = dict(security) if security else None
+        self._vault_refs = dict(vault_refs) if vault_refs else None
+        self._sandboxes: dict[str, Sandbox] = {}
+
+    # ── helpers ────────────────────────────────────────
+
+    def _resolved_template(self) -> str:
+        """Resolve the template name: constructor > env > default."""
+        return self._template_ref or os.environ.get(TEMPLATE_ENV_VAR) or DEFAULT_DECLAW_TEMPLATE
+
+    def _resolve(self, sandbox_id: str) -> Sandbox:
+        """
+        Return the cached handle for *sandbox_id*, connecting on first use.
+
+        :raises click.ClickException: When the SDK is not installed or the
+            sandbox does not exist (e.g. killed or aged past its lifetime).
+        """
+        _ensure_sdk()
+        from declaw import Sandbox
+        from declaw.exceptions import NotFoundException
+
+        handle = self._sandboxes.get(sandbox_id)
+        if handle is None:
+            try:
+                handle = Sandbox.connect(sandbox_id)
+            except NotFoundException as exc:
+                raise click.ClickException(
+                    f"Declaw sandbox '{sandbox_id}' not found — it may have been "
+                    "killed or passed its lifetime. Managed sessions provision a "
+                    "replacement on the next message; for a CLI host create a fresh "
+                    "one with `omnigent sandbox create --provider declaw`."
+                ) from exc
+            self._sandboxes[sandbox_id] = handle
+        return handle
+
+    def _resolve_sandbox_env(self) -> dict[str, str]:
+        """
+        Resolve the env vars to inject into created sandboxes.
+
+        Explicit constructor names win; otherwise
+        :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR` (comma-separated) applies.
+        Values come from the server's own environment — a configured name
+        that is unset there fails loud.
+
+        :returns: Name → value mapping for ``Sandbox.create(envs=…)``.
+        :raises click.ClickException: When a configured name is not set in the
+            server process environment.
+        """
+        if self._env_names is not None:
+            names: Sequence[str] = self._env_names
+        else:
+            names = [
+                name.strip()
+                for name in os.environ.get(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+                if name.strip()
+            ]
+        resolved: dict[str, str] = {}
+        for name in names:
+            value = os.environ.get(name)
+            if value is None:
+                raise click.ClickException(
+                    f"sandbox env passthrough names '{name}' but it is not set in the "
+                    "server's environment — set it (or remove it from "
+                    f"sandbox.declaw.env / {SANDBOX_ENV_PASSTHROUGH_ENV_VAR})."
+                )
+            resolved[name] = value
+        return resolved
+
+    def _build_security_policy(self) -> SecurityPolicy:
+        """
+        Build the Declaw ``SecurityPolicy`` for created sandboxes.
+
+        With no config (``self._security`` empty), returns the balanced
+        secure-by-default policy: PII redaction + audit on, the injection
+        cascade configured but scanning no domains (so it never blocks the
+        agent's own model endpoint). The CLI path can pick the posture via
+        :data:`SECURITY_MODE_ENV_VAR`.
+
+        With a config mapping, maps the curated knobs to Declaw's own config
+        classes — ``mode`` enables the full injection cascade, the rest layer
+        on declaw-shaped sub-blocks, and ``governance_pack`` / ``policy_ref`` /
+        ``inline_rego`` drive the OPA custom policy (the escape hatch). Fields
+        omitted from the block take Declaw's defaults (so omit the whole block
+        for the balanced default).
+        """
+        from declaw import (
+            AuditConfig,
+            CodeSecurityConfig,
+            ContentGateConfig,
+            CustomPolicyConfig,
+            InjectionDefenseConfig,
+            NetworkPolicy,
+            PIIConfig,
+            SecurityPolicy,
+            ToxicityConfig,
+        )
+
+        if not self._security:
+            mode = os.environ.get(SECURITY_MODE_ENV_VAR, _DEFAULT_SECURITY_MODE)
+            policy = SecurityPolicy.full_injection_defense(mode=mode)
+            policy.pii = PIIConfig(enabled=True, action="redact")
+            return policy
+
+        sec = dict(self._security)
+        mode = sec.pop("mode", None)
+        agent_policy = sec.pop("agent_policy", None)
+        governance_pack = sec.pop("governance_pack", None)
+        policy_ref = sec.pop("policy_ref", None)
+        inline_rego = sec.pop("inline_rego", None)
+        inline_modules = sec.pop("inline_modules", None)
+        inj_dict = _as_mapping(sec.get("injection_defense"))
+
+        if mode:
+            judge = inj_dict.get("judge")
+            judge_policy = judge.get("policy") if isinstance(judge, Mapping) else None
+            policy = SecurityPolicy.full_injection_defense(
+                mode=mode,
+                agent_policy=agent_policy or judge_policy,
+                action=inj_dict.get("action", "block"),
+                domains=inj_dict.get("domains"),
+                threshold=inj_dict.get("threshold", 0.95),
+            )
+        else:
+            policy = SecurityPolicy()
+
+        if "pii" in sec:
+            policy.pii = PIIConfig.from_dict(_as_mapping(sec["pii"]))
+        if "injection_defense" in sec and not mode:
+            policy.injection_defense = InjectionDefenseConfig.from_dict(inj_dict)
+        if "network" in sec:
+            policy.network = NetworkPolicy.from_dict(_normalize_network(sec["network"]))
+        if "audit" in sec:
+            audit = sec["audit"]
+            policy.audit = (
+                AuditConfig.from_dict(audit) if isinstance(audit, Mapping) else bool(audit)
+            )
+        if "toxicity" in sec:
+            policy.toxicity = ToxicityConfig.from_dict(_as_mapping(sec["toxicity"]))
+        if "code_security" in sec:
+            policy.code_security = CodeSecurityConfig.from_dict(_as_mapping(sec["code_security"]))
+        if "content_gate" in sec:
+            policy.content_gate = ContentGateConfig.from_dict(_as_mapping(sec["content_gate"]))
+
+        if governance_pack or policy_ref or inline_rego or inline_modules:
+            custom = policy.custom_policy or CustomPolicyConfig()
+            custom.enabled = True
+            ref = policy_ref or governance_pack
+            if ref:
+                custom.policy_ref = ref
+            if inline_rego:
+                custom.inline_rego = inline_rego
+            if inline_modules:
+                custom.inline_modules = list(inline_modules)
+            policy.custom_policy = custom
+
+        return policy
+
+    def _template_build_hint(self, template: str, exc: Exception) -> click.ClickException:
+        """Build the error pointing the operator at the Declaw template build step."""
+        return click.ClickException(
+            f"Declaw sandbox creation failed: template '{template}' is unavailable. "
+            "Build the Omnigent host image into a Declaw template first (see "
+            "deploy/declaw/README.md), or set the correct template via "
+            f"sandbox.declaw.template / {TEMPLATE_ENV_VAR}. ({exc})"
+        )
+
+    # ── lifecycle ──────────────────────────────────────
+
+    def prepare(self) -> None:
+        """
+        Local preflight: the Declaw SDK must be installed and an API key set.
+
+        :raises click.ClickException: When the SDK is missing or
+            ``DECLAW_API_KEY`` is not set.
+        """
+        _ensure_sdk()
+        if not os.environ.get(API_KEY_ENV_VAR):
+            raise click.ClickException(
+                "No Declaw credentials found — set DECLAW_API_KEY (and optionally "
+                "DECLAW_DOMAIN). Create a key in the Declaw dashboard."
+            )
+
+    def provision(self, name: str) -> str:
+        """
+        Create a new Declaw sandbox from the host template, wrapped in the
+        resolved ``SecurityPolicy``.
+
+        :param name: Human-readable label, recorded as sandbox metadata; the
+            returned id is the canonical reference.
+        :returns: The Declaw sandbox id.
+        :raises click.ClickException: If provisioning fails (including a
+            template that has not been built yet).
+        """
+        _ensure_sdk()
+        from declaw import Sandbox
+        from declaw.exceptions import (
+            AuthenticationException,
+            NotFoundException,
+            SandboxException,
+            TemplateException,
+        )
+
+        template = self._resolved_template()
+        lifetime = resolve_max_lifetime_s()
+        env_vars = self._resolve_sandbox_env()
+        policy = self._build_security_policy()
+        click.echo(f"▸ Creating Declaw sandbox '{name}' from template '{template}'")
+        try:
+            sandbox = Sandbox.create(
+                template=template,
+                timeout=lifetime,
+                metadata={"omnigent-name": name},
+                envs=env_vars or None,
+                vault_refs=self._vault_refs or None,
+                security=policy,
+                allow_internet_access=True,
+            )
+        except AuthenticationException as exc:
+            raise click.ClickException(
+                f"Declaw authentication failed — check DECLAW_API_KEY. ({exc})"
+            ) from exc
+        except (TemplateException, NotFoundException) as exc:
+            raise self._template_build_hint(template, exc) from exc
+        except SandboxException as exc:
+            raise click.ClickException(f"Declaw sandbox creation failed: {exc}") from exc
+        sandbox_id: str = sandbox.sandbox_id
+        self._sandboxes[sandbox_id] = sandbox
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
+
+    def attach(self, sandbox_id: str) -> None:
+        """
+        Validate that an existing sandbox is still running.
+
+        :raises click.ClickException: When the sandbox is missing or stopped.
+        """
+        click.echo(f"▸ Reusing existing Declaw sandbox '{sandbox_id}'")
+        handle = self._resolve(sandbox_id)
+        if not handle.is_running():
+            raise click.ClickException(
+                f"Declaw sandbox '{sandbox_id}' is not running (it may have been "
+                "killed or passed its lifetime). Create a fresh one with "
+                "`omnigent sandbox create --provider declaw`."
+            )
+
+    def keep_alive(self, sandbox_id: str) -> None:
+        """
+        Re-extend the sandbox timeout to the requested lifetime.
+
+        Soft-fail per the launcher contract: a rejected setting warns rather
+        than aborting the bootstrap.
+        """
+        from declaw.exceptions import SandboxException
+
+        lifetime = resolve_max_lifetime_s()
+        handle = self._resolve(sandbox_id)
+        try:
+            handle.set_timeout(lifetime)
+        except SandboxException as exc:
+            ui.console.print(
+                f"  → warning: could not extend the lifetime of '{sandbox_id}' "
+                f"({exc}); the sandbox will stop at its current timeout.",
+                style="omni.warning",
+                markup=False,
+            )
+        else:
+            click.echo(f"  → extended sandbox lifetime to {lifetime // 3600}h")
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        """
+        Run a shell command in the sandbox and capture its output.
+
+        ``bash -lc`` wraps the command so login PATH applies. The per-command
+        timeout is raised to :data:`_RUN_TIMEOUT_S` so installs / clones
+        aren't killed mid-run.
+
+        :raises click.ClickException: If the command could not be executed, or
+            *check* is ``True`` and it exited non-zero.
+        """
+        from declaw.exceptions import SandboxException
+
+        handle = self._resolve(sandbox_id)
+        wrapped = f"bash -lc {shlex.quote(command)}"
+        try:
+            result = handle.commands.run(
+                wrapped, timeout=_RUN_TIMEOUT_S, request_timeout=_RUN_TIMEOUT_S
+            )
+        except SandboxException as exc:
+            raise click.ClickException(
+                f"Remote command failed to execute on sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        _echo_lines(result.stdout)
+        _echo_lines(result.stderr, err=True)
+        if check and result.exit_code != 0:
+            raise click.ClickException(
+                f"Remote command failed on sandbox '{sandbox_id}' "
+                f"(exit {result.exit_code}): {command}"
+            )
+        return RemoteCommandResult(
+            returncode=result.exit_code, stdout=result.stdout, stderr=result.stderr
+        )
+
+    def put(self, sandbox_id: str, local_path: Path, remote_path: str) -> None:
+        """
+        Copy a local file into the sandbox via the SDK's filesystem API.
+
+        :raises click.ClickException: If the transfer fails.
+        """
+        from declaw.exceptions import FileUploadException, SandboxException
+
+        handle = self._resolve(sandbox_id)
+        try:
+            handle.files.write(remote_path, local_path.read_bytes())
+        except (FileUploadException, SandboxException) as exc:
+            raise click.ClickException(
+                f"File upload to sandbox '{sandbox_id}' failed: {exc}"
+            ) from exc
+
+    def stream_exec(self, sandbox_id: str, command: str, *, pty: bool = False) -> RemoteProcess:
+        """
+        Spawn a command in the sandbox and stream its combined output line by
+        line.
+
+        Declaw streams via ``commands.run_stream`` (SSE); the wrapping
+        :class:`_DeclawRemoteProcess` routes stdout + stderr into one queue,
+        so the *pty* flag is unused — the output is already combined.
+
+        :raises click.ClickException: When the command cannot be started.
+        """
+        del pty  # unused (see docstring)
+        handle = self._resolve(sandbox_id)
+        return _DeclawRemoteProcess(handle.commands, f"bash -lc {shlex.quote(command)}")
+
+    def exec_foreground(self, sandbox_id: str, command: str) -> int:
+        """
+        Run *command* in the sandbox, echoing its output to the local terminal
+        until it exits; Ctrl-C detaches.
+
+        ``TERM`` is forced to ``xterm-256color`` (native harnesses spawn tmux,
+        which refuses to start under a dumb/unset TERM). ``exec`` replaces the
+        wrapping shell so the streamed command's own exit code is reported.
+
+        :returns: The remote command's exit code.
+        :raises KeyboardInterrupt: Re-raised after detaching when the user
+            interrupts with Ctrl-C.
+        """
+        process = self.stream_exec(sandbox_id, f"TERM=xterm-256color exec {command}", pty=True)
+        try:
+            for line in process.lines:
+                click.echo(line, nl=False)
+            return process.wait()
+        except KeyboardInterrupt:
+            click.echo(
+                "\n  → detaching; the remote host keeps running until the sandbox is killed"
+            )
+            process.close()
+            raise
+
+    def wheel_install_command(self, remote_tgz_path: str) -> str:
+        """
+        Remote command that overlays the shipped wheels onto the host template
+        — see
+        :func:`~omnigent.onboarding.sandboxes.base.host_image_wheel_install_command`.
+        Applies because the Declaw template is built FROM the prebaked host
+        image.
+        """
+        return host_image_wheel_install_command(remote_tgz_path)
+
+    def terminate(self, sandbox_id: str) -> None:
+        """
+        Kill a sandbox, releasing its compute.
+
+        Idempotent from the caller's perspective: a sandbox that no longer
+        exists is treated as success. Unlike E2B's static kill, Declaw's
+        ``kill`` is an instance method, so terminate connects (or reuses the
+        cached handle) first.
+        """
+        _ensure_sdk()
+        from declaw import Sandbox
+        from declaw.exceptions import NotFoundException, SandboxException
+
+        try:
+            handle = self._sandboxes.get(sandbox_id) or Sandbox.connect(sandbox_id)
+            handle.kill(wait=True)
+        except NotFoundException:
+            pass  # already gone — the desired end state holds
+        except SandboxException as exc:
+            raise click.ClickException(
+                f"Failed to kill Declaw sandbox '{sandbox_id}': {exc}"
+            ) from exc
+        finally:
+            self._sandboxes.pop(sandbox_id, None)

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -136,10 +136,10 @@ _logger = logging.getLogger(__name__)
 # ManagedSandboxConfig directly are not constrained by either set —
 # their launcher factory IS the support.)
 SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
-    {"lakebox", "modal", "daytona", "boxlite", "cwsandbox", "islo", "e2b", "openshell"}
+    {"lakebox", "modal", "daytona", "boxlite", "cwsandbox", "islo", "e2b", "openshell", "declaw"}
 )
 PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
-    {"modal", "daytona", "boxlite", "cwsandbox", "islo", "e2b", "openshell"}
+    {"modal", "daytona", "boxlite", "cwsandbox", "islo", "e2b", "openshell", "declaw"}
 )
 
 # How long a managed launch waits for the sandboxed host to register
@@ -678,6 +678,20 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             cluster=_parse_provider_string(raw, "openshell", "cluster"),
         )
         token_ttl_s = OPENSHELL_MANAGED_TOKEN_TTL_S
+    elif provider == "declaw":
+        from omnigent.onboarding.sandboxes.declaw import managed_token_ttl_s
+
+        section = _declaw_section(raw)
+        launcher_factory = _declaw_launcher_factory(
+            template=_parse_declaw_template(section),
+            env=_parse_declaw_env(section),
+            security=_parse_declaw_security(section),
+            vault_refs=_parse_declaw_vault_refs(section),
+        )
+        # Derived from OMNIGENT_DECLAW_MAX_LIFETIME_S so the token always
+        # outlives the (operator-overridable) sandbox lifetime — mirrors the
+        # cwsandbox / e2b path.
+        token_ttl_s = managed_token_ttl_s()
     else:
         launcher_factory = _unsupported_launcher_factory(provider)
         # Never consulted (the factory rejects before any token is
@@ -1415,6 +1429,200 @@ def _parse_provider_positive_int(raw: dict[str, object], provider: str, key: str
     if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
         raise ValueError(f"server config 'sandbox.{provider}.{key}' must be a positive integer")
     return value
+
+
+# Keys accepted in the `sandbox.declaw` block and its nested `security` block.
+# The security sub-keys mirror Declaw's SecurityPolicy surface; structural
+# validation here (keys + leaf types) stays decoupled from Declaw's semantic
+# schema — the launcher maps the block to a SecurityPolicy via the SDK's own
+# config classes, and the policy_ref / inline_rego escape hatch covers anything
+# not surfaced as a named knob.
+_DECLAW_SECTION_KEYS: frozenset[str] = frozenset({"template", "env", "vault_refs", "security"})
+_DECLAW_SECURITY_KEYS: frozenset[str] = frozenset(
+    {
+        "mode",
+        "agent_policy",
+        "governance_pack",
+        "pii",
+        "injection_defense",
+        "network",
+        "audit",
+        "toxicity",
+        "code_security",
+        "content_gate",
+        "policy_ref",
+        "inline_rego",
+        "inline_modules",
+    }
+)
+
+
+def _reject_unknown_keys(mapping: dict[str, object], allowed: frozenset[str], path: str) -> None:
+    """
+    Fail loud on any key outside *allowed* — catches typos that would
+    otherwise be silently ignored and surface later as a confusing runtime
+    failure.
+    """
+    unknown = sorted(set(mapping) - allowed)
+    if unknown:
+        raise ValueError(
+            f"server config '{path}' has unknown key(s): {', '.join(unknown)} "
+            f"(allowed: {', '.join(sorted(allowed))})"
+        )
+
+
+def _declaw_section(raw: dict[str, object]) -> dict[str, object]:
+    """
+    Return the validated ``sandbox.declaw`` mapping (empty when absent).
+
+    :raises ValueError: When ``sandbox.declaw`` is present but not a mapping,
+        or carries an unknown key.
+    """
+    section = raw.get("declaw")
+    if section is None:
+        return {}
+    if not isinstance(section, dict):
+        raise ValueError("server config 'sandbox.declaw' must be a mapping")
+    _reject_unknown_keys(section, _DECLAW_SECTION_KEYS, "sandbox.declaw")
+    return section
+
+
+def _parse_declaw_template(section: dict[str, object]) -> str | None:
+    """
+    Extract and validate ``sandbox.declaw.template`` (optional).
+
+    Like E2B, Declaw boots from a NAMED template the omnigent host image was
+    built into — NOT a registry image reference. Absent → the launcher
+    resolves its env-var fallback then the default template.
+    """
+    template = section.get("template")
+    if template is None:
+        return None
+    if not isinstance(template, str) or not template.strip():
+        raise ValueError(
+            "server config 'sandbox.declaw.template' must be the NAME of a Declaw "
+            "template the omnigent host image was built into (e.g. 'omnigent-host'; "
+            "see deploy/declaw/README.md) — NOT a registry image reference (omit it "
+            "to use the default template)"
+        )
+    return template.strip()
+
+
+def _parse_declaw_env(section: dict[str, object]) -> list[str] | None:
+    """Extract and validate ``sandbox.declaw.env`` — server env var NAMES (optional)."""
+    env = section.get("env")
+    if env is None:
+        return None
+    if not isinstance(env, list) or not all(
+        isinstance(name, str) and name.strip() for name in env
+    ):
+        raise ValueError(
+            "server config 'sandbox.declaw.env' must be a list of server environment "
+            "variable NAMES to inject, e.g. ['ANTHROPIC_API_KEY', 'GIT_TOKEN']"
+        )
+    return [name.strip() for name in env]
+
+
+def _parse_declaw_vault_refs(section: dict[str, object]) -> dict[str, str] | None:
+    """
+    Extract and validate ``sandbox.declaw.vault_refs`` (optional).
+
+    A mapping of in-sandbox ENV_VAR_NAME → stored Declaw vault secret name.
+    The secret value is resolved server-side at provision and never enters the
+    config file or the VM image — the Declaw-native alternative to plaintext
+    ``env`` passthrough for harness credentials.
+    """
+    vault_refs = section.get("vault_refs")
+    if vault_refs is None:
+        return None
+    if not isinstance(vault_refs, dict) or not all(
+        isinstance(k, str) and k.strip() and isinstance(v, str) and v.strip()
+        for k, v in vault_refs.items()
+    ):
+        raise ValueError(
+            "server config 'sandbox.declaw.vault_refs' must be a mapping of in-sandbox "
+            "ENV_VAR_NAME → stored vault secret name, e.g. {OPENAI_API_KEY: openai-prod}"
+        )
+    return {k.strip(): v.strip() for k, v in vault_refs.items()}
+
+
+def _parse_declaw_security(section: dict[str, object]) -> dict[str, object] | None:
+    """
+    Structurally validate ``sandbox.declaw.security`` and return it for the launcher.
+
+    Validates only the top-level shape (allowed keys + leaf types); the
+    launcher maps it to a Declaw ``SecurityPolicy`` via the SDK's own config
+    classes, which own the semantic validation. This keeps the server config
+    parser decoupled from Declaw's evolving policy schema.
+    """
+    security = section.get("security")
+    if security is None:
+        return None
+    if not isinstance(security, dict):
+        raise ValueError("server config 'sandbox.declaw.security' must be a mapping")
+    _reject_unknown_keys(security, _DECLAW_SECURITY_KEYS, "sandbox.declaw.security")
+    for key in ("mode", "agent_policy", "governance_pack", "policy_ref", "inline_rego"):
+        value = security.get(key)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise ValueError(
+                f"server config 'sandbox.declaw.security.{key}' must be a non-empty string"
+            )
+    audit = security.get("audit")
+    if audit is not None and not isinstance(audit, (dict, bool)):
+        raise ValueError(
+            "server config 'sandbox.declaw.security.audit' must be a mapping or boolean"
+        )
+    for key in (
+        "pii",
+        "injection_defense",
+        "network",
+        "toxicity",
+        "code_security",
+        "content_gate",
+    ):
+        value = security.get(key)
+        if value is not None and not isinstance(value, dict):
+            raise ValueError(f"server config 'sandbox.declaw.security.{key}' must be a mapping")
+    modules = security.get("inline_modules")
+    if modules is not None and (
+        not isinstance(modules, list) or not all(isinstance(m, str) and m.strip() for m in modules)
+    ):
+        raise ValueError(
+            "server config 'sandbox.declaw.security.inline_modules' must be a list of "
+            "Rego module strings"
+        )
+    return security
+
+
+def _declaw_launcher_factory(
+    *,
+    template: str | None,
+    env: list[str] | None,
+    security: dict[str, object] | None,
+    vault_refs: dict[str, str] | None,
+) -> Callable[[], SandboxLauncher]:
+    """
+    Build the launcher factory for the YAML ``provider: declaw`` path.
+
+    :param template: Declaw template NAME the omnigent host image was built
+        into, or ``None`` for the launcher's env-var fallback / default.
+    :param env: Names of server-process environment variables injected into
+        every sandbox, or ``None`` to resolve from the launcher's fallback.
+    :param security: The validated ``sandbox.declaw.security`` mapping, or
+        ``None`` for the balanced secure-by-default policy.
+    :param vault_refs: ENV_VAR_NAME → vault secret name mapping, or ``None``.
+    :returns: A factory producing parameterized Declaw launchers.
+    """
+
+    def _build() -> SandboxLauncher:
+        """Construct the Declaw launcher (lazy SDK import inside)."""
+        from omnigent.onboarding.sandboxes.declaw import DeclawSandboxLauncher
+
+        return DeclawSandboxLauncher(
+            template=template, env=env, security=security, vault_refs=vault_refs
+        )
+
+    return _build
 
 
 async def launch_managed_host(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,11 @@ e2b = ["e2b>=2.26,<3"]
 # Self-hosted gRPC gateway; the SDK pulls grpcio + protobuf. Same
 # lazy-import posture as above. Pre-1.0 SDK: pin minor.
 openshell = ["openshell>=0.0.7,<1"]
+# Declaw sandbox launcher (`omnigent sandbox --provider declaw` and
+# server-managed `sandbox.provider: declaw`). Secure microVM sandboxes with
+# a built-in security plane (PII / injection / network / vault / governance).
+# Same lazy-import posture as above.
+declaw = ["declaw>=1.3,<2"]
 # MLflow tracing is opt-in: tracing is disabled by default and the
 # server degrades gracefully when mlflow is absent, so the (heavy) mlflow
 # dependency only installs for users who want it (`omnigent[tracing]`).
@@ -531,6 +536,12 @@ ignore_missing_imports = true
 # a base dependency, so its imports are unresolved in the default env too.
 [[tool.mypy.overrides]]
 module = "openshell.*"
+ignore_missing_imports = true
+
+# declaw is an optional dep (the `declaw` extra); same lazy-import posture as
+# modal above.
+[[tool.mypy.overrides]]
+module = "declaw.*"
 ignore_missing_imports = true
 
 # boxlite is an optional dep (the `boxlite` extra); same lazy-import posture

--- a/tests/onboarding/sandboxes/test_declaw.py
+++ b/tests/onboarding/sandboxes/test_declaw.py
@@ -1,0 +1,501 @@
+"""Tests for :mod:`omnigent.onboarding.sandboxes.declaw`."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import click
+import pytest
+
+from omnigent.onboarding.sandboxes import available_providers, get_launcher
+from omnigent.onboarding.sandboxes.declaw import (
+    DEFAULT_DECLAW_TEMPLATE,
+    MAX_LIFETIME_ENV_VAR,
+    SANDBOX_ENV_PASSTHROUGH_ENV_VAR,
+    SECURITY_MODE_ENV_VAR,
+    TEMPLATE_ENV_VAR,
+    DeclawSandboxLauncher,
+    managed_token_ttl_s,
+    resolve_max_lifetime_s,
+)
+
+# ── Fake declaw SDK ─────────────────────────────────────────
+#
+# The SDK is an optional dependency the test env does not install, and real
+# Sandbox/SecurityPolicy objects only exist server-side — so these are
+# hand-rolled stubs injected via sys.modules, resolving the launcher's
+# function-local `from declaw import ...` / `from declaw.exceptions import ...`.
+
+
+class _SandboxException(Exception):
+    pass
+
+
+class _NotFoundException(_SandboxException):
+    pass
+
+
+class _TemplateException(_SandboxException):
+    pass
+
+
+class _FileUploadException(_SandboxException):
+    pass
+
+
+class _CommandExitException(_SandboxException):
+    pass
+
+
+class _AuthenticationException(Exception):
+    # Mirrors the real class: extends Exception, NOT SandboxException.
+    pass
+
+
+# -- security config stubs: record constructor kwargs / from_dict payload --
+
+
+class _Recorder:
+    """Generic recording config: stores constructor kwargs and from_dict data."""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.from_dict_data: dict | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> _Recorder:
+        obj = cls()
+        obj.from_dict_data = dict(data)
+        return obj
+
+
+class _FakePIIConfig(_Recorder):
+    pass
+
+
+class _FakeInjectionDefenseConfig(_Recorder):
+    pass
+
+
+class _FakeNetworkPolicy(_Recorder):
+    pass
+
+
+class _FakeAuditConfig(_Recorder):
+    pass
+
+
+class _FakeToxicityConfig(_Recorder):
+    pass
+
+
+class _FakeCodeSecurityConfig(_Recorder):
+    pass
+
+
+class _FakeContentGateConfig(_Recorder):
+    pass
+
+
+class _FakeCustomPolicyConfig:
+    def __init__(
+        self,
+        enabled: bool = False,
+        inline_rego: str | None = None,
+        inline_modules: list | None = None,
+        policy_ref: str | None = None,
+        default_deny: bool = False,
+    ) -> None:
+        self.enabled = enabled
+        self.inline_rego = inline_rego
+        self.inline_modules = inline_modules
+        self.policy_ref = policy_ref
+        self.default_deny = default_deny
+
+
+class _FakeSecurityPolicy:
+    """Holder mirroring declaw's SecurityPolicy surface for mapping assertions."""
+
+    def __init__(self) -> None:
+        self.pii: object = None
+        self.injection_defense: object = False
+        self.network: object = None
+        self.audit: object = True
+        self.toxicity: object = None
+        self.code_security: object = None
+        self.content_gate: object = None
+        self.custom_policy: object = None
+        self.full_kwargs: dict | None = None
+        self.from_dict_data: dict | None = None
+
+    @classmethod
+    def full_injection_defense(cls, **kwargs: object) -> _FakeSecurityPolicy:
+        obj = cls()
+        obj.full_kwargs = dict(kwargs)
+        # Mirror the real factory: it also enables the prompt-injection OPA pack.
+        obj.custom_policy = _FakeCustomPolicyConfig(enabled=True, policy_ref="prompt-injection@v3")
+        return obj
+
+    @classmethod
+    def from_dict(cls, data: dict) -> _FakeSecurityPolicy:
+        obj = cls()
+        obj.from_dict_data = dict(data)
+        return obj
+
+
+@dataclass
+class _FakeCommandResult:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+@dataclass
+class _State:
+    """Shared recorder for assertions."""
+
+    create_kwargs: dict = field(default_factory=dict)
+    run_calls: list[dict] = field(default_factory=list)
+    written: list[tuple[str, bytes]] = field(default_factory=list)
+    killed: list[str] = field(default_factory=list)
+    set_timeouts: list[int] = field(default_factory=list)
+    connect_calls: list[str] = field(default_factory=list)
+    exec_result: _FakeCommandResult = field(default_factory=_FakeCommandResult)
+    stream_text: str = ""
+    stream_exit: int = 0
+    running: bool = True
+    connect_missing: bool = False
+    kill_missing: bool = False
+    create_raises: BaseException | None = None
+
+
+class _FakeCommands:
+    def __init__(self, state: _State) -> None:
+        self._state = state
+
+    def run(self, cmd: str, timeout=None, request_timeout=None, **kwargs):
+        self._state.run_calls.append({"cmd": cmd, "timeout": timeout})
+        return self._state.exec_result
+
+    def run_stream(self, cmd: str, on_stdout=None, on_stderr=None, timeout=None, **kwargs):
+        if on_stdout is not None and self._state.stream_text:
+            on_stdout(self._state.stream_text)
+        return _FakeCommandResult(exit_code=self._state.stream_exit)
+
+
+class _FakeFiles:
+    def __init__(self, state: _State) -> None:
+        self._state = state
+
+    def write(self, path: str, data: bytes, **kwargs):
+        self._state.written.append((path, data))
+        return object()  # WriteInfo stand-in
+
+
+class _FakeSandbox:
+    _state: _State
+
+    def __init__(self, sandbox_id: str = "sb-declaw-1") -> None:
+        self._sandbox_id = sandbox_id
+        self.commands = _FakeCommands(self._state)
+        self.files = _FakeFiles(self._state)
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._sandbox_id
+
+    @classmethod
+    def create(cls, **kwargs) -> _FakeSandbox:
+        cls._state.create_kwargs = kwargs
+        if cls._state.create_raises is not None:
+            raise cls._state.create_raises
+        return cls()
+
+    @classmethod
+    def connect(cls, sandbox_id: str, **kwargs) -> _FakeSandbox:
+        cls._state.connect_calls.append(sandbox_id)
+        if cls._state.connect_missing:
+            raise _NotFoundException(sandbox_id)
+        return cls(sandbox_id)
+
+    def kill(self, request_timeout=None, *, wait: bool = False) -> bool:
+        if self._state.kill_missing:
+            raise _NotFoundException(self._sandbox_id)
+        self._state.killed.append(self._sandbox_id)
+        return True
+
+    def is_running(self, request_timeout=None) -> bool:
+        return self._state.running
+
+    def set_timeout(self, timeout: int, **kwargs) -> None:
+        self._state.set_timeouts.append(timeout)
+
+
+def _install_fake_declaw(monkeypatch: pytest.MonkeyPatch, state: _State) -> None:
+    """Inject the fake ``declaw`` package + ``declaw.exceptions`` submodule."""
+    _FakeSandbox._state = state
+
+    mod = types.ModuleType("declaw")
+    mod.Sandbox = _FakeSandbox  # type: ignore[attr-defined]
+    mod.SecurityPolicy = _FakeSecurityPolicy  # type: ignore[attr-defined]
+    mod.PIIConfig = _FakePIIConfig  # type: ignore[attr-defined]
+    mod.InjectionDefenseConfig = _FakeInjectionDefenseConfig  # type: ignore[attr-defined]
+    mod.NetworkPolicy = _FakeNetworkPolicy  # type: ignore[attr-defined]
+    mod.AuditConfig = _FakeAuditConfig  # type: ignore[attr-defined]
+    mod.ToxicityConfig = _FakeToxicityConfig  # type: ignore[attr-defined]
+    mod.CodeSecurityConfig = _FakeCodeSecurityConfig  # type: ignore[attr-defined]
+    mod.ContentGateConfig = _FakeContentGateConfig  # type: ignore[attr-defined]
+    mod.CustomPolicyConfig = _FakeCustomPolicyConfig  # type: ignore[attr-defined]
+
+    exc = types.ModuleType("declaw.exceptions")
+    exc.SandboxException = _SandboxException  # type: ignore[attr-defined]
+    exc.NotFoundException = _NotFoundException  # type: ignore[attr-defined]
+    exc.TemplateException = _TemplateException  # type: ignore[attr-defined]
+    exc.AuthenticationException = _AuthenticationException  # type: ignore[attr-defined]
+    exc.FileUploadException = _FileUploadException  # type: ignore[attr-defined]
+    exc.CommandExitException = _CommandExitException  # type: ignore[attr-defined]
+    mod.exceptions = exc  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "declaw", mod)
+    monkeypatch.setitem(sys.modules, "declaw.exceptions", exc)
+
+
+@pytest.fixture()
+def sdk(monkeypatch: pytest.MonkeyPatch) -> _State:
+    state = _State()
+    _install_fake_declaw(monkeypatch, state)
+    monkeypatch.setenv("DECLAW_API_KEY", "declaw-test-key")
+    monkeypatch.delenv(TEMPLATE_ENV_VAR, raising=False)
+    monkeypatch.delenv(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, raising=False)
+    monkeypatch.delenv(SECURITY_MODE_ENV_VAR, raising=False)
+    monkeypatch.delenv(MAX_LIFETIME_ENV_VAR, raising=False)
+    return state
+
+
+# ── registration / capabilities ─────────────────────────────
+
+
+def test_declaw_is_a_registered_available_provider() -> None:
+    # The launcher module ships in the package, so the provider is available
+    # regardless of whether the optional declaw SDK is installed.
+    assert "declaw" in available_providers()
+    assert isinstance(get_launcher("declaw"), DeclawSandboxLauncher)
+
+
+def test_capability_flags() -> None:
+    launcher = DeclawSandboxLauncher()
+    assert launcher.provider == "declaw"
+    assert launcher.supports_cli_bootstrap is True
+    assert launcher.supports_local_port_forward is False
+
+
+def test_constructs_without_sdk() -> None:
+    # __init__ must not import the SDK (the CLI builds the launcher no-arg and
+    # the managed factory builds it with kwargs, both before any SDK call).
+    launcher = DeclawSandboxLauncher(
+        template="t", env=["X"], security={"mode": "strict"}, vault_refs={"K": "v"}
+    )
+    assert launcher._template_ref == "t"
+    assert launcher._env_names == ("X",)
+    assert launcher._security == {"mode": "strict"}
+    assert launcher._vault_refs == {"K": "v"}
+
+
+# ── prepare ──────────────────────────────────────────────────
+
+
+def test_prepare_requires_api_key(sdk: _State, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DECLAW_API_KEY")
+    with pytest.raises(click.ClickException, match="DECLAW_API_KEY"):
+        DeclawSandboxLauncher().prepare()
+
+
+def test_prepare_raises_install_hint_when_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A None entry in sys.modules makes `import declaw` raise ImportError.
+    monkeypatch.setitem(sys.modules, "declaw", None)
+    monkeypatch.setenv("DECLAW_API_KEY", "k")
+    with pytest.raises(click.ClickException, match=r"pip install 'omnigent\[declaw\]'"):
+        DeclawSandboxLauncher().prepare()
+
+
+# ── _build_security_policy (the declaw-specific mapping) ─────
+
+
+def test_security_secure_by_default_is_balanced_with_pii_redact(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher()._build_security_policy()
+    # Balanced injection cascade + PII redaction on, no injection domains yet.
+    assert policy.full_kwargs == {"mode": "balanced"}
+    assert isinstance(policy.pii, _FakePIIConfig)
+    assert policy.pii.kwargs == {"enabled": True, "action": "redact"}
+
+
+def test_security_default_mode_overridable_via_env(
+    sdk: _State, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(SECURITY_MODE_ENV_VAR, "strict")
+    policy = DeclawSandboxLauncher()._build_security_policy()
+    assert policy.full_kwargs == {"mode": "strict"}
+
+
+def test_security_curated_mode_enables_full_cascade(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher(
+        security={
+            "mode": "agentic-tool",
+            "agent_policy": "summarize docs",
+            "injection_defense": {"action": "block", "domains": ["api.github.com"]},
+        }
+    )._build_security_policy()
+    assert policy.full_kwargs["mode"] == "agentic-tool"
+    assert policy.full_kwargs["agent_policy"] == "summarize docs"
+    assert policy.full_kwargs["action"] == "block"
+    assert policy.full_kwargs["domains"] == ["api.github.com"]
+
+
+def test_security_pii_block_maps_to_pii_config(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher(
+        security={"pii": {"enabled": True, "action": "block"}}
+    )._build_security_policy()
+    assert isinstance(policy.pii, _FakePIIConfig)
+    assert policy.pii.from_dict_data == {"enabled": True, "action": "block"}
+    # No mode → no full cascade.
+    assert policy.full_kwargs is None
+
+
+def test_security_governance_pack_maps_to_custom_policy(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher(
+        security={"governance_pack": "owasp-llm-top10"}
+    )._build_security_policy()
+    assert policy.custom_policy.enabled is True
+    assert policy.custom_policy.policy_ref == "owasp-llm-top10"
+
+
+def test_security_escape_hatch_inline_rego(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher(
+        security={"inline_rego": "deny_command contains m if { true }"}
+    )._build_security_policy()
+    assert policy.custom_policy.enabled is True
+    assert policy.custom_policy.inline_rego.startswith("deny_command")
+
+
+def test_security_network_allow_deny_aliases_map_to_out(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher(
+        security={"network": {"allow": ["api.github.com"], "deny": ["169.254.169.254"]}}
+    )._build_security_policy()
+    assert isinstance(policy.network, _FakeNetworkPolicy)
+    assert policy.network.from_dict_data == {
+        "allow_out": ["api.github.com"],
+        "deny_out": ["169.254.169.254"],
+    }
+
+
+def test_security_audit_bool_passthrough(sdk: _State) -> None:
+    policy = DeclawSandboxLauncher(security={"audit": False})._build_security_policy()
+    assert policy.audit is False
+
+
+# ── provision ────────────────────────────────────────────────
+
+
+def test_provision_passes_template_lifetime_and_security(sdk: _State) -> None:
+    assert DeclawSandboxLauncher().provision("managed-x") == "sb-declaw-1"
+    assert sdk.create_kwargs["template"] == DEFAULT_DECLAW_TEMPLATE
+    assert sdk.create_kwargs["timeout"] == resolve_max_lifetime_s()
+    assert sdk.create_kwargs["metadata"] == {"omnigent-name": "managed-x"}
+    assert sdk.create_kwargs["allow_internet_access"] is True
+    assert isinstance(sdk.create_kwargs["security"], _FakeSecurityPolicy)
+
+
+def test_provision_forwards_vault_refs(sdk: _State) -> None:
+    DeclawSandboxLauncher(vault_refs={"OPENAI_API_KEY": "openai-prod"}).provision("x")
+    assert sdk.create_kwargs["vault_refs"] == {"OPENAI_API_KEY": "openai-prod"}
+
+
+def test_provision_env_passthrough_missing_var_fails_loud(sdk: _State) -> None:
+    with pytest.raises(click.ClickException, match="NOT_SET_ANYWHERE"):
+        DeclawSandboxLauncher(env=["NOT_SET_ANYWHERE"]).provision("x")
+
+
+def test_provision_missing_template_points_at_build(sdk: _State) -> None:
+    sdk.create_raises = _TemplateException("alias 'omnigent-host' not found")
+    with pytest.raises(click.ClickException, match="deploy/declaw/README"):
+        DeclawSandboxLauncher().provision("x")
+
+
+# ── run / put / lifecycle ────────────────────────────────────
+
+
+def test_run_maps_exit_code_to_returncode(sdk: _State) -> None:
+    sdk.exec_result = _FakeCommandResult(stdout="hi", stderr="", exit_code=0)
+    result = DeclawSandboxLauncher().run("sb", "echo hi")
+    assert result.returncode == 0
+    assert result.stdout == "hi"
+    # Command is bash -lc wrapped.
+    assert sdk.run_calls[-1]["cmd"].startswith("bash -lc ")
+
+
+def test_run_check_raises_on_nonzero(sdk: _State) -> None:
+    sdk.exec_result = _FakeCommandResult(exit_code=3)
+    with pytest.raises(click.ClickException, match="exit 3"):
+        DeclawSandboxLauncher().run("sb", "false")
+
+
+def test_run_check_false_returns_nonzero(sdk: _State) -> None:
+    sdk.exec_result = _FakeCommandResult(exit_code=3)
+    result = DeclawSandboxLauncher().run("sb", "false", check=False)
+    assert result.returncode == 3
+
+
+def test_put_writes_local_bytes(sdk: _State, tmp_path: Path) -> None:
+    local = tmp_path / "wheels.tgz"
+    local.write_bytes(b"payload")
+    DeclawSandboxLauncher().put("sb", local, "/tmp/oa-wheels.tgz")
+    assert sdk.written == [("/tmp/oa-wheels.tgz", b"payload")]
+
+
+def test_attach_running_ok_then_stopped_raises(sdk: _State) -> None:
+    DeclawSandboxLauncher().attach("sb")  # running=True default
+    sdk.running = False
+    with pytest.raises(click.ClickException, match="not running"):
+        DeclawSandboxLauncher().attach("sb")
+
+
+def test_keep_alive_extends_timeout(sdk: _State) -> None:
+    DeclawSandboxLauncher().keep_alive("sb")
+    assert sdk.set_timeouts == [resolve_max_lifetime_s()]
+
+
+def test_terminate_kills(sdk: _State) -> None:
+    DeclawSandboxLauncher().terminate("sb-declaw-1")
+    assert sdk.killed == ["sb-declaw-1"]
+
+
+def test_terminate_already_gone_is_success(sdk: _State) -> None:
+    sdk.connect_missing = True
+    # Not cached → connect raises NotFound → swallowed (desired end state holds).
+    DeclawSandboxLauncher().terminate("sb-gone")
+    assert sdk.killed == []
+
+
+def test_wheel_install_command_uses_host_image_overlay(sdk: _State) -> None:
+    cmd = DeclawSandboxLauncher().wheel_install_command("/tmp/oa-wheels.tgz")
+    assert "pip install" in cmd
+    assert "/tmp/oa-wheels.tgz" in cmd
+
+
+# ── stream_exec (threaded run_stream wrapper) ────────────────
+
+
+def test_stream_exec_streams_lines_and_exit_code(sdk: _State) -> None:
+    sdk.stream_text = "hello\n"
+    sdk.stream_exit = 0
+    process = DeclawSandboxLauncher().stream_exec("sb", "omnigent host")
+    lines = list(process.lines)
+    assert "".join(lines) == "hello\n"
+    assert process.wait() == 0
+
+
+def test_managed_token_ttl_exceeds_lifetime(sdk: _State) -> None:
+    assert managed_token_ttl_s() > resolve_max_lifetime_s()

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -11,6 +11,8 @@ from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from omnigent.db.utils import now_epoch
+from omnigent.onboarding.sandboxes.declaw import DeclawSandboxLauncher
+from omnigent.onboarding.sandboxes.declaw import managed_token_ttl_s as declaw_managed_token_ttl_s
 from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s as e2b_managed_token_ttl_s
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
@@ -412,6 +414,107 @@ def test_parse_e2b_template_rejects_non_string(monkeypatch: pytest.MonkeyPatch) 
                 "provider": "e2b",
                 "server_url": "https://s.example.com",
                 "e2b": {"template": ""},
+            }
+        )
+
+
+def test_parse_valid_declaw_config_builds_parameterized_factory() -> None:
+    """
+    The documented declaw YAML shape parses into a config whose factory
+    constructs a DeclawSandboxLauncher carrying the template alias, env
+    passthrough, vault refs, and the (structurally-validated) security block,
+    with the declaw token TTL derived from the sandbox lifetime.
+    """
+    cfg = parse_sandbox_config(
+        {
+            "provider": "declaw",
+            "server_url": "https://srv.example.com/",
+            "declaw": {
+                "template": "omnigent-host",
+                "env": ["OPENAI_API_KEY", "GIT_TOKEN"],
+                "vault_refs": {"OPENAI_API_KEY": "openai-prod"},
+                "security": {
+                    "mode": "balanced",
+                    "pii": {"enabled": True, "action": "redact"},
+                    "network": {"allow": ["api.github.com"]},
+                },
+            },
+        }
+    )
+    assert cfg is not None
+    assert cfg.server_url == "https://srv.example.com"
+    assert cfg.token_ttl_s == declaw_managed_token_ttl_s()
+    assert cfg.managed_launch_supported is True
+    assert cfg.provider == "declaw"
+    launcher = cfg.launcher_factory()
+    assert isinstance(launcher, DeclawSandboxLauncher)
+    assert launcher._template_ref == "omnigent-host"
+    assert launcher._env_names == ("OPENAI_API_KEY", "GIT_TOKEN")
+    assert launcher._vault_refs == {"OPENAI_API_KEY": "openai-prod"}
+    assert launcher._security["mode"] == "balanced"
+    assert launcher._security["pii"] == {"enabled": True, "action": "redact"}
+
+
+def test_parse_declaw_without_section_defaults() -> None:
+    """
+    `provider: declaw` + `server_url` is a complete config: template,
+    security, env, and vault refs are optional and reach the launcher as None
+    (its own env-var fallbacks / secure-by-default policy apply).
+    """
+    cfg = parse_sandbox_config({"provider": "declaw", "server_url": "https://s.example.com"})
+    assert cfg is not None
+    launcher = cfg.launcher_factory()
+    assert isinstance(launcher, DeclawSandboxLauncher)
+    assert launcher._template_ref is None
+    assert launcher._env_names is None
+    assert launcher._security is None
+    assert launcher._vault_refs is None
+
+
+def test_parse_declaw_section_unknown_key_rejected() -> None:
+    """A typo'd key in the declaw block fails loud at parse time."""
+    with pytest.raises(ValueError, match=r"sandbox\.declaw.*unknown key"):
+        parse_sandbox_config(
+            {
+                "provider": "declaw",
+                "server_url": "https://s.example.com",
+                "declaw": {"templatte": "typo"},
+            }
+        )
+
+
+def test_parse_declaw_security_unknown_key_rejected() -> None:
+    """An unknown key inside the nested security block fails loud."""
+    with pytest.raises(ValueError, match=r"sandbox\.declaw\.security.*unknown key"):
+        parse_sandbox_config(
+            {
+                "provider": "declaw",
+                "server_url": "https://s.example.com",
+                "declaw": {"security": {"pii": {}, "not_a_knob": True}},
+            }
+        )
+
+
+def test_parse_declaw_security_leaf_type_checked() -> None:
+    """A mistyped security leaf (string where a mapping is expected) fails loud."""
+    with pytest.raises(ValueError, match=r"sandbox\.declaw\.security\.pii"):
+        parse_sandbox_config(
+            {
+                "provider": "declaw",
+                "server_url": "https://s.example.com",
+                "declaw": {"security": {"pii": "yes"}},
+            }
+        )
+
+
+def test_parse_declaw_vault_refs_malformed_fails_loud() -> None:
+    """vault_refs must be a name→name mapping, not a list."""
+    with pytest.raises(ValueError, match=r"sandbox\.declaw\.vault_refs"):
+        parse_sandbox_config(
+            {
+                "provider": "declaw",
+                "server_url": "https://s.example.com",
+                "declaw": {"vault_refs": ["not", "a", "mapping"]},
             }
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1036,6 +1036,20 @@ wheels = [
 ]
 
 [[package]]
+name = "declaw"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "packaging" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/25/570533974ace1162be4884931a0b843129e50d42ca204b2abc082277a0a1/declaw-1.3.0.tar.gz", hash = "sha256:9dd98bd76ded820af73c1df7442660ab97e9464eb68467d359bded80e265f630", size = 64240, upload-time = "2026-06-11T22:18:31.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/91/3bc764220f7f61e733d1e76e3c0934f994bcbb1ef98978ee1f991b0b23ab/declaw-1.3.0-py3-none-any.whl", hash = "sha256:d8ee62a9b8c62b4ac30e16cbb66955249bb26cb925b20e6c6c28f80c9887a88c", size = 95760, upload-time = "2026-06-11T22:18:30.681Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1695,6 +1709,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
 ]
 
 [[package]]
@@ -2789,6 +2808,9 @@ databricks = [
 daytona = [
     { name = "daytona" },
 ]
+declaw = [
+    { name = "declaw" },
+]
 dev = [
     { name = "boto3" },
     { name = "filelock" },
@@ -2852,6 +2874,7 @@ requires-dist = [
     { name = "databricks-sdk", marker = "extra == 'all'", specifier = ">=0.56.0,<1" },
     { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.56.0,<1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.180,<1" },
+    { name = "declaw", marker = "extra == 'declaw'", specifier = ">=1.3,<2" },
     { name = "e2b", marker = "extra == 'e2b'", specifier = ">=2.26,<3" },
     { name = "fastapi", specifier = ">=0.100,<1" },
     { name = "filelock", marker = "extra == 'dev'", specifier = ">=3.0" },
@@ -2910,7 +2933,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "openshell", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "s3", "vertex", "modal", "daytona", "boxlite", "cwsandbox", "e2b", "openshell", "declaw", "tracing", "agents-sdk", "antigravity", "cursor", "databricks", "dev"]
 
 [[package]]
 name = "omnigent-client"


### PR DESCRIPTION
## Related issue

Closes #963

## Summary

- Adds **Declaw** as a remote sandbox provider (`SandboxLauncher`), alongside the existing e2b / modal / daytona / cwsandbox providers — running Omnigent hosts in secure cloud microVMs.
- Unlike the other providers, the Declaw launcher attaches a **security policy** at provision time (PII redaction, prompt-injection defense, network egress policy, credential vault, governance/OPA custom policy, audit), configured through the provider's own config surface; Omnigent's local sandbox-policy layer is untouched.
- **Secure-by-default**: with no `security` block the sandbox gets a balanced policy (PII redact + audit; injection cascade configured but scanning no domains, so it never blocks the agent's own model endpoint). `sandbox.declaw.security` surfaces curated knobs (`mode`, `governance_pack`, `pii`, `injection_defense`, `network`, `audit`) plus a `policy_ref` / `inline_rego` escape hatch.
- Supports both the CLI bootstrap flow and server-managed launch (`supports_local_port_forward=False`; managed hosts use the server-minted launch token). Ships `deploy/declaw/README.md`, the `declaw` optional extra (+ mypy override), and unit tests.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

**Unit tests added**, in the suites matching the changed areas:

- `tests/onboarding/sandboxes/test_declaw.py` — launcher behaviour + the security-policy mapping (secure-by-default, curated knobs, governance pack, `policy_ref`/`inline_rego` escape hatch, `network` allow/deny aliasing, `run` exit-code mapping, idempotent terminate), with the `declaw` SDK faked via `sys.modules` (the SDK is an optional extra, mirroring `test_e2b.py`).
- `tests/server/test_managed_hosts.py` — `parse_sandbox_config` happy path, nested `security` parsing, unknown-key rejection, and `vault_refs` validation.

**Commands run** (`uv run --frozen --extra all --extra dev …`):

- `python -m pytest tests/onboarding/sandboxes/ tests/server/test_managed_hosts.py` — all pass (262 in the sandbox/provider sweep + the managed-host suite), so the shared launcher-registry edit is non-breaking.
- `ruff check` + `ruff format --check` — clean.
- `python -m mypy omnigent/onboarding/sandboxes/declaw.py omnigent/server/managed_hosts.py` — clean.
- `pre-commit run --files <changed files>` — all hooks pass.

**No e2e test**: this matches the sandbox-provider convention — modal / daytona / boxlite / islo / openshell ship unit tests only (faked SDK); only cwsandbox and e2b additionally provide optional, infra-gated manual smoke drivers under `tests/e2e/integrations/deploy/`. A Declaw e2e driver would require a live Declaw account + a built host template, so it isn't included here; the launcher's SDK calls are exercised by the faked-SDK unit tests above.
