### PR TITLE
revert(polly-review): remove iptables egress restriction

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -346,48 +346,12 @@ jobs:
           permission-contents: read
 
       - name: Mint App token
-        # Minted here (before iptables DROP) so the GitHub API call succeeds.
-        # Used later by the Post review comment step.
         id: app-token
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true' && vars.OMNIGENT_BOT_APP_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.OMNIGENT_BOT_APP_ID }}
           private-key: ${{ secrets.OMNIGENT_BOT_APP_KEY }}
-
-      - name: Restrict egress to gateway and GitHub API
-        # Use iptables to enforce egress at the kernel level — simpler and
-        # more reliable than bwrap egress_rules, which requires a sandbox
-        # that breaks Polly's shell tool visibility. Resolves gateway host
-        # from GATEWAY_BASE_URL at runtime for a tight allowlist.
-        if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
-        env:
-          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
-        run: |
-          set -euo pipefail
-
-          GW_HOST=$(python3 -c "
-          import urllib.parse, os
-          gw = os.environ.get('GATEWAY_BASE_URL', '')
-          print(urllib.parse.urlparse(gw).netloc if gw else '')
-          ")
-
-          # Allow established connections and loopback (needed for the
-          # local Omnigent server Polly starts).
-          sudo iptables -I OUTPUT 1 -m state --state ESTABLISHED,RELATED -j ACCEPT
-          sudo iptables -I OUTPUT 2 -o lo -j ACCEPT
-          # Allow GitHub API (gh CLI for PR diff / context).
-          sudo iptables -A OUTPUT -d api.github.com -j ACCEPT
-          # Allow tiktoken encoding downloads (cl100k_base etc).
-          sudo iptables -A OUTPUT -d openaipublic.blob.core.windows.net -j ACCEPT
-          # Allow gateway (LLM calls).
-          if [ -n "$GW_HOST" ]; then
-            sudo iptables -A OUTPUT -d "$GW_HOST" -j ACCEPT
-          fi
-          # Drop all other outbound traffic.
-          sudo iptables -A OUTPUT -j DROP
-
-          echo "Egress restricted to: api.github.com, openaipublic.blob.core.windows.net${GW_HOST:+, $GW_HOST} + loopback"
 
       - name: Run Polly review
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
@@ -408,7 +372,6 @@ jobs:
           # Run Polly headlessly with -p; it starts a local server, sends
           # one turn, prints the assistant response, and exits.
           # --no-session: ephemeral run, no persistent session state.
-          # Egress is restricted by the iptables rules set in the previous step.
           uv run omnigent run examples/polly/ \
             -p "$prompt" \
             --no-session \


### PR DESCRIPTION
## Summary
Removes the iptables egress restriction introduced in #1010. It caused a cascade of issues — blocked tiktoken downloads (#1012), App token mints (#1011), and likely other unforeseen hosts. The allowlist kept growing and the approach proved too brittle without a complete picture of all outbound hosts Polly needs.

The other hardening from #1002 (read-only App token for Polly, secret masking, secret scan before posting) remains in place.

Egress restriction can be revisited once the full set of required hosts is known.

This pull request and its description were written by Isaac.