### PR TITLE
fix(managed-hosts): harden dormant-host wake settle (follow-up to #1003)

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -198,11 +198,16 @@ _HOST_LOG_PATH = "/tmp/omnigent-host.log"
 
 # How long a message POST waits for an in-flight managed launch to
 # settle before giving up (see ManagedLaunchTracker). Covers the full
-# launch pipeline: sandbox provision + host registration
-# (MANAGED_HOST_ONLINE_TIMEOUT_S) plus runner spawn/connect, with
-# slack. The wait resolves as soon as the launch settles — this bound
-# only matters when the background launch is itself stuck.
-MANAGED_LAUNCH_RENDEZVOUS_TIMEOUT_S = MANAGED_HOST_ONLINE_TIMEOUT_S + 60
+# launch/wake pipeline ON TOP OF the host-registration wait
+# (MANAGED_HOST_ONLINE_TIMEOUT_S): the provider's provision/resume call
+# (StartSandbox has no fixed upper bound), the host-tunnel reconnect on
+# this replica, and the runner spawn/connect. The 120s slack must cover
+# all of those so a slow cold launch/wake doesn't time the parked message
+# out before the background launch settles — otherwise the first
+# post-dormancy turn is lost even though the wake later succeeds. The wait
+# resolves as soon as the launch settles, so this bound only bites a
+# genuinely slow launch.
+MANAGED_LAUNCH_RENDEZVOUS_TIMEOUT_S = MANAGED_HOST_ONLINE_TIMEOUT_S + 120
 
 # Session label recording the repository-URL workspace a managed
 # session was created with (the raw ``<url>[#<branch>]`` request

--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -6092,6 +6092,22 @@ async def _run_managed_wake(
             return
         runner_id: str | None = None
         host_conn = host_registry.get(conv.host_id) if host_registry is not None else None
+        if host_registry is not None and host_conn is None:
+            # resume_managed_host waits on cross-replica host-store liveness, not
+            # this replica's in-memory tunnel registry — the woken host's tunnel
+            # can lag here (or land on another replica). Poll briefly so the runner
+            # launches once it reconnects, instead of settling "ready" with no
+            # runner; fail clearly if it never shows rather than losing the turn.
+            _host_reconnect_deadline = time.monotonic() + _HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S
+            while host_conn is None and time.monotonic() < _host_reconnect_deadline:
+                await asyncio.sleep(0.5)
+                host_conn = host_registry.get(conv.host_id)
+            if host_conn is None:
+                tracker.fail(session_id, "managed host did not reconnect after wake")
+                _publish_sandbox_status(
+                    session_id, "failed", "managed host did not reconnect after wake"
+                )
+                return
         if host_conn is not None:
             launch_attempt = await _launch_runner_on_host(
                 refreshed,


### PR DESCRIPTION
Follow-up to #1003 (resume/wake of a dormant managed host). Fixes two edge cases in the background wake path.

## 1. Wake could settle "ready" with no runner

`_run_managed_wake` settled the tracker as ready even when the woken host's tunnel had not (re)registered on this replica. `resume_managed_host` only waits on cross-replica host-store liveness — not this replica's in-memory `host_registry` — so the tunnel can lag, or land on another replica. The parked send would then unblock with no runner and lose the first post-wake turn.

Now it polls `host_registry` briefly (bounded by `_HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S`) and **fails clearly** if the host never reconnects, instead of settling "ready" without a runner.

## 2. Rendezvous budget too tight for a slow cold wake

The parked message's rendezvous budget (`MANAGED_LAUNCH_RENDEZVOUS_TIMEOUT_S`) left only 60s on top of the 120s host-online wait to cover the provider's (unbounded) provision/resume call + host-tunnel reconnect + runner connect. A slow cold launch/wake could time the message out even though the launch later succeeded.

Widened the slack to 120s. The wait still resolves as soon as the launch settles, so this only bites a genuinely slow launch. Benefits the relaunch path equally (shared constant).

## Scope
- `omnigent/server/routes/sessions.py` — `host_registry` reconnect poll in `_run_managed_wake`.
- `omnigent/server/managed_hosts.py` — widen `MANAGED_LAUNCH_RENDEZVOUS_TIMEOUT_S` slack 60s → 120s.