### PR TITLE
test(e2e-ui): migrate approval tests from native Claude to mock LLM

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -269,10 +269,6 @@ jobs:
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
-          # Needed at runtime by the native render-parity tests: the runner
-          # subprocess inherits this so the native CLI can resolve
-          # api_key_ref: "env:LLM_API_KEY" from ~/.omnigent/config.yaml.
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           # Always exclude @visual: the UI diff snapshot runs in its own
           # pinned-runner gate (ui-snapshot.yml) so its baseline matches the

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -206,9 +206,12 @@ jobs:
         # were migrated to mock LLM and no longer need it.
         # The native CLIs derive their gateway auth from omnigent provider
         # config. Register the Databricks gateway as the default for both
-        # anthropic (Claude Code) and openai (Codex).
+        # anthropic (Claude Code) and openai (Codex); the token reaches each
+        # CLI and the openai-agents harness via an env:LLM_API_KEY ref, so
+        # no literal secret hits disk.
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           mkdir -p "$HOME/.omnigent"
           # The Anthropic Messages surface and the Codex Responses surface live
@@ -229,6 +232,7 @@ jobs:
                 # the /anthropic suffix is required — without it Claude Code POSTs
                 # to .../serving-endpoints/v1/messages and gets no reply.
                 base_url: "${GATEWAY_BASE_URL}/anthropic"
+                api_key_ref: "env:LLM_API_KEY"
                 # The default model id is read from models.default (not a
                 # top-level default_model key). Without it the provider
                 # resolves model=None, Claude Code launches with no --model and
@@ -244,6 +248,7 @@ jobs:
                 # OpenAI-compatible surface. wire_api must be 'responses' — codex
                 # >= 0.137 rejects 'chat' at config load.
                 base_url: "${host}/ai-gateway/codex/v1"
+                api_key_ref: "env:LLM_API_KEY"
                 wire_api: responses
                 # The codex model id the e2e codex leg pins (tests/_model_pools).
                 models:
@@ -256,15 +261,19 @@ jobs:
         # keeps green runs cheap while capturing artifacts on failures.
         # The conftest's live_server fixture points the server subprocess at
         # the in-process mock LLM server (OPENAI_BASE_URL / ANTHROPIC_BASE_URL),
-        # so openai-agents, approvals, and other non-native tests need no real
-        # credentials. Native render-parity tests (claude, codex) are the only
-        # tests that still use the ~/.omnigent/config.yaml gateway written above.
+        # so the policy classifier needs no real credentials. The openai-agents
+        # harness and native render-parity tests use the ~/.omnigent/config.yaml
+        # gateway written above; LLM_API_KEY resolves the api_key_ref there.
         env:
           # Scheduled / manually dispatched runs are the full pass;
           # PR and push runs exclude @pytest.mark.nightly tests.
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
+          # The runner subprocess inherits this via os.environ so the
+          # openai-agents harness and native CLIs can resolve
+          # api_key_ref: "env:LLM_API_KEY" from ~/.omnigent/config.yaml.
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           # Always exclude @visual: the UI diff snapshot runs in its own
           # pinned-runner gate (ui-snapshot.yml) so its baseline matches the

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -44,10 +44,10 @@ env:
   # dedicated step, so the setup.py build would be a redundant npm hit.
   OMNIGENT_SKIP_WEB_UI: "true"
   # Scrub harness credentials the test server must not pick up.
-  # OPENAI_API_KEY / OPENAI_BASE_URL are NOT scrubbed here -- the "Run UI
-  # e2e tests" step sets them to the Databricks bearer + serving-endpoints
-  # URL so the spawned openai-agents hello_world agent can authenticate
-  # (the ~/.databrickscfg fallback didn't resolve our OAuth M2M in CI).
+  # OPENAI_API_KEY / OPENAI_BASE_URL are NOT scrubbed here — the
+  # conftest's live_server fixture overrides them to mock values
+  # (OPENAI_BASE_URL=<mock>/v1, OPENAI_API_KEY=mock-key) inside the
+  # spawned server subprocess, so ambient real credentials are a no-op.
   ANTHROPIC_API_KEY: ""
   DATABRICKS_TOKEN: ""
   CODEX: ""
@@ -204,6 +204,9 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Configure native-claude/codex gateway provider
+        # Required only by the native render-parity tests (claude, codex).
+        # The approval tests (test_exit_plan_mode, test_ask_user_question)
+        # were migrated to mock LLM and no longer need it.
         # The native CLIs derive their gateway auth from omnigent provider
         # config. Register the Databricks gateway as the default for both
         # anthropic (Claude Code) and openai (Codex); the token reaches each
@@ -258,11 +261,11 @@ jobs:
         # --ui-skip-build: the SPA was built in the previous step.
         # --tracing/--screenshot/--video default to off; retain-on-failure
         # keeps green runs cheap while capturing artifacts on failures.
-        # OPENAI_API_KEY / OPENAI_BASE_URL are set by the conftest's
-        # live_server fixture to point at the in-process mock LLM server —
-        # no real gateway credentials needed for the openai-agents harness.
-        # Native render-parity tests (claude-sdk/codex) still use the
-        # ~/.omnigent/config.yaml written in the step above.
+        # The conftest's live_server fixture points the server subprocess at
+        # the in-process mock LLM server (OPENAI_BASE_URL / ANTHROPIC_BASE_URL),
+        # so openai-agents, approvals, and other non-native tests need no real
+        # credentials. Native render-parity tests (claude, codex) are the only
+        # tests that still use the ~/.omnigent/config.yaml gateway written above.
         env:
           # Scheduled / manually dispatched runs are the full pass;
           # PR and push runs exclude @pytest.mark.nightly tests.

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -132,9 +132,6 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
-      - name: Set LLM credentials
-        run: echo "LLM_API_KEY=${{ secrets.LLM_API_KEY }}" >> "$GITHUB_ENV"
-
       - name: Install project + dev extras
         run: uv sync --locked --extra all --extra dev
 
@@ -272,6 +269,10 @@ jobs:
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
+          # Needed at runtime by the native render-parity tests: the runner
+          # subprocess inherits this so the native CLI can resolve
+          # api_key_ref: "env:LLM_API_KEY" from ~/.omnigent/config.yaml.
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           # Always exclude @visual: the UI diff snapshot runs in its own
           # pinned-runner gate (ui-snapshot.yml) so its baseline matches the

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -206,11 +206,9 @@ jobs:
         # were migrated to mock LLM and no longer need it.
         # The native CLIs derive their gateway auth from omnigent provider
         # config. Register the Databricks gateway as the default for both
-        # anthropic (Claude Code) and openai (Codex); the token reaches each
-        # CLI via an env:LLM_API_KEY ref, so no literal secret hits disk.
+        # anthropic (Claude Code) and openai (Codex).
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           mkdir -p "$HOME/.omnigent"
           # The Anthropic Messages surface and the Codex Responses surface live
@@ -231,7 +229,6 @@ jobs:
                 # the /anthropic suffix is required — without it Claude Code POSTs
                 # to .../serving-endpoints/v1/messages and gets no reply.
                 base_url: "${GATEWAY_BASE_URL}/anthropic"
-                api_key_ref: "env:LLM_API_KEY"
                 # The default model id is read from models.default (not a
                 # top-level default_model key). Without it the provider
                 # resolves model=None, Claude Code launches with no --model and
@@ -247,7 +244,6 @@ jobs:
                 # OpenAI-compatible surface. wire_api must be 'responses' — codex
                 # >= 0.137 rejects 'chat' at config load.
                 base_url: "${host}/ai-gateway/codex/v1"
-                api_key_ref: "env:LLM_API_KEY"
                 wire_api: responses
                 # The codex model id the e2e codex leg pins (tests/_model_pools).
                 models:

--- a/tests/e2e_ui/approvals/test_ask_user_question.py
+++ b/tests/e2e_ui/approvals/test_ask_user_question.py
@@ -1,42 +1,33 @@
-r"""E2E: native Claude's built-in AskUserQuestion renders as a web form.
+r"""E2E: AskUserQuestion renders as a web form (mock, no real Claude Code).
 
-When Claude Code calls its built-in ``AskUserQuestion`` tool, the native
-``PermissionRequest`` hook forwards the call to the Omnigent server, which
-detects the tool, stamps the structured ``ask_user_question`` payload onto the
-elicitation (``_structured_ask_user_question`` in
-``server/routes/sessions.py``), and publishes it. The SPA renders that payload
-as an ``AskUserQuestionForm`` inside the ``ApprovalCard`` — radio inputs for a
-single-select question, a Submit that posts the gathered answers back as the
-elicitation verdict. This suite drives that loop end-to-end on a real
-``claude-native`` session: ask Claude to pose a two-option question, answer it
-in the web form, and assert the parked prompt drains.
+A background thread POSTs directly to the server's
+``POST /v1/sessions/{session_id}/hooks/permission-request`` endpoint with an
+``AskUserQuestion`` payload. The server parks the elicitation (long-poll), the
+SPA renders it as an ``AskUserQuestionForm`` inside an ``ApprovalCard`` — radio
+inputs for a single-select question and a Submit button. The test selects an
+answer and submits it, confirming the parked HTTP call drains and the verdict
+flowed back through the PermissionRequest round-trip.
+
+This approach replaces the original native Claude Code session (real LLM turn)
+with a seeded session and a synthetic hook POST — no real Claude Code needed,
+test completes in seconds rather than minutes.
 
 This is the structured-form counterpart to the binary approval card
 (``test_approval_card.py``): the binary card covers a policy ASK, this covers
-Claude's own question tool. It rides the same ``native_claude_session`` fixture
-as the native render-parity suite — a real Claude Code boots in the session
-terminal — so it carries a 900s ceiling, and the prompt is explicit because it
-depends on the model actually reaching for ``AskUserQuestion``.
-
-The load-bearing assertion is that the server's parked elicitation drains after
-the form submits — proof the web answer flowed back through the same
-PermissionRequest round-trip Claude is blocked on, not a detached UI action.
+Claude's own question tool. It is the sibling of ``test_exit_plan_mode.py``:
+both cover a Claude built-in tool that surfaces a structured card rather than
+the binary policy ASK.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
 import time
 
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
-
-from tests.e2e_ui.messages.test_message_render_parity import _ensure_chat_view, _send
-from tests.e2e_ui.messages.test_native_claude_render_parity import (
-    _open_terminal_view,
-    _wait_terminal_connected,
-)
 
 _log = logging.getLogger(__name__)
 
@@ -44,21 +35,11 @@ _APPROVAL_CARD = '[data-testid="approval-card"]'
 _FORM = '[data-testid="ask-user-question-form"]'
 _SUBMIT = '[data-testid="ask-user-question-submit"]'
 
-# A native Claude turn is a full agent loop (real LLM, a tool call), far slower
-# than a single custom-agent call — matches the render-parity suite's budget.
-_NATIVE_TURN_TIMEOUT_MS = 180_000
+_MOCK_ELICITATION_TIMEOUT_MS = 15_000
 
-# The exact AskUserQuestion shape the prompt pins, so the form assertions are
-# deterministic regardless of how Claude phrases the surrounding prose.
+# The exact option labels used in the hook payload and form assertions.
 _OPTION_ONE = "Alpha"
 _OPTION_TWO = "Bravo"
-_ASK_PROMPT = (
-    "Use the AskUserQuestion tool right now to ask me exactly one question. "
-    'Set the question text to "Which option do you prefer?" and offer exactly '
-    f'two options with the labels "{_OPTION_ONE}" and "{_OPTION_TWO}". Do not '
-    "ask anything else, do not call any other tool, and do not answer the "
-    "question yourself."
-)
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -78,55 +59,67 @@ def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) ->
     raise AssertionError("condition not met within timeout")
 
 
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(90)
 def test_ask_user_question_form_renders_and_submits(
     page: Page,
-    native_claude_session: tuple[str, str],
+    seeded_session: tuple[str, str],
 ) -> None:
-    """Claude calls AskUserQuestion → web form renders → answer → prompt drains."""
-    base_url, session_id = native_claude_session
-    _log.info("native-claude session ready: base_url=%s session_id=%s", base_url, session_id)
+    """Mock AskUserQuestion permission-request → web form renders → answer → prompt drains."""
+    base_url, session_id = seeded_session
+    _log.info("seeded session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    result_holder: dict = {}
+
+    def _post_hook() -> None:
+        try:
+            resp = httpx.post(
+                f"{base_url}/v1/sessions/{session_id}/hooks/permission-request",
+                json={
+                    "tool_name": "AskUserQuestion",
+                    "tool_input": {
+                        "questions": [
+                            {
+                                "question": "Which option do you prefer?",
+                                "options": [_OPTION_ONE, _OPTION_TWO],
+                            }
+                        ]
+                    },
+                },
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            result_holder["response"] = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            result_holder["error"] = exc
+
+    hook_thread = threading.Thread(target=_post_hook, daemon=True)
+    hook_thread.start()
+
+    # Let the server park the elicitation before the SPA tries to render it.
+    page.wait_for_timeout(500)
+
     page.goto(f"{base_url}/c/{session_id}")
 
-    # Confirm Claude Code actually booted in the session terminal before asking
-    # it to do anything (the runner's claude-native auto-launch).
-    _open_terminal_view(page)
-    _wait_terminal_connected(page)
-    _ensure_chat_view(page)
-
-    # Ask Claude to pose the two-option question; its AskUserQuestion call rides
-    # the PermissionRequest hook to the server and surfaces as a form here.
-    _send(page, _ASK_PROMPT)
-
-    # Scope the wait to the pending approval card that *contains* the
-    # AskUserQuestion form, rather than grabbing ``.first`` pending card and
-    # then asserting the form inside it. The prompt forbids other tool calls,
-    # but if Claude ever calls an approval-requiring tool first (the same
-    # degree of freedom that flaked test_exit_plan_mode.py the other way),
-    # ``.first`` would latch onto that unrelated card and fail even though the
-    # question card appears moments later. Filtering by ``has=`` waits for the
-    # right card specifically. This does not weaken the assertion: if Claude
-    # never calls AskUserQuestion, no such card ever appears and the test still
-    # times out and fails.
     card = (
         page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
         .filter(has=page.locator(_FORM))
         .first
     )
-    expect(card).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(card).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
     form = card.locator(_FORM)
-    expect(form).to_be_visible(timeout=30_000)
+    expect(form).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
     expect(form.get_by_text(_OPTION_ONE, exact=True)).to_be_visible()
     expect(form.get_by_text(_OPTION_TWO, exact=True)).to_be_visible()
-    # The server is genuinely parked on this question, not an optimistic UI.
     assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
 
-    # Answer the (single-select) question and submit.
     form.get_by_role("radio", name=_OPTION_ONE).check()
     form.locator(_SUBMIT).click()
 
-    # The card flips to its responded state and the parked prompt drains —
-    # the answer reached the blocked Claude tool call.
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
-    expect(responded).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(responded).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
+
+    hook_thread.join(timeout=30)
+    if "error" in result_holder:
+        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder["error"]
+
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))

--- a/tests/e2e_ui/approvals/test_ask_user_question.py
+++ b/tests/e2e_ui/approvals/test_ask_user_question.py
@@ -89,7 +89,7 @@ def test_ask_user_question_form_renders_and_submits(
             )
             resp.raise_for_status()
             result_holder["response"] = resp.json()
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             result_holder["error"] = exc
 
     hook_thread = threading.Thread(target=_post_hook, daemon=True)
@@ -120,6 +120,8 @@ def test_ask_user_question_form_renders_and_submits(
 
     hook_thread.join(timeout=30)
     if "error" in result_holder:
-        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder["error"]
+        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder[
+            "error"
+        ]
 
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))

--- a/tests/e2e_ui/approvals/test_exit_plan_mode.py
+++ b/tests/e2e_ui/approvals/test_exit_plan_mode.py
@@ -1,80 +1,37 @@
-r"""E2E: native Claude's ExitPlanMode plan review renders and approves.
+r"""E2E: ExitPlanMode plan review renders and approves (mock, no real Claude Code).
 
-Claude Code in **plan mode** researches a task and then calls its built-in
-``ExitPlanMode`` tool to present the plan for the user's approval. On a native
-``claude-native`` session that call rides the ``PermissionRequest`` hook to the
-Omnigent server, which detects the tool and stamps the full ``exit_plan_mode``
-tool input (the plan markdown) onto the elicitation
-(``server/routes/sessions.py``). The SPA renders it as ``ExitPlanModeReview``
-inside the ``ApprovalCard`` — the plan plus plan-review actions ("use auto
-mode", "manually approve edits", "reject with feedback"). This suite drives that
-loop on a real plan-mode session: ask Claude to plan, then approve the plan in
-the web review card.
+A background thread POSTs directly to the server's
+``POST /v1/sessions/{session_id}/hooks/permission-request`` endpoint with an
+``ExitPlanMode`` payload. The server parks the elicitation (long-poll), the SPA
+renders it as an ``ExitPlanModeReview`` inside an ``ApprovalCard``, and the test
+approves it via the "Yes, manually approve edits" button. The parked HTTP call
+then returns, confirming the verdict flowed back through the PermissionRequest
+round-trip.
 
-Plan mode is set by launching the session with
-``terminal_launch_args=["--permission-mode", "plan", "--disallowedTools",
-"AskUserQuestion"]`` — see the ``native_claude_plan_session`` fixture. It is the
-sibling of ``test_ask_user_question.py``: both cover a Claude built-in tool that
-surfaces a structured card rather than the binary policy ASK. Rides a real
-Claude Code boot, so it carries a 900s ceiling.
+This approach replaces the original native Claude Code session (plan-mode boot,
+real LLM planning turn) with a seeded session and a synthetic hook POST — no
+real Claude Code needed, test completes in seconds rather than minutes.
 
-Two layers keep the model on the ExitPlanMode path (and off the clarifying
-``AskUserQuestion`` path, which would surface the wrong card and time the test
-out): the fixture disables ``AskUserQuestion`` outright, and the prompt pins the
-exact comment text/location and forbids questions. The AskUserQuestion render
-path keeps its own dedicated coverage in ``test_ask_user_question.py``, so
-removing the tool here loses no coverage.
-
-The load-bearing assertion is that the parked elicitation drains after the
-review's approve — proof the verdict flowed back through the PermissionRequest
-round-trip the planning Claude is blocked on.
+This is the sibling of ``test_ask_user_question.py``: both cover a Claude
+built-in tool that surfaces a structured card rather than the binary policy ASK.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
 import time
 
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.e2e_ui.messages.test_message_render_parity import _ensure_chat_view, _send
-from tests.e2e_ui.messages.test_native_claude_render_parity import (
-    _open_terminal_view,
-    _wait_terminal_connected,
-)
-
 _log = logging.getLogger(__name__)
 
 _APPROVAL_CARD = '[data-testid="approval-card"]'
 _PLAN_REVIEW = '[data-testid="exit-plan-mode-review"]'
 
-# A native Claude planning turn is a full agent loop (real LLM, research), far
-# slower than a single custom-agent call — matches the render-parity budget.
-_NATIVE_TURN_TIMEOUT_MS = 180_000
-
-# The prompt pins the comment text and location so there is nothing for Claude
-# to clarify, and explicitly forbids questions / mandates going straight to
-# ExitPlanMode. Combined with the fixture's ``--disallowedTools
-# AskUserQuestion`` (native_claude_plan_session), this keeps the model on the
-# ExitPlanMode path the review card under test depends on.
-#
-# The pinned file/comment only have to be *plausible* targets for a plan: Claude
-# is planning, never executing (the test never approves an edit), so the run is
-# unaffected even if ``README.md`` is later renamed or removed from the repo
-# root. The constant just keeps the prompt's intent explicit.
-_PLAN_FILE = "README.md"
-_PLAN_COMMENT = "<!-- Maintained by the Platform team -->"
-_PLAN_PROMPT = (
-    "You are in plan mode. Put together a short plan describing how you would "
-    f"add the one-line comment `{_PLAN_COMMENT}` as the final line of "
-    f"`{_PLAN_FILE}` in this repository. Do not ask any clarifying questions; "
-    "if any detail is unspecified, assume a reasonable default and proceed. "
-    "Then immediately use the ExitPlanMode tool to present that plan for my "
-    "approval. Keep the plan to a few bullet points and do not make any edits "
-    "yet."
-)
+_MOCK_ELICITATION_TIMEOUT_MS = 15_000
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -94,38 +51,58 @@ def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) ->
     raise AssertionError("condition not met within timeout")
 
 
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(90)
 def test_exit_plan_mode_review_renders_and_approves(
     page: Page,
-    native_claude_plan_session: tuple[str, str],
+    seeded_session: tuple[str, str],
 ) -> None:
-    """Plan-mode Claude calls ExitPlanMode → review card → approve → prompt drains."""
-    base_url, session_id = native_claude_plan_session
-    _log.info("native-claude plan session ready: base_url=%s session_id=%s", base_url, session_id)
+    """Mock ExitPlanMode permission-request → review card → approve → prompt drains."""
+    base_url, session_id = seeded_session
+    _log.info("seeded session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    result_holder: dict = {}
+
+    def _post_hook() -> None:
+        try:
+            resp = httpx.post(
+                f"{base_url}/v1/sessions/{session_id}/hooks/permission-request",
+                json={
+                    "tool_name": "ExitPlanMode",
+                    "tool_input": {
+                        "plan": "- Add comment `<!-- Maintained by the Platform team -->` as the final line of `README.md`."
+                    },
+                },
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            result_holder["response"] = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            result_holder["error"] = exc
+
+    hook_thread = threading.Thread(target=_post_hook, daemon=True)
+    hook_thread.start()
+
+    # Let the server park the elicitation before the SPA tries to render it.
+    page.wait_for_timeout(500)
+
     page.goto(f"{base_url}/c/{session_id}")
 
-    # Confirm Claude Code actually booted in the session terminal (plan mode) before
-    # asking it to plan.
-    _open_terminal_view(page)
-    _wait_terminal_connected(page)
-    _ensure_chat_view(page)
-
-    # Ask Claude to produce a plan; in plan mode it presents it via ExitPlanMode,
-    # which surfaces here as the plan-review card.
-    _send(page, _PLAN_PROMPT)
-
     card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
-    expect(card).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(card).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
     review = card.locator(_PLAN_REVIEW)
-    expect(review).to_be_visible(timeout=30_000)
+    expect(review).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
     # The server is genuinely parked on the plan approval, not an optimistic UI.
     assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
 
     # Approve the plan ("manually approve edits" maps to a plain accept verdict).
     review.get_by_role("button", name="Yes, manually approve edits").click()
 
-    # The card flips to its responded state and the parked prompt drains — the
-    # verdict reached the blocked ExitPlanMode call.
+    # The card flips to its responded state and the parked prompt drains.
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').first
-    expect(responded).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(responded).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
+
+    hook_thread.join(timeout=30)
+    if "error" in result_holder:
+        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder["error"]
+
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))

--- a/tests/e2e_ui/approvals/test_exit_plan_mode.py
+++ b/tests/e2e_ui/approvals/test_exit_plan_mode.py
@@ -69,14 +69,17 @@ def test_exit_plan_mode_review_renders_and_approves(
                 json={
                     "tool_name": "ExitPlanMode",
                     "tool_input": {
-                        "plan": "- Add comment `<!-- Maintained by the Platform team -->` as the final line of `README.md`."
+                        "plan": (
+                            "- Add comment `<!-- Maintained by the Platform team -->`"
+                            " as the final line of `README.md`."
+                        )
                     },
                 },
                 timeout=60.0,
             )
             resp.raise_for_status()
             result_holder["response"] = resp.json()
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             result_holder["error"] = exc
 
     hook_thread = threading.Thread(target=_post_hook, daemon=True)
@@ -103,6 +106,8 @@ def test_exit_plan_mode_review_renders_and_approves(
 
     hook_thread.join(timeout=30)
     if "error" in result_holder:
-        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder["error"]
+        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder[
+            "error"
+        ]
 
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))

--- a/tests/e2e_ui/approvals/test_persistent_approval.py
+++ b/tests/e2e_ui/approvals/test_persistent_approval.py
@@ -1,75 +1,42 @@
-r"""E2E: the persistent "don't ask again" approval button approves a scope once.
+r"""E2E: the persistent "don't ask again" approval button approves a scope once (mock).
 
-When Claude Code calls a non-edit tool under a prompting permission mode (e.g.
-``WebFetch`` in the default mode), the native ``PermissionRequest`` hook
-forwards the call to the Omnigent server, which stamps a ``remember_scope``
-extra onto the elicitation (``server/routes/sessions.py`` —
-``_allow_remember_eligible`` / ``_claude_native_remember_host``) and publishes
-it. The SPA renders a third button on the binary ``ApprovalCard``
-(``ap-web/src/components/blocks/ApprovalCard.tsx``): **"Approve & don't ask
-again for {host|tool}"**. Accepting through it sends ``content.remember`` back;
-the server re-derives the scope and echoes an ``addRules`` permission update so
-same-scope calls stop prompting — the web equivalent of Claude Code's native
-"don't ask again" option.
+A background thread POSTs directly to the server's
+``POST /v1/sessions/{session_id}/hooks/permission-request`` endpoint with a
+``WebFetch`` payload. The server parks the elicitation, stamps a
+``remember_scope`` with host ``github.com``, and surfaces the persistent-
+approval card. The test clicks the "Approve & don't ask again for github.com"
+button and asserts the parked prompt drains.
+
+This replaces the original ``native_claude_session`` approach (real Claude Code
++ real LLM to call WebFetch) with a ``seeded_session`` + synthetic hook POST —
+no native CLI required, completes in seconds.
 
 This is the persistent-allow-rule counterpart to ``test_ask_user_question.py``
 (Claude's question tool) and ``test_exit_plan_mode.py`` (the plan card): all
 three cover a claude-native ``PermissionRequest`` that surfaces a richer card
-than the binary policy ASK. It rides the same ``native_claude_session`` fixture
-— a real Claude Code boots in the session terminal — so it carries a 900s
-ceiling, and the prompt is explicit because the test depends on the model
-actually reaching for ``WebFetch``.
-
-The scope exercised is the **WebFetch domain** case: the rule (and the button /
-responded label) is scoped to the request host, ``github.com``. The tool-wide
-fallback (no host → a rule for the whole tool) is covered by the server
-integration tests
-(``tests/server/integration/test_sessions_permission_request_hook.py``) and the
-ApprovalCard unit tests (``ap-web/.../ApprovalCard.test.tsx``); like the sibling
-suites, this test drives exactly one forced tool call per real Claude boot to
-stay deterministic.
-
-The load-bearing assertion is that the parked elicitation drains after the
-remember-click — proof the ``remember`` verdict (and the ``addRules`` update it
-carries) flowed back through the PermissionRequest round-trip Claude is blocked
-on, not a detached UI action.
+than the binary policy ASK.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
 import time
 
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.e2e_ui.messages.test_message_render_parity import _ensure_chat_view, _send
-from tests.e2e_ui.messages.test_native_claude_render_parity import (
-    _open_terminal_view,
-    _wait_terminal_connected,
-)
-
 _log = logging.getLogger(__name__)
 
 _APPROVAL_CARD = '[data-testid="approval-card"]'
 _REMEMBER_BUTTON = '[data-testid="approval-card-remember"]'
 
-# A native Claude turn is a full agent loop (real LLM, a tool call), far slower
-# than a single custom-agent call — matches the sibling approval suites' budget.
-_NATIVE_TURN_TIMEOUT_MS = 180_000
+_MOCK_ELICITATION_TIMEOUT_MS = 15_000
 
 # WebFetch on a stable, well-known repo URL: the host the server scopes the
-# domain rule to is ``github.com``. The fetch never has to succeed — the
-# PermissionRequest fires on the tool *call*, before any network egress — so the
-# exact path is irrelevant to the assertion.
-_WEBFETCH_URL = "https://github.com/cli/cli"
+# domain rule to is ``github.com``.
 _WEBFETCH_HOST = "github.com"
-_WEBFETCH_PROMPT = (
-    f"Use the WebFetch tool right now to fetch {_WEBFETCH_URL} with the prompt "
-    '"summarize this page". Do not call any other tool first and do not ask any '
-    "questions — call WebFetch immediately."
-)
 
 
 def _pending_elicitations(base_url: str, session_id: str) -> list[dict]:
@@ -89,39 +56,49 @@ def _wait_for(predicate, *, timeout_s: float = 30.0, interval_s: float = 0.5) ->
     raise AssertionError("condition not met within timeout")
 
 
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(90)
 def test_persistent_approval_remembers_webfetch_domain(
     page: Page,
-    native_claude_session: tuple[str, str],
+    seeded_session: tuple[str, str],
 ) -> None:
-    """WebFetch → domain "don't ask again" button → click → responded + drain."""
-    base_url, session_id = native_claude_session
-    _log.info("native-claude session ready: base_url=%s session_id=%s", base_url, session_id)
+    """Mock WebFetch permission-request → domain remember button → click → drain."""
+    base_url, session_id = seeded_session
+    _log.info("seeded session ready: base_url=%s session_id=%s", base_url, session_id)
+
+    result_holder: dict = {}
+
+    def _post_hook() -> None:
+        try:
+            resp = httpx.post(
+                f"{base_url}/v1/sessions/{session_id}/hooks/permission-request",
+                json={
+                    "tool_name": "WebFetch",
+                    "tool_input": {
+                        "url": "https://github.com/cli/cli",
+                        "prompt": "summarize this page",
+                    },
+                },
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            result_holder["response"] = resp.json()
+        except Exception as exc:
+            result_holder["error"] = exc
+
+    hook_thread = threading.Thread(target=_post_hook, daemon=True)
+    hook_thread.start()
+
+    # Let the server park the elicitation before the SPA tries to render it.
+    page.wait_for_timeout(500)
+
     page.goto(f"{base_url}/c/{session_id}")
 
-    # Confirm Claude Code actually booted in the session terminal before asking
-    # it to do anything (the runner's claude-native auto-launch).
-    _open_terminal_view(page)
-    _wait_terminal_connected(page)
-    _ensure_chat_view(page)
-
-    # Ask Claude to call WebFetch; its call rides the PermissionRequest hook to
-    # the server, which stamps the WebFetch ``remember_scope`` (host github.com)
-    # and surfaces the persistent-approval card here.
-    _send(page, _WEBFETCH_PROMPT)
-
-    # Scope the wait to the pending card that actually carries the remember
-    # button (filter by ``has=``), not ``.first`` pending card — if Claude ever
-    # surfaces an unrelated approval first, ``.first`` would latch onto it and
-    # fail even though the right card appears moments later. This does not weaken
-    # the assertion: if the remember button never renders, no such card appears
-    # and the test still times out and fails.
     card = (
         page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
         .filter(has=page.locator(_REMEMBER_BUTTON))
         .first
     )
-    expect(card).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(card).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
     # The server is genuinely parked on this prompt, not an optimistic UI.
     assert _pending_elicitations(base_url, session_id), "server has no parked elicitation"
 
@@ -136,12 +113,17 @@ def test_persistent_approval_remembers_webfetch_domain(
 
     remember.click()
 
-    # The card flips to its responded state with the persistent-approval label —
-    # "Approved · won't ask again for github.com".
+    # The card flips to its responded state with the persistent-approval label.
     responded = page.locator(f'{_APPROVAL_CARD}[data-state="responded"]').filter(
         has_text=f"won't ask again for {_WEBFETCH_HOST}"
     )
-    expect(responded.first).to_be_visible(timeout=_NATIVE_TURN_TIMEOUT_MS)
-    # The parked prompt drains — the remember verdict reached the blocked
-    # WebFetch call, carrying the addRules update back to Claude Code.
+    expect(responded.first).to_be_visible(timeout=_MOCK_ELICITATION_TIMEOUT_MS)
+
+    hook_thread.join(timeout=30)
+    if "error" in result_holder:
+        raise AssertionError(f"hook thread failed: {result_holder['error']}") from result_holder[
+            "error"
+        ]
+
+    # The parked prompt drains — the remember verdict reached the blocked call.
     _wait_for(lambda: not _pending_elicitations(base_url, session_id))

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -32,6 +32,7 @@ pytest tmp dir so the test never touches the user's default
 
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import signal
@@ -39,8 +40,9 @@ import socket
 import subprocess
 import sys
 import tarfile
+import textwrap
 import time
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -477,13 +479,15 @@ def configure_mock_llm(
     responses: list[dict[str, Any]],
     *,
     key: str = "default",
+    match: str | None = None,
 ) -> None:
     """Configure a keyed response queue on the mock LLM server.
 
     Each dict in *responses* maps to a ``QueuedResponse`` on the mock
     server. The *key* determines which queue the responses are stored in
     — the mock server routes each request to the queue whose key matches
-    the request's ``model`` field.
+    the request's ``model`` field. When *match* is set, the queue fires
+    whenever the user text contains that substring, regardless of model.
 
     :param mock_url: Mock server base URL.
     :param responses: List of response configs. Keys:
@@ -492,10 +496,15 @@ def configure_mock_llm(
     :param key: Queue key — typically the model name baked into the
         agent spec. Defaults to ``"default"`` (matches any model
         not assigned to a more specific queue).
+    :param match: Optional substring to match against the user text for
+        content-based routing (in addition to model-name routing).
     """
+    body: dict[str, Any] = {"key": key, "responses": responses}
+    if match is not None:
+        body["match"] = match
     resp = httpx.post(
         f"{mock_url}/mock/configure",
-        json={"key": key, "responses": responses},
+        json=body,
         timeout=5.0,
     )
     resp.raise_for_status()
@@ -1666,6 +1675,8 @@ def server_pid(live_server: str) -> int:
 # 1 + executor.config.harness routes through the strict parser; arcname
 # config.yaml keeps it on that path.
 _CUSTOM_AGENT_NAME = "echo_probe"
+_CLAUDE_MOCK_MODEL = "claude-3-5-sonnet-20241022"
+_CODEX_MOCK_MODEL = "gpt-4o"
 _CUSTOM_AGENT_YAML = f"""\
 spec_version: 1
 name: {_CUSTOM_AGENT_NAME}
@@ -2023,6 +2034,128 @@ def native_codex_session(
             # Escalate to SIGKILL if the runner ignores SIGTERM, so a wedged
             # process can't raise in teardown and leak / fail unrelated tests
             # (matching terminal_session / seeded_session_pair).
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)
+
+
+@contextlib.contextmanager
+def _temp_omnigent_mock_config(
+    mock_llm_server_url: str, harness: str
+) -> Generator[None, None, None]:
+    """Temporarily write a mock provider config to ~/.omnigent/config.yaml.
+
+    The runner reads this at terminal-creation time, so it only needs to be
+    in place between the PATCH that binds a session to the runner (which
+    triggers auto-boot) and the terminal connecting. Restores the original
+    file (or removes it) on exit.
+
+    :param mock_llm_server_url: Base URL of the mock LLM server, e.g.
+        ``"http://127.0.0.1:51235"``. No /v1 suffix — each SDK appends it.
+    :param harness: ``"claude"`` or ``"codex"``.
+    """
+    config_dir = Path.home() / ".omnigent"
+    config_path = config_dir / "config.yaml"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    original = config_path.read_text() if config_path.exists() else None
+
+    if harness == "claude":
+        mock_config = textwrap.dedent(f"""\
+            providers:
+              mock-claude:
+                kind: key
+                default: [anthropic]
+                anthropic:
+                  base_url: "{mock_llm_server_url}"
+                  api_key: "mock-key"
+                  models:
+                    default: {_CLAUDE_MOCK_MODEL}
+            """)
+    else:  # codex
+        mock_config = textwrap.dedent(f"""\
+            providers:
+              mock-codex:
+                kind: key
+                default: [openai]
+                openai:
+                  base_url: "{mock_llm_server_url}"
+                  api_key: "mock-key"
+                  wire_api: responses
+                  models:
+                    default: {_CODEX_MOCK_MODEL}
+            """)
+
+    config_path.write_text(mock_config)
+    try:
+        yield
+    finally:
+        if original is not None:
+            config_path.write_text(original)
+        else:
+            config_path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def native_claude_mock_session(
+    live_server: str,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound claude-native session that routes LLM calls to the mock server.
+
+    Writes a mock anthropic provider config to ~/.omnigent/config.yaml just
+    before binding the session (the runner reads it at terminal-creation
+    time), then restores the original config on teardown.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param mock_llm_server_url: Session-scoped mock LLM server base URL.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    with _temp_omnigent_mock_config(mock_llm_server_url, "claude"):
+        session_id = _create_native_claude_session(live_server, runner_id)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)
+
+
+@pytest.fixture
+def native_codex_mock_session(
+    live_server: str,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound codex-native session that routes LLM calls to the mock server.
+
+    Mirrors native_claude_mock_session for the Codex wrapper.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param mock_llm_server_url: Session-scoped mock LLM server base URL.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    with _temp_omnigent_mock_config(mock_llm_server_url, "codex"):
+        session_id = _create_native_codex_session(live_server, runner_id)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
             try:
                 respawned.wait(timeout=5)
             except subprocess.TimeoutExpired:

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -2103,11 +2103,13 @@ def native_claude_mock_session(
     mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[tuple[str, str]]:
-    """A runner-bound claude-native session that routes LLM calls to the mock server.
+    """A runner-bound claude-native session whose LLM backend depends on env.
 
-    Writes a mock anthropic provider config to ~/.omnigent/config.yaml just
-    before binding the session (the runner reads it at terminal-creation
-    time), then restores the original config on teardown.
+    When ``LLM_API_KEY`` is set in the environment (local dev / CI with real
+    credentials), the existing ``~/.omnigent/config.yaml`` is left untouched so
+    the runner boots Claude Code against the real gateway. When ``LLM_API_KEY``
+    is absent, a mock anthropic provider config is written to
+    ``~/.omnigent/config.yaml`` and restored on teardown.
 
     :param live_server: Spawned server fixture; its runner is reused.
     :param mock_llm_server_url: Session-scoped mock LLM server base URL.
@@ -2116,7 +2118,12 @@ def native_claude_mock_session(
     """
     respawned = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
-    with _temp_omnigent_mock_config(mock_llm_server_url, "claude"):
+    use_mock = not os.environ.get("LLM_API_KEY")
+    if use_mock:
+        ctx: Any = _temp_omnigent_mock_config(mock_llm_server_url, "claude")
+    else:
+        ctx = contextlib.nullcontext()
+    with ctx:
         session_id = _create_native_claude_session(live_server, runner_id)
     try:
         yield (live_server, session_id)
@@ -2137,9 +2144,10 @@ def native_codex_mock_session(
     mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[tuple[str, str]]:
-    """A runner-bound codex-native session that routes LLM calls to the mock server.
+    """A runner-bound codex-native session whose LLM backend depends on env.
 
-    Mirrors native_claude_mock_session for the Codex wrapper.
+    Mirrors :func:`native_claude_mock_session` for the Codex wrapper: uses
+    mock LLM when ``LLM_API_KEY`` is absent, real gateway when it is set.
 
     :param live_server: Spawned server fixture; its runner is reused.
     :param mock_llm_server_url: Session-scoped mock LLM server base URL.
@@ -2148,7 +2156,12 @@ def native_codex_mock_session(
     """
     respawned = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
-    with _temp_omnigent_mock_config(mock_llm_server_url, "codex"):
+    use_mock = not os.environ.get("LLM_API_KEY")
+    if use_mock:
+        ctx: Any = _temp_omnigent_mock_config(mock_llm_server_url, "codex")
+    else:
+        ctx = contextlib.nullcontext()
+    with ctx:
         session_id = _create_native_codex_session(live_server, runner_id)
     try:
         yield (live_server, session_id)

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -1,4 +1,4 @@
-r"""UI journey: a native Claude Code session renders parity with its TUI.
+r"""UI journey: a native Claude Code session renders parity with its TUI (mock LLM).
 
 The native ``claude-native`` ("Claude Code") wrapper is terminal-first: a real
 ``claude`` CLI runs in the session terminal, the SPA's **Terminal** view
@@ -7,35 +7,15 @@ the SAME canonical transcript (``GET /v1/sessions/{id}/items``) the TUI prints.
 A native bridge forwards web-composer messages INTO the Claude process and
 forwards Claude's transcript back OUT as conversation items. This suite asserts
 that round-trips both ways and renders exactly once — the three properties the
-native forwarder has historically regressed on:
+native forwarder has historically regressed on.
 
-1. **Render parity with the TUI.** Composer turns are sent through the web SPA;
-   each per-turn user marker and assistant token the SPA shows in a bubble must
-   also appear in the canonical transcript, in the same order, exactly once. The
-   transcript is what the TUI prints, so transcript parity == "renders the same
-   as the TUI".
-
-2. **A TUI-originated message surfaces in the web UI.** A turn is typed directly
-   into the Claude Code TUI (the embedded xterm in the Terminal view) — never
-   through the composer. The native bridge must forward it back out as a user
-   item + assistant reply, so switching to Chat shows both as bubbles and the
-   transcript carries them. This is the OUT direction the composer turns don't
-   exercise.
-
-3. **No duplicate rendering.** Every marker/token — composer- and TUI-originated
-   alike — must land in EXACTLY ONE bubble and one transcript entry. The classic
-   native-forwarder bug double-rendered a reply as both a streaming live preview
-   and the committed bubble; per-turn unique tokens make that count unambiguous.
-
-Per-turn unique markers/tokens are load-bearing for the same reasons as the
-custom-agent suite: they keep the dedup count and order checks unambiguous even
-though Claude Code is far chattier than the ``echo_probe`` agent (it may emit
-thinking, tool calls, and prose around the echoed token). Every assertion counts
-*bubbles/entries containing the token*, never bubbles, so chattiness is fine.
-
-Requires the native-harness gateway auth the runner derives from its own
-credentials (the same gateway ``hello_world`` uses); CI exchanges Databricks
-OAuth before pytest. See ``native_claude_session`` in ``conftest.py``.
+The LLM calls are served by the in-process mock LLM server rather than a real
+Anthropic endpoint. Before each test run a mock ``anthropic`` provider config is
+written to ``~/.omnigent/config.yaml`` (see ``native_claude_mock_session`` in
+``conftest.py``), redirecting the runner's ``ANTHROPIC_BASE_URL`` to the mock
+server. Tokens are pre-generated and queued via content-based routing so the
+mock returns the expected assistant token for each turn regardless of how many
+extra LLM calls Claude Code makes internally.
 """
 
 from __future__ import annotations
@@ -45,6 +25,8 @@ import uuid
 
 import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm, reset_mock_llm, set_fallback_mock_llm
 
 # Reuse the custom-agent suite's helpers — both surfaces render from the same
 # canonical transcript, so parity / dedup / ordering are asserted identically.
@@ -66,12 +48,14 @@ _TERMINAL_VIEW = '[data-testid="terminal-view"]'
 # and typing is how a user (and Playwright) drives the embedded TUI.
 _XTERM_INPUT = ".xterm-helper-textarea"
 
-# A native Claude Code turn is a full agent loop (real LLM, possible tool use),
-# so it is far slower than a single custom-agent LLM call.
-_NATIVE_TURN_TIMEOUT_MS = 180_000
-# Claude Code boots in the terminal on bind; the auto-launch + first-run
-# pre-accept + WS attach can take a while on a cold CI runner.
+# Mock LLM responds instantly; budget covers native CLI boot + terminal attach.
+_MOCK_TURN_TIMEOUT_MS = 60_000
+# claude-native auto-launch + first-run pre-accept + WS attach.
 _TERMINAL_READY_TIMEOUT_MS = 120_000
+
+# Must match the model set in the mock anthropic provider config written by the
+# native_claude_mock_session fixture (conftest._CLAUDE_MOCK_MODEL).
+_CLAUDE_MOCK_MODEL = "claude-3-5-sonnet-20241022"
 
 # Two composer turns (the IN direction) + one TUI turn (the OUT direction).
 _COMPOSER_TURNS = 2
@@ -103,79 +87,73 @@ def _wait_terminal_connected(page: Page) -> None:
 def _type_into_tui(page: Page, text: str) -> None:
     """Type *text* into the embedded Claude Code TUI and submit with Enter.
 
-    Drives the real TUI exactly as a user would: focus the xterm input,
-    type the prompt, press Enter. This is the OUT direction — the message
-    originates in the terminal, not the web composer.
-
     :param page: The Playwright page, on the connected Terminal view.
     :param text: The single-line prompt to type into the TUI.
     """
-    # Scope to the active terminal-view (not page-level) so the lookup can't
-    # focus a stray textarea from another terminal widget — matches the shell
-    # E2E test pattern.
     xterm_input = page.locator(_TERMINAL_VIEW).last.locator(_XTERM_INPUT)
     expect(xterm_input).to_be_attached(timeout=30_000)
     xterm_input.focus()
-    # Type at a human-ish cadence: Claude Code's TUI composer can drop or
-    # reorder characters injected faster than it repaints.
     page.keyboard.type(text, delay=15)
     page.keyboard.press("Enter")
 
 
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(300)
 def test_native_claude_message_render_parity(
     page: Page,
-    native_claude_session: tuple[str, str],
+    native_claude_mock_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
-    """Native Claude Code renders parity with its TUI, both ways, with no dupes.
-
-    Covers all three properties on a single (expensive to spin up) native
-    session: composer parity (IN), a TUI-originated turn surfacing in the web UI
-    (OUT), and no duplicate rendering across every turn.
-    """
-    base_url, session_id = native_claude_session
-    _log.info("native-claude session ready: base_url=%s session_id=%s", base_url, session_id)
+    """Native Claude Code renders parity with its TUI, both ways, with no dupes (mock LLM)."""
+    base_url, session_id = native_claude_mock_session
+    _log.info("native-claude mock session ready: base_url=%s session_id=%s", base_url, session_id)
 
     page.goto(f"{base_url}/c/{session_id}")
-
-    # The Terminal view proves Claude Code actually booted in the session
-    # terminal (the runner's claude-native auto-launch) before we send anything.
     _open_terminal_view(page)
     _wait_terminal_connected(page)
     _log.info("Claude Code TUI attached (terminal-view connected)")
+    _ensure_chat_view(page)
+
+    # Pre-generate tokens for all turns so they can be queued in the mock
+    # before any message is sent. Content-based routing (match=user_marker)
+    # ensures the right token is returned regardless of extra internal calls.
+    nonces = [uuid.uuid4().hex[:8] for _ in range(_COMPOSER_TURNS + 1)]
+    turns = [
+        (f"usr-{i + 1}-{nonces[i]}", f"ast-{i + 1}-{nonces[i]}")
+        for i in range(_COMPOSER_TURNS + 1)
+    ]
+    reset_mock_llm(mock_llm_server_url)
+    for user_marker, assistant_token in turns:
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": assistant_token}],
+            key=user_marker,
+            match=user_marker,
+        )
+    set_fallback_mock_llm(mock_llm_server_url, _CLAUDE_MOCK_MODEL, "")
 
     user_markers: list[str] = []
     assistant_tokens: list[str] = []
 
-    def _new_turn(index: int) -> tuple[str, str]:
-        nonce = uuid.uuid4().hex[:8]
-        user_marker = f"usr-{index}-{nonce}"
-        assistant_token = f"ast-{index}-{nonce}"
+    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
+    for index, (user_marker, assistant_token) in enumerate(turns[:_COMPOSER_TURNS], start=1):
         user_markers.append(user_marker)
         assistant_tokens.append(assistant_token)
-        return user_marker, assistant_token
-
-    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
-    _ensure_chat_view(page)
-    for index in range(1, _COMPOSER_TURNS + 1):
-        user_marker, assistant_token = _new_turn(index)
         _log.info(
             "composer turn %d: sending (marker=%s token=%s)", index, user_marker, assistant_token
         )
         _send(page, _turn_prompt(index, user_marker, assistant_token))
-        # The echoed token in an assistant bubble = this turn produced its reply.
         expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
-            timeout=_NATIVE_TURN_TIMEOUT_MS
+            timeout=_MOCK_TURN_TIMEOUT_MS
         )
-        # Fully settle (working shimmer gone) before the next send, so any
-        # transient native live-preview has collapsed into the committed bubble.
-        expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=_MOCK_TURN_TIMEOUT_MS)
         expect(page.locator(_USER)).to_have_count(index, timeout=30_000)
         _log.info("composer turn %d: settled", index)
 
     # --- Property 2 & 3: a TUI-originated turn (OUT) surfaces in the web UI. ---
     tui_index = _COMPOSER_TURNS + 1
-    tui_marker, tui_token = _new_turn(tui_index)
+    tui_marker, tui_token = turns[_COMPOSER_TURNS]
+    user_markers.append(tui_marker)
+    assistant_tokens.append(tui_token)
     _open_terminal_view(page)
     _wait_terminal_connected(page)
     _log.info(
@@ -183,14 +161,12 @@ def test_native_claude_message_render_parity(
     )
     _type_into_tui(page, _turn_prompt(tui_index, tui_marker, tui_token))
 
-    # Back in Chat, the bridge must have forwarded the TUI turn OUT as a user
-    # item + assistant reply — both render as bubbles, exactly once.
     _ensure_chat_view(page)
     expect(page.locator(_ASSISTANT, has_text=tui_token).first).to_be_visible(
-        timeout=_NATIVE_TURN_TIMEOUT_MS
+        timeout=_MOCK_TURN_TIMEOUT_MS
     )
     expect(page.locator(_USER, has_text=tui_marker).first).to_be_visible(timeout=30_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=_MOCK_TURN_TIMEOUT_MS)
     expect(page.locator(_USER)).to_have_count(len(user_markers), timeout=30_000)
     _log.info("TUI turn %d: surfaced in web UI (user + assistant bubbles present)", tui_index)
 

--- a/tests/e2e_ui/messages/test_native_codex_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_codex_render_parity.py
@@ -1,4 +1,4 @@
-r"""UI journey: a native Codex session renders parity with its TUI.
+r"""UI journey: a native Codex session renders parity with its TUI (mock LLM).
 
 The native ``codex-native`` ("Codex") wrapper is terminal-first: a real
 ``codex`` CLI runs in the session terminal, the SPA's **Terminal** view
@@ -6,37 +6,16 @@ attaches to that live TUI over a WebSocket, and the SPA's **Chat** view renders
 the SAME canonical transcript (``GET /v1/sessions/{id}/items``) the TUI prints.
 A native bridge forwards web-composer messages INTO the Codex app-server thread
 and forwards Codex's transcript back OUT as conversation items. This suite
-asserts that round-trips both ways and renders exactly once — the three
-properties the native forwarder has historically regressed on:
+asserts that round-trips both ways and renders exactly once — the same three
+properties the claude native forwarder is pinned against.
 
-1. **Render parity with the TUI.** Composer turns are sent through the web SPA;
-   each per-turn user marker and assistant token the SPA shows in a bubble must
-   also appear in the canonical transcript, in the same order, exactly once. The
-   transcript is what the TUI prints, so transcript parity == "renders the same
-   as the TUI".
-
-2. **A TUI-originated message surfaces in the web UI.** A turn is typed directly
-   into the Codex TUI (the embedded xterm in the Terminal view) — never through
-   the composer. The native bridge must forward it back out as a user item +
-   assistant reply, so switching to Chat shows both as bubbles and the
-   transcript carries them. This is the OUT direction the composer turns don't
-   exercise.
-
-3. **No duplicate rendering.** Every marker/token — composer- and TUI-originated
-   alike — must land in EXACTLY ONE bubble and one transcript entry. The classic
-   native-forwarder bug double-rendered a reply as both a streaming live preview
-   and the committed bubble; per-turn unique tokens make that count unambiguous.
-
-Per-turn unique markers/tokens are load-bearing for the same reasons as the
-custom-agent suite: they keep the dedup count and order checks unambiguous even
-though Codex is far chattier than the ``echo_probe`` agent (it may emit
-reasoning, tool calls, and prose around the echoed token). Every assertion
-counts *bubbles/entries containing the token*, never bubbles, so chattiness is
-fine.
-
-Requires the native-harness gateway auth the runner derives from its own
-credentials (the same gateway ``hello_world`` uses); CI exchanges Databricks
-OAuth before pytest. See ``native_codex_session`` in ``conftest.py``.
+The LLM calls are served by the in-process mock LLM server rather than a real
+OpenAI endpoint. Before each test run a mock ``openai`` provider config is
+written to ``~/.omnigent/config.yaml`` (see ``native_codex_mock_session`` in
+``conftest.py``), redirecting the runner's ``OPENAI_BASE_URL`` to the mock
+server. Tokens are pre-generated and queued via content-based routing so the
+mock returns the expected assistant token for each turn regardless of how many
+extra LLM calls Codex makes internally.
 """
 
 from __future__ import annotations
@@ -46,6 +25,8 @@ import uuid
 
 import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm, reset_mock_llm, set_fallback_mock_llm
 
 # Reuse the custom-agent suite's helpers — both surfaces render from the same
 # canonical transcript, so parity / dedup / ordering are asserted identically.
@@ -67,12 +48,15 @@ _TERMINAL_VIEW = '[data-testid="terminal-view"]'
 # and typing is how a user (and Playwright) drives the embedded TUI.
 _XTERM_INPUT = ".xterm-helper-textarea"
 
-# A native Codex turn is a full agent loop (real LLM, possible tool use),
-# so it is far slower than a single custom-agent LLM call.
-_NATIVE_TURN_TIMEOUT_MS = 180_000
+# Mock LLM responds instantly; budget covers native CLI boot + terminal attach.
+_MOCK_TURN_TIMEOUT_MS = 60_000
 # Codex boots in the terminal on bind; the auto-launch + first-run
 # pre-accept + WS attach can take a while on a cold CI runner.
 _TERMINAL_READY_TIMEOUT_MS = 120_000
+
+# Must match the model set in the mock openai provider config written by the
+# native_codex_mock_session fixture (conftest._CODEX_MOCK_MODEL).
+_CODEX_MOCK_MODEL = "gpt-4o"
 
 # Two composer turns (the IN direction) + one TUI turn (the OUT direction).
 _COMPOSER_TURNS = 2
@@ -104,79 +88,73 @@ def _wait_terminal_connected(page: Page) -> None:
 def _type_into_tui(page: Page, text: str) -> None:
     """Type *text* into the embedded Codex TUI and submit with Enter.
 
-    Drives the real TUI exactly as a user would: focus the xterm input,
-    type the prompt, press Enter. This is the OUT direction — the message
-    originates in the terminal, not the web composer.
-
     :param page: The Playwright page, on the connected Terminal view.
     :param text: The single-line prompt to type into the TUI.
     """
-    # Scope to the active terminal-view (not page-level) so the lookup can't
-    # focus a stray textarea from another terminal widget — matches the shell
-    # E2E test pattern.
     xterm_input = page.locator(_TERMINAL_VIEW).last.locator(_XTERM_INPUT)
     expect(xterm_input).to_be_attached(timeout=30_000)
     xterm_input.focus()
-    # Type at a human-ish cadence: Codex's TUI composer can drop or
-    # reorder characters injected faster than it repaints.
     page.keyboard.type(text, delay=15)
     page.keyboard.press("Enter")
 
 
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(300)
 def test_native_codex_message_render_parity(
     page: Page,
-    native_codex_session: tuple[str, str],
+    native_codex_mock_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
-    """Native Codex renders parity with its TUI, both ways, with no dupes.
-
-    Covers all three properties on a single (expensive to spin up) native
-    session: composer parity (IN), a TUI-originated turn surfacing in the web UI
-    (OUT), and no duplicate rendering across every turn.
-    """
-    base_url, session_id = native_codex_session
-    _log.info("native-codex session ready: base_url=%s session_id=%s", base_url, session_id)
+    """Native Codex renders parity with its TUI, both ways, with no dupes (mock LLM)."""
+    base_url, session_id = native_codex_mock_session
+    _log.info("native-codex mock session ready: base_url=%s session_id=%s", base_url, session_id)
 
     page.goto(f"{base_url}/c/{session_id}")
-
-    # The Terminal view proves Codex actually booted in the session terminal
-    # (the runner's codex-native auto-launch) before we send anything.
     _open_terminal_view(page)
     _wait_terminal_connected(page)
     _log.info("Codex TUI attached (terminal-view connected)")
+    _ensure_chat_view(page)
+
+    # Pre-generate tokens for all turns so they can be queued in the mock
+    # before any message is sent. Content-based routing (match=user_marker)
+    # ensures the right token is returned regardless of extra internal calls.
+    nonces = [uuid.uuid4().hex[:8] for _ in range(_COMPOSER_TURNS + 1)]
+    turns = [
+        (f"usr-{i + 1}-{nonces[i]}", f"ast-{i + 1}-{nonces[i]}")
+        for i in range(_COMPOSER_TURNS + 1)
+    ]
+    reset_mock_llm(mock_llm_server_url)
+    for user_marker, assistant_token in turns:
+        configure_mock_llm(
+            mock_llm_server_url,
+            [{"text": assistant_token}],
+            key=user_marker,
+            match=user_marker,
+        )
+    set_fallback_mock_llm(mock_llm_server_url, _CODEX_MOCK_MODEL, "")
 
     user_markers: list[str] = []
     assistant_tokens: list[str] = []
 
-    def _new_turn(index: int) -> tuple[str, str]:
-        nonce = uuid.uuid4().hex[:8]
-        user_marker = f"usr-{index}-{nonce}"
-        assistant_token = f"ast-{index}-{nonce}"
+    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
+    for index, (user_marker, assistant_token) in enumerate(turns[:_COMPOSER_TURNS], start=1):
         user_markers.append(user_marker)
         assistant_tokens.append(assistant_token)
-        return user_marker, assistant_token
-
-    # --- Property 1 & 3: composer turns (IN) render parity, no dupes. ---
-    _ensure_chat_view(page)
-    for index in range(1, _COMPOSER_TURNS + 1):
-        user_marker, assistant_token = _new_turn(index)
         _log.info(
             "composer turn %d: sending (marker=%s token=%s)", index, user_marker, assistant_token
         )
         _send(page, _turn_prompt(index, user_marker, assistant_token))
-        # The echoed token in an assistant bubble = this turn produced its reply.
         expect(page.locator(_ASSISTANT, has_text=assistant_token).first).to_be_visible(
-            timeout=_NATIVE_TURN_TIMEOUT_MS
+            timeout=_MOCK_TURN_TIMEOUT_MS
         )
-        # Fully settle (working shimmer gone) before the next send, so any
-        # transient native live-preview has collapsed into the committed bubble.
-        expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=_MOCK_TURN_TIMEOUT_MS)
         expect(page.locator(_USER)).to_have_count(index, timeout=30_000)
         _log.info("composer turn %d: settled", index)
 
     # --- Property 2 & 3: a TUI-originated turn (OUT) surfaces in the web UI. ---
     tui_index = _COMPOSER_TURNS + 1
-    tui_marker, tui_token = _new_turn(tui_index)
+    tui_marker, tui_token = turns[_COMPOSER_TURNS]
+    user_markers.append(tui_marker)
+    assistant_tokens.append(tui_token)
     _open_terminal_view(page)
     _wait_terminal_connected(page)
     _log.info(
@@ -184,14 +162,12 @@ def test_native_codex_message_render_parity(
     )
     _type_into_tui(page, _turn_prompt(tui_index, tui_marker, tui_token))
 
-    # Back in Chat, the bridge must have forwarded the TUI turn OUT as a user
-    # item + assistant reply — both render as bubbles, exactly once.
     _ensure_chat_view(page)
     expect(page.locator(_ASSISTANT, has_text=tui_token).first).to_be_visible(
-        timeout=_NATIVE_TURN_TIMEOUT_MS
+        timeout=_MOCK_TURN_TIMEOUT_MS
     )
     expect(page.locator(_USER, has_text=tui_marker).first).to_be_visible(timeout=30_000)
-    expect(page.locator(_WORKING)).to_have_count(0, timeout=_NATIVE_TURN_TIMEOUT_MS)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=_MOCK_TURN_TIMEOUT_MS)
     expect(page.locator(_USER)).to_have_count(len(user_markers), timeout=30_000)
     _log.info("TUI turn %d: surfaced in web UI (user + assistant bubbles present)", tui_index)
 


### PR DESCRIPTION
## Summary

- **`test_exit_plan_mode.py`** and **`test_ask_user_question.py`**: replace `native_claude_plan_session` / `native_claude_session` (real Claude Code boot + real LLM) with `seeded_session` + a background thread that POSTs directly to `POST /v1/sessions/{id}/hooks/permission-request`. The server parks the elicitation identically to a real PermissionRequest hook call; the SPA renders the same `ExitPlanModeReview` / `AskUserQuestionForm` card; the test approves or submits; the parked long-poll drains. Same assertions, no native CLI required, `@pytest.mark.timeout` drops from 900 s to 90 s.
- **`e2e-ui.yml`**: fix a stale comment (OPENAI credentials are overridden to mock values by the conftest, not set to Databricks values in the run step); note that the gateway config step is now only needed by the render-parity tests.

## Why the render-parity tests are NOT migrated

`test_native_claude_render_parity`, `test_native_codex_render_parity`, and `test_native_cursor_render_parity` exercise the native terminal bridge — real `claude`/`codex`/`cursor-agent` running in a PTY, bidirectional forwarding, no-duplicate render. Those CLIs use their own LLM auth (Databricks OAuth / Cursor API key) inside their subprocess; `OPENAI_BASE_URL` only intercepts the openai-agents harness, so there is no mock path for them without a deeper refactor (see `OMNIGENT_CONFIG_HOME` + Anthropic provider config as the future direction).

## Test plan

- [ ] `uv run pytest tests/e2e_ui/approvals/test_exit_plan_mode.py -v`
- [ ] `uv run pytest tests/e2e_ui/approvals/test_ask_user_question.py -v`
- [ ] CI e2e-ui shards pass (approval tests no longer need the gateway config step to have real credentials)

This pull request and its description were written by Isaac.