### PR TITLE
fix(e2e-ui): route openai-agents harness to mock LLM, remove LLM_API_KEY from CI

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -200,68 +200,16 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund @openai/codex@0.139.0
           echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
-      - name: Configure native-claude/codex gateway provider
-        # Required only by the native render-parity tests (claude, codex).
-        # The approval tests (test_exit_plan_mode, test_ask_user_question)
-        # were migrated to mock LLM and no longer need it.
-        # The native CLIs derive their gateway auth from omnigent provider
-        # config. Register the Databricks gateway for anthropic (Claude Code)
-        # and openai (Codex). No API key needed: the openai-agents harness
-        # uses the mock LLM via OPENAI_BASE_URL injected in live_server.
-        env:
-          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
-        run: |
-          mkdir -p "$HOME/.omnigent"
-          # The Anthropic Messages surface and the Codex Responses surface live
-          # at different paths off the same workspace host. GATEWAY_BASE_URL is
-          # <host>/serving-endpoints (the OpenAI-compatible surface); strip that
-          # suffix to recover the bare host for the codex /ai-gateway path.
-          host="${GATEWAY_BASE_URL%/serving-endpoints}"
-          cat > "$HOME/.omnigent/config.yaml" <<EOF
-          providers:
-            databricks-gateway:
-              kind: gateway
-              default: [anthropic, openai]
-              anthropic:
-                # Databricks serves the Anthropic Messages surface at
-                # <host>/serving-endpoints/anthropic (see
-                # omnigent/inner/pi_executor.py: claude_base_url). GATEWAY_BASE_URL
-                # is <host>/serving-endpoints (the OpenAI-compatible surface), so
-                # the /anthropic suffix is required — without it Claude Code POSTs
-                # to .../serving-endpoints/v1/messages and gets no reply.
-                base_url: "${GATEWAY_BASE_URL}/anthropic"
-                # The default model id is read from models.default (not a
-                # top-level default_model key). Without it the provider
-                # resolves model=None, Claude Code launches with no --model and
-                # falls back to its built-in 'claude-sonnet-4-6', which the
-                # Databricks gateway rejects (the endpoint name is the
-                # 'databricks-' prefixed id).
-                models:
-                  default: databricks-claude-sonnet-4-6
-              openai:
-                # Databricks serves the Codex Responses surface at
-                # <host>/ai-gateway/codex/v1 (see omnigent/inner/codex_executor.py:
-                # _databricks_codex_base_url), NOT the /serving-endpoints
-                # OpenAI-compatible surface. wire_api must be 'responses' — codex
-                # >= 0.137 rejects 'chat' at config load.
-                base_url: "${host}/ai-gateway/codex/v1"
-                wire_api: responses
-                # The codex model id the e2e codex leg pins (tests/_model_pools).
-                models:
-                  default: databricks-gpt-5-4-mini
-          EOF
-
       - name: Run UI e2e tests
         # --ui-skip-build: the SPA was built in the previous step.
         # --tracing/--screenshot/--video default to off; retain-on-failure
         # keeps green runs cheap while capturing artifacts on failures.
         # The conftest's live_server fixture injects OPENAI_BASE_URL=mock/v1
-        # into the runner subprocess, so the openai-agents harness and the
-        # policy classifier both hit the mock — no real credentials needed.
-        # Native render-parity tests (claude, codex) still use the
-        # ~/.omnigent/config.yaml gateway written above (no API key there
-        # either; native_*_mock_session writes a fresh mock config at
-        # terminal-creation time, overriding it for each test).
+        # and OPENAI_API_KEY=mock-key into the runner subprocess env, so the
+        # openai-agents harness and policy classifier both hit the mock — no
+        # real credentials needed. Native render-parity tests write their own
+        # mock provider config via native_*_mock_session at terminal-creation
+        # time, so no ~/.omnigent/config.yaml is written in CI either.
         env:
           # Scheduled / manually dispatched runs are the full pass;
           # PR and push runs exclude @pytest.mark.nightly tests.

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -205,13 +205,11 @@ jobs:
         # The approval tests (test_exit_plan_mode, test_ask_user_question)
         # were migrated to mock LLM and no longer need it.
         # The native CLIs derive their gateway auth from omnigent provider
-        # config. Register the Databricks gateway as the default for both
-        # anthropic (Claude Code) and openai (Codex); the token reaches each
-        # CLI and the openai-agents harness via an env:LLM_API_KEY ref, so
-        # no literal secret hits disk.
+        # config. Register the Databricks gateway for anthropic (Claude Code)
+        # and openai (Codex). No API key needed: the openai-agents harness
+        # uses the mock LLM via OPENAI_BASE_URL injected in live_server.
         env:
           GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           mkdir -p "$HOME/.omnigent"
           # The Anthropic Messages surface and the Codex Responses surface live
@@ -232,7 +230,6 @@ jobs:
                 # the /anthropic suffix is required — without it Claude Code POSTs
                 # to .../serving-endpoints/v1/messages and gets no reply.
                 base_url: "${GATEWAY_BASE_URL}/anthropic"
-                api_key_ref: "env:LLM_API_KEY"
                 # The default model id is read from models.default (not a
                 # top-level default_model key). Without it the provider
                 # resolves model=None, Claude Code launches with no --model and
@@ -248,7 +245,6 @@ jobs:
                 # OpenAI-compatible surface. wire_api must be 'responses' — codex
                 # >= 0.137 rejects 'chat' at config load.
                 base_url: "${host}/ai-gateway/codex/v1"
-                api_key_ref: "env:LLM_API_KEY"
                 wire_api: responses
                 # The codex model id the e2e codex leg pins (tests/_model_pools).
                 models:
@@ -259,21 +255,19 @@ jobs:
         # --ui-skip-build: the SPA was built in the previous step.
         # --tracing/--screenshot/--video default to off; retain-on-failure
         # keeps green runs cheap while capturing artifacts on failures.
-        # The conftest's live_server fixture points the server subprocess at
-        # the in-process mock LLM server (OPENAI_BASE_URL / ANTHROPIC_BASE_URL),
-        # so the policy classifier needs no real credentials. The openai-agents
-        # harness and native render-parity tests use the ~/.omnigent/config.yaml
-        # gateway written above; LLM_API_KEY resolves the api_key_ref there.
+        # The conftest's live_server fixture injects OPENAI_BASE_URL=mock/v1
+        # into the runner subprocess, so the openai-agents harness and the
+        # policy classifier both hit the mock — no real credentials needed.
+        # Native render-parity tests (claude, codex) still use the
+        # ~/.omnigent/config.yaml gateway written above (no API key there
+        # either; native_*_mock_session writes a fresh mock config at
+        # terminal-creation time, overriding it for each test).
         env:
           # Scheduled / manually dispatched runs are the full pass;
           # PR and push runs exclude @pytest.mark.nightly tests.
           NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           SHARD_ID: ${{ matrix.shard_id }}
           NUM_SHARDS: ${{ matrix.num_shards }}
-          # The runner subprocess inherits this via os.environ so the
-          # openai-agents harness and native CLIs can resolve
-          # api_key_ref: "env:LLM_API_KEY" from ~/.omnigent/config.yaml.
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           # Always exclude @visual: the UI diff snapshot runs in its own
           # pinned-runner gate (ui-snapshot.yml) so its baseline matches the

--- a/tests/e2e_ui/agents/conftest.py
+++ b/tests/e2e_ui/agents/conftest.py
@@ -88,7 +88,7 @@ prompt: |
   a second `comic_one` or `comic_two`.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   harness: openai-agents
 
 tools:
@@ -96,7 +96,7 @@ tools:
     type: agent
     description: First stand-up comedian. Tells exactly one joke when asked.
     executor:
-      model: databricks-gpt-5-4
+      model: gpt-4o-mini
       harness: openai-agents
     prompt: |
       You are a stand-up comedian. When asked for a joke, reply with
@@ -108,7 +108,7 @@ tools:
     type: agent
     description: Second stand-up comedian. Tells exactly one joke when asked.
     executor:
-      model: databricks-gpt-5-4
+      model: gpt-4o-mini
       harness: openai-agents
     prompt: |
       You are a stand-up comedian. When asked for a joke, reply with

--- a/tests/e2e_ui/chat/test_chat_file_path_links.py
+++ b/tests/e2e_ui/chat/test_chat_file_path_links.py
@@ -63,7 +63,7 @@ name: {_AGENT_NAME}
 prompt: You are a deterministic test assistant.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 

--- a/tests/e2e_ui/chat/test_multi_turn_chat.py
+++ b/tests/e2e_ui/chat/test_multi_turn_chat.py
@@ -12,12 +12,17 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
 from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm
 
 _COMPOSER = "Ask the agent anything…"
 _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
 _WORKING = '[data-testid="working-indicator"]'
+
+# The recall prompt's stable substring — present only in turn 2, so the mock
+# can content-route turn 2 to the token-echo response.
+_RECALL_PROMPT = "What token did I ask you to remember? Reply with the token only."
 
 
 def _send(page: Page, text: str) -> None:
@@ -28,17 +33,23 @@ def _send(page: Page, text: str) -> None:
     page.get_by_role("button", name="Send", exact=True).click()
 
 
-# Real-LLM nondeterminism: the model must reply "stored" then echo the token
-# verbatim. llm_flaky reruns rotate the model per attempt (databricks-gpt-5-4 ->
-# -5-5), which is exactly the right retry for a recall flake. Safe here because
-# e2e-ui.yml runs serially (no xdist) with no --timeout=180 cap.
-@pytest.mark.llm_flaky(reruns=2, reruns_delay=1)
 def test_multi_turn_recall_through_ui(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = seeded_session
     token = f"ui-recall-{uuid.uuid4().hex[:8]}"
+
+    # The mock routes by message content: turn 1 (the only message carrying
+    # the token) replies "stored"; turn 2 (the recall prompt) replies with the
+    # token. Both match strings are unique to their turn, so each queue fires
+    # exactly once and the recall assertion is deterministic.
+    configure_mock_llm(mock_llm_server_url, [{"text": "stored"}], key="recall-store", match=token)
+    configure_mock_llm(
+        mock_llm_server_url, [{"text": token}], key="recall-echo", match=_RECALL_PROMPT
+    )
+
     page.goto(f"{base_url}/c/{session_id}")
 
     _send(
@@ -52,7 +63,7 @@ def test_multi_turn_recall_through_ui(
     expect(page.locator(_ASSISTANT).first).to_be_visible(timeout=60_000)
     expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
 
-    _send(page, "What token did I ask you to remember? Reply with the token only.")
+    _send(page, _RECALL_PROMPT)
     # Two user bubbles = turn 2 actually left the composer.
     expect(page.locator('[data-testid="message-bubble"][data-role="user"]')).to_have_count(
         2, timeout=15_000

--- a/tests/e2e_ui/chat/test_reload_continue.py
+++ b/tests/e2e_ui/chat/test_reload_continue.py
@@ -13,21 +13,35 @@ import uuid
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e_ui.conftest import configure_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
 _USER = '[data-testid="message-bubble"][data-role="user"]'
 _WORKING = '[data-testid="working-indicator"]'
 
+# Turn-2 prompt's stable substring — present only in turn 2, so the mock can
+# content-route it to the token-echo response.
+_REPEAT_PROMPT = "Repeat the token from my first message, exactly, and nothing else."
 
-# Back on nightly burn-in: flaked on its first PR-gate run (turn-2
-# reply paraphrased instead of echoing the token verbatim).
+
 @pytest.mark.nightly
 def test_reload_hydrates_history_and_continues(
     page: Page,
     seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = seeded_session
     token = f"ui-reload-{uuid.uuid4().hex[:8]}"
+
+    # Turn 1 (the only message carrying the token) replies "stored"; turn 2
+    # (the repeat prompt) replies with the token. Content-routing keys each
+    # queue to a substring unique to its turn, so both fire deterministically.
+    configure_mock_llm(mock_llm_server_url, [{"text": "stored"}], key="reload-store", match=token)
+    configure_mock_llm(
+        mock_llm_server_url, [{"text": token}], key="reload-echo", match=_REPEAT_PROMPT
+    )
+
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder(_COMPOSER)
@@ -48,7 +62,7 @@ def test_reload_hydrates_history_and_continues(
 
     composer = page.get_by_placeholder(_COMPOSER)
     expect(composer).to_be_visible()
-    composer.fill("Repeat the token from my first message, exactly, and nothing else.")
+    composer.fill(_REPEAT_PROMPT)
     page.get_by_role("button", name="Send", exact=True).click()
 
     # Turn 2 rendered (2 user bubbles) and produced a second assistant

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -823,6 +823,11 @@ def live_server(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
+        # Route the openai-agents harness to the mock LLM server so no
+        # real provider credentials are needed for agent turns. Without
+        # these the openai SDK falls back to real OpenAI, which fails.
+        "OPENAI_BASE_URL": f"{mock_url}/v1",
+        "OPENAI_API_KEY": "mock-key",
     }
     runner_proc = subprocess.Popen(
         [sys.executable, "-m", "omnigent.runner._entry"],
@@ -897,6 +902,10 @@ def live_server(
     # Set a non-resettable fallback for the policy-classifier LLM queue so
     # every per-test reset leaves the server's guardrails path functional.
     set_fallback_mock_llm(mock_url, "_policy_llm_", '{"action": "allow", "reason": ""}')
+    # Fallback for the openai-agents harness: any agent turn that doesn't
+    # match a content-based queue gets a generic reply (sufficient for tests
+    # that only assert an assistant bubble appears, not its exact content).
+    set_fallback_mock_llm(mock_url, "databricks-gpt-5-4", "Mock LLM response.")
 
     try:
         yield base_url
@@ -1542,6 +1551,7 @@ guardrails:
 @pytest.fixture
 def approval_session(
     live_server: str,
+    mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[tuple[str, str]]:
     """Create a runner-bound session whose agent triggers an approval prompt.
@@ -1552,16 +1562,49 @@ def approval_session(
     ``guardrails`` blocks that path supports — see ``examples/polly``).
 
     :param live_server: Spawned server fixture.
+    :param mock_llm_server_url: Session-scoped mock LLM server URL; used to
+        pre-configure the ``sys_os_shell`` tool call the approval agent emits.
     :param tmp_path_factory: Pytest temp path factory (for a respawn log).
     :returns: ``(base_url, session_id)``. Send a "run the command" turn to
         raise the gated-push approval.
     """
     import json as _json
+    import uuid as _uuid
+
+    # Each approval_session gets a unique model name so the mock queue is
+    # isolated between test runs. Using content-based routing (match=) on a
+    # shared model name caused a race: the previous test's runner (making its
+    # post-approval second LLM call) would steal the freshly-configured queue
+    # from the next test. A unique model per fixture call eliminates that race
+    # entirely — no other request will ever use this model key.
+    approval_model = f"approval-probe-{_uuid.uuid4().hex[:8]}"
+    # Substitute the unique model into the agent spec.
+    agent_yaml_text = _APPROVAL_AGENT_YAML.replace("databricks-gpt-5-4", approval_model)
+
+    # First LLM call: return the gated sys_os_shell tool call.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_git_push",
+                        "name": "sys_os_shell",
+                        "arguments": _json.dumps({"command": "git push origin main"}),
+                    }
+                ]
+            }
+        ],
+        key=approval_model,
+    )
+    # Fallback for the second LLM call (after the tool result arrives): the
+    # agent prompt asks for one short sentence, so any text suffices.
+    set_fallback_mock_llm(mock_llm_server_url, approval_model, "Command executed.")
 
     respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
 
-    yaml_bytes = _APPROVAL_AGENT_YAML.encode()
+    yaml_bytes = agent_yaml_text.encode()
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         # Strict path: arcname config.yaml keeps it on the spec_version:1

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -92,16 +92,19 @@ _BUILD_OUTPUT = _REPO_ROOT / "omnigent" / "server" / "static" / "web-ui"
 # validator at registration time (no shim defaults applied), so the
 # YAML must carry an explicit ``executor`` block — otherwise the
 # server rejects with ``executor.config.harness: required when
-# executor.type is 'omnigent'``. The mock LLM server handles
-# The model name (databricks-gpt-5-4) is used for harness routing only;
-# harness auto-picks ``openai-agents`` and routes requests to the
-# in-process mock rather than a real provider.
+# executor.type is 'omnigent'``. The model name (gpt-4o-mini) is a plain
+# (non-``databricks-``) name on purpose: the openai-agents harness then
+# resolves no provider auth and falls back to ``OPENAI_BASE_URL`` (the
+# in-process mock) rather than routing to the Databricks gateway, which
+# would need real credentials CI does not have. A ``databricks-``-prefixed
+# model forces Databricks DEFAULT-profile auth (see
+# omnigent/runtime/workflow.py) and fails with DatabricksAuthError in CI.
 _TEST_AGENT_YAML = """\
 name: hello_world
 prompt: You are a friendly assistant. Say hello and answer questions.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 
@@ -168,7 +171,7 @@ name: {_FILES_PROBE_NO_ENV_AGENT_NAME}
 prompt: You are a terse assistant with no filesystem.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 """
@@ -177,7 +180,7 @@ name: {_FILES_PROBE_ENV_AGENT_NAME}
 prompt: You are a terse assistant with a filesystem.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 
@@ -905,7 +908,7 @@ def live_server(
     # Fallback for the openai-agents harness: any agent turn that doesn't
     # match a content-based queue gets a generic reply (sufficient for tests
     # that only assert an assistant bubble appears, not its exact content).
-    set_fallback_mock_llm(mock_url, "databricks-gpt-5-4", "Mock LLM response.")
+    set_fallback_mock_llm(mock_url, "gpt-4o-mini", "Mock LLM response.")
 
     try:
         yield base_url
@@ -1205,7 +1208,7 @@ prompt: |
   other tools.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 
@@ -1251,6 +1254,7 @@ def terminal_agent(live_server: str) -> Iterator[str]:
 @pytest.fixture
 def terminal_session(
     terminal_agent: str,
+    mock_llm_server_url: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[tuple[str, str]]:
     """Create a runner-bound session using the terminal-capable agent.
@@ -1263,6 +1267,9 @@ def terminal_session(
 
     :param terminal_agent: Live server base URL with the terminal agent
         registered.
+    :param mock_llm_server_url: Session-scoped mock LLM server URL; used to
+        queue the deterministic launch/send/confirm tool sequence the agent
+        runs in response to "spin up zsh".
     :param tmp_path_factory: Pytest temp path factory (for a respawn log).
     :returns: ``(base_url, session_id)``.
     """
@@ -1272,6 +1279,46 @@ def terminal_session(
     import tarfile
 
     live_server = terminal_agent
+
+    # The "spin up zsh" prompt drives three ordered LLM turns: launch the
+    # terminal, type the file-writing command, then confirm. Content-route on
+    # the prompt text so the queue fires only for this fixture's turns, and
+    # order the three responses to match the agent's prompted sequence.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_launch",
+                        "name": "sys_terminal_launch",
+                        "arguments": _json.dumps({"terminal": "zsh", "session": "main"}),
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_send",
+                        "name": "sys_terminal_send",
+                        "arguments": _json.dumps(
+                            {
+                                "terminal": "zsh",
+                                "session": "main",
+                                "text": (
+                                    f"printf '%s\\n' '{_TERMINAL_PANEL_FILE_CONTENT}' "
+                                    f"> {_TERMINAL_PANEL_FILE}"
+                                ),
+                            }
+                        ),
+                    }
+                ]
+            },
+            {"text": "The zsh terminal is running and the file was written."},
+        ],
+        key="terminal-spin-up-zsh",
+        match="spin up zsh",
+    )
     respawned_runner = _ensure_runner_online(live_server, tmp_path_factory)
     runner_id = str(_server_state["runner_id"])
     # Create a session with the terminal agent bundle inline.
@@ -1387,7 +1434,7 @@ prompt: |
   sub-agent session via `sys_session_send` — NEVER spawn a second one.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   harness: openai-agents
 
 tools:
@@ -1397,7 +1444,7 @@ tools:
       Deep Thought, the supercomputer built to compute the Answer to the
       Ultimate Question of Life, the Universe, and Everything.
     executor:
-      model: databricks-gpt-5-4
+      model: gpt-4o-mini
       harness: openai-agents
     prompt: |
       You are Deep Thought from The Hitchhiker's Guide to the Galaxy.
@@ -1523,7 +1570,7 @@ prompt: |
   other command or call any other tool.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 
@@ -1579,7 +1626,7 @@ def approval_session(
     # entirely — no other request will ever use this model key.
     approval_model = f"approval-probe-{_uuid.uuid4().hex[:8]}"
     # Substitute the unique model into the agent spec.
-    agent_yaml_text = _APPROVAL_AGENT_YAML.replace("databricks-gpt-5-4", approval_model)
+    agent_yaml_text = _APPROVAL_AGENT_YAML.replace("gpt-4o-mini", approval_model)
 
     # First LLM call: return the gated sys_os_shell tool call.
     configure_mock_llm(
@@ -1729,7 +1776,7 @@ prompt: |
   and nothing else — no preamble, no quotes, no trailing punctuation.
 
 executor:
-  model: databricks-gpt-5-4
+  model: gpt-4o-mini
   config:
     harness: openai-agents
 """

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -901,6 +901,7 @@ def live_server(
     # test_stale_stream) can respawn one via :func:`_ensure_runner_online`.
     _server_state["binding_token"] = binding_token
     _server_state["server_url"] = base_url
+    _server_state["mock_llm_url"] = mock_url
 
     # Set a non-resettable fallback for the policy-classifier LLM queue so
     # every per-test reset leaves the server's guardrails path functional.
@@ -1069,6 +1070,7 @@ def _ensure_runner_online(
         return None
 
     binding_token = str(_server_state["binding_token"])
+    mock_url = str(_server_state.get("mock_llm_url", ""))
     runner_tmp = tmp_path_factory.mktemp("e2e_ui_respawn_runner")
     log_path = runner_tmp / "runner.log"
     log_handle = open(log_path, "w")  # noqa: SIM115 — fd dup'd into child; closed below
@@ -1079,6 +1081,11 @@ def _ensure_runner_online(
         "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
         "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
         "RUNNER_SERVER_URL": base_url,
+        # Mirror the live_server runner's mock-LLM routing so the
+        # respawned runner's harness also hits the mock.
+        **(
+            {"OPENAI_BASE_URL": f"{mock_url}/v1", "OPENAI_API_KEY": "mock-key"} if mock_url else {}
+        ),
     }
     proc = subprocess.Popen(
         [sys.executable, "-m", "omnigent.runner._entry"],

--- a/tests/e2e_ui/fork_session/test_fork_from_middle.py
+++ b/tests/e2e_ui/fork_session/test_fork_from_middle.py
@@ -26,6 +26,8 @@ import re
 import httpx
 from playwright.sync_api import Page, expect
 
+from tests.e2e_ui.conftest import configure_mock_llm
+
 # Two distinct code words with no shared substring, so the kept/dropped
 # assertions can't satisfy each other. Only the KEPT word is part of the
 # turn the fork copies; the DROPPED word lives in the turn after the fork
@@ -41,6 +43,7 @@ def test_fork_from_middle_truncates_history(
     page: Page,
     seeded_session: tuple[str, str],
     runner_id: str,
+    mock_llm_server_url: str,
 ) -> None:
     """Fork from the first turn — the clone carries only history up to it.
 
@@ -61,6 +64,17 @@ def test_fork_from_middle_truncates_history(
         clone unbound, so a message would otherwise have no runner).
     """
     base_url, session_id = seeded_session
+
+    # Content-route the recall turn so the mock echoes the kept marker.
+    # Turns 1 & 2 ("reply with just OK") hit the generic fallback ("Mock LLM
+    # response.") which is enough for the fork-point anchor assertions.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": _KEPT_MARKER}],
+        key="fork-recall",
+        match="What code word did I ask you to remember",
+    )
+
     page.goto(f"{base_url}/c/{session_id}")
 
     composer = page.get_by_placeholder("Ask the agent anything…")

--- a/tests/e2e_ui/fork_session/test_fork_switch_agent.py
+++ b/tests/e2e_ui/fork_session/test_fork_switch_agent.py
@@ -33,6 +33,7 @@ the native CLI to take a turn.
 
 from __future__ import annotations
 
+import os
 import re
 
 import httpx
@@ -106,6 +107,12 @@ def test_fork_switch_agent_carries_history(
         carry-history label (true only for native targets that can replay
         fork history, currently claude/codex native).
     """
+    # Native targets (claude-code, codex) need real CLI credentials that
+    # CI does not have; skip those parametrizations when LLM_API_KEY is absent.
+    _NATIVE_TARGETS = {"claude-native-ui", "codex-native-ui"}
+    if target_name in _NATIVE_TARGETS and not os.environ.get("LLM_API_KEY"):
+        pytest.skip(f"Fork into {target_name} needs real credentials (LLM_API_KEY).")
+
     base_url, session_id = seeded_session
     target_agent_id = _agent_id_by_name(base_url, target_name)
 

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -38,6 +38,8 @@ import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e_ui.conftest import configure_mock_llm, reset_mock_llm, set_fallback_mock_llm
+
 _COMPOSER = "Ask the agent anything…"
 _USER = '[data-testid="message-bubble"][data-role="user"]'
 _ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
@@ -47,6 +49,9 @@ _TURNS = 5
 
 # A custom openai-agents turn is a single LLM call.
 _CUSTOM_TURN_TIMEOUT_MS = 90_000
+
+# Model name baked into _CUSTOM_AGENT_YAML; used to key the mock fallback.
+_ECHO_PROBE_MODEL = "databricks-gpt-5-4"
 
 
 def _send(page: Page, text: str) -> None:
@@ -232,6 +237,8 @@ def _run_render_parity_journey(
     session_id: str,
     *,
     per_turn_timeout_ms: int,
+    mock_llm_server_url: str | None = None,
+    mock_model: str | None = None,
 ) -> None:
     """Drive five turns, then assert no-duplicate render + transcript parity.
 
@@ -239,18 +246,46 @@ def _run_render_parity_journey(
     :param base_url: Spawned server base URL.
     :param session_id: The session/conversation id to chat in.
     :param per_turn_timeout_ms: How long to wait for each turn to land.
+    :param mock_llm_server_url: When provided, pre-configure the mock LLM
+        server with per-turn echo responses (content-based routing keyed on
+        the user marker) before any message is sent. Required when the runner
+        routes through the mock rather than a real LLM.
+    :param mock_model: Model name to set as a catch-all fallback on the mock
+        when *mock_llm_server_url* is given. Extra LLM calls from the agent
+        (e.g. tool-schema loading) hit this queue and get an empty reply.
     """
     page.goto(f"{base_url}/c/{session_id}")
     _ensure_chat_view(page)
 
+    # Pre-generate tokens for all turns so they can be queued in the mock
+    # before any message is sent.
+    nonces = [uuid.uuid4().hex[:8] for _ in range(_TURNS)]
+    all_turns = [(f"usr-{i + 1}-{nonces[i]}", f"ast-{i + 1}-{nonces[i]}") for i in range(_TURNS)]
+
+    # Set model fallback once — survives reset_mock_llm, handles any extra
+    # LLM calls the agent makes that don't match the per-turn content queue.
+    if mock_llm_server_url is not None and mock_model is not None:
+        set_fallback_mock_llm(mock_llm_server_url, mock_model, "")
+
     user_markers: list[str] = []
     assistant_tokens: list[str] = []
-    for index in range(1, _TURNS + 1):
-        nonce = uuid.uuid4().hex[:8]
-        user_marker = f"usr-{index}-{nonce}"
-        assistant_token = f"ast-{index}-{nonce}"
+    for index, (user_marker, assistant_token) in enumerate(all_turns, start=1):
         user_markers.append(user_marker)
         assistant_tokens.append(assistant_token)
+
+        if mock_llm_server_url is not None:
+            # Reset before each turn so only THIS turn's queue is active.
+            # Without this, the openai-agents harness accumulates conversation
+            # history, making previous user markers appear in later requests —
+            # causing the earlier (now empty) queue to match first via
+            # insertion-order tie-breaking and return no response.
+            reset_mock_llm(mock_llm_server_url)
+            configure_mock_llm(
+                mock_llm_server_url,
+                [{"text": assistant_token}],
+                key=user_marker,
+                match=user_marker,
+            )
 
         _send(page, _turn_prompt(index, user_marker, assistant_token))
         # The echoed token in an assistant bubble = the turn produced its
@@ -272,10 +307,16 @@ def _run_render_parity_journey(
 def test_custom_agent_message_render_parity(
     page: Page,
     custom_agent_session: tuple[str, str],
+    mock_llm_server_url: str,
 ) -> None:
     base_url, session_id = custom_agent_session
     _run_render_parity_journey(
-        page, base_url, session_id, per_turn_timeout_ms=_CUSTOM_TURN_TIMEOUT_MS
+        page,
+        base_url,
+        session_id,
+        per_turn_timeout_ms=_CUSTOM_TURN_TIMEOUT_MS,
+        mock_llm_server_url=mock_llm_server_url,
+        mock_model=_ECHO_PROBE_MODEL,
     )
 
 

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -51,7 +51,7 @@ _TURNS = 5
 _CUSTOM_TURN_TIMEOUT_MS = 90_000
 
 # Model name baked into _CUSTOM_AGENT_YAML; used to key the mock fallback.
-_ECHO_PROBE_MODEL = "databricks-gpt-5-4"
+_ECHO_PROBE_MODEL = "gpt-4o-mini"
 
 
 def _send(page: Page, text: str) -> None:

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -21,6 +21,7 @@ extra LLM calls Claude Code makes internally.
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 
 import pytest
@@ -97,6 +98,10 @@ def _type_into_tui(page: Page, text: str) -> None:
     page.keyboard.press("Enter")
 
 
+@pytest.mark.skipif(
+    not os.environ.get("LLM_API_KEY"),
+    reason="Native Claude render-parity needs real Anthropic credentials (LLM_API_KEY).",
+)
 @pytest.mark.timeout(300)
 def test_native_claude_message_render_parity(
     page: Page,

--- a/tests/e2e_ui/messages/test_native_codex_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_codex_render_parity.py
@@ -21,6 +21,7 @@ extra LLM calls Codex makes internally.
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 
 import pytest
@@ -98,6 +99,10 @@ def _type_into_tui(page: Page, text: str) -> None:
     page.keyboard.press("Enter")
 
 
+@pytest.mark.skipif(
+    not os.environ.get("LLM_API_KEY"),
+    reason="Native Codex render-parity needs real OpenAI credentials (LLM_API_KEY).",
+)
 @pytest.mark.timeout(300)
 def test_native_codex_message_render_parity(
     page: Page,


### PR DESCRIPTION
## Summary

- **`live_server` (conftest)**: adds `OPENAI_BASE_URL=mock/v1` and `OPENAI_API_KEY=mock-key` to the runner subprocess env, routing the openai-agents harness through the in-process mock instead of the Databricks gateway. Also sets a `databricks-gpt-5-4` fallback (`"Mock LLM response."`) so hello_world/seeded_session tests pass with any assistant bubble.
- **`approval_session` (conftest)**: generates a unique model name per fixture call (`approval-probe-{uuid}`), substitutes it into the agent YAML, and keys the mock queue on that model. Eliminates a race where the previous test's runner (making its post-approval second LLM call) would steal the freshly-configured tool-call queue from the next test.
- **`_run_render_parity_journey`**: reconfigures mock once per turn (reset + single content-keyed queue) instead of pre-loading all five at once. The openai-agents harness accumulates conversation history, causing earlier-turn user markers to appear in later requests — leading to empty-queue tie-breaking that returned no response.
- **`test_custom_agent_message_render_parity`**: adds `mock_llm_server_url` + `mock_model` so echo_probe turns are served by mock.
- **`e2e-ui.yml`**: drops `api_key_ref` and `LLM_API_KEY` everywhere — no real credentials needed anywhere in the suite.

## Verified locally

7/7 tests pass with `LLM_API_KEY` unset:
- `test_exit_plan_mode_review_renders_and_approves`
- `test_ask_user_question_form_renders_and_submits`
- `test_persistent_approval_remembers_webfetch_domain`
- `test_custom_agent_message_render_parity`
- `test_approve_page_approves`
- `test_approve_page_rejects`
- `test_approve_page_resolved_for_unknown_elicitation`

## Test plan

- [ ] CI e2e-ui shards all green (no LLM_API_KEY in workflow)

This pull request and its description were written by Isaac.