### PR TITLE
iOS: Add native Liquid Glass Chat/Terminal navigation bar

### DIFF
--- a/ap-web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/ap-web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B1000000000000000000000A /* WebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000A /* WebViewModel.swift */; };
 		B1000000000000000000000B /* OmnigentWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000B /* OmnigentWebView.swift */; };
 		B1000000000000000000000C /* URL+Omnigent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000C /* URL+Omnigent.swift */; };
+		B10000000000000000000011 /* ChatTerminalBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* ChatTerminalBar.swift */; };
 		B1000000000000000000000D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000D /* Assets.xcassets */; };
 		B1000000000000000000000E /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000000E /* AppIcon.icon */; };
 		B20000000000000000000001 /* ServerURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* ServerURLTests.swift */; };
@@ -49,6 +50,7 @@
 		A1000000000000000000000A /* WebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModel.swift; sourceTree = "<group>"; };
 		A1000000000000000000000B /* OmnigentWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnigentWebView.swift; sourceTree = "<group>"; };
 		A1000000000000000000000C /* URL+Omnigent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Omnigent.swift"; sourceTree = "<group>"; };
+		A10000000000000000000011 /* ChatTerminalBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTerminalBar.swift; sourceTree = "<group>"; };
 		A1000000000000000000000D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1000000000000000000000E /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = AppIcon.icon; path = "../platform-assets/AppIcon.icon"; sourceTree = "<group>"; };
 		A1000000000000000000000F /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				A1000000000000000000000A /* WebViewModel.swift */,
 				A1000000000000000000000B /* OmnigentWebView.swift */,
 				A1000000000000000000000C /* URL+Omnigent.swift */,
+				A10000000000000000000011 /* ChatTerminalBar.swift */,
 				A1000000000000000000000D /* Assets.xcassets */,
 				A1000000000000000000000F /* Info-Debug.plist */,
 				A10000000000000000000010 /* Info-Release.plist */,
@@ -249,6 +252,7 @@
 				B1000000000000000000000A /* WebViewModel.swift in Sources */,
 				B1000000000000000000000B /* OmnigentWebView.swift in Sources */,
 				B1000000000000000000000C /* URL+Omnigent.swift in Sources */,
+				B10000000000000000000011 /* ChatTerminalBar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ap-web/ios/Omnigent/ChatTerminalBar.swift
+++ b/ap-web/ios/Omnigent/ChatTerminalBar.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// The native Chat/Terminal switcher rendered over the bottom of the web view.
+///
+/// On iOS 26+ the capsule uses the system Liquid Glass material; on iOS 18–25 it
+/// falls back to `.ultraThinMaterial`, matching the look of `ServerSwitcher`.
+struct ChatTerminalBar: View {
+  @Binding var mode: WebViewMode
+  let terminalEnabled: Bool
+  let terminalStartingUp: Bool
+  let onSelect: (WebViewMode) -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+  @Namespace private var selection
+
+  var body: some View {
+    HStack(spacing: 4) {
+      segment(.chat, title: "Chat", systemImage: "message")
+      segment(.terminal, title: "Terminal", systemImage: "terminal")
+    }
+    .padding(4)
+    .modifier(GlassCapsule(colorScheme: colorScheme))
+    .animation(.easeInOut(duration: 0.18), value: mode)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("View mode")
+  }
+
+  @ViewBuilder
+  private func segment(_ target: WebViewMode, title: String, systemImage: String) -> some View {
+    let isSelected = mode == target
+    let isDisabled = target == .terminal && !terminalEnabled
+
+    Button {
+      guard !isDisabled, mode != target else { return }
+      onSelect(target)
+    } label: {
+      HStack(spacing: 5) {
+        if target == .terminal && terminalStartingUp {
+          ProgressView()
+            .controlSize(.mini)
+        } else {
+          Image(systemName: systemImage)
+            .font(.system(size: 13, weight: .medium))
+        }
+        Text(title)
+          .font(.system(size: 13, weight: .medium))
+      }
+      .foregroundStyle(
+        isSelected ? DesignTokens.foreground(colorScheme) : DesignTokens.mutedForeground(colorScheme)
+      )
+      .padding(.horizontal, 14)
+      .frame(height: 34)
+      .background {
+        if isSelected {
+          Capsule(style: .continuous)
+            .fill(Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08))
+            .matchedGeometryEffect(id: "selection", in: selection)
+        }
+      }
+      .contentShape(Capsule(style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .disabled(isDisabled)
+    .opacity(isDisabled ? 0.4 : 1)
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+  }
+}
+
+/// Wraps the bar in the system glass material where available, otherwise a
+/// hand-rolled material capsule that mirrors `ServerSwitcher`'s styling.
+private struct GlassCapsule: ViewModifier {
+  let colorScheme: ColorScheme
+
+  func body(content: Content) -> some View {
+    if #available(iOS 26.0, *) {
+      content.glassEffect(.regular.interactive(), in: .capsule)
+    } else {
+      content
+        .background(.ultraThinMaterial, in: Capsule(style: .continuous))
+        .overlay {
+          Capsule(style: .continuous)
+            .stroke(Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.10), lineWidth: 0.5)
+        }
+        .shadow(color: .black.opacity(colorScheme == .dark ? 0.22 : 0.08), radius: 10, y: 4)
+    }
+  }
+}

--- a/ap-web/ios/Omnigent/OmnigentWebView.swift
+++ b/ap-web/ios/Omnigent/OmnigentWebView.swift
@@ -103,16 +103,26 @@ struct OmnigentWebView: UIViewRepresentable {
       document.addEventListener("DOMContentLoaded", ensureViewportFit, { once: true });
     }
     const callbacks = new Set();
-    Object.defineProperty(window, "__omnigentNativeEmitNotificationActivated", {
-      configurable: false,
-      enumerable: false,
-      writable: false,
-      value(path) {
-        if (typeof path !== "string" || !path.startsWith("/")) return;
-        for (const callback of callbacks) {
-          try { callback(path); } catch {}
-        }
-      },
+    const viewModeCallbacks = new Set();
+    const defineEmit = (name, fn) => {
+      Object.defineProperty(window, name, {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: fn,
+      });
+    };
+    defineEmit("__omnigentNativeEmitNotificationActivated", (path) => {
+      if (typeof path !== "string" || !path.startsWith("/")) return;
+      for (const callback of callbacks) {
+        try { callback(path); } catch {}
+      }
+    });
+    defineEmit("__omnigentNativeEmitViewModeChanged", (mode) => {
+      if (mode !== "chat" && mode !== "terminal") return;
+      for (const callback of viewModeCallbacks) {
+        try { callback(mode); } catch {}
+      }
     });
     window.omnigentNative = Object.freeze({
       kind: "ios",
@@ -150,6 +160,21 @@ struct OmnigentWebView: UIViewRepresentable {
           method: "setServerSwitcherHidden",
           hidden: open === true,
         });
+      },
+      setViewMode(params) {
+        const mode = params && params.mode === "terminal" ? "terminal" : "chat";
+        window.webkit.messageHandlers.omnigentNative.postMessage({
+          method: "setViewMode",
+          mode,
+          terminalEnabled: !!(params && params.terminalEnabled),
+          terminalStartingUp: !!(params && params.terminalStartingUp),
+          visible: !!(params && params.visible),
+        });
+      },
+      onViewModeChanged(callback) {
+        if (typeof callback !== "function") return () => {};
+        viewModeCallbacks.add(callback);
+        return () => viewModeCallbacks.delete(callback);
       },
     });
   })();
@@ -206,6 +231,12 @@ struct OmnigentWebView: UIViewRepresentable {
         parent.model.serverSwitcherHidden = (body["hidden"] as? NSNumber)?.boolValue ?? true
       case "setSidebarOpen":
         parent.model.serverSwitcherHidden = (body["open"] as? NSNumber)?.boolValue ?? true
+      case "setViewMode":
+        let mode: WebViewMode = (body["mode"] as? String) == "terminal" ? .terminal : .chat
+        parent.model.viewMode = mode
+        parent.model.terminalEnabled = (body["terminalEnabled"] as? NSNumber)?.boolValue ?? false
+        parent.model.terminalStartingUp = (body["terminalStartingUp"] as? NSNumber)?.boolValue ?? false
+        parent.model.bottomBarVisible = (body["visible"] as? NSNumber)?.boolValue ?? false
       default:
         return
       }

--- a/ap-web/ios/Omnigent/WebShellView.swift
+++ b/ap-web/ios/Omnigent/WebShellView.swift
@@ -42,6 +42,27 @@ struct WebShellView: View {
       .animation(.easeInOut(duration: 0.16), value: model.serverSwitcherHidden)
       .ignoresSafeArea(.keyboard)
       .background(DesignTokens.background(colorScheme).ignoresSafeArea())
+      .overlay(alignment: .bottom) {
+        // Always present, shown/hidden by opacity rather than insert/remove, so
+        // a transient visibility flip never slides the bar in and out. The web
+        // layer reserves a fixed footprint for it (`.omnigent-native-bottom-
+        // spacer` in index.css), so there's no size round-trip to coordinate.
+        ChatTerminalBar(
+          mode: $model.viewMode,
+          terminalEnabled: model.terminalEnabled,
+          terminalStartingUp: model.terminalStartingUp,
+          onSelect: { newMode in
+            model.viewMode = newMode
+            model.emitViewModeChanged(newMode)
+          }
+        )
+        .padding(.bottom, 6)
+        .opacity(model.bottomBarVisible ? 1 : 0)
+        .allowsHitTesting(model.bottomBarVisible)
+        .accessibilityHidden(!model.bottomBarVisible)
+        .animation(.easeInOut(duration: 0.2), value: model.bottomBarVisible)
+      }
+      .ignoresSafeArea(.keyboard)
     }
     .onChange(of: router.pendingNotificationPath) { _, _ in
       if let path = router.consumeNotificationPath() {

--- a/ap-web/ios/Omnigent/WebViewModel.swift
+++ b/ap-web/ios/Omnigent/WebViewModel.swift
@@ -1,11 +1,26 @@
 import Foundation
 import WebKit
 
+enum WebViewMode: String {
+  case chat
+  case terminal
+}
+
 @MainActor
 final class WebViewModel: ObservableObject {
   @Published var currentURL: URL?
   @Published var isLoading = false
   @Published var serverSwitcherHidden = true
+
+  /// Whether the native Chat/Terminal switcher should be shown. The web app owns
+  /// this truth and pushes it via `setViewMode`; we only render when it asks us to.
+  @Published var bottomBarVisible = false
+  /// Currently selected mode, kept in sync with the web app in both directions.
+  @Published var viewMode: WebViewMode = .chat
+  /// Whether the Terminal option is selectable (web is connected to a session).
+  @Published var terminalEnabled = false
+  /// Terminal is booting but not yet openable — drives a spinner on the segment.
+  @Published var terminalStartingUp = false
 
   weak var webView: WKWebView?
 
@@ -16,6 +31,12 @@ final class WebViewModel: ObservableObject {
   func emitNotificationActivation(_ path: String) {
     guard path.starts(with: "/") else { return }
     let script = "window.__omnigentNativeEmitNotificationActivated?.(\(Self.javascriptString(path)));"
+    webView?.evaluateJavaScript(script)
+  }
+
+  /// Tell the web app the user tapped a segment in the native switcher.
+  func emitViewModeChanged(_ mode: WebViewMode) {
+    let script = "window.__omnigentNativeEmitViewModeChanged?.(\(Self.javascriptString(mode.rawValue)));"
     webView?.evaluateJavaScript(script)
   }
 

--- a/ap-web/src/hooks/useNativeServerSwitcher.ts
+++ b/ap-web/src/hooks/useNativeServerSwitcher.ts
@@ -1,32 +1,27 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { isIOSShell, setNativeServerSwitcherHidden } from "@/lib/nativeBridge";
 
 /**
- * Drive the iOS shell's native server switcher overlay so it shows only while
- * `surface` is the frontmost element on screen and `active` is true. The
- * switcher is a native chrome element the web app toggles via the bridge; it
- * must hide whenever the sidebar (or any other overlay) covers the main
- * surface, and whenever the surface is unmounted.
- *
- * No-ops outside the iOS shell. Used by both the in-session main surface
- * (ChatPage) and the new-session landing screen (NewChatDialog).
+ * Tracks whether `surface` is the frontmost element at its own centre — i.e.
+ * not covered by a drawer / sidebar / sheet. Returns false when inactive,
+ * outside the iOS shell, or while obscured. Re-checks on the layout signals a
+ * drawer transition emits (mutations, transitions, viewport changes). Both the
+ * native server switcher and the native Chat/Terminal bar hide off this signal
+ * so neither floats over an opened panel.
  */
-export function useNativeServerSwitcherForMainSurface(
-  surface: HTMLElement | null,
-  active: boolean,
-) {
+export function useSurfaceFrontmost(surface: HTMLElement | null, active: boolean): boolean {
+  const [frontmost, setFrontmost] = useState(false);
   useEffect(() => {
-    if (!isIOSShell()) return;
-    if (!active) {
-      setNativeServerSwitcherHidden(true);
+    if (!isIOSShell() || !active) {
+      setFrontmost(false);
       return;
     }
 
     let frame = 0;
     const sync = () => {
       frame = 0;
-      setNativeServerSwitcherHidden(!isSurfaceFrontmost(surface));
+      setFrontmost(isSurfaceFrontmost(surface));
     };
     const schedule = () => {
       if (frame !== 0) cancelAnimationFrame(frame);
@@ -66,9 +61,35 @@ export function useNativeServerSwitcherForMainSurface(
       window.removeEventListener("focusout", schedule, true);
       window.visualViewport?.removeEventListener("resize", schedule);
       window.visualViewport?.removeEventListener("scroll", schedule);
-      setNativeServerSwitcherHidden(true);
+      setFrontmost(false);
     };
   }, [active, surface]);
+  return frontmost;
+}
+
+/**
+ * Drive the iOS shell's native server switcher overlay so it shows only while
+ * `surface` is the frontmost element on screen and `active` is true. The
+ * switcher is a native chrome element the web app toggles via the bridge; it
+ * must hide whenever the sidebar (or any other overlay) covers the main
+ * surface, and whenever the surface is unmounted.
+ *
+ * No-ops outside the iOS shell. Used by both the in-session main surface
+ * (ChatPage) and the new-session landing screen (NewChatDialog).
+ */
+export function useNativeServerSwitcherForMainSurface(
+  surface: HTMLElement | null,
+  active: boolean,
+) {
+  const frontmost = useSurfaceFrontmost(surface, active);
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    setNativeServerSwitcherHidden(!frontmost);
+  }, [frontmost]);
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    return () => setNativeServerSwitcherHidden(true);
+  }, []);
 }
 
 function isSurfaceFrontmost(surface: HTMLElement | null): boolean {
@@ -81,7 +102,25 @@ function isSurfaceFrontmost(surface: HTMLElement | null): boolean {
   const x = clamp(window.innerWidth / 2, rect.left + xInset, rect.right - xInset);
   const y = clamp(rect.top + rect.height * 0.38, rect.top + yInset, rect.bottom - yInset);
   const topElement = document.elementFromPoint(x, y);
-  return topElement !== null && surface.contains(topElement);
+
+  // A Radix dropdown / select / popover sets `pointer-events: none` on the body
+  // while open WITHOUT covering the surface, so elementFromPoint falls through
+  // to the document root (or null). That's a transient layer, not a panel —
+  // keep the surface "frontmost" so the native overlays don't blink out.
+  if (!topElement || topElement === document.documentElement || topElement === document.body) {
+    return true;
+  }
+  // Likewise if a popover/menu/listbox actually covers the probe point: those
+  // are transient, unlike a persistent drawer/sidebar/sheet.
+  if (
+    topElement.closest(
+      '[data-radix-popper-content-wrapper], [role="menu"], [role="listbox"], [role="tooltip"]',
+    )
+  ) {
+    return true;
+  }
+
+  return surface.contains(topElement);
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/ap-web/src/index.css
+++ b/ap-web/src/index.css
@@ -463,6 +463,19 @@
     padding-bottom: calc(0.35rem + env(safe-area-inset-bottom, 0px));
   }
 
+  /* Reserve room for the native Liquid Glass switcher that floats over the web
+     view (the in-page pill is suppressed in the iOS shell). Fixed height: the
+     bar's footprint above the home-indicator inset (env). Chat sits 1rem
+     tighter — its composer status line already cushions the gap to the bar. */
+  [data-ios-native] .omnigent-native-bottom-spacer {
+    height: calc(3rem + env(safe-area-inset-bottom, 0px));
+    flex: none;
+  }
+
+  [data-ios-native] .omnigent-native-bottom-spacer--chat {
+    height: calc(2rem + env(safe-area-inset-bottom, 0px));
+  }
+
   [data-ios-native] .terminal-first-switcher {
     min-height: 46px;
     gap: 0.25rem;

--- a/ap-web/src/lib/nativeBridge.ts
+++ b/ap-web/src/lib/nativeBridge.ts
@@ -51,6 +51,28 @@ interface NativeShellApi {
    * fallback so a newer SPA can still ask an older shell to hide the switcher.
    */
   setSidebarOpen?: (open: boolean) => void;
+  /**
+   * Drive the native Chat/Terminal switcher (iOS). The web app owns the truth
+   * and pushes the current mode, whether the terminal is reachable / booting,
+   * and whether the switcher should be shown at all. Absent on older shells,
+   * in which case the web renders its own in-page pill instead.
+   */
+  setViewMode?: (params: NativeViewModeParams) => void;
+  /** Subscribe to taps on the native switcher; returns an unsubscribe. */
+  onViewModeChanged?: (callback: (mode: NativeViewMode) => void) => () => void;
+}
+
+export type NativeViewMode = "chat" | "terminal";
+
+export interface NativeViewModeParams {
+  /** Currently selected view. */
+  mode: NativeViewMode;
+  /** Whether the Terminal option is selectable (a reachable PTY exists). */
+  terminalEnabled: boolean;
+  /** Terminal is booting but not yet openable — drives a spinner. */
+  terminalStartingUp?: boolean;
+  /** Whether the switcher should be shown at all right now. */
+  visible: boolean;
 }
 
 /**
@@ -221,6 +243,39 @@ export function setNativeServerSwitcherHidden(hidden: boolean): void {
 /** @deprecated Use setNativeServerSwitcherHidden. */
 export function setNativeSidebarOpen(open: boolean): void {
   setNativeServerSwitcherHidden(open);
+}
+
+/**
+ * Push the current Chat/Terminal state to the native switcher (iOS). The web
+ * app owns this state; the native bar is a thin control surface that renders it
+ * and reports taps back via {@link onNativeViewModeChanged}. No-op on shells
+ * without the native switcher (older iOS shells, Electron, plain browser) — the
+ * caller renders its own in-page pill there.
+ */
+export function setNativeViewMode(params: NativeViewModeParams): void {
+  const native = nativeApi();
+  if (!native?.setViewMode) return;
+  try {
+    native.setViewMode(params);
+  } catch (err) {
+    console.warn("[nativeBridge] native setViewMode failed:", err);
+  }
+}
+
+/**
+ * Subscribe to taps on the native Chat/Terminal switcher. The shell sends the
+ * mode the user selected; route it into the web view's own state. Returns an
+ * unsubscribe; a no-op outside a shell that exposes the native switcher.
+ */
+export function onNativeViewModeChanged(callback: (mode: NativeViewMode) => void): () => void {
+  const native = nativeApi();
+  if (!native?.onViewModeChanged) return () => {};
+  try {
+    return native.onViewModeChanged(callback);
+  } catch (err) {
+    console.warn("[nativeBridge] native onViewModeChanged failed:", err);
+    return () => {};
+  }
 }
 
 /**

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -58,7 +58,13 @@ import { parseSystemMessage } from "@/lib/systemMessage";
 import { Button } from "@/components/ui/button";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { cn } from "@/lib/utils";
-import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
+import { useSurfaceFrontmost } from "@/hooks/useNativeServerSwitcher";
+import {
+  isIOSShell,
+  onNativeViewModeChanged,
+  setNativeServerSwitcherHidden,
+  setNativeViewMode,
+} from "@/lib/nativeBridge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1275,10 +1281,20 @@ function MainAgentSurface({
     setContainerEl(el);
   }, []);
   const [terminalSurfaceEl, setTerminalSurfaceEl] = useState<HTMLElement | null>(null);
-  useNativeServerSwitcherForMainSurface(
+  // True only while the chat/terminal surface is the frontmost thing on screen.
+  // Drives both native overlays so neither floats over an opened drawer.
+  const surfaceFrontmost = useSurfaceFrontmost(
     showTerminal ? terminalSurfaceEl : containerEl,
     !!conversationId,
   );
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    setNativeServerSwitcherHidden(!surfaceFrontmost);
+  }, [surfaceFrontmost]);
+  useEffect(() => {
+    if (!isIOSShell()) return;
+    return () => setNativeServerSwitcherHidden(true);
+  }, []);
   // The conversation's scroll container + the StickToBottom controls needed to
   // override its bottom-lock, lifted out of the context by
   // ConversationScrollRefBridge so the pinned-but-unmasked JumpToTopButton can
@@ -1331,7 +1347,11 @@ function MainAgentSurface({
           // agent via the composer instead. Server enforces this too.
           readOnly={!isOwnerLevel(permissionLevel)}
         />
-        <ConnectionIndicator liveness={liveness} onShowReconnectHelp={onShowReconnectHelp} />
+        <ConnectionIndicator
+          liveness={liveness}
+          onShowReconnectHelp={onShowReconnectHelp}
+          surfaceFrontmost={surfaceFrontmost}
+        />
       </>
     );
   }
@@ -1483,7 +1503,11 @@ function MainAgentSurface({
       {/* Chat/Terminal toggle for terminal-first sessions, reconnect-or-
           fork banner when unreachable, nothing otherwise. Sits below the
           composer so its position is consistent with the terminal view. */}
-      <ConnectionIndicator liveness={liveness} onShowReconnectHelp={onShowReconnectHelp} />
+      <ConnectionIndicator
+        liveness={liveness}
+        onShowReconnectHelp={onShowReconnectHelp}
+        surfaceFrontmost={surfaceFrontmost}
+      />
     </>
   );
 }
@@ -2028,9 +2052,13 @@ export function SandboxFailedIndicator({ status }: { status: SandboxStatus }) {
 export function ConnectionIndicator({
   liveness,
   onShowReconnectHelp,
+  surfaceFrontmost = true,
 }: {
   liveness: SessionLiveness;
   onShowReconnectHelp: () => void;
+  // Whether the chat/terminal surface is frontmost (not under a drawer). Gates
+  // the native iOS bar so it doesn't float over an opened sidebar/panel.
+  surfaceFrontmost?: boolean;
 }) {
   const terminalFirst = useTerminalFirst();
   const keyboardVisible = useIOSNativeKeyboardVisible(
@@ -2038,6 +2066,27 @@ export function ConnectionIndicator({
     terminalFirst?.view === "chat",
   );
   const sandboxStatus = useChatStore((s) => s.sandboxStatus);
+  // Genuinely-unreachable states get the reconnect banner, for
+  // both terminal-first and regular sessions. `runner_asleep` (host up,
+  // runner relaunches on the next message) and `unknown` (pre-poll) are
+  // NOT unreachable — they're handled below.
+  const unreachable = liveness.kind === "host_offline" || liveness.kind === "local_stranded";
+
+  // In the iOS shell the Chat/Terminal toggle is the native Liquid Glass bar,
+  // not the in-page pill. Drive it from here (always mounted) with the SAME
+  // visibility the pill would have, expressed as a stable boolean so switching
+  // views never flickers the bar. Hook is called unconditionally (before any
+  // early return) to satisfy the rules of hooks.
+  const nativeBarVisible =
+    isIOSShell() &&
+    terminalFirst?.isTerminalFirst === true &&
+    !terminalFirst.isShellView &&
+    sandboxStatus?.stage !== "failed" &&
+    !unreachable &&
+    !keyboardVisible &&
+    surfaceFrontmost;
+  useNativeChatTerminalBar(terminalFirst, nativeBarVisible);
+
   if (sandboxStatus !== null) {
     // A failed launch owns this band with its reason. An IN-FLIGHT
     // launch renders in the chat thread (RunnerStartingIndicator)
@@ -2048,11 +2097,6 @@ export function ConnectionIndicator({
     }
     return null;
   }
-  // Genuinely-unreachable states get the reconnect banner, for
-  // both terminal-first and regular sessions. `runner_asleep` (host up,
-  // runner relaunches on the next message) and `unknown` (pre-poll) are
-  // NOT unreachable — they're handled below.
-  const unreachable = liveness.kind === "host_offline" || liveness.kind === "local_stranded";
   if (unreachable) {
     return (
       <button
@@ -2084,6 +2128,22 @@ export function ConnectionIndicator({
   // as the runner comes back. The strict `runner_online` still gates the
   // inline PTY *view* (it needs a live tunnel) — but not the toggle.
   if (terminalFirst?.isTerminalFirst) {
+    // In the iOS shell the toggle is the native bar (driven above). Render only
+    // a spacer reserving its fixed footprint so the composer clears it — and
+    // nothing when the bar is hidden.
+    if (isIOSShell()) {
+      // Chat reserves a touch less than terminal: the composer's own bottom
+      // content (the status line) already cushions the gap to the bar.
+      return nativeBarVisible ? (
+        <div
+          aria-hidden
+          className={cn(
+            "omnigent-native-bottom-spacer",
+            terminalFirst.view === "chat" && "omnigent-native-bottom-spacer--chat",
+          )}
+        />
+      ) : null;
+    }
     // A rail-opened shell owns the main view chrome-free — no pill: a
     // "Chat" option under someone else's shell misreads as the shell
     // being the agent. The shell view carries its own close affordance
@@ -2193,8 +2253,63 @@ export function RunnerStartingIndicator({ variant }: { variant: "hero" | "row" }
 }
 
 /**
+ * Mirrors the Chat/Terminal state onto the iOS shell's native Liquid Glass
+ * switcher and routes its taps back into `setView`. Driven by a stable
+ * `visible` boolean (not this hook's mount/unmount), so toggling Chat/Terminal
+ * updates the bar in place instead of flickering it hidden→shown. A no-op
+ * outside the iOS shell; the caller renders its own in-page pill there.
+ */
+function useNativeChatTerminalBar(
+  ctx: ReturnType<typeof useTerminalFirst> | null,
+  visible: boolean,
+): void {
+  const native = isIOSShell();
+  const view = ctx?.view ?? "chat";
+  const terminalsAvailable = ctx?.terminalsAvailable ?? false;
+  const terminalStartingUp = ctx?.terminalStartingUp ?? false;
+
+  // Keep `setView` reachable from the subscribe-once effect without
+  // resubscribing whenever the callback identity changes.
+  const setViewRef = useRef(ctx?.setView);
+  setViewRef.current = ctx?.setView;
+
+  // Push current state + visibility down whenever any of it changes.
+  useEffect(() => {
+    if (!native) return;
+    setNativeViewMode({
+      mode: view,
+      terminalEnabled: terminalsAvailable,
+      terminalStartingUp,
+      visible,
+    });
+  }, [native, view, terminalsAvailable, terminalStartingUp, visible]);
+
+  // Belt-and-suspenders: hide the bar if the host component ever unmounts.
+  useEffect(() => {
+    if (!native) return;
+    return () => {
+      setNativeViewMode({
+        mode: "chat",
+        terminalEnabled: false,
+        terminalStartingUp: false,
+        visible: false,
+      });
+    };
+  }, [native]);
+
+  // Route native taps back into the web layer.
+  useEffect(() => {
+    if (!native) return;
+    return onNativeViewModeChanged((mode) => setViewRef.current?.(mode));
+  }, [native]);
+}
+
+/**
  * Chat/Terminal segmented control for terminal-first sessions. Status
  * lives in the sidebar — this band is purely a view toggle.
+ *
+ * Only rendered outside the iOS shell; inside it the switcher is drawn natively
+ * (Liquid Glass) over the web view — see {@link useNativeChatTerminalBar}.
  */
 function ConnectedTerminalFirstPill({
   ctx,
@@ -2207,6 +2322,7 @@ function ConnectedTerminalFirstPill({
   // reachable: greyed-and-spinning reads as "loading", greyed-and-static as
   // "no terminal / stopped".
   const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
+
   return (
     <div
       className={cn(


### PR DESCRIPTION
## Summary

- Replace the in-webview Chat/Terminal pill with a native SwiftUI switcher rendered over the WKWebView. Uses iOS 26 `.glassEffect` (Liquid Glass), with an `.ultraThinMaterial` fallback for iOS 18-25.
- Two-way sync over the `omnigentNative` bridge: the web app owns the truth and pushes mode/terminalEnabled/terminalStartingUp/visible via `setViewMode`; native reports taps back via `onViewModeChanged`.
- The bar is an always-present, opacity-driven overlay (no insert/remove transition, so a transient visibility flip never slides it). The web reserves a fixed footprint via `.omnigent-native-bottom-spacer`, with a chat-specific variant that sits 1rem tighter since the composer's status line already cushions the gap.
- Hide the bar (and the server switcher) when a drawer/sidebar covers the surface via a reusable `useSurfaceFrontmost` hook, while staying visible under transient Radix dropdowns/popovers/selects (which set body `pointer-events: none` without covering the probe point).
- Drive it from the always-mounted `ConnectionIndicator` with a stable `nativeBarVisible` boolean so toggling Chat/Terminal updates in place.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Existing ConnectionIndicator/indicator suites (48 tests) pass; web type-check and oxlint are clean and the iOS target builds against the 26.5 SDK. Behavior was verified manually on device across chat/terminal toggles, keyboard, and opening files/agents/sessions drawers vs model dropdowns, since the bar's positioning and visibility are visual.