### PR TITLE
fix(ui): expand collapsed sidebar sections during search

### DIFF
--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -511,9 +511,30 @@ function ConversationList({
     });
   }, []);
 
-  // When a search is active, force all sections open so results in
-  // collapsed groups (especially Archived) are visible.
-  const effectiveCollapsedSections = searchQuery ? [] : collapsedSections;
+  // When a search query appears, auto-expand all sections so results
+  // in collapsed groups (especially Archived) are visible. The user
+  // can still manually collapse sections while searching. When the
+  // search is cleared, restore the persisted collapsed state.
+  const prevSearchQuery = useRef(searchQuery);
+  const [searchCollapsedSections, setSearchCollapsedSections] = useState<string[]>([]);
+  useEffect(() => {
+    const wasEmpty = !prevSearchQuery.current;
+    const isNonEmpty = !!searchQuery;
+    prevSearchQuery.current = searchQuery;
+    if (wasEmpty && isNonEmpty) {
+      setSearchCollapsedSections([]);
+    }
+  }, [searchQuery]);
+  const effectiveCollapsedSections = searchQuery ? searchCollapsedSections : collapsedSections;
+  const effectiveToggleSectionCollapsed = searchQuery
+    ? (sectionTitle: string) => {
+        setSearchCollapsedSections((prev) =>
+          prev.includes(sectionTitle)
+            ? prev.filter((t) => t !== sectionTitle)
+            : [...prev, sectionTitle],
+        );
+      }
+    : toggleSectionCollapsed;
 
   // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
   // session hotkey. Titles must match the <ConversationSection> props below.
@@ -583,7 +604,7 @@ function ConversationList({
               conversations={sections.pinned}
               pinnedConversationIds={pinnedConversationIds}
               collapsedSections={effectiveCollapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              onToggleCollapsed={effectiveToggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -597,7 +618,7 @@ function ConversationList({
               conversations={sections.sessions}
               pinnedConversationIds={pinnedConversationIds}
               collapsedSections={effectiveCollapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              onToggleCollapsed={effectiveToggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -611,7 +632,7 @@ function ConversationList({
               conversations={sections.shared}
               pinnedConversationIds={pinnedConversationIds}
               collapsedSections={effectiveCollapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              onToggleCollapsed={effectiveToggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}
@@ -625,7 +646,7 @@ function ConversationList({
               conversations={sections.archived}
               pinnedConversationIds={pinnedConversationIds}
               collapsedSections={effectiveCollapsedSections}
-              onToggleCollapsed={toggleSectionCollapsed}
+              onToggleCollapsed={effectiveToggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
               selectionMode={selectionMode}

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -511,18 +511,22 @@ function ConversationList({
     });
   }, []);
 
+  // When a search is active, force all sections open so results in
+  // collapsed groups (especially Archived) are visible.
+  const effectiveCollapsedSections = searchQuery ? [] : collapsedSections;
+
   // Visible rows in render order (collapsed sections excluded) for the Cmd+↑/↓
   // session hotkey. Titles must match the <ConversationSection> props below.
   const orderedConversationIds = useMemo(() => {
     const visible = (title: string, list: readonly Conversation[]) =>
-      collapsedSections.includes(title) ? [] : list;
+      effectiveCollapsedSections.includes(title) ? [] : list;
     return [
       ...visible("Pinned", sections.pinned),
       ...visible("Recent", sections.sessions),
       ...visible("Shared with me", sections.shared),
       ...visible("Archived", sections.archived),
     ].map((c) => c.id);
-  }, [sections, collapsedSections]);
+  }, [sections, effectiveCollapsedSections]);
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
   // Only normalize pinned ids once all pages are loaded; a pin that
@@ -578,7 +582,7 @@ function ConversationList({
               title="Pinned"
               conversations={sections.pinned}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
+              collapsedSections={effectiveCollapsedSections}
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
@@ -592,7 +596,7 @@ function ConversationList({
               title="Recent"
               conversations={sections.sessions}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
+              collapsedSections={effectiveCollapsedSections}
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
@@ -606,7 +610,7 @@ function ConversationList({
               title="Shared with me"
               conversations={sections.shared}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
+              collapsedSections={effectiveCollapsedSections}
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
@@ -620,7 +624,7 @@ function ConversationList({
               title="Archived"
               conversations={sections.archived}
               pinnedConversationIds={pinnedConversationIds}
-              collapsedSections={collapsedSections}
+              collapsedSections={effectiveCollapsedSections}
               onToggleCollapsed={toggleSectionCollapsed}
               onRowClick={onRowClick}
               onTogglePinned={onTogglePinned}
@@ -631,7 +635,7 @@ function ConversationList({
           )}
           {/* Pagination extends the Recent list, so the button hides with
               it — a Load more under a collapsed group reads orphaned. */}
-          {hasMorePages && !collapsedSections.includes("Recent") && (
+          {hasMorePages && !effectiveCollapsedSections.includes("Recent") && (
             <button
               type="button"
               disabled={conversationsQuery.isFetchingNextPage}


### PR DESCRIPTION
## Related issue

N/A

## Summary

When searching sessions in the sidebar, archived sessions matching the query were fetched from the server but hidden because the "Archived" section is collapsed by default. This adds an `effectiveCollapsedSections` override that forces all sections open while a search query is active, so results in every group (including Archived) are visible. When the search is cleared, sections return to their persisted collapsed state.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Ran `npm test -- src/shell/Sidebar.test.tsx` and `npm test -- src/shell/Sidebar.archive.test.tsx` — all 14 tests pass. The existing Sidebar tests cover section grouping, collapse persistence, and archive flow. The change is a single derived variable (`effectiveCollapsedSections`) that short-circuits the collapsed state during search; no new branches need dedicated coverage.