### PR TITLE
Backcompat: full pairwise (server, runner) version matrix, every 12h

### DIFF
--- a/.github/actions/e2e-run/action.yml
+++ b/.github/actions/e2e-run/action.yml
@@ -39,6 +39,13 @@ inputs:
       to server_version.
     required: false
     default: ""
+  artifact_suffix:
+    description: >
+      Appended to uploaded-artifact names so they stay unique across matrix
+      cells (e.g. "-sv0.2.0-rmain"). Default empty — the normal gate has one
+      cell per shard, so its names are already unique.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -198,7 +205,7 @@ runs:
       if: ${{ failure() || cancelled() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
-        name: e2e-server-logs-${{ github.run_id }}-shard${{ inputs.shard_id }}
+        name: e2e-server-logs-${{ github.run_id }}-shard${{ inputs.shard_id }}${{ inputs.artifact_suffix }}
         path: |
           /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ inputs.shard_id }}/**/server.log
           /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ inputs.shard_id }}/**/runner.log
@@ -213,7 +220,7 @@ runs:
       if: ${{ always() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
-        name: e2e-tokens-${{ github.run_id }}-shard${{ inputs.shard_id }}
+        name: e2e-tokens-${{ github.run_id }}-shard${{ inputs.shard_id }}${{ inputs.artifact_suffix }}
         path: /tmp/omnigent-e2e-${{ github.run_id }}-shard${{ inputs.shard_id }}/tokens*.json
         retention-days: 14
         if-no-files-found: warn

--- a/.github/actions/integration-run/action.yml
+++ b/.github/actions/integration-run/action.yml
@@ -33,6 +33,13 @@ inputs:
       (Config 2 backwards-compat run). Orthogonal to server_version.
     required: false
     default: ""
+  artifact_suffix:
+    description: >
+      Appended to uploaded-artifact names so they stay unique across matrix
+      cells (e.g. "-sv0.2.0-rmain"). Default empty — the normal gate runs one
+      cell, so its harness-scoped names are already unique.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -163,7 +170,7 @@ runs:
       if: ${{ failure() || cancelled() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
-        name: integration-server-logs-${{ inputs.harness }}-${{ github.run_id }}
+        name: integration-server-logs-${{ inputs.harness }}-${{ github.run_id }}${{ inputs.artifact_suffix }}
         path: |
           /tmp/omnigent-integration-${{ github.run_id }}-${{ inputs.harness }}/**/server.log
           /tmp/omnigent-integration-${{ github.run_id }}-${{ inputs.harness }}/**/runner.log
@@ -174,7 +181,7 @@ runs:
       if: ${{ always() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
-        name: integration-${{ inputs.harness }}-${{ github.run_id }}
+        name: integration-${{ inputs.harness }}-${{ github.run_id }}${{ inputs.artifact_suffix }}
         path: artifacts/
         retention-days: 14
         if-no-files-found: ignore

--- a/.github/scripts/ci/backcompat-pairwise-matrix.sh
+++ b/.github/scripts/ci/backcompat-pairwise-matrix.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Emit the FULL pairwise (server, runner) backwards-compat matrices on
+# $GITHUB_OUTPUT as `e2e_matrix` and `integration_matrix`.
+#
+# The version universe is `main` (the checked-out code = client + tests, always)
+# plus every non-rc release tag. We cross every server version with every runner
+# version — each cell pins the server and/or runner subprocess to that build
+# (an empty/"main" value leaves that component on the checked-out code). The
+# (main, main) cell is omitted: it pins nothing and is exactly the normal e2e
+# gate. Integration is the single openai-agents leg (claude-sdk/codex reject the
+# mock LLM's "mock-model" — see integration-matrix.sh), crossed with the pairs.
+#
+# Env in:
+#   VERSIONS    optional comma-separated override of the version set used for
+#               BOTH axes (e.g. "main,v0.2.0"). Empty = main + all non-rc tags.
+#   NUM_SHARDS  e2e shard count per cell (default 4).
+# Out (GITHUB_OUTPUT):
+#   e2e_matrix={"include":[{"server":..,"runner":..,"shard_id":..,"num_shards":..}, ...]}
+#   integration_matrix={"include":[{"server":..,"runner":..,"harness":..,"model":..,"workers":..}, ...]}
+
+set -euo pipefail
+
+if [ -n "${VERSIONS:-}" ]; then
+  IFS=',' read -ra V <<<"$VERSIONS"
+else
+  # Portable (no mapfile/bash-4): main + every non-rc release tag, newest first.
+  V=("main")
+  while IFS= read -r tag; do
+    [ -n "$tag" ] && V+=("$tag")
+  done < <(git tag --sort=-v:refname | grep -vi rc)
+fi
+num_shards="${NUM_SHARDS:-4}"
+
+# The integration suite runs a single openai-agents leg in mock mode (matches
+# integration-matrix.sh); the model name is unused under the mock LLM.
+integ_harness="openai-agents"
+integ_model="databricks-gpt-5-4-mini"
+integ_workers="4"
+
+e2e_items=()
+integ_items=()
+for s in "${V[@]}"; do
+  for r in "${V[@]}"; do
+    # Skip the all-main cell: it pins nothing (== the normal e2e gate).
+    if [ "$s" = "main" ] && [ "$r" = "main" ]; then
+      continue
+    fi
+    integ_items+=("{\"server\":\"$s\",\"runner\":\"$r\",\"harness\":\"$integ_harness\",\"model\":\"$integ_model\",\"workers\":$integ_workers}")
+    for ((i = 0; i < num_shards; i++)); do
+      e2e_items+=("{\"server\":\"$s\",\"runner\":\"$r\",\"shard_id\":$i,\"num_shards\":$num_shards}")
+    done
+  done
+done
+
+e2e_json=$(
+  IFS=,
+  echo "${e2e_items[*]}"
+)
+integ_json=$(
+  IFS=,
+  echo "${integ_items[*]}"
+)
+
+{
+  echo "e2e_matrix={\"include\":[$e2e_json]}"
+  echo "integration_matrix={\"include\":[$integ_json]}"
+} >>"${GITHUB_OUTPUT:-/dev/stdout}"
+
+echo "versions: ${V[*]}" >&2
+echo "pairs: $((${#integ_items[@]})) (excludes main/main); e2e jobs: ${#e2e_items[@]}; integration jobs: ${#integ_items[@]}" >&2

--- a/.github/scripts/ci/backcompat-pairwise-matrix.sh
+++ b/.github/scripts/ci/backcompat-pairwise-matrix.sh
@@ -13,6 +13,7 @@
 # Env in:
 #   VERSIONS    optional comma-separated override of the version set used for
 #               BOTH axes (e.g. "main,v0.2.0"). Empty = main + all non-rc tags.
+#               Blank entries are dropped and surrounding whitespace trimmed.
 #   NUM_SHARDS  e2e shard count per cell (default 4).
 # Out (GITHUB_OUTPUT):
 #   e2e_matrix={"include":[{"server":..,"runner":..,"shard_id":..,"num_shards":..}, ...]}
@@ -20,16 +21,52 @@
 
 set -euo pipefail
 
+# A version token is "main" or a release tag (vX.Y[.Z][pre/dev suffix]). Anything
+# else is rejected so it can't break the matrix JSON or reach a `git worktree add`.
+_valid_version() {
+  [ "$1" = "main" ] || [[ "$1" =~ ^v?[0-9]+\.[0-9]+(\.[0-9]+)?([a-z0-9.]*)?$ ]]
+}
+
+raw=()
 if [ -n "${VERSIONS:-}" ]; then
-  IFS=',' read -ra V <<<"$VERSIONS"
+  IFS=',' read -ra raw <<<"$VERSIONS"
 else
-  # Portable (no mapfile/bash-4): main + every non-rc release tag, newest first.
-  V=("main")
-  while IFS= read -r tag; do
-    [ -n "$tag" ] && V+=("$tag")
-  done < <(git tag --sort=-v:refname | grep -vi rc)
+  raw=("main")
+  # `[^a-z]rc[0-9]` so we drop vX.Y.ZrcN without over-excluding tags that merely
+  # contain the substring "rc" (e.g. a hypothetical "...march").
+  while IFS= read -r tag; do raw+=("$tag"); done < <(git tag --sort=-v:refname | grep -viE '(^|[^a-z])rc[0-9]')
 fi
+
+# Trim whitespace, drop blanks, reject invalid tokens.
+V=()
+for v in "${raw[@]}"; do
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  [ -z "$v" ] && continue
+  if ! _valid_version "$v"; then
+    echo "skipping invalid version token: '$v'" >&2
+    continue
+  fi
+  V+=("$v")
+done
+
 num_shards="${NUM_SHARDS:-4}"
+
+# GitHub caps a matrix at 256 jobs. e2e jobs = (|V|² − [main present]) × shards.
+# If we'd exceed it, drop the OLDEST versions (V is newest-first in auto mode)
+# until under, logging each drop — never silently truncate.
+_pairs() {
+  local n=${#V[@]} mm=0 x
+  for x in "${V[@]}"; do [ "$x" = "main" ] && mm=1 && break; done
+  echo "$((n * n - mm))"
+}
+max_e2e=256
+while [ "${#V[@]}" -gt 2 ] && [ "$(($(_pairs) * num_shards))" -gt "$max_e2e" ]; do
+  dropped="${V[${#V[@]} - 1]}"
+  unset 'V[${#V[@]}-1]'
+  V=("${V[@]}")
+  echo "version-matrix cap: dropped oldest version '$dropped' to keep e2e jobs <= $max_e2e" >&2
+done
 
 # The integration suite runs a single openai-agents leg in mock mode (matches
 # integration-matrix.sh); the model name is unused under the mock LLM.
@@ -54,11 +91,11 @@ done
 
 e2e_json=$(
   IFS=,
-  echo "${e2e_items[*]}"
+  echo "${e2e_items[*]:-}"
 )
 integ_json=$(
   IFS=,
-  echo "${integ_items[*]}"
+  echo "${integ_items[*]:-}"
 )
 
 {
@@ -66,5 +103,5 @@ integ_json=$(
   echo "integration_matrix={\"include\":[$integ_json]}"
 } >>"${GITHUB_OUTPUT:-/dev/stdout}"
 
-echo "versions: ${V[*]}" >&2
-echo "pairs: $((${#integ_items[@]})) (excludes main/main); e2e jobs: ${#e2e_items[@]}; integration jobs: ${#integ_items[@]}" >&2
+echo "versions: ${V[*]:-(none)}" >&2
+echo "pairs: ${#integ_items[@]} (excludes main/main); e2e jobs: ${#e2e_items[@]}; integration jobs: ${#integ_items[@]}" >&2

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -1,228 +1,126 @@
 name: Backwards-Compat
 
-# Cross-version backwards-compatibility sweep, both directions, against main's
-# e2e + integration suites. The test runs are the SAME composite actions the
-# normal gates use (.github/actions/e2e-run, integration-run), invoked with one
-# component pinned to an older release — so they run byte-for-byte the way
-# e2e.yml / integration.yml do (mock LLM), differing only in which subprocess is
-# the old build. See docs/SERVER_VERSION_COMPAT_CI.md.
+# Cross-version backwards-compatibility sweep against main's e2e + integration
+# suites, over the FULL pairwise (server, runner) version matrix.
 #
-#   Config 1 (backcompat-{e2e,integration}):        OLD server, new runner/host/client/tests.
-#   Config 2 (backcompat-runner-{e2e,integration}): OLD runner+host, new server/client/tests.
+# The version universe is `main` (the checked-out code = client + tests, always)
+# plus every non-rc release tag; we cross every server version with every runner
+# version. Each cell pins the server and/or runner subprocess to that build
+# (a "main" axis value leaves that component on the checked-out code) while the
+# client and tests stay on main. The (main, main) cell is omitted — it pins
+# nothing and is exactly the normal e2e gate. So the matrix subsumes the old
+# single-pin jobs: (old, main) = Config 1; (main, old) = Config 2; (old, old) =
+# both old; etc. Runner and host are colocated, so the runner axis pins both.
 #
-# Runner and host are colocated (one install), so a single knob pins both. The
-# server and runner knobs are orthogonal (tests/_helpers/compat.py): each job
-# pins exactly one component and leaves the rest on main.
+# The test runs are the SAME composite actions the normal gates use
+# (.github/actions/e2e-run, integration-run); a cell differs only in which
+# subprocess(es) are the old build. See docs/SERVER_VERSION_COMPAT_CI.md.
 #
 # Triggers:
-#   workflow_dispatch   manual; server_version / runner_version pick the old tags.
-#   schedule            every 4h; both default to the latest non-rc release tag.
+#   workflow_dispatch   manual; optional `versions` CSV overrides the set.
+#   schedule            every 12h; full pairwise over main + all non-rc tags.
 
 on:
   workflow_dispatch:
     inputs:
-      server_version:
-        description: "Old SERVER tag for Config 1, e.g. v0.1.1. Empty = latest non-rc tag."
-        required: false
-        default: ""
-      runner_version:
-        description: "Old RUNNER/HOST tag for Config 2, e.g. v0.1.1. Empty = latest non-rc tag."
+      versions:
+        description: "Comma-separated version set for BOTH axes (e.g. 'main,v0.2.0'). Empty = main + all non-rc tags."
         required: false
         default: ""
   schedule:
-    # Every 4 hours.
-    - cron: "0 */4 * * *"
+    # Every 12 hours (00:00 and 12:00 UTC).
+    - cron: "0 */12 * * *"
 
 concurrency:
-  group: backcompat-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: backcompat-${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  # Compute the SAME matrices the gates use (e2e-shard-matrix.sh /
-  # integration-matrix.sh), so backcompat runs exactly the shards/legs the real
-  # gate runs for this event — no hardcoded list to drift. Notably integration
-  # is openai-agents only: claude-sdk/codex reject the mock LLM's "mock-model"
-  # so the gate excludes them (see integration-matrix.sh); backcompat must too.
+  # Compute the full pairwise (server, runner) matrices. Integration is the
+  # single openai-agents leg (claude-sdk/codex reject the mock LLM's
+  # "mock-model"); e2e is sharded per cell. See backcompat-pairwise-matrix.sh.
   setup:
     name: setup
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      e2e_matrix: ${{ steps.e2e.outputs.matrix }}
-      integration_matrix: ${{ steps.integration.outputs.matrix }}
+      e2e_matrix: ${{ steps.matrix.outputs.e2e_matrix }}
+      integration_matrix: ${{ steps.matrix.outputs.integration_matrix }}
     steps:
-      - name: Check out CI scripts
+      - name: Check out CI scripts + tags
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           sparse-checkout: .github/scripts/ci
+          # Full history so `git tag` sees every release tag for the matrix.
+          fetch-depth: 0
           persist-credentials: false
-      - name: Compute e2e shard matrix
-        id: e2e
+      - name: Compute pairwise matrices
+        id: matrix
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          IS_DRAFT: ${{ github.event.pull_request.draft }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          VERSIONS: ${{ github.event.inputs.versions }}
           NUM_SHARDS: "4"
-        run: bash .github/scripts/ci/e2e-shard-matrix.sh
-      - name: Compute integration matrix
-        id: integration
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          IS_DRAFT: ${{ github.event.pull_request.draft }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-        run: bash .github/scripts/ci/integration-matrix.sh
+        run: bash .github/scripts/ci/backcompat-pairwise-matrix.sh
 
-  # ── Config 1: OLD server, new runner/host/client/tests ────────────────
+  # tests/e2e for every (server, runner) cell × shard.
   backcompat-e2e:
-    name: Backcompat e2e (server ${{ github.event.inputs.server_version || 'latest-release' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    name: Backcompat e2e (server ${{ matrix.server }} / runner ${{ matrix.runner }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
     needs: setup
     runs-on: ubuntu-latest
     # Job-level cap (composite run steps can't set timeout-minutes); mirrors
-    # e2e.yml's ~30-min test budget + setup + old-build install.
-    timeout-minutes: 40
+    # e2e.yml's ~30-min test budget + setup + up to two old-build installs.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
-      max-parallel: 4
+      # Bound concurrency: the full matrix is large (versions² × shards). Tune
+      # here if the org's runner pool is over/under-subscribed.
+      max-parallel: 10
       matrix: ${{ fromJSON(needs.setup.outputs.e2e_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          # Test the merge result on PRs (matches e2e.yml); fall back to the
-          # dispatched/triggering ref otherwise. fetch-depth 0 so the action
-          # can `git worktree add` the old release tag.
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
+          # fetch-depth 0 so the action can `git worktree add` the old tags.
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Resolve old version
-        id: resolve
-        env:
-          VERSION_INPUT: ${{ github.event.inputs.server_version }}
-        run: |
-          tag="$VERSION_INPUT"
-          if [ -z "$tag" ]; then
-            tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
-          fi
-          echo "Resolved old tag: $tag"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Run e2e suite against old server
+      - name: Run e2e suite for this cell
         uses: ./.github/actions/e2e-run
         with:
-          server_version: ${{ steps.resolve.outputs.tag }}
+          # "main" axis -> empty input (use checked-out code); else the tag.
+          # GHA ternary: `!= 'main' && x || ''` (the naive `== 'main' && '' || x`
+          # breaks because '' is falsy and falls through to x).
+          server_version: ${{ matrix.server != 'main' && matrix.server || '' }}
+          runner_version: ${{ matrix.runner != 'main' && matrix.runner || '' }}
           shard_id: ${{ matrix.shard_id }}
           num_shards: ${{ matrix.num_shards }}
           parallelism: "2"
           nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
+  # tests/integration for every (server, runner) cell (openai-agents leg).
   backcompat-integration:
-    name: Backcompat integration (server ${{ github.event.inputs.server_version || 'latest-release' }}, ${{ matrix.harness }})
-    needs: setup
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    strategy:
-      fail-fast: false
-      # openai-agents only (per integration-matrix.sh) — same as the gate.
-      matrix: ${{ fromJSON(needs.setup.outputs.integration_matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
-          fetch-depth: 0
-
-      - name: Resolve old version
-        id: resolve
-        env:
-          VERSION_INPUT: ${{ github.event.inputs.server_version }}
-        run: |
-          tag="$VERSION_INPUT"
-          if [ -z "$tag" ]; then
-            tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
-          fi
-          echo "Resolved old tag: $tag"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Run integration suite against old server
-        uses: ./.github/actions/integration-run
-        with:
-          server_version: ${{ steps.resolve.outputs.tag }}
-          harness: ${{ matrix.harness }}
-          model: ${{ matrix.model }}
-          workers: ${{ matrix.workers }}
-
-  # ── Config 2: OLD runner/host, new server/client/tests ────────────────
-  backcompat-runner-e2e:
-    name: Backcompat e2e (runner ${{ github.event.inputs.runner_version || 'latest-release' }}, shard ${{ matrix.shard_id }}/${{ matrix.num_shards }})
+    name: Backcompat integration (server ${{ matrix.server }} / runner ${{ matrix.runner }}, ${{ matrix.harness }})
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      max-parallel: 4
-      matrix: ${{ fromJSON(needs.setup.outputs.e2e_matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
-          fetch-depth: 0
-
-      - name: Resolve old version
-        id: resolve
-        env:
-          VERSION_INPUT: ${{ github.event.inputs.runner_version }}
-        run: |
-          tag="$VERSION_INPUT"
-          if [ -z "$tag" ]; then
-            tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
-          fi
-          echo "Resolved old tag: $tag"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Run e2e suite against old runner/host
-        uses: ./.github/actions/e2e-run
-        with:
-          runner_version: ${{ steps.resolve.outputs.tag }}
-          shard_id: ${{ matrix.shard_id }}
-          num_shards: ${{ matrix.num_shards }}
-          parallelism: "2"
-          nightly_full: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-
-  backcompat-runner-integration:
-    name: Backcompat integration (runner ${{ github.event.inputs.runner_version || 'latest-release' }}, ${{ matrix.harness }})
-    needs: setup
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    strategy:
-      fail-fast: false
+      max-parallel: 5
       matrix: ${{ fromJSON(needs.setup.outputs.integration_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Resolve old version
-        id: resolve
-        env:
-          VERSION_INPUT: ${{ github.event.inputs.runner_version }}
-        run: |
-          tag="$VERSION_INPUT"
-          if [ -z "$tag" ]; then
-            tag="$(git tag --sort=-v:refname | grep -vi rc | head -1)"
-          fi
-          echo "Resolved old tag: $tag"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Run integration suite against old runner
+      - name: Run integration suite for this cell
         uses: ./.github/actions/integration-run
         with:
-          runner_version: ${{ steps.resolve.outputs.tag }}
+          server_version: ${{ matrix.server != 'main' && matrix.server || '' }}
+          runner_version: ${{ matrix.runner != 'main' && matrix.runner || '' }}
           harness: ${{ matrix.harness }}
           model: ${{ matrix.model }}
           workers: ${{ matrix.workers }}

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -14,7 +14,7 @@ name: Backwards-Compat
 #
 # The test runs are the SAME composite actions the normal gates use
 # (.github/actions/e2e-run, integration-run); a cell differs only in which
-# subprocess(es) are the old build. See docs/SERVER_VERSION_COMPAT_CI.md.
+# subprocess(es) are the old build.
 #
 # Triggers:
 #   workflow_dispatch   manual; optional `versions` CSV overrides the set.
@@ -94,6 +94,10 @@ jobs:
           # breaks because '' is falsy and falls through to x).
           server_version: ${{ matrix.server != 'main' && matrix.server || '' }}
           runner_version: ${{ matrix.runner != 'main' && matrix.runner || '' }}
+          # Unique per cell so upload-artifact@v4 doesn't collide across the
+          # matrix (every integration cell shares the harness; e2e cells share
+          # a shard_id).
+          artifact_suffix: "-s${{ matrix.server }}-r${{ matrix.runner }}"
           shard_id: ${{ matrix.shard_id }}
           num_shards: ${{ matrix.num_shards }}
           parallelism: "2"
@@ -121,6 +125,10 @@ jobs:
         with:
           server_version: ${{ matrix.server != 'main' && matrix.server || '' }}
           runner_version: ${{ matrix.runner != 'main' && matrix.runner || '' }}
+          # Unique per cell so upload-artifact@v4 doesn't collide across the
+          # matrix (every integration cell shares the harness; e2e cells share
+          # a shard_id).
+          artifact_suffix: "-s${{ matrix.server }}-r${{ matrix.runner }}"
           harness: ${{ matrix.harness }}
           model: ${{ matrix.model }}
           workers: ${{ matrix.workers }}


### PR DESCRIPTION
## What

Evolves the scheduled **Backwards-Compat** workflow (added in #990) to run the **full pairwise `(server, runner)` version matrix** instead of the four single-pin job groups.

- **Version universe** = `main` (checked-out code = client + tests, always) + every non-rc release tag, computed dynamically (`backcompat-pairwise-matrix.sh`) so new releases auto-join.
- **Every server version × every runner version.** Each cell pins the server and/or runner subprocess to that build; the `(main, main)` cell is dropped (it's the normal gate). Runner+host are colocated, so the runner axis pins both.
- **Subsumes the old jobs**: `(old, main)` = Config 1, `(main, old)` = Config 2, `(old, old)` = both old, plus all mixed pairs.
- **Schedule: every 12h** (`workflow_dispatch` takes an optional `versions` CSV override).

## Cost

Current universe (`main` + `v0.2.0`/`v0.1.1`/`v0.1.0`) = **15 cells = 60 e2e + 15 integration jobs per sweep**, ×2/day. It's mock-LLM (no gateway cost) and grows quadratically with new tags — `NUM_SHARDS`, `max-parallel`, the version set, and cadence are all one-line knobs if the runner pool gets tight.

## Builds on #990

The composite actions' `server_version` + `runner_version` inputs (orthogonal redirects) are already on `main` via #990; a cell that pins both just sets both inputs. The matrix script is the only new file.

## Testing

- ✅ `backcompat-pairwise-matrix.sh` unit-exercised locally: emits the correct 15 cells (60 e2e / 15 integration), `(main,main)` excluded, `VERSIONS` override works, portable (no bash-4 `mapfile`).
- ✅ Workflow YAML valid; `main`-axis → empty composite input via the `!= 'main' && x || ''` ternary (the naive form breaks on falsy `''`).
- ✅ The redirect mechanism itself is already proven green on #990 (Config-1 and Config-2 both ran on Actions).
- The backcompat workflow runs on schedule/dispatch only (not on this PR); I'll dispatch a full-matrix run once it's on `main` to confirm end-to-end.
