### PR TITLE
feat(polly): add /fix comment command to trigger automated fixes

### DIFF
--- a/.github/workflows/polly-fix.yml
+++ b/.github/workflows/polly-fix.yml
@@ -9,8 +9,8 @@ name: Polly Fix on /fix comment
 # list is always read from main's tip (never the PR head) to prevent a PR from
 # editing the list to grant itself access.
 #
-# The workflow checks out the default branch and fetches the PR diff via the
-# API — it never executes PR-authored code in a privileged context.
+# The workflow checks out the PR branch so Polly's sub-agents see the actual
+# code under review. This is safe because the trigger is maintainer-gated.
 
 on:
   issue_comment:
@@ -35,6 +35,7 @@ jobs:
     outputs:
       ok: ${{ steps.authz.outputs.ok }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
     steps:
       # Checkout main only for load-maintainers.sh.
       - name: Checkout (for the maintainer script)
@@ -62,10 +63,17 @@ jobs:
             echo "::notice::@$ACTOR is not in .github/MAINTAINER; ignoring /fix."
           fi
 
-      - name: Resolve PR number
+      - name: Resolve PR number and head ref
         id: pr
         if: steps.authz.outputs.ok == 'true'
-        run: echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
 
       - name: Acknowledge /fix
         if: steps.authz.outputs.ok == 'true'
@@ -103,13 +111,13 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Always check out the default branch (trusted). The PR diff is fetched
-      # via the API — we never execute PR-authored code in a privileged context.
-      - name: Check out repo
+      # Check out the PR branch so Polly's sub-agents see the actual code under
+      # review. Safe because this job only runs after maintainer authorization.
+      - name: Check out PR branch
         if: steps.creds.outputs.available == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ needs.authorize.outputs.head_ref }}
           persist-credentials: false
 
       - name: Set up Python
@@ -245,12 +253,37 @@ jobs:
             --json title,body,baseRefName,headRefName,additions,deletions,changedFiles \
             > /tmp/pr_meta.json
 
-          # Build the fix prompt safely using python.
+          # Fetch PR issue comments (general thread comments, e.g. Polly review).
+          # Capped at 32 KB total to stay within prompt limits.
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | {author: .user.login, body: .body}]' \
+            | head -c 32768 > /tmp/pr_comments.json
+
+          # Fetch PR review comments (inline code comments).
+          # Capped at 32 KB total.
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+            --jq '[.[] | {author: .user.login, path: .path, line: .line, body: .body}]' \
+            | head -c 32768 > /tmp/pr_review_comments.json
+
+          # Build the fix prompt safely using python — all untrusted fields
+          # (title, body, diff, comments) are read from files, never
+          # interpolated into shell heredocs.
           python3 <<'PYEOF'
           import json, pathlib
 
           meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
           diff = pathlib.Path("/tmp/pr_diff.txt").read_text()
+          comments = json.loads(pathlib.Path("/tmp/pr_comments.json").read_text())
+          review_comments = json.loads(pathlib.Path("/tmp/pr_review_comments.json").read_text())
+
+          def fmt_comments(items):
+              if not items:
+                  return "*(none)*"
+              parts = []
+              for c in items:
+                  loc = f" [{c['path']}:{c.get('line', '?')}]" if 'path' in c else ""
+                  parts.append(f"**{c['author']}**{loc}:\n{c['body'][:2048]}")
+              return "\n\n---\n\n".join(parts)
 
           prompt = f"""Fix the blocking issues in this pull request.
 
@@ -262,6 +295,12 @@ jobs:
           ## PR Description
           {(meta.get('body') or '')[:4096]}{"  *(truncated)*" if len(meta.get('body') or '') > 4096 else ""}
 
+          ## PR Comments
+          {fmt_comments(comments)}
+
+          ## Inline Review Comments
+          {fmt_comments(review_comments)}
+
           ## Diff
           ```diff
           {diff}
@@ -270,9 +309,15 @@ jobs:
           ## Instructions
           Load the fix-blocking-issues skill and follow it exactly.
 
+          The codebase is checked out at the PR branch, so files reflect the
+          code exactly as it would land if merged. Use `gh` CLI commands freely
+          to fetch any additional PR context you need — CI status, linked
+          issues, review threads, etc. The PR number is in the environment
+          variable POLLY_PR_NUMBER and the repo in POLLY_REPO.
+
           Identify only issues that are genuinely blocking — correctness bugs,
           broken contracts, or real security risks that actually exist in the
-          changed code above. Do not fix non-blocking notes, style issues, or
+          changed code. Do not fix non-blocking notes, style issues, or
           speculative concerns.
 
           Dispatch implementer sub-agents to fix each blocking issue in an
@@ -311,9 +356,13 @@ jobs:
         id: polly
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          # Expose a write-capable token so Polly's sub-agents can push fix
-          # branches and open PRs via gh CLI.
+          # Expose a write-capable token so Polly and its sub-agents can use
+          # the gh CLI to read PR details and push fix branches / open PRs.
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          # Make the PR number available so Polly can fetch additional context
+          # (CI status, linked issues, etc.) without it being in the prompt.
+          POLLY_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          POLLY_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/polly-fix.yml
+++ b/.github/workflows/polly-fix.yml
@@ -1,0 +1,376 @@
+name: Polly Fix on /fix comment
+
+# A maintainer comments `/fix` on a PR to have Polly identify the blocking
+# issues in the diff, dispatch implementer sub-agents to fix them in isolated
+# worktrees, cross-review each fix, and open fix PRs.
+#
+# Authorization: only .github/MAINTAINER entries may trigger this — it
+# dispatches coding sub-agents that push branches and open PRs. The MAINTAINER
+# list is always read from main's tip (never the PR head) to prevent a PR from
+# editing the list to grant itself access.
+#
+# The workflow checks out the default branch and fetches the PR diff via the
+# API — it never executes PR-authored code in a privileged context.
+
+on:
+  issue_comment:
+    types: [created]
+
+# Read-only at the top level; write scopes on the fix job only.
+permissions:
+  contents: read
+
+jobs:
+  # Gate: confirm a `/fix` comment on a PR by a maintainer.
+  authorize:
+    permissions:
+      contents: read
+      issues: write        # react to the triggering comment
+    if: >-
+      github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/fix')
+      && !endsWith(github.actor, '[bot]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ok: ${{ steps.authz.outputs.ok }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    steps:
+      # Checkout main only for load-maintainers.sh.
+      - name: Checkout (for the maintainer script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Load maintainers from .github/MAINTAINER
+        id: maint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/merge-ready/load-maintainers.sh
+
+      - name: Authorize commenter
+        id: authz
+        env:
+          LIST: ${{ steps.maint.outputs.list }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          ok=false
+          for u in $LIST; do
+            if [ "$u" = "$ACTOR" ]; then ok=true; break; fi
+          done
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" != "true" ]; then
+            echo "::notice::@$ACTOR is not in .github/MAINTAINER; ignoring /fix."
+          fi
+
+      - name: Resolve PR number
+        id: pr
+        if: steps.authz.outputs.ok == 'true'
+        run: echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge /fix
+        if: steps.authz.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes --silent || true
+
+  fix:
+    name: Polly Fix
+    needs: authorize
+    if: needs.authorize.outputs.ok == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Write access for sub-agents pushing fix branches and creating PRs.
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: polly-fix-${{ needs.authorize.outputs.pr_number }}
+      cancel-in-progress: true
+    steps:
+      - name: Check LLM credentials available
+        id: creds
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          if [ -z "$LLM_API_KEY" ]; then
+            echo "::notice::Skipping Polly fix — LLM credentials not available (fork PR or missing secrets)."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Always check out the default branch (trusted). The PR diff is fetched
+      # via the API — we never execute PR-authored code in a privileged context.
+      - name: Check out repo
+        if: steps.creds.outputs.available == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        if: steps.creds.outputs.available == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        if: steps.creds.outputs.available == 'true'
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
+        with:
+          enable-cache: true
+
+      - name: Install bubblewrap
+        if: steps.creds.outputs.available == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap tmux
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Cache virtualenv
+        if: steps.creds.outputs.available == 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install dependencies
+        if: steps.creds.outputs.available == 'true'
+        run: uv sync --extra all --extra dev
+
+      - name: Install Claude Code CLI
+        if: steps.creds.outputs.available == 'true'
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          node node_modules/@anthropic-ai/claude-code/install.cjs
+          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Install Codex CLI
+        if: steps.creds.outputs.available == 'true'
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.codex-cli" && cd "${GITHUB_WORKSPACE}/.codex-cli"
+          npm install --ignore-scripts --no-audit --no-fund @openai/codex@0.139.0
+          echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Set LLM credentials
+        if: steps.creds.outputs.available == 'true'
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: echo "LLM_API_KEY=${LLM_API_KEY}" >> "$GITHUB_ENV"
+
+      - name: Write gateway profile (~/.databrickscfg)
+        if: steps.creds.outputs.available == 'true'
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          python3 -c "
+          import pathlib, os
+          cfg = '[default]\nhost  = {host}\ntoken = {token}\n'.format(
+              host=os.environ['GATEWAY_BASE_URL'].removesuffix('/serving-endpoints'),
+              token=os.environ['LLM_API_KEY'],
+          )
+          pathlib.Path.home().joinpath('.databrickscfg').write_text(cfg)
+          "
+          echo "DATABRICKS_BEARER=${LLM_API_KEY}" >> "$GITHUB_ENV"
+
+      - name: Write Omnigent provider config
+        if: steps.creds.outputs.available == 'true'
+        env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+        run: |
+          mkdir -p "$HOME/.omnigent"
+          python3 -c "
+          import pathlib, os, json
+          gw = os.environ['GATEWAY_BASE_URL']
+          host = gw.removesuffix('/serving-endpoints')
+          cfg = {
+              'providers': {
+                  'databricks-gateway': {
+                      'kind': 'gateway',
+                      'default': ['anthropic', 'openai'],
+                      'anthropic': {
+                          'base_url': gw + '/anthropic',
+                          'api_key_ref': 'env:LLM_API_KEY',
+                          'models': {'default': 'databricks-claude-opus-4-8'},
+                      },
+                      'openai': {
+                          'base_url': host + '/ai-gateway/codex/v1',
+                          'api_key_ref': 'env:LLM_API_KEY',
+                          'wire_api': 'responses',
+                          'models': {'default': 'databricks-gpt-5-5'},
+                      },
+                  }
+              }
+          }
+          pathlib.Path.home().joinpath('.omnigent', 'config.yaml').write_text(
+              json.dumps(cfg, indent=2)
+          )
+          "
+
+      - name: Mint App token
+        id: app-token
+        if: steps.creds.outputs.available == 'true' && vars.OMNIGENT_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
+
+      - name: Collect PR context
+        if: steps.creds.outputs.available == 'true'
+        id: ctx
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          # Fetch the diff (capped at 64 KB to stay within prompt limits).
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+            -H "Accept: application/vnd.github.v3.diff" \
+            | head -c 65536 > /tmp/pr_diff.txt
+
+          # Fetch PR metadata.
+          gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json title,body,baseRefName,headRefName,additions,deletions,changedFiles \
+            > /tmp/pr_meta.json
+
+          # Build the fix prompt safely using python.
+          python3 <<'PYEOF'
+          import json, pathlib
+
+          meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
+          diff = pathlib.Path("/tmp/pr_diff.txt").read_text()
+
+          prompt = f"""Fix the blocking issues in this pull request.
+
+          ## PR Metadata
+          - **Title:** {meta['title']}
+          - **Branch:** {meta['headRefName']} → {meta['baseRefName']}
+          - **Stats:** +{meta['additions']} / -{meta['deletions']} across {meta['changedFiles']} file(s)
+
+          ## PR Description
+          {(meta.get('body') or '')[:4096]}{"  *(truncated)*" if len(meta.get('body') or '') > 4096 else ""}
+
+          ## Diff
+          ```diff
+          {diff}
+          ```
+
+          ## Instructions
+          Load the fix-blocking-issues skill and follow it exactly.
+
+          Identify only issues that are genuinely blocking — correctness bugs,
+          broken contracts, or real security risks that actually exist in the
+          changed code above. Do not fix non-blocking notes, style issues, or
+          speculative concerns.
+
+          Dispatch implementer sub-agents to fix each blocking issue in an
+          isolated worktree, cross-review each fix, and open fix PRs.
+
+          IMPORTANT: Your output will be posted directly as a PR comment. When
+          all fix PRs are open and cross-review is clean — or if no blocking
+          issues were found — emit the exact sentinel <!-- POLLY_FIX_DONE -->
+          on its own line, then list each fix PR URL one per line (or the
+          message "No blocking issues found — nothing to fix." if there were
+          none). Nothing before the sentinel will be shown.
+          """
+          pathlib.Path("/tmp/fix_prompt.txt").write_text(prompt)
+          PYEOF
+
+      - name: Post "in progress" comment
+        if: steps.creds.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(cat <<EOF
+          <!-- polly-fix-bot -->
+          ## <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="20" valign="middle" /> Polly Fix in progress…
+
+          Polly is analyzing the diff and dispatching fix sub-agents. This may take a few minutes.
+
+          [workflow run](${RUN_URL})
+          EOF
+          )"
+
+      - name: Run Polly fix
+        if: steps.creds.outputs.available == 'true'
+        id: polly
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          # Expose a write-capable token so Polly's sub-agents can push fix
+          # branches and open PRs via gh CLI.
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          set -euo pipefail
+
+          prompt=$(cat /tmp/fix_prompt.txt)
+
+          uv run omnigent run examples/polly/ \
+            -p "$prompt" \
+            --no-session \
+            2>polly-fix-stderr.log \
+            | tee /tmp/polly_fix_output.txt \
+            || { echo "::warning::Polly fix exited non-zero"; cat polly-fix-stderr.log; }
+
+          # Extract output after the done sentinel. If the sentinel is absent,
+          # write empty string — the post step is skipped and raw coordination
+          # messages are never posted as a PR comment.
+          python3 -c "
+          import pathlib
+          raw = pathlib.Path('/tmp/polly_fix_output.txt').read_text()
+          sentinel = '<!-- POLLY_FIX_DONE -->'
+          idx = raw.find(sentinel)
+          cleaned = raw[idx + len(sentinel):].lstrip('\n') if idx >= 0 else ''
+          pathlib.Path('/tmp/polly_fix_output.txt').write_text(cleaned)
+          "
+
+          delim="FIX_$(openssl rand -hex 8)"
+          echo "fix_text<<${delim}" >> "$GITHUB_OUTPUT"
+          head -c 61440 /tmp/polly_fix_output.txt >> "$GITHUB_OUTPUT"
+          echo "${delim}" >> "$GITHUB_OUTPUT"
+
+      - name: Post fix result comment
+        if: steps.polly.outputs.fix_text != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          FIX_TEXT: ${{ steps.polly.outputs.fix_text }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+          {
+            echo "<!-- polly-fix-bot -->"
+            echo "## <img src=\"https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg\" alt=\"\" height=\"20\" valign=\"middle\" /> Polly Fix"
+            echo ""
+            echo "$FIX_TEXT"
+            echo ""
+            echo "---"
+            echo "<sub>Automated fix by Polly · [workflow run](${RUN_URL})</sub>"
+          } > /tmp/fix_comment.md
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/fix_comment.md
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: polly-fix-logs-${{ github.run_id }}
+          path: |
+            polly-fix-stderr.log
+            /tmp/polly_fix_output.txt
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -394,7 +394,7 @@ jobs:
             echo "$REVIEW_TEXT"
             echo ""
             echo "---"
-            echo "<sub>Automated review by Polly · [workflow run](${RUN_URL})</sub>"
+            echo "<sub>Automated review by Polly · [workflow run](${RUN_URL}) · Maintainers: comment \`/fix\` to have Polly fix the blocking issues above</sub>"
           } > /tmp/comment.md
 
           # Post a fresh comment for every review run, so each trigger (push,

--- a/examples/polly/skills/fix-blocking-issues/SKILL.md
+++ b/examples/polly/skills/fix-blocking-issues/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: fix-blocking-issues
+description: Identify blocking issues in a PR diff, fix them in isolated worktrees via implementer sub-agents, cross-review each fix, and open fix PRs for the human to merge.
+---
+
+# fix-blocking-issues — automated fix dispatch
+
+Use when a human triggers `/fix` on a PR. Your job: identify the blocking
+issues in the diff and description, fix them in isolated worktrees, and open
+fix PRs. You never merge; the human does.
+
+## What counts as blocking
+
+Only issues that are actually present in the changed code AND fall into one
+of these categories:
+- Correctness bug (wrong logic, off-by-one, missed case)
+- Broken contract (violates an explicit API or behaviour guarantee)
+- Real security risk (injection, auth bypass, secret exposure, path traversal,
+  etc.)
+
+Do NOT fix non-blocking notes, style issues, or speculative concerns.
+If no blocking issues exist in the diff, skip to step 5 (emit done sentinel).
+
+## Procedure
+
+1. **Identify blocking issues** — read the full diff and PR description.
+   List only genuine blocking issues with file:line evidence. Double-check
+   each: does the problem actually exist in the diff, not just nearby or in
+   the surrounding context?
+
+2. **Plan fix tasks** — group related issues into coherent tasks. Prefer one
+   task covering all issues unless they touch completely disjoint areas (no
+   shared files, no ordering dependency). One worktree per task.
+
+3. **Dispatch implementers** — for each task:
+   `sys_os_shell("git worktree add .worktrees/<task_id> -b polly/fix/<task_id>")`,
+   then `sys_session_send(agent="claude_code"|"codex", title="fix-<slug>",
+   args={purpose: "implement", input: "<diff slice> + <acceptance contract> +
+   worktree path. Stay strictly within .worktrees/<task_id>. Drive to green
+   (tests/lint/typecheck), push your branch, open a PR."})`.
+   Emit all worktree creates and dispatches in the SAME turn — never announce
+   then yield. Record each `conversation_id` in the registry.
+
+4. **Cross-review each fix PR** via the `cross-review` skill: a different-vendor
+   reviewer judges the fix diff against its contract. Blocking issues in the
+   fix loop back to the implementer in the same worktree/branch.
+
+5. **Emit the done sentinel** when all fix PRs are open and cross-review is
+   clean — or immediately if there were no blocking issues:
+
+   ```
+   <!-- POLLY_FIX_DONE -->
+   <one fix PR URL per line, or "No blocking issues found — nothing to fix.">
+   ```
+
+   Nothing before the sentinel will be shown in the PR comment.
+
+## Notes
+- Use short, task-based worktree names: `fix-null-check`, `fix-auth-bypass`.
+  Never `claude_code`, `codex`, `pi`, or other vendor names.
+- Every commit the implementer authors must end with a blank line followed by
+  the co-sign trailer as its final line:
+  `Co-authored-by: omnigent <noreply@omnigent.ai>`
+- Never run `git merge` or `gh pr merge` — PRs are the deliverable.
+- Remove a finished worktree only after its PR is open and cross-review is
+  clean: `git worktree remove .worktrees/<task_id>`.


### PR DESCRIPTION
## Summary
- Adds `polly-fix.yml` — a new workflow that fires when a maintainer comments `/fix` on a PR. It spins up Polly with the PR diff, dispatches implementer sub-agents to fix blocking issues in isolated worktrees, cross-reviews each fix, and posts fix PR links back as a comment.
- Adds `examples/polly/skills/fix-blocking-issues/SKILL.md` — the Polly skill that defines the fix identification and dispatch procedure, including what counts as blocking, how to group tasks, co-sign requirements, and the `<!-- POLLY_FIX_DONE -->` sentinel format.
- Updates `polly-review.yml` footer to advertise `/fix` to maintainers.

**Auth**: gated to `.github/MAINTAINER` (read from `main`'s tip), same pattern as `/regen`. Bots are excluded. Non-maintainers are silently ignored.

## Test plan
- [ ] Comment `/fix` as a non-maintainer — confirm it is silently ignored (no reaction, no workflow run)
- [ ] Comment `/fix` as a maintainer on a PR with blocking issues — confirm eyes reaction, "in progress" comment, and eventual fix PR links posted
- [ ] Comment `/fix` on a PR with no blocking issues — confirm "No blocking issues found" result comment
- [ ] Verify the review comment footer now shows the `/fix` hint

This pull request and its description were written by Isaac.