### PR TITLE
fix(cli): preserve proxy env for host daemon

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -696,6 +696,18 @@ _LOCAL_DAEMON_ENV_PREFIXES: tuple[str, ...] = (
     "OMNIGENT_",
     "OPENAI_",
 )
+_HOST_DAEMON_PROXY_ENV_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    }
+)
 _HostJsonValue: TypeAlias = (
     str | int | float | bool | None | list["_HostJsonValue"] | dict[str, "_HostJsonValue"]
 )
@@ -3021,6 +3033,7 @@ def _build_host_daemon_env(
             for key, value in os.environ.items()
             if key in _RUNNER_ENV_ALLOWLIST
             or key in _LOCAL_DAEMON_ENV_ALLOWLIST
+            or key in _HOST_DAEMON_PROXY_ENV_ALLOWLIST
             or key.startswith(daemon_env_prefixes)
         }
     else:
@@ -3032,7 +3045,9 @@ def _build_host_daemon_env(
         env = {
             key: value
             for key, value in os.environ.items()
-            if key in _RUNNER_ENV_ALLOWLIST or key.startswith(daemon_env_prefixes)
+            if key in _RUNNER_ENV_ALLOWLIST
+            or key in _HOST_DAEMON_PROXY_ENV_ALLOWLIST
+            or key.startswith(daemon_env_prefixes)
         }
     return env
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3038,9 +3038,9 @@ def _build_host_daemon_env(
         }
     else:
         # Allowlist the remote daemon's environment (W8): pass process
-        # essentials + TLS trust + the user's Databricks auth (the daemon
-        # authenticates to the server with it), but not unrelated provider
-        # secrets like ANTHROPIC_API_KEY / OPENAI_API_KEY.
+        # essentials + TLS trust + standard proxy selectors + the user's
+        # Databricks auth (the daemon authenticates to the server with it), but
+        # not unrelated provider secrets like ANTHROPIC_API_KEY / OPENAI_API_KEY.
         daemon_env_prefixes = (*_RUNNER_ENV_ALLOWLIST_PREFIXES, "DATABRICKS_")
         env = {
             key: value

--- a/tests/cli/test_host_daemon_env.py
+++ b/tests/cli/test_host_daemon_env.py
@@ -1,0 +1,96 @@
+"""Host-daemon environment boundary regression tests."""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pytest
+
+from omnigent.cli import _build_host_daemon_env
+from omnigent.host.connect import (
+    RUNNER_ENV_PASSTHROUGH_ENV_VAR,
+    _build_runner_env,
+)
+
+_REMOTE_SERVER_URL: Final = "https://example.databricksapps.com"
+_PROXY_ENV: Final = {
+    "HTTP_PROXY": "http://upper-http-proxy.example.com:3128",
+    "HTTPS_PROXY": "http://upper-https-proxy.example.com:3128",
+    "ALL_PROXY": "socks5://upper-proxy.example.com:1080",
+    "NO_PROXY": "localhost,127.0.0.1",
+    "http_proxy": "http://lower-http-proxy.example.com:3128",
+    "https_proxy": "http://lower-https-proxy.example.com:3128",
+    "all_proxy": "socks5://lower-proxy.example.com:1080",
+    "no_proxy": "localhost,127.0.0.2",
+}
+
+
+@pytest.mark.parametrize(
+    ("server_url", "keeps_provider_secret"),
+    [(None, True), (_REMOTE_SERVER_URL, False)],
+)
+def test_host_daemon_env_preserves_proxy_vars_and_provider_secret_split(
+    monkeypatch: pytest.MonkeyPatch,
+    server_url: str | None,
+    keeps_provider_secret: bool,
+) -> None:
+    """Proxy selectors reach both daemon modes without widening provider secrets."""
+    # Given
+    for name, value in _PROXY_ENV.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "corp")
+    monkeypatch.setenv("OPENAI_API_KEY", "local-provider-secret")
+
+    # When
+    env = _build_host_daemon_env(server_url=server_url)
+
+    # Then
+    assert {name: env.get(name) for name in _PROXY_ENV} == _PROXY_ENV
+    assert env["DATABRICKS_CONFIG_PROFILE"] == "corp"
+    assert ("OPENAI_API_KEY" in env) is keeps_provider_secret
+
+
+def test_runner_env_excludes_proxy_vars_by_default() -> None:
+    """Daemon proxy credentials do not cross into runner subprocesses by default."""
+    # Given
+    base_env = {"PATH": "/usr/bin", **_PROXY_ENV}
+
+    # When
+    env = _build_runner_env(
+        base_env,
+        server_url=_REMOTE_SERVER_URL,
+        runner_id="runner_proxy",
+        binding_token="binding-proxy",
+        workspace="/tmp/workspace",
+        parent_pid=12345,
+    )
+
+    # Then
+    assert set(_PROXY_ENV).isdisjoint(env)
+
+
+def test_runner_env_explicit_proxy_passthrough_remains_available() -> None:
+    """Runner proxy forwarding remains opt-in through the existing passthrough."""
+    # Given
+    explicit_names = {"HTTPS_PROXY", "http_proxy"}
+    base_env = {
+        "PATH": "/usr/bin",
+        **_PROXY_ENV,
+        RUNNER_ENV_PASSTHROUGH_ENV_VAR: ",".join(explicit_names),
+    }
+
+    # When
+    env = _build_runner_env(
+        base_env,
+        server_url=_REMOTE_SERVER_URL,
+        runner_id="runner_proxy",
+        binding_token="binding-proxy",
+        workspace="/tmp/workspace",
+        parent_pid=12345,
+    )
+
+    # Then
+    assert {name: env[name] for name in explicit_names} == {
+        name: _PROXY_ENV[name] for name in explicit_names
+    }
+    assert (set(_PROXY_ENV) - explicit_names).isdisjoint(env)


### PR DESCRIPTION
## Related issue

Closes #1022

## Summary

Corporate-proxy users could not bring the background host daemon online because
its allowlisted environment dropped the standard proxy selectors before the
daemon contacted a model backend.

- preserve `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, and lowercase
  variants in both local and remote host-daemon modes
- keep proxy variables out of runner subprocesses by default; the existing
  `OMNIGENT_RUNNER_ENV_PASSTHROUGH` opt-in remains unchanged
- add focused coverage for both daemon modes, uppercase/lowercase names, the
  runner boundary, and the local/remote provider-secret split

ELI5: the trusted host daemon can use the operator's corporate proxy, while an
agent runner still receives proxy credentials only when the operator explicitly
opts in.

```text
operator shell ── proxy env ──> host daemon ── filtered env ──> runner
                               retained                     excluded by default
```

## Test Plan

- `OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/cli/test_host_daemon_env.py -q`
  - RED on current `main`: `2 failed, 2 passed` because both daemon modes
    omitted all eight proxy names while the runner-boundary cases passed
  - GREEN after the fix: `4 passed`
- focused existing daemon/runner regression selection: `11 passed`
- controlled helper matrix using `uv run python`: both daemon modes retained all
  eight names; runner default retained none; explicit passthrough retained only
  the two named proxies; local/remote provider-secret behavior remained split
- `OMNIGENT_SKIP_WEB_UI=true uv run ruff check omnigent/cli.py tests/cli/test_host_daemon_env.py`
- `OMNIGENT_SKIP_WEB_UI=true uv run ruff format --check omnigent/cli.py tests/cli/test_host_daemon_env.py`
- `OMNIGENT_SKIP_WEB_UI=true uv run pre-commit run --files omnigent/cli.py tests/cli/test_host_daemon_env.py --show-diff-on-failure`
- `git diff --check`

`pre-commit run --all-files` also passed every backend and repository-hygiene
hook, but could not run the unrelated `web-prettier` hook because npm is not
installed in the verification environment. No `web/` file changed.

## Demo

N/A — non-visual daemon environment fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deterministic environment-builder seam covers the bug without requiring a
live corporate proxy or model backend. A controlled helper probe exercised the
real daemon and runner environment builders with synthetic values and asserted
the full boundary matrix. This bug fix does not introduce new user-facing
functionality, so no new e2e test is required.

## Changelog

Host daemons now honor standard proxy environment variables without forwarding
them to runners by default.
