### PR TITLE
iOS: show server selector on new-session page, hide find-in-page, fix dismiss shadow flicker

### DIFF
--- a/ap-web/ios/Omnigent/WebShellView.swift
+++ b/ap-web/ios/Omnigent/WebShellView.swift
@@ -31,8 +31,7 @@ struct WebShellView: View {
           maxWidth: ServerSwitcherMetrics.maxWidth(for: geometry.size.width),
           switchServer: switchServer,
           connectToNewServer: connectToNewServer,
-          reload: model.reload,
-          find: model.showFind
+          reload: model.reload
         )
         .padding(.top, 8)
         .opacity(model.serverSwitcherHidden ? 0 : 1)
@@ -65,7 +64,6 @@ private struct ServerSwitcher: View {
   let switchServer: (String) -> Void
   let connectToNewServer: () -> Void
   let reload: () -> Void
-  let find: () -> Void
 
   @Environment(\.colorScheme) private var colorScheme
 
@@ -95,10 +93,6 @@ private struct ServerSwitcher: View {
         Label("Reload", systemImage: "arrow.clockwise")
       }
 
-      Button(action: find) {
-        Label("Find in Page", systemImage: "magnifyingglass")
-      }
-
       Divider()
 
       Button(action: connectToNewServer) {
@@ -126,15 +120,20 @@ private struct ServerSwitcher: View {
       .padding(.horizontal, 10)
       .frame(height: 28)
       .frame(maxWidth: maxWidth)
-      .background(.ultraThinMaterial)
-      .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
-      .overlay {
-        RoundedRectangle(cornerRadius: 9, style: .continuous)
-          .stroke(Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.10), lineWidth: 0.5)
-      }
-      .shadow(color: .black.opacity(colorScheme == .dark ? 0.22 : 0.08), radius: 10, y: 4)
+      .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
     }
     .buttonStyle(.plain)
+    // The material/border/shadow live OUTSIDE the `label:` closure, on the
+    // Menu's persistent host view. Applied inside the closure, UIKit's menu
+    // presentation snapshots the styled label for its open/dismiss morph and
+    // drops the shadow layer — leaving the pill flat (no shadow) for a beat
+    // after dismissal. Keeping the chrome on the Menu sidesteps that snapshot.
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 9, style: .continuous)
+        .stroke(Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.10), lineWidth: 0.5)
+    }
+    .shadow(color: .black.opacity(colorScheme == .dark ? 0.22 : 0.08), radius: 10, y: 4)
     .accessibilityLabel("Switch server")
   }
 }

--- a/ap-web/ios/Omnigent/WebViewModel.swift
+++ b/ap-web/ios/Omnigent/WebViewModel.swift
@@ -13,12 +13,6 @@ final class WebViewModel: ObservableObject {
     webView?.reload()
   }
 
-  func showFind() {
-    guard let webView else { return }
-    webView.isFindInteractionEnabled = true
-    webView.findInteraction?.presentFindNavigator(showingReplace: false)
-  }
-
   func emitNotificationActivation(_ path: String) {
     guard path.starts(with: "/") else { return }
     let script = "window.__omnigentNativeEmitNotificationActivated?.(\(Self.javascriptString(path)));"

--- a/ap-web/src/hooks/useNativeServerSwitcher.ts
+++ b/ap-web/src/hooks/useNativeServerSwitcher.ts
@@ -1,0 +1,90 @@
+import { useEffect } from "react";
+
+import { isIOSShell, setNativeServerSwitcherHidden } from "@/lib/nativeBridge";
+
+/**
+ * Drive the iOS shell's native server switcher overlay so it shows only while
+ * `surface` is the frontmost element on screen and `active` is true. The
+ * switcher is a native chrome element the web app toggles via the bridge; it
+ * must hide whenever the sidebar (or any other overlay) covers the main
+ * surface, and whenever the surface is unmounted.
+ *
+ * No-ops outside the iOS shell. Used by both the in-session main surface
+ * (ChatPage) and the new-session landing screen (NewChatDialog).
+ */
+export function useNativeServerSwitcherForMainSurface(
+  surface: HTMLElement | null,
+  active: boolean,
+) {
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    if (!active) {
+      setNativeServerSwitcherHidden(true);
+      return;
+    }
+
+    let frame = 0;
+    const sync = () => {
+      frame = 0;
+      setNativeServerSwitcherHidden(!isSurfaceFrontmost(surface));
+    };
+    const schedule = () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(sync);
+    };
+
+    schedule();
+
+    const observer =
+      typeof MutationObserver !== "undefined" ? new MutationObserver(schedule) : null;
+    observer?.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["class", "style", "aria-hidden", "data-state", "data-collapsed", "open"],
+    });
+
+    window.addEventListener("resize", schedule);
+    window.addEventListener("orientationchange", schedule);
+    window.addEventListener("scroll", schedule, true);
+    window.addEventListener("transitionend", schedule, true);
+    window.addEventListener("animationend", schedule, true);
+    window.addEventListener("focusin", schedule, true);
+    window.addEventListener("focusout", schedule, true);
+    window.visualViewport?.addEventListener("resize", schedule);
+    window.visualViewport?.addEventListener("scroll", schedule);
+
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      observer?.disconnect();
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("orientationchange", schedule);
+      window.removeEventListener("scroll", schedule, true);
+      window.removeEventListener("transitionend", schedule, true);
+      window.removeEventListener("animationend", schedule, true);
+      window.removeEventListener("focusin", schedule, true);
+      window.removeEventListener("focusout", schedule, true);
+      window.visualViewport?.removeEventListener("resize", schedule);
+      window.visualViewport?.removeEventListener("scroll", schedule);
+      setNativeServerSwitcherHidden(true);
+    };
+  }, [active, surface]);
+}
+
+function isSurfaceFrontmost(surface: HTMLElement | null): boolean {
+  if (!surface) return false;
+  const rect = surface.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
+
+  const xInset = Math.min(24, Math.max(1, rect.width / 4));
+  const yInset = Math.min(24, Math.max(1, rect.height / 4));
+  const x = clamp(window.innerWidth / 2, rect.left + xInset, rect.right - xInset);
+  const y = clamp(rect.top + rect.height * 0.38, rect.top + yInset, rect.bottom - yInset);
+  const topElement = document.elementFromPoint(x, y);
+  return topElement !== null && surface.contains(topElement);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -58,7 +58,7 @@ import { parseSystemMessage } from "@/lib/systemMessage";
 import { Button } from "@/components/ui/button";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { cn } from "@/lib/utils";
-import { isIOSShell, setNativeServerSwitcherHidden } from "@/lib/nativeBridge";
+import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1162,80 +1162,6 @@ export function shouldShowTerminalSurface(
   return (
     !!conversationId && terminalFirst?.isTerminalFirst === true && terminalFirst.view === "terminal"
   );
-}
-
-function useNativeServerSwitcherForMainSurface(surface: HTMLElement | null, active: boolean) {
-  useEffect(() => {
-    if (!isIOSShell()) return;
-    if (!active) {
-      setNativeServerSwitcherHidden(true);
-      return;
-    }
-
-    let frame = 0;
-    const sync = () => {
-      frame = 0;
-      setNativeServerSwitcherHidden(!isSurfaceFrontmost(surface));
-    };
-    const schedule = () => {
-      if (frame !== 0) cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(sync);
-    };
-
-    schedule();
-
-    const observer =
-      typeof MutationObserver !== "undefined" ? new MutationObserver(schedule) : null;
-    observer?.observe(document.body, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      attributeFilter: ["class", "style", "aria-hidden", "data-state", "data-collapsed", "open"],
-    });
-
-    window.addEventListener("resize", schedule);
-    window.addEventListener("orientationchange", schedule);
-    window.addEventListener("scroll", schedule, true);
-    window.addEventListener("transitionend", schedule, true);
-    window.addEventListener("animationend", schedule, true);
-    window.addEventListener("focusin", schedule, true);
-    window.addEventListener("focusout", schedule, true);
-    window.visualViewport?.addEventListener("resize", schedule);
-    window.visualViewport?.addEventListener("scroll", schedule);
-
-    return () => {
-      if (frame !== 0) cancelAnimationFrame(frame);
-      observer?.disconnect();
-      window.removeEventListener("resize", schedule);
-      window.removeEventListener("orientationchange", schedule);
-      window.removeEventListener("scroll", schedule, true);
-      window.removeEventListener("transitionend", schedule, true);
-      window.removeEventListener("animationend", schedule, true);
-      window.removeEventListener("focusin", schedule, true);
-      window.removeEventListener("focusout", schedule, true);
-      window.visualViewport?.removeEventListener("resize", schedule);
-      window.visualViewport?.removeEventListener("scroll", schedule);
-      setNativeServerSwitcherHidden(true);
-    };
-  }, [active, surface]);
-}
-
-function isSurfaceFrontmost(surface: HTMLElement | null): boolean {
-  if (!surface) return false;
-  const rect = surface.getBoundingClientRect();
-  if (rect.width <= 0 || rect.height <= 0) return false;
-
-  const xInset = Math.min(24, Math.max(1, rect.width / 4));
-  const yInset = Math.min(24, Math.max(1, rect.height / 4));
-  const x = clamp(window.innerWidth / 2, rect.left + xInset, rect.right - xInset);
-  const y = clamp(rect.top + rect.height * 0.38, rect.top + yInset, rect.bottom - yInset);
-  const topElement = document.elementFromPoint(x, y);
-  return topElement !== null && surface.contains(topElement);
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (max < min) return min;
-  return Math.min(Math.max(value, min), max);
 }
 
 /**

--- a/ap-web/src/shell/NewChatDialog.tsx
+++ b/ap-web/src/shell/NewChatDialog.tsx
@@ -58,6 +58,7 @@ import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
+import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import type { Conversation } from "@/hooks/useConversations";
 import { OttoEyes } from "@/components/OttoEyes";
 import { SkillPills } from "@/components/SkillPills";
@@ -715,6 +716,12 @@ export function NewChatLandingScreen() {
     [agentList],
   );
 
+  // Surface element backing the iOS native server switcher overlay, which
+  // the in-session view shows too — the picker stays reachable while starting
+  // a new session. The hook hides it whenever the sidebar covers the surface.
+  const [landingSurface, setLandingSurface] = useState<HTMLElement | null>(null);
+  useNativeServerSwitcherForMainSurface(landingSurface, true);
+
   const [message, setMessage] = useState<string>("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
@@ -1259,7 +1266,11 @@ export function NewChatLandingScreen() {
   return (
     // pb-12 lifts the content slightly above the geometric center, where
     // the hero reads better optically.
-    <div className="flex flex-1 items-center justify-center" data-testid="new-chat-landing">
+    <div
+      ref={setLandingSurface}
+      className="flex flex-1 items-center justify-center"
+      data-testid="new-chat-landing"
+    >
       {/* Padding lives inside the 840px cap, so the composer renders at
           840 − 80 = 760px max. */}
       <div className="flex w-full max-w-[840px] flex-col items-center gap-8 px-10 pt-8 pb-16">


### PR DESCRIPTION
## Summary

- Surface the iOS native server selector on the new-session landing screen, not just inside an active conversation. Extracted the visibility hook from `ChatPage` into a shared `useNativeServerSwitcher` module (avoids a circular import, since `ChatPage` already imports `NewChatLandingScreen`) and wired it into `NewChatLandingScreen` against the landing surface element.
- Removed the "Find in Page" item from the iOS `ServerSwitcher` menu and dropped the now-unused `WebViewModel.showFind()`.
- Fixed a jarring UX glitch where the selector pill lost its drop shadow for a beat after the menu was dismissed. The chrome (material/border/shadow) was inside the `Menu`'s `label:` closure, so UIKit's menu-presentation snapshot dropped the shadow layer during the open/dismiss morph. Moved that chrome onto the Menu's persistent host view so it survives the snapshot.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Web side verified with `npm run type-check` (clean) and the existing suites `npx vitest run src/lib/nativeBridge.test.ts` (23 passed) plus `src/shell/NewChatDialog.test.tsx` and `NewChatDialog.flow.test.tsx` (132 passed, 1 skipped). iOS changes verified by a full simulator build (`xcodebuild ... build` -> BUILD SUCCEEDED); the shadow-flicker fix is a visual/timing behavior not expressible as an automated test.
