### PR TITLE
feat(claude-native): surface MCP-server elicitations to the web UI

### DIFF
--- a/ap-web/src/components/blocks/ApprovalCard.test.tsx
+++ b/ap-web/src/components/blocks/ApprovalCard.test.tsx
@@ -1007,3 +1007,90 @@ describe("ApprovalCard — ExitPlanMode plan review", () => {
     );
   });
 });
+
+describe("ApprovalCard — MCP elicitation form", () => {
+  it("renders the generic schema form and submits typed content via the store", () => {
+    // A third-party MCP server's elicitation arrives marked with
+    // policy_name "claude_native_mcp_elicitation" and a renderable
+    // requestedSchema. The card must render the typed form (not the
+    // binary buttons) and route the submitted values through
+    // submitApproval as MCP ElicitResult.content.
+    const submitSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ submitApproval: submitSpy } as Partial<
+      ReturnType<typeof useChatStore.getState>
+    >);
+
+    render(
+      <ApprovalCard
+        elicitationId="elic_mcp"
+        message="Approve the following?"
+        phase="mcp_elicitation"
+        policyName="claude_native_mcp_elicitation"
+        contentPreview=""
+        requestedSchema={{
+          type: "object",
+          properties: { name: { type: "string", title: "Name" } },
+          required: ["name"],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.getByText("Input requested")).toBeDefined();
+    expect(screen.getByTestId("mcp-elicitation-form")).toBeDefined();
+
+    fireEvent.change(screen.getByTestId("mcp-elicit-field-name"), { target: { value: "blue" } });
+    fireEvent.click(screen.getByTestId("mcp-elicitation-submit"));
+    expect(submitSpy).toHaveBeenCalledWith("elic_mcp", "accept", { name: "blue" });
+  });
+
+  it("routes Cancel to the MCP cancel action (distinct from decline)", () => {
+    const submitSpy = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({ submitApproval: submitSpy } as Partial<
+      ReturnType<typeof useChatStore.getState>
+    >);
+
+    render(
+      <ApprovalCard
+        elicitationId="elic_mcp_cancel"
+        message="Approve the following?"
+        phase="mcp_elicitation"
+        policyName="claude_native_mcp_elicitation"
+        contentPreview=""
+        requestedSchema={{
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("mcp-elicitation-cancel"));
+    expect(submitSpy).toHaveBeenCalledWith("elic_mcp_cancel", "cancel", undefined);
+  });
+
+  it("falls back to the binary card for an unrenderable schema", () => {
+    // A schema with a nested object can't be rendered as a flat form;
+    // the card must degrade to binary approve/reject so the prompt is
+    // still answerable.
+    render(
+      <ApprovalCard
+        elicitationId="elic_mcp_nested"
+        message="Approve the following?"
+        phase="mcp_elicitation"
+        policyName="claude_native_mcp_elicitation"
+        contentPreview=""
+        requestedSchema={{ type: "object", properties: { nested: { type: "object" } } }}
+        status="pending"
+        response={null}
+      />,
+    );
+
+    expect(screen.queryByTestId("mcp-elicitation-form")).toBeNull();
+    expect(screen.getByRole("button", { name: /approve/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeDefined();
+  });
+});

--- a/ap-web/src/components/blocks/ApprovalCard.tsx
+++ b/ap-web/src/components/blocks/ApprovalCard.tsx
@@ -52,6 +52,7 @@ import { formatPreview } from "@/lib/previewFormat";
 import { useChatStore } from "@/store/chatStore";
 import { AskUserQuestionForm, type AskUserQuestionAnswers } from "./AskUserQuestionForm";
 import { ExitPlanModeReview } from "./ExitPlanModeReview";
+import { McpElicitationForm, schemaIsRenderable } from "./McpElicitationForm";
 
 /**
  * Extract the answer-option labels from an AskUserQuestion-shaped
@@ -79,7 +80,7 @@ function extractOptionLabels(schema: Record<string, unknown>): string[] {
  */
 export type SubmitApprovalFn = (
   elicitationId: string,
-  action: "accept" | "decline",
+  action: "accept" | "decline" | "cancel",
   content?: Record<string, unknown>,
 ) => void;
 
@@ -199,6 +200,18 @@ export function ApprovalCard({
     const trimmed = feedback.trim();
     submit(elicitationId, "decline", trimmed ? { feedback: trimmed } : undefined);
   };
+  const submitMcpForm = (content: Record<string, unknown>) => {
+    // The typed form values ARE MCP's ``ElicitResult.content`` (a flat
+    // ``{[field]: scalar}`` map); the server passes them straight to
+    // Claude's Elicitation hook ``content`` on accept.
+    submit(elicitationId, "accept", content);
+  };
+  const submitMcpCancel = () => {
+    // ``cancel`` (dismissed) is distinct from ``decline`` (explicit
+    // refusal) in MCP semantics; the server forwards the literal action
+    // so the MCP server can branch on it.
+    submit(elicitationId, "cancel");
+  };
 
   // Mode detection. Prefer the server-stamped structured payload
   // (full, non-truncated); fall back to parsing the content_preview
@@ -218,6 +231,12 @@ export function ApprovalCard({
   const isAskUserQuestion = askPayload !== null;
   const isMultiChoice = optionLabels.length > 0;
   const isCodexCommandApproval = codexCommand !== null && codexCommand !== undefined;
+  // Generic MCP-server elicitation (claude-native ``Elicitation`` hook):
+  // render ``requestedSchema`` as a typed form. Falls back to the binary
+  // card when the schema carries a property type the form can't render,
+  // so the prompt is always answerable.
+  const isMcpElicitation =
+    policyName === "claude_native_mcp_elicitation" && schemaIsRenderable(requestedSchema);
   // External URL: the elicitation points to a third-party page (OAuth,
   // external MCP server, etc.) — show a link. Our own /approve/...
   // paths are handled inline with approve/reject buttons.
@@ -233,7 +252,7 @@ export function ApprovalCard({
   // approvals get a dedicated command render below, so showing the
   // transport JSON would expose unrelated ids and duplicate details.
   const formattedPreview =
-    isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval
+    isAskUserQuestion || isExitPlanMode || isMultiChoice || isCodexCommandApproval || isMcpElicitation
       ? ""
       : formatPreview(contentPreview);
   const execPolicyAmendment =
@@ -298,7 +317,9 @@ export function ApprovalCard({
     // (flat ``{[question]: answer}``) — matches MCP's
     // ElicitResult.content shape.
     const submittedAnswers =
-      isAskUserQuestion && response.content && Object.keys(response.content).length > 0
+      (isAskUserQuestion || isMcpElicitation) &&
+      response.content &&
+      Object.keys(response.content).length > 0
         ? response.content
         : null;
     const selectedAnswer =
@@ -316,8 +337,13 @@ export function ApprovalCard({
         ? response.content.feedback
         : null;
 
-    let icon = <XIcon className="size-4 text-destructive" />;
-    let label = isExitPlanMode ? "Plan rejected" : "Rejected";
+    const cancelled = response.action === "cancel";
+    let icon = cancelled ? (
+      <InfoIcon className="size-4 text-muted-foreground" />
+    ) : (
+      <XIcon className="size-4 text-destructive" />
+    );
+    let label = cancelled ? "Cancelled" : isExitPlanMode ? "Plan rejected" : "Rejected";
     if (autoResolved) {
       // Card was cleared by the chat store when the gated tool's
       // function_call_output arrived without a UI verdict —
@@ -417,11 +443,13 @@ export function ApprovalCard({
               ? askUserQuestionTitle
               : isMultiChoice
                 ? "Choose an option"
-                : "Approval required"}
-        {policyName && !isAskUserQuestion && !isExitPlanMode && (
+                : isMcpElicitation
+                  ? "Input requested"
+                  : "Approval required"}
+        {policyName && !isAskUserQuestion && !isExitPlanMode && !isMcpElicitation && (
           <span className="text-muted-foreground text-xs">· {policyName}</span>
         )}
-        {phase && !isMultiChoice && !isAskUserQuestion && !isExitPlanMode && (
+        {phase && !isMultiChoice && !isAskUserQuestion && !isExitPlanMode && !isMcpElicitation && (
           <span className="text-muted-foreground text-xs">({phase})</span>
         )}
       </AlertTitle>
@@ -442,6 +470,16 @@ export function ApprovalCard({
             onSubmit={submitAnswers}
             onReject={() => submitBinary("decline")}
           />
+        ) : isMcpElicitation ? (
+          <>
+            <span>{message}</span>
+            <McpElicitationForm
+              requestedSchema={requestedSchema}
+              onSubmit={submitMcpForm}
+              onDecline={() => submitBinary("decline")}
+              onCancel={submitMcpCancel}
+            />
+          </>
         ) : isCodexCommandApproval ? (
           <>
             <span>Codex wants to run this command.</span>

--- a/ap-web/src/components/blocks/McpElicitationForm.test.tsx
+++ b/ap-web/src/components/blocks/McpElicitationForm.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpElicitationForm, schemaIsRenderable } from "./McpElicitationForm";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("schemaIsRenderable", () => {
+  it("accepts a flat primitive schema", () => {
+    expect(
+      schemaIsRenderable({
+        type: "object",
+        properties: { name: { type: "string" }, count: { type: "integer" } },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects an empty / property-less schema (→ binary fallback)", () => {
+    expect(schemaIsRenderable({})).toBe(false);
+    expect(schemaIsRenderable({ type: "object", properties: {} })).toBe(false);
+  });
+
+  it("rejects a nested object or array property (→ binary fallback)", () => {
+    expect(
+      schemaIsRenderable({ type: "object", properties: { nested: { type: "object" } } }),
+    ).toBe(false);
+    expect(
+      schemaIsRenderable({ type: "object", properties: { items: { type: "array" } } }),
+    ).toBe(false);
+  });
+});
+
+describe("McpElicitationForm", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      approve: { type: "boolean", title: "Approve" },
+      name: { type: "string", title: "Name" },
+    },
+    required: ["name"],
+  };
+
+  it("gates submit on required fields and submits typed content", () => {
+    const onSubmit = vi.fn();
+    render(
+      <McpElicitationForm
+        requestedSchema={schema}
+        onSubmit={onSubmit}
+        onDecline={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const submit = screen.getByTestId("mcp-elicitation-submit") as HTMLButtonElement;
+    // ``name`` is required and empty → submit disabled.
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(screen.getByTestId("mcp-elicit-field-name"), {
+      target: { value: "blue" },
+    });
+    expect(submit.disabled).toBe(false);
+
+    fireEvent.click(submit);
+    // Boolean fields are always included (default false); the untouched
+    // ``approve`` switch submits false, ``name`` carries the typed value.
+    expect(onSubmit).toHaveBeenCalledWith({ approve: false, name: "blue" });
+  });
+
+  it("coerces number fields and applies schema defaults", () => {
+    const onSubmit = vi.fn();
+    render(
+      <McpElicitationForm
+        requestedSchema={{
+          type: "object",
+          properties: {
+            flag: { type: "boolean", default: true },
+            qty: { type: "integer", title: "Qty" },
+          },
+          required: ["qty"],
+        }}
+        onSubmit={onSubmit}
+        onDecline={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("mcp-elicit-field-qty"), { target: { value: "7" } });
+    fireEvent.click(screen.getByTestId("mcp-elicitation-submit"));
+    // ``flag`` honors its default (true); ``qty`` is submitted as a number.
+    expect(onSubmit).toHaveBeenCalledWith({ flag: true, qty: 7 });
+  });
+
+  it("calls onDecline and onCancel for the negative actions", () => {
+    const onDecline = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <McpElicitationForm
+        requestedSchema={schema}
+        onSubmit={vi.fn()}
+        onDecline={onDecline}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("mcp-elicitation-decline"));
+    expect(onDecline).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("mcp-elicitation-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ap-web/src/components/blocks/McpElicitationForm.tsx
+++ b/ap-web/src/components/blocks/McpElicitationForm.tsx
@@ -1,0 +1,287 @@
+// Generic JSON-Schema form for MCP-server elicitations surfaced in
+// claude-native (the `Elicitation` hook → `/hooks/elicitation` →
+// `response.elicitation_request` with `policy_name ===
+// "claude_native_mcp_elicitation"`).
+//
+// MCP elicitation schemas are a restricted subset of JSON Schema: a
+// flat object whose properties are primitives (string / number /
+// integer / boolean) or a string/number enum — no nested objects or
+// arrays of objects. This renders one input per property:
+//
+//   - string            → text input
+//   - number / integer  → number input
+//   - boolean           → switch
+//   - enum              → select
+//
+// Submit gathers the typed values into a flat `{[prop]: value}` map
+// (MCP's `ElicitResult.content` shape) with correct value types, gated
+// on every `required` field being filled and valid. Decline and Cancel
+// map to the MCP `decline` / `cancel` actions respectively.
+//
+// `schemaIsRenderable` lets the caller (ApprovalCard) fall back to the
+// binary approve/reject card when a schema contains a property type
+// this form can't render — guaranteeing the prompt is always answerable.
+
+import { CheckIcon, XIcon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+
+type FieldType = "string" | "number" | "integer" | "boolean" | "enum";
+
+interface FieldSpec {
+  key: string;
+  title: string;
+  description: string | null;
+  type: FieldType;
+  required: boolean;
+  /** Stringified enum options for the select (enum fields only). */
+  enumOptions: string[];
+  /** Original enum values, so the submitted content keeps its type. */
+  enumRaw: (string | number)[];
+  /** JSON-Schema default, or undefined. */
+  default: unknown;
+}
+
+/**
+ * Classify a JSON-Schema property into a renderable field type, or
+ * ``null`` when it is a shape this form can't render (nested object,
+ * array, untyped, etc.).
+ */
+function fieldType(prop: Record<string, unknown>): FieldType | null {
+  if (Array.isArray(prop.enum)) return "enum";
+  switch (prop.type) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "integer":
+      return "integer";
+    case "boolean":
+      return "boolean";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Parse a ``requestedSchema`` into an ordered list of field specs, or
+ * ``null`` when the schema is empty or contains any unrenderable
+ * property — the signal for ApprovalCard to degrade to a binary card.
+ */
+function parseFields(schema: Record<string, unknown>): FieldSpec[] | null {
+  const properties = schema.properties;
+  if (!properties || typeof properties !== "object" || Array.isArray(properties)) return null;
+  const props = properties as Record<string, unknown>;
+  const keys = Object.keys(props);
+  if (keys.length === 0) return null;
+  const required = Array.isArray(schema.required)
+    ? (schema.required.filter((r): r is string => typeof r === "string") as string[])
+    : [];
+  const fields: FieldSpec[] = [];
+  for (const key of keys) {
+    const prop = props[key];
+    if (!prop || typeof prop !== "object" || Array.isArray(prop)) return null;
+    const p = prop as Record<string, unknown>;
+    const type = fieldType(p);
+    if (type === null) return null;
+    let enumRaw: (string | number)[] = [];
+    if (type === "enum") {
+      enumRaw = (p.enum as unknown[]).filter(
+        (v): v is string | number => typeof v === "string" || typeof v === "number",
+      );
+      // An enum with no usable (string/number) options can't render.
+      if (enumRaw.length === 0) return null;
+    }
+    fields.push({
+      key,
+      title: typeof p.title === "string" && p.title ? p.title : key,
+      description: typeof p.description === "string" && p.description ? p.description : null,
+      type,
+      required: required.includes(key),
+      enumOptions: enumRaw.map(String),
+      enumRaw,
+      default: p.default,
+    });
+  }
+  return fields;
+}
+
+/**
+ * Whether ApprovalCard should render the generic form for this schema.
+ * False for empty schemas or any unrenderable property type → caller
+ * falls back to the binary approve/reject card.
+ */
+export function schemaIsRenderable(schema: Record<string, unknown>): boolean {
+  return parseFields(schema) !== null;
+}
+
+/** Form value state: booleans store a bool, everything else a string. */
+type FormValues = Record<string, string | boolean>;
+
+function initialValues(fields: FieldSpec[]): FormValues {
+  const init: FormValues = {};
+  for (const f of fields) {
+    if (f.type === "boolean") {
+      init[f.key] = f.default === true;
+    } else if (f.default !== undefined && f.default !== null) {
+      init[f.key] = String(f.default);
+    } else {
+      init[f.key] = "";
+    }
+  }
+  return init;
+}
+
+/**
+ * Validate one field's current value. Required fields must be filled
+ * and (for numbers) numeric; an optional field is valid empty but, when
+ * filled, must still parse.
+ */
+function fieldValid(f: FieldSpec, v: string | boolean): boolean {
+  if (f.type === "boolean") return true;
+  const s = typeof v === "string" ? v.trim() : "";
+  if (s === "") return !f.required;
+  if (f.type === "number" || f.type === "integer") {
+    const n = Number(s);
+    if (!Number.isFinite(n)) return false;
+    if (f.type === "integer" && !Number.isInteger(n)) return false;
+  }
+  if (f.type === "enum") return f.enumOptions.includes(s);
+  return true;
+}
+
+interface McpElicitationFormProps {
+  requestedSchema: Record<string, unknown>;
+  onSubmit: (content: Record<string, unknown>) => void;
+  onDecline: () => void;
+  onCancel: () => void;
+}
+
+export function McpElicitationForm({
+  requestedSchema,
+  onSubmit,
+  onDecline,
+  onCancel,
+}: McpElicitationFormProps) {
+  // ApprovalCard only mounts this when ``schemaIsRenderable`` is true,
+  // so ``parseFields`` is non-null here; guard defensively regardless.
+  const fields = parseFields(requestedSchema);
+  const [values, setValues] = useState<FormValues>(() => initialValues(fields ?? []));
+  if (fields === null) return null;
+
+  const allValid = fields.every((f) => fieldValid(f, values[f.key]));
+
+  const handleSubmit = () => {
+    const content: Record<string, unknown> = {};
+    for (const f of fields) {
+      const v = values[f.key];
+      if (f.type === "boolean") {
+        content[f.key] = Boolean(v);
+        continue;
+      }
+      const s = typeof v === "string" ? v.trim() : "";
+      if (s === "") continue; // omit empty optional fields
+      if (f.type === "number" || f.type === "integer") {
+        content[f.key] = Number(s);
+      } else if (f.type === "enum") {
+        const raw = f.enumRaw.find((e) => String(e) === s);
+        content[f.key] = raw !== undefined ? raw : s;
+      } else {
+        content[f.key] = s;
+      }
+    }
+    onSubmit(content);
+  };
+
+  return (
+    <div className="flex flex-col gap-3 text-foreground" data-testid="mcp-elicitation-form">
+      {fields.map((f) => {
+        const inputId = `mcp-elicit-${f.key}`;
+        const v = values[f.key];
+        return (
+          <div key={f.key} className="flex flex-col gap-1">
+            <label htmlFor={inputId} className="flex items-center gap-1 text-sm font-medium">
+              {f.title}
+              {f.required && <span className="text-destructive">*</span>}
+            </label>
+            {f.description && (
+              <span className="text-muted-foreground text-xs">{f.description}</span>
+            )}
+            {f.type === "boolean" ? (
+              <Switch
+                id={inputId}
+                checked={Boolean(v)}
+                onCheckedChange={(checked) =>
+                  setValues((prev) => ({ ...prev, [f.key]: checked }))
+                }
+                data-testid={`mcp-elicit-field-${f.key}`}
+              />
+            ) : f.type === "enum" ? (
+              <Select
+                value={typeof v === "string" ? v : ""}
+                onValueChange={(val) => setValues((prev) => ({ ...prev, [f.key]: val }))}
+              >
+                <SelectTrigger id={inputId} data-testid={`mcp-elicit-field-${f.key}`}>
+                  <SelectValue placeholder="Select…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {f.enumOptions.map((opt) => (
+                    <SelectItem key={opt} value={opt}>
+                      {opt}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                id={inputId}
+                type={f.type === "string" ? "text" : "number"}
+                value={typeof v === "string" ? v : String(v ?? "")}
+                onChange={(e) => setValues((prev) => ({ ...prev, [f.key]: e.target.value }))}
+                data-testid={`mcp-elicit-field-${f.key}`}
+              />
+            )}
+          </div>
+        );
+      })}
+      <div className="flex flex-wrap items-center gap-2 pt-1">
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!allValid}
+          data-testid="mcp-elicitation-submit"
+        >
+          <CheckIcon className="mr-1 size-3.5" />
+          Submit
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onDecline}
+          data-testid="mcp-elicitation-decline"
+        >
+          <XIcon className="mr-1 size-3.5" />
+          Decline
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onCancel}
+          className="ml-auto"
+          data-testid="mcp-elicitation-cancel"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ap-web/src/pages/InboxPage.tsx
+++ b/ap-web/src/pages/InboxPage.tsx
@@ -60,7 +60,7 @@ import { conversationDisplayLabel, getConversationAgentType } from "@/shell/side
 /** Optimistic verdicts keyed by elicitation id, mirroring the chat store's flip. */
 type RespondedMap = Record<
   string,
-  { action: "accept" | "decline"; content?: Record<string, unknown> }
+  { action: "accept" | "decline" | "cancel"; content?: Record<string, unknown> }
 >;
 
 export function InboxPage() {

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1120,6 +1120,40 @@ def build_hook_settings(
         }
         hooks["PermissionRequest"] = [{"hooks": [permission_hook]}]
 
+        # ``Elicitation`` fires when a third-party MCP server requests
+        # input mid-tool-call (the MCP ``elicitation/create`` flow). In
+        # claude-native Claude Code is the MCP client, so this hook is
+        # Omnigent's only window onto such prompts — without it an MCP
+        # server's form renders only in the TUI and a web-UI-driven user
+        # never sees it. Route it like ``PermissionRequest``: forward to
+        # the web UI and long-poll for the verdict. It is a deciding hook
+        # (stdout ``hookSpecificOutput.action`` accept/decline/cancel plus
+        # ``content`` on accept) and fires in every permission mode, so
+        # unlike ``AskUserQuestion`` it needs no bypassPermissions twin.
+        elicitation_command_parts = [
+            python,
+            "-I",
+            "-m",
+            "omnigent.claude_native_hook",
+            "elicitation",
+            "--bridge-dir",
+            str(bridge_dir),
+        ]
+        elicitation_hook: dict[str, Any] = {
+            "type": "command",
+            "command": shlex.join(elicitation_command_parts),
+            # Same day-long budget as PermissionRequest: an interactive
+            # web-UI form may take minutes to answer, and Claude Code's
+            # default command-hook timeout would sever the long-poll and
+            # drop the prompt back into the TUI. Kept in lockstep with the
+            # subprocess/AP-side elicitation budgets so none caps first.
+            "timeout": 86400,
+        }
+        # No matcher → fires for every MCP server. The web form is generic
+        # over the elicitation's ``requested_schema``, so it is not scoped
+        # per-server.
+        hooks["Elicitation"] = [{"hooks": [elicitation_hook]}]
+
         # Policy-gate native Claude Code tools, not just relay/MCP tools.
         evaluate_policy_command_parts = [
             python,

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -82,6 +82,8 @@ def main(argv: list[str] | None = None) -> int:
         return _main_permission_request(raw_argv[1:])
     if raw_argv and raw_argv[0] == "ask-user-question":
         return _main_ask_user_question(raw_argv[1:])
+    if raw_argv and raw_argv[0] == "elicitation":
+        return _main_elicitation(raw_argv[1:])
     if raw_argv and raw_argv[0] == "evaluate-policy":
         return _main_evaluate_policy(raw_argv[1:])
     # Backwards compat: older bridge dirs may still reference the
@@ -613,6 +615,67 @@ def _main_permission_request(argv: list[str]) -> int:
         f"{url_component(session_id)}/hooks/permission-request"
     )
     resp = _post_hook_with_reattach(url, headers, payload, "claude permission")
+    if resp is None:
+        return 0
+    if resp.content:
+        sys.stdout.write(resp.text)
+    return 0
+
+
+def _main_elicitation(argv: list[str]) -> int:
+    """
+    Forward one Claude ``Elicitation`` hook to the active Omnigent session.
+
+    Claude Code fires the ``Elicitation`` hook when a third-party MCP
+    server requests input mid-tool-call (the MCP ``elicitation/create``
+    flow). In claude-native Claude Code is the MCP client, so this hook
+    is the only point at which Omnigent can route the prompt to the web
+    UI. The observed payload carries ``message``, ``requested_schema``
+    (a flat JSON Schema), ``mcp_server_name``, and ``mode`` (``"form"``;
+    URL-mode elicitations are left to Claude's own TUI).
+
+    Mirrors :func:`_main_permission_request`: POSTs to the active
+    session's ``/hooks/elicitation`` endpoint, long-polls for the web
+    verdict via :func:`_post_hook_with_reattach`, and writes the server's
+    fully-formed ``hookSpecificOutput`` JSON straight to stdout. On any
+    transport failure it returns ``0`` with no output so Claude falls
+    back to its built-in TUI elicitation form (fail-ask).
+
+    :param argv: CLI argv after the ``elicitation`` subcommand, e.g.
+        ``["--bridge-dir", "/tmp/x"]``.
+    :returns: Process exit code. Returns ``0`` on transport failures so
+        Claude Code falls back to its terminal form.
+    """
+    args = _parse_permission_args(argv)
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        print(f"omnigent claude elicitation hook: malformed JSON: {exc}", file=sys.stderr)
+        return 0
+    if not isinstance(payload, dict):
+        print("omnigent claude elicitation hook: expected JSON object", file=sys.stderr)
+        return 0
+    bridge_dir = Path(args.bridge_dir)
+    session_id = read_active_session_id(bridge_dir)
+    if not session_id:
+        print("omnigent claude elicitation hook: active session missing", file=sys.stderr)
+        return 0
+    config = read_permission_hook_config(bridge_dir)
+    ap_server_url = args.omnigent_server_url or config.get("ap_server_url")
+    if not isinstance(ap_server_url, str) or not ap_server_url:
+        print("omnigent claude elicitation hook: Omnigent server URL missing", file=sys.stderr)
+        return 0
+    headers = _parse_headers(args.omnigent_auth_headers_json)
+    if not headers:
+        raw_headers = config.get("ap_auth_headers")
+        if isinstance(raw_headers, dict):
+            headers = {str(key): str(value) for key, value in raw_headers.items()}
+    url = (
+        f"{ap_server_url.rstrip('/')}/v1/sessions/"
+        f"{url_component(session_id)}/hooks/elicitation"
+    )
+    resp = _post_hook_with_reattach(url, headers, payload, "claude elicitation")
     if resp is None:
         return 0
     if resp.content:

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14200,6 +14200,149 @@ def create_sessions_router(
             media_type="application/json",
         )
 
+    # ── POST /sessions/{session_id}/hooks/elicitation ────────────
+
+    @router.post(
+        "/sessions/{session_id}/hooks/elicitation",
+        response_model=None,
+        # CSRF hardening: body is parsed via request.json(); require a JSON
+        # Content-Type so a cross-site text/plain request can't reach it.
+        dependencies=[Depends(require_json_content_type)],
+    )
+    async def claude_elicitation_hook(
+        request: Request,
+        session_id: str,
+    ) -> Response:
+        """
+        Claude Code ``Elicitation`` HTTP hook endpoint.
+
+        Receives Claude Code's ``Elicitation`` hook payload — emitted
+        when a third-party MCP server requests input mid-tool-call (the
+        MCP ``elicitation/create`` flow) — publishes a
+        ``response.elicitation_request`` SSE event so the web UI renders
+        the server's ``requested_schema`` as an interactive form, and
+        long-polls until the verdict arrives via the session ``approval``
+        path.
+
+        In claude-native, Claude Code (not Omnigent) is the MCP client,
+        so this hook is the only point at which an MCP elicitation can be
+        surfaced to the web UI. Unlike ``PermissionRequest`` it fires in
+        every permission mode (it is not a permission gate), so no
+        bypassPermissions twin is needed.
+
+        Response follows Claude Code's ``Elicitation`` hook contract:
+        ``hookSpecificOutput.action`` is ``"accept"`` / ``"decline"`` /
+        ``"cancel"``, with ``content`` (the filled form values) on
+        accept. On timeout / disconnect the endpoint returns ``200`` with
+        an empty body — Claude Code treats that as "defer to the TUI
+        form" (fail-ask), matching the wrapper's contract.
+
+        :param request: FastAPI request — body is Claude Code's
+            ``Elicitation`` hook payload as JSON.
+        :param session_id: Omnigent conversation id from the URL path.
+        :returns: Claude ``Elicitation`` hookSpecificOutput JSON, or
+            ``200`` with empty body on timeout / url-mode (fail-ask).
+        :raises OmnigentError: 404 if the session doesn't exist, 400 if
+            the body fails JSON parse or is not an object.
+        """
+        user_id = _get_user_id(request, auth_provider)
+        await _require_access(
+            user_id, session_id, LEVEL_READ, permission_store, conversation_store
+        )
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError as exc:
+            raise OmnigentError(
+                f"Invalid JSON in Elicitation hook body: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+        if not isinstance(payload, dict):
+            raise OmnigentError(
+                "Elicitation hook body must be a JSON object.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        # Claude Code's Elicitation hook payload uses snake_case
+        # ``requested_schema`` (empirically captured), whereas the MCP
+        # spec / our SSE params use camelCase ``requestedSchema`` — map
+        # across the boundary here.
+        message = payload.get("message")
+        if not isinstance(message, str):
+            message = ""
+        requested_schema = payload.get("requested_schema")
+        if requested_schema is not None and not isinstance(requested_schema, dict):
+            requested_schema = None
+        server_name = payload.get("mcp_server_name")
+        if not isinstance(server_name, str) or not server_name:
+            server_name = None
+        # Only form-mode elicitations carry a schema we can render. A
+        # url-mode elicitation (OAuth / out-of-band) has no form, so
+        # fail-ask and let Claude handle it in the TUI (browser flow).
+        if payload.get("mode") == "url":
+            return Response(status_code=status.HTTP_200_OK)
+        # Client-minted stable id so a retry re-parks the same elicitation
+        # (same ``elicit_claude_`` namespace as the permission hook).
+        elicitation_id = _client_supplied_hook_elicitation_id(payload, session_id)
+
+        try:
+            preview_str = json.dumps(requested_schema or {}, ensure_ascii=False)
+        except (TypeError, ValueError):
+            preview_str = repr(requested_schema)
+        preview_str = preview_str[:1024]
+
+        # ``policy_name`` is the marker the web UI keys on to pick the
+        # generic schema-form renderer; ``requestedSchema`` (camelCase) is
+        # the form definition; ``mcp_server_name`` rides as an MCP extra
+        # (params allow extras) so the card can name the requesting server.
+        extras: dict[str, Any] = {}
+        if server_name is not None:
+            extras["mcp_server_name"] = server_name
+        params = ElicitationRequestParams(
+            mode="form",
+            message=(
+                message
+                or (f"**{server_name}** needs input" if server_name else "An MCP server needs input")
+            ),
+            requestedSchema=requested_schema,
+            url=None,
+            phase="mcp_elicitation",
+            policy_name="claude_native_mcp_elicitation",
+            content_preview=preview_str,
+            **extras,
+        )
+        result = await _publish_and_wait_for_harness_elicitation(
+            request,
+            session_id=session_id,
+            params=params,
+            timeout_s=_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S,
+            conversation_store=conversation_store,
+            elicitation_id=elicitation_id,
+            # No gated tool to correlate: an MCP elicitation happens mid
+            # ``tools/call`` and has no tool result of its own, so the
+            # terminal-resolved fast path does not apply. The wait ends on
+            # the web verdict, disconnect, or timeout.
+            tool_name=None,
+            tool_input=None,
+        )
+        if result is None:
+            # Disconnect or timeout — Claude is no longer waiting; empty
+            # 2xx → Claude defers to its built-in TUI form (fail-ask).
+            return Response(status_code=status.HTTP_200_OK)
+
+        # The MCP ``ElicitationResult`` (action + flat content map) maps
+        # 1:1 onto Claude's Elicitation hook output: ``content`` rides
+        # through verbatim on accept; decline / cancel carry no content.
+        hook_specific: dict[str, Any] = {
+            "hookEventName": "Elicitation",
+            "action": result.action,
+        }
+        if result.action == "accept" and isinstance(result.content, dict):
+            hook_specific["content"] = result.content
+        body = {"hookSpecificOutput": hook_specific}
+        return Response(
+            content=json.dumps(body),
+            media_type="application/json",
+        )
+
     # ── Proto event-type → internal Phase mapping ────────────────────
     _PROTO_EVENT_TYPE_TO_PHASE: dict[str, Phase] = {
         "PHASE_TOOL_CALL": Phase.TOOL_CALL,

--- a/tests/server/integration/test_sessions_elicitation_hook.py
+++ b/tests/server/integration/test_sessions_elicitation_hook.py
@@ -1,0 +1,234 @@
+"""
+Integration tests for ``POST /v1/sessions/{id}/hooks/elicitation``.
+
+The endpoint receives Claude Code's ``Elicitation`` HTTP hook payload —
+fired when a third-party MCP server requests input mid-tool-call (the
+MCP ``elicitation/create`` flow) and ``omnigent claude`` wraps the native
+TUI. It parks on the same in-memory elicitation registry the
+permission-request path uses, emits a ``response.elicitation_request``
+SSE event (marked as the generic MCP form so the web UI renders
+``requestedSchema`` as a typed form), and returns Claude's
+``hookSpecificOutput`` ``action``/``content`` JSON once the UI verdict
+arrives.
+
+Tests cover three paths:
+
+- Accept: the UI submits the form → endpoint returns
+  ``action == "accept"`` with the submitted ``content``.
+- Decline: the UI declines → ``action == "decline"`` (no content).
+- URL mode: the elicitation has no inline form → endpoint returns
+  ``200`` with empty body so Claude handles the out-of-band flow in
+  its TUI (fail-ask).
+
+Uses the shared ``client`` fixture from ``tests/server/conftest.py``
+so the tests exercise the real route → ``_harness_elicitation_registry``
+→ SSE-publish pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runtime import session_stream
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_session(client: httpx.AsyncClient, agent_id: str) -> str:
+    """
+    Create a minimal session and return its id.
+
+    :param client: Test HTTP client.
+    :param agent_id: Agent to bind.
+    :returns: New session id.
+    """
+    resp = await client.post("/v1/sessions", json={"agent_id": agent_id})
+    assert resp.status_code == 201, f"create failed: {resp.status_code} {resp.text}"
+    return resp.json()["id"]
+
+
+async def _drain_until_elicitation(
+    session_id: str,
+    *,
+    timeout_s: float = 5.0,
+) -> dict[str, Any]:
+    """
+    Block on the session SSE stream until a
+    ``response.elicitation_request`` event arrives, then return it.
+
+    :param session_id: Session to subscribe to.
+    :param timeout_s: Maximum seconds to wait before failing the test.
+    :returns: The captured elicitation_request event dict.
+    """
+    async with asyncio.timeout(timeout_s):
+        async for event in session_stream.subscribe(session_id):
+            if event.get("type") == "response.elicitation_request":
+                elicitation_id = event.get("elicitation_id")
+                assert isinstance(elicitation_id, str) and elicitation_id, (
+                    f"elicitation event missing id: {event!r}"
+                )
+                return event
+    raise AssertionError("subscribe loop ended without an elicitation event")
+
+
+async def _post_approval(
+    client: httpx.AsyncClient,
+    session_id: str,
+    elicitation_id: str,
+    action: str,
+    content: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """
+    Resolve a published elicitation through the session event API.
+
+    :param client: Test HTTP client.
+    :param session_id: Session that emitted the elicitation.
+    :param elicitation_id: Elicitation id from the stream event.
+    :param action: MCP ``ElicitResult.action`` literal.
+    :param content: Optional MCP ``ElicitResult.content`` payload.
+    :returns: The HTTP response from the session event route.
+    """
+    data: dict[str, Any] = {"elicitation_id": elicitation_id, "action": action}
+    if content is not None:
+        data["content"] = content
+    return await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "approval", "data": data},
+    )
+
+
+def _claude_elicitation_payload(*, mode: str = "form") -> dict[str, Any]:
+    """
+    Build a realistic Claude ``Elicitation`` hook body.
+
+    Mirrors the empirically-captured wire shape: snake_case
+    ``requested_schema`` and ``mcp_server_name`` alongside the common
+    hook fields.
+
+    :param mode: Elicitation mode, ``"form"`` or ``"url"``.
+    :returns: JSON-serializable hook payload.
+    """
+    return {
+        "session_id": "claude_sess_abc",
+        "transcript_path": "/tmp/transcript.jsonl",
+        "cwd": "/tmp/cwd",
+        "permission_mode": "default",
+        "hook_event_name": "Elicitation",
+        "mcp_server_name": "elicit-demo",
+        "message": "Approve the following?",
+        "mode": mode,
+        "requested_schema": {
+            "type": "object",
+            "properties": {
+                "approve": {
+                    "type": "boolean",
+                    "title": "Approve",
+                    "description": "Approve this action?",
+                },
+                "note": {"type": "string", "title": "Note", "default": ""},
+            },
+            "required": ["approve"],
+        },
+    }
+
+
+async def test_elicitation_hook_accept_round_trip(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    UI submits the MCP form → endpoint returns ``action == "accept"``
+    with the submitted content in Claude's Elicitation hook shape.
+
+    Also asserts the published elicitation marks itself as the generic
+    MCP form (``policy_name``) and carries ``requestedSchema`` through
+    verbatim — the two things the web form renderer keys on. Catches: SSE
+    never emitted, schema not forwarded (UI can't build the form), or the
+    verdict→hookSpecificOutput mapping dropping the content.
+    """
+    agent = await create_test_agent(client, "test-elicitation-accept")
+    session_id = await _create_session(client, agent["id"])
+    payload = _claude_elicitation_payload()
+
+    drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
+    # Let the subscriber register before the publisher fires (publish is
+    # broadcast-to-current-subscribers; pre-subscribe events are lost).
+    await asyncio.sleep(0.05)
+    hook_task = asyncio.create_task(
+        client.post(f"/v1/sessions/{session_id}/hooks/elicitation", json=payload)
+    )
+
+    event = await drain_task
+    params = event["params"]
+    assert params["mode"] == "form"
+    assert params["policy_name"] == "claude_native_mcp_elicitation"
+    assert params["requestedSchema"] == payload["requested_schema"]
+    assert params.get("mcp_server_name") == "elicit-demo"
+
+    verdict = await _post_approval(
+        client,
+        session_id,
+        event["elicitation_id"],
+        "accept",
+        content={"approve": True, "note": "ship it"},
+    )
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await hook_task
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "hookSpecificOutput": {
+            "hookEventName": "Elicitation",
+            "action": "accept",
+            "content": {"approve": True, "note": "ship it"},
+        }
+    }
+
+
+async def test_elicitation_hook_decline_round_trip(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    UI declines → endpoint returns ``action == "decline"`` with no
+    content, so the MCP server sees an explicit refusal.
+    """
+    agent = await create_test_agent(client, "test-elicitation-decline")
+    session_id = await _create_session(client, agent["id"])
+    payload = _claude_elicitation_payload()
+
+    drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
+    await asyncio.sleep(0.05)
+    hook_task = asyncio.create_task(
+        client.post(f"/v1/sessions/{session_id}/hooks/elicitation", json=payload)
+    )
+
+    event = await drain_task
+    verdict = await _post_approval(client, session_id, event["elicitation_id"], "decline")
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await hook_task
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "hookSpecificOutput": {"hookEventName": "Elicitation", "action": "decline"}
+    }
+
+
+async def test_elicitation_hook_url_mode_fail_asks(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A ``url``-mode elicitation has no inline form to render, so the
+    endpoint returns ``200`` with an empty body immediately (no SSE, no
+    parking) and Claude handles the out-of-band flow in its TUI.
+    """
+    agent = await create_test_agent(client, "test-elicitation-url")
+    session_id = await _create_session(client, agent["id"])
+    payload = _claude_elicitation_payload(mode="url")
+
+    resp = await client.post(f"/v1/sessions/{session_id}/hooks/elicitation", json=payload)
+    assert resp.status_code == 200
+    assert resp.text == ""

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2029,6 +2029,62 @@ def test_augment_claude_args_registers_permission_command_hook(
     assert "omnigent.claude_native_status" in settings["statusLine"]["command"]
 
 
+def test_augment_claude_args_registers_elicitation_command_hook(
+    tmp_path: Path,
+) -> None:
+    """
+    Passing ``ap_server_url`` registers Claude's ``Elicitation`` hook as
+    a long-timeout command hook so third-party MCP-server elicitations
+    surface in the web UI instead of only the TUI.
+
+    In claude-native Claude Code is the MCP client, so this hook is the
+    only window onto an MCP ``elicitation/create``. A regression here
+    means an MCP server's form renders only in the terminal and a
+    web-driven user can never answer it.
+    """
+    args = augment_claude_args(
+        (),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+        ap_server_url="http://127.0.0.1:8787/",
+        ap_auth_headers={"Authorization": "Bearer xyz"},
+    )
+    settings = json.loads(args[args.index("--settings") + 1])
+    entries = settings["hooks"]["Elicitation"]
+    assert len(entries) == 1
+    # No matcher → fires for every MCP server (the form is generic over
+    # the elicitation's requested_schema).
+    assert "matcher" not in entries[0]
+    hooks = entries[0]["hooks"]
+    assert len(hooks) == 1
+    hook = hooks[0]
+    assert hook["type"] == "command"
+    # Same day-long budget as PermissionRequest: a web-UI form may take
+    # minutes to answer and the default command-hook timeout would sever
+    # the long-poll and drop the prompt back into the TUI.
+    assert hook["timeout"] == 86400
+    assert "omnigent.claude_native_hook elicitation" in hook["command"]
+    assert "--bridge-dir" in hook["command"]
+
+
+def test_augment_claude_args_omits_elicitation_hook_without_omnigent_server(
+    tmp_path: Path,
+) -> None:
+    """
+    No ``Elicitation`` hook is registered without an Omnigent server URL.
+
+    Without a server to POST the elicitation to, the hook would have
+    nowhere to forward — Claude must fall back to its built-in TUI form.
+    """
+    args = augment_claude_args(
+        (),
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+    )
+    settings = json.loads(args[args.index("--settings") + 1])
+    assert "Elicitation" not in settings["hooks"]
+
+
 def test_augment_claude_args_registers_user_prompt_submit_policy_hook(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1868,3 +1868,112 @@ def test_evaluate_policy_retries_5xx_and_succeeds(
     assert captured.out == ""
     # Two 503s then one 200 = 3 total attempts.
     assert call_count == 3
+
+
+def test_elicitation_hook_forwards_payload_and_returns_verdict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    The ``elicitation`` subcommand POSTs the hook payload to the active
+    session's ``/hooks/elicitation`` endpoint and writes the server's
+    ``hookSpecificOutput`` verdict straight to stdout.
+
+    This is the claude-native path that surfaces a third-party MCP
+    server's ``elicitation/create`` form to the web UI. A regression
+    means MCP elicitations never reach the web UI (the form shows only
+    in the TUI).
+    """
+    captured_posts: list[tuple[str, dict[str, object]]] = []
+    server_verdict = {
+        "hookSpecificOutput": {
+            "hookEventName": "Elicitation",
+            "action": "accept",
+            "content": {"approve": True, "note": "ship it"},
+        }
+    }
+
+    class _FakeHttpxClient:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _FakeHttpxClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            captured_posts.append((url, json))
+            return httpx.Response(200, json=server_verdict, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    bridge_dir = prepare_bridge_dir("conv_x", workspace=tmp_path)
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="http://127.0.0.1:8787",
+        ap_auth_headers={"Authorization": "Bearer xyz"},
+    )
+    payload = {
+        "hook_event_name": "Elicitation",
+        "mcp_server_name": "elicit-demo",
+        "message": "Approve the following?",
+        "mode": "form",
+        "requested_schema": {
+            "type": "object",
+            "properties": {"approve": {"type": "boolean"}},
+            "required": ["approve"],
+        },
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    exit_code = claude_native_hook.main(["elicitation", "--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # Server returns the fully-formed hookSpecificOutput; the hook just
+    # relays it verbatim so Claude applies the accept + content.
+    assert json.loads(captured.out) == server_verdict
+    assert len(captured_posts) == 1
+    url, body = captured_posts[0]
+    assert url == "http://127.0.0.1:8787/v1/sessions/conv_x/hooks/elicitation"
+    # The full hook payload is forwarded, plus a client-minted re-attach
+    # id in the ``elicit_claude_`` namespace the server validates.
+    assert body["mcp_server_name"] == "elicit-demo"
+    assert body["requested_schema"] == payload["requested_schema"]
+    assert re.fullmatch(r"elicit_claude_[0-9a-f]{32}", str(body["_omnigent_elicitation_id"]))
+
+
+def test_elicitation_hook_fail_asks_on_empty_server_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    An empty 200 from the server (its timeout / disconnect / url-mode
+    fail-ask) makes the hook exit 0 with no stdout, so Claude falls back
+    to its built-in TUI elicitation form rather than blocking the tool.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client("empty_body"))
+    bridge_dir = prepare_bridge_dir("conv_x", workspace=tmp_path)
+    build_hook_settings(
+        bridge_dir,
+        ap_server_url="http://127.0.0.1:8787",
+        ap_auth_headers={"Authorization": "Bearer xyz"},
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "Elicitation", "mode": "form"})),
+    )
+
+    exit_code = claude_native_hook.main(["elicitation", "--bridge-dir", str(bridge_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == ""


### PR DESCRIPTION
## What

Surfaces **third-party MCP-server elicitations to the web UI** for the claude-native harness, with a generic JSON-Schema form so users type real answers that flow back to Claude.

## Why

In claude-native, **Claude Code is the MCP client** — Omnigent only ever observes Claude's *hooks*, never the MCP protocol. The bridge registered no `Elicitation` hook, so when an MCP server called `elicitation/create` (e.g. an approval form), the form rendered **only in the TUI**. A web-UI-driven user never saw it and the turn blocked until someone answered in the terminal.

This is asymmetric with what already worked: Claude's own prompts (`PermissionRequest`, built-in `AskUserQuestion`) were forwarded, and Omnigent's *own* MCP elicitations (SDK path, where Omnigent is the client) already reached the UI. Only third-party MCP elicitations in claude-native fell through.

## How

Mirrors the `PermissionRequest` path and reuses the existing server elicitation machinery (`_publish_and_wait_for_harness_elicitation`, `_resolve_elicitation`, the resolve endpoint, inbox/badge plumbing).

- **bridge** (`claude_native_bridge.py`): register `Elicitation` as a catch-all command hook with a day-long timeout (the default 600s would sever the web long-poll).
- **client hook** (`claude_native_hook.py`): `_main_elicitation` subcommand, reusing the reattach long-poll; maps the deciding-hook `accept`/`decline`/`cancel` + `content` contract; fail-asks to the TUI on transport failure.
- **server** (`server/routes/sessions.py`): `claude_elicitation_hook` route builds `ElicitationRequestParams(mode="form", requestedSchema=…, policy_name="claude_native_mcp_elicitation")`, parks with `tool_name=None` (an MCP elicitation has no tool result of its own, so the terminal-resolved fast path correctly doesn't apply), and maps the verdict back to the hook output shape.
- **web** (`McpElicitationForm.tsx`, `ApprovalCard.tsx`): new generic schema renderer (string/number/integer/boolean/enum), an `isMcpElicitation` branch, and the action union widened to include `cancel`. Degrades to the binary approve/decline card for empty or unrenderable schemas so the prompt is always answerable.

The `Elicitation` hook input payload was empirically captured first (confirming snake_case `requested_schema`, `mcp_server_name`, `mode`, and that it fires under `bypassPermissions`), since the docs specify only the output contract.

## Testing

- **Backend**: bridge registration (timeout + catch-all), client hook payload→verdict mapping + empty-body fail-ask, and server-route accept / decline / url-mode integration round-trips. ✅
- **Frontend**: `McpElicitationForm` + `ApprovalCard` branch (39 tests). ✅
- **Not yet run**: live end-to-end against a real MCP server (a local demo server exists for this) — manual verification still pending.

This pull request and its description were written by Isaac.
