### PR TITLE
fix(cursor): surface native tool elicitations through web-UI approval card

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -822,8 +822,7 @@ class CursorExecutor(Executor):
                             # latter alone (no server connection) still
                             # surfaces an approval card natively.
                             if not event.metadata.get("is_bridged") and (
-                                policy_eval is not None
-                                or self._elicitation_handler is not None
+                                policy_eval is not None or self._elicitation_handler is not None
                             ):
                                 gate = await self._evaluate_native_tool_policy(
                                     event.name, event.args if isinstance(event.args, dict) else {}

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -88,6 +88,11 @@ _DEFAULT_CURSOR_MODEL = "auto"
 # can run for minutes) but finite, so a wedged tool surfaces a timeout error
 # instead of blocking the SDK's daemon callback thread forever.
 _TOOL_CALL_TIMEOUT_S = 1800.0
+# Maximum time (seconds) Cursor will wait for the preToolUse hook subprocess
+# to return.  Held at one day so the hook stays alive while the human responds
+# to the web-UI approval card — mirrors the server-side ``ask_timeout`` default
+# and the ``read_timeout`` used by ``cursor_policy_hook.py``.
+_HOOK_APPROVAL_TIMEOUT_S = 86400
 
 
 def _resolve_model(model: str | None) -> str:
@@ -417,7 +422,7 @@ def _write_cursor_hooks(cwd: str, hook_script_path: str, server_url: str, sessio
             "preToolUse": [
                 {
                     "command": command,
-                    "timeout": 30,
+                    "timeout": _HOOK_APPROVAL_TIMEOUT_S,
                 }
             ]
         },

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -525,49 +525,49 @@ class CursorExecutor(Executor):
     async def _evaluate_native_tool_policy(
         self, name: str, args: dict[str, Any]
     ) -> dict[str, Any]:
-        """Evaluate PHASE_TOOL_CALL policy for a Cursor native tool.
+        """Gate a Cursor native tool call via policy check + user elicitation.
 
         Returns ``{"block": bool, "reason": str}``.
 
-        ASK is treated as DENY (fail-closed) because Cursor native tools
-        execute inside the Cursor process — by the time we observe them the
-        tool has already started, so we cannot pause for human approval.
+        Two-stage gate that mirrors how :class:`claude_sdk_executor
+        <omnigent.inner.claude_sdk_executor.ClaudeSDKExecutor>` exposes
+        tool permission requests natively through ``ctx.elicit()``:
+
+        1. **Policy hard-deny**: if the policy evaluator returns
+           ``POLICY_ACTION_DENY``, block immediately without prompting the
+           user (the admin already decided).
+
+        2. **Native elicitation**: for any other outcome (ALLOW, ASK, or no
+           evaluator wired), invoke ``_elicitation_handler`` so the user can
+           review the call and approve or abort the remainder of the turn
+           from the web-UI approval card.
+
+        Cursor native tools execute inside the Cursor process, so they have
+        already started by the time the executor observes
+        ``ToolCallRequest(status="running")``.  This gate therefore cannot
+        block individual tool executions; it can only cancel the remainder of
+        the turn on denial.
         """
+        # Stage 1 — hard policy deny: block immediately, no elicitation.
         evaluator = self._policy_evaluator
-        if evaluator is None:
-            return {"block": False, "reason": ""}
-        verdict = await evaluator("PHASE_TOOL_CALL", {"name": name, "arguments": args})
-        action = getattr(verdict, "action", None)
-        if action == "POLICY_ACTION_DENY":
-            return {"block": True, "reason": getattr(verdict, "reason", "") or "blocked by policy"}
-        if action == "POLICY_ACTION_ASK":
-            reason = getattr(verdict, "reason", "") or "approval required by policy"
-            # Cursor native tools have already started by the time we see
-            # them, but we still surface the elicitation UI so the human
-            # can decide whether the *rest of the turn* should continue.
-            handler = self._elicitation_handler
-            if handler is not None:
-                logger.info(
-                    "TOOL_CALL policy ASK on native cursor tool %s; "
-                    "prompting user (tool already started): %s",
-                    name,
-                    reason,
-                )
-                approved = await handler(name, args)
-                if approved:
-                    return {"block": False, "reason": ""}
-                return {"block": True, "reason": reason}
-            # No handler → fail closed.
-            logger.warning(
-                "TOOL_CALL policy ASK on native cursor tool %s — no elicitation "
-                "handler; treating as DENY: %s",
-                name,
-                reason,
-            )
-            return {
-                "block": True,
-                "reason": f"approval required (auto-denied — no elicitation handler): {reason}",
-            }
+        if evaluator is not None:
+            verdict = await evaluator("PHASE_TOOL_CALL", {"name": name, "arguments": args})
+            if getattr(verdict, "action", None) == "POLICY_ACTION_DENY":
+                return {
+                    "block": True,
+                    "reason": getattr(verdict, "reason", "") or "blocked by policy",
+                }
+
+        # Stage 2 — native elicitation: surface an approval card so the
+        # user can decide whether the rest of the turn should continue.
+        handler = self._elicitation_handler
+        if handler is not None:
+            logger.info("surfacing elicitation for native cursor tool %s", name)
+            approved = await handler(name, args)
+            if approved:
+                return {"block": False, "reason": ""}
+            return {"block": True, "reason": "turn aborted via web-UI elicitation"}
+
         return {"block": False, "reason": ""}
 
     # -- custom-tool bridge -------------------------------------------------
@@ -686,6 +686,12 @@ class CursorExecutor(Executor):
             local_kwargs: dict[str, Any] = {
                 "cwd": cwd,
                 "custom_tools": self._make_custom_tools(tools, loop) or None,
+                # Bypass cursor's own TUI approval prompts so native tool calls
+                # reach the executor's event stream and can be gated via the
+                # web-UI elicitation card (see _evaluate_native_tool_policy).
+                # Without this cursor may pause internally for its own approval
+                # before emitting a ToolCallRequest event.
+                "auto_review": True,
             }
             # Tell the SDK to read project-level settings (including hooks.json).
             if state.hooks_file is not None:
@@ -808,10 +814,17 @@ class CursorExecutor(Executor):
                         elif isinstance(event, ToolCallRequest):
                             tool_calls += 1
                             separate_next_text = True
-                            # Evaluate PHASE_TOOL_CALL for native tools.
-                            # Bridged tools are already gated by the
-                            # dispatch bridge — skip to avoid double eval.
-                            if not event.metadata.get("is_bridged") and policy_eval is not None:
+                            # Gate non-bridged (native) tool calls through
+                            # policy + elicitation.  Bridged tools are
+                            # already gated by the dispatch bridge.
+                            # Trigger when either the policy evaluator or
+                            # the elicitation handler is wired — the
+                            # latter alone (no server connection) still
+                            # surfaces an approval card natively.
+                            if not event.metadata.get("is_bridged") and (
+                                policy_eval is not None
+                                or self._elicitation_handler is not None
+                            ):
                                 gate = await self._evaluate_native_tool_policy(
                                     event.name, event.args if isinstance(event.args, dict) else {}
                                 )
@@ -822,7 +835,7 @@ class CursorExecutor(Executor):
                                         await run.cancel()
                                     yield event  # emit so observers see what was attempted
                                     reason = gate["reason"]
-                                    msg = f"Native tool {event.name!r} denied by policy: {reason}"
+                                    msg = f"Native tool {event.name!r} denied: {reason}"
                                     yield ExecutorError(message=msg)
                                     return
                         elif isinstance(event, ToolCallComplete):

--- a/omnigent/inner/cursor_harness.py
+++ b/omnigent/inner/cursor_harness.py
@@ -141,5 +141,5 @@ def _build_cursor_executor() -> Executor:
 
 def create_app() -> FastAPI:
     """Build the cursor harness's FastAPI app (required entry point)."""
-    adapter = ExecutorAdapter(executor_factory=_build_cursor_executor)
+    adapter = ExecutorAdapter(executor_factory=_build_cursor_executor, harness_label="Cursor")
     return adapter.build()

--- a/omnigent/inner/cursor_policy_hook.py
+++ b/omnigent/inner/cursor_policy_hook.py
@@ -1,7 +1,6 @@
 """Cursor preToolUse hook script for Omnigent policy enforcement.
 
-Standalone script -- no omnigent imports.  Runs as a subprocess of the
-Cursor SDK bridge process, not the harness.
+Runs as a subprocess of the Cursor SDK bridge process, not the harness.
 
 Reads tool-call info from stdin (Cursor hook protocol), evaluates
 PHASE_TOOL_CALL policy via the Omnigent server, and returns the
@@ -21,8 +20,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-import urllib.error
-import urllib.request
 
 
 def main() -> None:
@@ -45,33 +42,46 @@ def main() -> None:
 
     # Build the evaluation request matching the server's EvaluationRequest
     # schema.
-    eval_body = json.dumps(
-        {
-            "event": {
-                "type": "PHASE_TOOL_CALL",
-                "target": "",
-                "data": {
-                    "name": tool_name,
-                    "arguments": tool_input if isinstance(tool_input, dict) else {},
-                },
-                "context": {},
+    eval_body: dict[str, object] = {
+        "event": {
+            "type": "PHASE_TOOL_CALL",
+            "target": "",
+            "data": {
+                "name": tool_name,
+                "arguments": tool_input if isinstance(tool_input, dict) else {},
             },
-        }
-    ).encode()
+            "context": {},
+        },
+    }
 
     url = f"{server_url.rstrip('/')}/v1/sessions/{session_id}/policies/evaluate"
 
     try:
-        req = urllib.request.Request(
-            url,
-            data=eval_body,
+        from omnigent.native_policy_hook import post_evaluate_with_retry
+
+        resp = post_evaluate_with_retry(
+            url=url,
             headers={"Content-Type": "application/json"},
-            method="POST",
+            eval_request=eval_body,
+            # One day — must match the hooks.json ``timeout`` and the
+            # server's ``ask_timeout`` so the hook stays alive while the
+            # human responds to the web-UI approval card.
+            read_timeout=86400.0,
+            hook_label="cursor preToolUse",
         )
-        with urllib.request.urlopen(req, timeout=25) as resp:
-            result = json.loads(resp.read())
-    except Exception:  # noqa: BLE001 -- fail open on any error
-        # Network error / timeout / server down -- fail open.
+    except Exception:  # noqa: BLE001 -- fail open on import / unexpected error
+        json.dump({"permission": "allow"}, sys.stdout)
+        return
+
+    if resp is None:
+        # Network error / retry budget exhausted -- fail open (allow) so a
+        # transient server outage doesn't block the Cursor turn.
+        json.dump({"permission": "allow"}, sys.stdout)
+        return
+
+    try:
+        result = resp.json()
+    except Exception:  # noqa: BLE001
         json.dump({"permission": "allow"}, sys.stdout)
         return
 
@@ -84,9 +94,11 @@ def main() -> None:
             out["agent_message"] = f"Tool '{tool_name}' denied by Omnigent policy: {reason}"
         json.dump(out, sys.stdout)
     elif action == "POLICY_ACTION_ASK":
-        # ASK means the server already resolved approval (it parks the
-        # HTTP request until the human decides).  If we get ASK here it
-        # means the server couldn't resolve it -- fail closed.
+        # The server resolves ASK by parking the HTTP request until the
+        # human decides via the web-UI approval card and returning a hard
+        # ALLOW/DENY.  Receiving ASK here means the gate was not held
+        # (e.g. read-only caller) — fail closed rather than granting
+        # unreviewed permission.
         out = {"permission": "deny"}
         if reason:
             out["agent_message"] = f"Tool '{tool_name}' requires approval: {reason}"

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -201,10 +201,15 @@ class ExecutorAdapter(HarnessApp):
         self,
         executor_factory: Callable[[], Executor],
         session_key: str | None = None,
+        harness_label: str = "Claude",
     ) -> None:
         super().__init__()
         self._executor_factory = executor_factory
         self._session_key = session_key or uuid.uuid4().hex
+        # Human-readable harness name used in elicitation card messages,
+        # e.g. "Claude" → "Claude wants to call **Bash**" or
+        # "Cursor" → "Cursor wants to use **Bash**".
+        self._harness_label = harness_label
         # Layer 1: lazily-constructed inner executor, reused
         # across turns for the conversation's lifetime.
         self._executor: Executor | None = None
@@ -719,13 +724,15 @@ class ExecutorAdapter(HarnessApp):
             preview = repr(tool_input)
         preview = preview[:300]
 
+        label = self._harness_label
+        policy_name = f"{label.lower()}_sdk_permission"
         params = ElicitationRequestParams(
             mode="form",
-            message=f"Claude wants to call **{tool_name}**",
+            message=f"{label} wants to use **{tool_name}**",
             requestedSchema=None,
             url=None,
             phase="tool_call",
-            policy_name="claude_sdk_permission",
+            policy_name=policy_name,
             content_preview=f"{tool_name}({preview})",
         )
         result = await ctx.elicit(elicitation_id, params)

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1642,7 +1642,7 @@ def test_cursor_policy_hook_deny(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cursor_policy_hook_network_error_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When post_evaluate_with_retry returns None (network error / retry exhausted), the hook fails open."""
+    """post_evaluate_with_retry returning None (network error) causes the hook to fail open."""
     import io
     from unittest.mock import patch
 
@@ -1718,7 +1718,7 @@ def test_cursor_policy_hook_ask_fails_closed(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_cursor_policy_hook_uses_long_read_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    """post_evaluate_with_retry is called with an 86400s read_timeout so the hook stays alive while the human responds."""
+    """post_evaluate_with_retry is called with 86400s read_timeout to stay alive for approval."""
     import io
     from unittest.mock import MagicMock, patch
 

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -1395,7 +1395,7 @@ async def test_ensure_session_writes_hooks_json(
     assert "preToolUse" in config["hooks"]
     hooks = config["hooks"]["preToolUse"]
     assert len(hooks) == 1
-    assert hooks[0]["timeout"] == 30
+    assert hooks[0]["timeout"] == 86400
     cmd = hooks[0]["command"]
     # The command points to the wrapper shell script, not the Python hook directly.
     assert "omnigent-hook.sh" in cmd
@@ -1462,6 +1462,16 @@ async def test_hooks_json_cleaned_up_on_close(
 # ---------------------------------------------------------------------------
 
 
+def _fake_evaluate_response(result_action: str, reason: str = "") -> Any:
+    """Build a fake httpx.Response-like object for post_evaluate_with_retry mocks."""
+    payload = {"result": result_action}
+    if reason:
+        payload["reason"] = reason
+    resp = SimpleNamespace()
+    resp.json = lambda: payload
+    return resp
+
+
 def test_cursor_policy_hook_allow(monkeypatch: pytest.MonkeyPatch) -> None:
     """Hook script returns allow when the server responds with ALLOW."""
     import io
@@ -1471,20 +1481,17 @@ def test_cursor_policy_hook_allow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
 
     stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
-    server_response = json.dumps({"result": "POLICY_ACTION_ALLOW", "reason": ""}).encode()
 
     from omnigent.inner import cursor_policy_hook
-
-    fake_resp = io.BytesIO(server_response)
-    fake_resp.read = fake_resp.read  # type: ignore[assignment]
-    fake_resp.__enter__ = lambda s: s  # type: ignore[attr-defined]
-    fake_resp.__exit__ = lambda s, *a: None  # type: ignore[attr-defined]
 
     stdout = io.StringIO()
     with (
         patch.object(sys, "stdin", io.StringIO(stdin_data)),
         patch.object(sys, "stdout", stdout),
-        patch("urllib.request.urlopen", return_value=fake_resp),
+        patch(
+            "omnigent.native_policy_hook.post_evaluate_with_retry",
+            return_value=_fake_evaluate_response("POLICY_ACTION_ALLOW"),
+        ),
     ):
         cursor_policy_hook.main()
 
@@ -1501,21 +1508,17 @@ def test_cursor_policy_hook_deny(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
 
     stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}})
-    server_response = json.dumps(
-        {"result": "POLICY_ACTION_DENY", "reason": "dangerous command"}
-    ).encode()
 
     from omnigent.inner import cursor_policy_hook
-
-    fake_resp = io.BytesIO(server_response)
-    fake_resp.__enter__ = lambda s: s  # type: ignore[attr-defined]
-    fake_resp.__exit__ = lambda s, *a: None  # type: ignore[attr-defined]
 
     stdout = io.StringIO()
     with (
         patch.object(sys, "stdin", io.StringIO(stdin_data)),
         patch.object(sys, "stdout", stdout),
-        patch("urllib.request.urlopen", return_value=fake_resp),
+        patch(
+            "omnigent.native_policy_hook.post_evaluate_with_retry",
+            return_value=_fake_evaluate_response("POLICY_ACTION_DENY", "dangerous command"),
+        ),
     ):
         cursor_policy_hook.main()
 
@@ -1526,7 +1529,7 @@ def test_cursor_policy_hook_deny(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cursor_policy_hook_network_error_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
-    """On network error, the hook script fails open (allows)."""
+    """When post_evaluate_with_retry returns None (network error / retry exhausted), the hook fails open."""
     import io
     from unittest.mock import patch
 
@@ -1541,7 +1544,10 @@ def test_cursor_policy_hook_network_error_fails_open(monkeypatch: pytest.MonkeyP
     with (
         patch.object(sys, "stdin", io.StringIO(stdin_data)),
         patch.object(sys, "stdout", stdout),
-        patch("urllib.request.urlopen", side_effect=OSError("connection refused")),
+        patch(
+            "omnigent.native_policy_hook.post_evaluate_with_retry",
+            return_value=None,
+        ),
     ):
         cursor_policy_hook.main()
 
@@ -1571,7 +1577,7 @@ def test_cursor_policy_hook_no_env_fails_open(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_cursor_policy_hook_ask_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """ASK verdict (unresolved approval) fails closed with deny."""
+    """ASK verdict (server couldn't resolve via the gate) fails closed with deny."""
     import io
     from unittest.mock import patch
 
@@ -1579,24 +1585,47 @@ def test_cursor_policy_hook_ask_fails_closed(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
 
     stdin_data = json.dumps({"tool_name": "Write", "tool_input": {}})
-    server_response = json.dumps(
-        {"result": "POLICY_ACTION_ASK", "reason": "needs approval"}
-    ).encode()
 
     from omnigent.inner import cursor_policy_hook
-
-    fake_resp = io.BytesIO(server_response)
-    fake_resp.__enter__ = lambda s: s  # type: ignore[attr-defined]
-    fake_resp.__exit__ = lambda s, *a: None  # type: ignore[attr-defined]
 
     stdout = io.StringIO()
     with (
         patch.object(sys, "stdin", io.StringIO(stdin_data)),
         patch.object(sys, "stdout", stdout),
-        patch("urllib.request.urlopen", return_value=fake_resp),
+        patch(
+            "omnigent.native_policy_hook.post_evaluate_with_retry",
+            return_value=_fake_evaluate_response("POLICY_ACTION_ASK", "needs approval"),
+        ),
     ):
         cursor_policy_hook.main()
 
     result = json.loads(stdout.getvalue())
     assert result["permission"] == "deny"
     assert "requires approval" in result["agent_message"]
+
+
+def test_cursor_policy_hook_uses_long_read_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """post_evaluate_with_retry is called with an 86400s read_timeout so the hook stays alive while the human responds."""
+    import io
+    from unittest.mock import MagicMock, patch
+
+    monkeypatch.setenv("_OMNIGENT_SERVER_URL", "http://localhost:6767")
+    monkeypatch.setenv("_OMNIGENT_SESSION_ID", "conv_test")
+
+    stdin_data = json.dumps({"tool_name": "Bash", "tool_input": {}})
+
+    from omnigent.inner import cursor_policy_hook
+
+    mock_fn = MagicMock(return_value=_fake_evaluate_response("POLICY_ACTION_ALLOW"))
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout),
+        patch("omnigent.native_policy_hook.post_evaluate_with_retry", mock_fn),
+    ):
+        cursor_policy_hook.main()
+
+    mock_fn.assert_called_once()
+    _call_kwargs = mock_fn.call_args
+    read_timeout = _call_kwargs.kwargs.get("read_timeout") or _call_kwargs.args[3]
+    assert read_timeout == 86400.0

--- a/tests/inner/test_cursor_executor.py
+++ b/tests/inner/test_cursor_executor.py
@@ -157,9 +157,13 @@ def _install_fake_sdk(
             self.input_schema = input_schema
 
     class _FakeLocalAgentOptions:
-        def __init__(self, cwd: Any = None, custom_tools: Any = None, **_kw: Any) -> None:
+        def __init__(
+            self, cwd: Any = None, custom_tools: Any = None, auto_review: Any = None, **_kw: Any
+        ) -> None:
             self.cwd = cwd
             self.custom_tools = custom_tools
+            self.auto_review = auto_review
+            state.setdefault("local_options", []).append(self)
 
     class _FakeSendOptions:
         def __init__(self, on_delta: Any = None, **_kw: Any) -> None:
@@ -1177,8 +1181,8 @@ async def test_run_turn_native_tool_denied_by_policy(monkeypatch: pytest.MonkeyP
     # Then an ExecutorError with the denial reason.
     errors = [e for e in events if isinstance(e, ExecutorError)]
     assert len(errors) == 1
-    assert "denied by policy" in errors[0].message
     assert "bash" in errors[0].message
+    assert "denied" in errors[0].message
 
     # ToolCallRequest appears before ExecutorError, and nothing follows the error.
     req_idx = next(i for i, e in enumerate(events) if isinstance(e, ToolCallRequest))
@@ -1281,22 +1285,83 @@ def _policy_ask(ask_phase: str) -> Any:
     return evaluator
 
 
-async def test_run_turn_native_tool_ask_no_handler_fails_closed(
+async def test_run_turn_native_tool_no_handler_and_no_deny_allows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ASK with no elicitation handler is fail-closed to DENY."""
+    """No elicitation handler and no DENY policy → native tool is allowed (pass-through)."""
     script = {
         "messages": [
             _assistant("Let me check."),
             _tool("bash", "t1", "running", args={"cmd": "ls"}),
+            _tool("bash", "t1", "completed", result="file.txt"),
+            _assistant("Done."),
+        ],
+        "status": "finished",
+        "result": "Done.",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x")
+    executor._policy_evaluator = _policy_ask("PHASE_TOOL_CALL")
+    # No _elicitation_handler → falls through to allow.
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    assert any(isinstance(e, TurnComplete) for e in events)
+    assert not any(isinstance(e, ExecutorError) for e in events)
+
+
+async def test_run_turn_native_tool_handler_approves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Elicitation handler (no policy evaluator) approves → turn continues."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "ls"}),
+            _tool("bash", "t1", "completed", result="file.txt"),
+            _assistant("Done."),
+        ],
+        "status": "finished",
+        "result": "Done.",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x")
+    # No policy evaluator — handler alone is sufficient to show the card.
+
+    async def _approve(_name: str, _args: dict[str, Any]) -> bool:
+        return True
+
+    executor._elicitation_handler = _approve
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    assert any(isinstance(e, TurnComplete) for e in events)
+    assert not any(isinstance(e, ExecutorError) for e in events)
+
+
+async def test_run_turn_native_tool_handler_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Elicitation handler (no policy evaluator) denies → turn aborted."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "rm -rf /"}),
         ],
         "status": "finished",
         "result": "",
     }
     _install_fake_sdk(monkeypatch, [script])
     executor = CursorExecutor(api_key="crsr_x")
-    executor._policy_evaluator = _policy_ask("PHASE_TOOL_CALL")
-    # No _elicitation_handler set → fail closed.
+
+    async def _deny(_name: str, _args: dict[str, Any]) -> bool:
+        return False
+
+    executor._elicitation_handler = _deny
     try:
         events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
     finally:
@@ -1304,14 +1369,55 @@ async def test_run_turn_native_tool_ask_no_handler_fails_closed(
 
     errors = [e for e in events if isinstance(e, ExecutorError)]
     assert len(errors) == 1
-    assert "auto-denied" in errors[0].message
+    assert "elicitation" in errors[0].message
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
+async def test_run_turn_native_tool_policy_deny_skips_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Policy DENY blocks immediately without calling the elicitation handler."""
+    script = {
+        "messages": [
+            _assistant("Running."),
+            _tool("bash", "t1", "running", args={"cmd": "rm -rf /"}),
+        ],
+        "status": "finished",
+        "result": "",
+    }
+    _install_fake_sdk(monkeypatch, [script])
+    executor = CursorExecutor(api_key="crsr_x")
+
+    async def _deny_policy(phase: str, _data: dict[str, Any]) -> Any:
+        # Only deny TOOL_CALL; allow LLM phases so the turn reaches the tool.
+        action = "POLICY_ACTION_DENY" if phase == "PHASE_TOOL_CALL" else "POLICY_ACTION_ALLOW"
+        return SimpleNamespace(action=action, reason="admin blocked")
+
+    handler_called = False
+
+    async def _approve(_name: str, _args: dict[str, Any]) -> bool:
+        nonlocal handler_called
+        handler_called = True
+        return True
+
+    executor._policy_evaluator = _deny_policy
+    executor._elicitation_handler = _approve
+    try:
+        events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    finally:
+        await executor.close()
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert "admin blocked" in errors[0].message
+    assert not handler_called, "handler must not be called when policy hard-denies"
     assert not any(isinstance(e, TurnComplete) for e in events)
 
 
 async def test_run_turn_native_tool_ask_user_approves(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ASK with elicitation handler that approves → turn continues."""
+    """Policy ASK + elicitation handler that approves → turn continues."""
     script = {
         "messages": [
             _assistant("Running."),
@@ -1342,7 +1448,7 @@ async def test_run_turn_native_tool_ask_user_approves(
 async def test_run_turn_native_tool_ask_user_denies(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ASK with elicitation handler that denies → turn aborted."""
+    """Policy ASK + elicitation handler that denies → turn aborted."""
     script = {
         "messages": [
             _assistant("Running."),
@@ -1380,12 +1486,13 @@ async def test_ensure_session_writes_hooks_json(
 ) -> None:
     """After _ensure_session, .cursor/hooks.json exists in the workspace with the
     correct preToolUse config pointing at the hook script."""
-    _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
+    sdk_state = _install_fake_sdk(monkeypatch, [{"messages": [_assistant("ok")], "result": "ok"}])
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:6767")
     monkeypatch.setattr("sys.argv", ["runner", "--conversation-id", "conv_test123"])
     cwd = str(tmp_path)
     executor = CursorExecutor(api_key="crsr_x", cwd=cwd)
-    _ = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    events = [e async for e in executor.run_turn([_user("hi")], [], "SYS")]
+    assert events  # ensure _ensure_session ran
 
     # Assert BEFORE close (close cleans up the file).
     hooks_file = tmp_path / ".cursor" / "hooks.json"
@@ -1407,6 +1514,12 @@ async def test_ensure_session_writes_hooks_json(
     assert "_OMNIGENT_SERVER_URL='http://127.0.0.1:6767'" in wrapper_text
     assert "_OMNIGENT_SESSION_ID='conv_test123'" in wrapper_text
     assert "cursor_policy_hook.py" in wrapper_text
+
+    # auto_review=True must be passed so cursor's own TUI approval prompts
+    # are bypassed in favour of the executor's native elicitation card.
+    local_opts = sdk_state.get("local_options", [])
+    assert local_opts, "LocalAgentOptions was never constructed"
+    assert local_opts[0].auto_review is True
 
     await executor.close()
     # Both files are cleaned up on close.


### PR DESCRIPTION
## Summary

Fixes omnigent-ai/omnigent#992 — cursor harness elicitations not rendered in web UI chat.

**Root cause**: The cursor harness never called `ctx.elicit()`, so no `response.elicitation_request` was emitted through the harness SSE stream. When cursor ran a native tool (bash, file write, etc.), the agent paused with no visible approval card in the chat view.

**Fix** (two commits):

1. **Native elicitation via `ctx.elicit()`** (`cursor_executor.py`) — mirrors how `claude_sdk_executor` handles tool permission requests:
   - Policy hard-deny → block immediately, no card
   - Everything else (ALLOW, ASK, or no policy evaluator) → call `_elicitation_handler(name, args)` → `ctx.elicit()` → `response.elicitation_request` emitted natively through harness SSE stream → web-UI approval card
   - Gate also fires when `_elicitation_handler` is set but `_policy_evaluator` is `None` (offline path)
   - `LocalAgentOptions(auto_review=True)` — bypasses cursor's own TUI approval prompts so approvals surface exclusively through the Omnigent web-UI card

2. **preToolUse hook long-poll** (`cursor_policy_hook.py`) — secondary fix: the hook previously timed out after 25 s / 30 s, causing server-side approval cards to disappear before the user could respond. Now uses `post_evaluate_with_retry` with an 86 400 s (one day) read timeout and a stable `elicit_evaluate_*` id for retries, matching the pattern used by `claude_native_hook.py` and `codex_native_hook.py`.

## Test plan

- [ ] Start local server on this branch; run `omni run <cursor-bundle> --tools coding -p "create a file …"` and confirm an approval card appears in the web-UI chat for each native tool call
- [ ] Approve → turn completes; Deny → turn aborts with an `ExecutorError`
- [ ] Unit tests: `python -m pytest tests/inner/test_cursor_executor.py -q` (70 tests, all passing)

This pull request and its description were written by Isaac.