### PR TITLE
Backwards-compat Config 2: old runner/host -> new server

### DIFF
--- a/.github/actions/e2e-run/action.yml
+++ b/.github/actions/e2e-run/action.yml
@@ -31,6 +31,14 @@ inputs:
       server subprocess to it (backwards-compat run).
     required: false
     default: ""
+  runner_version:
+    description: >
+      Empty = run the checked-out runner/host (normal gate). Set to a release
+      tag = build that old runner+host into a venv and redirect the runner and
+      host-daemon subprocesses to it (Config 2 backwards-compat run). Orthogonal
+      to server_version.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -114,6 +122,31 @@ runs:
         "$venv/bin/omnigent" --version
         echo "OMNIGENT_COMPAT_SERVER_PYTHON=$venv/bin/python" >> "$GITHUB_ENV"
         echo "OMNIGENT_COMPAT_SERVER_VERSION=${tag#v}" >> "$GITHUB_ENV"
+
+    - name: Build pinned old runner/host (backwards-compat only)
+      # Only runs when runner_version is set (Config 2). Builds the released tag
+      # into an isolated venv and points the runner + host-daemon subprocesses
+      # at it via OMNIGENT_COMPAT_RUNNER_PYTHON (apply_runner_env drops the
+      # worktree PYTHONPATH/CWD shadow). Distinct paths from the server build so
+      # both can coexist. Requires fetch-depth 0 in the caller.
+      if: ${{ inputs.runner_version != '' }}
+      shell: bash
+      env:
+        RUNNER_VERSION_INPUT: ${{ inputs.runner_version }}
+      run: |
+        tag="$RUNNER_VERSION_INPUT"
+        if ! [[ "$tag" =~ ^v?[0-9]+\.[0-9]+(\.[0-9]+)?([a-z0-9.]*)?$ ]]; then
+          echo "Invalid runner_version: '$tag'" >&2; exit 1
+        fi
+        src="$RUNNER_TEMP/runner-src"
+        venv="$RUNNER_TEMP/runner-env"
+        git worktree add --detach "$src" "$tag"
+        uv venv --python 3.12 "$venv"
+        uv pip install --python "$venv/bin/python" \
+          -e "$src" -e "$src/sdks/python-client" -e "$src/sdks/ui"
+        "$venv/bin/omnigent" --version
+        echo "OMNIGENT_COMPAT_RUNNER_PYTHON=$venv/bin/python" >> "$GITHUB_ENV"
+        echo "OMNIGENT_COMPAT_RUNNER_VERSION=${tag#v}" >> "$GITHUB_ENV"
 
     - name: Run e2e tests
       shell: bash

--- a/.github/actions/integration-run/action.yml
+++ b/.github/actions/integration-run/action.yml
@@ -26,6 +26,13 @@ inputs:
       to it (backwards-compat run).
     required: false
     default: ""
+  runner_version:
+    description: >
+      Empty = run the checked-out runner (normal gate). Set to a release tag =
+      build that old runner into a venv and redirect the runner subprocess to it
+      (Config 2 backwards-compat run). Orthogonal to server_version.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -96,6 +103,29 @@ runs:
         "$venv/bin/omnigent" --version
         echo "OMNIGENT_COMPAT_SERVER_PYTHON=$venv/bin/python" >> "$GITHUB_ENV"
         echo "OMNIGENT_COMPAT_SERVER_VERSION=${tag#v}" >> "$GITHUB_ENV"
+
+    - name: Build pinned old runner (backwards-compat only)
+      # Config 2: redirect the runner subprocess to the pinned old build via
+      # OMNIGENT_COMPAT_RUNNER_PYTHON. See e2e-run for the full rationale.
+      # Distinct paths from the server build. Requires fetch-depth 0 in the caller.
+      if: ${{ inputs.runner_version != '' }}
+      shell: bash
+      env:
+        RUNNER_VERSION_INPUT: ${{ inputs.runner_version }}
+      run: |
+        tag="$RUNNER_VERSION_INPUT"
+        if ! [[ "$tag" =~ ^v?[0-9]+\.[0-9]+(\.[0-9]+)?([a-z0-9.]*)?$ ]]; then
+          echo "Invalid runner_version: '$tag'" >&2; exit 1
+        fi
+        src="$RUNNER_TEMP/runner-src"
+        venv="$RUNNER_TEMP/runner-env"
+        git worktree add --detach "$src" "$tag"
+        uv venv --python 3.12 "$venv"
+        uv pip install --python "$venv/bin/python" \
+          -e "$src" -e "$src/sdks/python-client" -e "$src/sdks/ui"
+        "$venv/bin/omnigent" --version
+        echo "OMNIGENT_COMPAT_RUNNER_PYTHON=$venv/bin/python" >> "$GITHUB_ENV"
+        echo "OMNIGENT_COMPAT_RUNNER_VERSION=${tag#v}" >> "$GITHUB_ENV"
 
     - name: Run integration tests
       shell: bash

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -19,6 +19,11 @@ name: Backwards-Compat
 #   schedule            every 4h; both default to the latest non-rc release tag.
 
 on:
+  # TEMP(backcompat validation): run on PR pushes so the backcompat jobs (both
+  # directions) execute on Actions before this merges (workflow_dispatch needs
+  # the file on the default branch). REVERT before merge — backcompat is meant
+  # to be dispatch/nightly only.
+  pull_request:
   workflow_dispatch:
     inputs:
       server_version:

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -1,25 +1,32 @@
-name: Server Backwards-Compat
+name: Backwards-Compat
 
-# Runs main's e2e + integration suites against a PINNED OLDER server, to catch
-# backwards-incompatible server changes before release. Only the server
-# subprocess is the old build; the client, runner, and tests are all the
-# checked-out ref. See docs/SERVER_VERSION_COMPAT_CI.md.
+# Cross-version backwards-compatibility sweep, both directions, against main's
+# e2e + integration suites. The test runs are the SAME composite actions the
+# normal gates use (.github/actions/e2e-run, integration-run), invoked with one
+# component pinned to an older release — so they run byte-for-byte the way
+# e2e.yml / integration.yml do (mock LLM), differing only in which subprocess is
+# the old build. See docs/SERVER_VERSION_COMPAT_CI.md.
 #
-# The actual test runs are the SAME composite actions the normal gates use
-# (.github/actions/e2e-run, .github/actions/integration-run) — invoked here
-# with `server_version` set. So these backcompat jobs run the suites byte-for-
-# byte the way e2e.yml / integration.yml do (mock LLM), differing only in that
-# the server subprocess is redirected to the old build. No drift.
+#   Config 1 (backcompat-{e2e,integration}):        OLD server, new runner/host/client/tests.
+#   Config 2 (backcompat-runner-{e2e,integration}): OLD runner+host, new server/client/tests.
+#
+# Runner and host are colocated (one install), so a single knob pins both. The
+# server and runner knobs are orthogonal (tests/_helpers/compat.py): each job
+# pins exactly one component and leaves the rest on main.
 #
 # Triggers:
-#   workflow_dispatch   manual; `server_version` input picks the old tag.
-#   schedule            nightly; pins the latest non-rc release tag.
+#   workflow_dispatch   manual; server_version / runner_version pick the old tags.
+#   schedule            every 4h; both default to the latest non-rc release tag.
 
 on:
   workflow_dispatch:
     inputs:
       server_version:
-        description: "Old server tag to test against, e.g. v0.1.1. Empty = latest non-rc tag."
+        description: "Old SERVER tag for Config 1, e.g. v0.1.1. Empty = latest non-rc tag."
+        required: false
+        default: ""
+      runner_version:
+        description: "Old RUNNER/HOST tag for Config 2, e.g. v0.1.1. Empty = latest non-rc tag."
         required: false
         default: ""
   schedule:
@@ -27,7 +34,7 @@ on:
     - cron: "0 */4 * * *"
 
 concurrency:
-  group: server-compat-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.server_version || github.sha }}
+  group: backcompat-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -68,13 +75,13 @@ jobs:
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: bash .github/scripts/ci/integration-matrix.sh
 
-  # tests/e2e against the pinned old server — same shards as e2e.yml.
+  # ── Config 1: OLD server, new runner/host/client/tests ────────────────
   backcompat-e2e:
     name: Backcompat e2e (server ${{ github.event.inputs.server_version || 'latest' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     needs: setup
     runs-on: ubuntu-latest
     # Job-level cap (composite run steps can't set timeout-minutes); mirrors
-    # e2e.yml's ~30-min test budget + setup + old-server build.
+    # e2e.yml's ~30-min test budget + setup + old-build install.
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -90,16 +97,16 @@ jobs:
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
           fetch-depth: 0
 
-      - name: Resolve old server version
+      - name: Resolve old version
         id: resolve
         env:
-          SERVER_VERSION_INPUT: ${{ github.event.inputs.server_version }}
+          VERSION_INPUT: ${{ github.event.inputs.server_version }}
         run: |
-          tag="$SERVER_VERSION_INPUT"
+          tag="$VERSION_INPUT"
           if [ -z "$tag" ]; then
             tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
           fi
-          echo "Resolved old server tag: $tag"
+          echo "Resolved old tag: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Run e2e suite against old server
@@ -111,14 +118,10 @@ jobs:
           parallelism: "2"
           nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
-  # tests/integration against the pinned old server — same harness matrix as
-  # integration.yml.
   backcompat-integration:
     name: Backcompat integration (server ${{ github.event.inputs.server_version || 'latest' }}, ${{ matrix.harness }})
     needs: setup
     runs-on: ubuntu-latest
-    # Job-level cap (composite run steps can't set timeout-minutes); mirrors
-    # integration.yml's 30-min budget + the old-server build.
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -131,22 +134,95 @@ jobs:
           ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
           fetch-depth: 0
 
-      - name: Resolve old server version
+      - name: Resolve old version
         id: resolve
         env:
-          SERVER_VERSION_INPUT: ${{ github.event.inputs.server_version }}
+          VERSION_INPUT: ${{ github.event.inputs.server_version }}
         run: |
-          tag="$SERVER_VERSION_INPUT"
+          tag="$VERSION_INPUT"
           if [ -z "$tag" ]; then
             tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
           fi
-          echo "Resolved old server tag: $tag"
+          echo "Resolved old tag: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Run integration suite against old server
         uses: ./.github/actions/integration-run
         with:
           server_version: ${{ steps.resolve.outputs.tag }}
+          harness: ${{ matrix.harness }}
+          model: ${{ matrix.model }}
+          workers: ${{ matrix.workers }}
+
+  # ── Config 2: OLD runner/host, new server/client/tests ────────────────
+  backcompat-runner-e2e:
+    name: Backcompat e2e (runner ${{ github.event.inputs.runner_version || 'latest' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.setup.outputs.e2e_matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve old version
+        id: resolve
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.runner_version }}
+        run: |
+          tag="$VERSION_INPUT"
+          if [ -z "$tag" ]; then
+            tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
+          fi
+          echo "Resolved old tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Run e2e suite against old runner/host
+        uses: ./.github/actions/e2e-run
+        with:
+          runner_version: ${{ steps.resolve.outputs.tag }}
+          shard_id: ${{ matrix.shard_id }}
+          num_shards: ${{ matrix.num_shards }}
+          parallelism: "2"
+          nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+
+  backcompat-runner-integration:
+    name: Backcompat integration (runner ${{ github.event.inputs.runner_version || 'latest' }}, ${{ matrix.harness }})
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.integration_matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve old version
+        id: resolve
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.runner_version }}
+        run: |
+          tag="$VERSION_INPUT"
+          if [ -z "$tag" ]; then
+            tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
+          fi
+          echo "Resolved old tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Run integration suite against old runner
+        uses: ./.github/actions/integration-run
+        with:
+          runner_version: ${{ steps.resolve.outputs.tag }}
           harness: ${{ matrix.harness }}
           model: ${{ matrix.model }}
           workers: ${{ matrix.workers }}

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -19,11 +19,6 @@ name: Backwards-Compat
 #   schedule            every 4h; both default to the latest non-rc release tag.
 
 on:
-  # TEMP(backcompat validation): run on PR pushes so the backcompat jobs (both
-  # directions) execute on Actions before this merges (workflow_dispatch needs
-  # the file on the default branch). REVERT before merge — backcompat is meant
-  # to be dispatch/nightly only.
-  pull_request:
   workflow_dispatch:
     inputs:
       server_version:

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -77,7 +77,7 @@ jobs:
 
   # ── Config 1: OLD server, new runner/host/client/tests ────────────────
   backcompat-e2e:
-    name: Backcompat e2e (server ${{ github.event.inputs.server_version || 'latest' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    name: Backcompat e2e (server ${{ github.event.inputs.server_version || 'latest-release' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     needs: setup
     runs-on: ubuntu-latest
     # Job-level cap (composite run steps can't set timeout-minutes); mirrors
@@ -119,7 +119,7 @@ jobs:
           nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   backcompat-integration:
-    name: Backcompat integration (server ${{ github.event.inputs.server_version || 'latest' }}, ${{ matrix.harness }})
+    name: Backcompat integration (server ${{ github.event.inputs.server_version || 'latest-release' }}, ${{ matrix.harness }})
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 35
@@ -156,7 +156,7 @@ jobs:
 
   # ── Config 2: OLD runner/host, new server/client/tests ────────────────
   backcompat-runner-e2e:
-    name: Backcompat e2e (runner ${{ github.event.inputs.runner_version || 'latest' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    name: Backcompat e2e (runner ${{ github.event.inputs.runner_version || 'latest-release' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -193,7 +193,7 @@ jobs:
           nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   backcompat-runner-integration:
-    name: Backcompat integration (runner ${{ github.event.inputs.runner_version || 'latest' }}, ${{ matrix.harness }})
+    name: Backcompat integration (runner ${{ github.event.inputs.runner_version || 'latest-release' }}, ${{ matrix.harness }})
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 35

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,7 @@ markers = [
     "in_process_sessions: run a server integration test with the legacy in-process sessions path instead of sessions-native runner dispatch.",
     "nightly: runs only in the scheduled/dispatch pass of its suite; PR and push runs exclude it via -m 'not nightly'. Remove the marker to promote a burned-in test to the PR gate.",
     "min_server_version(version): skip this test when the live server under test is older than `version` (PEP 440 release-tuple comparison, so a `.devN` of X satisfies X). Used by the server-version backwards-compat CI (docs/SERVER_VERSION_COMPAT_CI.md); inert in normal runs where the server is current.",
+    "min_runner_version(version): skip this test when the pinned runner/host under test is older than `version` (PEP 440 release-tuple comparison, so a `.devN` of X satisfies X). Used by the runner/host backwards-compat CI (Config 2); inert in normal runs (no OMNIGENT_COMPAT_RUNNER_VERSION set).",
     "mock_only: tests/integration test that only works in mock-LLM mode (no --llm-api-key). Skipped by tests/integration/conftest.py when a real --llm-api-key is supplied (the real-LLM Integration jobs). Use for tests whose mock LLM is scripted with a fixed tool-call sequence — a real LLM cannot reproduce the scripted markers.",
     "visual: UI diff visual-regression snapshot (pytest-playwright-visual-snapshot). Runs only in the pinned-runner gate (.github/workflows/ui-snapshot.yml); the main e2e_ui suite excludes it via -m 'not visual' since it runs on the unpinned ubuntu-latest.",
 ]

--- a/tests/_helpers/compat.py
+++ b/tests/_helpers/compat.py
@@ -1,18 +1,25 @@
 """
-Helpers for the server-version backwards-compatibility harness.
+Helpers for the version backwards-compatibility harness.
 
-See ``docs/SERVER_VERSION_COMPAT_CI.md``. Two concerns:
+See ``docs/SERVER_VERSION_COMPAT_CI.md``. Two independent redirect knobs and
+their version skips:
 
-1. **Server redirect** — in compat mode the ``omnigent.cli server``
-   subprocess is launched from a *different* venv (one holding a pinned,
-   older ``omnigent`` build) than the test process. Driven by
-   ``OMNIGENT_COMPAT_SERVER_PYTHON``.
-2. **Version skip** — resolve the running server's version and enforce
-   ``@pytest.mark.min_server_version(...)`` so tests for features newer
-   than the server-under-test are skipped rather than failing.
+1. **Server redirect (Config 1)** — pin the ``omnigent.cli server`` subprocess
+   to an older build (``OMNIGENT_COMPAT_SERVER_PYTHON``) while the client,
+   runner, host, and tests stay on main. Skip newer-than-server features with
+   ``@pytest.mark.min_server_version(...)``.
+2. **Runner/host redirect (Config 2)** — pin the ``omnigent.runner._entry`` and
+   ``omnigent.host._daemon_entry`` subprocesses to an older build
+   (``OMNIGENT_COMPAT_RUNNER_PYTHON``) while the server, client, and tests stay
+   on main. Runner and host are colocated (one install, one version), so a
+   single knob governs both. Skip newer-than-runner features with
+   ``@pytest.mark.min_runner_version(...)``.
 
-Outside compat mode (neither env var set) every function here is inert and
-the test harness behaves exactly as before.
+The two knobs are orthogonal: each spawn site consults its own knob, so a run
+pins the server OR the runner/host (or neither), never shadowing the other.
+
+Outside compat mode (no env var set) every function here is inert and the test
+harness behaves exactly as before.
 """
 
 from __future__ import annotations
@@ -24,19 +31,72 @@ import tempfile
 import httpx
 from packaging.version import Version
 
-# Stable empty directory used as the server subprocess CWD in compat mode
-# (created lazily; see :func:`compat_server_cwd`).
-_compat_cwd: str | None = None
+# CWD caches keyed by component label ("server" / "runner"), created lazily.
+_compat_cwds: dict[str, str] = {}
 
 # Interpreter for the SERVER subprocess. Set to a venv python holding the
 # pinned older build; unset in normal runs (use the test process's python).
 COMPAT_SERVER_PYTHON_ENV = "OMNIGENT_COMPAT_SERVER_PYTHON"
 # Version string the workflow pinned (e.g. "0.1.1"). Backstop / cross-check
-# for the skip logic — never used to launch anything.
+# for the server skip logic — never used to launch anything.
 COMPAT_SERVER_VERSION_ENV = "OMNIGENT_COMPAT_SERVER_VERSION"
+# Interpreter for the RUNNER and HOST subprocesses (colocated → one knob).
+COMPAT_RUNNER_PYTHON_ENV = "OMNIGENT_COMPAT_RUNNER_PYTHON"
+# Version string the workflow pinned for the runner/host. The runner and host
+# expose no ``/api/version`` endpoint, so this env var is the *only* source for
+# the ``min_runner_version`` skip (no live cross-check).
+COMPAT_RUNNER_VERSION_ENV = "OMNIGENT_COMPAT_RUNNER_VERSION"
 
 
-# ── Server redirect ────────────────────────────────────────────────────
+# ── Redirect core (shared by server + runner/host) ─────────────────────
+
+
+def _compat_python(env_var: str) -> str | None:
+    """
+    The pinned-build interpreter named by *env_var*, or ``None``.
+
+    :param env_var: The redirect env var, e.g.
+        ``"OMNIGENT_COMPAT_SERVER_PYTHON"``.
+    :returns: The venv python path (e.g. ``"/tmp/old-env/bin/python"``) when
+        that component's compat mode is active, else ``None``.
+    """
+    return os.environ.get(env_var) or None
+
+
+def _compat_executable(env_var: str) -> str:
+    """
+    Interpreter to launch a component's subprocess with.
+
+    :param env_var: The component's redirect env var.
+    :returns: The pinned interpreter in compat mode, else ``sys.executable``.
+    """
+    return _compat_python(env_var) or sys.executable
+
+
+def _compat_cwd(env_var: str, label: str) -> str | None:
+    """
+    A neutral working directory for a redirected subprocess, or ``None``.
+
+    ``python -m omnigent...`` puts the CWD on ``sys.path[0]``, so a subprocess
+    launched from the repo checkout would import the worktree's ``omnigent/``
+    package — shadowing the pinned older install exactly like a ``PYTHONPATH``
+    prepend would. A stable empty directory forces the pinned venv's installed
+    ``omnigent`` to resolve.
+
+    :param env_var: The component's redirect env var.
+    :param label: Component label for the cache + temp-dir prefix, e.g.
+        ``"server"`` or ``"runner"``.
+    :returns: A stable empty directory path in compat mode; ``None`` otherwise
+        (inherit the parent's CWD — today's behavior).
+    """
+    if _compat_python(env_var) is None:
+        return None
+    if label not in _compat_cwds:
+        _compat_cwds[label] = tempfile.mkdtemp(prefix=f"omnigent-compat-{label}-cwd-")
+    return _compat_cwds[label]
+
+
+# ── Server redirect (Config 1) ─────────────────────────────────────────
 
 
 def compat_server_python() -> str | None:
@@ -47,7 +107,7 @@ def compat_server_python() -> str | None:
         path, e.g. ``"/tmp/server-env/bin/python"``) when compat mode is
         active, else ``None``.
     """
-    return os.environ.get(COMPAT_SERVER_PYTHON_ENV) or None
+    return _compat_python(COMPAT_SERVER_PYTHON_ENV)
 
 
 def server_executable() -> str:
@@ -57,7 +117,7 @@ def server_executable() -> str:
     :returns: The compat interpreter in compat mode, else ``sys.executable``
         (the test process's own python).
     """
-    return compat_server_python() or sys.executable
+    return _compat_executable(COMPAT_SERVER_PYTHON_ENV)
 
 
 def server_pythonpath(repo_root: str | os.PathLike[str]) -> str | None:
@@ -86,22 +146,14 @@ def compat_server_cwd() -> str | None:
     """
     Working directory for the server subprocess, or ``None`` to inherit.
 
-    In compat mode the subprocess must **not** run with the worktree as its
-    CWD: ``python -m omnigent.cli`` puts the CWD on ``sys.path[0]``, so the
-    worktree's ``omnigent/`` package would shadow the pinned older install
-    exactly like the ``PYTHONPATH`` prepend would — and CI runs from the repo
-    checkout root, which contains ``omnigent/``. Returning a stable empty
-    directory forces the compat venv's installed ``omnigent`` to resolve.
+    See :func:`_compat_cwd`. In compat mode the server runs from a stable
+    empty directory so the worktree's ``omnigent/`` doesn't shadow the pinned
+    older install via ``sys.path[0]``.
 
     :returns: A stable empty directory path in compat mode; ``None`` outside
         compat mode (inherit the parent's CWD — today's behavior).
     """
-    global _compat_cwd
-    if compat_server_python() is None:
-        return None
-    if _compat_cwd is None:
-        _compat_cwd = tempfile.mkdtemp(prefix="omnigent-compat-cwd-")
-    return _compat_cwd
+    return _compat_cwd(COMPAT_SERVER_PYTHON_ENV, "server")
 
 
 def apply_server_env(env: dict[str, str], repo_root: str | os.PathLike[str]) -> dict[str, str]:
@@ -124,6 +176,65 @@ def apply_server_env(env: dict[str, str], repo_root: str | os.PathLike[str]) -> 
     return env
 
 
+# ── Runner / host redirect (Config 2) ──────────────────────────────────
+
+
+def compat_runner_python() -> str | None:
+    """
+    Interpreter the runner and host subprocesses should run under, or ``None``.
+
+    :returns: The value of ``OMNIGENT_COMPAT_RUNNER_PYTHON`` (a venv python
+        path) when runner/host compat mode is active, else ``None``.
+    """
+    return _compat_python(COMPAT_RUNNER_PYTHON_ENV)
+
+
+def runner_executable() -> str:
+    """
+    Interpreter to launch ``omnigent.runner._entry`` / ``omnigent.host._daemon_entry``.
+
+    :returns: The pinned-old interpreter in runner compat mode, else
+        ``sys.executable`` (the test process's own python = main).
+    """
+    return _compat_executable(COMPAT_RUNNER_PYTHON_ENV)
+
+
+def compat_runner_cwd() -> str | None:
+    """
+    Working directory for the runner/host subprocess, or ``None`` to inherit.
+
+    See :func:`_compat_cwd` — neutral dir in runner compat mode so the worktree
+    doesn't shadow the pinned old runner/host install.
+
+    :returns: A stable empty directory path in runner compat mode; ``None``
+        otherwise.
+    """
+    return _compat_cwd(COMPAT_RUNNER_PYTHON_ENV, "runner")
+
+
+def apply_runner_env(env: dict[str, str]) -> dict[str, str]:
+    """
+    Neutralize ``PYTHONPATH`` on a runner/host-subprocess env dict in compat mode.
+
+    Unlike :func:`apply_server_env`, this is **neutralize-only**: in runner
+    compat mode it drops any inherited ``PYTHONPATH`` (so the pinned old build
+    in the compat venv resolves instead of being shadowed by the worktree);
+    outside compat mode it leaves *env* untouched. It never *adds* a prepend,
+    because the runner inherits its base env from the server fixture and the
+    host tests each set their own ``PYTHONPATH`` convention — forcing a prepend
+    here would change normal-mode behavior.
+
+    Mutates *env* in place (and returns it).
+
+    :param env: The runner/host subprocess environment being assembled.
+    :returns: The same dict, with ``PYTHONPATH`` removed in runner compat mode
+        and unchanged otherwise.
+    """
+    if compat_runner_python() is not None:
+        env.pop("PYTHONPATH", None)
+    return env
+
+
 # ── Version resolution + skip ──────────────────────────────────────────
 
 
@@ -142,6 +253,20 @@ def release_tuple(version: str) -> tuple[int, ...]:
     return Version(version).release
 
 
+def meets_min_version(actual: str, required: str) -> bool:
+    """
+    Whether *actual* is new enough to run a *required*-gated test.
+
+    Component-agnostic release-tuple comparison shared by the server and
+    runner skips.
+
+    :param actual: The running component's version, e.g. ``"0.1.1"``.
+    :param required: The marker's minimum version, e.g. ``"0.1.2"``.
+    :returns: ``True`` iff *actual*'s release tuple is ``>=`` *required*'s.
+    """
+    return release_tuple(actual) >= release_tuple(required)
+
+
 def meets_min_server_version(server_version: str, required: str) -> bool:
     """
     Whether *server_version* is new enough to run a *required*-gated test.
@@ -152,7 +277,36 @@ def meets_min_server_version(server_version: str, required: str) -> bool:
     :returns: ``True`` iff the server's release tuple is ``>=`` the
         required release tuple.
     """
-    return release_tuple(server_version) >= release_tuple(required)
+    return meets_min_version(server_version, required)
+
+
+def meets_min_runner_version(runner_version: str, required: str) -> bool:
+    """
+    Whether *runner_version* is new enough to run a *required*-gated test.
+
+    :param runner_version: The pinned runner/host version, e.g. ``"0.2.0"``.
+    :param required: The ``min_runner_version`` marker argument, e.g.
+        ``"0.2.1"``.
+    :returns: ``True`` iff the runner's release tuple is ``>=`` the required
+        release tuple.
+    """
+    return meets_min_version(runner_version, required)
+
+
+def pinned_runner_version() -> str | None:
+    """
+    The pinned runner/host version from the env backstop, or ``None``.
+
+    The runner and host have no ``/api/version`` endpoint to query, so unlike
+    :func:`resolve_server_version` there is no live source to reconcile — the
+    workflow-set ``OMNIGENT_COMPAT_RUNNER_VERSION`` is authoritative. ``None``
+    (normal runs) means "newest / unbounded", so no ``min_runner_version`` test
+    is skipped.
+
+    :returns: The pinned version string (e.g. ``"0.2.0"``), or ``None`` outside
+        runner compat mode.
+    """
+    return os.environ.get(COMPAT_RUNNER_VERSION_ENV) or None
 
 
 def reconcile_server_version(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -43,10 +43,15 @@ import yaml
 
 from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests._helpers.compat import (
+    apply_runner_env,
     apply_server_env,
+    compat_runner_cwd,
     compat_server_cwd,
+    meets_min_runner_version,
     meets_min_server_version,
+    pinned_runner_version,
     resolve_server_version,
+    runner_executable,
     server_executable,
 )
 from tests._model_pools import current_attempt, resolve_model
@@ -120,6 +125,36 @@ def _enforce_min_server_version(request: pytest.FixtureRequest) -> None:
     required = marker.args[0]
     if not meets_min_server_version(server_ver, required):
         pytest.skip(f"requires server >= {required}; running {server_ver}")
+
+
+@pytest.fixture(autouse=True)
+def _enforce_min_runner_version(request: pytest.FixtureRequest) -> None:
+    """Skip tests marked ``@pytest.mark.min_runner_version(X)`` on older runners/hosts.
+
+    The runner/host backwards-compat run (Config 2) pins the
+    ``omnigent.runner._entry`` / ``omnigent.host._daemon_entry`` subprocesses to
+    an older build and sets ``OMNIGENT_COMPAT_RUNNER_VERSION``. The runner/host
+    expose no ``/api/version`` endpoint, so — unlike the server skip — the
+    version comes purely from that env backstop
+    (:func:`tests._helpers.compat.pinned_runner_version`); ``None`` (normal
+    runs) means "newest", so unmarked / non-compat runs skip nothing.
+
+    Comparison is on the PEP 440 release tuple, so a ``.devN`` of ``X``
+    satisfies ``min_runner_version("X")``.
+
+    :param request: The pytest request, used to read the marker.
+    """
+    marker = request.node.get_closest_marker("min_runner_version")
+    if marker is None:
+        return
+    if not marker.args:
+        raise pytest.UsageError("min_runner_version marker requires a version argument")
+    pinned = pinned_runner_version()
+    if pinned is None:
+        return
+    required = marker.args[0]
+    if not meets_min_runner_version(pinned, required):
+        pytest.skip(f"requires runner >= {required}; running {pinned}")
 
 
 # Agent bundle directories relative to repo root.
@@ -704,17 +739,25 @@ def live_server(
     base_url = f"http://localhost:{port}"
 
     # ── Spawn runner as sibling subprocess ───────────────
+    # Compat-aware: the test process's python normally, the pinned OLD runner's
+    # venv python in runner compat mode (Config 2). apply_runner_env drops the
+    # inherited worktree PYTHONPATH in that mode so the old build resolves; the
+    # server above is independently main or old per its own knob.
     runner_log = tmp_path_factory.mktemp("e2e_logs") / "runner.log"
     runner_log_handle = open(runner_log, "w")  # noqa: SIM115
-    runner_proc = subprocess.Popen(
-        [sys.executable, "-m", "omnigent.runner._entry"],
-        env={
+    runner_env = apply_runner_env(
+        {
             **env,
             "OMNIGENT_RUNNER_ID": runner_id,
             "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
             "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
             "RUNNER_SERVER_URL": base_url,
-        },
+        }
+    )
+    runner_proc = subprocess.Popen(
+        [runner_executable(), "-m", "omnigent.runner._entry"],
+        env=runner_env,
+        cwd=compat_runner_cwd(),
         stdout=runner_log_handle,
         stderr=subprocess.STDOUT,
     )

--- a/tests/e2e/test_host_claude_native_e2e.py
+++ b/tests/e2e/test_host_claude_native_e2e.py
@@ -70,7 +70,6 @@ import shutil
 import signal
 import stat
 import subprocess
-import sys
 import time
 import uuid
 from collections.abc import Iterator
@@ -80,6 +79,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.helpers import POLL_INTERVAL_S
 
 # Opt-in only. claude-native needs a real *interactive* Claude login
@@ -201,8 +201,10 @@ def _spawn_host_daemon(
     daemon_log = tmp_path / "host-daemon.log"
     with open(daemon_log, "w") as log_fh:
         return subprocess.Popen(
-            [sys.executable, "-m", "omnigent.host._daemon_entry", "--server", live_server],
-            env=env,
+            # Compat-aware: pinned OLD host venv in runner compat mode (Config 2).
+            [runner_executable(), "-m", "omnigent.host._daemon_entry", "--server", live_server],
+            env=apply_runner_env(env),
+            cwd=compat_runner_cwd(),
             stdout=subprocess.DEVNULL,
             stderr=log_fh,
         )

--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -22,7 +22,6 @@ import os
 import shutil
 import signal
 import subprocess
-import sys
 import threading
 import time
 import uuid
@@ -32,6 +31,7 @@ import httpx
 import pytest
 
 from omnigent.entities.session_resources import terminal_resource_id
+from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.helpers import POLL_INTERVAL_S
 
 _CODEX_NATIVE_AGENT_NAME = "codex-native-ui"
@@ -66,14 +66,18 @@ def _spawn_host_daemon(
     daemon_log = tmp_path / "host-daemon.log"
     with open(daemon_log, "w") as log_fh:
         return subprocess.Popen(
+            # Compat-aware: pinned OLD host venv in runner compat mode (Config 2).
+            # apply_runner_env drops this test's repo_root PYTHONPATH in that mode
+            # so the old host build resolves; no-op in normal runs.
             [
-                sys.executable,
+                runner_executable(),
                 "-m",
                 "omnigent.host._daemon_entry",
                 "--server",
                 live_server,
             ],
-            env=env,
+            env=apply_runner_env(env),
+            cwd=compat_runner_cwd(),
             stdout=subprocess.DEVNULL,
             stderr=log_fh,
         )

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -22,7 +22,6 @@ import re
 import shutil
 import signal
 import subprocess
-import sys
 import time
 import uuid
 from dataclasses import dataclass
@@ -32,6 +31,7 @@ import httpx
 import pytest
 import yaml
 
+from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.conftest import (
     POLL_INTERVAL_S,
     configure_mock_llm,
@@ -112,8 +112,13 @@ def _spawn_host_daemon(
     daemon_log = tmp_path / "host-daemon.log"
     with open(daemon_log, "w") as log_fh:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "omnigent.host._daemon_entry", "--server", live_server],
-            env=env,
+            # Compat-aware: pinned OLD host venv in runner compat mode (Config 2),
+            # else the test process's python. apply_runner_env drops the inherited
+            # worktree PYTHONPATH in that mode; the old host launches old runners
+            # (colocated) from its own venv.
+            [runner_executable(), "-m", "omnigent.host._daemon_entry", "--server", live_server],
+            env=apply_runner_env(env),
+            cwd=compat_runner_cwd(),
             stdout=subprocess.DEVNULL,
             stderr=log_fh,
         )
@@ -700,8 +705,13 @@ def _spawn_host_daemon_for_mock_claude(
     daemon_log = tmp_path / "host-daemon.log"
     with open(daemon_log, "w") as log_fh:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "omnigent.host._daemon_entry", "--server", live_server],
-            env=env,
+            # Compat-aware: pinned OLD host venv in runner compat mode (Config 2),
+            # else the test process's python. apply_runner_env drops the inherited
+            # worktree PYTHONPATH in that mode; the old host launches old runners
+            # (colocated) from its own venv.
+            [runner_executable(), "-m", "omnigent.host._daemon_entry", "--server", live_server],
+            env=apply_runner_env(env),
+            cwd=compat_runner_cwd(),
             stdout=subprocess.DEVNULL,
             stderr=log_fh,
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,6 +31,7 @@ import pytest
 from tests import _model_pools
 from tests.e2e._harness_probes import skip_if_harness_cli_missing
 from tests.e2e.conftest import (  # noqa: F401  (re-exported pytest fixtures)
+    _enforce_min_runner_version,
     _enforce_min_server_version,
     create_runner_bound_session,
     databricks_workspace_host,

--- a/tests/test_server_compat.py
+++ b/tests/test_server_compat.py
@@ -104,3 +104,66 @@ def test_server_redirect_active_with_env(monkeypatch: pytest.MonkeyPatch) -> Non
     assert cwd is not None
     assert os.path.isdir(cwd)
     assert not os.path.exists(os.path.join(cwd, "omnigent"))
+
+
+# ── Runner / host redirect (Config 2) ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("runner", "required", "expected"),
+    [
+        ("0.2.0.dev0", "0.2.0", True),
+        ("0.2.0", "0.2.0", True),
+        ("0.3.0", "0.2.1", True),
+        ("0.2.0", "0.2.1", False),
+    ],
+)
+def test_meets_min_runner_version(runner: str, required: str, expected: bool) -> None:
+    assert compat.meets_min_runner_version(runner, required) is expected
+
+
+def test_pinned_runner_version_env_driven(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No env -> None (normal runs: "newest", skip nothing).
+    monkeypatch.delenv(compat.COMPAT_RUNNER_VERSION_ENV, raising=False)
+    assert compat.pinned_runner_version() is None
+    monkeypatch.setenv(compat.COMPAT_RUNNER_VERSION_ENV, "0.2.0")
+    assert compat.pinned_runner_version() == "0.2.0"
+
+
+def test_runner_redirect_inert_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(compat.COMPAT_RUNNER_PYTHON_ENV, raising=False)
+    assert compat.compat_runner_python() is None
+    assert compat.runner_executable() == sys.executable
+    assert compat.compat_runner_cwd() is None
+    # Neutralize-only: outside compat mode a pre-set PYTHONPATH is left as-is
+    # (NOT dropped, NOT a prepend added).
+    env = {"PYTHONPATH": "/repo/root:/x"}
+    compat.apply_runner_env(env)
+    assert env["PYTHONPATH"] == "/repo/root:/x"
+    # And an env without PYTHONPATH stays without one (no prepend imposed).
+    bare: dict[str, str] = {}
+    compat.apply_runner_env(bare)
+    assert "PYTHONPATH" not in bare
+
+
+def test_runner_redirect_active_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(compat.COMPAT_RUNNER_PYTHON_ENV, "/old-agent/bin/python")
+    assert compat.compat_runner_python() == "/old-agent/bin/python"
+    assert compat.runner_executable() == "/old-agent/bin/python"
+    # Compat mode drops the inherited worktree PYTHONPATH so the pinned old
+    # runner/host resolves.
+    env = {"PYTHONPATH": "/repo/root:/x"}
+    compat.apply_runner_env(env)
+    assert "PYTHONPATH" not in env
+    # Neutral CWD with no omnigent/ package (mirrors the server cwd guard).
+    cwd = compat.compat_runner_cwd()
+    assert cwd is not None
+    assert os.path.isdir(cwd)
+    assert not os.path.exists(os.path.join(cwd, "omnigent"))
+
+
+def test_server_and_runner_cwds_are_distinct(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The two knobs are orthogonal; their neutral CWDs must not collide.
+    monkeypatch.setenv(compat.COMPAT_SERVER_PYTHON_ENV, "/srv/bin/python")
+    monkeypatch.setenv(compat.COMPAT_RUNNER_PYTHON_ENV, "/old-agent/bin/python")
+    assert compat.compat_server_cwd() != compat.compat_runner_cwd()


### PR DESCRIPTION
## What

Adds **Config 2** to the backwards-compat harness: run main's e2e + integration suites with the **runner and host pinned to an older release** while the server, client, and tests stay on main. This is the mirror of the server-version harness (Config 1, #896) for the agent side.

Runner and host are **colocated** (one install, one version), so a single knob pins both:
- `OMNIGENT_COMPAT_RUNNER_PYTHON` → redirects the `omnigent.runner._entry` and `omnigent.host._daemon_entry` subprocesses to the old build.
- `OMNIGENT_COMPAT_RUNNER_VERSION` → the version backstop for the skip marker.

The server and runner knobs are **orthogonal** — each spawn site consults its own, so a run pins exactly one component and leaves the rest on main.

## Pieces

- **`tests/_helpers/compat.py`** — generalized the redirect into a component-parameterized core; `server_*` and the new `runner_*` helpers (`runner_executable`, `apply_runner_env`, `compat_runner_cwd`, `pinned_runner_version`, `meets_min_runner_version`) are thin wrappers over it.
  - `apply_runner_env` is **neutralize-only**: it drops the inherited worktree `PYTHONPATH` in compat mode but never force-adds a prepend (the host tests have heterogeneous normal-mode `PYTHONPATH`; we don't disturb them).
- **`min_runner_version` marker** — registered in `pyproject`. The runner/host expose no `/api/version`, so the guard reads the version **purely from the env backstop** (no live cross-check); `None` (normal runs) → skip nothing.
- **Spawn sites pinned** — the main e2e `live_server` runner + all four host-daemon spawns (`test_host_e2e` ×2, claude-native, codex-native). The old host launches old runners from its own venv (colocation, free).
- **Composite actions** gained a `runner_version` input (build the old runner/host venv + export the redirect env vars). **`server-compat.yml` → renamed `Backwards-Compat`**, now both directions, with `backcompat-runner-{e2e,integration}` jobs.

## Out of scope (documented)

- 3 niche custom-fixture direct-runner spawns (filesystem/non-git changed-files, `session_resources`) keep their workspace-cwd semantics and stay on the test python — a neutral cwd would break their git-vs-non-git filesystem-registry detection. In a Config-2 run they run new-runner→new-server (normal, no breakage).
- `tests/e2e_ui` (needs an npm build), same as Config 1.

## Testing

- ✅ 26 unit tests (`tests/test_server_compat.py`) — added runner-helper coverage incl. neutralize-only semantics + distinct server/runner cwds.
- ✅ lint + format clean; both conftests import.
- ✅ **Decisive resolution proof**: under the exact runner spawn conditions (old venv python + dropped `PYTHONPATH` + neutral cwd), `import omnigent.runner._entry` resolves to the **old** source; both counterfactuals (cwd=worktree, or `PYTHONPATH`=worktree) load main — so both neutralizations are necessary and the implementation does both.

## Notes

- The `pull_request` trigger on `server-compat.yml` is **temporary** (marked REVERT-before-merge) so the backcompat jobs run on this PR. It's dispatch/nightly-only otherwise.
- Scheduled runs now exercise **both** directions every 4h (mock-LLM, no gateway cost). Easy to dial the runner legs to nightly if preferred.
