### PR TITLE
fix(polly-review): add bwrap read_paths for workspace/home, fix SyntaxWarning

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -300,7 +300,7 @@ jobs:
           skip these — they are a supply chain attack surface. Do NOT read the
           full hunk (it is noise). Instead extract just the changed package
           names and versions:
-            gh pr diff $POLLY_PR_NUMBER --repo $POLLY_REPO -- uv.lock | grep '^[+-]name\|^[+-]version' | grep -v '^---\|^+++' | head -200
+            gh pr diff $POLLY_PR_NUMBER --repo $POLLY_REPO -- uv.lock | grep '^[+-]name\\|^[+-]version' | grep -v '^---\\|^+++' | head -200
           Flag as a **blocking security issue** any of:
           - A package added to the lockfile that is not declared (directly or
             transitively via a declared dep) in pyproject.toml.
@@ -386,7 +386,21 @@ jobs:
                   f'POST {gw_host}/**',
               ]
 
-          sandbox = {'type': 'linux_bwrap', 'egress_rules': rules}
+          import os as _os
+          workspace = _os.environ.get('GITHUB_WORKSPACE', '')
+          home = str(pathlib.Path.home())
+
+          # read_paths: grant the workspace (CLIs, venv, repo) and home
+          # (gh config, omnigent config, .databrickscfg) so bwrap's
+          # restricted filesystem view doesn't break Polly's shell tools.
+          read_paths = [workspace, home] if workspace else [home]
+
+          sandbox = {
+              'type': 'linux_bwrap',
+              'egress_rules': rules,
+              'read_paths': read_paths,
+              'write_paths': ['/tmp'],
+          }
           cfg['os_env']['sandbox'] = sandbox
           cfg['terminals']['shell']['os_env']['sandbox'] = dict(sandbox)
 


### PR DESCRIPTION
## Summary
Two issues found in CI after #1002 merged ([run](https://github.com/omnigent-ai/omnigent/actions/runs/28012387628/job/82908430653)):

**1. bwrap sandbox missing read_paths**
The `linux_bwrap` sandbox restricts filesystem visibility to `cwd` by default. Tools installed outside `cwd` — Claude CLI at `.cc-cli/`, `gh`, `~/.omnigent/`, `~/.databrickscfg` — were not visible inside sandboxed shell commands, causing `FileNotFoundError`. Added `read_paths: [GITHUB_WORKSPACE, HOME]` and `write_paths: [/tmp]`.

**2. `SyntaxWarning: invalid escape sequence '\|'`**
The grep command embedded in the prompt had `\|` inside a Python f-string. Escaped as `\\|` so the shell receives the correct `\|` alternation.

## Test plan
- [ ] Trigger a `/review` comment and confirm Polly runs to completion and posts a review comment
- [ ] Confirm no `SyntaxWarning` in the Collect PR context step logs

This pull request and its description were written by Isaac.