### PR TITLE
feat(tools): sys_session_share — agent-facing session sharing

### DIFF
--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -773,13 +773,15 @@ class AgentDef:
     # sub-agent types. Session reads are always on. YAML key:
     # ``spawn:``.
     spawn: bool = False
-    # Session-sharing authority for sys_session_share, the SOLE enabler
-    # of that tool (independent of spawn / declared agents). Raw YAML
-    # string from ``share:`` — "none" (default, tool off), "non-public"
-    # (grant named users), or "public" (also allow __public__ anonymous
-    # read). Kept as a str here (inner datamodel has no spec.types dep);
-    # mapped to SharePolicy when translated to an AgentSpec.
-    share: str = "none"
+    # Authority for the agent to share the session it runs in, via
+    # sys_session_share — the SOLE enabler of that tool (independent of
+    # spawn / declared agents, and unrelated to server-API / CLI
+    # sharing). Raw YAML string from ``agent_session_sharing:`` — "none"
+    # (default, tool off), "non-public" (grant named users), or "public"
+    # (also allow __public__ anonymous read). Kept as a str here (inner
+    # datamodel has no spec.types dep); mapped to SharePolicy when
+    # translated to an AgentSpec.
+    agent_session_sharing: str = "none"
     os_env: OSEnvSpec | None = None
     terminals: dict[str, TerminalEnvSpec] = field(default_factory=dict)
     skills: SkillRegistry = field(default_factory=dict)

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -773,6 +773,13 @@ class AgentDef:
     # sub-agent types. Session reads are always on. YAML key:
     # ``spawn:``.
     spawn: bool = False
+    # Session-sharing authority for sys_session_share, the SOLE enabler
+    # of that tool (independent of spawn / declared agents). Raw YAML
+    # string from ``share:`` — "none" (default, tool off), "non-public"
+    # (grant named users), or "public" (also allow __public__ anonymous
+    # read). Kept as a str here (inner datamodel has no spec.types dep);
+    # mapped to SharePolicy when translated to an AgentSpec.
+    share: str = "none"
     os_env: OSEnvSpec | None = None
     terminals: dict[str, TerminalEnvSpec] = field(default_factory=dict)
     skills: SkillRegistry = field(default_factory=dict)

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -252,7 +252,7 @@ def _parse_agent_def(
     agent.runtime = data.get("runtime", False)
     agent.timers = data.get("timers", False)
     agent.spawn = data.get("spawn", False)
-    agent.share = data.get("share", "none")
+    agent.agent_session_sharing = data.get("agent_session_sharing", "none")
     agent.os_env = _parse_os_env_spec(data.get("os_env"))
 
     # Executor

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -252,6 +252,7 @@ def _parse_agent_def(
     agent.runtime = data.get("runtime", False)
     agent.timers = data.get("timers", False)
     agent.spawn = data.get("spawn", False)
+    agent.share = data.get("share", "none")
     agent.os_env = _parse_os_env_spec(data.get("os_env"))
 
     # Executor

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -207,13 +207,20 @@ _SUBAGENT_TOOLS = frozenset({"sys_session_send"})
 # as _execute_subagent_tool.
 _SESSION_CREATE_TOOLS = frozenset({"sys_session_create"})
 
-# Priority 5f.0: Session query tools — peek/list/close/get_info. The runner
-# has no in-process ConversationStore, so these read/mutate session state via
-# the Omnigent server's existing REST endpoints (GET /items, GET /child_sessions,
-# GET /sessions/{id}, PATCH /sessions/{id}) over server_client — same channel
-# and security posture as _execute_subagent_tool / _execute_comment_tool.
+# Priority 5f.0: Session query tools — peek/list/close/get_info/share. The
+# runner has no in-process ConversationStore, so these read/mutate session
+# state via the Omnigent server's existing REST endpoints (GET /items, GET
+# /child_sessions, GET /sessions/{id}, PATCH /sessions/{id}, PUT
+# /sessions/{id}/permissions) over server_client — same channel and security
+# posture as _execute_subagent_tool / _execute_comment_tool.
 _SESSION_QUERY_TOOLS = frozenset(
-    {"sys_session_get_history", "sys_session_list", "sys_session_close", "sys_session_get_info"}
+    {
+        "sys_session_get_history",
+        "sys_session_list",
+        "sys_session_close",
+        "sys_session_get_info",
+        "sys_session_share",
+    }
 )
 
 # Priority 5f.1: web_fetch — translates the LLM-facing query/url
@@ -2464,6 +2471,8 @@ async def _execute_session_query_tool(
       best-effort ``GET /v1/runners/{id}/status`` for connectivity)
     - ``sys_session_close`` → ``GET`` the target snapshot then ``PATCH
       /v1/sessions/{target}`` with a tombstoned title
+    - ``sys_session_share`` → ``PUT /v1/sessions/{target}/permissions``
+      with the grantee + numeric level
 
     Output shapes mirror the in-process tools in
     :mod:`omnigent.tools.builtins.spawn` so the LLM sees identical
@@ -2473,7 +2482,8 @@ async def _execute_session_query_tool(
     :func:`_execute_subagent_tool`.
 
     :param tool_name: ``"sys_session_get_history"``, ``"sys_session_list"``,
-        ``"sys_session_close"``, or ``"sys_session_get_info"``.
+        ``"sys_session_close"``, ``"sys_session_get_info"``, or
+        ``"sys_session_share"``.
     :param arguments: JSON-encoded arguments string from the LLM, e.g.
         ``'{"conversation_id": "conv_abc123", "tail_items": 5}'``.
     :param conversation_id: The calling session id, e.g. ``"conv_root1"``;
@@ -2497,6 +2507,8 @@ async def _execute_session_query_tool(
         return await _session_get_history_via_rest(args, server_client)
     if tool_name == "sys_session_get_info":
         return await _session_get_info_via_rest(args, conversation_id, server_client)
+    if tool_name == "sys_session_share":
+        return await _session_share_via_rest(args, conversation_id, server_client)
     return await _session_close_via_rest(args, conversation_id, server_client)
 
 
@@ -2600,6 +2612,66 @@ async def _session_get_info_via_rest(
             "pending_elicitations": pending,
             "pending_elicitation_count": len(pending),
         }
+    )
+
+
+async def _session_share_via_rest(
+    args: dict[str, Any],
+    conversation_id: str,
+    server_client: httpx.AsyncClient,
+) -> str:
+    """
+    Grant a user access to a session via ``PUT /v1/sessions/{id}/permissions``.
+
+    Resolves the target from ``args["session_id"]`` (falling back to the
+    caller's own ``conversation_id`` when omitted), maps the friendly
+    ``level`` name to the server's numeric level, and PUTs the grant.
+    Same channel and security posture as the other session REST tools:
+    the server enforces that ``server_client``'s identity holds
+    manage-level access on the target (the session owner does), and caps
+    public (``__public__``) grants at read.
+
+    Maps 404 to ``session_not_found`` and 401/403 to ``access_denied``.
+
+    :param args: Parsed tool arguments. Requires ``user_id`` (grantee
+        email or ``"__public__"``); optional ``level`` (``"read"``
+        default / ``"edit"`` / ``"manage"``) and ``session_id``.
+    :param conversation_id: The caller's own session id, used as the
+        default target when ``session_id`` is omitted.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :returns: JSON ``{"shared": true, ...}`` on success, or a JSON
+        error object.
+    """
+    target = args.get("session_id") or conversation_id
+    if not isinstance(target, str) or not target:
+        return json.dumps({"error": "sys_session_share requires a non-empty 'session_id' string"})
+    user_id = args.get("user_id")
+    if not isinstance(user_id, str) or not user_id:
+        return json.dumps({"error": "sys_session_share requires a non-empty 'user_id'"})
+    # Friendly level name -> the server's numeric permission level
+    # (GrantPermissionRequest accepts 1=read, 2=edit, 3=manage).
+    level_by_name = {"read": 1, "edit": 2, "manage": 3}
+    level_name = args.get("level", "read")
+    if level_name not in level_by_name:
+        return json.dumps(
+            {"error": f"sys_session_share: level must be one of {sorted(level_by_name)}"}
+        )
+    try:
+        resp = await server_client.put(
+            f"/v1/sessions/{target}/permissions",
+            json={"user_id": user_id, "level": level_by_name[level_name]},
+            timeout=30.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": f"sys_session_share failed: {exc}"})
+    if resp.status_code == 404:
+        return json.dumps({"error": "session_not_found", "session_id": target})
+    if resp.status_code in (401, 403):
+        return json.dumps({"error": "access_denied", "session_id": target})
+    if resp.status_code >= 400:
+        return json.dumps({"error": f"sys_session_share returned {resp.status_code}"})
+    return json.dumps(
+        {"shared": True, "session_id": target, "user_id": user_id, "level": level_name}
     )
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -224,14 +224,16 @@ _SESSION_QUERY_TOOLS = frozenset(
 )
 
 # Grantee sentinel for an anonymous, public read-only share. Mirrors the
-# server's RESERVED_USER_PUBLIC; only specs with ``share: public`` may
-# grant it (enforced in _session_share_via_rest — the server can't see
-# the agent's share policy, so the runner is the gate).
+# server's RESERVED_USER_PUBLIC; only specs with
+# ``agent_session_sharing: public`` may grant it (enforced in
+# _session_share_via_rest — the server can't see the agent's sharing
+# policy, so the runner is the gate).
 _PUBLIC_USER_SENTINEL = "__public__"
 
-# Spec ``share:`` policy values (omnigent.spec.types.SharePolicy) that
-# enable the sys_session_share tool. Compared as plain strings since
-# SharePolicy is a str-enum; anything else (incl. "none"/absent) is off.
+# Spec ``agent_session_sharing:`` policy values
+# (omnigent.spec.types.SharePolicy) that enable the sys_session_share
+# tool. Compared as plain strings since SharePolicy is a str-enum;
+# anything else (incl. "none"/absent) is off.
 _SHARE_ENABLED_POLICIES = frozenset({"non-public", "public"})
 _SHARE_PUBLIC_POLICY = "public"
 
@@ -2504,9 +2506,10 @@ async def _execute_session_query_tool(
     :param server_client: HTTP client pointed at the Omnigent server; ``None``
         if unavailable (returns an error string).
     :param agent_spec: The session's :class:`AgentSpec`. Used only by
-        ``sys_session_share`` to read the spec's ``share:`` policy (the
-        server can't see it, so the runner is the gate). ``None`` when no
-        spec is available — sharing then fails closed.
+        ``sys_session_share`` to read the spec's
+        ``agent_session_sharing:`` policy (the server can't see it, so
+        the runner is the gate). ``None`` when no spec is available —
+        sharing then fails closed.
     :returns: Tool output JSON string matching the in-process tool shape.
     """
     if server_client is None:
@@ -2679,9 +2682,10 @@ async def _session_share_via_rest(
     manage-level access on the target (the session owner does), and caps
     public (``__public__``) grants at read.
 
-    The spec's ``share:`` policy is enforced HERE, in the runner, because
-    the server cannot see it: a ``share: none`` (or unknown) spec refuses
-    every grant, and a ``share: non-public`` spec refuses ``__public__``.
+    The spec's ``agent_session_sharing:`` policy is enforced HERE, in the
+    runner, because the server cannot see it: an ``agent_session_sharing:
+    none`` (or unknown) spec refuses every grant, and an
+    ``agent_session_sharing: non-public`` spec refuses ``__public__``.
     This is the real gate — tool *advertisement* is gated in the
     ToolManager, but an unadvertised-yet-named call must still be denied
     so a prompt-injected agent can't escalate by emitting the tool name.
@@ -2697,9 +2701,10 @@ async def _session_share_via_rest(
     :param conversation_id: The caller's own session id, used as the
         default target when ``session_id`` is omitted.
     :param server_client: HTTP client pointed at the Omnigent server.
-    :param agent_spec: The session's :class:`AgentSpec`; its ``share``
-        policy gates this call. ``None`` (or ``share: none``) fails
-        closed — no grant is attempted.
+    :param agent_spec: The session's :class:`AgentSpec`; its
+        ``agent_session_sharing`` policy gates this call. ``None`` (or
+        ``agent_session_sharing: none``) fails closed — no grant is
+        attempted.
     :returns: JSON ``{"shared": true, ...}`` on success, or a JSON
         error object.
     """
@@ -2709,16 +2714,17 @@ async def _session_share_via_rest(
     user_id = args.get("user_id")
     if not isinstance(user_id, str) or not user_id:
         return json.dumps({"error": "sys_session_share requires a non-empty 'user_id'"})
-    # Enforce the spec's ``share:`` policy (SharePolicy is a str-enum, so
-    # compare its value directly). ``none``/absent disables the feature;
-    # ``__public__`` requires the ``public`` tier specifically.
-    share_policy = getattr(agent_spec, "share", None)
+    # Enforce the spec's ``agent_session_sharing:`` policy (SharePolicy is
+    # a str-enum, so compare its value directly). ``none``/absent disables
+    # the feature; ``__public__`` requires the ``public`` tier specifically.
+    share_policy = getattr(agent_spec, "agent_session_sharing", None)
     if share_policy not in _SHARE_ENABLED_POLICIES:
         return json.dumps(
             {
                 "error": (
                     "sys_session_share: session sharing is not enabled for this "
-                    "agent (set share: non-public or share: public in the spec)"
+                    "agent (set agent_session_sharing: non-public or "
+                    "agent_session_sharing: public in the spec)"
                 ),
                 "session_id": target,
             }
@@ -2728,8 +2734,8 @@ async def _session_share_via_rest(
             {
                 "error": (
                     "sys_session_share: public ('__public__') sharing is not "
-                    "enabled for this agent (requires share: public); grant a "
-                    "specific user instead"
+                    "enabled for this agent (requires agent_session_sharing: "
+                    "public); grant a specific user instead"
                 ),
                 "session_id": target,
             }

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -223,6 +223,18 @@ _SESSION_QUERY_TOOLS = frozenset(
     }
 )
 
+# Grantee sentinel for an anonymous, public read-only share. Mirrors the
+# server's RESERVED_USER_PUBLIC; only specs with ``share: public`` may
+# grant it (enforced in _session_share_via_rest — the server can't see
+# the agent's share policy, so the runner is the gate).
+_PUBLIC_USER_SENTINEL = "__public__"
+
+# Spec ``share:`` policy values (omnigent.spec.types.SharePolicy) that
+# enable the sys_session_share tool. Compared as plain strings since
+# SharePolicy is a str-enum; anything else (incl. "none"/absent) is off.
+_SHARE_ENABLED_POLICIES = frozenset({"non-public", "public"})
+_SHARE_PUBLIC_POLICY = "public"
+
 # Priority 5f.1: web_fetch — translates the LLM-facing query/url
 # arguments into a sys_session_send call against the built-in
 # ``__web_researcher`` sub-agent, then reuses
@@ -2455,6 +2467,7 @@ async def _execute_session_query_tool(
     *,
     conversation_id: str | None,
     server_client: httpx.AsyncClient | None,
+    agent_spec: Any | None = None,
 ) -> str:
     """
     Runner-local handler for ``sys_session_get_history`` / ``sys_session_list`` /
@@ -2490,6 +2503,10 @@ async def _execute_session_query_tool(
         used as the parent for ``sys_session_list``.
     :param server_client: HTTP client pointed at the Omnigent server; ``None``
         if unavailable (returns an error string).
+    :param agent_spec: The session's :class:`AgentSpec`. Used only by
+        ``sys_session_share`` to read the spec's ``share:`` policy (the
+        server can't see it, so the runner is the gate). ``None`` when no
+        spec is available — sharing then fails closed.
     :returns: Tool output JSON string matching the in-process tool shape.
     """
     if server_client is None:
@@ -2508,7 +2525,7 @@ async def _execute_session_query_tool(
     if tool_name == "sys_session_get_info":
         return await _session_get_info_via_rest(args, conversation_id, server_client)
     if tool_name == "sys_session_share":
-        return await _session_share_via_rest(args, conversation_id, server_client)
+        return await _session_share_via_rest(args, conversation_id, server_client, agent_spec)
     return await _session_close_via_rest(args, conversation_id, server_client)
 
 
@@ -2649,6 +2666,7 @@ async def _session_share_via_rest(
     args: dict[str, Any],
     conversation_id: str,
     server_client: httpx.AsyncClient,
+    agent_spec: Any | None,
 ) -> str:
     """
     Grant a user access to a session via ``PUT /v1/sessions/{id}/permissions``.
@@ -2661,6 +2679,13 @@ async def _session_share_via_rest(
     manage-level access on the target (the session owner does), and caps
     public (``__public__``) grants at read.
 
+    The spec's ``share:`` policy is enforced HERE, in the runner, because
+    the server cannot see it: a ``share: none`` (or unknown) spec refuses
+    every grant, and a ``share: non-public`` spec refuses ``__public__``.
+    This is the real gate — tool *advertisement* is gated in the
+    ToolManager, but an unadvertised-yet-named call must still be denied
+    so a prompt-injected agent can't escalate by emitting the tool name.
+
     Maps 404 to ``session_not_found`` and 401/403 to ``access_denied``;
     other 4xx/5xx surface the server's own error message when present
     (e.g. the "public is read-only" rejection of a ``__public__`` grant
@@ -2672,6 +2697,9 @@ async def _session_share_via_rest(
     :param conversation_id: The caller's own session id, used as the
         default target when ``session_id`` is omitted.
     :param server_client: HTTP client pointed at the Omnigent server.
+    :param agent_spec: The session's :class:`AgentSpec`; its ``share``
+        policy gates this call. ``None`` (or ``share: none``) fails
+        closed — no grant is attempted.
     :returns: JSON ``{"shared": true, ...}`` on success, or a JSON
         error object.
     """
@@ -2681,6 +2709,31 @@ async def _session_share_via_rest(
     user_id = args.get("user_id")
     if not isinstance(user_id, str) or not user_id:
         return json.dumps({"error": "sys_session_share requires a non-empty 'user_id'"})
+    # Enforce the spec's ``share:`` policy (SharePolicy is a str-enum, so
+    # compare its value directly). ``none``/absent disables the feature;
+    # ``__public__`` requires the ``public`` tier specifically.
+    share_policy = getattr(agent_spec, "share", None)
+    if share_policy not in _SHARE_ENABLED_POLICIES:
+        return json.dumps(
+            {
+                "error": (
+                    "sys_session_share: session sharing is not enabled for this "
+                    "agent (set share: non-public or share: public in the spec)"
+                ),
+                "session_id": target,
+            }
+        )
+    if user_id == _PUBLIC_USER_SENTINEL and share_policy != _SHARE_PUBLIC_POLICY:
+        return json.dumps(
+            {
+                "error": (
+                    "sys_session_share: public ('__public__') sharing is not "
+                    "enabled for this agent (requires share: public); grant a "
+                    "specific user instead"
+                ),
+                "session_id": target,
+            }
+        )
     # Friendly level name -> the server's numeric permission level
     # (GrantPermissionRequest accepts 1=read, 2=edit, 3=manage).
     level_by_name = {"read": 1, "edit": 2, "manage": 3}
@@ -3713,6 +3766,7 @@ async def execute_tool(
                 arguments,
                 conversation_id=conversation_id,
                 server_client=server_client,
+                agent_spec=agent_spec,
             )
         elif tool_name in _WEB_FETCH_TOOLS:
             output = await _execute_web_fetch_tool(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2615,6 +2615,36 @@ async def _session_get_info_via_rest(
     )
 
 
+def _omnigent_error_message(resp: httpx.Response) -> str | None:
+    """
+    Extract the human-readable message from an Omnigent error response.
+
+    The server renders :class:`omnigent.errors.OmnigentError` as
+    ``{"error": {"code": ..., "message": ...}}`` (see the exception
+    handler in ``omnigent/server/app.py``). Return that ``message`` so a
+    tool can surface the server's own explanation rather than a bare
+    status code; return ``None`` when the body is not that envelope (a
+    non-JSON body, or a differently-shaped payload) so the caller can
+    fall back to a generic message.
+
+    :param resp: The HTTP response whose body to parse, e.g. a 400 from
+        ``PUT /v1/sessions/{id}/permissions``.
+    :returns: The ``error.message`` string, or ``None`` if absent.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        # Non-JSON error body (e.g. an HTML proxy page) — no detail to surface.
+        return None
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict):
+            message = err.get("message")
+            if isinstance(message, str) and message:
+                return message
+    return None
+
+
 async def _session_share_via_rest(
     args: dict[str, Any],
     conversation_id: str,
@@ -2631,7 +2661,10 @@ async def _session_share_via_rest(
     manage-level access on the target (the session owner does), and caps
     public (``__public__``) grants at read.
 
-    Maps 404 to ``session_not_found`` and 401/403 to ``access_denied``.
+    Maps 404 to ``session_not_found`` and 401/403 to ``access_denied``;
+    other 4xx/5xx surface the server's own error message when present
+    (e.g. the "public is read-only" rejection of a ``__public__`` grant
+    above read level) instead of a bare status code.
 
     :param args: Parsed tool arguments. Requires ``user_id`` (grantee
         email or ``"__public__"``); optional ``level`` (``"read"``
@@ -2669,6 +2702,15 @@ async def _session_share_via_rest(
     if resp.status_code in (401, 403):
         return json.dumps({"error": "access_denied", "session_id": target})
     if resp.status_code >= 400:
+        # Surface the server's own message when present — e.g. the 400
+        # rejecting a __public__ grant above read level carries "Public
+        # access is limited to read-only (level 1)", which is far more
+        # actionable for the agent than a bare status code.
+        detail = _omnigent_error_message(resp)
+        if detail is not None:
+            return json.dumps(
+                {"error": detail, "status_code": resp.status_code, "session_id": target}
+            )
         return json.dumps({"error": f"sys_session_share returned {resp.status_code}"})
     return json.dumps(
         {"shared": True, "session_id": target, "user_id": user_id, "level": level_name}

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -1177,9 +1177,10 @@ def agent_def_to_agent_spec(
         terminals=terminals,
         timers=agent_def.timers,
         spawn=agent_def.spawn,
-        # AgentDef.share is the raw YAML string ("none"/"non-public"/
-        # "public"); map it to the SharePolicy enum AgentSpec expects.
-        share=SharePolicy(agent_def.share),
+        # AgentDef.agent_session_sharing is the raw YAML string
+        # ("none"/"non-public"/"public"); map it to the SharePolicy enum
+        # AgentSpec expects.
+        agent_session_sharing=SharePolicy(agent_def.agent_session_sharing),
         skills_filter=skills_filter,
     )
 

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -58,6 +58,7 @@ from omnigent.spec.types import (
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
+    SharePolicy,
     ToolRuntime,
     ToolsConfig,
 )
@@ -1176,6 +1177,9 @@ def agent_def_to_agent_spec(
         terminals=terminals,
         timers=agent_def.timers,
         spawn=agent_def.spawn,
+        # AgentDef.share is the raw YAML string ("none"/"non-public"/
+        # "public"); map it to the SharePolicy enum AgentSpec expects.
+        share=SharePolicy(agent_def.share),
         skills_filter=skills_filter,
     )
 

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -213,12 +213,13 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     # the specified sub-agent types. Defaults to False — session
     # reads stay always-on, but every write grant is explicit.
     spawn = bool(raw.get("spawn", False))
-    # Top-level ``share:`` flag is the SOLE enabler of the
-    # ``sys_session_share`` tool, independent of ``spawn`` /
-    # ``tools.agents``. ``none`` (default) leaves it unregistered;
-    # ``non-public`` allows granting named users; ``public`` also
-    # allows ``__public__`` anonymous read.
-    share = _parse_share_policy(raw.get("share"))
+    # Top-level ``agent_session_sharing:`` flag is the SOLE enabler of
+    # the ``sys_session_share`` tool, independent of ``spawn`` /
+    # ``tools.agents`` (and unrelated to server-API / CLI sharing).
+    # ``none`` (default) leaves it unregistered; ``non-public`` allows
+    # granting named users; ``public`` also allows ``__public__``
+    # anonymous read.
+    agent_session_sharing = _parse_share_policy(raw.get("agent_session_sharing"))
 
     # Honor ``prompt:`` as the legacy alias for ``instructions:`` (per
     # ``_OMNIGENT_SYSTEM_PROMPT_KEYS``); ``instructions:`` wins if both set.
@@ -255,7 +256,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         terminals=terminals,
         timers=timers,
         spawn=spawn,
-        share=share,
+        agent_session_sharing=agent_session_sharing,
     )
 
 
@@ -1743,7 +1744,8 @@ def _resolve_instructions(root: Path, raw_value: object) -> str | None:
 
 def _parse_share_policy(raw: object) -> SharePolicy:
     """
-    Parse the top-level YAML ``share:`` field into a :class:`SharePolicy`.
+    Parse the top-level YAML ``agent_session_sharing:`` field into a
+    :class:`SharePolicy`.
 
     This flag is the sole enabler of the ``sys_session_share`` tool
     (independent of ``spawn`` / ``tools.agents``). Sharing mutates
@@ -1771,7 +1773,7 @@ def _parse_share_policy(raw: object) -> SharePolicy:
     except ValueError:
         valid = ", ".join(repr(p.value) for p in SharePolicy)
         raise OmnigentError(
-            f"top-level share: must be one of {valid}; got {raw!r}",
+            f"top-level agent_session_sharing: must be one of {valid}; got {raw!r}",
             code=ErrorCode.INVALID_INPUT,
         ) from None
 

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -46,6 +46,7 @@ from omnigent.spec.types import (
     ProviderAuth,
     RetryPolicy,
     SandboxConfig,
+    SharePolicy,
     SkillSpec,
     ToolsConfig,
 )
@@ -212,6 +213,12 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     # the specified sub-agent types. Defaults to False — session
     # reads stay always-on, but every write grant is explicit.
     spawn = bool(raw.get("spawn", False))
+    # Top-level ``share:`` flag is the SOLE enabler of the
+    # ``sys_session_share`` tool, independent of ``spawn`` /
+    # ``tools.agents``. ``none`` (default) leaves it unregistered;
+    # ``non-public`` allows granting named users; ``public`` also
+    # allows ``__public__`` anonymous read.
+    share = _parse_share_policy(raw.get("share"))
 
     # Honor ``prompt:`` as the legacy alias for ``instructions:`` (per
     # ``_OMNIGENT_SYSTEM_PROMPT_KEYS``); ``instructions:`` wins if both set.
@@ -248,6 +255,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         terminals=terminals,
         timers=timers,
         spawn=spawn,
+        share=share,
     )
 
 
@@ -1731,6 +1739,41 @@ def _resolve_instructions(root: Path, raw_value: object) -> str | None:
         except OSError:
             pass
     return None
+
+
+def _parse_share_policy(raw: object) -> SharePolicy:
+    """
+    Parse the top-level YAML ``share:`` field into a :class:`SharePolicy`.
+
+    This flag is the sole enabler of the ``sys_session_share`` tool
+    (independent of ``spawn`` / ``tools.agents``). Sharing mutates
+    access control, so it is off by default and an unrecognized value
+    fails loud rather than silently disabling the feature.
+
+    Supported YAML shapes:
+
+    - field omitted / ``null`` → :attr:`SharePolicy.NONE` (default;
+      tool not registered).
+    - ``"none"`` / ``"non-public"`` / ``"public"`` → the matching
+      :class:`SharePolicy` member.
+
+    :param raw: The raw YAML value (already parsed). ``None`` or one
+        of the three policy strings, e.g. ``"non-public"``.
+    :returns: The resolved :class:`SharePolicy`.
+    :raises OmnigentError: When the value is neither ``None`` nor one
+        of the recognized policy strings (e.g. a boolean, a typo like
+        ``"private"``, or a non-string).
+    """
+    if raw is None:
+        return SharePolicy.NONE
+    try:
+        return SharePolicy(raw)
+    except ValueError:
+        valid = ", ".join(repr(p.value) for p in SharePolicy)
+        raise OmnigentError(
+            f"top-level share: must be one of {valid}; got {raw!r}",
+            code=ErrorCode.INVALID_INPUT,
+        ) from None
 
 
 def _parse_skills_filter(raw: object) -> str | list[str]:

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -968,8 +968,8 @@ class ToolRuntime(str, Enum):
 class SharePolicy(str, Enum):
     """How much session-sharing authority ``sys_session_share`` grants.
 
-    Maps the top-level ``share:`` YAML flag. The flag is the *only*
-    thing that enables the ``sys_session_share`` tool — it is
+    Maps the top-level ``agent_session_sharing:`` YAML flag. The flag is
+    the *only* thing that enables the ``sys_session_share`` tool — it is
     independent of ``spawn`` / ``tools.agents`` (which gate the
     spawn-lifecycle tools). Sharing mutates access control, so it is
     off by default and the public tier is a deliberate extra opt-in.
@@ -1472,10 +1472,12 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
         ``sys_session_get_history`` / ``sys_session_get_info``)
         are always registered and are not affected by either
         opt-in.
-    :param share: Session-sharing authority granted to
-        ``sys_session_share``. YAML key is ``share:`` (top-level, like
-        ``spawn:``). This flag is the SOLE enabler of the share tool —
-        it is independent of ``spawn`` / ``tools.agents``. One of
+    :param agent_session_sharing: Authority for the agent to share the
+        session it is running in, via ``sys_session_share``. YAML key is
+        ``agent_session_sharing:`` (top-level, like ``spawn:``). This
+        flag is the SOLE enabler of that tool — it is independent of
+        ``spawn`` / ``tools.agents``, and has no bearing on sharing the
+        session through the server API or CLI. One of
         :class:`SharePolicy`: ``none`` (default — tool not registered),
         ``non-public`` (grant named users only), or ``public`` (also
         allow ``__public__`` anonymous read). **Defaults to
@@ -1525,4 +1527,4 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     terminals: dict[str, TerminalEnvSpec] | None = None
     timers: bool = False
     spawn: bool = False
-    share: SharePolicy = SharePolicy.NONE
+    agent_session_sharing: SharePolicy = SharePolicy.NONE

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -965,6 +965,28 @@ class ToolRuntime(str, Enum):
     UC_FUNCTION = "uc_function"
 
 
+class SharePolicy(str, Enum):
+    """How much session-sharing authority ``sys_session_share`` grants.
+
+    Maps the top-level ``share:`` YAML flag. The flag is the *only*
+    thing that enables the ``sys_session_share`` tool — it is
+    independent of ``spawn`` / ``tools.agents`` (which gate the
+    spawn-lifecycle tools). Sharing mutates access control, so it is
+    off by default and the public tier is a deliberate extra opt-in.
+
+    - :attr:`NONE`: sharing disabled — ``sys_session_share`` is not
+      registered at all (default).
+    - :attr:`NON_PUBLIC`: the agent may grant access to named users
+      (emails), but NOT to ``__public__`` — no anonymous-read exposure.
+    - :attr:`PUBLIC`: the agent may additionally grant ``__public__``
+      (anonymous read of the full transcript).
+    """
+
+    NONE = "none"
+    NON_PUBLIC = "non-public"
+    PUBLIC = "public"
+
+
 @dataclass
 class LocalToolInfo:  # type: ignore[explicit-any]  # parameters: dict[str, Any] field (see below)
     """
@@ -1450,6 +1472,14 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
         ``sys_session_get_history`` / ``sys_session_get_info``)
         are always registered and are not affected by either
         opt-in.
+    :param share: Session-sharing authority granted to
+        ``sys_session_share``. YAML key is ``share:`` (top-level, like
+        ``spawn:``). This flag is the SOLE enabler of the share tool —
+        it is independent of ``spawn`` / ``tools.agents``. One of
+        :class:`SharePolicy`: ``none`` (default — tool not registered),
+        ``non-public`` (grant named users only), or ``public`` (also
+        allow ``__public__`` anonymous read). **Defaults to
+        ``SharePolicy.NONE``.**
     """
 
     spec_version: int
@@ -1495,3 +1525,4 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     terminals: dict[str, TerminalEnvSpec] | None = None
     timers: bool = False
     spawn: bool = False
+    share: SharePolicy = SharePolicy.NONE

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -53,6 +53,7 @@ from omnigent.tools.builtins.spawn import (
     SysSessionGetInfoTool,
     SysSessionListTool,
     SysSessionSendTool,
+    SysSessionShareTool,
 )
 from omnigent.tools.builtins.timer import (
     SysTimerCancelTool,
@@ -80,6 +81,7 @@ __all__ = [
     "SysSessionGetInfoTool",
     "SysSessionListTool",
     "SysSessionSendTool",
+    "SysSessionShareTool",
     "SysTimerCancelTool",
     "SysTimerSetTool",
     "UpdateCommentTool",

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -547,6 +547,93 @@ class SysSessionGetInfoTool(Tool):
         }
 
 
+class SysSessionShareTool(Tool):
+    """
+    Grant another user (or the public) access to a session.
+
+    ``session_id`` is optional — when omitted, the caller's own session
+    is shared, which is the common case ("share this session with X").
+    ``user_id`` is the grantee's email, or the sentinel ``"__public__"``
+    for anonymous read-only access. ``level`` is ``"read"`` (default),
+    ``"edit"``, or ``"manage"``; the server caps public grants at read.
+
+    Runner-dispatched: the runner proxies ``PUT
+    /v1/sessions/{id}/permissions`` using its authenticated server
+    client, so the grant runs with the session user's own identity and
+    is subject to the server's permission checks (the caller needs
+    manage-level access — which the session owner has). Returns
+    ``access_denied`` when the server refuses and ``session_not_found``
+    for an unknown id.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"sys_session_share"``."""
+        return "sys_session_share"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Human-readable description of the tool."""
+        return (
+            "Share a session with another user by granting them access. "
+            "Pass user_id (the grantee's email, or '__public__' for "
+            "anonymous read-only access) and an optional level "
+            "('read' default, 'edit', or 'manage'). Omit session_id to "
+            "share the calling session itself, or pass it to share "
+            "another session you manage. Requires manage-level access "
+            "(the session owner has it)."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """
+        Return the OpenAI-format tool schema.
+
+        :returns: Dict with ``"type": "function"`` and a ``"function"``
+            sub-dict; ``user_id`` is required, ``level`` and
+            ``session_id`` optional.
+        """
+        return {
+            "type": "function",
+            "function": {
+                "name": SysSessionShareTool.name(),
+                "description": SysSessionShareTool.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "user_id": {
+                            "type": "string",
+                            "description": (
+                                "Grantee's email, e.g. "
+                                "'alice@example.com', or the sentinel "
+                                "'__public__' for anonymous read-only "
+                                "access."
+                            ),
+                        },
+                        "level": {
+                            "type": "string",
+                            "enum": ["read", "edit", "manage"],
+                            "description": (
+                                "Permission level to grant. Defaults to "
+                                "'read'. Public grants are capped at "
+                                "'read' regardless of this value."
+                            ),
+                        },
+                        "session_id": {
+                            "type": "string",
+                            "description": (
+                                "The session (conversation_id) to share, "
+                                "e.g. 'conv_abc123'. Omit to share the "
+                                "calling session itself."
+                            ),
+                        },
+                    },
+                    "required": ["user_id"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+
 class SysSessionCreateTool(Tool):
     """
     Create a child session from an existing agent or a local bundle.

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -551,7 +551,7 @@ class SysSessionShareTool(Tool):
     """
     Grant another user (or the public) access to a session.
 
-    Enabled by the spec's top-level ``share:`` flag
+    Enabled by the spec's top-level ``agent_session_sharing:`` flag
     (:class:`omnigent.spec.types.SharePolicy`), which is its sole gate:
     ``none`` leaves the tool unregistered, ``non-public`` allows
     granting named users, and ``public`` additionally allows the
@@ -576,14 +576,15 @@ class SysSessionShareTool(Tool):
     for an unknown id.
 
     :param allow_public: Whether ``__public__`` grants are permitted —
-        ``True`` only when the spec's ``share:`` flag is ``public``.
-        Reflected in the schema and hard-enforced by the runner.
+        ``True`` only when the spec's ``agent_session_sharing:`` flag is
+        ``public``. Reflected in the schema and hard-enforced by the runner.
     """
 
     def __init__(self, allow_public: bool) -> None:
         """
-        :param allow_public: ``True`` when the spec's ``share:`` policy
-            is ``public`` — permits granting the ``__public__`` sentinel.
+        :param allow_public: ``True`` when the spec's
+            ``agent_session_sharing:`` policy is ``public`` — permits
+            granting the ``__public__`` sentinel.
             ``False`` for ``non-public`` (named users only).
         """
         self._allow_public = allow_public

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -551,11 +551,21 @@ class SysSessionShareTool(Tool):
     """
     Grant another user (or the public) access to a session.
 
+    Enabled by the spec's top-level ``share:`` flag
+    (:class:`omnigent.spec.types.SharePolicy`), which is its sole gate:
+    ``none`` leaves the tool unregistered, ``non-public`` allows
+    granting named users, and ``public`` additionally allows the
+    ``__public__`` sentinel (anonymous read of the full transcript).
+    ``allow_public`` carries that last tier into the tool so it can
+    both advertise and refuse public grants when the policy is
+    ``non-public``.
+
     ``session_id`` is optional — when omitted, the caller's own session
     is shared, which is the common case ("share this session with X").
-    ``user_id`` is the grantee's email, or the sentinel ``"__public__"``
-    for anonymous read-only access. ``level`` is ``"read"`` (default),
-    ``"edit"``, or ``"manage"``; the server caps public grants at read.
+    ``user_id`` is the grantee's email, or (when ``allow_public``) the
+    sentinel ``"__public__"`` for anonymous read-only access. ``level``
+    is ``"read"`` (default), ``"edit"``, or ``"manage"``; the server
+    caps public grants at read.
 
     Runner-dispatched: the runner proxies ``PUT
     /v1/sessions/{id}/permissions`` using its authenticated server
@@ -564,7 +574,19 @@ class SysSessionShareTool(Tool):
     manage-level access — which the session owner has). Returns
     ``access_denied`` when the server refuses and ``session_not_found``
     for an unknown id.
+
+    :param allow_public: Whether ``__public__`` grants are permitted —
+        ``True`` only when the spec's ``share:`` flag is ``public``.
+        Reflected in the schema and hard-enforced by the runner.
     """
+
+    def __init__(self, allow_public: bool) -> None:
+        """
+        :param allow_public: ``True`` when the spec's ``share:`` policy
+            is ``public`` — permits granting the ``__public__`` sentinel.
+            ``False`` for ``non-public`` (named users only).
+        """
+        self._allow_public = allow_public
 
     @classmethod
     def name(cls) -> str:
@@ -575,23 +597,37 @@ class SysSessionShareTool(Tool):
     def description(cls) -> str:
         """:returns: Human-readable description of the tool."""
         return (
-            "Share a session with another user by granting them access. "
-            "Pass user_id (the grantee's email, or '__public__' for "
-            "anonymous read-only access) and an optional level "
-            "('read' default, 'edit', or 'manage'). Omit session_id to "
-            "share the calling session itself, or pass it to share "
-            "another session you manage. Requires manage-level access "
-            "(the session owner has it)."
+            "Share a session with another user by granting them access "
+            "(level 'read' default, 'edit', or 'manage'). Omit "
+            "session_id to share the calling session itself, or pass it "
+            "to share another session you manage. Requires manage-level "
+            "access (the session owner has it)."
         )
 
     def get_schema(self) -> dict[str, Any]:
         """
         Return the OpenAI-format tool schema.
 
+        The ``user_id`` description reflects ``allow_public``: it only
+        advertises the ``__public__`` sentinel when public grants are
+        permitted, so the model isn't told about an option the runner
+        would reject.
+
         :returns: Dict with ``"type": "function"`` and a ``"function"``
             sub-dict; ``user_id`` is required, ``level`` and
             ``session_id`` optional.
         """
+        if self._allow_public:
+            user_id_desc = (
+                "Grantee's email, e.g. 'alice@example.com', or the "
+                "sentinel '__public__' for anonymous read-only access "
+                "(anyone with the link)."
+            )
+        else:
+            user_id_desc = (
+                "Grantee's email, e.g. 'alice@example.com'. "
+                "Public/anonymous sharing is not enabled for this agent."
+            )
         return {
             "type": "function",
             "function": {
@@ -602,12 +638,7 @@ class SysSessionShareTool(Tool):
                     "properties": {
                         "user_id": {
                             "type": "string",
-                            "description": (
-                                "Grantee's email, e.g. "
-                                "'alice@example.com', or the sentinel "
-                                "'__public__' for anonymous read-only "
-                                "access."
-                            ),
+                            "description": user_id_desc,
                         },
                         "level": {
                             "type": "string",

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -376,38 +376,45 @@ class ToolManager:
         Register the sub-agent tool surface.
 
         The read-only discovery tools — ``sys_session_list``,
-        ``sys_session_get_history``, and ``sys_session_get_info`` — plus
-        ``sys_session_share`` are registered for **every** agent. Any
-        agent can be part of a multi-agent session (most importantly a
-        user-added agent that declares no sub-agents of its own but needs
-        to read ``main``/siblings for context), so listing, peeking, and
+        ``sys_session_get_history``, and ``sys_session_get_info`` — are
+        registered for **every** agent. Any agent can be part of a
+        multi-agent session (most importantly a user-added agent that
+        declares no sub-agents of its own but needs to read
+        ``main``/siblings for context), so listing, peeking, and
         metadata reads are always available; access is enforced
         server-side (each proxies an auth-gated ``GET`` endpoint).
-        ``sys_session_share`` defaults to the caller's own session and
-        is likewise server-gated (the caller needs manage-level access),
-        so it is always advertised without granting extra authority.
         ``peek`` / ``get_info`` take a ``conversation_id`` (from
         ``sys_session_list`` or a prior ``sys_session_send`` handle),
         so they need no ``sub_specs`` map.
 
-        The spawn-lifecycle tools are opt-in, with two distinct grants:
+        The mutating tools are opt-in, gated behind ``tools.agents``
+        (declared sub-agents) or the top-level ``spawn: true`` flag:
 
-        - ``tools.agents`` (declared sub-agents) registers
-          ``sys_session_send`` (named ``(agent, title)`` mode limited
-          to the declared-type enum, plus ``session_id`` mode for
-          driving existing children), ``sys_session_close``, and
-          ``sys_list_models`` (per-worker model availability for
-          picking a valid ``args.model``) — the agent may spawn THE
-          SPECIFIED LIST of sub-agents, nothing else.
-        - ``spawn: true`` (top-level flag) additionally registers
-          ``sys_session_create`` — launching arbitrary children from
-          an existing agent_id or a custom locally-authored bundle
-          (``config_path``). It also registers send/close (an agent
-          must be able to drive and tombstone the children it
-          creates); without declared sub-agents, send's schema omits
-          the named-mode parameters.
+        - ``tools.agents`` registers ``sys_session_send`` (named
+          ``(agent, title)`` mode limited to the declared-type enum,
+          plus ``session_id`` mode for driving existing children),
+          ``sys_session_close``, and ``sys_list_models`` (per-worker
+          model availability for picking a valid ``args.model``) — the
+          agent may spawn THE SPECIFIED LIST of sub-agents, nothing else.
+        - ``spawn: true`` additionally registers ``sys_session_create``
+          — launching arbitrary children from an existing agent_id or a
+          custom locally-authored bundle (``config_path``). It also
+          registers send/close (an agent must be able to drive and
+          tombstone the children it creates); without declared
+          sub-agents, send's schema omits the named-mode parameters.
 
-        All writes are child-only, enforced at dispatch/server level;
+        ``sys_session_share`` is gated behind the SAME opt-in (either
+        grant). Unlike the read-only discovery tools it MUTATES access
+        control — it can expose a session to a third party or, via
+        ``__public__``, to anonymous read of the full transcript. The
+        server can confirm the caller holds manage-level access but
+        cannot distinguish "the owner intended this" from "the agent
+        was prompt-injected into sharing", so it is not advertised to
+        every agent by default — only to specs that have already opted
+        into the multi-agent / spawn surface, matching send/close.
+
+        The spawn writes are child-only and ``sys_session_share`` is
+        owner-authority-bounded, both enforced at dispatch/server level;
         the opt-ins control advertisement, not authority.
         (Cancellation uses the unified ``sys_cancel_task``; inspection
         is via inbox auto-delivery.)
@@ -416,13 +423,8 @@ class ToolManager:
         self._tools[SysSessionListTool.name()] = SysSessionListTool()
         self._tools[SysSessionGetHistoryTool.name()] = SysSessionGetHistoryTool()
         self._tools[SysSessionGetInfoTool.name()] = SysSessionGetInfoTool()
-        # Session sharing: always available. Acts on the caller's own
-        # session by default; the server enforces that the caller holds
-        # manage-level access (the session owner does), so advertising it
-        # to every agent grants no authority the server wouldn't check.
-        self._tools[SysSessionShareTool.name()] = SysSessionShareTool()
 
-        # send + close: opt-in via declared sub-agents or spawn: true.
+        # send + close + share: opt-in via declared sub-agents or spawn: true.
         if not (self._spec.tools.agents or self._spec.spawn):
             return
 
@@ -431,6 +433,14 @@ class ToolManager:
             sub_specs=sub_specs,
         )
         self._tools[SysSessionCloseTool.name()] = SysSessionCloseTool()
+        # Session sharing MUTATES access control (it can expose the
+        # session to a third party or, via __public__, to anonymous read
+        # of the full transcript), so it is opt-in behind the same grant
+        # as send/close rather than always-on like the read-only
+        # discovery tools: the server can confirm the caller has
+        # manage-level access but not that the owner — versus a
+        # prompt-injected agent — intended the share.
+        self._tools[SysSessionShareTool.name()] = SysSessionShareTool()
         # Model awareness pairs with the dispatch grant: the per-worker
         # listing exists to pick a valid ``args.model`` for send.
         self._tools[SysListModelsTool.name()] = SysListModelsTool(spec=self._spec)

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -387,18 +387,19 @@ class ToolManager:
         ``sys_session_list`` or a prior ``sys_session_send`` handle),
         so they need no ``sub_specs`` map.
 
-        ``sys_session_share`` is gated by its OWN dedicated ``share:``
-        flag (:class:`SharePolicy`), independent of the spawn grants.
-        Sharing MUTATES access control — it can expose a session to a
-        third party or, via ``__public__``, to anonymous read of the
-        full transcript — and the server can confirm the caller holds
-        manage-level access but cannot distinguish "the owner intended
-        this" from "the agent was prompt-injected into sharing". So it
-        is off unless the spec opts in: ``none`` (default) leaves it
-        unregistered; ``non-public`` registers it for granting named
-        users; ``public`` additionally lets it grant ``__public__``
-        (the tool advertises and enforces that extra tier via
-        ``allow_public``).
+        ``sys_session_share`` is gated by its OWN dedicated
+        ``agent_session_sharing:`` flag (:class:`SharePolicy`),
+        independent of the spawn grants (and unrelated to sharing via
+        the server API or CLI). Sharing MUTATES access control — it can
+        expose a session to a third party or, via ``__public__``, to
+        anonymous read of the full transcript — and the server can
+        confirm the caller holds manage-level access but cannot
+        distinguish "the owner intended this" from "the agent was
+        prompt-injected into sharing". So it is off unless the spec opts
+        in: ``none`` (default) leaves it unregistered; ``non-public``
+        registers it for granting named users; ``public`` additionally
+        lets it grant ``__public__`` (the tool advertises and enforces
+        that extra tier via ``allow_public``).
 
         The spawn-lifecycle tools are a SEPARATE opt-in, gated behind
         ``tools.agents`` (declared sub-agents) or the top-level
@@ -428,17 +429,18 @@ class ToolManager:
         self._tools[SysSessionGetHistoryTool.name()] = SysSessionGetHistoryTool()
         self._tools[SysSessionGetInfoTool.name()] = SysSessionGetInfoTool()
 
-        # Session sharing: opt-in via the dedicated ``share`` flag,
-        # independent of spawn / declared sub-agents. ``none`` leaves it
-        # unregistered; ``public`` additionally permits __public__ grants
-        # (the tool reflects that in its schema and the runner enforces
-        # it). It is its own flag — not folded into the spawn grant —
-        # because exposing a session is a distinct authority from
-        # spawning children, and the public tier warrants an explicit
-        # extra opt-in given the prompt-injection exposure.
-        if self._spec.share is not SharePolicy.NONE:
+        # Session sharing: opt-in via the dedicated
+        # ``agent_session_sharing`` flag, independent of spawn / declared
+        # sub-agents. ``none`` leaves it unregistered; ``public``
+        # additionally permits __public__ grants (the tool reflects that
+        # in its schema and the runner enforces it). It is its own flag —
+        # not folded into the spawn grant — because letting the agent
+        # expose a session is a distinct authority from spawning
+        # children, and the public tier warrants an explicit extra opt-in
+        # given the prompt-injection exposure.
+        if self._spec.agent_session_sharing is not SharePolicy.NONE:
             self._tools[SysSessionShareTool.name()] = SysSessionShareTool(
-                allow_public=self._spec.share is SharePolicy.PUBLIC,
+                allow_public=self._spec.agent_session_sharing is SharePolicy.PUBLIC,
             )
 
         # send + close: opt-in via declared sub-agents or spawn: true.

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -34,6 +34,7 @@ from omnigent.tools.builtins import (
     SysSessionGetInfoTool,
     SysSessionListTool,
     SysSessionSendTool,
+    SysSessionShareTool,
     SysTimerCancelTool,
     SysTimerSetTool,
     UpdateCommentTool,
@@ -375,13 +376,16 @@ class ToolManager:
         Register the sub-agent tool surface.
 
         The read-only discovery tools — ``sys_session_list``,
-        ``sys_session_get_history``, and ``sys_session_get_info`` — are
-        registered for **every** agent. Any agent can be part of a
-        multi-agent session (most importantly a user-added agent that
-        declares no sub-agents of its own but needs to read
-        ``main``/siblings for context), so listing, peeking, and
+        ``sys_session_get_history``, and ``sys_session_get_info`` — plus
+        ``sys_session_share`` are registered for **every** agent. Any
+        agent can be part of a multi-agent session (most importantly a
+        user-added agent that declares no sub-agents of its own but needs
+        to read ``main``/siblings for context), so listing, peeking, and
         metadata reads are always available; access is enforced
         server-side (each proxies an auth-gated ``GET`` endpoint).
+        ``sys_session_share`` defaults to the caller's own session and
+        is likewise server-gated (the caller needs manage-level access),
+        so it is always advertised without granting extra authority.
         ``peek`` / ``get_info`` take a ``conversation_id`` (from
         ``sys_session_list`` or a prior ``sys_session_send`` handle),
         so they need no ``sub_specs`` map.
@@ -412,6 +416,11 @@ class ToolManager:
         self._tools[SysSessionListTool.name()] = SysSessionListTool()
         self._tools[SysSessionGetHistoryTool.name()] = SysSessionGetHistoryTool()
         self._tools[SysSessionGetInfoTool.name()] = SysSessionGetInfoTool()
+        # Session sharing: always available. Acts on the caller's own
+        # session by default; the server enforces that the caller holds
+        # manage-level access (the session owner does), so advertising it
+        # to every agent grants no authority the server wouldn't check.
+        self._tools[SysSessionShareTool.name()] = SysSessionShareTool()
 
         # send + close: opt-in via declared sub-agents or spawn: true.
         if not (self._spec.tools.agents or self._spec.spawn):

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -14,7 +14,7 @@ from typing import Any
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.inner.os_env import OSEnvironment
 from omnigent.spec import AgentSpec
-from omnigent.spec.types import ToolRuntime
+from omnigent.spec.types import SharePolicy, ToolRuntime
 from omnigent.tools._srt import is_srt_available
 from omnigent.tools.base import Tool, ToolContext, is_valid_tool_name
 from omnigent.tools.builtins import (
@@ -387,8 +387,22 @@ class ToolManager:
         ``sys_session_list`` or a prior ``sys_session_send`` handle),
         so they need no ``sub_specs`` map.
 
-        The mutating tools are opt-in, gated behind ``tools.agents``
-        (declared sub-agents) or the top-level ``spawn: true`` flag:
+        ``sys_session_share`` is gated by its OWN dedicated ``share:``
+        flag (:class:`SharePolicy`), independent of the spawn grants.
+        Sharing MUTATES access control — it can expose a session to a
+        third party or, via ``__public__``, to anonymous read of the
+        full transcript — and the server can confirm the caller holds
+        manage-level access but cannot distinguish "the owner intended
+        this" from "the agent was prompt-injected into sharing". So it
+        is off unless the spec opts in: ``none`` (default) leaves it
+        unregistered; ``non-public`` registers it for granting named
+        users; ``public`` additionally lets it grant ``__public__``
+        (the tool advertises and enforces that extra tier via
+        ``allow_public``).
+
+        The spawn-lifecycle tools are a SEPARATE opt-in, gated behind
+        ``tools.agents`` (declared sub-agents) or the top-level
+        ``spawn: true`` flag:
 
         - ``tools.agents`` registers ``sys_session_send`` (named
           ``(agent, title)`` mode limited to the declared-type enum,
@@ -403,16 +417,6 @@ class ToolManager:
           tombstone the children it creates); without declared
           sub-agents, send's schema omits the named-mode parameters.
 
-        ``sys_session_share`` is gated behind the SAME opt-in (either
-        grant). Unlike the read-only discovery tools it MUTATES access
-        control — it can expose a session to a third party or, via
-        ``__public__``, to anonymous read of the full transcript. The
-        server can confirm the caller holds manage-level access but
-        cannot distinguish "the owner intended this" from "the agent
-        was prompt-injected into sharing", so it is not advertised to
-        every agent by default — only to specs that have already opted
-        into the multi-agent / spawn surface, matching send/close.
-
         The spawn writes are child-only and ``sys_session_share`` is
         owner-authority-bounded, both enforced at dispatch/server level;
         the opt-ins control advertisement, not authority.
@@ -424,7 +428,20 @@ class ToolManager:
         self._tools[SysSessionGetHistoryTool.name()] = SysSessionGetHistoryTool()
         self._tools[SysSessionGetInfoTool.name()] = SysSessionGetInfoTool()
 
-        # send + close + share: opt-in via declared sub-agents or spawn: true.
+        # Session sharing: opt-in via the dedicated ``share`` flag,
+        # independent of spawn / declared sub-agents. ``none`` leaves it
+        # unregistered; ``public`` additionally permits __public__ grants
+        # (the tool reflects that in its schema and the runner enforces
+        # it). It is its own flag — not folded into the spawn grant —
+        # because exposing a session is a distinct authority from
+        # spawning children, and the public tier warrants an explicit
+        # extra opt-in given the prompt-injection exposure.
+        if self._spec.share is not SharePolicy.NONE:
+            self._tools[SysSessionShareTool.name()] = SysSessionShareTool(
+                allow_public=self._spec.share is SharePolicy.PUBLIC,
+            )
+
+        # send + close: opt-in via declared sub-agents or spawn: true.
         if not (self._spec.tools.agents or self._spec.spawn):
             return
 
@@ -433,14 +450,6 @@ class ToolManager:
             sub_specs=sub_specs,
         )
         self._tools[SysSessionCloseTool.name()] = SysSessionCloseTool()
-        # Session sharing MUTATES access control (it can expose the
-        # session to a third party or, via __public__, to anonymous read
-        # of the full transcript), so it is opt-in behind the same grant
-        # as send/close rather than always-on like the read-only
-        # discovery tools: the server can confirm the caller has
-        # manage-level access but not that the owner — versus a
-        # prompt-injected agent — intended the share.
-        self._tools[SysSessionShareTool.name()] = SysSessionShareTool()
         # Model awareness pairs with the dispatch grant: the per-worker
         # listing exists to pick a valid ``args.model`` for send.
         self._tools[SysListModelsTool.name()] = SysListModelsTool(spec=self._spec)

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -56,7 +56,7 @@ from omnigent.runner.app import (
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from omnigent.session_lifecycle import CLOSED_LABEL_KEY, CLOSED_LABEL_VALUE
-from omnigent.spec.types import AgentSpec, ExecutorSpec
+from omnigent.spec.types import AgentSpec, ExecutorSpec, SharePolicy
 from tests.runner.helpers import NullServerClient
 
 _TEST_HARNESS_NAME = "runner-test-default"
@@ -6246,6 +6246,8 @@ async def test_sys_session_share_defaults_to_caller_and_puts_grant() -> None:
             arguments=json.dumps({"user_id": "alice@example.com", "level": "edit"}),
             server_client=server_client,
             conversation_id="conv_caller",
+            # Sharing a named user only needs the non-public tier enabled.
+            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
         )
 
     # Exactly one PUT to the caller's own permissions sub-resource, with
@@ -6302,6 +6304,7 @@ async def test_sys_session_share_maps_error_statuses(
             arguments=json.dumps({"user_id": "alice@example.com", "session_id": "conv_x"}),
             server_client=server_client,
             conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
         )
 
     result = json.loads(output)
@@ -6335,6 +6338,8 @@ async def test_sys_session_share_rejects_bad_level_without_calling_server() -> N
             arguments=json.dumps({"user_id": "alice@example.com", "level": "admin"}),
             server_client=server_client,
             conversation_id="conv_caller",
+            # Share enabled (non-public) so the call reaches level validation.
+            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
         )
 
     assert called is False  # validation must short-circuit before the PUT
@@ -6373,6 +6378,9 @@ async def test_sys_session_share_surfaces_server_message_on_4xx() -> None:
             ),
             server_client=server_client,
             conversation_id="conv_caller",
+            # share: public lets __public__ pass the runner gate and reach
+            # the server, which is what rejects level>read for public.
+            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.PUBLIC),
         )
 
     result = json.loads(output)
@@ -6380,6 +6388,131 @@ async def test_sys_session_share_surfaces_server_message_on_4xx() -> None:
     assert result["error"] == server_message
     assert result["status_code"] == 400
     assert result["session_id"] == "conv_x"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "share_policy",
+    [
+        pytest.param(None, id="no-spec"),
+        pytest.param(SharePolicy.NONE, id="share-none"),
+    ],
+)
+async def test_sys_session_share_disabled_without_share_flag(
+    share_policy: SharePolicy | None,
+) -> None:
+    """
+    With no spec (``None``) or ``share: none``, the runner refuses the
+    grant client-side and never PUTs — the share flag is the real gate,
+    not just tool advertisement, so a prompt-injected call naming the
+    tool can't escalate. A PUT reaching the handler would mean the
+    runner-side policy gate regressed.
+
+    :param share_policy: The spec's ``share`` policy under test (or
+        ``None`` for a missing spec).
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    called = False
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={})
+
+    spec = None if share_policy is None else AgentSpec(spec_version=1, share=share_policy)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "session_id": "conv_x"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=spec,
+        )
+
+    assert called is False  # the gate must short-circuit before the PUT
+    assert "not enabled" in json.loads(output)["error"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_non_public_rejects_public_grant() -> None:
+    """
+    Under ``share: non-public`` a grant to a named user is allowed, but
+    a ``__public__`` grant is refused client-side before any PUT — the
+    non-public tier must not be able to expose the transcript anonymously
+    even if the model (or an injection) asks for it. A PUT here would
+    mean the public sub-gate regressed.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    called = False
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "__public__", "session_id": "conv_x"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
+        )
+
+    assert called is False  # public sub-gate must short-circuit before the PUT
+    assert "public" in json.loads(output)["error"]
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_public_allows_public_grant() -> None:
+    """
+    Under ``share: public`` a ``__public__`` read grant passes the runner
+    gate and PUTs to the permissions endpoint — the positive case the
+    non-public/none gates exclude. If the gate wrongly blocked it, public
+    sharing would be impossible even when the spec explicitly opts in.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200,
+            json={"user_id": "__public__", "conversation_id": "conv_caller", "level": 1},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "__public__"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.PUBLIC),
+        )
+
+    # __public__ reached the server as a level-1 (read) grant on the caller.
+    assert requests == [
+        ("PUT", "/v1/sessions/conv_caller/permissions", {"user_id": "__public__", "level": 1})
+    ]
+    result = json.loads(output)
+    assert result == {
+        "shared": True,
+        "session_id": "conv_caller",
+        "user_id": "__public__",
+        "level": "read",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6342,6 +6342,47 @@ async def test_sys_session_share_rejects_bad_level_without_calling_server() -> N
 
 
 @pytest.mark.asyncio
+async def test_sys_session_share_surfaces_server_message_on_4xx() -> None:
+    """
+    A 4xx the typed branches don't claim (here the server's 400 for a
+    ``__public__`` grant above read level) surfaces the server's own
+    ``{"error": {"message": ...}}`` text rather than a bare "returned
+    400". If the detail-extraction regressed, the agent would see only
+    the status code and couldn't tell that public is read-only — the
+    exact actionable reason the server gave.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    # Mirrors the OmnigentError envelope the server's exception handler
+    # emits (omnigent/server/app.py) for the public + level>read guard.
+    server_message = "Public access is limited to read-only (level 1)"
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400, json={"error": {"code": "INVALID_INPUT", "message": server_message}}
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps(
+                {"user_id": "__public__", "level": "edit", "session_id": "conv_x"}
+            ),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    result = json.loads(output)
+    # The server's verbatim message is surfaced, not flattened to a status.
+    assert result["error"] == server_message
+    assert result["status_code"] == 400
+    assert result["session_id"] == "conv_x"
+
+
+@pytest.mark.asyncio
 async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() -> None:
     """
     ``sys_session_get_info`` projects ``GET /v1/sessions/{id}`` metadata

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6247,7 +6247,7 @@ async def test_sys_session_share_defaults_to_caller_and_puts_grant() -> None:
             server_client=server_client,
             conversation_id="conv_caller",
             # Sharing a named user only needs the non-public tier enabled.
-            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
         )
 
     # Exactly one PUT to the caller's own permissions sub-resource, with
@@ -6304,7 +6304,7 @@ async def test_sys_session_share_maps_error_statuses(
             arguments=json.dumps({"user_id": "alice@example.com", "session_id": "conv_x"}),
             server_client=server_client,
             conversation_id="conv_caller",
-            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
         )
 
     result = json.loads(output)
@@ -6339,7 +6339,7 @@ async def test_sys_session_share_rejects_bad_level_without_calling_server() -> N
             server_client=server_client,
             conversation_id="conv_caller",
             # Share enabled (non-public) so the call reaches level validation.
-            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
         )
 
     assert called is False  # validation must short-circuit before the PUT
@@ -6378,9 +6378,9 @@ async def test_sys_session_share_surfaces_server_message_on_4xx() -> None:
             ),
             server_client=server_client,
             conversation_id="conv_caller",
-            # share: public lets __public__ pass the runner gate and reach
-            # the server, which is what rejects level>read for public.
-            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.PUBLIC),
+            # agent_session_sharing: public lets __public__ pass the runner
+            # gate and reach the server, which rejects level>read for public.
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.PUBLIC),
         )
 
     result = json.loads(output)
@@ -6402,14 +6402,15 @@ async def test_sys_session_share_disabled_without_share_flag(
     share_policy: SharePolicy | None,
 ) -> None:
     """
-    With no spec (``None``) or ``share: none``, the runner refuses the
-    grant client-side and never PUTs — the share flag is the real gate,
-    not just tool advertisement, so a prompt-injected call naming the
-    tool can't escalate. A PUT reaching the handler would mean the
-    runner-side policy gate regressed.
+    With no spec (``None``) or ``agent_session_sharing: none``, the
+    runner refuses the grant client-side and never PUTs — the
+    ``agent_session_sharing`` flag is the real gate, not just tool
+    advertisement, so a prompt-injected call naming the tool can't
+    escalate. A PUT reaching the handler would mean the runner-side
+    policy gate regressed.
 
-    :param share_policy: The spec's ``share`` policy under test (or
-        ``None`` for a missing spec).
+    :param share_policy: The spec's ``agent_session_sharing`` policy
+        under test (or ``None`` for a missing spec).
     """
     from omnigent.runner.tool_dispatch import execute_tool
 
@@ -6420,7 +6421,11 @@ async def test_sys_session_share_disabled_without_share_flag(
         called = True
         return httpx.Response(200, json={})
 
-    spec = None if share_policy is None else AgentSpec(spec_version=1, share=share_policy)
+    spec = (
+        None
+        if share_policy is None
+        else AgentSpec(spec_version=1, agent_session_sharing=share_policy)
+    )
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(_server_handler),
         base_url="http://server",
@@ -6440,8 +6445,9 @@ async def test_sys_session_share_disabled_without_share_flag(
 @pytest.mark.asyncio
 async def test_sys_session_share_non_public_rejects_public_grant() -> None:
     """
-    Under ``share: non-public`` a grant to a named user is allowed, but
-    a ``__public__`` grant is refused client-side before any PUT — the
+    Under ``agent_session_sharing: non-public`` a grant to a named user
+    is allowed, but a ``__public__`` grant is refused client-side before
+    any PUT — the
     non-public tier must not be able to expose the transcript anonymously
     even if the model (or an injection) asks for it. A PUT here would
     mean the public sub-gate regressed.
@@ -6464,7 +6470,7 @@ async def test_sys_session_share_non_public_rejects_public_grant() -> None:
             arguments=json.dumps({"user_id": "__public__", "session_id": "conv_x"}),
             server_client=server_client,
             conversation_id="conv_caller",
-            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC),
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC),
         )
 
     assert called is False  # public sub-gate must short-circuit before the PUT
@@ -6474,8 +6480,9 @@ async def test_sys_session_share_non_public_rejects_public_grant() -> None:
 @pytest.mark.asyncio
 async def test_sys_session_share_public_allows_public_grant() -> None:
     """
-    Under ``share: public`` a ``__public__`` read grant passes the runner
-    gate and PUTs to the permissions endpoint — the positive case the
+    Under ``agent_session_sharing: public`` a ``__public__`` read grant
+    passes the runner gate and PUTs to the permissions endpoint — the
+    positive case the
     non-public/none gates exclude. If the gate wrongly blocked it, public
     sharing would be impossible even when the spec explicitly opts in.
     """
@@ -6499,7 +6506,7 @@ async def test_sys_session_share_public_allows_public_grant() -> None:
             arguments=json.dumps({"user_id": "__public__"}),
             server_client=server_client,
             conversation_id="conv_caller",
-            agent_spec=AgentSpec(spec_version=1, share=SharePolicy.PUBLIC),
+            agent_spec=AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.PUBLIC),
         )
 
     # __public__ reached the server as a level-1 (read) grant on the caller.

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -6217,6 +6217,131 @@ async def test_sys_session_get_info_maps_error_statuses(
 
 
 @pytest.mark.asyncio
+async def test_sys_session_share_defaults_to_caller_and_puts_grant() -> None:
+    """
+    Omitting ``session_id`` shares the caller's own session: the runner
+    PUTs to ``/v1/sessions/{conversation_id}/permissions`` with the
+    grantee and the numeric level mapped from the friendly name. If the
+    default-to-caller logic or the name->level mapping regressed, the
+    request path or body would be wrong (and an agent's "share this
+    session" would silently hit the wrong session or wrong level).
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200,
+            json={"user_id": "alice@example.com", "conversation_id": "conv_caller", "level": 2},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "level": "edit"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    # Exactly one PUT to the caller's own permissions sub-resource, with
+    # level "edit" mapped to the server's numeric 2 (1=read/2=edit/3=manage).
+    assert requests == [
+        (
+            "PUT",
+            "/v1/sessions/conv_caller/permissions",
+            {"user_id": "alice@example.com", "level": 2},
+        )
+    ]
+    result = json.loads(output)
+    assert result == {
+        "shared": True,
+        "session_id": "conv_caller",
+        "user_id": "alice@example.com",
+        "level": "edit",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        pytest.param(404, "session_not_found", id="not-found"),
+        pytest.param(403, "access_denied", id="forbidden"),
+        pytest.param(401, "access_denied", id="unauthorized"),
+    ],
+)
+async def test_sys_session_share_maps_error_statuses(
+    status_code: int,
+    expected_error: str,
+) -> None:
+    """
+    A 404 maps to ``session_not_found``; 401/403 map to ``access_denied``
+    — a typed reason instead of a raw status, matching the sibling
+    session tools so the LLM can distinguish "no such session" from
+    "you can't manage it".
+
+    :param status_code: HTTP status the mocked Omnigent server returns.
+    :param expected_error: The typed error string the tool should emit.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={"detail": "x"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "session_id": "conv_x"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    result = json.loads(output)
+    assert result["error"] == expected_error
+    assert result["session_id"] == "conv_x"
+
+
+@pytest.mark.asyncio
+async def test_sys_session_share_rejects_bad_level_without_calling_server() -> None:
+    """
+    An unknown ``level`` is rejected client-side before any PUT — so a
+    typo can't fall through to the server or silently skip the grant. A
+    request reaching the handler would mean the level validation
+    regressed.
+    """
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    called = False
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_session_share",
+            arguments=json.dumps({"user_id": "alice@example.com", "level": "admin"}),
+            server_client=server_client,
+            conversation_id="conv_caller",
+        )
+
+    assert called is False  # validation must short-circuit before the PUT
+    assert "level must be one of" in json.loads(output)["error"]
+
+
+@pytest.mark.asyncio
 async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() -> None:
     """
     ``sys_session_get_info`` projects ``GET /v1/sessions/{id}`` metadata

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -2357,16 +2357,16 @@ def test_parse_spawn_true_sets_flag(tmp_path: Path) -> None:
 
 def test_parse_share_defaults_to_none_when_omitted(agent_dir: Path) -> None:
     """
-    Without a top-level ``share:`` key the parsed ``AgentSpec.share`` is
-    :attr:`SharePolicy.NONE` — sharing is off by default, so
-    ``sys_session_share`` is not registered. A regression flipping the
-    default would expose the access-control mutation (incl. ``__public__``)
-    to every agent.
+    Without a top-level ``agent_session_sharing:`` key the parsed
+    ``AgentSpec.agent_session_sharing`` is :attr:`SharePolicy.NONE` —
+    sharing is off by default, so ``sys_session_share`` is not
+    registered. A regression flipping the default would expose the
+    access-control mutation (incl. ``__public__``) to every agent.
 
     :param agent_dir: Temporary agent directory fixture.
     """
     spec = parse(agent_dir)
-    assert spec.share is SharePolicy.NONE
+    assert spec.agent_session_sharing is SharePolicy.NONE
 
 
 @pytest.mark.parametrize(
@@ -2383,34 +2383,34 @@ def test_parse_share_maps_each_policy_string(
     expected: SharePolicy,
 ) -> None:
     """
-    Each recognized ``share:`` string round-trips to its
+    Each recognized ``agent_session_sharing:`` string round-trips to its
     :class:`SharePolicy` member. The flag is the sole enabler of
     ``sys_session_share`` (and ``public`` of the ``__public__`` tier);
     a parser regression dropping or mismapping it would silently change
     what the agent is allowed to expose.
 
     :param tmp_path: pytest-provided temporary directory.
-    :param value: The YAML ``share:`` string under test.
+    :param value: The YAML ``agent_session_sharing:`` string under test.
     :param expected: The :class:`SharePolicy` it must parse to.
     """
-    config = {"spec_version": 1, "name": "share-agent", "share": value}
+    config = {"spec_version": 1, "name": "share-agent", "agent_session_sharing": value}
     (tmp_path / "config.yaml").write_text(yaml.dump(config))
     spec = parse(tmp_path)
-    assert spec.share is expected
+    assert spec.agent_session_sharing is expected
 
 
 def test_parse_share_invalid_value_fails_loud(tmp_path: Path) -> None:
     """
-    An unrecognized ``share:`` value (here a plausible typo) raises
-    rather than silently disabling sharing — fail-loud, so a
-    misconfigured capability surfaces at parse time instead of becoming
+    An unrecognized ``agent_session_sharing:`` value (here a plausible
+    typo) raises rather than silently disabling sharing — fail-loud, so
+    a misconfigured capability surfaces at parse time instead of becoming
     a confusing "the tool isn't there" at runtime.
 
     :param tmp_path: pytest-provided temporary directory.
     """
-    config = {"spec_version": 1, "name": "bad-share", "share": "private"}
+    config = {"spec_version": 1, "name": "bad-share", "agent_session_sharing": "private"}
     (tmp_path / "config.yaml").write_text(yaml.dump(config))
-    with pytest.raises(OmnigentError, match="share:"):
+    with pytest.raises(OmnigentError, match="agent_session_sharing"):
         parse(tmp_path)
 
 

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -9,7 +9,7 @@ import yaml
 
 from omnigent.errors import OmnigentError
 from omnigent.spec.parser import discover_host_skills, parse
-from omnigent.spec.types import ApiKeyAuth, DatabricksAuth, ProviderAuth
+from omnigent.spec.types import ApiKeyAuth, DatabricksAuth, ProviderAuth, SharePolicy
 
 
 @pytest.fixture()
@@ -2353,6 +2353,65 @@ def test_parse_spawn_true_sets_flag(tmp_path: Path) -> None:
     (tmp_path / "config.yaml").write_text(yaml.dump(config))
     spec = parse(tmp_path)
     assert spec.spawn is True
+
+
+def test_parse_share_defaults_to_none_when_omitted(agent_dir: Path) -> None:
+    """
+    Without a top-level ``share:`` key the parsed ``AgentSpec.share`` is
+    :attr:`SharePolicy.NONE` — sharing is off by default, so
+    ``sys_session_share`` is not registered. A regression flipping the
+    default would expose the access-control mutation (incl. ``__public__``)
+    to every agent.
+
+    :param agent_dir: Temporary agent directory fixture.
+    """
+    spec = parse(agent_dir)
+    assert spec.share is SharePolicy.NONE
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("none", SharePolicy.NONE),
+        ("non-public", SharePolicy.NON_PUBLIC),
+        ("public", SharePolicy.PUBLIC),
+    ],
+)
+def test_parse_share_maps_each_policy_string(
+    tmp_path: Path,
+    value: str,
+    expected: SharePolicy,
+) -> None:
+    """
+    Each recognized ``share:`` string round-trips to its
+    :class:`SharePolicy` member. The flag is the sole enabler of
+    ``sys_session_share`` (and ``public`` of the ``__public__`` tier);
+    a parser regression dropping or mismapping it would silently change
+    what the agent is allowed to expose.
+
+    :param tmp_path: pytest-provided temporary directory.
+    :param value: The YAML ``share:`` string under test.
+    :param expected: The :class:`SharePolicy` it must parse to.
+    """
+    config = {"spec_version": 1, "name": "share-agent", "share": value}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert spec.share is expected
+
+
+def test_parse_share_invalid_value_fails_loud(tmp_path: Path) -> None:
+    """
+    An unrecognized ``share:`` value (here a plausible typo) raises
+    rather than silently disabling sharing — fail-loud, so a
+    misconfigured capability surfaces at parse time instead of becoming
+    a confusing "the tool isn't there" at runtime.
+
+    :param tmp_path: pytest-provided temporary directory.
+    """
+    config = {"spec_version": 1, "name": "bad-share", "share": "private"}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match="share:"):
+        parse(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -53,14 +53,11 @@ _ALWAYS_PRESENT_TOOLS: frozenset[str] = frozenset(
         # Read-only session discovery tools are registered for every
         # agent (a user-added agent that declares no sub-agents still
         # needs to list/peek/get-info on its session-mates); the
-        # spawn-lifecycle writes (sys_session_send/close/create) are
+        # mutating tools (sys_session_send/close/create/share) are
         # opt-in via tools.agents or the top-level ``spawn: true``.
         "sys_session_get_history",
         "sys_session_list",
         "sys_session_get_info",
-        # Session sharing is always available; it defaults to the caller's
-        # own session and the server enforces manage-level access.
-        "sys_session_share",
         # Read-only agent discovery tools are likewise always available
         # (global, permission-bounded reads of any accessible session's
         # agent / bundle).
@@ -303,11 +300,13 @@ def test_session_reads_registered_but_writes_gated_without_opt_in() -> None:
     ``sys_session_list`` / ``sys_session_get_info``) is registered for
     **every** agent, even one that declares no sub-agents — so a
     user-added agent can read its session-mates for context. The
-    spawn-lifecycle writes (``sys_session_send`` /
-    ``sys_session_close`` / ``sys_session_create``) are NOT registered
-    without an opt-in (``tools.agents`` or top-level ``spawn: true``).
-    A regression that registered the writes by default would expose
-    the child-session spawn surface to every custom agent.
+    mutating session tools (``sys_session_send`` /
+    ``sys_session_close`` / ``sys_session_create`` /
+    ``sys_session_share``) are NOT registered without an opt-in
+    (``tools.agents`` or top-level ``spawn: true``). A regression that
+    registered the writes by default would expose the child-session
+    spawn surface — and, for share, the ability to expose the session
+    to a third party or ``__public__`` — to every custom agent.
     """
     mgr = ToolManager(_make_spec([]))
     names = {s["function"]["name"] for s in mgr.get_tool_schemas()}
@@ -318,13 +317,15 @@ def test_session_reads_registered_but_writes_gated_without_opt_in() -> None:
     # in _register_sub_agent_tools regressed and the orchestrator can't
     # check session status.
     assert "sys_session_get_info" in names
-    # Sharing is always available too: it defaults to the caller's own
-    # session and the server enforces manage-level access, so advertising
-    # it to every agent grants no authority the server wouldn't check.
-    assert "sys_session_share" in names
     assert "sys_session_send" not in names
     assert "sys_session_close" not in names
     assert "sys_session_create" not in names
+    # Sharing MUTATES access control (it can expose the session to a
+    # third party or, via __public__, to anonymous read), so it is
+    # gated behind the same opt-in as send/close — NOT always-on like
+    # the read-only discovery tools. A regression registering it here
+    # would let any prompt-injected agent share its session by default.
+    assert "sys_session_share" not in names
     # Model awareness pairs with the dispatch grant — without send there
     # is no args.model to pick, so the listing tool must stay gated too.
     assert "sys_list_models" not in names
@@ -349,6 +350,8 @@ def test_spawn_flag_registers_write_tools_without_sub_agents() -> None:
     assert "sys_session_create" in names
     # The dispatch grant brings model awareness along with it.
     assert "sys_list_models" in names
+    # Sharing is gated behind the same opt-in — present once spawn is on.
+    assert "sys_session_share" in names
 
 
 def test_session_send_schema_drops_named_mode_without_sub_agents() -> None:
@@ -406,6 +409,8 @@ def test_declared_agents_grant_send_close_but_not_create() -> None:
     assert "sys_session_create" not in names
     # Model awareness rides the same grant as send.
     assert "sys_list_models" in names
+    # Declaring sub-agents also opts into sharing (same gate as send/close).
+    assert "sys_session_share" in names
 
 
 def test_both_grants_compose() -> None:

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -58,6 +58,9 @@ _ALWAYS_PRESENT_TOOLS: frozenset[str] = frozenset(
         "sys_session_get_history",
         "sys_session_list",
         "sys_session_get_info",
+        # Session sharing is always available; it defaults to the caller's
+        # own session and the server enforces manage-level access.
+        "sys_session_share",
         # Read-only agent discovery tools are likewise always available
         # (global, permission-bounded reads of any accessible session's
         # agent / bundle).
@@ -315,6 +318,10 @@ def test_session_reads_registered_but_writes_gated_without_opt_in() -> None:
     # in _register_sub_agent_tools regressed and the orchestrator can't
     # check session status.
     assert "sys_session_get_info" in names
+    # Sharing is always available too: it defaults to the caller's own
+    # session and the server enforces manage-level access, so advertising
+    # it to every agent grants no authority the server wouldn't check.
+    assert "sys_session_share" in names
     assert "sys_session_send" not in names
     assert "sys_session_close" not in names
     assert "sys_session_create" not in names

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -419,14 +419,15 @@ def test_declared_agents_grant_send_close_but_not_create() -> None:
 
 def test_share_non_public_registers_share_tool_without_public() -> None:
     """
-    ``share: non-public`` alone (no spawn / declared agents) registers
-    ``sys_session_share`` — proving the flag is independently sufficient
-    AND does not drag in the spawn-lifecycle tools. The advertised
-    ``user_id`` schema must NOT mention ``__public__``, so the model is
-    not offered a grantee the runner would reject. If the gating
-    regressed to the spawn opt-in, share would be absent here.
+    ``agent_session_sharing: non-public`` alone (no spawn / declared
+    agents) registers ``sys_session_share`` — proving the flag is
+    independently sufficient AND does not drag in the spawn-lifecycle
+    tools. The advertised ``user_id`` schema must NOT mention
+    ``__public__``, so the model is not offered a grantee the runner
+    would reject. If the gating regressed to the spawn opt-in, share
+    would be absent here.
     """
-    mgr = ToolManager(AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC))
+    mgr = ToolManager(AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.NON_PUBLIC))
     schemas = {s["function"]["name"]: s for s in mgr.get_tool_schemas()}
     assert "sys_session_share" in schemas
     # Sharing is decoupled from spawn — none of the spawn writes ride along.
@@ -442,13 +443,14 @@ def test_share_non_public_registers_share_tool_without_public() -> None:
 
 def test_share_public_registers_share_tool_advertising_public() -> None:
     """
-    ``share: public`` registers ``sys_session_share`` and the advertised
-    ``user_id`` schema DOES mention ``__public__`` — the only tier where
-    anonymous-read grants are permitted. If ``allow_public`` weren't
-    threaded from the flag into the tool, the public option would be
-    hidden (or, worse, advertised under non-public).
+    ``agent_session_sharing: public`` registers ``sys_session_share``
+    and the advertised ``user_id`` schema DOES mention ``__public__`` —
+    the only tier where anonymous-read grants are permitted. If
+    ``allow_public`` weren't threaded from the flag into the tool, the
+    public option would be hidden (or, worse, advertised under
+    non-public).
     """
-    mgr = ToolManager(AgentSpec(spec_version=1, share=SharePolicy.PUBLIC))
+    mgr = ToolManager(AgentSpec(spec_version=1, agent_session_sharing=SharePolicy.PUBLIC))
     schemas = {s["function"]["name"]: s for s in mgr.get_tool_schemas()}
     assert "sys_session_share" in schemas
     user_id_desc = schemas["sys_session_share"]["function"]["parameters"]["properties"]["user_id"][

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -15,6 +15,7 @@ from omnigent.spec.types import (
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
+    SharePolicy,
     SkillSpec,
     ToolRuntime,
     ToolsConfig,
@@ -320,11 +321,10 @@ def test_session_reads_registered_but_writes_gated_without_opt_in() -> None:
     assert "sys_session_send" not in names
     assert "sys_session_close" not in names
     assert "sys_session_create" not in names
-    # Sharing MUTATES access control (it can expose the session to a
-    # third party or, via __public__, to anonymous read), so it is
-    # gated behind the same opt-in as send/close — NOT always-on like
-    # the read-only discovery tools. A regression registering it here
-    # would let any prompt-injected agent share its session by default.
+    # Sharing has its OWN dedicated `share:` flag (default `none`), so it
+    # is absent here even though this spec also lacks spawn/agents. A
+    # regression registering it by default would let any prompt-injected
+    # agent expose its session (incl. via __public__).
     assert "sys_session_share" not in names
     # Model awareness pairs with the dispatch grant — without send there
     # is no args.model to pick, so the listing tool must stay gated too.
@@ -350,8 +350,11 @@ def test_spawn_flag_registers_write_tools_without_sub_agents() -> None:
     assert "sys_session_create" in names
     # The dispatch grant brings model awareness along with it.
     assert "sys_list_models" in names
-    # Sharing is gated behind the same opt-in — present once spawn is on.
-    assert "sys_session_share" in names
+    # Sharing is DECOUPLED from spawn — its own `share:` flag governs it,
+    # so `spawn: true` alone (share defaulting to `none`) does NOT
+    # register it. A regression coupling them would re-expose sharing to
+    # every spawn-capable agent.
+    assert "sys_session_share" not in names
 
 
 def test_session_send_schema_drops_named_mode_without_sub_agents() -> None:
@@ -409,8 +412,49 @@ def test_declared_agents_grant_send_close_but_not_create() -> None:
     assert "sys_session_create" not in names
     # Model awareness rides the same grant as send.
     assert "sys_list_models" in names
-    # Declaring sub-agents also opts into sharing (same gate as send/close).
-    assert "sys_session_share" in names
+    # Declaring sub-agents does NOT enable sharing — that is the separate
+    # `share:` flag's job, decoupled from the spawn/agents grant.
+    assert "sys_session_share" not in names
+
+
+def test_share_non_public_registers_share_tool_without_public() -> None:
+    """
+    ``share: non-public`` alone (no spawn / declared agents) registers
+    ``sys_session_share`` — proving the flag is independently sufficient
+    AND does not drag in the spawn-lifecycle tools. The advertised
+    ``user_id`` schema must NOT mention ``__public__``, so the model is
+    not offered a grantee the runner would reject. If the gating
+    regressed to the spawn opt-in, share would be absent here.
+    """
+    mgr = ToolManager(AgentSpec(spec_version=1, share=SharePolicy.NON_PUBLIC))
+    schemas = {s["function"]["name"]: s for s in mgr.get_tool_schemas()}
+    assert "sys_session_share" in schemas
+    # Sharing is decoupled from spawn — none of the spawn writes ride along.
+    assert "sys_session_send" not in schemas
+    assert "sys_session_close" not in schemas
+    assert "sys_session_create" not in schemas
+    # non-public must not advertise the public sentinel.
+    user_id_desc = schemas["sys_session_share"]["function"]["parameters"]["properties"]["user_id"][
+        "description"
+    ]
+    assert "__public__" not in user_id_desc
+
+
+def test_share_public_registers_share_tool_advertising_public() -> None:
+    """
+    ``share: public`` registers ``sys_session_share`` and the advertised
+    ``user_id`` schema DOES mention ``__public__`` — the only tier where
+    anonymous-read grants are permitted. If ``allow_public`` weren't
+    threaded from the flag into the tool, the public option would be
+    hidden (or, worse, advertised under non-public).
+    """
+    mgr = ToolManager(AgentSpec(spec_version=1, share=SharePolicy.PUBLIC))
+    schemas = {s["function"]["name"]: s for s in mgr.get_tool_schemas()}
+    assert "sys_session_share" in schemas
+    user_id_desc = schemas["sys_session_share"]["function"]["parameters"]["properties"]["user_id"][
+        "description"
+    ]
+    assert "__public__" in user_id_desc
 
 
 def test_both_grants_compose() -> None:


### PR DESCRIPTION
## Summary

Adds a runner-dispatched `sys_session_share` built-in tool so an agent can grant
another user (or the public) access to **the session it is running in** — or
another session it manages — from inside its own run, with no shell, no
`omnigent` binary, and no PATH/sandbox assumptions. It proxies
`PUT /v1/sessions/{id}/permissions` over the runner's authenticated server
client, wired into the session-query REST surface via `_SESSION_QUERY_TOOLS`
and dispatched through a new `_session_share_via_rest` handler.

- **Gated by a dedicated `agent_session_sharing` spec flag** (top-level, tri-state
  `SharePolicy`, modeled like `spawn:`): `none` (default — tool not registered),
  `non-public` (grant named users only), or `public` (also allow the
  `__public__` anonymous-read sentinel). This flag is the *sole* enabler of the
  tool — fully decoupled from `spawn` / `tools.agents`, and unrelated to sharing
  a session via the server API or CLI. It is plumbed through both spec paths
  (the `AgentSpec` parser and the inner `AgentDef` to `AgentSpec` translation),
  mirroring how `spawn` flows.
- `session_id` defaults to the caller's own conversation (share "this" session
  with just a `user_id`); `level` is the friendly `read` / `edit` / `manage`
  mapped to the server's numeric level (`1` / `2` / `3`); `__public__` grants
  anonymous read.
- **Two-layer enforcement.** *Advertisement:* `ToolManager` registers the tool
  only when `agent_session_sharing != none`, and passes `allow_public` so the
  schema advertises the `__public__` sentinel only under `public`. *Hard gate:*
  the runner enforces the policy in `_session_share_via_rest` **before** the PUT
  (`none`/unknown -> refuse all; `non-public` -> refuse `__public__`). The server
  cannot see the spec's flag, so the runner is the real gate — a prompt-injected
  call that merely names the tool cannot escalate.
- Maps `404 -> session_not_found` and `401/403 -> access_denied` (matching the
  sibling session tools), and surfaces the server's own error message on other
  4xx (e.g. "Public access is limited to read-only (level 1)") instead of a bare
  status code.

**Part 1 of #983** — the agent-first path of the session-sharing CUJ. The
companion `omnigent share` CLI (the human/script path) follows as a separate PR.

This reflects the review feedback on the original always-on design: unlike the
read-only discovery tools, sharing *mutates access control* and can expose a
session to a third party or, via `__public__`, to anonymous read of the full
transcript. Since the agent acts as the session owner, the server can confirm
manage-level access but cannot distinguish "the owner intended this" from "the
agent was prompt-injected into sharing" — so the tool is opt-in, with the public
tier a deliberate extra opt-in.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

**Unit tests.**
- Parser (`tests/spec/test_parser.py`): `agent_session_sharing` parses each
  policy string to its `SharePolicy` member, defaults to `none` when omitted,
  and fails loud on an invalid value.
- Registration (`tests/tools/test_manager.py`): the tool is gated by the flag
  and decoupled from spawn/agents (absent under `none`, under `spawn: true`, and
  under declared sub-agents; present under `non-public` and `public`), and the
  advertised `user_id` schema reflects `allow_public` (omits `__public__` under
  `non-public`, includes it under `public`).
- Dispatch (`tests/runner/test_runner_dispatch.py`): default-to-caller plus the
  friendly-name to numeric-level mapping (asserts the exact PUT path and body),
  typed `404`/`401`/`403` error mapping, client-side rejection of an unknown
  `level` before any PUT, the runner gate refusing when disabled / refusing
  `__public__` under `non-public` / allowing it under `public`, and 4xx
  server-message surfacing.

Ran `tests/spec/test_parser.py`, `tests/tools/test_manager.py`, and the
`sys_session_share` dispatch tests in `tests/runner/test_runner_dispatch.py`
(all pass); pre-commit clean (ruff format/check + project lint hooks).

**Manual verification.** Confirmed end-to-end through the real REPL
(`omnigent run`) across all six tiers: `public` grants a named user and
`__public__`; `non-public` grants a named user but refuses `__public__` with the
typed error; `none` and `spawn: true`-without-the-flag do not advertise the tool
at all. This exercises the live streaming path the polling/mock tests don't, per
the repo's e2e-verification guidance.

This is an additive, server-gated tool that proxies an existing REST endpoint;
it does not modify the sub-agent spawning / parking / auto-collect / PATCH /
GET-response-builder paths that mandate the full e2e suite, so the targeted unit
tests plus the manual REPL run are the coverage.
