### PR TITLE
fix(ci): enforce uv.lock integrity and extend security gate window

### DIFF
--- a/.github/actions/e2e-run/action.yml
+++ b/.github/actions/e2e-run/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Install project and dev dependencies
       shell: bash
-      run: uv sync --extra all --extra dev
+      run: uv sync --locked --extra all --extra dev
 
     - name: Install binary dependencies
       # npm install against .github/ci-deps/package.json with --ignore-scripts

--- a/.github/actions/integration-run/action.yml
+++ b/.github/actions/integration-run/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Install project and dev dependencies
       shell: bash
-      run: uv sync --extra all --extra dev
+      run: uv sync --locked --extra all --extra dev
 
     - name: Install binary dependencies
       # Mirrors e2e.yml. --ignore-scripts blocks npm postinstall hooks; we run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
-        run: uv sync --extra all --extra dev
+        run: uv sync --locked --extra all --extra dev
 
       - name: Run pytest
         shell: bash
@@ -241,7 +241,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
 
       - name: Install dependencies
-        run: uv sync --extra all --extra dev
+        run: uv sync --locked --extra all --extra dev
 
       - name: Build parity sidecar
         run: |

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -136,7 +136,7 @@ jobs:
         run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
 
       - name: Install project + dev extras
-        run: uv sync --extra all --extra dev
+        run: uv sync --locked --extra all --extra dev
 
       - name: Install bubblewrap + tmux
         # bubblewrap: the UI tests open terminals under os_env, whose

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -23,7 +23,7 @@ jobs:
   gate:
     name: Security Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 12
     steps:
       - name: Check out trust check from main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -71,7 +71,7 @@ jobs:
           q='[.check_runs[] | select(.name=="Security Scan")] | sort_by(.started_at) | last'
           conclusion=""
           details_url=""
-          for _ in $(seq 1 72); do   # up to ~6 min (72 * 5s)
+          for _ in $(seq 1 108); do  # up to ~9 min (108 * 5s)
             status=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .status" 2>/dev/null || echo "")
             if [ "$status" = "completed" ]; then
               conclusion=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq "$q | .conclusion")

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -132,6 +132,23 @@ jobs:
         if: ${{ steps.gate.outputs.scan == 'true' }}
         uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
 
+      - name: OSV advisory scan (uv.lock)
+        # Checks every package version pinned in the PR's uv.lock against the
+        # OSV advisory database, which covers known-malicious, typosquatted,
+        # and CVE-flagged versions. Only fires when uv.lock is in the changeset
+        # to avoid blocking PRs when main's baseline lockfile already has open
+        # advisories on main.
+        if: ${{ steps.gate.outputs.scan == 'true' }}
+        working-directory: pr
+        run: |
+          if ! grep -qxF 'uv.lock' "$GITHUB_WORKSPACE/changed.txt"; then
+            echo "uv.lock not changed; skipping OSV scan."
+            exit 0
+          fi
+          uv export --frozen --format requirements-txt --all-extras \
+            > /tmp/uv-req.txt
+          uvx pip-audit --requirement /tmp/uv-req.txt --no-deps
+
       - name: Semgrep (changed files, local rules)
         if: ${{ steps.gate.outputs.scan == 'true' }}
         env:


### PR DESCRIPTION
## Summary

- **Add `--locked` to all PR-gated `uv sync` calls** (`ci.yml`, `e2e-ui.yml`, `e2e-run` composite action, `integration-run` composite action). Previously only `lint.yml` enforced `--locked`; the other workflows silently re-resolved if `uv.lock` diverged from `pyproject.toml`, meaning a contributor-modified lockfile that is inconsistent with the declared constraints would be discarded rather than caught.
- **Extend the security-gate poller timeout** from 72 × 5 s (≈ 6 min) to 108 × 5 s (≈ 9 min) and bump `timeout-minutes` from 8 → 12. This shrinks the fail-open window where a slow security-scan run lets the gate proceed before the scan concludes.

## Motivation

A malicious external contributor could pin `uv.lock` to an attacker-controlled package version. The lockfile already contains full SHA-256 hashes per artifact, and the registry-normalization check in `lint.yml` catches non-PyPI URL injection — but without `--locked`, the heavy CI workflows (unit tests, e2e, integration) would silently bypass those protections by re-resolving the dependency graph from `pyproject.toml` alone.