### PR TITLE
fix(triage): make P2 the default for substantive feature requests

### DIFF
--- a/.github/triage/config.yaml
+++ b/.github/triage/config.yaml
@@ -67,8 +67,19 @@ prompt: |
   **priority**:
   - `P0-critical` — service down, data loss, security vulnerability
   - `P1-high` — major feature broken, no workaround
-  - `P2-medium` — bug with workaround, or important feature request
-  - `P3-low` — minor issue, cosmetic, nice-to-have
+  - `P2-medium` — a bug with a workaround, OR a substantive feature
+    request. A feature request is substantive (P2) when it adds a real new
+    capability — e.g. support for a new harness / provider / model /
+    integration, a new tool, or a new user-facing workflow. **P2 is the
+    default for feature requests**, and equivalent requests must get the
+    same priority (e.g. "add harness X" and "add harness Y" are both P2).
+  - `P3-low` — ONLY genuinely minor things: minor or cosmetic bugs, small
+    UI/UX polish, trivial conveniences, or narrowly-scoped nice-to-haves that
+    add no real new capability. Do NOT drop a feature to P3 just because it
+    isn't urgent or you personally judge demand to be low — a new
+    capability/integration is P2 even if non-urgent.
+
+  When you are unsure between P2 and P3 for a feature request, choose P2.
 
   **help_wanted** — `true` if the issue could benefit from community
   contribution.


### PR DESCRIPTION
## Problem

The issue-triage bot rates feature-request **priority** inconsistently. The P2/P3 line ("important feature request" vs "nice-to-have") is subjective, and the classifier sees no demand signal, so equivalent requests land on different rungs:

- Add Copilot harness (#92) → P2, Add Antigravity harness (#56) → P2
- Add OpenCode harness (#45) → **P3**, Add Gemini sub-agent (#89) → **P3**

Same class of request, different priority — and it skews low overall (in a 15-issue validation, every priority miss was one level too low).

## Fix (prompt-only)

Sharpen the priority rubric. No change to the tool-free, injection-hardened classifier architecture:
- **P2 is the default for substantive feature requests** — anything adding a real new capability (new harness / provider / model / integration, a new tool, or a new user-facing workflow). Equivalent requests get the same priority.
- **P3** is reserved for genuinely minor / cosmetic / trivial changes (minor or cosmetic bugs, small UI/UX polish, narrow nice-to-haves).
- When unsure between P2 and P3, choose P2.

## Verification (A/B on real issues, read-only)

| Issue | Old | New | |
|--|--|--|--|
| #45 OpenCode harness | P3 | **P2** | fixed |
| #89 Debby Gemini sub-agent | P3 | **P2** | fixed |
| #56 Antigravity harness | P2 | P2 | no regression |
| #92 Copilot harness | P2 | P2 | no regression |
| #206 pin input box (cosmetic) | P3 | P3 | control held |

Spec parses cleanly; `comp:tui` and the rest of the config are untouched.