### PR TITLE
fix(polly-review): fix bwrap sandbox paths, setup-uv Node 24, drop invalid CONNECT rules

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Set up uv
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
-        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           enable-cache: true
 
@@ -375,14 +375,13 @@ jobs:
           cfg = yaml.safe_load(cfg_path.read_text())
 
           # Allowlist: GitHub API (gh CLI reads) + gateway (LLM calls).
+          # CONNECT is not a valid egress_rules method — only HTTP verbs.
           rules = [
-              'CONNECT api.github.com/**',
               'GET api.github.com/**',
               'POST api.github.com/**',
           ]
           if gw_host:
               rules += [
-                  f'CONNECT {gw_host}/**',
                   f'GET {gw_host}/**',
                   f'POST {gw_host}/**',
               ]


### PR DESCRIPTION
## Summary
Fixes three issues caught in CI runs after #1002 merged.

**1. bwrap sandbox missing read_paths** ([run](https://github.com/omnigent-ai/omnigent/actions/runs/28012387628/job/82908430653))
The `linux_bwrap` sandbox restricts filesystem visibility, so tools installed outside `cwd` (Claude CLI at `.cc-cli/`, `gh`, home-dir configs) were not visible inside sandboxed shell commands. Added `read_paths: [GITHUB_WORKSPACE, HOME]` and `write_paths: [/tmp]` so Polly's shell tools work correctly under the egress-restricted sandbox.

**2. Invalid CONNECT in egress_rules** ([run](https://github.com/omnigent-ai/omnigent/actions/runs/28011544277/job/82905684369))
`CONNECT` is not a valid HTTP method in the egress DSL. Removed; `GET` + `POST` are sufficient for the gateway and GitHub API.

**3. SyntaxWarning: invalid escape `\|` in Python f-string**
The grep command embedded in the prompt had `\|` inside a Python f-string, triggering a `SyntaxWarning`. Escaped as `\\|`.

**4. astral-sh/setup-uv v6.1.0 → v8.2.0** (Node.js 20 → 24)

## Test plan
- [ ] Trigger a `/review` comment and confirm the Polly run succeeds end-to-end and posts a review comment
- [ ] Confirm no egress_rules validation errors, no SyntaxWarning, no Node.js 20 deprecation warnings

This pull request and its description were written by Isaac.