### PR TITLE
feat(polly-review): tighten blocking criteria and add package-extras guidance

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -301,7 +301,7 @@ jobs:
           Do NOT comment on code style, formatting, naming conventions, or other cosmetic issues — omit them entirely.
           Be concise. Do not restate the diff. Focus on what matters.
 
-          Before labeling anything **blocking**, double-check: does it actually introduce a correctness bug, break an explicit contract, or create a real security risk? Style preferences, speculative concerns, and minor omissions are non-blocking at most. If in doubt, downgrade.
+          Before labeling anything **blocking**, double-check: does this issue actually exist in the diff? Verify the problem is real and present in the changed code — not inferred, speculative, or already handled elsewhere. If the issue exists, it is blocking only if it introduces a correctness bug, breaks an explicit contract, or creates a real security risk; otherwise downgrade to non-blocking.
 
           **Package extras** — when the diff adds or modifies optional dependency groups (extras):
           - Each harness deserves its own extra.

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -301,6 +301,14 @@ jobs:
           Do NOT comment on code style, formatting, naming conventions, or other cosmetic issues — omit them entirely.
           Be concise. Do not restate the diff. Focus on what matters.
 
+          Before labeling anything **blocking**, double-check: does it actually introduce a correctness bug, break an explicit contract, or create a real security risk? Style preferences, speculative concerns, and minor omissions are non-blocking at most. If in doubt, downgrade.
+
+          **Package extras** — when the diff adds or modifies optional dependency groups (extras):
+          - Each harness deserves its own extra.
+          - Combine harnesses and other integrations from the same vendor into one extra (e.g. a single `google` extra may cover Vertex and Antigravity).
+          - Each sandbox deserves its own extra.
+          - Nothing else warrants a new extra — flag any new extras that don't fit one of these three categories as a blocking issue.
+
           IMPORTANT: Your output will be posted directly as a PR comment. Output
           ONLY the final structured review — no coordination messages, no status
           updates about dispatching sub-agents, no referring to "reviewers", no "waiting for results" narration.


### PR DESCRIPTION
## Summary
- Adds a pre-labeling double-check rule: before calling something **blocking**, the reviewer must confirm it's a genuine correctness bug, contract violation, or security risk — not a style preference or speculative concern. Doubt → downgrade to non-blocking.
- Adds package extras guidelines: one extra per harness, combine same-vendor integrations (e.g. one `google` extra for Vertex + Antigravity), one extra per sandbox, nothing else warrants a new extra.