### PR TITLE
iOS: left-edge swipe opens the sidebar instead of navigating back

### DIFF
--- a/ap-web/ios/Omnigent/OmnigentWebView.swift
+++ b/ap-web/ios/Omnigent/OmnigentWebView.swift
@@ -31,13 +31,24 @@ struct OmnigentWebView: UIViewRepresentable {
     let webView = AccessoryFreeWebView(frame: .zero, configuration: configuration)
     webView.navigationDelegate = context.coordinator
     webView.uiDelegate = context.coordinator
-    webView.allowsBackForwardNavigationGestures = true
+    // The left-edge swipe is repurposed to open the web app's sidebar (see the
+    // edge-pan recognizer below), so the native back/forward gesture is off —
+    // the two would otherwise fight over the same edge.
+    webView.allowsBackForwardNavigationGestures = false
     webView.isFindInteractionEnabled = true
     webView.isOpaque = false
     webView.backgroundColor = .clear
     webView.underPageBackgroundColor = .clear
     webView.scrollView.backgroundColor = .clear
     webView.scrollView.contentInsetAdjustmentBehavior = .never
+
+    let edgePan = UIScreenEdgePanGestureRecognizer(
+      target: context.coordinator,
+      action: #selector(Coordinator.handleLeftEdgePan(_:))
+    )
+    edgePan.edges = .left
+    edgePan.delegate = context.coordinator
+    webView.addGestureRecognizer(edgePan)
 
     model.webView = webView
     context.coordinator.attach(webView)
@@ -124,6 +135,22 @@ struct OmnigentWebView: UIViewRepresentable {
         try { callback(mode); } catch {}
       }
     });
+    const sidebarDragCallbacks = new Set();
+    Object.defineProperty(window, "__omnigentNativeEmitSidebarDrag", {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value(phase, progress) {
+        if (typeof phase !== "string") return;
+        const fraction =
+          typeof progress === "number" && Number.isFinite(progress)
+            ? Math.max(0, Math.min(1, progress))
+            : 0;
+        for (const callback of sidebarDragCallbacks) {
+          try { callback(phase, fraction); } catch {}
+        }
+      },
+    });
     window.omnigentNative = Object.freeze({
       kind: "ios",
       setBadgeCount(count) {
@@ -148,6 +175,11 @@ struct OmnigentWebView: UIViewRepresentable {
         if (typeof callback !== "function") return () => {};
         callbacks.add(callback);
         return () => callbacks.delete(callback);
+      },
+      onSidebarDrag(callback) {
+        if (typeof callback !== "function") return () => {};
+        sidebarDragCallbacks.add(callback);
+        return () => sidebarDragCallbacks.delete(callback);
       },
       setServerSwitcherHidden(hidden) {
         window.webkit.messageHandlers.omnigentNative.postMessage({
@@ -181,7 +213,7 @@ struct OmnigentWebView: UIViewRepresentable {
   """
 
   @MainActor
-  final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
+  final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, UIGestureRecognizerDelegate {
     var parent: OmnigentWebView
     private weak var webView: WKWebView?
     private(set) var pinnedURL: URL?
@@ -197,6 +229,43 @@ struct OmnigentWebView: UIViewRepresentable {
 
     func detach() {
       webView = nil
+    }
+
+    // A left-edge swipe drives the web app's sidebar as an interactive drawer.
+    // The sidebar's right edge tracks the finger — progress 0→1 maps the drag
+    // across the view width to closed→open — and on release we settle open or
+    // closed from how far it was dragged and the flick velocity. This replaces
+    // the native back gesture (disabled above), which owned this same edge.
+    private static let openProgressThreshold = 0.33
+    private static let openVelocityThreshold: CGFloat = 600
+
+    @objc func handleLeftEdgePan(_ recognizer: UIScreenEdgePanGestureRecognizer) {
+      guard let view = recognizer.view, view.bounds.width > 0 else { return }
+      let width = view.bounds.width
+      let progress = Double(max(0, min(width, recognizer.translation(in: view).x)) / width)
+
+      switch recognizer.state {
+      case .began:
+        parent.model.emitSidebarDrag(phase: "begin", progress: progress)
+      case .changed:
+        parent.model.emitSidebarDrag(phase: "move", progress: progress)
+      case .ended:
+        let velocity = recognizer.velocity(in: view).x
+        let open = progress > Self.openProgressThreshold || velocity > Self.openVelocityThreshold
+        parent.model.emitSidebarDrag(phase: open ? "open" : "close", progress: progress)
+      case .cancelled, .failed:
+        parent.model.emitSidebarDrag(phase: "close", progress: progress)
+      default:
+        break
+      }
+    }
+
+    // Let the edge swipe coexist with the page's own scrolling/pan gestures.
+    func gestureRecognizer(
+      _ gestureRecognizer: UIGestureRecognizer,
+      shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+      true
     }
 
     func load(_ url: URL, in webView: WKWebView) {

--- a/ap-web/ios/Omnigent/WebViewModel.swift
+++ b/ap-web/ios/Omnigent/WebViewModel.swift
@@ -40,6 +40,12 @@ final class WebViewModel: ObservableObject {
     webView?.evaluateJavaScript(script)
   }
 
+  func emitSidebarDrag(phase: String, progress: Double) {
+    let clamped = max(0, min(1, progress))
+    let script = "window.__omnigentNativeEmitSidebarDrag?.(\(Self.javascriptString(phase)), \(clamped));"
+    webView?.evaluateJavaScript(script)
+  }
+
   static func javascriptString(_ value: String) -> String {
     guard let data = try? JSONEncoder().encode(value),
           let encoded = String(data: data, encoding: .utf8) else {

--- a/ap-web/src/lib/nativeBridge.test.ts
+++ b/ap-web/src/lib/nativeBridge.test.ts
@@ -6,6 +6,7 @@ import {
   isNativeShell,
   nativeNotify,
   onNativeNotificationActivated,
+  onNativeSidebarDrag,
   setBadgeCount as bridgeSetBadge,
   setNativeServerSwitcherHidden,
 } from "./nativeBridge";
@@ -21,6 +22,8 @@ const iosSetBadge = vi.fn();
 const iosNotify = vi.fn().mockResolvedValue(true);
 const iosUnsubscribe = vi.fn();
 const iosOnNotificationActivated = vi.fn().mockReturnValue(iosUnsubscribe);
+const iosOnSidebarDragUnsubscribe = vi.fn();
+const iosOnSidebarDrag = vi.fn().mockReturnValue(iosOnSidebarDragUnsubscribe);
 const iosSetServerSwitcherHidden = vi.fn();
 const iosSetSidebarOpen = vi.fn();
 
@@ -56,6 +59,7 @@ function setIOS(on: boolean, withClickRouting = true): void {
       notify: (...args: unknown[]) => iosNotify(...args),
       setServerSwitcherHidden: (...args: unknown[]) => iosSetServerSwitcherHidden(...args),
       setSidebarOpen: (...args: unknown[]) => iosSetSidebarOpen(...args),
+      onSidebarDrag: (...args: unknown[]) => iosOnSidebarDrag(...args),
       ...(withClickRouting
         ? {
             onNotificationActivated: (...args: unknown[]) => iosOnNotificationActivated(...args),
@@ -199,6 +203,43 @@ describe("onNativeNotificationActivated", () => {
       throw new Error("ipc down");
     });
     const unsubscribe = onNativeNotificationActivated(vi.fn());
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});
+
+describe("onNativeSidebarDrag", () => {
+  it("returns a no-op unsubscribe outside any native shell", () => {
+    setIOS(false);
+    const cb = vi.fn();
+    const unsubscribe = onNativeSidebarDrag(cb);
+    expect(iosOnSidebarDrag).not.toHaveBeenCalled();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("subscribes through the iOS bridge and returns its unsubscribe", () => {
+    setIOS(true);
+    const cb = vi.fn();
+    const unsubscribe = onNativeSidebarDrag(cb);
+    expect(iosOnSidebarDrag).toHaveBeenCalledWith(cb);
+    unsubscribe();
+    expect(iosOnSidebarDragUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("returns a no-op unsubscribe under a shell lacking the gesture hook", () => {
+    setIOS(true);
+    delete (window as unknown as { omnigentNative: Record<string, unknown> }).omnigentNative
+      .onSidebarDrag;
+    const unsubscribe = onNativeSidebarDrag(vi.fn());
+    expect(iosOnSidebarDrag).not.toHaveBeenCalled();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("returns a no-op unsubscribe when the bridge throws", () => {
+    setIOS(true);
+    iosOnSidebarDrag.mockImplementationOnce(() => {
+      throw new Error("bridge down");
+    });
+    const unsubscribe = onNativeSidebarDrag(vi.fn());
     expect(() => unsubscribe()).not.toThrow();
   });
 });

--- a/ap-web/src/lib/nativeBridge.ts
+++ b/ap-web/src/lib/nativeBridge.ts
@@ -21,6 +21,13 @@
 //     notifications in the browser path.
 
 /**
+ * Phase of a native sidebar-drag gesture (see `onSidebarDrag`). `begin` and
+ * `move` are live drag frames carrying an open fraction; `open` and `close`
+ * are the settle decision the shell made on release.
+ */
+export type SidebarDragPhase = "begin" | "move" | "open" | "close";
+
+/**
  * Minimal API surface exposed by native shells. Electron exposes the legacy
  * `window.omnigentDesktop`; newer shells expose `window.omnigentNative`.
  * Kept intentionally tiny and string/number only so it survives bridge
@@ -41,6 +48,15 @@ interface NativeShellApi {
    * path the notification carried (its `navigatePath`); returns an unsubscribe.
    */
   onNotificationActivated?: (callback: (path: string) => void) => () => void;
+  /**
+   * Subscribe to native sidebar-drag events. The iOS shell streams a left-edge
+   * swipe here (the gesture it repurposed from back-navigation) so the renderer
+   * can drive its sidebar as an interactive drawer: `begin`/`move` carry a 0→1
+   * open fraction the sidebar should track live (no transition), and
+   * `open`/`close` are the settle decision on release (animate to that resting
+   * state). Returns an unsubscribe.
+   */
+  onSidebarDrag?: (callback: (phase: SidebarDragPhase, progress: number) => void) => () => void;
   /**
    * Let native chrome react to web UI state. The iOS shell uses this to show
    * its floating server switcher only when the chat transcript is visible.
@@ -203,6 +219,29 @@ export function onNativeNotificationActivated(callback: (path: string) => void):
     return native.onNotificationActivated(callback);
   } catch (err) {
     console.warn("[nativeBridge] native onNotificationActivated failed:", err);
+    return () => {};
+  }
+}
+
+/**
+ * Subscribe to native sidebar-drag events from the iOS shell's left-edge swipe
+ * (the gesture it repurposed from back-navigation), so the renderer can drive
+ * its sidebar as an interactive drawer — tracking the finger on `begin`/`move`
+ * and animating to the settled state on `open`/`close`.
+ *
+ * Returns an unsubscribe function. A no-op (returning a no-op unsubscribe)
+ * outside a native shell or under a shell too old to support the gesture, so
+ * callers can register it unconditionally.
+ */
+export function onNativeSidebarDrag(
+  callback: (phase: SidebarDragPhase, progress: number) => void,
+): () => void {
+  const native = nativeApi();
+  if (!native?.onSidebarDrag) return () => {};
+  try {
+    return native.onSidebarDrag(callback);
+  } catch (err) {
+    console.warn("[nativeBridge] native onSidebarDrag failed:", err);
     return () => {};
   }
 }

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -8,7 +8,7 @@ import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
-import { isIOSShell, isMacElectronShell } from "@/lib/nativeBridge";
+import { isIOSShell, isMacElectronShell, onNativeSidebarDrag } from "@/lib/nativeBridge";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 import {
   Dialog,
@@ -49,7 +49,7 @@ import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
-import { Sidebar } from "./Sidebar";
+import { isMobileViewport, Sidebar } from "./Sidebar";
 import { TitleBarServerPicker } from "./TitleBarServerPicker";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { useRootSessionId, useSession } from "@/hooks/useSession";
@@ -126,6 +126,27 @@ export function AppShell() {
     useResizableInlinePanel(conversationId ?? null, inlinePanelMinWidth);
   const [searchParams, setSearchParams] = useSearchParams();
   const [sidebarOpen, setSidebarOpen] = useState(initialSidebarOpen);
+  // Live open fraction (0→1) while the iOS edge-swipe drags the sidebar; null
+  // when not dragging. Drives the mobile overlay's finger-tracking transform.
+  const [sidebarDragProgress, setSidebarDragProgress] = useState<number | null>(null);
+  // The iOS shell repurposes the left-edge swipe (normally back-navigation) to
+  // drive the sidebar as an interactive drawer, streaming it over the native
+  // bridge. begin/move track the finger (mobile overlay only — the desktop
+  // width-based sidebar can't be partially slid, so it just settles); open/close
+  // are the settle decision on release. No-op outside the iOS shell.
+  useEffect(
+    () =>
+      onNativeSidebarDrag((phase, progress) => {
+        if (phase === "open" || phase === "close") {
+          setSidebarDragProgress(null);
+          setSidebarOpen(phase === "open");
+          return;
+        }
+        if (!isMobileViewport()) return;
+        setSidebarDragProgress(progress);
+      }),
+    [],
+  );
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).selectedFilePath ?? null) : null,
   );
@@ -959,7 +980,11 @@ export function AppShell() {
             {isMacElectronShell() && (
               <TitleBarServerPicker threadTitle={activeSession?.title ?? activeConv?.title} />
             )}
-            <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+            <Sidebar
+              open={sidebarOpen}
+              dragProgress={sidebarDragProgress}
+              onClose={() => setSidebarOpen(false)}
+            />
 
             {/* Content region (everything right of the sidebar): a relative
           flex row holding the chat+workspace group and the push panels

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -95,6 +95,14 @@ const TIME_MARKER_SLOT_CLASS =
 interface SidebarProps {
   open: boolean;
   onClose: () => void;
+  /**
+   * Live open fraction (0 = closed, 1 = open) while the iOS shell's left-edge
+   * swipe is dragging the sidebar; `null` when not dragging. When set, the
+   * mobile overlay tracks it directly (transition suppressed) so the drawer
+   * follows the finger; on release the parent clears it and toggles `open`,
+   * letting the CSS transition animate to the resting state.
+   */
+  dragProgress?: number | null;
 }
 
 /**
@@ -133,7 +141,7 @@ function useActiveNavItem(): { isNewChatPage: boolean; isInboxPage: boolean } {
  *     scrollback is fine; users typically want the conversations list
  *     to stay visible while they switch around.
  */
-export function Sidebar({ open, onClose }: SidebarProps) {
+export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [pinnedConversationIds, setPinnedConversationIds] = useState(readPinnedConversationIds);
@@ -224,6 +232,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   // full-screen overlay (``fixed inset-0``) and the variable is ignored.
   const { width: sidebarWidth, handleProps: resizeHandleProps } = useResizableSidebar();
 
+  // While the iOS edge-swipe is dragging, the overlay is on-screen and
+  // interactive even though `open` hasn't flipped yet — treat a live drag as
+  // visually open so it isn't `inert`/`aria-hidden` mid-gesture.
+  const dragging = dragProgress != null;
+  const effectiveOpen = open || dragging;
+
   return (
     <aside
       aria-label="Conversations"
@@ -244,7 +258,13 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         // there the sidebar pushes content aside, so nothing sits behind it.
         "max-md:bg-card-solid",
         "fixed inset-0 z-50",
-        open ? "translate-x-0" : "-translate-x-full",
+        // Mobile only: animate the slide so the iOS edge-swipe settles
+        // smoothly on release. Suppressed inline while a drag is live (the
+        // overlay must track the finger 1:1). Scoped to transform so it can't
+        // re-introduce the width-animation lag the base comment warns about,
+        // and gated to mobile so the desktop floating card is unaffected.
+        "max-md:transition-transform max-md:duration-200 max-md:ease-out",
+        effectiveOpen ? "translate-x-0" : "-translate-x-full",
         // Desktop: a floating card. Detached from the window edges by a
         // margin, rounded, and lifted off the bg-sidebar canvas with a
         // full border + shadow. Width (the user-resizable variable) animates
@@ -255,14 +275,23 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           ? "md:m-2 md:w-[var(--sidebar-width)] md:rounded-xl md:border md:border-border md:shadow-lg"
           : "md:m-0 md:w-0 md:border-0",
       )}
-      style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}
+      style={
+        {
+          "--sidebar-width": `${sidebarWidth}px`,
+          // Track the finger: map the 0→1 open fraction to translateX
+          // -100%→0% and kill the transition so it follows the drag exactly.
+          ...(dragging
+            ? { transform: `translateX(${(dragProgress - 1) * 100}%)`, transition: "none" }
+            : null),
+        } as CSSProperties
+      }
       // Hide from the accessibility tree when closed so screen readers
       // don't see the empty-state contents while focus is elsewhere.
-      aria-hidden={!open}
-      data-collapsed={!open || undefined}
+      aria-hidden={!effectiveOpen}
+      data-collapsed={!effectiveOpen || undefined}
       // Match the keyboard-focus story: when closed, the sidebar's
       // children shouldn't receive tabs.
-      inert={!open}
+      inert={!effectiveOpen}
     >
       {/* Right-edge resize handle (desktop only), mirroring the right rail's
           left-edge handle. Hidden on mobile, where the sidebar is a
@@ -1745,7 +1774,7 @@ function BulkActionBar({
  *
  * SSR-safe (returns false when window is undefined).
  */
-function isMobileViewport(): boolean {
+export function isMobileViewport(): boolean {
   if (typeof window === "undefined") return false;
   return !window.matchMedia("(min-width: 768px)").matches;
 }


### PR DESCRIPTION
## Summary

- In the iOS WKWebView shell, repurpose the left-edge swipe to open the web app's sidebar rather than triggering WKWebView's back/forward navigation gesture (the two contend for the same edge).
- `OmnigentWebView`: disable `allowsBackForwardNavigationGestures` and add a left `UIScreenEdgePanGestureRecognizer` that, on `.began`, calls the model to ask the web app to open its sidebar. The Coordinator now conforms to `UIGestureRecognizerDelegate` so the edge swipe coexists with the page's own scroll/pan gestures.
- Extend the injected native bridge with an `onOpenSidebar(callback)` subscription and a frozen `__omnigentNativeEmitOpenSidebar` global, mirroring the existing notification-activation hook. `WebViewModel` gains `emitOpenSidebar()`.
- Web side: add optional `onOpenSidebar` to the native bridge interface and an exported `onNativeOpenSidebar` helper (no-op outside a native shell or under an older shell, swallows bridge errors). `AppShell` subscribes to open its sidebar in response.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added four unit tests for onNativeOpenSidebar (subscribe/unsubscribe, missing hook, throwing bridge); ran `npx vitest run src/lib/nativeBridge.test.ts` (27 passed) and `npx tsc -b` (clean). The iOS shell compiles via `xcodebuild build -scheme Omnigent` (BUILD SUCCEEDED); the gesture wiring itself is UIKit glue verified by the successful build.