### PR TITLE
Add example: web agent via an MCP tool source

### DIFF
--- a/examples/web/config.yaml
+++ b/examples/web/config.yaml
@@ -1,0 +1,47 @@
+spec_version: 1
+name: web
+description: >-
+  A web agent that navigates sites, fills forms, and extracts page data through
+  a Notte MCP server. Use it to check a deployed app, reproduce a UI issue, or
+  pull reference docs a coding task depends on.
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are a web operator. You complete web tasks for the human or a calling
+  agent: navigate to a page, read its interactive elements, click and fill, and
+  extract structured data. You drive a real cloud browser through the Notte
+  tools, so you can reach pages a plain HTTP fetch cannot.
+
+  How to work:
+  - For an open-ended goal on a site ("sign up and confirm the welcome page",
+    "find the price on this page"), call notte_operator with the task and the
+    start URL, and let it run the multi-step browser flow.
+  - To read a page, call notte_scrape with the URL. Pass instructions when you
+    need structured fields rather than raw markdown.
+  - For step-by-step control, call notte_observe to list the interactive
+    elements (each gets an id like B1, I1, L1), then notte_execute to click or
+    fill a specific element.
+  - Report what you did and what you found. If a task fails, say why.
+
+# The Notte MCP server runs a hosted cloud browser. It defaults to SSE, so the
+# command below sets NOTTE_MCP_SERVER_PROTOCOL=stdio to run it over stdio. It
+# reads NOTTE_API_KEY (sk-notte-...) from the environment; get a key at
+# https://console.notte.cc and install the server with `pip install notte-mcp`.
+tools:
+  notte:
+    type: mcp
+    command: env
+    args:
+      - NOTTE_MCP_SERVER_PROTOCOL=stdio
+      - python
+      - -m
+      - notte_mcp.server
+    tools:
+      - notte_operator
+      - notte_scrape
+      - notte_observe
+      - notte_execute


### PR DESCRIPTION
# Add an example: web agent via an MCP tool source

## What

Adds `examples/web/`, an agent that reaches the web through an MCP server declared with `type: mcp`. It navigates pages, fills forms, runs multi-step browser tasks, and extracts structured data, for cases like checking a deployed app, reproducing a UI issue, or pulling reference docs a coding task depends on.

This is the first example in the repo that uses `type: mcp` (polly and debby use sub-agent tools), so it doubles as a worked reference for wiring any MCP server into an agent.

## How it works

The agent declares one MCP tool source and filters to four tools:

```yaml
tools:
  notte:
    type: mcp
    command: env
    args: [NOTTE_MCP_SERVER_PROTOCOL=stdio, python, -m, notte_mcp.server]
    tools: [notte_operator, notte_scrape, notte_observe, notte_execute]
```

The server is Notte's MCP server, which drives a hosted cloud browser. `notte_operator` runs a multi-step task from a goal and a URL, `notte_scrape` returns a page as markdown or structured data, and `notte_observe` plus `notte_execute` give step-by-step control over interactive elements.

## Setup

```bash
pip install notte-mcp
export NOTTE_API_KEY=sk-notte-...   # from https://console.notte.cc
omnigent run examples/web/
```

## Notes

- No core changes; one new example folder. Happy to add a mention in the README if you would like to feature it.
- The MCP server reads `NOTTE_API_KEY` from the environment. It defaults to SSE, so the example runs it with `NOTTE_MCP_SERVER_PROTOCOL=stdio` to speak stdio to omnigent.

## Checklist

- [ ] `uv run pytest`
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] `uv run pre-commit run --all-files`
- [ ] commits signed off (`git commit -s`)
