### PR TITLE
docs(codex-native): update stale config.toml isolation comment

### DIFF
--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -275,18 +275,13 @@ def read_codex_config_model(bridge_dir: Path) -> str | None:
     config with no top-level ``model``) returns ``None``, so the caller falls
     back to the server-resolved model rather than crashing.
 
-    KNOWN LIMITATION — this file is SHARED across all codex sessions.
-    ``config.toml`` here is symlinked to the single real ``~/.codex/config.toml``
-    (see ``_CODEX_HOME_CONFIG_FILES`` /  ``_populate_codex_home_config`` in
-    ``omnigent.inner.codex_executor``). So the model returned is whatever the
-    LAST ``/model`` from ANY codex session wrote — it is NOT per-session.
-    Consequences for the cost gate: (1) one session's ``/model`` to a cheap
-    model makes a *different* session still on an EXPENSIVE model read the
-    cheap value and never get gated; (2) a freshly spawned session reads a
-    leftover value that may not match its own launch ``--model``. Acceptable
-    for single-user/local use; a hole under concurrent/multi-user codex
-    sessions. Fix (not yet done): copy config.toml per-session + seed it with
-    the session's launch model.
+    Per-session isolation: ``config.toml`` is **copied** (not symlinked)
+    into each session's private ``CODEX_HOME`` by
+    ``_populate_codex_home_config`` (see ``_CODEX_HOME_COPY_FILES`` in
+    ``omnigent.inner.codex_executor``), then seeded with the session's
+    launch model by ``_pin_codex_config_model`` in
+    ``omnigent.codex_native_app_server``. An in-TUI ``/model`` writes
+    only to that session's copy, so concurrent sessions do not interfere.
 
     :param bridge_dir: The session's native-Codex bridge directory.
     :returns: The top-level ``model`` from ``config.toml`` (e.g.


### PR DESCRIPTION
## Related issue

N/A — stale comment cleanup; no behavioral change.

## Summary

The `KNOWN LIMITATION` docstring in `read_codex_config_model` (codex_native_bridge.py:278) still described `config.toml` as symlinked across all sessions and the per-session fix as "not yet done." The fix has been in place since #34 (`_CODEX_HOME_COPY_FILES` copies instead of symlinking) and `_pin_codex_config_model` (seeds the launch model). Updated the comment to reflect the current copy-and-seed behavior and corrected the stale `_CODEX_HOME_CONFIG_FILES` reference to `_CODEX_HOME_COPY_FILES`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Existing tests cover this change
- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage rationale

Comment-only change — no code behavior modified. Ran `pytest tests/test_codex_native_bridge.py` (13 passed) to confirm nothing broke.