### PR TITLE
fix(web-ui): allow following links in the markdown editor via ⌘/Ctrl+click

### DIFF
--- a/ap-web/src/shell/MarkdownRichTextViewer.test.tsx
+++ b/ap-web/src/shell/MarkdownRichTextViewer.test.tsx
@@ -275,6 +275,65 @@ describe("MarkdownRichTextViewer dirty banners", () => {
   });
 });
 
+// ── Link following ───────────────────────────────────────────────────────────
+
+describe("MarkdownRichTextViewer link following", () => {
+  const HREF = "https://omnigent.ai/docs/build/harnesses";
+
+  // The TipTap editor (and the links it renders, incl. those in table cells)
+  // is mocked to null here, so inject an anchor into the scroll container to
+  // exercise the container's click handler directly.
+  function clickLink(
+    container: HTMLElement,
+    eventInit: Parameters<typeof fireEvent.click>[1] = {},
+  ) {
+    const scroll = container.querySelector(".overflow-auto");
+    if (!scroll) throw new Error("scroll container not found");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", HREF);
+    scroll.appendChild(anchor);
+    fireEvent.click(anchor, eventInit);
+  }
+
+  it("opens a link in a new tab on a plain click in read-only mode", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    setupReadOnlyHooks();
+    const { container } = renderViewer("[harnesses](" + HREF + ")");
+
+    clickLink(container);
+
+    // Read-only: nothing to edit, so any link click should follow.
+    expect(open).toHaveBeenCalledWith(HREF, "_blank", "noopener,noreferrer");
+  });
+
+  it("does NOT follow a link on a plain click in edit mode (click places the cursor)", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    setupEditHooks();
+    const { container } = renderViewer("[harnesses](" + HREF + ")");
+
+    clickLink(container);
+
+    // Edit mode: a bare click must position the cursor, not navigate away.
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("follows a link on ⌘/Ctrl+click in edit mode (escape hatch)", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    setupEditHooks();
+    const { container } = renderViewer("[harnesses](" + HREF + ")");
+
+    clickLink(container, { metaKey: true });
+    expect(open).toHaveBeenCalledWith(HREF, "_blank", "noopener,noreferrer");
+
+    open.mockClear();
+    clickLink(container, { ctrlKey: true });
+    expect(open).toHaveBeenCalledWith(HREF, "_blank", "noopener,noreferrer");
+  });
+});
+
 // ── Truncated-file guard ─────────────────────────────────────────────────────
 
 describe("MarkdownRichTextViewer truncated guard", () => {

--- a/ap-web/src/shell/MarkdownRichTextViewer.tsx
+++ b/ap-web/src/shell/MarkdownRichTextViewer.tsx
@@ -398,17 +398,19 @@ function MarkdownRichTextViewerInner({
       <div
         ref={scrollContainerRef}
         className="relative flex-1 overflow-auto px-8 py-6"
-        onClick={
-          !canEdit
-            ? (e) => {
-                const anchor = (e.target as Element).closest("a[href]");
-                if (anchor) {
-                  e.preventDefault();
-                  window.open(anchor.getAttribute("href")!, "_blank", "noopener,noreferrer");
-                }
-              }
-            : undefined
-        }
+        // Link following. The Link extension runs with openOnClick:false so a
+        // plain click in edit mode positions the cursor instead of navigating.
+        // Read-only: any click on a link opens it. Edit mode: only a
+        // modifier-click (⌘/Ctrl) opens it, so plain-click-to-edit is preserved
+        // while still giving an escape hatch to follow links (incl. in tables).
+        onClick={(e) => {
+          if (canEdit && !e.metaKey && !e.ctrlKey) return;
+          const anchor = (e.target as Element).closest("a[href]");
+          if (anchor) {
+            e.preventDefault();
+            window.open(anchor.getAttribute("href")!, "_blank", "noopener,noreferrer");
+          }
+        }}
       >
         {!canEdit && (
           <button


### PR DESCRIPTION
## Problem

In the markdown rich-text viewer (`MarkdownRichTextViewer.tsx`), links — including links inside table cells — are not clickable when the file is open in **edit mode**.

Root cause: the Link extension is configured with `openOnClick: false`, so TipTap never follows a link click itself. A compensating click handler on the scroll container opened links in a new tab, but it was **only attached in read-only mode** (`onClick={!canEdit ? handler : undefined}`). In edit mode there was no equivalent, so a click on a link just placed the cursor and there was no way to follow it.

## Fix

Unify both modes through a single container click handler:

- **Read-only:** any click on a link opens it in a new tab (unchanged).
- **Edit mode:** plain click still positions the cursor (needed for editing); **⌘-click / Ctrl-click** follows the link — the standard editor escape hatch that was missing.

This keys off `canEdit`, not table context, so it works for links anywhere including table cells.

## Testing

- Added a "link following" test block covering all three paths: read-only plain-click opens, edit-mode plain-click does **not** open, edit-mode ⌘/Ctrl+click opens.
- `npm test` — full suite passes (2931 passed, 3 expected-fail).
- `npm run build` — typecheck + production build succeed.
- Manually verified in `npm run dev`.