### PR TITLE
docs(elicitation): correct PermissionRequest tool_use_id comment and drop fake id from fixtures

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -14117,11 +14117,13 @@ def create_sessions_router(
                 "PermissionRequest hook body 'tool_input' must be an object when present.",
                 code=ErrorCode.INVALID_INPUT,
             )
-        # ``tool_use_id`` is not stable on Claude Code's
-        # PermissionRequest payload, and newer builds can write the
-        # transcript ``function_call`` (tool_use) before this hook
-        # returns — so neither can correlate/resolve the parked
-        # request. The parked wait ends on one of three signals: an
+        # Claude Code's PermissionRequest payload carries no
+        # ``tool_use_id`` (verified against a real payload — the field
+        # is absent, not merely unstable; the id is only minted when the
+        # tool call is emitted, AFTER this permission check). And newer
+        # builds can write the transcript ``function_call`` (tool_use)
+        # before this hook returns — so neither can correlate/resolve the
+        # parked request. The parked wait ends on one of three signals: an
         # explicit web verdict, hook disconnect, or the mirrored
         # ``function_call_output`` (tool_result) for this gated tool,
         # which — unlike the tool_use — is written only AFTER the

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -374,6 +374,9 @@ def _claude_permission_payload(tool_name: str = "Bash") -> dict[str, Any]:
     :param tool_name: Tool Claude wants to call, e.g. ``"Bash"``.
     :returns: JSON-serializable payload mirroring Claude Code's
         published wire shape for the ``PermissionRequest`` event.
+        Deliberately carries no ``tool_use_id``: the real
+        PermissionRequest payload has no per-call id (it is minted only
+        when the tool call is emitted, after this permission check).
     """
     return {
         "session_id": "claude_sess_abc",
@@ -383,7 +386,6 @@ def _claude_permission_payload(tool_name: str = "Bash") -> dict[str, Any]:
         "hook_event_name": "PermissionRequest",
         "tool_name": tool_name,
         "tool_input": {"command": "ls -la"},
-        "tool_use_id": "tool_use_xyz",
     }
 
 
@@ -420,7 +422,6 @@ def _claude_ask_user_question_payload() -> dict[str, Any]:
                 },
             ],
         },
-        "tool_use_id": "tool_use_ask",
     }
 
 

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -72,7 +72,7 @@ async def _drain_until_elicitation(
     elicitation future, so subscribing here is the simplest way to
     learn the id without monkey-patching ``uuid``. Returning the
     whole event lets callers also inspect the params block for the
-    Claude-native extras (``tool_use_id``, ``cwd``, ``permission_mode``).
+    Claude-native extras (``cwd``, ``permission_mode``).
 
     :param session_id: Session to subscribe to.
     :param timeout_s: Maximum seconds to wait for the elicitation
@@ -128,6 +128,9 @@ async def _claude_permission_payload(tool_name: str = "Bash") -> dict[str, Any]:
     :param tool_name: Tool Claude wants to call.
     :returns: JSON-serializable payload mirroring Claude Code's
         published wire shape for the ``PermissionRequest`` event.
+        Deliberately carries no ``tool_use_id``: the real
+        PermissionRequest payload has no per-call id (it is minted only
+        when the tool call is emitted, after this permission check).
     """
     return {
         "session_id": "claude_sess_abc",
@@ -137,7 +140,6 @@ async def _claude_permission_payload(tool_name: str = "Bash") -> dict[str, Any]:
         "hook_event_name": "PermissionRequest",
         "tool_name": tool_name,
         "tool_input": {"command": "ls -la"},
-        "tool_use_id": "tool_use_xyz",
     }
 
 
@@ -440,7 +442,6 @@ async def _claude_webfetch_payload(url: str = "https://github.com/cli/cli") -> d
         "hook_event_name": "PermissionRequest",
         "tool_name": "WebFetch",
         "tool_input": {"url": url, "prompt": "summarize"},
-        "tool_use_id": "tool_use_wf",
     }
 
 
@@ -711,8 +712,8 @@ async def test_permission_request_hook_forwards_cwd_and_permission_mode(
     ``permission_mode`` lets the UI badge the card with the mode
     Claude is in (``"default"`` / ``"acceptEdits"`` / ``"plan"``).
 
-    Note: ``tool_use_id`` is intentionally not asserted here.
-    Claude Code's PermissionRequest payload doesn't carry one
+    Note: ``tool_use_id`` is intentionally absent — the fixtures omit
+    it because Claude Code's PermissionRequest payload doesn't carry one
     (the id is only minted when the tool call is emitted, AFTER
     the permission check). The UI's auto-clear falls back to a
     "first pending" heuristic instead — see


### PR DESCRIPTION
## What

Claude Code's `PermissionRequest` hook payload carries **no** `tool_use_id` — confirmed by capturing a real payload. Two things in the tree implied otherwise:

- The comment in `omnigent/server/routes/sessions.py` described the field as *"not stable"* rather than absent.
- Several test fixtures (`_claude_permission_payload`, `_claude_webfetch_payload`, `_claude_ask_user_question_payload`) fabricated a `tool_use_id`, making it look like a parked permission prompt could be correlated to its tool call by id.

## Changes

- Correct the source comment to state the field is **absent** (and why), keeping the rationale for correlating on `tool_name` / `tool_input`.
- Remove the fake `tool_use_id` from the `PermissionRequest` fixtures in both integration suites so they match the real wire shape, and update the related docstring + note.
- Left the `tool_use_id`s inside `tool_result` transcript blocks (`test_claude_native_bridge.py`) untouched — those are real transcript ids.

## Why it matters

The fake id sends the next reader down a dead end: trying to correlate the terminal-resolved elicitation fast path to its tool call by id. There is no per-call id on `PermissionRequest`, so `(tool_name, tool_input)` is the only correlation available. Comment + test-data only — **no behavior change**.

## Testing

`uv run pytest` on both affected suites: **70 passed**. One unrelated, pre-existing failure (`test_top_level_elicitations_route_is_not_mounted`) fails identically on `main` without these changes.

This pull request and its description were written by Isaac.
