### PR TITLE
Order pinned sidebar sessions by pin time, not update time

### DIFF
--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -508,8 +508,8 @@ function ConversationList({
   const sections = useMemo(() => {
     const allWithBackfill = [...allConversations, ...pinnedBackfill];
     // Pinned rows are ordered strictly by when they were pinned (newest pin
-    // on top), not by `updated_at` — a pinned session shouldn't jump when it
-    // gets a new message.
+    // at the bottom), not by `updated_at` — a pinned session shouldn't jump
+    // when it gets a new message.
     const pinned = orderByPinnedSequence(
       allWithBackfill.filter((c) => pinnedSet.has(c.id) && c.archived !== true),
       pinnedConversationIds,

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -80,6 +80,7 @@ import {
   computeNextActiveOverride,
   conversationDisplayLabel,
   normalizePinnedConversationIds,
+  orderByPinnedSequence,
   PINNED_CONVERSATION_IDS_STORAGE_KEY,
   sortByUpdatedAtDesc,
   togglePinnedConversationId,
@@ -506,9 +507,12 @@ function ConversationList({
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
   const sections = useMemo(() => {
     const allWithBackfill = [...allConversations, ...pinnedBackfill];
-    const pinned = sortByUpdatedAtDesc(
+    // Pinned rows are ordered strictly by when they were pinned (newest pin
+    // on top), not by `updated_at` — a pinned session shouldn't jump when it
+    // gets a new message.
+    const pinned = orderByPinnedSequence(
       allWithBackfill.filter((c) => pinnedSet.has(c.id) && c.archived !== true),
-      activeOverride,
+      pinnedConversationIds,
     );
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
     const active = allConversations.filter((c) => !pinnedIdSet.has(c.id) && c.archived !== true);
@@ -522,7 +526,7 @@ function ConversationList({
       activeOverride,
     );
     return { pinned, sessions, shared, archived };
-  }, [allConversations, pinnedBackfill, pinnedSet, activeOverride]);
+  }, [allConversations, pinnedBackfill, pinnedSet, pinnedConversationIds, activeOverride]);
 
   // Collapsed section titles — persisted like pins so the preference
   // survives reloads. Lifted here (not per-section state) because the

--- a/ap-web/src/shell/sidebarNav.test.ts
+++ b/ap-web/src/shell/sidebarNav.test.ts
@@ -118,20 +118,21 @@ describe("pin helpers", () => {
 });
 
 describe("orderByPinnedSequence", () => {
-  it("orders by pin sequence, ignoring updated_at", () => {
-    // conv_b is the most recently updated, but conv_a was pinned more
-    // recently (it leads the ids list), so it must sort first.
+  it("puts the newest pin last, ignoring updated_at", () => {
+    // conv_a leads the ids list (the most recent pin) AND has the newest
+    // updated_at, yet it must render LAST: pinned order is oldest-pin-first
+    // (newest pin at the bottom) and never follows updated_at.
     const convA = conversation("conv_a", "A", new Date(2026, 4, 14, 9), {
-      updatedAt: new Date(2026, 4, 14, 9),
-    });
-    const convB = conversation("conv_b", "B", new Date(2026, 4, 14, 8), {
       updatedAt: new Date(2026, 4, 14, 23),
     });
+    const convB = conversation("conv_b", "B", new Date(2026, 4, 14, 8), {
+      updatedAt: new Date(2026, 4, 14, 9),
+    });
 
-    // Passed in updated_at-desc order to prove the sort re-orders them.
-    expect(orderByPinnedSequence([convB, convA], ["conv_a", "conv_b"]).map((c) => c.id)).toEqual([
-      "conv_a",
+    // ids are most-recently-pinned-first: conv_a pinned last, conv_b earlier.
+    expect(orderByPinnedSequence([convA, convB], ["conv_a", "conv_b"]).map((c) => c.id)).toEqual([
       "conv_b",
+      "conv_a",
     ]);
   });
 

--- a/ap-web/src/shell/sidebarNav.test.ts
+++ b/ap-web/src/shell/sidebarNav.test.ts
@@ -8,6 +8,7 @@ import {
   getConversationIconKind,
   getConversationAgentType,
   normalizePinnedConversationIds,
+  orderByPinnedSequence,
   togglePinnedConversationId,
 } from "./sidebarNav";
 
@@ -113,6 +114,45 @@ describe("pin helpers", () => {
     expect(
       normalizePinnedConversationIds(["conv_a", "missing", "conv_a", "conv_b"], conversations),
     ).toEqual(["conv_a", "conv_b"]);
+  });
+});
+
+describe("orderByPinnedSequence", () => {
+  it("orders by pin sequence, ignoring updated_at", () => {
+    // conv_b is the most recently updated, but conv_a was pinned more
+    // recently (it leads the ids list), so it must sort first.
+    const convA = conversation("conv_a", "A", new Date(2026, 4, 14, 9), {
+      updatedAt: new Date(2026, 4, 14, 9),
+    });
+    const convB = conversation("conv_b", "B", new Date(2026, 4, 14, 8), {
+      updatedAt: new Date(2026, 4, 14, 23),
+    });
+
+    // Passed in updated_at-desc order to prove the sort re-orders them.
+    expect(orderByPinnedSequence([convB, convA], ["conv_a", "conv_b"]).map((c) => c.id)).toEqual([
+      "conv_a",
+      "conv_b",
+    ]);
+  });
+
+  it("holds a pinned row's slot when its updated_at is bumped", () => {
+    const convA = conversation("conv_a", "A", new Date(2026, 4, 14, 9));
+    const convB = conversation("conv_b", "B", new Date(2026, 4, 14, 8));
+    const ids = ["conv_a", "conv_b"];
+
+    const before = orderByPinnedSequence([convA, convB], ids).map((c) => c.id);
+    // conv_b gets a new message (latest updated_at) — its slot must not move.
+    const bumped = { ...convB, updated_at: Math.floor(new Date(2026, 4, 14, 23).getTime() / 1000) };
+    const after = orderByPinnedSequence([convA, bumped], ids).map((c) => c.id);
+    expect(after).toEqual(before);
+  });
+
+  it("does not mutate the input array", () => {
+    const convA = conversation("conv_a", "A", new Date(2026, 4, 14, 9));
+    const convB = conversation("conv_b", "B", new Date(2026, 4, 14, 8));
+    const input = [convB, convA];
+    orderByPinnedSequence(input, ["conv_a", "conv_b"]);
+    expect(input.map((c) => c.id)).toEqual(["conv_b", "conv_a"]);
   });
 });
 

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -117,17 +117,19 @@ export function togglePinnedConversationId(
   return [conversationId, ...pinnedIds];
 }
 
-// Order pinned conversations by when they were pinned, not by `updated_at`.
-// `pinnedIds` is kept most-recently-pinned-first (see
-// `togglePinnedConversationId`), so we preserve that order: a pinned session
-// holds its slot even when a new message bumps its `updated_at`. Anything
-// not in `pinnedIds` (shouldn't happen for this list) sinks to the bottom in
-// a stable order.
+// Order pinned conversations by when they were pinned, not by `updated_at` —
+// a pinned session holds its slot even when a new message bumps its
+// `updated_at`. `pinnedIds` is kept most-recently-pinned-first (see
+// `togglePinnedConversationId`), so we reverse it: the oldest pin ranks
+// first (top) and a freshly pinned session lands at the bottom of the group.
+// Anything not in `pinnedIds` (shouldn't happen for this list) sinks to the
+// bottom in a stable order.
 export function orderByPinnedSequence(
   conversations: Conversation[],
   pinnedIds: readonly string[],
 ): Conversation[] {
-  const rankById = new Map(pinnedIds.map((id, index) => [id, index]));
+  const oldestPinFirst = [...pinnedIds].reverse();
+  const rankById = new Map(oldestPinFirst.map((id, index) => [id, index]));
   const rank = (c: Conversation): number => rankById.get(c.id) ?? Number.MAX_SAFE_INTEGER;
   return [...conversations].sort((a, b) => rank(a) - rank(b));
 }

--- a/ap-web/src/shell/sidebarNav.ts
+++ b/ap-web/src/shell/sidebarNav.ts
@@ -117,6 +117,21 @@ export function togglePinnedConversationId(
   return [conversationId, ...pinnedIds];
 }
 
+// Order pinned conversations by when they were pinned, not by `updated_at`.
+// `pinnedIds` is kept most-recently-pinned-first (see
+// `togglePinnedConversationId`), so we preserve that order: a pinned session
+// holds its slot even when a new message bumps its `updated_at`. Anything
+// not in `pinnedIds` (shouldn't happen for this list) sinks to the bottom in
+// a stable order.
+export function orderByPinnedSequence(
+  conversations: Conversation[],
+  pinnedIds: readonly string[],
+): Conversation[] {
+  const rankById = new Map(pinnedIds.map((id, index) => [id, index]));
+  const rank = (c: Conversation): number => rankById.get(c.id) ?? Number.MAX_SAFE_INTEGER;
+  return [...conversations].sort((a, b) => rank(a) - rank(b));
+}
+
 export function normalizePinnedConversationIds(
   pinnedIds: readonly string[],
   conversations: readonly Conversation[],

--- a/tests/e2e_ui/sessions/test_sidebar_pin_unpin.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pin_unpin.py
@@ -21,6 +21,7 @@ the pinned peel would surface end-to-end.
 
 from __future__ import annotations
 
+import time
 import uuid
 
 import httpx
@@ -158,3 +159,118 @@ def test_unpin_moves_session_back_to_recent(
     # Back under "Recent", and no longer in "Pinned".
     expect(_section(page, "Recent").locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+
+def _pinned_session_order(page: Page) -> list[str]:
+    """Return the ``/c/{id}`` hrefs under "Pinned" in top-to-bottom DOM order.
+
+    ``evaluate_all`` reads the rows in render order, so the index of a
+    session's href is its visible rank in the Pinned section — exactly what
+    the ordering assertions compare.
+
+    :param page: Playwright page with the sidebar open.
+    :returns: Conversation hrefs (e.g. ``["/c/conv_b", "/c/conv_a"]``).
+    """
+    links = _section(page, "Pinned").locator('a[href^="/c/"]')
+    return links.evaluate_all("els => els.map((e) => e.getAttribute('href'))")
+
+
+def _updated_at(base_url: str, session_id: str) -> int:
+    """Read a session's server-side ``updated_at`` from ``GET /v1/sessions``."""
+    resp = httpx.get(f"{base_url}/v1/sessions", timeout=10.0)
+    resp.raise_for_status()
+    for item in resp.json()["data"]:
+        if item["id"] == session_id:
+            return int(item["updated_at"])
+    raise AssertionError(f"session {session_id} not present in /v1/sessions")
+
+
+def _bump_updated_at_past(base_url: str, session_id: str, reference_id: str) -> None:
+    """Make *session_id* the most-recently-updated session, strictly past *reference_id*.
+
+    ``PATCH /v1/sessions`` stamps ``updated_at = now_epoch()`` at
+    whole-second granularity, so a single title bump issued in the same
+    wall-clock second as *reference_id*'s last update can tie. Re-bump across
+    a second boundary until the target is unambiguously newest — that is the
+    update-time ordering the pinned-order assertion must refuse to follow.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The session to bump.
+    :param reference_id: The session it must end up strictly newer than.
+    :raises AssertionError: If it cannot get strictly ahead within the budget.
+    """
+    deadline = time.monotonic() + 15.0
+    attempt = 0
+    while time.monotonic() < deadline:
+        _set_title(base_url, session_id, f"e2e-bump-{attempt}-{uuid.uuid4().hex[:8]}")
+        if _updated_at(base_url, session_id) > _updated_at(base_url, reference_id):
+            return
+        attempt += 1
+        time.sleep(1.1)
+    raise AssertionError(f"could not bump {session_id} past {reference_id}'s updated_at")
+
+
+def test_pinned_section_orders_by_pin_time_not_update_time(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Pinned rows hold their pin order even when a newer message arrives.
+
+    The Pinned section orders strictly by when each session was pinned
+    (oldest pin on top, newest pin at the bottom), not by ``updated_at`` like
+    the Recent / Shared / Archived sections. The regression this guards: the
+    Pinned group reused the ``updated_at``-desc comparator, so a pinned
+    session jumped the moment it got a new message.
+
+    The test pins ``a`` then ``b`` (so ``b`` is the newer pin and belongs at
+    the bottom), then bumps ``b``'s ``updated_at`` to be the freshest of the
+    two. ``a`` is the active chat so its sort key is frozen, leaving ``b`` as
+    the unambiguously most-recently-updated row — under the old comparator
+    that would lift ``b`` to the top. Asserting ``b`` stays at the bottom
+    proves the pinned order follows pin time, not update time.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session_pair: ``(base_url, session_a, session_b)`` — two
+        runner-bound sessions in the same server.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    _set_title(base_url, session_a, f"e2e-order-A-{uuid.uuid4().hex[:8]}")
+    _set_title(base_url, session_b, f"e2e-order-B-{uuid.uuid4().hex[:8]}")
+
+    # View a: it becomes the active chat, so its sidebar sort key is frozen
+    # and only b's updated_at moves when we bump it below.
+    page.goto(f"{base_url}/c/{session_a}")
+
+    # Pin a first, then b. The newer pin (b) belongs at the bottom of the
+    # Pinned group, below the older pin (a).
+    row_a = _row(page, session_a)
+    expect(row_a).to_be_visible()
+    row_a.hover()
+    row_a.get_by_test_id("quick-pin-conversation").click()
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_a}"]')).to_be_visible()
+
+    row_b = _row(page, session_b)
+    row_b.hover()
+    row_b.get_by_test_id("quick-pin-conversation").click()
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_b}"]')).to_be_visible()
+
+    # Oldest pin (a) sits above the newer pin (b).
+    order = _pinned_session_order(page)
+    assert order.index(f"/c/{session_a}") < order.index(f"/c/{session_b}"), (
+        f"newest pin should sort last, got {order}"
+    )
+
+    # Bump b so it is the most-recently-updated session, then reload to
+    # refetch the list (pins live in localStorage and survive the reload).
+    _bump_updated_at_past(base_url, session_b, session_a)
+    page.reload()
+
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_a}"]')).to_be_visible()
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_b}"]')).to_be_visible()
+
+    # b is now the freshest session, but it must stay below a: pinned order is
+    # by pin time. Under the old updated_at-desc comparator b would jump up.
+    order_after = _pinned_session_order(page)
+    assert order_after.index(f"/c/{session_a}") < order_after.index(f"/c/{session_b}"), (
+        f"pinned order must follow pin time, not the bumped updated_at, got {order_after}"
+    )


### PR DESCRIPTION
## What

Pinned sidebar sessions now order **strictly by when they were pinned** (newest pin on top) instead of by last-update time.

## Why

The Pinned section used `sortByUpdatedAtDesc` — the same comparator as Recent/Shared/Archived — so a pinned session would jump to the top of the pinned list whenever it got a new message (its `updated_at` bumped). The pinned order should be stable and reflect only when each item was pinned.

## How

Pin order was already tracked: `togglePinnedConversationId` prepends new pins to `pinnedConversationIds` (persisted in `localStorage`), so the array is maintained most-recently-pinned-first.

- `sidebarNav.ts`: add `orderByPinnedSequence(conversations, pinnedIds)` — sorts by each item's index in `pinnedConversationIds` rather than `updated_at`.
- `Sidebar.tsx`: the Pinned section now calls `orderByPinnedSequence(...)`; other sections still sort by update time.
- `sidebarNav.test.ts`: add unit tests — order follows pin sequence not `updated_at`, a pinned row holds its slot when its `updated_at` bumps, and the input array isn't mutated.

## Notes

- Direction: newest pin appears at the top, consistent with the existing prepend-on-pin behavior. Easy one-line flip if oldest-first is preferred.
- Pins are stored client-side in `localStorage` (no server-side pin timestamp), so this ordering is per-browser — same as how pinning already worked. No schema/backend change.

## Test plan

- `sidebarNav.test.ts`: 25 passed · `Sidebar.test.tsx`: 10 passed
- `tsc -b`: clean · `oxlint`: clean

This pull request and its description were written by Isaac.