### PR TITLE
feat(polly-review): let Polly fetch the full PR diff via gh CLI

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -286,12 +286,22 @@ jobs:
 
           **Step 1 — fetch the diff.** Use `sys_os_shell` to run:
             gh pr diff $POLLY_PR_NUMBER --repo $POLLY_REPO
-          This gives you the full diff without a size cap. For large PRs, skip
-          lockfile hunks (uv.lock, package-lock.json, *.lock, *.sum) — they are
-          almost never worth reviewing. You may fetch per-file diffs with:
+          This gives you the full diff without a size cap. You may also fetch
+          per-file diffs with:
             gh api repos/$POLLY_REPO/pulls/$POLLY_PR_NUMBER/files
           to inspect specific files in depth. Read source files from the
           checked-out codebase for additional context when needed.
+
+          **Lockfiles (uv.lock, package-lock.json, *.lock, *.sum):** do NOT
+          skip these — they are a supply chain attack surface. Do NOT read the
+          full hunk (it is noise). Instead extract just the changed package
+          names and versions:
+            gh pr diff $POLLY_PR_NUMBER --repo $POLLY_REPO -- uv.lock | grep '^[+-]name\|^[+-]version' | grep -v '^---\|^+++' | head -200
+          Flag as a **blocking security issue** any of:
+          - A package added to the lockfile that is not declared (directly or
+            transitively via a declared dep) in pyproject.toml.
+          - A version that does not satisfy the constraint in pyproject.toml.
+          - A suspicious version downgrade on a security-sensitive package.
 
           **Step 2 — review.** Report:
           1. **Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -256,25 +256,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fetch the diff (capped at 64 KB to stay within prompt limits).
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-            -H "Accept: application/vnd.github.v3.diff" \
-            | head -c 65536 > /tmp/pr_diff.txt
-
-          # Fetch PR metadata to separate files — avoids embedding
-          # attacker-controlled strings (PR title/body) into heredocs.
+          # Fetch PR metadata only — the diff is fetched by Polly itself at
+          # review time via gh CLI so it can read the full diff without a
+          # hard cap, skip noise (lockfiles), and fetch specific file diffs
+          # as needed. Avoids embedding attacker-controlled strings into heredocs.
           gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json title,body,baseRefName,headRefName,additions,deletions,changedFiles \
             > /tmp/pr_meta.json
 
           # Build the review prompt safely using python — all untrusted
-          # fields (title, body, diff) are read from files, never
-          # interpolated into shell heredocs.
+          # fields (title, body) are read from files, never interpolated
+          # into shell heredocs.
           python3 <<'PYEOF'
           import json, pathlib
 
           meta = json.loads(pathlib.Path("/tmp/pr_meta.json").read_text())
-          diff = pathlib.Path("/tmp/pr_diff.txt").read_text()
 
           prompt = f"""Review this pull request and provide structured feedback.
 
@@ -286,13 +282,18 @@ jobs:
           ## PR Description
           {(meta.get('body') or '')[:4096]}{"  *(truncated)*" if len(meta.get('body') or '') > 4096 else ""}
 
-          ## Diff
-          ```diff
-          {diff}
-          ```
-
           ## Instructions
-          Review the diff against the PR description. Report:
+
+          **Step 1 — fetch the diff.** Use `sys_os_shell` to run:
+            gh pr diff $POLLY_PR_NUMBER --repo $POLLY_REPO
+          This gives you the full diff without a size cap. For large PRs, skip
+          lockfile hunks (uv.lock, package-lock.json, *.lock, *.sum) — they are
+          almost never worth reviewing. You may fetch per-file diffs with:
+            gh api repos/$POLLY_REPO/pulls/$POLLY_PR_NUMBER/files
+          to inspect specific files in depth. Read source files from the
+          checked-out codebase for additional context when needed.
+
+          **Step 2 — review.** Report:
           1. **Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.
           2. **Security vulnerabilities** — injection (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.
           3. **Non-blocking notes** — design concerns or edge cases worth flagging (brief).
@@ -324,6 +325,11 @@ jobs:
         id: polly
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          # Read-only token so Polly can fetch the full diff and file list
+          # via gh CLI without a size cap.
+          GH_TOKEN: ${{ github.token }}
+          POLLY_PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          POLLY_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Removes the 64 KB hard cap on the pre-fetched diff — no more silent truncation on large PRs
- Instead, Polly is told to fetch the diff itself with `gh pr diff` as its first step, and can call `gh api .../pulls/.../files` for per-file inspection
- `GH_TOKEN`, `POLLY_PR_NUMBER`, and `POLLY_REPO` are now set in the Polly run env (read-only token)
- Polly is instructed to skip lockfile hunks (`uv.lock`, `package-lock.json`, etc.) which are the main source of diff bloat on most PRs