### PR TITLE
fix(policies): log 400 error detail on /policies/evaluate

### DIFF
--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -346,8 +346,10 @@ def post_evaluate_with_retry(
                 return resp
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code < 500:
+                body_preview = exc.response.text[:200] if exc.response.content else ""
                 print(
-                    f"omnigent {hook_label}: Omnigent returned {exc.response.status_code}",
+                    f"omnigent {hook_label}: Omnigent returned {exc.response.status_code}"
+                    + (f": {body_preview}" if body_preview else ""),
                     file=sys.stderr,
                 )
                 return None

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1078,7 +1078,7 @@ def create_app(
 
     @app.exception_handler(OmnigentError)
     async def _handle_omnigent_error(
-        request: Request,  # noqa: ARG001 — FastAPI exception-handler signature requires (request, exc); we only use exc
+        request: Request,
         exc: OmnigentError,
     ) -> JSONResponse:
         """
@@ -1090,6 +1090,10 @@ def create_app(
         """
         if exc.http_status >= 500:
             _logger.error("Internal error: %s", exc.message, exc_info=True)
+        elif exc.http_status == 400 and request.url.path.endswith("/policies/evaluate"):
+            _logger.warning(
+                "Policy evaluate rejected 400 on %s: %s", request.url.path, exc.message
+            )
         return JSONResponse(
             status_code=exc.http_status,
             content={"error": {"code": exc.code, "message": exc.message}},


### PR DESCRIPTION
## Summary

- **Server**: adds a `WARNING` log when `POST /policies/evaluate` returns 400, including the `OmnigentError` message — previously only ≥500 errors were logged, making 400s invisible in `otel_logs`
- **Hook**: appends the first 200 chars of the response body to the existing stderr line on 4xx, so affected users see the actual error in their Claude Code terminal

## Background

Investigation of the "Omnigent policy evaluation unavailable; failing closed" user reports found that ~1–2% of `/policies/evaluate` calls have been returning **400 Bad Request** consistently since June 4 (confirmed via `omnigents.server_logs.otel_logs`). The 400s fire in bursts of 2–3 at the start of new turns, then recover within ~8s — a race condition pattern. Because 4xx is not retried by the hook, each one causes a fail-closed deny that blocks a tool call.

The error message is currently swallowed server-side (only `>= 500` is logged) and the hook only logs the status code, not the body. This PR adds the missing logging so the next deployment will reveal the exact validation branch being hit.