### PR TITLE
refactor: update History.get_context_window docstring to point to compaction

### DIFF
--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -108,95 +108,18 @@ class History:
     def append(self, msg: Message) -> None:
         self.messages.append(msg)
 
-    @staticmethod
-    def _estimate_tokens(msg: Message) -> int:
-        """Estimate token count for a message using chars/4 heuristic."""
-        text = msg.content if isinstance(msg.content, str) else str(msg.content)
-        return max(1, len(text) // 4)
+    def get_context_window(self, max_tokens: int | None = None) -> list[Message]:  # noqa: ARG002
+        """Return the full message list.
 
-    @staticmethod
-    def _tool_call_pair_size(messages: list[Message], idx: int) -> int:
-        """Return 2 if ``messages[idx]`` starts a tool_call/tool_result pair, else 1."""
-        if (
-            idx + 1 < len(messages)
-            and messages[idx].role == "tool_call"
-            and messages[idx + 1].role == "tool_result"
-        ):
-            return 2
-        return 1
-
-    def get_context_window(self, max_tokens: int | None = None) -> list[Message]:
-        """Return messages that fit in the context window.
-
-        This is a lightweight, dependency-free fallback for callers
-        that use :class:`History` directly.  The primary context
-        management path is the layered compaction system in
-        :mod:`omnigent.runtime.compaction`, which uses tiktoken-based
-        counting and LLM summarization on the executor-facing message
-        format.
-
-        When *max_tokens* is ``None``, all messages are returned.
-        Otherwise, context selection mirrors the compaction module's
-        approach:
-
-        1. System messages are always kept.
-        2. Tool call / tool result pairs are kept or dropped
-           together (never orphaned).
-        3. The most recent non-system messages are included
-           newest-first until the budget is exhausted; older
-           messages are dropped.
+        The *max_tokens* parameter is accepted for interface
+        compatibility but is intentionally ignored here.  Token-aware
+        context trimming (including tool-call pair integrity,
+        surgical clearing, and LLM summarization) is handled by the
+        layered compaction system in
+        :mod:`omnigent.runtime.compaction`, which operates on the
+        executor-facing message format with tiktoken-based counting.
         """
-        if max_tokens is None:
-            return list(self.messages)
-
-        system_msgs: list[Message] = []
-        non_system_msgs: list[Message] = []
-        for msg in self.messages:
-            if msg.role == "system":
-                system_msgs.append(msg)
-            else:
-                non_system_msgs.append(msg)
-
-        budget = max_tokens
-
-        for msg in system_msgs:
-            budget -= self._estimate_tokens(msg)
-
-        if budget <= 0:
-            return list(system_msgs)
-
-        # Walk non-system messages from newest to oldest, keeping
-        # tool_call/tool_result pairs atomic.
-        kept_indices: list[int] = []
-        i = len(non_system_msgs) - 1
-        while i >= 0:
-            pair = self._tool_call_pair_size(non_system_msgs, i - 1) if i >= 1 else 1
-            if pair == 2:
-                cost = (
-                    self._estimate_tokens(non_system_msgs[i - 1])
-                    + self._estimate_tokens(non_system_msgs[i])
-                )
-                if cost <= budget:
-                    kept_indices.append(i - 1)
-                    kept_indices.append(i)
-                    budget -= cost
-                    i -= 2
-                    continue
-                else:
-                    break
-            else:
-                cost = self._estimate_tokens(non_system_msgs[i])
-                if cost <= budget:
-                    kept_indices.append(i)
-                    budget -= cost
-                    i -= 1
-                else:
-                    break
-        kept_indices.sort()
-        result = list(system_msgs)
-        for idx in kept_indices:
-            result.append(non_system_msgs[idx])
-        return result
+        return list(self.messages)
 
     def search(self, query: str) -> list[Message]:
         """Simple substring search over message content."""

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -108,14 +108,53 @@ class History:
     def append(self, msg: Message) -> None:
         self.messages.append(msg)
 
-    def get_context_window(self, max_tokens: int | None = None) -> list[Message]:  # noqa: ARG002 — placeholder API; token-based trimming not yet implemented
-        """
-        Return messages that fit in the context window.
+    @staticmethod
+    def _estimate_tokens(msg: Message) -> int:
+        """Estimate token count for a message using chars/4 heuristic."""
+        text = msg.content if isinstance(msg.content, str) else str(msg.content)
+        return max(1, len(text) // 4)
 
-        For now, return all messages.  A real implementation would count tokens
-        and summarise older messages.
+    def get_context_window(self, max_tokens: int | None = None) -> list[Message]:
+        """Return messages that fit in the context window.
+
+        When *max_tokens* is ``None``, all messages are returned.
+        Otherwise, messages are selected to stay within the budget:
+        system messages are always kept, then the most recent
+        non-system messages are included newest-first until the
+        budget is exhausted.  Older messages beyond the budget are
+        dropped.
         """
-        return list(self.messages)
+        if max_tokens is None:
+            return list(self.messages)
+
+        system_msgs: list[Message] = []
+        non_system_msgs: list[Message] = []
+        for msg in self.messages:
+            if msg.role == "system":
+                system_msgs.append(msg)
+            else:
+                non_system_msgs.append(msg)
+
+        budget = max_tokens
+        result: list[Message] = []
+
+        for msg in system_msgs:
+            cost = self._estimate_tokens(msg)
+            if cost <= budget:
+                result.append(msg)
+                budget -= cost
+
+        kept: list[Message] = []
+        for msg in reversed(non_system_msgs):
+            cost = self._estimate_tokens(msg)
+            if cost <= budget:
+                kept.append(msg)
+                budget -= cost
+            else:
+                break
+        kept.reverse()
+        result.extend(kept)
+        return result
 
     def search(self, query: str) -> list[Message]:
         """Simple substring search over message content."""

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -114,15 +114,37 @@ class History:
         text = msg.content if isinstance(msg.content, str) else str(msg.content)
         return max(1, len(text) // 4)
 
+    @staticmethod
+    def _tool_call_pair_size(messages: list[Message], idx: int) -> int:
+        """Return 2 if ``messages[idx]`` starts a tool_call/tool_result pair, else 1."""
+        if (
+            idx + 1 < len(messages)
+            and messages[idx].role == "tool_call"
+            and messages[idx + 1].role == "tool_result"
+        ):
+            return 2
+        return 1
+
     def get_context_window(self, max_tokens: int | None = None) -> list[Message]:
         """Return messages that fit in the context window.
 
+        This is a lightweight, dependency-free fallback for callers
+        that use :class:`History` directly.  The primary context
+        management path is the layered compaction system in
+        :mod:`omnigent.runtime.compaction`, which uses tiktoken-based
+        counting and LLM summarization on the executor-facing message
+        format.
+
         When *max_tokens* is ``None``, all messages are returned.
-        Otherwise, messages are selected to stay within the budget:
-        system messages are always kept, then the most recent
-        non-system messages are included newest-first until the
-        budget is exhausted.  Older messages beyond the budget are
-        dropped.
+        Otherwise, context selection mirrors the compaction module's
+        approach:
+
+        1. System messages are always kept.
+        2. Tool call / tool result pairs are kept or dropped
+           together (never orphaned).
+        3. The most recent non-system messages are included
+           newest-first until the budget is exhausted; older
+           messages are dropped.
         """
         if max_tokens is None:
             return list(self.messages)
@@ -136,24 +158,44 @@ class History:
                 non_system_msgs.append(msg)
 
         budget = max_tokens
-        result: list[Message] = []
 
         for msg in system_msgs:
-            cost = self._estimate_tokens(msg)
-            if cost <= budget:
-                result.append(msg)
-                budget -= cost
+            budget -= self._estimate_tokens(msg)
 
-        kept: list[Message] = []
-        for msg in reversed(non_system_msgs):
-            cost = self._estimate_tokens(msg)
-            if cost <= budget:
-                kept.append(msg)
-                budget -= cost
+        if budget <= 0:
+            return list(system_msgs)
+
+        # Walk non-system messages from newest to oldest, keeping
+        # tool_call/tool_result pairs atomic.
+        kept_indices: list[int] = []
+        i = len(non_system_msgs) - 1
+        while i >= 0:
+            pair = self._tool_call_pair_size(non_system_msgs, i - 1) if i >= 1 else 1
+            if pair == 2:
+                cost = (
+                    self._estimate_tokens(non_system_msgs[i - 1])
+                    + self._estimate_tokens(non_system_msgs[i])
+                )
+                if cost <= budget:
+                    kept_indices.append(i - 1)
+                    kept_indices.append(i)
+                    budget -= cost
+                    i -= 2
+                    continue
+                else:
+                    break
             else:
-                break
-        kept.reverse()
-        result.extend(kept)
+                cost = self._estimate_tokens(non_system_msgs[i])
+                if cost <= budget:
+                    kept_indices.append(i)
+                    budget -= cost
+                    i -= 1
+                else:
+                    break
+        kept_indices.sort()
+        result = list(system_msgs)
+        for idx in kept_indices:
+            result.append(non_system_msgs[idx])
         return result
 
     def search(self, query: str) -> list[Message]:

--- a/tests/inner/test_datamodel.py
+++ b/tests/inner/test_datamodel.py
@@ -99,6 +99,30 @@ class TestHistory(unittest.TestCase):
         result = h.get_context_window(max_tokens=1)
         self.assertEqual(len(result), 0)
 
+    def test_get_context_window_keeps_tool_call_pairs(self):
+        h = History()
+        h.append(Message(role="user", content="x" * 400))  # ~100 tokens
+        h.append(Message(role="tool_call", content="call"))  # ~1 token
+        h.append(Message(role="tool_result", content="result"))  # ~1 token
+        h.append(Message(role="assistant", content="done"))  # ~1 token
+        # Budget fits the pair + assistant but not the user message
+        result = h.get_context_window(max_tokens=10)
+        roles = [m.role for m in result]
+        self.assertIn("tool_call", roles)
+        self.assertIn("tool_result", roles)
+
+    def test_get_context_window_drops_pair_together(self):
+        h = History()
+        h.append(Message(role="tool_call", content="c" * 400))
+        h.append(Message(role="tool_result", content="r" * 400))
+        h.append(Message(role="assistant", content="ok" * 4))
+        # Budget only fits the assistant message, not the pair
+        result = h.get_context_window(max_tokens=5)
+        roles = [m.role for m in result]
+        self.assertNotIn("tool_call", roles)
+        self.assertNotIn("tool_result", roles)
+        self.assertIn("assistant", roles)
+
 
 class TestConnection(unittest.TestCase):
     def test_send_receive(self):

--- a/tests/inner/test_datamodel.py
+++ b/tests/inner/test_datamodel.py
@@ -60,68 +60,12 @@ class TestHistory(unittest.TestCase):
         self.assertIn("[user] ping", text)
         self.assertIn("[assistant] pong", text)
 
-    def test_get_context_window_returns_all_when_no_limit(self):
+    def test_get_context_window_returns_all(self):
         h = History()
         for i in range(5):
             h.append(Message(role="user", content=f"msg {i}"))
         self.assertEqual(len(h.get_context_window()), 5)
-        self.assertEqual(len(h.get_context_window(max_tokens=None)), 5)
-
-    def test_get_context_window_trims_oldest(self):
-        h = History()
-        h.append(Message(role="user", content="a" * 40))  # ~10 tokens
-        h.append(Message(role="user", content="b" * 40))  # ~10 tokens
-        h.append(Message(role="user", content="c" * 40))  # ~10 tokens
-        result = h.get_context_window(max_tokens=20)
-        self.assertEqual(len(result), 2)
-        self.assertIn("b", result[0].content)
-        self.assertIn("c", result[1].content)
-
-    def test_get_context_window_preserves_system_messages(self):
-        h = History()
-        h.append(Message(role="system", content="You are helpful."))
-        h.append(Message(role="user", content="a" * 400))
-        h.append(Message(role="user", content="b" * 40))
-        result = h.get_context_window(max_tokens=20)
-        roles = [m.role for m in result]
-        self.assertIn("system", roles)
-
-    def test_get_context_window_large_budget_keeps_all(self):
-        h = History()
-        for i in range(5):
-            h.append(Message(role="user", content=f"msg {i}"))
-        result = h.get_context_window(max_tokens=999999)
-        self.assertEqual(len(result), 5)
-
-    def test_get_context_window_tiny_budget(self):
-        h = History()
-        h.append(Message(role="user", content="a" * 400))
-        result = h.get_context_window(max_tokens=1)
-        self.assertEqual(len(result), 0)
-
-    def test_get_context_window_keeps_tool_call_pairs(self):
-        h = History()
-        h.append(Message(role="user", content="x" * 400))  # ~100 tokens
-        h.append(Message(role="tool_call", content="call"))  # ~1 token
-        h.append(Message(role="tool_result", content="result"))  # ~1 token
-        h.append(Message(role="assistant", content="done"))  # ~1 token
-        # Budget fits the pair + assistant but not the user message
-        result = h.get_context_window(max_tokens=10)
-        roles = [m.role for m in result]
-        self.assertIn("tool_call", roles)
-        self.assertIn("tool_result", roles)
-
-    def test_get_context_window_drops_pair_together(self):
-        h = History()
-        h.append(Message(role="tool_call", content="c" * 400))
-        h.append(Message(role="tool_result", content="r" * 400))
-        h.append(Message(role="assistant", content="ok" * 4))
-        # Budget only fits the assistant message, not the pair
-        result = h.get_context_window(max_tokens=5)
-        roles = [m.role for m in result]
-        self.assertNotIn("tool_call", roles)
-        self.assertNotIn("tool_result", roles)
-        self.assertIn("assistant", roles)
+        self.assertEqual(len(h.get_context_window(max_tokens=4096)), 5)
 
 
 class TestConnection(unittest.TestCase):

--- a/tests/inner/test_datamodel.py
+++ b/tests/inner/test_datamodel.py
@@ -60,11 +60,44 @@ class TestHistory(unittest.TestCase):
         self.assertIn("[user] ping", text)
         self.assertIn("[assistant] pong", text)
 
-    def test_get_context_window_returns_all(self):
+    def test_get_context_window_returns_all_when_no_limit(self):
         h = History()
         for i in range(5):
             h.append(Message(role="user", content=f"msg {i}"))
         self.assertEqual(len(h.get_context_window()), 5)
+        self.assertEqual(len(h.get_context_window(max_tokens=None)), 5)
+
+    def test_get_context_window_trims_oldest(self):
+        h = History()
+        h.append(Message(role="user", content="a" * 40))  # ~10 tokens
+        h.append(Message(role="user", content="b" * 40))  # ~10 tokens
+        h.append(Message(role="user", content="c" * 40))  # ~10 tokens
+        result = h.get_context_window(max_tokens=20)
+        self.assertEqual(len(result), 2)
+        self.assertIn("b", result[0].content)
+        self.assertIn("c", result[1].content)
+
+    def test_get_context_window_preserves_system_messages(self):
+        h = History()
+        h.append(Message(role="system", content="You are helpful."))
+        h.append(Message(role="user", content="a" * 400))
+        h.append(Message(role="user", content="b" * 40))
+        result = h.get_context_window(max_tokens=20)
+        roles = [m.role for m in result]
+        self.assertIn("system", roles)
+
+    def test_get_context_window_large_budget_keeps_all(self):
+        h = History()
+        for i in range(5):
+            h.append(Message(role="user", content=f"msg {i}"))
+        result = h.get_context_window(max_tokens=999999)
+        self.assertEqual(len(result), 5)
+
+    def test_get_context_window_tiny_budget(self):
+        h = History()
+        h.append(Message(role="user", content="a" * 400))
+        result = h.get_context_window(max_tokens=1)
+        self.assertEqual(len(result), 0)
 
 
 class TestConnection(unittest.TestCase):


### PR DESCRIPTION
## Related issue

N/A

## Summary

`History.get_context_window` had a placeholder comment saying "token-based trimming not yet implemented." Updated the docstring to clarify that `max_tokens` is intentionally ignored here — token-aware context trimming (tool-call pair integrity, surgical clearing, LLM summarization) is handled by the layered compaction system in `omnigent.runtime.compaction`, which operates on the executor-facing message format with tiktoken-based counting.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added an assertion to the existing `test_get_context_window_returns_all` test verifying that passing `max_tokens` still returns all messages (confirming the pass-through behavior). All 19 tests pass via `python -m pytest tests/inner/test_datamodel.py -q`.