### PR TITLE
support word-wrap code blocks in addition to horizontal scroll

### DIFF
--- a/ap-web/src/components/ai-elements/message.tsx
+++ b/ap-web/src/components/ai-elements/message.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { copyText } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
-import { CheckIcon, ChevronLeftIcon, ChevronRightIcon, CopyIcon } from "lucide-react";
+import { CheckIcon, ChevronLeftIcon, ChevronRightIcon, CopyIcon, WrapTextIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement, ReactNode } from "react";
 import {
   cloneElement,
@@ -325,6 +325,13 @@ function extractCodeText(children: ReactNode): string {
   return "";
 }
 
+// Shared visual style for the buttons overlaid on a chat code block (copy,
+// wrap toggle). The frosted/ghost look matches the rest of the chat surface;
+// positioning lives on the container in ChatCodeBlockPre, not here, so the
+// buttons stay layout-agnostic.
+const CODE_BLOCK_OVERLAY_BUTTON_CLASS =
+  "size-8 bg-sidebar/80 text-muted-foreground hover:text-foreground supports-[backdrop-filter]:bg-sidebar/70 supports-[backdrop-filter]:backdrop-blur";
+
 function ChatCodeBlockCopyButton({ getCode }: { getCode: () => string }) {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
@@ -360,7 +367,7 @@ function ChatCodeBlockCopyButton({ getCode }: { getCode: () => string }) {
   return (
     <Button
       aria-label="Copy Code"
-      className="absolute top-2 right-12 z-10 size-8 bg-sidebar/80 text-muted-foreground hover:text-foreground supports-[backdrop-filter]:bg-sidebar/70 supports-[backdrop-filter]:backdrop-blur"
+      className={CODE_BLOCK_OVERLAY_BUTTON_CLASS}
       onClick={handleClick}
       size="icon-sm"
       title="Copy Code"
@@ -372,17 +379,46 @@ function ChatCodeBlockCopyButton({ getCode }: { getCode: () => string }) {
   );
 }
 
+function ChatCodeBlockWrapToggle({ wrap, onToggle }: { wrap: boolean; onToggle: () => void }) {
+  return (
+    <Button
+      aria-label="Toggle word wrap"
+      aria-pressed={wrap}
+      // Brighten when active so the pressed state reads at a glance.
+      className={cn(CODE_BLOCK_OVERLAY_BUTTON_CLASS, wrap && "text-foreground")}
+      onClick={onToggle}
+      size="icon-sm"
+      title={wrap ? "Disable word wrap" : "Enable word wrap"}
+      type="button"
+      variant="ghost"
+    >
+      <WrapTextIcon size={14} />
+    </Button>
+  );
+}
+
 function ChatCodeBlockPre({ children }: ComponentProps<"pre">) {
   const code = extractCodeText(children);
   const getCode = useCallback(() => code, [code]);
+  // Soft-wrap long lines by default so users don't have to scroll horizontally
+  // to read code blocks. The toggle restores Streamdown's native
+  // horizontal-scroll view for when column alignment matters.
+  const [wrap, setWrap] = useState(true);
+  const toggleWrap = useCallback(() => setWrap((w) => !w), []);
   const block = isValidElement(children)
     ? cloneElement(children, { "data-block": "true" } as Record<string, unknown>)
     : children;
 
   return (
-    <div className="relative">
+    <div className={cn("relative", wrap && "chat-code-wrap")}>
       {block}
-      <ChatCodeBlockCopyButton getCode={getCode} />
+      {/* Overlay actions, anchored left of Streamdown's own download button
+          (which sits at the header's right edge). A flex row lets the buttons
+          self-arrange, so neither needs a hardcoded horizontal offset. */}
+      <div className="absolute top-2 right-12 z-10 flex items-center gap-1">
+        <ChatCodeBlockWrapToggle onToggle={toggleWrap} wrap={wrap} />
+        <ChatCodeBlockCopyButton getCode={getCode} />
+      </div>
     </div>
   );
 }

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -503,6 +503,27 @@
   font-size: 0.875em;
 }
 
+/* Word-wrap toggle for chat code blocks (see ChatCodeBlockPre in message.tsx).
+ * Streamdown renders the body with `overflow-x-auto` and the <code> with
+ * `white-space: pre`, so long lines scroll horizontally. When `.chat-code-wrap`
+ * is set we soft-wrap instead so everything fits the column width. */
+.chat-code-wrap [data-streamdown="code-block-body"] {
+  overflow-x: hidden;
+}
+.chat-code-wrap [data-streamdown="code-block-body"] pre,
+.chat-code-wrap [data-streamdown="code-block-body"] code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+/* Hang-indent wrapped continuation lines past the line-number gutter so they
+ * align with the code, not under the numbers. Gutter = before:w-6 (1.5rem) +
+ * before:mr-4 (1rem) = 2.5rem; the negative text-indent pulls the first line
+ * (and its ::before number) back to the left edge. */
+.chat-code-wrap [data-streamdown="code-block-body"] code > span {
+  padding-left: 2.5rem;
+  text-indent: -2.5rem;
+}
+
 /* Streamdown's <button> link-safety-modal variant and wrap-anywhere reset can
  * leave the default arrow cursor on links — force pointer to signal affordance. */
 [data-streamdown="link"] {

--- a/tests/e2e_ui/chat/test_chat_code_block_wrap.py
+++ b/tests/e2e_ui/chat/test_chat_code_block_wrap.py
@@ -1,0 +1,128 @@
+"""E2E: chat code blocks soft-wrap by default and expose a wrap toggle.
+
+Regression guard for the code-block readability fix. Streamdown renders a
+fenced code block with ``overflow-x-auto`` on the body and the inner
+``<code>`` at ``white-space: pre``, so a long line forces a horizontal
+scrollbar and can't be read without scrolling sideways. ``ChatCodeBlockPre``
+now soft-wraps by default (``.chat-code-wrap``) and renders a "Toggle word
+wrap" button that flips back to the native horizontal-scroll view.
+
+A deterministic assistant message (seeded via the ``external_assistant_message``
+event — no LLM run) carries a fenced ``markdown`` block with intentionally long
+lines (plus one long unbroken token, to exercise ``overflow-wrap: anywhere``).
+The test asserts the observable behavior:
+
+  - **Default (wrapped):** the code-block body does NOT overflow horizontally
+    (``scrollWidth <= clientWidth``), and the toggle reports ``aria-pressed=true``.
+  - **After clicking the toggle (unwrapped):** the long lines no longer wrap, so
+    the body overflows horizontally (``scrollWidth > clientWidth``) and the
+    toggle reports ``aria-pressed=false``.
+  - **Clicking again** restores the wrapped, non-overflowing state.
+
+Using ``scrollWidth``/``clientWidth`` (rather than asserting a class name) keeps
+the test tied to what the user actually sees — whether the content fits the
+column or needs horizontal scrolling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_AGENT_NAME = "hello_world"
+_CODE_BODY = '[data-streamdown="code-block-body"]'
+_TOGGLE = "Toggle word wrap"
+
+# A long, unbroken run of text (no spaces) that comfortably exceeds the chat
+# column width — exercises overflow-wrap: anywhere. A repeated word keeps it
+# low-entropy (so the secret scanner doesn't flag it) and obviously not a real
+# token.
+_LONG_WORD = "horizontalScrolling" * 14
+
+# Fenced ``markdown`` block whose source has deliberately long lines, so it can
+# only fit the column by wrapping. Generic joke content (no real identifiers).
+_MESSAGE_TEXT = (
+    "Here is the doc rendered as markdown source:\n\n"
+    "```markdown\n"
+    "# The Compendium of Coding Jokes, Programmer Puns, and Other Crimes Against Productivity\n\n"
+    "Welcome, weary traveler of the call stack, to a meticulously over-engineered collection of "
+    "jokes that absolutely no product manager asked for, was scoped for two story points, somehow "
+    "shipped after three sprints, and is now technically considered legacy code that nobody is "
+    "brave enough to refactor or delete.\n\n"
+    "This document is intentionally formatted with extremely long line widths because we believe "
+    "that horizontal scrolling builds character, strengthens the wrists, and prepares you "
+    "emotionally for the day you open a single line of source that just keeps going like this: "
+    f"{_LONG_WORD}\n"
+    "```\n"
+)
+
+# JS predicates: does the code-block body overflow horizontally (beyond a 1px
+# rounding tolerance)? ``_FITS`` is the wrapped state; ``_OVERFLOWS`` the scroll.
+_OVERFLOWS = (
+    "() => { const el = document.querySelector('"
+    + _CODE_BODY
+    + "'); return !!el && el.scrollWidth - el.clientWidth > 1; }"
+)
+_FITS = (
+    "() => { const el = document.querySelector('"
+    + _CODE_BODY
+    + "'); return !!el && el.scrollWidth - el.clientWidth <= 1; }"
+)
+
+
+@pytest.fixture
+def code_block_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Seed a runner-bound session with a long-lined markdown code block reply.
+
+    Reuses :func:`seeded_session` (a ``hello_world`` session already bound to the
+    spawned runner) and appends a deterministic assistant bubble via
+    ``external_assistant_message`` so no LLM turn runs.
+
+    :param seeded_session: ``(base_url, session_id)`` for a runner-bound session.
+    :returns: the same ``(base_url, session_id)`` after the reply is seeded.
+    """
+    base_url, session_id = seeded_session
+    event_resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": _MESSAGE_TEXT},
+        },
+        timeout=10.0,
+    )
+    event_resp.raise_for_status()
+    yield (base_url, session_id)
+
+
+def test_chat_code_block_wraps_by_default_and_toggle_switches(
+    page: Page,
+    code_block_session: tuple[str, str],
+) -> None:
+    """Code blocks wrap by default; the toggle switches to horizontal scroll."""
+    base_url, session_id = code_block_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # The assistant bubble and its rendered code block must be present. Shiki
+    # highlights asynchronously, so wait for the body element to mount.
+    body = page.locator(_CODE_BODY).first
+    expect(body).to_be_visible(timeout=30_000)
+
+    # Default: wrapped — the long lines fit the column with no horizontal scroll.
+    page.wait_for_function(_FITS, timeout=30_000)
+
+    toggle = page.get_by_role("button", name=_TOGGLE)
+    expect(toggle).to_be_visible(timeout=30_000)
+    expect(toggle).to_have_attribute("aria-pressed", "true")
+
+    # Toggle off: the long lines no longer wrap, so the body overflows sideways.
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-pressed", "false")
+    page.wait_for_function(_OVERFLOWS, timeout=10_000)
+
+    # Toggle back on: wrapping is restored and the overflow is gone again.
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-pressed", "true")
+    page.wait_for_function(_FITS, timeout=10_000)


### PR DESCRIPTION
## Problem

Code blocks in chat messages (rendered by Streamdown) force a **horizontal scrollbar** for long lines, so you have to scroll sideways to read them instead of having everything fit the column width.


https://github.com/user-attachments/assets/9b1ec1c3-9108-4c39-85b4-ecd60937a7f7

<img width="905" height="596" alt="image" src="https://github.com/user-attachments/assets/66f44e89-3959-4d0c-9a9e-1a5992416553" />

<img width="902" height="692" alt="image" src="https://github.com/user-attachments/assets/0b69c015-163d-4600-90d2-58863539d551" />


Root cause: Streamdown renders the code-block body with `overflow-x-auto` and the inner `<code>` at `white-space: pre`, and there's no built-in prop to make it wrap.

## Fix

Extends the existing `ChatCodeBlockPre` Streamdown `pre` override (where the custom copy button already lives) — no fork of Streamdown needed:

- **Soft-wrap by default.** A `.chat-code-wrap` class on the wrapper sets `white-space: pre-wrap; overflow-wrap: anywhere` on the body so long lines (and long unbroken tokens) wrap to the column width — no horizontal scrollbar.
- **Wrap toggle button.** A `WrapText` icon button next to the copy button lets users switch back to Streamdown's native horizontal-scroll view when column alignment matters.
- **Hanging indent.** Wrapped continuation lines are indented past the line-number gutter (`before:w-6` + `before:mr-4` = 2.5rem) so they align with the code rather than sliding under the line numbers.

### Files
- `ap-web/src/components/ai-elements/message.tsx` — wrap state + toggle button in `ChatCodeBlockPre`
- `ap-web/src/index.css` — `.chat-code-wrap` wrapping rules
- `tests/e2e_ui/chat/test_chat_code_block_wrap.py` — e2e_ui coverage of the wrap default + toggle interaction

## Verification
- `tsc --noEmit` — clean (exit 0)
- `oxlint` — no findings on changed files
- Verified in the running app: a fenced markdown block with deliberately long lines wraps to the column by default (no horizontal scrollbar) and the toggle switches back to horizontal scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)