### PR TITLE
feat(web): collapsible dropdown for nested subagents

### DIFF
--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import {
   BookOpenIcon,
   Code2Icon,
@@ -92,6 +92,15 @@ function childRow(container: HTMLElement, childId: string): HTMLElement {
   const el = container.querySelector<HTMLElement>(`[data-child-session-id="${childId}"]`);
   if (!el) throw new Error(`subagent row ${childId} not rendered`);
   return el;
+}
+
+function collapseToggleFor(container: HTMLElement, childId: string): HTMLElement {
+  const row = childRow(container, childId);
+  const toggle = row
+    .closest("li")
+    ?.querySelector<HTMLElement>('[data-testid="subagent-collapse-toggle"]');
+  if (!toggle) throw new Error(`collapse toggle for ${childId} not rendered`);
+  return toggle;
 }
 
 /** Point useChildSessions at an id-keyed tree of children. The panel
@@ -1369,6 +1378,66 @@ describe("SubagentsPanel", () => {
     const pad = (id: string) => parseInt(childRow(container, id).style.paddingLeft, 10);
     expect(pad("conv_grandchild")).toBeGreaterThan(pad("conv_child"));
     expect(pad("conv_ggchild")).toBeGreaterThan(pad("conv_grandchild"));
+  });
+
+  it("collapses and expands a row's nested subagents", () => {
+    mockChildTree({
+      conv_root: [
+        childInfo({ id: "conv_child", tool: "researcher", session_name: "auth" }),
+        childInfo({ id: "conv_leaf", tool: "Explore", session_name: "leaf" }),
+      ],
+      conv_child: [childInfo({ id: "conv_grandchild", tool: "Explore", session_name: "files" })],
+    });
+
+    const { container } = renderPanel({ rootSessionId: "conv_root" });
+
+    expect(childRow(container, "conv_grandchild")).toBeInTheDocument();
+    expect(screen.getAllByTestId("subagent-collapse-toggle")).toHaveLength(1);
+
+    const toggle = screen.getByTestId("subagent-collapse-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-label", "Collapse subagents");
+
+    fireEvent.click(toggle);
+
+    expect(container.querySelector('[data-child-session-id="conv_grandchild"]')).toBeNull();
+    expect(childRow(container, "conv_leaf")).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle).toHaveAttribute("aria-label", "Expand subagents");
+
+    fireEvent.click(toggle);
+
+    expect(childRow(container, "conv_grandchild")).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-label", "Collapse subagents");
+  });
+
+  it("preserves a nested row's collapsed state when its parent unmounts it", () => {
+    mockChildTree({
+      conv_root: [childInfo({ id: "conv_child", tool: "researcher", session_name: "auth" })],
+      conv_child: [childInfo({ id: "conv_grandchild", tool: "Explore", session_name: "files" })],
+      conv_grandchild: [childInfo({ id: "conv_ggchild", tool: "Explore", session_name: "deep" })],
+    });
+
+    const { container } = renderPanel({ rootSessionId: "conv_root" });
+
+    const childToggle = collapseToggleFor(container, "conv_child");
+    const grandchildToggle = collapseToggleFor(container, "conv_grandchild");
+
+    fireEvent.click(grandchildToggle);
+    expect(container.querySelector('[data-child-session-id="conv_ggchild"]')).toBeNull();
+    expect(grandchildToggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(childToggle);
+    expect(container.querySelector('[data-child-session-id="conv_grandchild"]')).toBeNull();
+
+    fireEvent.click(childToggle);
+    expect(childRow(container, "conv_grandchild")).toBeInTheDocument();
+    expect(container.querySelector('[data-child-session-id="conv_ggchild"]')).toBeNull();
+    expect(collapseToggleFor(container, "conv_grandchild")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   it("stops fetching and rendering below the depth cap", () => {

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -21,6 +21,8 @@ import {
   BotIcon,
   Code2Icon,
   CompassIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   CornerDownRightIcon,
   FileTextIcon,
   FlaskConicalIcon,
@@ -102,6 +104,10 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
   const { children, isLoading, error } = useChildSessions(rootSessionId);
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>({});
+  const toggleCollapsedRow = (id: string) => {
+    setCollapsedRows((current) => ({ ...current, [id]: !current[id] }));
+  };
 
   // Loading/error states only surface when there's no cached data to
   // show alongside the "main" row.
@@ -152,7 +158,14 @@ export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanel
       <ul className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-1">
         <MainRow rootSessionId={rootSessionId} isActive={conversationId === rootSessionId} />
         {children.map((child) => (
-          <SubagentRow key={child.id} child={child} depth={1} conversationId={conversationId} />
+          <SubagentRow
+            key={child.id}
+            child={child}
+            depth={1}
+            conversationId={conversationId}
+            collapsedRows={collapsedRows}
+            onToggleCollapsed={toggleCollapsedRow}
+          />
         ))}
       </ul>
       {/* Mounted only while open so a closed rail issues no /v1/agents
@@ -684,18 +697,28 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
 // as a tree.
 const ROW_BASE_PADDING_PX = 24;
 const ROW_DEPTH_STEP_PX = 14;
+const ROW_TOGGLE_SIZE_PX = 16;
+
+function rowPaddingLeft(depth: number): number {
+  return ROW_BASE_PADDING_PX + (depth - 1) * ROW_DEPTH_STEP_PX;
+}
 
 function SubagentRow({
   child,
   depth,
   conversationId,
+  collapsedRows,
+  onToggleCollapsed,
 }: {
   child: ChildSessionInfo;
   /** Levels below the root, 1 = direct child of "main". */
   depth: number;
   /** The conversation currently rendered in main, for row highlighting. */
   conversationId: string;
+  collapsedRows: Record<string, boolean>;
+  onToggleCollapsed: (id: string) => void;
 }) {
+  const collapsed = collapsedRows[child.id] ?? false;
   const status = childStatus(child);
   const search = railLinkSearch(useLocation().search);
   const Icon = brandChildIcon(child) ?? iconForAgentType(child.tool);
@@ -704,12 +727,31 @@ function SubagentRow({
   // De-emphasize settled rows (done/idle) so working/failed agents dominate
   // — but never the row the user is currently viewing.
   const dim = !isActive && SETTLED_STATE[status.activity];
-  // Disabled (null id) at the depth cap so the fan-out is bounded;
-  // ``useChildSessions`` skips the query entirely for null.
+  // This child's own sub-agents, rendered as the next tree level.
+  // Disabled (null id) at the depth cap so the fan-out of fetches is
+  // bounded; ``useChildSessions`` skips the query entirely for null.
   const { children: grandchildren } = useChildSessions(depth < MAX_TREE_DEPTH ? child.id : null);
+  const hasGrandchildren = grandchildren.length > 0;
+  const ToggleIcon = collapsed ? ChevronRightIcon : ChevronDownIcon;
   return (
     <>
-      <li>
+      <li className="relative">
+        {hasGrandchildren && (
+          <button
+            type="button"
+            data-testid="subagent-collapse-toggle"
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand subagents" : "Collapse subagents"}
+            style={{ left: rowPaddingLeft(depth) - ROW_TOGGLE_SIZE_PX }}
+            className="absolute top-2 z-10 flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleCollapsed(child.id);
+            }}
+          >
+            <ToggleIcon aria-hidden="true" className="size-3.5" />
+          </button>
+        )}
         <Link
           // See MainRow: drop session-scoped params on rail navigation
           // (preserving global ones like ``?debug=1``) so a sticky
@@ -720,7 +762,7 @@ function SubagentRow({
           data-depth={depth}
           // Left gutter (depth-stepped) + connector glyph nests this row
           // under its parent, signaling where it sits in the tree.
-          style={{ paddingLeft: ROW_BASE_PADDING_PX + (depth - 1) * ROW_DEPTH_STEP_PX }}
+          style={{ paddingLeft: rowPaddingLeft(depth) }}
           className={cn(
             "flex w-full flex-col gap-0.5 py-2 pr-2.5 text-left hover:bg-accent/60",
             isActive && "bg-accent",
@@ -728,12 +770,16 @@ function SubagentRow({
           )}
         >
           <div className="flex w-full items-center gap-1">
-            <CornerDownRightIcon
-              // Decorative nesting connector — the role icon beside it carries
-              // the meaning, so hide this from the accessibility tree.
-              aria-hidden="true"
-              className="-ml-3 size-3 shrink-0 text-muted-foreground/60"
-            />
+            {hasGrandchildren ? (
+              <span aria-hidden="true" className="-ml-3 size-3 shrink-0" />
+            ) : (
+              <CornerDownRightIcon
+                // Decorative nesting connector — the role icon beside it carries
+                // the meaning, so hide this from the accessibility tree.
+                aria-hidden="true"
+                className="-ml-3 size-3 shrink-0 text-muted-foreground/60"
+              />
+            )}
             <Icon className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="shrink-0 truncate text-xs font-medium">{primary}</span>
             <span className="flex-1" />
@@ -750,14 +796,17 @@ function SubagentRow({
           )}
         </Link>
       </li>
-      {grandchildren.map((grandchild) => (
-        <SubagentRow
-          key={grandchild.id}
-          child={grandchild}
-          depth={depth + 1}
-          conversationId={conversationId}
-        />
-      ))}
+      {!collapsed &&
+        grandchildren.map((grandchild) => (
+          <SubagentRow
+            key={grandchild.id}
+            child={grandchild}
+            depth={depth + 1}
+            conversationId={conversationId}
+            collapsedRows={collapsedRows}
+            onToggleCollapsed={onToggleCollapsed}
+          />
+        ))}
     </>
   );
 }


### PR DESCRIPTION
## Summary
Nested (L2+) subagents in the subagents panel can now be collapsed via a dropdown, so deep subagent trees stay readable.

## Changes
Adds collapse state to the recursive `SubagentRow` in `SubagentsPanel.tsx`. Self-contained UI change; no data or backend changes.

## Testing
Extended `SubagentsPanel.test.tsx` to cover collapsing/expanding nested rows.

Fixes #957

AI was used for assistance.
