### PR TITLE
fix(polly-review): mint App token before iptables egress DROP

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -345,6 +345,16 @@ jobs:
           permission-pull-requests: read
           permission-contents: read
 
+      - name: Mint App token
+        # Minted here (before the iptables egress DROP) so the GitHub API
+        # call succeeds. Used later by the Post review comment step.
+        id: app-token
+        if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true' && vars.OMNIGENT_BOT_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
+          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
+
       - name: Restrict egress to gateway and GitHub API
         # Use iptables to enforce egress at the kernel level — simpler and
         # more reliable than bwrap egress_rules, which requires a sandbox
@@ -444,14 +454,6 @@ jobs:
             echo "::error::Review output contains LLM_API_KEY — aborting post to prevent secret exfiltration."
             exit 1
           fi
-
-      - name: Mint App token
-        id: app-token
-        if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true' && vars.OMNIGENT_BOT_APP_ID != ''
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
-          private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
 
       - name: Post review comment
         if: steps.polly.outputs.review_text != ''


### PR DESCRIPTION
## Summary
The "Mint App token" step (used to post the review comment) was running *after* the iptables `OUTPUT -j DROP` rule, blocking its GitHub API call.

Moved both App token mints to before the iptables step:
- "Mint read-only token for Polly" — already there
- "Mint App token" — moved up, with a comment explaining why

The iptables step now runs immediately before the Polly review run, which is the only window that needs egress restriction.

## Test plan
- [ ] Trigger a `/review` comment and confirm the review posts successfully

This pull request and its description were written by Isaac.