### PR TITLE
feat: Escape key closes the active file tab instead of the entire UI

### DIFF
--- a/ap-web/src/shell/CodeViewer.tsx
+++ b/ap-web/src/shell/CodeViewer.tsx
@@ -315,14 +315,15 @@ export function CodeViewer({
         selection.removeAllRanges();
         selection.addRange(range);
         selectAllPendingRef.current = true;
-      } else if (e.key === "Escape") {
+      } else if (e.key === "Escape" && searchOpen) {
+        e.preventDefault();
         setSearchOpen(false);
         setSearchQuery("");
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [panelOpen, isMarkdownEditor, showMonaco, setSearchOpen, searchInputRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [panelOpen, isMarkdownEditor, showMonaco, searchOpen, setSearchOpen, searchInputRef]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // In Monaco mode the custom search bar isn't rendered; the editor opens its
   // native find when `searchOpen` is set (once it has mounted), then calls this

--- a/ap-web/src/shell/FileViewer.test.tsx
+++ b/ap-web/src/shell/FileViewer.test.tsx
@@ -1007,3 +1007,59 @@ describe("FileViewer keyboard shortcut — Alt+← / Alt+→", () => {
     document.body.removeChild(input);
   });
 });
+
+describe("FileViewer Escape closes the active tab", () => {
+  // Escape closes the open file tab via onCloseTab, but only when the press
+  // wasn't already consumed (in-file search or an overlay) and focus isn't in
+  // a text field — so dismissing a dialog or hitting Escape while typing never
+  // collapses the tab out from under the user.
+  function renderWithCloseTab(onCloseTab: () => void) {
+    useCommentsMock.mockReturnValue(makeCommentsQuery(undefined));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/"]}>
+          <FileViewer
+            open
+            conversationId="conv_1"
+            path="file1.py"
+            onClose={vi.fn()}
+            onCloseTab={onCloseTab}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  it("closes the tab on Escape when nothing else handled the key", () => {
+    const onCloseTab = vi.fn();
+    renderWithCloseTab(onCloseTab);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCloseTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Escape while focus is in a text field", () => {
+    const onCloseTab = vi.fn();
+    renderWithCloseTab(onCloseTab);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onCloseTab).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it("ignores Escape already consumed by an overlay (defaultPrevented)", () => {
+    const onCloseTab = vi.fn();
+    renderWithCloseTab(onCloseTab);
+    // A Radix dialog dismisses on Escape in the capture phase and calls
+    // preventDefault; mirror that here so the tab-close guard bails.
+    const swallow = (e: KeyboardEvent) => {
+      if (e.key === "Escape") e.preventDefault();
+    };
+    window.addEventListener("keydown", swallow, { capture: true });
+    fireEvent.keyDown(window, { key: "Escape" });
+    window.removeEventListener("keydown", swallow, { capture: true });
+    expect(onCloseTab).not.toHaveBeenCalled();
+  });
+});

--- a/ap-web/src/shell/FileViewer.tsx
+++ b/ap-web/src/shell/FileViewer.tsx
@@ -277,6 +277,8 @@ interface FileViewerProps {
    * when the viewer is embedded inside the inline right panel.
    */
   frameless?: boolean;
+  /** Called when the user presses Escape to close the active file tab. */
+  onCloseTab?: () => void;
   /** Called when the comments panel opens or closes inside the viewer. */
   onCommentsOpenChange?: (open: boolean) => void;
   /**
@@ -311,6 +313,7 @@ function FileViewerBody({
   conversationId,
   path,
   onClose,
+  onCloseTab,
   onNavigateTo,
   permissionLevel,
   frameless,
@@ -571,6 +574,26 @@ function FileViewerBody({
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [open, onNavigateTo, currentNavIdx, prevPath, nextPath, guardDirty]);
+
+  // Escape closes the active file tab (when search is not open).
+  useEffect(() => {
+    if (!open || !onCloseTab) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      if (searchOpen) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest('textarea, input, [contenteditable="true"]')
+      ) {
+        return;
+      }
+      e.preventDefault();
+      guardDirty(onCloseTab);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onCloseTab, searchOpen, guardDirty]);
 
   // View mode toggle — preview is the default for md/html, source for everything else.
   const lang = detectLang(path);

--- a/ap-web/src/shell/WorkspacePanel.tsx
+++ b/ap-web/src/shell/WorkspacePanel.tsx
@@ -1,5 +1,5 @@
 import { BotIcon, FileIcon, ListTodoIcon, TerminalIcon, XIcon } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { FilesPanel } from "./FilesPanel";
@@ -250,6 +250,12 @@ export function WorkspacePanel({
   filesPanelShowHidden,
   onShowHiddenChange,
 }: WorkspacePanelProps) {
+  // Memoized so FileViewer's Escape-to-close effect doesn't re-subscribe its
+  // window keydown listener on every render — an inline arrow would change
+  // identity each render and thrash the effect's add/remove cycle.
+  const handleCloseTab = useCallback(() => {
+    if (selectedFilePath !== null) onCloseFile(selectedFilePath);
+  }, [onCloseFile, selectedFilePath]);
   return (
     <aside
       aria-label="Workspace"
@@ -411,7 +417,7 @@ export function WorkspacePanel({
             conversationId={conversationId}
             path={selectedFilePath}
             onClose={onShowScopeView}
-            onCloseTab={() => onCloseFile(selectedFilePath)}
+            onCloseTab={handleCloseTab}
             onNavigateTo={openFileViewer}
             permissionLevel={permissionLevel}
             onCommentsOpenChange={onCommentsOpenChange}

--- a/ap-web/src/shell/WorkspacePanel.tsx
+++ b/ap-web/src/shell/WorkspacePanel.tsx
@@ -411,6 +411,7 @@ export function WorkspacePanel({
             conversationId={conversationId}
             path={selectedFilePath}
             onClose={onShowScopeView}
+            onCloseTab={() => onCloseFile(selectedFilePath)}
             onNavigateTo={openFileViewer}
             permissionLevel={permissionLevel}
             onCommentsOpenChange={onCommentsOpenChange}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- When a file tab is open in the workspace panel, pressing Escape now closes only that tab (switching to its neighbor) rather than affecting the broader UI.
- If the in-file search bar is open, Escape still closes the search first — only when search is already closed does Escape close the tab.
- Uses `guardDirty` to respect unsaved-changes protection before closing.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Manually verified the following scenarios:
- Pressing Escape with a file tab open closes the tab and activates the neighbor tab.
- Pressing Escape with the search bar open closes the search bar (not the tab).
- Pressing Escape while focused in an input/textarea does not close the tab.
- No regressions in existing keyboard shortcuts (Alt+Arrow file navigation, Cmd+F search).