### PR TITLE
fix(model-catalog): enumerate cursor-native as curated static listing 

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -771,22 +771,33 @@ def _listing_for_provider(
 def _static_subscription_listing(provider: ResolvedModelProvider) -> ModelListing:
     """Build the curated static listing for a no-listing-API provider.
 
-    Covers the subscription CLI logins (claude / codex) and cursor — none of
-    which expose an enumerable listing at resolve time.
+    Covers the subscription CLI logins (claude / codex) and cursor. The
+    subscription CLIs expose no model-listing API at all, whereas cursor is
+    an SDK harness whose ``cursor-agent models`` command does exist but is
+    account-scoped/auth-gated and is not enumerated here — so each gets a
+    note that states the correct reason its listing is static.
 
     :param provider: A ``kind="subscription"`` provider descriptor.
     :returns: A ``source="static"`` listing with ``verified=False``.
     """
     ids = _SUBSCRIPTION_STATIC_MODELS.get(provider.cli or "", ())
+    if provider.cli == "cursor":
+        note = (
+            "curated static model set for the cursor-native SDK harness "
+            "(no listing API is enumerated here; availability depends on "
+            "the logged-in Cursor plan)"
+        )
+    else:
+        note = (
+            f"curated aliases for the {provider.cli or 'unknown'} CLI login "
+            "(subscription logins expose no model-listing API; availability "
+            "depends on the logged-in plan)"
+        )
     return ModelListing(
         source="static",
         verified=False,
         models=tuple(ModelEntry(id=i, family=model_family_token(i)) for i in ids),
-        note=(
-            f"curated aliases for the {provider.cli or 'unknown'} CLI login "
-            "(subscription logins expose no model-listing API; availability "
-            "depends on the logged-in plan)"
-        ),
+        note=note,
     )
 
 

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -72,11 +72,29 @@ _LLM_NAME_TOKENS = ("claude", "gpt", "codex", "gemini", "llama", "qwen", "kimi")
 # Chat-capable endpoint tasks ("llm/v1/chat"); embeddings/rerankers don't match.
 _LLM_TASK_TOKENS = ("chat", "completion")
 
-# Subscription CLIs expose no listing API: curated ids matching the bundled
-# catalog pin (claude) and the codex ids the codebase already references.
+# Curated static model ids for providers with no enumerable listing API at
+# resolve time. The claude/codex entries are subscription CLI logins; the
+# cursor entry is the cursor-native harness (Cursor SDK), which talks only to
+# Cursor's own backend (no Databricks gateway / OpenAI-compatible /v1/models)
+# and whose ``cursor-agent models`` listing is account-scoped + needs auth — so
+# we pin a stable representative subset of Cursor's base model families
+# (sourced from ``cursor-agent models``) rather than gate the row on a key.
 _SUBSCRIPTION_STATIC_MODELS: dict[str, tuple[str, ...]] = {
     "claude": ("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"),
     "codex": ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"),
+    "cursor": (
+        "auto",
+        "composer-2.5",
+        "gpt-5.5",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-5.3-codex",
+        "claude-opus-4-8",
+        "claude-4.6-sonnet",
+        "claude-haiku-4-5",
+        "gemini-3.1-pro",
+        "gemini-3.5-flash",
+    ),
 }
 
 # Harness spellings -> the workflow harness whose provider resolution they
@@ -100,6 +118,13 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
     "agy": "antigravity",
     "google-antigravity": "antigravity",
 }
+
+# cursor-native has no AgentHarnessType sibling to resolve through (the Cursor
+# SDK talks only to Cursor's backend — no Databricks gateway / OpenAI-compatible
+# /v1/models — so cursor is deliberately excluded from the shared provider
+# machinery). It enumerates from the same curated static path as the
+# subscription CLIs instead (see resolve_model_provider).
+_CURSOR_HARNESSES = frozenset({"cursor", "cursor-native", "native-cursor"})
 
 # Preferred inline family per single-family harness (pi consumes both).
 _KEY_AUTH_FAMILY: dict[str, str] = {
@@ -327,6 +352,11 @@ def _resolve_model_provider_unsafe(spec: Any, harness: str | None) -> ResolvedMo
     # consumed from the runner's dispatch path.
     from omnigent.runtime.workflow import _resolve_provider_for_build
 
+    if (harness or "") in _CURSOR_HARNESSES:
+        # cursor enumerates from the curated static path (its model set is
+        # SDK-determined and not auth-gated); it has no AgentHarnessType sibling
+        # to feed _resolve_provider_for_build.
+        return ResolvedModelProvider(kind=SUBSCRIPTION_KIND, cli="cursor", detail="cursor-native")
     harness_type = _PROVIDER_RESOLUTION_HARNESS.get(harness or "")
     if harness_type is None:
         return ResolvedModelProvider(
@@ -739,7 +769,10 @@ def _listing_for_provider(
 
 
 def _static_subscription_listing(provider: ResolvedModelProvider) -> ModelListing:
-    """Build the curated static listing for a subscription CLI login.
+    """Build the curated static listing for a no-listing-API provider.
+
+    Covers the subscription CLI logins (claude / codex) and cursor — none of
+    which expose an enumerable listing at resolve time.
 
     :param provider: A ``kind="subscription"`` provider descriptor.
     :returns: A ``source="static"`` listing with ``verified=False``.

--- a/tests/e2e/test_cursor_model_catalog_e2e.py
+++ b/tests/e2e/test_cursor_model_catalog_e2e.py
@@ -1,0 +1,260 @@
+"""Mock-LLM e2e: ``sys_list_models`` reports a cursor-native worker.
+
+Boots a throwaway LOCAL server from this working tree and drives a minimal
+orchestrator (one cursor-native sub-agent) headless using a mock LLM. The mock
+brain emits a single scripted ``sys_list_models`` tool call, so the runner
+exercises the real catalog-enumeration path the tool dispatches without
+requiring a ``CURSOR_API_KEY`` or the ``cursor-agent`` binary — cursor-native's
+listing is a curated static set, not an authenticated fetch.
+
+Regression guard: cursor-native was absent from the model-catalog provider
+resolution map, so this row came back ``source: "none"`` even though the worker
+runs fine when dispatched. After the fix it must resolve to ``source: "static"``
+with the curated Cursor model ids (incl. the pinned ``gpt-5.5``).
+
+The repo's ``examples/polly`` has no cursor sub-agent, so this test materializes
+its own minimal orchestrator bundle rather than reuse ``_mock_polly_spec_dir``.
+
+Run::
+
+    pytest tests/e2e/test_cursor_model_catalog_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.e2e.test_polly_e2e import (
+    _MOCK_BRAIN_MODEL,
+    _REPO,
+    _SERVER_BOOT_TIMEOUT_SEC,
+    _free_port,
+    _mock_env,
+    _wait_for_health,
+)
+
+# Mock runs are fast (no real model inference) so a short timeout is enough.
+_RUN_TIMEOUT_SEC = 300
+_ORCH_NAME = "cursor_orch"
+
+
+def _api(base_url: str, path: str) -> dict[str, Any]:
+    """
+    GET a local-server API path and decode the JSON body.
+
+    :param base_url: Server base URL, e.g. ``"http://127.0.0.1:8811"``.
+    :param path: API path starting with ``/``, e.g. ``"/v1/sessions"``.
+    :returns: Decoded JSON object.
+    """
+    with urllib.request.urlopen(f"{base_url}{path}", timeout=15) as resp:
+        return json.load(resp)
+
+
+def _mock_cursor_orchestrator_dir(tmp_path: Path, mock_llm_server_url: str) -> Path:
+    """
+    Materialize a minimal orchestrator bundle with one cursor-native sub-agent.
+
+    The brain runs the ``openai-agents`` harness wired to the mock LLM server
+    (api_key + connection blocks, mirroring ``_mock_polly_spec_dir``); the sole
+    sub-agent (``cursor``) keeps the ``cursor-native`` harness with a pinned
+    model so ``sys_list_models`` enumerates it. The cursor worker is never
+    dispatched — only listed — so no Cursor credential or binary is needed.
+
+    :param tmp_path: Per-test temp dir to write the bundle into.
+    :param mock_llm_server_url: The mock LLM server base URL.
+    :returns: Path to the orchestrator bundle directory.
+    """
+    base = f"{mock_llm_server_url}/v1"
+    dst = tmp_path / _ORCH_NAME
+    (dst / "agents" / "cursor").mkdir(parents=True)
+
+    orchestrator = {
+        "spec_version": 1,
+        "name": _ORCH_NAME,
+        "description": "Test orchestrator with a cursor-native sub-agent.",
+        "async": True,
+        "executor": {
+            "type": "omnigent",
+            "model": _MOCK_BRAIN_MODEL,
+            "config": {"harness": "openai-agents"},
+            "auth": {"type": "api_key", "api_key": "mock-key", "base_url": base},
+            "connection": {"base_url": base, "api_key": "mock-key"},
+        },
+        "prompt": "You are a test orchestrator. Call sys_list_models, then stop.",
+        "tools": {"agents": ["cursor"]},
+    }
+    (dst / "config.yaml").write_text(yaml.safe_dump(orchestrator, sort_keys=False))
+
+    cursor_worker = {
+        "spec_version": 1,
+        "name": "cursor",
+        "description": "Cursor coding worker (cursor-native harness, pinned model).",
+        "executor": {
+            "type": "omnigent",
+            "model": "gpt-5.5",
+            "config": {"harness": "cursor-native"},
+        },
+        "prompt": "You are a Cursor coding sub-agent.",
+    }
+    (dst / "agents" / "cursor" / "config.yaml").write_text(
+        yaml.safe_dump(cursor_worker, sort_keys=False)
+    )
+    return dst
+
+
+@pytest.fixture
+def local_server(tmp_path: Path) -> Iterator[str]:
+    """
+    Start a throwaway local ``omnigent server`` from this working tree.
+
+    Own sqlite DB + artifact dir under ``tmp_path`` keep it isolated from the
+    developer's real omnigent state.
+
+    :param tmp_path: pytest-provided per-test temp dir for the DB + artifacts.
+    :yields: The base URL of the running server.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    import os
+
+    env = {
+        **os.environ,
+        "OMNIGENT_SKIP_ONBOARD": "1",
+        "OMNIGENT_NO_UPDATE_CHECK": "1",
+    }
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{tmp_path / 'cursor_model_e2e.db'}",
+            "--artifact-location",
+            str(tmp_path / "artifacts"),
+        ],
+        cwd=str(_REPO),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_health(base_url, time.monotonic() + _SERVER_BOOT_TIMEOUT_SEC)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_sys_list_models_reports_cursor_worker_as_static(
+    local_server: str,
+    mock_llm_server_url: str,
+    tmp_path: Path,
+) -> None:
+    """
+    The mock brain calls ``sys_list_models``; the cursor worker row is static.
+
+    End-to-end proof that the runner-dispatched ``sys_list_models`` enumerates a
+    cursor-native worker as ``source: "static"`` with the curated Cursor models
+    (incl. the pinned ``gpt-5.5``) — not the pre-fix ``source: "none"`` — without
+    any cursor credential or binary on the box.
+
+    :param local_server: Base URL of the in-tree local server fixture.
+    :param mock_llm_server_url: Mock LLM server base URL.
+    :param tmp_path: Per-test temp dir for the orchestrator bundle.
+    """
+    from tests.e2e.conftest import configure_mock_llm, reset_mock_llm
+
+    reset_mock_llm(mock_llm_server_url)
+    orch_dir = _mock_cursor_orchestrator_dir(tmp_path, mock_llm_server_url)
+    tag = uuid.uuid4().hex[:8]
+
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            # Step 1: call sys_list_models.
+            {
+                "tool_calls": [
+                    {
+                        "call_id": f"call-lm-{tag}",
+                        "name": "sys_list_models",
+                        "arguments": "{}",
+                    }
+                ]
+            },
+            # Step 2: after the catalog arrives, end the turn.
+            {"text": "Listed models. Cursor worker enumerated."},
+        ],
+        key=_MOCK_BRAIN_MODEL,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "run",
+            str(orch_dir),
+            "--server",
+            local_server,
+            "-p",
+            "Call sys_list_models and report the cursor worker's models.",
+        ],
+        cwd=str(_REPO),
+        env=_mock_env(mock_llm_server_url),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+    assert result.returncode == 0, (
+        f"orchestrator run exited {result.returncode}\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+    sessions = _api(local_server, "/v1/sessions").get("data", [])
+    parents = [s["id"] for s in sessions if s.get("agent_name") == _ORCH_NAME]
+    assert parents, f"no {_ORCH_NAME} session found among {len(sessions)} sessions"
+    parent = parents[0]
+
+    items = _api(local_server, f"/v1/sessions/{parent}/items").get("data", [])
+    call_ids = {
+        item.get("call_id")
+        for item in items
+        if item.get("type") == "function_call" and item.get("name") == "sys_list_models"
+    }
+    assert call_ids, "no sys_list_models function_call found in the parent transcript"
+    catalogs = [
+        json.loads(item.get("output") or "{}")
+        for item in items
+        if item.get("type") == "function_call_output" and item.get("call_id") in call_ids
+    ]
+    assert catalogs, "no sys_list_models tool result found in the parent transcript"
+
+    cursor_row = catalogs[-1].get("cursor")
+    assert cursor_row, f"sys_list_models result has no 'cursor' row: {catalogs[-1]}"
+    # The regression: this row was "none" before cursor was added to the catalog.
+    assert cursor_row["source"] == "static", (
+        f"cursor worker row should be static, got: {cursor_row}"
+    )
+    assert "gpt-5.5" in {m["id"] for m in cursor_row["models"]}, (
+        f"cursor models missing the pinned gpt-5.5: {cursor_row['models']}"
+    )

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -732,6 +732,72 @@ def test_subscription_listing_is_static_and_unverified(
     assert "CLI login" in listing.note
 
 
+def test_cursor_native_listing_is_static_without_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cursor-native yields a curated static list, not ``source="none"``.
+
+    Regression: cursor-native was absent from the provider-resolution map, so
+    ``sys_list_models`` reported ``source="none"`` even though the worker runs
+    fine. Its model set is config/SDK-determined (not auth-gated), so the row
+    must resolve to the curated static listing with NO cursor key configured —
+    here the isolated config has no ``providers:`` / cursor block at all.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+    spec = _worker_spec("cursor-native", model="gpt-5.5")
+    provider = resolve_model_provider(spec, "cursor-native")
+    assert provider.kind == "subscription"
+    assert provider.cli == "cursor"
+
+    listing = list_models_for_worker(spec, "cursor-native")
+    assert listing.source == "static"
+    assert listing.verified is False
+    ids = [m.id for m in listing.models]
+    # The pinned default survives the (multi-model) cursor family filter; the
+    # exact curated set is owned by _SUBSCRIPTION_STATIC_MODELS["cursor"].
+    assert "gpt-5.5" in ids
+
+
+def test_catalog_reports_cursor_subagent_as_static(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A polly-style parent with a cursor-native sub-agent gets a static row.
+
+    Exercises the full ``catalog_for_spec`` path the ``sys_list_models`` tool
+    dispatches, proving the cursor worker row is no longer ``"none"``.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    parent = AgentSpec(
+        spec_version=1,
+        name="orchestrator",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+        sub_agents=[
+            AgentSpec(
+                spec_version=1,
+                name="cursor",
+                executor=ExecutorSpec(
+                    type="omnigent",
+                    model="gpt-5.5",
+                    config={"harness": "cursor-native"},
+                ),
+            )
+        ],
+    )
+
+    catalog = catalog_for_spec(parent)
+
+    assert catalog["cursor"]["source"] == "static"
+    assert "gpt-5.5" in {m["id"] for m in catalog["cursor"]["models"]}
+
+
 def test_none_listing_explains_dead_worker(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -763,6 +763,36 @@ def test_cursor_native_listing_is_static_without_key(
     assert "gpt-5.5" in ids
 
 
+def test_cursor_native_listing_keeps_non_gpt_families(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cursor's curated list survives intact across gpt/claude/gemini families.
+
+    Regression guard for the multi-model contract: cursor-native is treated as
+    a multi-vendor harness and is NOT in any single-vendor reject set, so the
+    family filter in ``list_models_for_worker`` must keep non-GPT ids too. If
+    someone later added cursor to a single-family set, the gemini/claude/
+    composer ids would be silently dropped and only GPT ids would survive —
+    this asserts representative non-GPT ids from
+    ``_SUBSCRIPTION_STATIC_MODELS["cursor"]`` stay present.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Per-test temp dir.
+    """
+    _isolate_config(monkeypatch, tmp_path, "")
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+    spec = _worker_spec("cursor-native", model="gpt-5.5")
+    listing = list_models_for_worker(spec, "cursor-native")
+
+    assert listing.source == "static"
+    ids = {m.id for m in listing.models}
+    # Non-GPT families and the cursor-only aliases must all survive the filter.
+    assert "gemini-3.1-pro" in ids
+    assert "claude-opus-4-8" in ids
+    assert "composer-2.5" in ids
+
+
 def test_catalog_reports_cursor_subagent_as_static(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

`cursor-native` was missing from the model-catalog provider-resolution map, so `sys_list_models` reported a perfectly runnable Cursor sub-agent as source: "none". This wires cursor-native into the catalog as a curated static listing (source: "static", verified: false), so the row reflects reality.

Fixes omnigent-ai/omnigent#998

This PR contains the base cursor-native fix **plus two design-review follow-ups**:

### 1\. Cursor-specific static-listing note

`_static_subscription_listing` now branches `ModelListing.note` by `provider.cli`. The shared note claimed *"subscription logins expose no model-listing API"* — untrue for cursor, which is an SDK harness whose `cursor-agent models` command does exist but is account-scoped/auth-gated and simply isn't enumerated here. cursor now gets an accurate note; claude/codex keep the original.

### 2\. Multi-family filter regression test

`test_cursor_native_listing_keeps_non_gpt_families` pins the multi-vendor contract: the curated cursor list mixes gpt/claude/gemini families plus `auto`/`composer-2.5`, and works only because cursor is treated as multi-model and is in no single-vendor reject set. The test asserts `gemini-3.1-pro`, `claude-opus-4-8`, and `composer-2.5` survive the family filter, guarding against cursor being silently added to a single-family set.

## Testing

* `uv run pytest tests/test_model_catalog.py -q` → **43 passed**
* `uv run ruff check omnigent/model_catalog.py tests/test_model_catalog.py` → clean
* `uv run mypy omnigent/model_catalog.py` → 9 pre-existing baseline errors, no new ones