### PR TITLE
feat(managed-hosts): wake a dormant resumable host from the web

### DIFF
--- a/ap-web/src/hooks/useSessionLiveness.test.ts
+++ b/ap-web/src/hooks/useSessionLiveness.test.ts
@@ -1,8 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { livenessRowFromSession, useSessionLiveness } from "./useSessionLiveness";
+import { type LivenessRow, livenessRowFromSession, useSessionLiveness } from "./useSessionLiveness";
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
-import type { Conversation } from "@/hooks/useConversations";
 import type { Session } from "@/lib/types";
 
 // Drive the two split signals directly so the test pins the derivation
@@ -29,16 +28,20 @@ function freshCreatedAt(): number {
 }
 
 /** Build a minimal conv row carrying just the fields the hook reads. */
-function conv(
-  partial: Partial<Pick<Conversation, "host_id" | "permission_level" | "created_at">>,
-): Pick<Conversation, "host_id" | "permission_level" | "created_at"> {
-  return { host_id: null, permission_level: null, created_at: SOME_CREATED_AT, ...partial };
+function conv(partial: Partial<LivenessRow>): LivenessRow {
+  return {
+    host_id: null,
+    permission_level: null,
+    created_at: SOME_CREATED_AT,
+    host_resumable: false,
+    ...partial,
+  };
 }
 
 function derive(
   runner: boolean | undefined,
   host: boolean | null | undefined,
-  c: Pick<Conversation, "host_id" | "permission_level" | "created_at"> | null,
+  c: LivenessRow | null,
   opts?: { turnActive?: boolean },
 ) {
   runnerMock.mockReturnValue(runner);
@@ -114,6 +117,37 @@ describe("useSessionLiveness — derivation truth table", () => {
     expect(derive(false, false, conv({ host_id: "h1", permission_level: 3 }))).toEqual({
       kind: "host_offline",
       isOwner: false,
+    });
+  });
+
+  it("host_asleep when a resumable managed host is down — composer stays open", () => {
+    // A dormant resumable managed host the server wakes on the next message:
+    // NOT the host_offline dead-end. host_resumable flips row 3.
+    expect(derive(false, false, conv({ host_id: "h1", host_resumable: true }))).toEqual({
+      kind: "host_asleep",
+    });
+    // The wake is server-side, not owner-gated: resumable wins the offline
+    // split even when shared (non-owner).
+    expect(
+      derive(false, false, conv({ host_id: "h1", permission_level: 1, host_resumable: true })),
+    ).toEqual({ kind: "host_asleep" });
+  });
+
+  it("starting (NOT host_asleep) while a just-sent turn is waking the resumable host", () => {
+    // turnActive means the send is resuming the sandbox now — show the
+    // "Connecting…" intermediate through the cold wake, not a blank
+    // host_asleep screen.
+    expect(
+      derive(false, false, conv({ host_id: "h1", host_resumable: true }), { turnActive: true }),
+    ).toEqual({ kind: "starting" });
+  });
+
+  it("host_offline (not host_asleep) when the down host is NOT resumable", () => {
+    // The default for an external/non-resumable host: the actionable
+    // reconnect/fork dead-end, unchanged.
+    expect(derive(false, false, conv({ host_id: "h1", host_resumable: false }))).toEqual({
+      kind: "host_offline",
+      isOwner: true,
     });
   });
 
@@ -236,10 +270,15 @@ describe("useSessionLiveness — derivation truth table", () => {
       } as Session;
     }
 
-    it("maps hostId / permissionLevel / createdAt into the snake_case row", () => {
+    it("maps hostId / permissionLevel / createdAt / hostResumable into the snake_case row", () => {
       expect(
         livenessRowFromSession(session({ hostId: "h1", permissionLevel: 1, createdAt: 123 })),
-      ).toEqual({ host_id: "h1", permission_level: 1, created_at: 123 });
+      ).toEqual({ host_id: "h1", permission_level: 1, created_at: 123, host_resumable: false });
+      // hostResumable flows through so an off-sidebar resumable host can
+      // classify host_asleep rather than dead-ending on host_offline.
+      expect(livenessRowFromSession(session({ hostId: "h1", hostResumable: true }))).toMatchObject({
+        host_resumable: true,
+      });
     });
 
     it("returns null for a null/undefined snapshot", () => {

--- a/ap-web/src/hooks/useSessionLiveness.ts
+++ b/ap-web/src/hooks/useSessionLiveness.ts
@@ -31,7 +31,16 @@ import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHeal
 export const STARTING_GRACE_S = 45;
 
 /** The subset of a conversation row this hook reads. */
-export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "created_at">;
+export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "created_at"> & {
+  /**
+   * Whether this session's host is a resumable managed host the server wakes
+   * on the next message. NOT a `Conversation` field — the sidebar row doesn't
+   * carry it; it rides the session snapshot, and the open view splices it in
+   * via {@link livenessRowFromSession}. Drives the `host_asleep` vs
+   * `host_offline` split (row 3). Absent ⇒ treated `false`.
+   */
+  host_resumable?: boolean;
+};
 
 /**
  * Build a {@link LivenessRow} from the single-session snapshot
@@ -44,13 +53,17 @@ export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "c
  * snapshot carries the same three fields, so it's an exact stand-in.
  */
 export function livenessRowFromSession(
-  session: Pick<Session, "hostId" | "permissionLevel" | "createdAt"> | null | undefined,
+  session:
+    | Pick<Session, "hostId" | "permissionLevel" | "createdAt" | "hostResumable">
+    | null
+    | undefined,
 ): LivenessRow | null {
   if (!session) return null;
   return {
     host_id: session.hostId,
     permission_level: session.permissionLevel,
     created_at: session.createdAt,
+    host_resumable: session.hostResumable ?? false,
   };
 }
 
@@ -75,10 +88,20 @@ export function livenessRowFromSession(
  *   host relaunches the runner on the next message, so the composer stays
  *   open. The open view renders no banner for this state — typing
  *   silently relaunches the runner (which then flips it to `starting`).
- * - `host_offline` — the session is host-bound and the host tunnel is
- *   down. Nothing the web UI sends can wake it; the owner must reconnect
- *   the host from that machine (`isOwner` true), and any viewer can fork
- *   to continue independently.
+ * - `host_asleep` — the session is host-bound, the host tunnel is down, but
+ *   the host is a resumable managed host: the server wakes the sandbox on the
+ *   next message (the send-message relaunch path calls `resume_managed_host`).
+ *   Treated like `runner_asleep` — the composer stays open, no reconnect
+ *   banner, and typing wakes it. This is what makes the backend resume
+ *   reachable from the web; without it a resumable host would dead-end on
+ *   `host_offline` below. While a just-sent turn is waking it (`turnActive`),
+ *   this upgrades to `starting` so the ~85s cold wake shows a "Connecting…"
+ *   intermediate rather than a blank screen.
+ * - `host_offline` — the session is host-bound and the host tunnel is down,
+ *   and the host is NOT resumable from the web (an external/laptop host, or a
+ *   managed provider without a stop/resume lifecycle). The owner must
+ *   reconnect the host from that machine (`isOwner` true), and any viewer can
+ *   fork to continue independently.
  * - `local_stranded` — not host-bound (no `host_id`) and the runner is
  *   down. There's no host to relaunch it; the user restarts from their
  *   own machine, and forking is the escape hatch.
@@ -91,6 +114,7 @@ export type SessionLiveness =
   | { kind: "online" }
   | { kind: "starting" }
   | { kind: "runner_asleep" }
+  | { kind: "host_asleep" }
   | { kind: "host_offline"; isOwner: boolean }
   | { kind: "local_stranded" }
   | { kind: "unknown" };
@@ -117,7 +141,9 @@ function isOwner(conv: Pick<Conversation, "permission_level"> | null | undefined
  * |---|---------------|-------------|---------|------------|----------------------|
  * | 1 | true          | (any)       | (any)   | (any)      | online               |
  * | 2 | not-true      | (any)       | (any)   | (any)      | starting (fresh*)    |
- * | 3 | not-true      | false       | set     | (any)      | host_offline {owner} |
+ * | 3 | not-true      | false       | set+resumable | true  | starting (waking)    |
+ * | 3'| not-true      | false       | set+resumable | false | host_asleep          |
+ * | 3"| not-true      | false       | set, non-resum| (any) | host_offline {owner} |
  * | 4 | undefined     | (any)       | (any)   | (any)      | unknown (pre-poll)   |
  * | 5 | false         | true        | (any)   | true       | starting (relaunch)  |
  * | 5'| false         | true        | (any)   | false      | runner_asleep        |
@@ -133,7 +159,10 @@ function isOwner(conv: Pick<Conversation, "permission_level"> | null | undefined
  * runner tunnel is the only signal that means "chat now." A just-created
  * session whose runner hasn't registered yet (row 2) is cold-booting, not
  * stranded: surface `starting` rather than a reconnect banner until the
- * grace window lapses. A confirmed host-down (row 3) is actionable.
+ * grace window lapses. A confirmed host-down splits on resumability: a
+ * resumable managed host is `host_asleep` (row 3 — wakeable by sending a
+ * message, composer open), a non-resumable one is `host_offline` (row 3' —
+ * reconnect / fork).
  * Pre-poll `undefined` (row 4) stays `unknown` so a not-yet-resolved poll
  * doesn't flash a banner over a live session. A known-down runner with a
  * live host then splits on whether a turn is in flight: a just-sent turn
@@ -144,9 +173,10 @@ function isOwner(conv: Pick<Conversation, "permission_level"> | null | undefined
  *
  * @param sessionId The open conversation's id, or undefined when none is
  *   open. Undefined yields `unknown`.
- * @param conv The open conversation row (carries `host_id` +
- *   `permission_level`). Null/undefined while loading; the host-bound vs.
- *   local distinction and ownership read from it.
+ * @param conv The open session's liveness row (carries `host_id`,
+ *   `permission_level`, and `host_resumable`). Null/undefined while loading;
+ *   the host-bound vs. local distinction, ownership, and the
+ *   host_asleep-vs-host_offline split read from it.
  * @param opts.turnActive Whether a turn is currently in flight for the
  *   open session (the user just sent, or a cross-client turn is running).
  *   When the runner is down but the host is up, this upgrades the idle
@@ -156,7 +186,7 @@ function isOwner(conv: Pick<Conversation, "permission_level"> | null | undefined
  */
 export function useSessionLiveness(
   sessionId: string | undefined,
-  conv: Pick<Conversation, "host_id" | "permission_level" | "created_at"> | null | undefined,
+  conv: LivenessRow | null | undefined,
   opts?: { turnActive?: boolean },
 ): SessionLiveness {
   const runnerOnline = useSessionRunnerOnline(sessionId);
@@ -206,9 +236,18 @@ export function useSessionLiveness(
     return { kind: "starting" };
   }
 
-  // 3. A host-bound session whose host is confirmed offline is genuinely
-  // stuck and actionable — surface the reconnect/fork affordance.
+  // 3. A host-bound session whose host is confirmed offline. If the host is
+  // a resumable managed host, the server wakes the sandbox on the next
+  // message (the send-message relaunch path calls resume_managed_host). A
+  // just-sent turn (turnActive) is waking it *now* — surface the same
+  // `starting` "Connecting…" intermediate as a fresh launch so the ~85s cold
+  // wake isn't a blank screen; idle (no turn) stays `host_asleep` (composer
+  // open, no banner). Either way it's NOT the host_offline dead-end.
+  // Otherwise (non-resumable) it's genuinely stuck: `host_offline`.
   if (hostId && hostOnline === false) {
+    if (conv?.host_resumable) {
+      return opts?.turnActive ? { kind: "starting" } : { kind: "host_asleep" };
+    }
     return { kind: "host_offline", isOwner: isOwner(conv) };
   }
 

--- a/ap-web/src/lib/sessionsApi.test.ts
+++ b/ap-web/src/lib/sessionsApi.test.ts
@@ -74,6 +74,7 @@ describe("createSession", () => {
       agentName: null,
       runnerId: undefined,
       hostId: null,
+      hostResumable: false,
       status: "idle",
       createdAt: 1704067200,
       title: null,

--- a/ap-web/src/lib/sessionsApi.ts
+++ b/ap-web/src/lib/sessionsApi.ts
@@ -99,6 +99,14 @@ interface SessionResponseWire {
    * other carrier and it's absent for those.
    */
   host_id?: string | null;
+  /**
+   * Whether this session is bound to a dormant managed host the server can
+   * wake in place (its sandbox provider supports resume). Read only when the
+   * host is offline, to tell a recoverable "asleep" state (send a message —
+   * the server resumes the sandbox) from the terminal host_offline dead-end.
+   * Absent/`false` for non-managed/non-resumable hosts.
+   */
+  host_resumable?: boolean;
   status: SessionStatus;
   created_at: number;
   /**
@@ -250,6 +258,7 @@ function sessionFromWire(wire: SessionResponseWire): Session {
     agentName: wire.agent_name ?? null,
     runnerId: wire.runner_id,
     hostId: wire.host_id ?? null,
+    hostResumable: wire.host_resumable ?? false,
     status: wire.status,
     createdAt: wire.created_at,
     title: wire.title ?? null,

--- a/ap-web/src/lib/types.ts
+++ b/ap-web/src/lib/types.ts
@@ -248,6 +248,13 @@ export interface Session {
    * older recorded fixtures may omit it (treated as `null`).
    */
   hostId?: string | null;
+  /**
+   * Whether this session's host is a dormant resumable managed host the
+   * server can wake on the next message. Carried on the snapshot so the open
+   * view shows a wakeable "asleep" state instead of the terminal host_offline
+   * dead-end. `false`/absent otherwise.
+   */
+  hostResumable?: boolean;
   status: SessionStatus;
   createdAt: number;
   /**

--- a/ap-web/src/pages/ChatPage.tsx
+++ b/ap-web/src/pages/ChatPage.tsx
@@ -104,6 +104,7 @@ import { useSession } from "@/hooks/useSession";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useRefreshSessionStateOnRunnerOnline } from "@/hooks/useSessionOnlineRefresh";
 import {
+  type LivenessRow,
   type SessionLiveness,
   livenessRowFromSession,
   useSessionLiveness,
@@ -734,7 +735,15 @@ export function ChatPage() {
   // so `host_id` still reaches the hook — otherwise a host-bound, host-down
   // session misclassifies as `local_stranded` and shows the wrong reconnect
   // path. See `livenessRowFromSession`.
-  const livenessRow = activeConv ?? livenessRowFromSession(activeSession);
+  //
+  // Always source `host_resumable` from the session snapshot — the sidebar
+  // `Conversation` row doesn't carry it. activeSession is loaded for the open
+  // session, so a host-bound, host-down session whose host is a resumable
+  // managed host classifies as `host_asleep` (composer open, send wakes it)
+  // instead of dead-ending on `host_offline`.
+  const livenessRow: LivenessRow | null = activeConv
+    ? { ...activeConv, host_resumable: activeSession?.hostResumable ?? false }
+    : livenessRowFromSession(activeSession);
   const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {
     turnActive: status === "streaming",
   });
@@ -1490,7 +1499,8 @@ function MainAgentSurface({
         showCodexPlanMode={showCodexPlanMode}
         isTerminalFirst={isTerminalFirst}
         isNativeWrapper={isNativeWrapper}
-        reconnectHint={liveness.kind === "runner_asleep"}
+        reconnectHint={liveness.kind === "runner_asleep" || liveness.kind === "host_asleep"}
+        sandboxAsleepHint={liveness.kind === "host_asleep"}
         unreachable={
           !sandboxLaunching &&
           (liveness.kind === "host_offline" || liveness.kind === "local_stranded")
@@ -2068,7 +2078,8 @@ export function ConnectionIndicator({
   const sandboxStatus = useChatStore((s) => s.sandboxStatus);
   // Genuinely-unreachable states get the reconnect banner, for
   // both terminal-first and regular sessions. `runner_asleep` (host up,
-  // runner relaunches on the next message) and `unknown` (pre-poll) are
+  // runner relaunches on the next message), `host_asleep` (resumable managed
+  // host the server wakes on the next message), and `unknown` (pre-poll) are
   // NOT unreachable — they're handled below.
   const unreachable = liveness.kind === "host_offline" || liveness.kind === "local_stranded";
 
@@ -2172,8 +2183,8 @@ export function ConnectionIndicator({
   }
 
   // `online`/`unknown` for a non-terminal-first session and
-  // `runner_asleep` for any session: status lives in the sidebar / the
-  // composer stays open, so render nothing here.
+  // `runner_asleep`/`host_asleep` for any session: status lives in the
+  // sidebar / the composer stays open, so render nothing here.
   return null;
 }
 
@@ -2697,6 +2708,14 @@ interface ComposerProps {
    */
   reconnectHint?: boolean;
   /**
+   * The session is host-bound to a dormant resumable managed host that is
+   * offline (`host_asleep`): the composer stays enabled, and the placeholder
+   * tells the user their next message will resume the sandbox host (which can
+   * take a few minutes) so the wake latency is expected, not surprising.
+   * Ignored once a turn is streaming.
+   */
+  sandboxAsleepHint?: boolean;
+  /**
    * The session is unreachable (`host_offline` / `local_stranded`): a message
    * can't wake it. The composer is blocked (disabled) and the reconnect
    * banner below is the only affordance.
@@ -3063,6 +3082,7 @@ export function Composer({
   isTerminalFirst = false,
   isNativeWrapper = false,
   reconnectHint = false,
+  sandboxAsleepHint = false,
   unreachable = false,
   costRoutingVerdict = null,
   costRoutingEligible = false,
@@ -3770,9 +3790,11 @@ export function Composer({
                         ? "Waiting for agents…"
                         : isStreaming
                           ? "Send a follow-up (queued) — Esc to stop"
-                          : reconnectHint
-                            ? "Send a message to reconnect this session"
-                            : "Ask the agent anything…"
+                          : sandboxAsleepHint
+                            ? "Current session's host is offline. Next message will resume the sandbox host which can take minutes"
+                            : reconnectHint
+                              ? "Send a message to reconnect this session"
+                              : "Ask the agent anything…"
             }
             rows={1}
             disabled={disabled || isReadOnly || unreachable || hasPendingElicitation}

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -184,6 +184,16 @@ class SandboxLauncher(ABC):
     # ``host_type="managed"`` instead of a mid-flow capability error.
     supports_cli_bootstrap: ClassVar[bool] = True
 
+    # Whether this provider can resume a stopped sandbox IN PLACE
+    # (reattaching its persistent volume) rather than only provisioning a
+    # fresh one. The server's managed-host wake path checks this BEFORE
+    # attempting a resume: providers with a stop/resume lifecycle + a
+    # persistent volume override it to ``True``; providers whose sandboxes
+    # are ephemeral (Modal — no volume to reattach) leave it ``False``, so a
+    # dormant host there stays gone (the user starts a new session) instead
+    # of being silently revived onto an empty workspace.
+    can_resume: ClassVar[bool] = False
+
     @abstractmethod
     def prepare(self) -> None:
         """
@@ -376,6 +386,27 @@ class SandboxLauncher(ABC):
             "sandbox termination — delete the sandbox with the provider's "
             "own tooling."
         )
+
+    def resume(self, sandbox_id: str) -> None:
+        """
+        Resume a stopped sandbox in place, reattaching its persistent
+        volume, so a dormant managed host can be revived under the SAME
+        sandbox id.
+
+        Optional capability: the default implementation raises
+        :class:`SandboxCapabilityError`. Providers whose backend has a
+        stop/resume lifecycle with a persistent volume override it AND set
+        :attr:`can_resume` to ``True``. Used by the server's managed-host
+        wake path; the host process itself is restarted separately (resume
+        only brings the compute + volume back).
+
+        :param sandbox_id: The stopped sandbox to resume, e.g.
+            ``"sb-a1b2c3"``.
+        :raises SandboxCapabilityError: When the provider cannot resume a
+            stopped sandbox (ephemeral sandboxes / no persistent volume).
+        :raises click.ClickException: If the resume fails.
+        """
+        raise self._capability_error("resume a stopped sandbox")
 
     def exec_foreground(self, sandbox_id: str, command: str) -> int:
         """

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1844,6 +1844,140 @@ def _launcher_for_teardown(
     return launcher
 
 
+def host_resume_supported(
+    host: Host,
+    config: ManagedSandboxConfig | None,
+) -> bool:
+    """
+    Whether :func:`resume_managed_host` could wake this host in place.
+
+    ``True`` iff the host is bound to a sandbox whose provider has a
+    stop/resume lifecycle with a persistent volume
+    (:attr:`SandboxLauncher.can_resume`) and still matches the deployment's
+    current launcher. This is the SAME gate :func:`resume_managed_host`
+    applies before a wake, exposed so the open-session snapshot
+    (``SessionResponse.host_resumable``) can render a dormant such host as a
+    wakeable "asleep" state instead of the terminal ``host_offline``
+    dead-end.
+
+    :param host: The session's bound managed host.
+    :param config: The deployment's current sandbox config, or ``None``
+        when the ``sandbox:`` section has been removed since launch.
+    :returns: ``True`` when a wake would be attempted; ``False`` for a
+        non-managed / non-resumable provider, a dropped config, or a
+        host with no recorded ``sandbox_id``.
+    """
+    launcher = _launcher_for_teardown(host, config)
+    return launcher is not None and launcher.can_resume and host.sandbox_id is not None
+
+
+# ── Managed-host wake (resume a dormant host on demand) ─────────────────────
+
+# Per-host resume single-flight: one in-flight resume per host_id on this
+# replica, else two host processes flap the tunnel registration. Reused across a
+# host's many idle-stop/resume cycles, so not reaped — a .pop() could also race
+# a resume still holding it; one idle Lock per host woken is negligible.
+_resume_locks: dict[str, asyncio.Lock] = {}
+
+
+async def resume_managed_host(
+    host_id: str,
+    host_store: HostStore,
+    config: ManagedSandboxConfig | None,
+) -> None:
+    """
+    Wake a dormant managed host so a session bound to it can run again.
+
+    The send-message relaunch path calls this when a host-bound session has no
+    live runner. If the host is a *resumable* managed host — a provider whose
+    sandbox idle-stops but retains its persistent volume
+    (:attr:`SandboxLauncher.can_resume`) — and is currently offline, this
+    resumes the sandbox under the SAME sandbox id, re-arms its launch token,
+    re-execs ``omnigent host``, and waits for it to re-register. The caller's
+    existing relaunch then spawns a fresh runner.
+
+    No-op when the host is already online, is unknown, or its provider cannot
+    resume (e.g. Modal — the caller falls through to its normal host-offline
+    behavior, i.e. the user starts a new session). Single-flight and
+    idempotent: concurrent callers serialize on a per-host lock and re-check
+    liveness under it, so only the first wakes the host.
+
+    Unlike a launch, a failed wake does NOT tear the sandbox down — the volume
+    + workspace are the user's and must survive for a retry.
+
+    :param host_id: The session's bound host id, e.g. ``"host_a1b2c3d4..."``.
+    :param host_store: Persistent host registrations (cross-replica liveness).
+    :param config: The deployment's managed-sandbox config, or ``None`` when
+        the ``sandbox:`` section has been removed since launch.
+    :raises HTTPException: 502 when the resume or host restart fails.
+    """
+    if config is None:
+        return
+    # Cross-replica DB liveness (freshness-gated): never trust the per-replica
+    # registry alone. Cheap gate before taking the lock.
+    if await asyncio.to_thread(host_store.is_online, host_id):
+        return
+    host = await asyncio.to_thread(host_store.get_host, host_id)
+    if host is None:
+        return
+    # Provider-matched launcher (None if config dropped / provider changed).
+    # Resume needs a reattachable volume; others (e.g. Modal) fall through to
+    # the caller's host-offline path (the user starts a new session).
+    launcher = _launcher_for_teardown(host, config)
+    if launcher is None or not launcher.can_resume or host.sandbox_id is None:
+        return
+    sandbox_id = host.sandbox_id
+    # Single-flight per host (see _resume_locks).
+    resume_lock = _resume_locks.setdefault(host_id, asyncio.Lock())
+    async with resume_lock:
+        # Re-check under the lock: a concurrent waker may have brought the host
+        # online while we waited.
+        if await asyncio.to_thread(host_store.is_online, host_id):
+            return
+        _logger.info(
+            "Waking dormant managed host %s (sandbox %s, provider %s)",
+            host.host_id,
+            sandbox_id,
+            launcher.provider,
+        )
+        try:
+            await asyncio.to_thread(launcher.resume, sandbox_id)
+            # Mint a fresh token: the old one died with the host process's env
+            # (only its hash persists). register_managed_host's relaunch branch
+            # overwrites it in place, keeping the host_id's session bindings.
+            token = secrets.token_urlsafe(32)
+            await asyncio.to_thread(
+                host_store.register_managed_host,
+                host_id=host.host_id,
+                name=host.name,
+                owner=host.owner,
+                token=token,
+                provider=launcher.provider,
+                sandbox_id=sandbox_id,
+                token_expires_at=now_epoch() + config.token_ttl_s,
+            )
+            await asyncio.to_thread(
+                _start_host_in_sandbox,
+                launcher,
+                sandbox_id,
+                token=token,
+                host_id=host.host_id,
+                host_name=host.name,
+                server_url=config.server_url,
+                repo=None,  # the persistent volume already holds the workspace
+            )
+            await _wait_for_host_online(host_store, host.host_id)
+        except Exception as exc:
+            # A failed wake must NOT tear the sandbox down (the volume is the
+            # user's); just surface it.
+            if isinstance(exc, HTTPException):
+                raise
+            message = exc.message if isinstance(exc, click.ClickException) else str(exc)
+            raise HTTPException(
+                status_code=502, detail=f"managed host wake failed: {message}"
+            ) from exc
+
+
 async def terminate_managed_host(
     host: Host,
     host_store: HostStore,

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -159,6 +159,7 @@ from omnigent.server.managed_hosts import (
     ManagedLaunchTracker,
     ManagedSandboxConfig,
     RepoWorkspace,
+    host_resume_supported,
 )
 from omnigent.server.mcp_pool import ServerMcpPool
 from omnigent.server.permissions import check_session_access
@@ -2154,6 +2155,7 @@ def _build_session_response(
     skills: list[SkillSummary] | None = None,
     runner_online: bool | None = None,
     host_online: bool | None = None,
+    host_resumable: bool = False,
     pending_elicitation_events: list[dict[str, Any]] | None = None,
     subtree_usage: dict[str, Any] | None = None,
     model_options: list[dict[str, Any]] | None = None,
@@ -2244,6 +2246,7 @@ def _build_session_response(
         host_id=conv.host_id,
         runner_online=runner_online,
         host_online=host_online,
+        host_resumable=host_resumable,
         reasoning_effort=conv.reasoning_effort,
         items=items,
         permission_level=permission_level,
@@ -5875,16 +5878,33 @@ async def _maybe_relaunch_managed_sandbox(
         return False
     launch = tracker.get(session_id)
     if launch is None or launch.settled.is_set():
-        _kick_managed_relaunch(
-            session_id=session_id,
-            conv=conv,
-            host=host,
-            sandbox_config=sandbox_config,
-            tracker=tracker,
-            conversation_store=conversation_store,
-            host_store=host_store,
-            app_state=app_state,
-        )
+        # A resumable managed host whose sandbox merely idle-stopped is WOKEN
+        # in place (resume: same sandbox + workspace volume) rather than
+        # relaunched onto a fresh empty sandbox — same gate the wake itself
+        # uses (host_resume_supported). Both run in the background through this
+        # same tracker, so the message parks on the rendezvous either way; only
+        # the provision step differs.
+        if host_resume_supported(host, sandbox_config):
+            _kick_managed_wake(
+                session_id=session_id,
+                conv=conv,
+                sandbox_config=sandbox_config,
+                tracker=tracker,
+                conversation_store=conversation_store,
+                host_store=host_store,
+                app_state=app_state,
+            )
+        else:
+            _kick_managed_relaunch(
+                session_id=session_id,
+                conv=conv,
+                host=host,
+                sandbox_config=sandbox_config,
+                tracker=tracker,
+                conversation_store=conversation_store,
+                host_store=host_store,
+                app_state=app_state,
+            )
         launch = tracker.get(session_id)
     if launch is not None:
         await _await_settled_managed_launch(launch)
@@ -5964,6 +5984,148 @@ def _kick_managed_relaunch(
     )
     _managed_launch_tasks.add(relaunch_task)
     relaunch_task.add_done_callback(_managed_launch_tasks.discard)
+
+
+def _kick_managed_wake(
+    *,
+    session_id: str,
+    conv: Conversation,
+    sandbox_config: ManagedSandboxConfig,
+    tracker: ManagedLaunchTracker,
+    conversation_store: ConversationStore,
+    host_store: HostStore,
+    app_state: Any,
+) -> None:
+    """
+    Register and spawn the background WAKE for a dormant resumable host.
+
+    Unlike :func:`_kick_managed_relaunch` (which provisions a NEW sandbox and
+    re-clones the repo), this resumes the SAME stopped sandbox in place
+    (reattaching its persistent volume) — so it does NOT re-bind the session's
+    host/workspace. Reuses the launch tracker so a racing message POST parks on
+    the rendezvous instead of forwarding into a half-woken host or triggering a
+    workspace-destroying relaunch.
+
+    :param session_id: Session/conversation identifier.
+    :param conv: The session row bound to the dormant host.
+    :param sandbox_config: The deployment's sandbox config.
+    :param tracker: The app's launch tracker.
+    :param conversation_store: Store holding the session row.
+    :param host_store: Persistent host registrations.
+    :param app_state: ``request.app.state`` — supplies the registries.
+    """
+    _logger.info(
+        "Managed host %s (session %s) is dormant but resumable; waking in background",
+        conv.host_id,
+        session_id,
+    )
+    tracker.begin(session_id)
+    # Seed the progress indicator immediately — the user is watching the
+    # session page when the wake fires (the composer let them send into a
+    # host_asleep session).
+    _publish_sandbox_status(session_id, "provisioning")
+    wake_task = asyncio.create_task(
+        _run_managed_wake(
+            session_id=session_id,
+            conv=conv,
+            sandbox_config=sandbox_config,
+            tracker=tracker,
+            conversation_store=conversation_store,
+            host_store=host_store,
+            host_registry=getattr(app_state, "host_registry", None),
+            tunnel_registry=getattr(app_state, "tunnel_registry", None),
+        )
+    )
+    _managed_launch_tasks.add(wake_task)
+    wake_task.add_done_callback(_managed_launch_tasks.discard)
+
+
+async def _run_managed_wake(
+    *,
+    session_id: str,
+    conv: Conversation,
+    sandbox_config: ManagedSandboxConfig,
+    tracker: ManagedLaunchTracker,
+    conversation_store: ConversationStore,
+    host_store: HostStore,
+    host_registry: HostRegistry | None,
+    tunnel_registry: TunnelRegistry | None,
+) -> None:
+    """
+    Wake a dormant resumable managed host in the background, settling the
+    tracker so a parked message POST forwards once the host is back.
+
+    Resumes the stopped sandbox in place (:func:`resume_managed_host`: resume +
+    re-arm token + re-exec host, preserving the workspace volume — no re-bind),
+    then launches a runner on the woken host and waits for its tunnel so a
+    rendezvoused message resolves on the first try. The parked send runs the
+    session-init handshake (transcript forwarder attach) before forwarding, so
+    the first post-wake turn is mirrored + persisted.
+
+    Mirrors :func:`_bind_and_launch_managed_runner` (launch runner + wait
+    tunnel + settle) but with a resume instead of a fresh provision + bind.
+    Every exit settles the tracker — a failed wake does NOT tear the sandbox
+    down (the volume is the user's), it just surfaces the reason to the waiter.
+
+    :param session_id: Session/conversation identifier.
+    :param conv: The session row bound to the dormant host.
+    :param sandbox_config: The deployment's sandbox config.
+    :param tracker: The app's launch tracker (this session's entry was begun
+        by the caller).
+    :param conversation_store: Store holding the session row.
+    :param host_store: Persistent host registrations.
+    :param host_registry: Live host tunnels, used to send the launch-runner
+        frame. ``None`` in minimal test wirings.
+    :param tunnel_registry: Runner-tunnel registry used to await the launched
+        runner's connection. ``None`` in minimal test wirings.
+    """
+    from omnigent.server.managed_hosts import resume_managed_host
+
+    try:
+        # Wake the same sandbox in place; resume_managed_host is single-flight
+        # per host and a no-op if it's already online.
+        await resume_managed_host(conv.host_id, host_store, sandbox_config)
+        _publish_sandbox_status(session_id, "connecting")
+        refreshed = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+        if refreshed is None:
+            tracker.fail(session_id, "session not found after wake")
+            return
+        runner_id: str | None = None
+        host_conn = host_registry.get(conv.host_id) if host_registry is not None else None
+        if host_conn is not None:
+            launch_attempt = await _launch_runner_on_host(
+                refreshed,
+                conversation_store,
+                host_registry,
+                host_conn,
+            )
+            if launch_attempt.error_code == _HARNESS_NOT_CONFIGURED_ERROR_CODE:
+                reason = launch_attempt.error or "harness not configured on the sandbox host"
+                tracker.fail(session_id, reason)
+                _publish_sandbox_status(session_id, "failed", reason)
+                return
+            runner_id = launch_attempt.runner_id
+        if runner_id is not None and tunnel_registry is not None:
+            # Wait for the runner tunnel before settling so a rendezvoused
+            # message resolves its runner client on the first try (the
+            # post-settle session-init handshake then attaches the forwarder
+            # before the message is forwarded).
+            await tunnel_registry.wait_for_runner(
+                runner_id,
+                timeout_s=_HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S,
+            )
+        tracker.finish(session_id)
+        _publish_sandbox_status(session_id, "ready")
+    except HTTPException as exc:
+        tracker.fail(session_id, str(exc.detail))
+        _publish_sandbox_status(session_id, "failed", str(exc.detail))
+    except Exception:
+        # Fire-and-forget task — settle the tracker (else a waiting message
+        # POST hangs to its timeout) and never escape as an unhandled-task
+        # traceback. A failed wake leaves the sandbox intact for a retry.
+        _logger.exception("Managed host wake crashed for session %s", session_id)
+        tracker.fail(session_id, "internal error during managed host wake")
+        _publish_sandbox_status(session_id, "failed", "internal error during managed host wake")
 
 
 # Matches the create / PATCH handshake timeout — POST /v1/sessions caches
@@ -12696,6 +12858,8 @@ def create_sessions_router(
             include_items=include_items,
             runner_exit_reports=runner_exit_reports,
             refresh_state=refresh_state,
+            host_store=getattr(request.app.state, "host_store", None),
+            sandbox_config=getattr(request.app.state, "sandbox_config", None),
         )
 
     @router.get(
@@ -18292,6 +18456,8 @@ async def _get_session_snapshot(
     include_items: bool = True,
     runner_exit_reports: RunnerExitReports | None = None,
     refresh_state: bool = False,
+    host_store: HostStore | None = None,
+    sandbox_config: ManagedSandboxConfig | None = None,
 ) -> SessionResponse:
     """
     Read a full session snapshot from the store.
@@ -18516,6 +18682,17 @@ async def _get_session_snapshot(
     # parent's own session_usage would under-report. Off the event loop
     # because it pages the conversation tree from the store.
     subtree_usage = await asyncio.to_thread(load_session_usage, conv.id, conv_store)
+    # Static signal telling the open view a host-bound, host-down session is a
+    # resumable managed host it can wake by sending a message, vs a terminal
+    # host_offline dead-end. Computed independently of liveness_lookup (the web
+    # chat passes include_liveness=False, so host_online is None here and
+    # liveness arrives via the poll/stream). One indexed host read, gated to
+    # host-bound sessions.
+    host_resumable = False
+    if host_store is not None and sandbox_config is not None and conv.host_id is not None:
+        host_for_resume = await asyncio.to_thread(host_store.get_host, conv.host_id)
+        if host_for_resume is not None:
+            host_resumable = host_resume_supported(host_for_resume, sandbox_config)
     return _build_session_response(
         conv,
         items,
@@ -18530,6 +18707,7 @@ async def _get_session_snapshot(
         model_options=model_options,
         runner_online=runner_online,
         host_online=host_online,
+        host_resumable=host_resumable,
         pending_elicitation_events=await asyncio.to_thread(
             _pending_elicitation_snapshot_for_session,
             conv_store,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1425,6 +1425,14 @@ class SessionResponse(BaseModel):
         ``runner_online`` is ``False`` — host alive ⇒ "send a
         message to wake the runner"; host dead ⇒ "reconnect /
         fork". Never participates in the reachability decision.
+    :param host_resumable: Whether this session is bound to a dormant
+        managed host the server can wake in place (its provider sets
+        :attr:`SandboxLauncher.can_resume`). The open view reads it only
+        when ``host_online`` is ``False``, to split a confirmed host-down
+        into a recoverable "asleep" state (send a message — the relaunch
+        path resumes the sandbox) versus the terminal ``host_offline``
+        dead-end (reconnect from your machine / fork). ``False`` for
+        non-managed or non-resumable hosts.
     :param reasoning_effort: Per-session reasoning-effort hint.
         Accepted metadata values are ``"none"``, ``"minimal"``,
         ``"low"``, ``"medium"``, ``"high"``, ``"xhigh"``, and
@@ -1601,6 +1609,7 @@ class SessionResponse(BaseModel):
     host_id: str | None = None
     runner_online: bool | None = None
     host_online: bool | None = None
+    host_resumable: bool = False
     reasoning_effort: str | None = None
     items: list[ConversationItem] = Field(default_factory=list)
     permission_level: int | None = None

--- a/tests/e2e_ui/sessions/test_host_asleep_composer.py
+++ b/tests/e2e_ui/sessions/test_host_asleep_composer.py
@@ -1,0 +1,144 @@
+"""E2E: a dormant resumable managed host keeps the composer open.
+
+When a session is bound to a managed host whose sandbox idle-stopped, the
+open-session view must NOT dead-end on the ``host_offline`` reconnect banner:
+the host is resumable, so the composer stays ENABLED and its placeholder tells
+the user the next message will resume the sandbox host. This drives the
+``host_asleep`` liveness variant (see ``ap-web/src/hooks/useSessionLiveness.ts``
+row 3) end to end — host-bound + ``host_online=false`` + ``host_resumable=true``
++ the runner offline, and outside the startup grace.
+
+The server fixture seeds a normal runner-bound ``hello_world`` session; the
+harness has no real stop/resume managed provider, so the browser's view of the
+session is patched into the ``host_asleep`` shape via route interception:
+
+- ``GET /v1/sessions/{id}`` (snapshot) → ``host_id`` set, ``host_resumable``
+  true, and an old ``created_at`` (so the session is past the startup grace, or
+  a fresh session reads as ``starting`` and masks ``host_asleep``).
+- ``GET /v1/sessions?...`` (sidebar list) → the session is dropped from the
+  list so the open-session row resolves off-sidebar straight from the patched
+  snapshot (host-bound), instead of the real runner-bound sidebar row.
+- ``GET /health`` → the session reports ``runner_online=false`` +
+  ``host_online=false``; the open-session poll overrides the WS stream.
+- ``WS /v1/sessions/updates`` → blocked so a stream push can't re-add the
+  session to the sidebar or revert its liveness to the real (online) values.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+_ASLEEP_PLACEHOLDER = (
+    "Current session's host is offline. "
+    "Next message will resume the sandbox host which can take minutes"
+)
+_FAKE_HOST_ID = "host_test_managed"
+# Unix seconds well before now so the session is outside the startup grace
+# (STARTING_GRACE_S) — see useSessionLiveness row 2.
+_OLD_CREATED_AT = 1_700_000_000
+
+
+def _force_host_asleep(page: Page, session_id: str) -> None:
+    """Patch the browser's view of ``session_id`` into the host_asleep state.
+
+    Registered before navigation: three HTTP route patches plus one WS block.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch, e.g. ``"conv_abc123"``.
+    """
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["host_id"] = payload.get("host_id") or _FAKE_HOST_ID
+        payload["host_resumable"] = True
+        # Age the session out of the startup grace (STARTING_GRACE_S): a
+        # freshly-created session whose runner has never been seen online reads
+        # as `starting` (cold-boot) and would mask the host_asleep row.
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_list(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/v1/sessions":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(rows, list):
+            payload["data"] = [
+                r for r in rows if not (isinstance(r, dict) and r.get("id") == session_id)
+            ]
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/health":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        offline = {"runner_online": False, "host_online": False}
+        # Plural shape used by the open-session fallback poll:
+        # {"sessions": {"<id>": {...}}}.
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = offline
+        # Singular shape ({"session": {...}}) for the session_id= variant.
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **offline}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    # Snapshot route registered last so it wins for /v1/sessions/{id} (Playwright
+    # matches most-recently-registered first); the list/health handlers fall
+    # through via continue_() for anything they don't own.
+    page.route(re.compile(r"/v1/sessions(\?|$)"), _patch_list)
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+
+def test_host_asleep_keeps_composer_open_with_resume_placeholder(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """In ``host_asleep`` the composer stays enabled with the wake placeholder.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to the host_asleep shape.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _force_host_asleep(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=15_000)
+    # The placeholder is the host_asleep tell: composer open, message resumes
+    # the sandbox host. NOT the host_offline "Session offline — reconnect"
+    # dead-end.
+    expect(composer).to_have_attribute("placeholder", _ASLEEP_PLACEHOLDER, timeout=15_000)
+    # Key behavior: a resumable dormant host keeps the composer usable.
+    expect(composer).not_to_be_disabled()


### PR DESCRIPTION
## Summary

A web session bound to a managed host whose sandbox idle-stopped showed a terminal **"Host is offline"** state: the composer was disabled, so the user could never send the message that would wake it. This adds a resume lifecycle for managed sandboxes and surfaces it as a recoverable **"asleep"** state the user wakes by sending a message.

## Resume foundation

- `SandboxLauncher` gains a `can_resume` capability flag (default `False`) and a `resume(sandbox_id)` method (default raises). Providers with a stop/resume lifecycle + a persistent volume override both; ephemeral providers (e.g. Modal) leave `can_resume` `False` so a dormant host there stays gone.
- `managed_hosts.resume_managed_host()`: wakes a dormant resumable host under the **same** sandbox id — resume + re-arm launch token + re-exec the host, preserving the workspace volume. Single-flight per host; a failed wake never tears the sandbox down (the volume is the user's).

## Wake from the web

- `host_resume_supported()` exposes the same gate `resume_managed_host` applies, and `SessionResponse.host_resumable` surfaces it on the open-session snapshot.
- The send-path relaunch fork routes a resumable dormant host through `_maybe_relaunch_managed_sandbox` to a background `_kick_managed_wake` / `_run_managed_wake` (resume in place via the launch tracker) instead of relaunching a fresh sandbox. The message parks on the rendezvous and forwards once the woken runner + transcript forwarder are ready.
- **ap-web:** `useSessionLiveness` gains a `host_asleep` variant (host down + `host_resumable`); `ChatPage` keeps the composer enabled and the placeholder tells the user the next message resumes the sandbox host (which can take minutes).

## Test plan

- [ ] `useSessionLiveness` unit tests cover the new `host_asleep` variant
- [ ] Manual: idle-stop a managed host, confirm the web composer stays enabled and a message wakes the host in place
