### PR TITLE
fix(e2e): de-flake test_repl_two_turns by syncing on reply text

### DIFF
--- a/tests/e2e/test_repl_approval_e2e.py
+++ b/tests/e2e/test_repl_approval_e2e.py
@@ -568,9 +568,11 @@ def test_repl_two_turns_fires_one_approval_per_turn(
         child.expect("approval required", timeout=30)
         child.send("y" + "\r")
         child.expect("approved", timeout=5)
-        # Wait for the turn to fully land — the stream-done
-        # elapsed-time label is the cleanest signal.
-        _wait_for_turn_complete(child, timeout=30)
+        # Wait for the turn to fully land by syncing on the
+        # scripted reply text (deterministic content) rather than
+        # the cosmetic `· ready` idle-settle, which can race /
+        # not-render under CI load (the observed flake).
+        child.expect("Nice to meet you", timeout=30)
 
         # Drain anything queued so the next expect starts
         # from a clean slate. Generous wait because the REPL
@@ -612,7 +614,9 @@ def test_repl_two_turns_fires_one_approval_per_turn(
         # Approve and confirm one-and-done.
         child.send("y" + "\r")
         child.expect("approved", timeout=5)
-        _wait_for_turn_complete(child, timeout=30)
+        # Sync on the scripted turn-2 reply (deterministic content)
+        # instead of the racy `· ready` idle-settle marker.
+        child.expect("Sure thing", timeout=30)
 
         # Final sweep: no extra approval banners after the
         # two we expected.


### PR DESCRIPTION
## Problem

`tests/e2e/test_repl_approval_e2e.py::test_repl_two_turns_fires_one_approval_per_turn` is flaky in CI (e.g. [this run](https://github.com/omnigent-ai/omnigent/actions/runs/27936132769/job/82658273412?pr=812)). It fails with `pexpect.exceptions.TIMEOUT` at the post-turn-2 `_wait_for_turn_complete` call — **not** an assertion failure. The test's load-bearing checks (exactly one approval per turn, correct `kk` preview, no historical `Hello` preview) all pass before the timeout.

## Root cause

`_wait_for_turn_complete` waits for the cosmetic `· ready` idle-settle marker on prompt_toolkit's bottom toolbar. Under CI load that repaint can race or fail to render within the timeout, so `expect` times out even though the turn finished correctly. This file already migrated several other tests *away* from `· ready` toward deterministic content markers for exactly this reason.

## Fix

Both turn-completion waits in this test now sync on the mock's scripted reply text (`"Nice to meet you"` for turn 1, `"Sure thing"` for turn 2) — deterministic content that only renders once the turn lands. The regression-guard assertions are untouched. `_wait_for_turn_complete` is left in place; other tests still use it.

## Verification

Run locally under background CPU load to mimic CI contention:

| Version | Runs | Pass | Fail |
|---|---|---|---|
| Before fix (load=5) | 10 | 9 | 1 |
| Before fix (load=10) | 8 | 6 | 2 |
| After fix (load=5) | 10 | **10** | **0** |

## Note / follow-up

The startup wait `_wait_for_prompt_ready` still relies on `· ready` (there's no scripted content before the first user message), so it remains a separate, pre-existing flake shared by every test in this file. This PR only addresses the line-615 site that failed in the linked CI run. Hardening startup readiness is a broader change left for a follow-up.