### PR TITLE
fix(ap-web): protect TipTap type-only augmentation imports from oxlint --fix

### DIFF
--- a/ap-web/src/shell/MarkdownEditorToolbar.tsx
+++ b/ap-web/src/shell/MarkdownEditorToolbar.tsx
@@ -36,8 +36,10 @@ import "@tiptap/markdown";
 // Type-only import: activates @tiptap/extension-table's TypeScript module
 // augmentation so editor.chain() includes table commands (insertTable, etc.)
 // without pulling the full extension into the runtime bundle.
+// eslint-disable-next-line import/no-empty-named-blocks -- deliberate type-only augmentation trigger, not a stray empty import
 import type {} from "@tiptap/extension-table";
 // Same trick for the list package's command augmentation (toggleTaskList).
+// eslint-disable-next-line import/no-empty-named-blocks -- deliberate type-only augmentation trigger, not a stray empty import
 import type {} from "@tiptap/extension-list";
 import { TableMap, cellAround, colCount, findTable, isInTable } from "@tiptap/pm/tables";
 import { cn } from "@/lib/utils";

--- a/ap-web/src/shell/TableBubbleMenu.tsx
+++ b/ap-web/src/shell/TableBubbleMenu.tsx
@@ -16,6 +16,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Editor } from "@tiptap/react";
+// Type-only import: activates @tiptap/extension-table's TypeScript module
+// augmentation so the editor's table commands resolve, without pulling the
+// extension into the runtime bundle.
+// eslint-disable-next-line import/no-empty-named-blocks -- deliberate type-only augmentation trigger, not a stray empty import
 import type {} from "@tiptap/extension-table";
 import { TextSelection } from "@tiptap/pm/state";
 import { Fragment } from "@tiptap/pm/model";


### PR DESCRIPTION
## Summary

- `oxlint`'s `import/no-empty-named-blocks` rule flags the deliberate `import type {} from "@tiptap/..."` lines as empty named import blocks, so `oxlint --fix` silently deletes them. Those imports are type-only side-effect triggers for TipTap's TypeScript module augmentation (table and list commands); removing them breaks `editor.chain()` typings.
- Added inline `// eslint-disable-next-line import/no-empty-named-blocks` directives (with a documenting reason) above each of the three occurrences in `MarkdownEditorToolbar.tsx` and `TableBubbleMenu.tsx`, plus an explanatory comment on the previously-uncommented one in `TableBubbleMenu.tsx`. Suppressed case-by-case rather than disabling the rule repo-wide, so genuine stray empty imports are still caught.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Verified `npx oxlint` no longer reports no-empty-named-blocks on the two files, confirmed a subsequent `oxlint --fix` leaves all three imports intact (counts unchanged), and ran `npm run type-check` clean. This is a lint-directive change with no runtime behavior to unit test.