### PR TITLE
backcompat: green the 12h matrix (v0.2.0 floor + skip sub-agent tests on older servers)

### DIFF
--- a/.github/scripts/ci/backcompat-pairwise-matrix.sh
+++ b/.github/scripts/ci/backcompat-pairwise-matrix.sh
@@ -3,7 +3,9 @@
 # $GITHUB_OUTPUT as `e2e_matrix` and `integration_matrix`.
 #
 # The version universe is `main` (the checked-out code = client + tests, always)
-# plus every non-rc release tag. We cross every server version with every runner
+# plus every non-rc release tag AT OR ABOVE the backcompat floor (MIN_VERSION,
+# default 0.2.0 — the first release with the mock-LLM e2e infra; see below).
+# We cross every server version with every runner
 # version — each cell pins the server and/or runner subprocess to that build
 # (an empty/"main" value leaves that component on the checked-out code). The
 # (main, main) cell is omitted: it pins nothing and is exactly the normal e2e
@@ -27,6 +29,26 @@ _valid_version() {
   [ "$1" = "main" ] || [[ "$1" =~ ^v?[0-9]+\.[0-9]+(\.[0-9]+)?([a-z0-9.]*)?$ ]]
 }
 
+# Minimum release the backcompat matrix tests against. v0.2.0 is the first
+# release with the mock-LLM e2e infrastructure (tests/e2e/conftest.py has 0
+# mock-LLM refs at v0.1.x, 31 at v0.2.0) AND the runner-side harness mock
+# routing — empirically, main's mock-based e2e suite 401s ("Incorrect API key
+# provided: mock-key") against v0.1.0/v0.1.1 server+runner builds, so those
+# pairs are guaranteed-red infrastructure mismatch, not a compat signal.
+# `main` is the dev tip and always sorts above any release, so it is never
+# floored. Override with BACKCOMPAT_MIN_VERSION (e.g. "0.0.0" to disable).
+MIN_VERSION="${BACKCOMPAT_MIN_VERSION:-0.2.0}"
+
+# True (0) when release tag $1 is older than MIN_VERSION (by PEP-440-ish release
+# order). "main" is never below the floor. Compares the numeric tuple via
+# `sort -V` after stripping the leading "v".
+_below_floor() {
+  [ "$1" = "main" ] && return 1
+  local v="${1#v}"
+  [ "$v" = "$MIN_VERSION" ] && return 1
+  [ "$(printf '%s\n%s\n' "$v" "$MIN_VERSION" | sort -V | head -1)" = "$v" ]
+}
+
 raw=()
 if [ -n "${VERSIONS:-}" ]; then
   IFS=',' read -ra raw <<<"$VERSIONS"
@@ -37,7 +59,7 @@ else
   while IFS= read -r tag; do raw+=("$tag"); done < <(git tag --sort=-v:refname | grep -viE '(^|[^a-z])rc[0-9]')
 fi
 
-# Trim whitespace, drop blanks, reject invalid tokens.
+# Trim whitespace, drop blanks, reject invalid tokens, drop below-floor releases.
 V=()
 for v in "${raw[@]}"; do
   v="${v#"${v%%[![:space:]]*}"}"
@@ -45,6 +67,10 @@ for v in "${raw[@]}"; do
   [ -z "$v" ] && continue
   if ! _valid_version "$v"; then
     echo "skipping invalid version token: '$v'" >&2
+    continue
+  fi
+  if _below_floor "$v"; then
+    echo "skipping '$v': below backcompat floor $MIN_VERSION (predates the mock-LLM e2e infra)" >&2
     continue
   fi
   V+=("$v")

--- a/.github/scripts/ci/backcompat-pairwise-matrix.sh
+++ b/.github/scripts/ci/backcompat-pairwise-matrix.sh
@@ -37,7 +37,11 @@ _valid_version() {
 # pairs are guaranteed-red infrastructure mismatch, not a compat signal.
 # `main` is the dev tip and always sorts above any release, so it is never
 # floored. Override with BACKCOMPAT_MIN_VERSION (e.g. "0.0.0" to disable).
+# Strip a leading "v" so a "v0.2.0"-style override compares cleanly against the
+# v-stripped tags in _below_floor (without this, the floor version itself would
+# be dropped).
 MIN_VERSION="${BACKCOMPAT_MIN_VERSION:-0.2.0}"
+MIN_VERSION="${MIN_VERSION#v}"
 
 # True (0) when release tag $1 is older than MIN_VERSION (by PEP-440-ish release
 # order). "main" is never below the floor. Compares the numeric tuple via

--- a/tests/e2e/test_coder_subagent.py
+++ b/tests/e2e/test_coder_subagent.py
@@ -41,6 +41,11 @@ _tool_mod = _get_tool_set("coding")
 TOOLS: list[dict[str, Any]] = _tool_mod.TOOLS
 execute_tool = _tool_mod.execute_tool
 
+# Spawning sub-agents and auto-collecting their results requires server-side
+# support added after v0.2.0 (see test_named_sub_agent_persistence.py). The
+# backwards-compat matrix skips these against servers < 0.3.0; they run on main.
+pytestmark = pytest.mark.min_server_version("0.3.0")
+
 
 def _wait_for_markers(
     http_client: httpx.Client,

--- a/tests/e2e/test_coder_subagent.py
+++ b/tests/e2e/test_coder_subagent.py
@@ -42,8 +42,9 @@ TOOLS: list[dict[str, Any]] = _tool_mod.TOOLS
 execute_tool = _tool_mod.execute_tool
 
 # These tests use per-sub-agent mock-LLM routing (each child on its own mock
-# model + auth.base_url), which a server < 0.3.0 does not propagate — the child
-# reaches the real gateway and fails, so its result never surfaces (see
+# model + auth.base_url), which a server < 0.3.0 does not propagate (fixed in
+# #779, which landed ~2h after v0.2.0 was tagged) — the child reaches the real
+# gateway and fails, so its result never surfaces (see
 # test_named_sub_agent_persistence.py for the verified mechanism). A mock-LLM
 # test-infra gap, not a product regression. The backwards-compat matrix skips
 # these against servers < 0.3.0; they run unchanged on main.

--- a/tests/e2e/test_coder_subagent.py
+++ b/tests/e2e/test_coder_subagent.py
@@ -41,9 +41,12 @@ _tool_mod = _get_tool_set("coding")
 TOOLS: list[dict[str, Any]] = _tool_mod.TOOLS
 execute_tool = _tool_mod.execute_tool
 
-# Spawning sub-agents and auto-collecting their results requires server-side
-# support added after v0.2.0 (see test_named_sub_agent_persistence.py). The
-# backwards-compat matrix skips these against servers < 0.3.0; they run on main.
+# These tests use per-sub-agent mock-LLM routing (each child on its own mock
+# model + auth.base_url), which a server < 0.3.0 does not propagate — the child
+# reaches the real gateway and fails, so its result never surfaces (see
+# test_named_sub_agent_persistence.py for the verified mechanism). A mock-LLM
+# test-infra gap, not a product regression. The backwards-compat matrix skips
+# these against servers < 0.3.0; they run unchanged on main.
 pytestmark = pytest.mark.min_server_version("0.3.0")
 
 

--- a/tests/e2e/test_default_executor_auto_collect.py
+++ b/tests/e2e/test_default_executor_auto_collect.py
@@ -29,8 +29,9 @@ from tests.e2e.conftest import (
 )
 
 # This test uses per-sub-agent mock-LLM routing (the child runs on its own mock
-# model + auth.base_url), which a server < 0.3.0 does not propagate — the child
-# reaches the real gateway and fails, so its result never surfaces (see
+# model + auth.base_url), which a server < 0.3.0 does not propagate (fixed in
+# #779, which landed ~2h after v0.2.0 was tagged) — the child reaches the real
+# gateway and fails, so its result never surfaces (see
 # test_named_sub_agent_persistence.py for the verified mechanism). A mock-LLM
 # test-infra gap, not a product regression. The backwards-compat matrix skips
 # this against servers < 0.3.0; it runs unchanged on main.

--- a/tests/e2e/test_default_executor_auto_collect.py
+++ b/tests/e2e/test_default_executor_auto_collect.py
@@ -28,6 +28,11 @@ from tests.e2e.conftest import (
     send_user_message_to_session,
 )
 
+# Default-executor sub-agent auto-collection requires server-side support added
+# after v0.2.0 (see test_named_sub_agent_persistence.py). The backwards-compat
+# matrix skips these against servers < 0.3.0; they run normally on main.
+pytestmark = pytest.mark.min_server_version("0.3.0")
+
 
 def _extract_all_text(body: dict[str, Any]) -> str:
     """

--- a/tests/e2e/test_default_executor_auto_collect.py
+++ b/tests/e2e/test_default_executor_auto_collect.py
@@ -28,9 +28,12 @@ from tests.e2e.conftest import (
     send_user_message_to_session,
 )
 
-# Default-executor sub-agent auto-collection requires server-side support added
-# after v0.2.0 (see test_named_sub_agent_persistence.py). The backwards-compat
-# matrix skips these against servers < 0.3.0; they run normally on main.
+# This test uses per-sub-agent mock-LLM routing (the child runs on its own mock
+# model + auth.base_url), which a server < 0.3.0 does not propagate — the child
+# reaches the real gateway and fails, so its result never surfaces (see
+# test_named_sub_agent_persistence.py for the verified mechanism). A mock-LLM
+# test-infra gap, not a product regression. The backwards-compat matrix skips
+# this against servers < 0.3.0; it runs unchanged on main.
 pytestmark = pytest.mark.min_server_version("0.3.0")
 
 

--- a/tests/e2e/test_named_sub_agent_persistence.py
+++ b/tests/e2e/test_named_sub_agent_persistence.py
@@ -76,14 +76,15 @@ from tests.e2e.helpers import POLL_INTERVAL_S
 # down on a genuine timeout.
 # These sub-agent tests drive each child agent through per-sub-agent mock-LLM
 # routing — every child runs on its own mock model and auth.base_url. A server
-# < 0.3.0 does not propagate the sub-agent executor's mock base_url, so the
-# child harness reaches the real gateway and its mock-only model name is
-# rejected (HTTP 400); the child returns nothing, so the parent's auto-wake has
-# nothing to surface. Verified against a v0.2.0 server: the child 400s on the
-# real gateway while auto-wake itself works (waiting downgraded, no 500). This
-# is a mock-LLM test-infrastructure gap, not a product regression. The
-# backwards-compat matrix skips these against servers < 0.3.0 via
-# min_server_version; they run unchanged on main and in the gate.
+# < 0.3.0 does not propagate the sub-agent executor's mock base_url (fixed in
+# #779, which added auth to the inner ExecutorSpec; it landed ~2h after v0.2.0
+# was tagged, so v0.2.0 just missed it), so the child harness reaches the real
+# gateway and its mock-only model name is rejected (HTTP 400); the child returns
+# nothing, so the parent's auto-wake has nothing to surface. Verified against a
+# v0.2.0 server: the child 400s on the real gateway while auto-wake itself works
+# (waiting downgraded, no 500). This is a mock-LLM test-infrastructure gap, not
+# a product regression. The backwards-compat matrix skips these against servers
+# < 0.3.0 via min_server_version; they run unchanged on main and in the gate.
 pytestmark = [
     pytest.mark.timeout(600, method="signal"),
     pytest.mark.min_server_version("0.3.0"),

--- a/tests/e2e/test_named_sub_agent_persistence.py
+++ b/tests/e2e/test_named_sub_agent_persistence.py
@@ -74,7 +74,15 @@ from tests.e2e.helpers import POLL_INTERVAL_S
 # thread default protects, because these tests block only in
 # main-thread httpx polls, so the worker survives and fixtures tear
 # down on a genuine timeout.
-pytestmark = pytest.mark.timeout(600, method="signal")
+# Sub-agent auto-wake (the parent is re-dispatched when a named child completes)
+# is server-side support that shipped after v0.2.0 — verified: these tests fail
+# against a v0.2.0 server even with a main runner (the result never reaches the
+# parent). The backwards-compat matrix skips them against servers < 0.3.0 via
+# min_server_version; they run normally on main and in the gate.
+pytestmark = [
+    pytest.mark.timeout(600, method="signal"),
+    pytest.mark.min_server_version("0.3.0"),
+]
 
 _FIXTURES_DIR = Path(__file__).resolve().parents[1] / "_fixtures" / "agents"
 _NAMED_FIXTURE = _FIXTURES_DIR / "named-sub-agent-test"

--- a/tests/e2e/test_named_sub_agent_persistence.py
+++ b/tests/e2e/test_named_sub_agent_persistence.py
@@ -74,11 +74,16 @@ from tests.e2e.helpers import POLL_INTERVAL_S
 # thread default protects, because these tests block only in
 # main-thread httpx polls, so the worker survives and fixtures tear
 # down on a genuine timeout.
-# Sub-agent auto-wake (the parent is re-dispatched when a named child completes)
-# is server-side support that shipped after v0.2.0 — verified: these tests fail
-# against a v0.2.0 server even with a main runner (the result never reaches the
-# parent). The backwards-compat matrix skips them against servers < 0.3.0 via
-# min_server_version; they run normally on main and in the gate.
+# These sub-agent tests drive each child agent through per-sub-agent mock-LLM
+# routing — every child runs on its own mock model and auth.base_url. A server
+# < 0.3.0 does not propagate the sub-agent executor's mock base_url, so the
+# child harness reaches the real gateway and its mock-only model name is
+# rejected (HTTP 400); the child returns nothing, so the parent's auto-wake has
+# nothing to surface. Verified against a v0.2.0 server: the child 400s on the
+# real gateway while auto-wake itself works (waiting downgraded, no 500). This
+# is a mock-LLM test-infrastructure gap, not a product regression. The
+# backwards-compat matrix skips these against servers < 0.3.0 via
+# min_server_version; they run unchanged on main and in the gate.
 pytestmark = [
     pytest.mark.timeout(600, method="signal"),
     pytest.mark.min_server_version("0.3.0"),

--- a/tests/e2e/test_sub_agent_phase3_e2e.py
+++ b/tests/e2e/test_sub_agent_phase3_e2e.py
@@ -54,8 +54,9 @@ from tests.e2e.helpers import POLL_INTERVAL_S
 # Each test is 3+ serial gateway turns (dispatch + sub-agent + auto-wake),
 # so 600s absorbs potential backoff.
 # These sub-agent tests use per-sub-agent mock-LLM routing (each child on its
-# own mock model + auth.base_url), which a server < 0.3.0 does not propagate —
-# the child reaches the real gateway and fails, so its result never surfaces
+# own mock model + auth.base_url), which a server < 0.3.0 does not propagate
+# (fixed in #779, which landed ~2h after v0.2.0 was tagged) — the child reaches
+# the real gateway and fails, so its result never surfaces
 # (see test_named_sub_agent_persistence.py for the verified mechanism). A
 # mock-LLM test-infra gap, not a product regression. The backwards-compat
 # matrix skips these against servers < 0.3.0; they run unchanged on main.

--- a/tests/e2e/test_sub_agent_phase3_e2e.py
+++ b/tests/e2e/test_sub_agent_phase3_e2e.py
@@ -53,7 +53,13 @@ from tests.e2e.helpers import POLL_INTERVAL_S
 
 # Each test is 3+ serial gateway turns (dispatch + sub-agent + auto-wake),
 # so 600s absorbs potential backoff.
-pytestmark = pytest.mark.timeout(600, method="signal")
+# Sub-agent spawn + result auto-collection requires server-side support added
+# after v0.2.0 (see test_named_sub_agent_persistence.py). The backwards-compat
+# matrix skips these against servers < 0.3.0; they run normally on main.
+pytestmark = [
+    pytest.mark.timeout(600, method="signal"),
+    pytest.mark.min_server_version("0.3.0"),
+]
 
 # Stable marker strings checked in the session snapshot.
 _RESEARCHER_MARKER = "RESEARCHER_MARKER_2025"

--- a/tests/e2e/test_sub_agent_phase3_e2e.py
+++ b/tests/e2e/test_sub_agent_phase3_e2e.py
@@ -53,9 +53,12 @@ from tests.e2e.helpers import POLL_INTERVAL_S
 
 # Each test is 3+ serial gateway turns (dispatch + sub-agent + auto-wake),
 # so 600s absorbs potential backoff.
-# Sub-agent spawn + result auto-collection requires server-side support added
-# after v0.2.0 (see test_named_sub_agent_persistence.py). The backwards-compat
-# matrix skips these against servers < 0.3.0; they run normally on main.
+# These sub-agent tests use per-sub-agent mock-LLM routing (each child on its
+# own mock model + auth.base_url), which a server < 0.3.0 does not propagate —
+# the child reaches the real gateway and fails, so its result never surfaces
+# (see test_named_sub_agent_persistence.py for the verified mechanism). A
+# mock-LLM test-infra gap, not a product regression. The backwards-compat
+# matrix skips these against servers < 0.3.0; they run unchanged on main.
 pytestmark = [
     pytest.mark.timeout(600, method="signal"),
     pytest.mark.min_server_version("0.3.0"),

--- a/tests/e2e/test_subagent_autowake_e2e.py
+++ b/tests/e2e/test_subagent_autowake_e2e.py
@@ -48,7 +48,13 @@ _WAKE_NOTICE_SIGNATURE = "waiting in inbox"
 _RESEARCHER_MARKER = "RESEARCHER_MARKER_2025"
 
 # Each test is 3+ serial gateway turns, so 600s absorbs potential backoff.
-pytestmark = pytest.mark.timeout(600, method="signal")
+# Auto-wake (idle parent re-dispatched when a child completes) is server-side
+# support added after v0.2.0 (see test_named_sub_agent_persistence.py). The
+# backwards-compat matrix skips these against servers < 0.3.0; they run on main.
+pytestmark = [
+    pytest.mark.timeout(600, method="signal"),
+    pytest.mark.min_server_version("0.3.0"),
+]
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_subagent_autowake_e2e.py
+++ b/tests/e2e/test_subagent_autowake_e2e.py
@@ -49,8 +49,9 @@ _RESEARCHER_MARKER = "RESEARCHER_MARKER_2025"
 
 # Each test is 3+ serial gateway turns, so 600s absorbs potential backoff.
 # These tests use per-sub-agent mock-LLM routing (each child on its own mock
-# model + auth.base_url), which a server < 0.3.0 does not propagate — the child
-# reaches the real gateway and fails, so its result never surfaces (see
+# model + auth.base_url), which a server < 0.3.0 does not propagate (fixed in
+# #779, which landed ~2h after v0.2.0 was tagged) — the child reaches the real
+# gateway and fails, so its result never surfaces (see
 # test_named_sub_agent_persistence.py for the verified mechanism). A mock-LLM
 # test-infra gap, not a product regression. The backwards-compat matrix skips
 # these against servers < 0.3.0; they run unchanged on main.

--- a/tests/e2e/test_subagent_autowake_e2e.py
+++ b/tests/e2e/test_subagent_autowake_e2e.py
@@ -48,9 +48,12 @@ _WAKE_NOTICE_SIGNATURE = "waiting in inbox"
 _RESEARCHER_MARKER = "RESEARCHER_MARKER_2025"
 
 # Each test is 3+ serial gateway turns, so 600s absorbs potential backoff.
-# Auto-wake (idle parent re-dispatched when a child completes) is server-side
-# support added after v0.2.0 (see test_named_sub_agent_persistence.py). The
-# backwards-compat matrix skips these against servers < 0.3.0; they run on main.
+# These tests use per-sub-agent mock-LLM routing (each child on its own mock
+# model + auth.base_url), which a server < 0.3.0 does not propagate — the child
+# reaches the real gateway and fails, so its result never surfaces (see
+# test_named_sub_agent_persistence.py for the verified mechanism). A mock-LLM
+# test-infra gap, not a product regression. The backwards-compat matrix skips
+# these against servers < 0.3.0; they run unchanged on main.
 pytestmark = [
     pytest.mark.timeout(600, method="signal"),
     pytest.mark.min_server_version("0.3.0"),


### PR DESCRIPTION
## What

Make the scheduled **Backwards-Compat** 12h pairwise matrix green again. It was **46/74 red** ([run 28036306894](https://github.com/omnigent-ai/omnigent/actions/runs/28036306894)). Two changes, both addressing diagnosed root causes (every failure is e2e; all 15 integration jobs passed):

### 1. Floor the version universe at v0.2.0 (`backcompat-pairwise-matrix.sh`)
~38 of the 46 failures were cells pinning **v0.1.0 / v0.1.1**, signature `401 Incorrect API key provided: mock-key` / "Invalid API key".

Root cause (verified): **v0.1.x predates the mock-LLM e2e infrastructure** — `tests/e2e/conftest.py` has **0** mock-LLM refs at v0.1.0/v0.1.1 vs **31** at v0.2.0; with the server fixed at `main`, only the *runner* version flips the result (`runner v0.2.0` → 4/4 green; `runner v0.1.1`/`v0.1.0` → 11 mock-key 401s each). main's mock-based suite **cannot** run against pre-v0.2.0 builds — guaranteed-red infra mismatch, not a compat signal.

`MIN_VERSION` floor (default `0.2.0`, override `BACKCOMPAT_MIN_VERSION`): below-floor tags dropped **with a logged reason**; `main` never floored; applies to auto + explicit `VERSIONS`. Matrix auto-grows as releases ≥ floor ship.

### 2. Skip the sub-agent e2e tests against servers < 0.3.0 (5 test modules)
The residual `{main, v0.2.0}` window still failed the sub-agent suite against a **v0.2.0 server**. **Root-caused** (re-ran a marked test against a v0.2.0 server with the waiting-status fix + log capture):

- The child sub-agent's harness routes to the **real gateway, not the mock** — a v0.2.0 server **does not propagate the per-sub-agent executor's mock `auth.base_url`**. The child's mock-only per-model name (e.g. `gpt-5.4-named-researcher`) is then rejected by the real gateway (**HTTP 400**), the child returns nothing, and the parent's auto-wake correctly has nothing to surface → 240s timeout.
- **Auto-wake itself works** (wake POSTs return 2xx; `waiting` downgraded to `running`; no 500). This is **not** an auto-wake regression — auto-wake is present at v0.2.0. It is a **mock-LLM test-infrastructure gap** (the per-sub-agent mock-routing pattern the tests were rewritten to use isn't honored by a v0.2.0 server) — the **same class as the floor's dominant mode**.

Marked the 5 sub-agent modules `min_server_version("0.3.0")` (evidence-scoped: exactly the modules that failed against a v0.2.0 server; other sub-agent e2e files passed and are left unmarked).

## Validation
- Floor: auto universe → `main + v0.2.0`; v0.1.x dropped with a log line; edge cases (`v0.3.0`/`v0.2.1`/`v0.10.0`) kept; override + disable work.
- Markers — **skip** against an old server: the test that took **262s (timeout) now `SKIPPED: requires server >= 0.3.0`** against a pinned v0.2.0 server.
- Markers — **no coverage loss on main**: on this PR's e2e gate (server=main), **all 12 marked tests PASSED, 0 skipped, 0 marker-fires** (CI's fresh `uv sync` reports `0.3.0.dev0`).

## Result
The `{main, v0.2.0}` window goes green: `main/v0.2.0` was already green; `v0.2.0/main` and `v0.2.0/v0.2.0` skip the mock-infra-incompatible sub-agent tests and pass the rest. The one remaining `test_repl_single_approval` pexpect timeout is a pre-existing load-sensitive REPL flake (not compat) — the floor's lighter job count reduces it.

## Notes
- The sub-agent **waiting-500** is subsumed for the matrix (those tests now skip against v0.2.0). The runner `/api/version` gate in **#994** remains the correct *product* fix (a new runner shouldn't 500 a real old server).
- Backcompat is dispatch/nightly-only; no PR gates affected.
- Full CI-green confirmation needs this merged + a scheduled/dispatched run.
