### PR TITLE
feat(ap-web): attach workspace files, folders & line ranges to native coding agents

### DIFF
--- a/web/src/components/FileMentionMenu.tsx
+++ b/web/src/components/FileMentionMenu.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from "react";
+import { FileTextIcon, FolderIcon, PlusIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
+
+interface FileMentionMenuProps {
+  /** Directory currently being browsed ("" = workspace root). */
+  currentDir: string;
+  /** Index of the highlighted row (-1 = none). */
+  activeIndex: number;
+  /** Entries of the current directory (folders first), already filtered + capped. */
+  entries: WorkspaceFile[];
+  /**
+   * True while the directory listing is still fetching (cold-boot root load or
+   * a sub-directory's first load). Renders a loading row so "@" gives feedback
+   * instead of appearing dead while ``entries`` is transiently empty.
+   */
+  loading?: boolean;
+  /** Open (drill into) a folder by its workspace-relative path. */
+  onOpenDir: (path: string) => void;
+  /** Attach a file (isDir=false) or whole folder (isDir=true) as a unit. */
+  onAttach: (path: string, isDir: boolean) => void;
+}
+
+/**
+ * Floating drill-down file/folder browser shown when the user types ``@`` in
+ * a native coding-agent session. Folders open (drill in) on click so nested
+ * files are reachable; a file attaches on click, and a folder's ``+`` button
+ * attaches the whole directory as a unit. Mirrors {@link SlashCommandMenu}'s
+ * keep-the-active-row-visible behaviour. Exported for direct unit testing.
+ */
+export function FileMentionMenu({
+  currentDir,
+  activeIndex,
+  entries,
+  loading = false,
+  onOpenDir,
+  onAttach,
+}: FileMentionMenuProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (activeIndex < 0 || !listRef.current) return;
+    listRef.current.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+  if (entries.length === 0 && !loading) return null;
+
+  return (
+    <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
+      <div className="w-80 max-w-[calc(100vw-2rem)] shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-lg">
+        <div className="flex items-center justify-between gap-2 px-2 pb-0.5 pt-1.5 text-[11px] font-medium text-muted-foreground">
+          <span className="truncate">{currentDir ? `/${currentDir}` : "Workspace"}</span>
+          <span className="shrink-0 text-[10px]">↵ open · ⇥ attach</span>
+        </div>
+        {entries.length === 0 && loading ? (
+          <div className="px-3 py-2 text-[13px] text-muted-foreground">Loading…</div>
+        ) : (
+          <div ref={listRef} role="listbox" className="max-h-80 overflow-y-auto p-1">
+          {entries.map((entry, i) => {
+            const isDir = entry.type === "directory";
+            return (
+              <div
+                key={`${entry.type}:${entry.path}`}
+                role="option"
+                aria-selected={i === activeIndex}
+                data-testid={`file-mention-item-${i}`}
+                data-active={i === activeIndex ? "true" : undefined}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] text-foreground",
+                  i === activeIndex && "bg-accent",
+                )}
+              >
+                <button
+                  type="button"
+                  // preventDefault keeps the textarea focused while clicking.
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => (isDir ? onOpenDir(entry.path) : onAttach(entry.path, false))}
+                  className="flex min-w-0 flex-1 items-center gap-2 hover:text-foreground"
+                  title={isDir ? `Open ${entry.name}` : `Attach ${entry.name}`}
+                >
+                  {isDir ? (
+                    <FolderIcon className="size-3.5 shrink-0 text-slate-500 dark:text-slate-400" />
+                  ) : (
+                    <FileTextIcon className="size-3.5 shrink-0 text-slate-500 dark:text-slate-400" />
+                  )}
+                  <span className="truncate">
+                    {entry.name}
+                    {isDir ? "/" : ""}
+                  </span>
+                </button>
+                {isDir && (
+                  <button
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => onAttach(entry.path, true)}
+                    className="flex shrink-0 items-center gap-0.5 rounded-md border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+                    aria-label={`Attach whole folder ${entry.name}`}
+                    title={`Attach whole folder ${entry.name}`}
+                  >
+                    <PlusIcon className="size-3" />
+                    folder
+                  </button>
+                )}
+              </div>
+            );
+          })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/FileMentionMenu.tsx
+++ b/web/src/components/FileMentionMenu.tsx
@@ -55,54 +55,54 @@ export function FileMentionMenu({
           <div className="px-3 py-2 text-[13px] text-muted-foreground">Loading…</div>
         ) : (
           <div ref={listRef} role="listbox" className="max-h-80 overflow-y-auto p-1">
-          {entries.map((entry, i) => {
-            const isDir = entry.type === "directory";
-            return (
-              <div
-                key={`${entry.type}:${entry.path}`}
-                role="option"
-                aria-selected={i === activeIndex}
-                data-testid={`file-mention-item-${i}`}
-                data-active={i === activeIndex ? "true" : undefined}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] text-foreground",
-                  i === activeIndex && "bg-accent",
-                )}
-              >
-                <button
-                  type="button"
-                  // preventDefault keeps the textarea focused while clicking.
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => (isDir ? onOpenDir(entry.path) : onAttach(entry.path, false))}
-                  className="flex min-w-0 flex-1 items-center gap-2 hover:text-foreground"
-                  title={isDir ? `Open ${entry.name}` : `Attach ${entry.name}`}
-                >
-                  {isDir ? (
-                    <FolderIcon className="size-3.5 shrink-0 text-slate-500 dark:text-slate-400" />
-                  ) : (
-                    <FileTextIcon className="size-3.5 shrink-0 text-slate-500 dark:text-slate-400" />
+            {entries.map((entry, i) => {
+              const isDir = entry.type === "directory";
+              return (
+                <div
+                  key={`${entry.type}:${entry.path}`}
+                  role="option"
+                  aria-selected={i === activeIndex}
+                  data-testid={`file-mention-item-${i}`}
+                  data-active={i === activeIndex ? "true" : undefined}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] text-foreground",
+                    i === activeIndex && "bg-accent",
                   )}
-                  <span className="truncate">
-                    {entry.name}
-                    {isDir ? "/" : ""}
-                  </span>
-                </button>
-                {isDir && (
+                >
                   <button
                     type="button"
+                    // preventDefault keeps the textarea focused while clicking.
                     onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => onAttach(entry.path, true)}
-                    className="flex shrink-0 items-center gap-0.5 rounded-md border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
-                    aria-label={`Attach whole folder ${entry.name}`}
-                    title={`Attach whole folder ${entry.name}`}
+                    onClick={() => (isDir ? onOpenDir(entry.path) : onAttach(entry.path, false))}
+                    className="flex min-w-0 flex-1 items-center gap-2 hover:text-foreground"
+                    title={isDir ? `Open ${entry.name}` : `Attach ${entry.name}`}
                   >
-                    <PlusIcon className="size-3" />
-                    folder
+                    {isDir ? (
+                      <FolderIcon className="size-3.5 shrink-0 text-slate-500 dark:text-slate-400" />
+                    ) : (
+                      <FileTextIcon className="size-3.5 shrink-0 text-slate-500 dark:text-slate-400" />
+                    )}
+                    <span className="truncate">
+                      {entry.name}
+                      {isDir ? "/" : ""}
+                    </span>
                   </button>
-                )}
-              </div>
-            );
-          })}
+                  {isDir && (
+                    <button
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => onAttach(entry.path, true)}
+                      className="flex shrink-0 items-center gap-0.5 rounded-md border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+                      aria-label={`Attach whole folder ${entry.name}`}
+                      title={`Attach whole folder ${entry.name}`}
+                    >
+                      <PlusIcon className="size-3" />
+                      folder
+                    </button>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/web/src/hooks/useMentionBrowser.ts
+++ b/web/src/hooks/useMentionBrowser.ts
@@ -49,8 +49,15 @@ export interface MentionBrowser {
  * state and supplies the directory listing (its data source differs).
  */
 export function useMentionBrowser(params: MentionBrowserParams): MentionBrowser {
-  const { mention, setMention, mentionEntries, text, setText, textareaRef, isMobile = false } =
-    params;
+  const {
+    mention,
+    setMention,
+    mentionEntries,
+    text,
+    setText,
+    textareaRef,
+    isMobile = false,
+  } = params;
   const [mentionIndex, setMentionIndex] = useState(-1);
   const [mentionedItems, setMentionedItems] = useState<MentionItem[]>([]);
   const mentionOpen = mentionEntries.length > 0;

--- a/web/src/hooks/useMentionBrowser.ts
+++ b/web/src/hooks/useMentionBrowser.ts
@@ -1,0 +1,162 @@
+import { type KeyboardEvent, type RefObject, useRef, useState } from "react";
+
+import { type MentionItem, type MentionState } from "@/lib/composerMentions";
+import { composerAttachmentKey } from "@/store/chatStore";
+import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
+
+/**
+ * Inputs the host composer supplies. The data source (workspace API vs. host
+ * filesystem) and the mention-token state live in the composer — only the
+ * stateful glue (selection index, tagged chips, attach/drill/remove handlers,
+ * keyboard navigation, top-row preselect) is shared here, so the two composers
+ * can't drift.
+ */
+export interface MentionBrowserParams {
+  /** Active mention token, owned by the composer (recomputed on text change). */
+  mention: MentionState | null;
+  /** Clear or replace the active token (e.g. on attach, drill, or dismiss). */
+  setMention: (next: MentionState | null) => void;
+  /** Current directory's entries — already filtered, folders-first, capped. */
+  mentionEntries: WorkspaceFile[];
+  /** The textarea value and a setter (which may also flag the draft dirty). */
+  text: string;
+  setText: (next: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  /** On mobile, Enter inserts a newline rather than acting on the menu. */
+  isMobile?: boolean;
+}
+
+export interface MentionBrowser {
+  mentionIndex: number;
+  mentionOpen: boolean;
+  mentionedItems: MentionItem[];
+  setMentionedItems: React.Dispatch<React.SetStateAction<MentionItem[]>>;
+  /** Attach a file (isDir=false) or whole folder (isDir=true) as a chip. */
+  attachMention: (path: string, isDir: boolean) => void;
+  /** Drill into a folder: rewrite the token to ``@<dir>/`` and keep browsing. */
+  openMentionDir: (path: string) => void;
+  removeMentionedItem: (index: number) => void;
+  /** Handle a key event for the open menu; returns true when it consumed it. */
+  handleKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  /** Dismiss the menu (e.g. on blur). */
+  dismiss: () => void;
+}
+
+/**
+ * Shared ``@``-file-mention controller for the in-session composer and the
+ * new-session launcher. Owns the selection index, the tagged-chip list, and
+ * the attach/drill/remove + keyboard behaviour; the composer owns the token
+ * state and supplies the directory listing (its data source differs).
+ */
+export function useMentionBrowser(params: MentionBrowserParams): MentionBrowser {
+  const { mention, setMention, mentionEntries, text, setText, textareaRef, isMobile = false } =
+    params;
+  const [mentionIndex, setMentionIndex] = useState(-1);
+  const [mentionedItems, setMentionedItems] = useState<MentionItem[]>([]);
+  const mentionOpen = mentionEntries.length > 0;
+
+  // Pre-select the top row whenever the listing changes — lets Enter/Tab act on
+  // the top hit without arrowing first. Keyed by type+path so a file and a dir
+  // of the same name stay distinct. (Render-phase state adjustment, the React
+  // "store-previous-props" pattern — mirrors the slash menu's reset.)
+  const prevMentionMatchesRef = useRef<string[]>([]);
+  const mentionEntryKeys = mentionEntries.map((e) => `${e.type}:${e.path}`);
+  if (
+    mentionEntryKeys.length !== prevMentionMatchesRef.current.length ||
+    mentionEntryKeys.some((k, i) => k !== prevMentionMatchesRef.current[i])
+  ) {
+    prevMentionMatchesRef.current = mentionEntryKeys;
+    setMentionIndex(mentionEntryKeys.length > 0 ? 0 : -1);
+  }
+
+  const attachMention = (path: string, isDir: boolean) => {
+    if (!mention) return;
+    setText(text.slice(0, mention.start) + text.slice(mention.end));
+    // Dedup on the shared attachment key (path + dir-ness + range) — the same
+    // identity the store queue uses — so the "@" menu and the file viewer's
+    // "Attach to agent" never disagree about what counts as a duplicate.
+    const item: MentionItem = { path, isDir };
+    const itemKey = composerAttachmentKey(item);
+    setMentionedItems((prev) =>
+      prev.some((it) => composerAttachmentKey(it) === itemKey) ? prev : [...prev, item],
+    );
+    setMention(null);
+    setMentionIndex(-1);
+    // Restore the caret to where the token was so typing continues naturally.
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      if (ta) ta.setSelectionRange(mention.start, mention.start);
+      ta?.focus();
+    });
+  };
+
+  const openMentionDir = (path: string) => {
+    if (!mention) return;
+    const inserted = `@${path}/`;
+    const next = text.slice(0, mention.start) + inserted + text.slice(mention.end);
+    setText(next);
+    const caret = mention.start + inserted.length;
+    setMention({ query: `${path}/`, start: mention.start, end: caret });
+    setMentionIndex(0);
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      if (ta) ta.setSelectionRange(caret, caret);
+      ta?.focus();
+    });
+  };
+
+  const removeMentionedItem = (index: number) =>
+    setMentionedItems((prev) => prev.filter((_, i) => i !== index));
+
+  const dismiss = () => {
+    if (!mention) return;
+    setMention(null);
+    setMentionIndex(-1);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (!mentionOpen) return false;
+    const active = mentionIndex >= 0 ? mentionEntries[mentionIndex] : undefined;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setMentionIndex((i) => (i + 1) % mentionEntries.length);
+      return true;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setMentionIndex((i) => (i <= 0 ? mentionEntries.length - 1 : i - 1));
+      return true;
+    }
+    // Enter: open a folder (drill in) or attach a file. Tab: attach the
+    // highlighted row as a unit — whole folder or file — without drilling.
+    if (e.key === "Enter" && !e.shiftKey && !isMobile && active) {
+      e.preventDefault();
+      if (active.type === "directory") openMentionDir(active.path);
+      else attachMention(active.path, false);
+      return true;
+    }
+    if (e.key === "Tab" && active) {
+      e.preventDefault();
+      attachMention(active.path, active.type === "directory");
+      return true;
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      dismiss();
+      return true;
+    }
+    return false;
+  };
+
+  return {
+    mentionIndex,
+    mentionOpen,
+    mentionedItems,
+    setMentionedItems,
+    attachMention,
+    openMentionDir,
+    removeMentionedItem,
+    handleKeyDown,
+    dismiss,
+  };
+}

--- a/web/src/lib/composerMentions.ts
+++ b/web/src/lib/composerMentions.ts
@@ -1,0 +1,92 @@
+import { type ComposerAttachment } from "@/store/chatStore";
+import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
+
+/**
+ * Pure ``@``-file-mention utilities shared by the in-session composer
+ * (``ChatPage``) and the new-session launcher (``NewChatDialog``). Kept free of
+ * React/state so both surfaces parse, serialize, and mark up tagged paths
+ * identically — and so the trigger logic is unit-testable without rendering.
+ */
+
+/** An active ``@``-file-mention being typed in a composer. */
+export interface MentionState {
+  /**
+   * Text typed after the ``@`` (no whitespace), which doubles as a path:
+   * the part up to the last ``/`` is the directory being browsed, the rest
+   * filters that directory's entries. E.g. ``"src/fo"`` browses ``src`` and
+   * filters by ``"fo"``; ``"src/"`` browses ``src`` with no filter.
+   */
+  query: string;
+  /** Index of the ``@`` character in the textarea value. */
+  start: number;
+  /** Caret index (one past the last query char) — end of the token. */
+  end: number;
+}
+
+/**
+ * A workspace path tagged in a composer — via the ``@``-mention menu
+ * (file/folder) or the file viewer's "Attach to agent" button (line range).
+ * Structurally identical to the store's queued attachment, so it is the same
+ * type: a chip drained from ``pendingComposerAttachments`` is a ``MentionItem``
+ * unchanged.
+ */
+export type MentionItem = ComposerAttachment;
+
+/** Serialize a tagged item to the path string that goes inside its marker. */
+export function mentionItemPath(item: MentionItem): string {
+  if (item.lineRange) return `${item.path}:${item.lineRange.start}-${item.lineRange.end}`;
+  return item.isDir ? `${item.path}/` : item.path;
+}
+
+// Token preceding the caret: an "@" at the start of the inspected string or
+// after whitespace, followed by a run with no whitespace and no further "@".
+// (``^`` anchors to the start of the sliced ``before`` text, not a line — a
+// mid-string "@" still matches because the newline before it counts as the
+// ``\s``.) Mirrors the terminal FileMentionCompleter's "@"-trigger so the web
+// behaves the same.
+const MENTION_RE = /(?:^|\s)@([^\s@]*)$/;
+
+/**
+ * Detect an in-progress ``@``-mention immediately before the caret.
+ *
+ * Looks only at ``text`` up to ``caret`` so a trailing space (token
+ * finished) closes the menu. Returns ``null`` when there is no active
+ * mention token.
+ *
+ * :param text: The full textarea value.
+ * :param caret: The caret offset (``selectionStart``).
+ * :returns: The active :class:`MentionState`, or ``null``.
+ */
+export function detectMentionAt(text: string, caret: number): MentionState | null {
+  const before = text.slice(0, caret);
+  const m = MENTION_RE.exec(before);
+  if (!m) return null;
+  const query = m[1];
+  // ``m.index`` points at the matched whitespace (or -1+1=0 at line start);
+  // the "@" sits just before the captured query.
+  const start = caret - query.length - 1;
+  return { query, start, end: caret };
+}
+
+/**
+ * Build the attachment marker for an "@"-tagged workspace ``path``, in the
+ * wording the given native harness's executor uses for file delivery.
+ *
+ * Claude / pi / cursor executors emit ``[Attached: <path>]``; codex emits
+ * ``[Attached file: <path>]`` (``codex_native_executor.py``). Both forms are
+ * stripped from seeded titles by ``_ATTACHMENT_MARKER_RE``, but matching the
+ * vendor's own wording keeps the marker consistent with what codex echoes
+ * back in its mirrored transcript.
+ *
+ * Resolves the harness through ``nativeCodingAgentForHarness`` so reversed
+ * spellings (``native-codex``) canonicalize to the same wording as
+ * ``codex-native`` rather than silently falling through to the default.
+ *
+ * :param harness: The session harness, e.g. ``"codex-native"``.
+ * :param path: Workspace-relative file path.
+ * :returns: A single-line ``[Attached…: <path>]`` marker.
+ */
+export function mentionMarkerFor(harness: string | null, path: string): string {
+  const isCodex = nativeCodingAgentForHarness(harness)?.key === "codex";
+  return isCodex ? `[Attached file: ${path}]` : `[Attached: ${path}]`;
+}

--- a/web/src/lib/composerMentions.ts
+++ b/web/src/lib/composerMentions.ts
@@ -90,3 +90,49 @@ export function mentionMarkerFor(harness: string | null, path: string): string {
   const isCodex = nativeCodingAgentForHarness(harness)?.key === "codex";
   return isCodex ? `[Attached file: ${path}]` : `[Attached: ${path}]`;
 }
+
+/** Default cap on how many mention rows the menu renders for one directory. */
+export const MENTION_MATCH_CAP = 50;
+
+/**
+ * Split a mention query into the directory being browsed and the filter typed
+ * within it. ``"src/fo"`` → browse ``"src"``, filter ``"fo"``; ``"src/"`` →
+ * browse ``"src"``, no filter; ``"fo"`` → browse root (``""``), filter ``"fo"``.
+ */
+export function parseMentionToken(query: string): { dir: string; filter: string } {
+  const slash = query.lastIndexOf("/");
+  return slash >= 0
+    ? { dir: query.slice(0, slash), filter: query.slice(slash + 1) }
+    : { dir: "", filter: query };
+}
+
+/**
+ * Filter a directory's entries by the typed segment, sort folders-first then
+ * alphabetically, and cap the list. Generic over any ``{ name, type }`` row so
+ * both the workspace-API and host-filesystem sources share one ranking. The cap
+ * trims only the rendered *list*, never what gets delivered.
+ */
+export function rankMentionEntries<T extends { name: string; type: string }>(
+  entries: T[],
+  filter: string,
+  cap: number = MENTION_MATCH_CAP,
+): T[] {
+  const needle = filter.toLowerCase();
+  return entries
+    .filter((e) => e.name.toLowerCase().includes(needle))
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, cap);
+}
+
+/**
+ * Assemble the attachment preamble prepended to an outgoing message: one
+ * harness-aware marker per tagged item, on its own line, terminated by a blank
+ * line. Returns ``""`` when nothing is tagged.
+ */
+export function buildMentionPreamble(items: MentionItem[], harness: string | null): string {
+  if (items.length === 0) return "";
+  return items.map((it) => mentionMarkerFor(harness, mentionItemPath(it))).join("\n") + "\n\n";
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -2,6 +2,18 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
+
+// Composer reads workspace files via a TanStack query hook (for "@"-file
+// mentions). These slash-command tests don't exercise that, so stub the hook
+// to avoid needing a QueryClientProvider around every bare render.
+vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useWorkspaceChangedFiles")>();
+  return {
+    ...actual,
+    useWorkspaceAllFiles: () => ({ data: undefined }),
+    useWorkspaceDirectory: () => ({ data: undefined }),
+  };
+});
 import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer } from "./ChatPage";

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -1,0 +1,436 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatStore } from "@/store/chatStore";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
+
+// Drill-down "@"-mention browses one directory at a time, so the test stubs
+// both sources: the root listing (useWorkspaceAllFiles) and the per-directory
+// listing (useWorkspaceDirectory). Root holds a "src" folder + a file; "src"
+// holds two nested files reachable only by opening it.
+//
+// Mock returns read from mutable hoisted state so a single test can flip a
+// listing to "still loading" or swap in a larger set, without re-mocking the
+// module. ``resetWorkspaceMock`` (called in beforeEach) restores the defaults.
+const ws = vi.hoisted(() => ({
+  rootEntries: [] as unknown[],
+  srcEntries: [] as unknown[],
+  rootLoading: false,
+  dirLoading: false,
+}));
+const ROOT_ENTRIES: WorkspaceFile[] = [
+  { path: "src", name: "src", type: "directory", bytes: null, modified_at: null },
+  { path: "readme.md", name: "readme.md", type: "file", bytes: 10, modified_at: null },
+];
+const SRC_ENTRIES: WorkspaceFile[] = [
+  { path: "src/server.ts", name: "server.ts", type: "file", bytes: 10, modified_at: null },
+  { path: "src/client.ts", name: "client.ts", type: "file", bytes: 10, modified_at: null },
+];
+function resetWorkspaceMock() {
+  ws.rootEntries = ROOT_ENTRIES;
+  ws.srcEntries = SRC_ENTRIES;
+  ws.rootLoading = false;
+  ws.dirLoading = false;
+}
+vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useWorkspaceChangedFiles")>();
+  return {
+    ...actual,
+    useWorkspaceAllFiles: () => ({
+      data: { available: true, data: ws.rootEntries },
+      isLoading: ws.rootLoading,
+    }),
+    useWorkspaceDirectory: (_conv: string | undefined, dirPath: string | null) => ({
+      data: dirPath === "src" ? ws.srcEntries : undefined,
+      isLoading: ws.dirLoading,
+    }),
+  };
+});
+
+import { Composer, detectMentionAt, mentionMarkerFor } from "./ChatPage";
+
+function composerProps(overrides: Partial<Parameters<typeof Composer>[0]> = {}) {
+  return {
+    status: "idle" as const,
+    isWorking: false,
+    disabled: false,
+    onSend: vi.fn(),
+    onStop: vi.fn(),
+    agents: undefined,
+    agentsLoading: false,
+    selectedAgentId: null,
+    onSelectAgent: vi.fn(),
+    permissionLevel: null,
+    readOnlyReason: null,
+    replyQuotes: [],
+    onRemoveQuote: vi.fn(),
+    onClearAllQuotes: vi.fn(),
+    effortLevels: ["low", "medium", "high"] as const,
+    showEffort: true,
+    showModels: false,
+    modelPickerKind: null,
+    codexModelOptions: [],
+    showCodexPlanMode: false,
+    ...overrides,
+  };
+}
+
+function textarea() {
+  return screen.getByLabelText("Message the agent") as HTMLTextAreaElement;
+}
+
+/** Type `text` into the composer with the caret at the end. */
+function type(text: string) {
+  fireEvent.change(textarea(), { target: { value: text, selectionStart: text.length } });
+}
+
+function renderWithTooltips(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe("detectMentionAt", () => {
+  it("triggers on an @ at line start", () => {
+    expect(detectMentionAt("@ser", 4)).toEqual({ query: "ser", start: 0, end: 4 });
+  });
+
+  it("triggers on an @ after whitespace, capturing only the token", () => {
+    expect(detectMentionAt("look @src/cli", 13)).toEqual({ query: "src/cli", start: 5, end: 13 });
+  });
+
+  it("does NOT trigger when the @ is glued to a preceding word (e.g. an email)", () => {
+    // WHY: "me@host" is an email, not a mention — gluing to a word must not
+    // open the file browser mid-typing.
+    expect(detectMentionAt("me@host", 7)).toBeNull();
+  });
+
+  it("closes once the token is finished by a space", () => {
+    // WHY: a trailing space means the user finished the token; the menu must
+    // close so the next keystroke isn't captured as a mention.
+    expect(detectMentionAt("@server.ts ", 11)).toBeNull();
+  });
+
+  it("reads the token at the caret, ignoring text after it (mid-token edit)", () => {
+    // WHY: the user can move the caret back into a token to refine it; only the
+    // text up to the caret defines the active query, never the trailing text.
+    expect(detectMentionAt("@server.ts and more", 4)).toEqual({
+      query: "ser",
+      start: 0,
+      end: 4,
+    });
+  });
+
+  it("triggers after a newline (the @ sits at the start of a later line)", () => {
+    // WHY: ^ anchors to the start of the sliced string, but a preceding newline
+    // counts as \s, so an "@" beginning a second line still triggers.
+    expect(detectMentionAt("hello\n@src", 10)).toEqual({ query: "src", start: 6, end: 10 });
+  });
+
+  it("triggers on a bare '@/' (root-relative path opener)", () => {
+    expect(detectMentionAt("@/", 2)).toEqual({ query: "/", start: 0, end: 2 });
+  });
+
+  it("captures only the LAST @ when several appear", () => {
+    // WHY: a second "@" after whitespace starts a fresh token; an earlier one
+    // in the line must not bleed into the query.
+    expect(detectMentionAt("@a @b", 5)).toEqual({ query: "b", start: 3, end: 5 });
+  });
+});
+
+describe("mentionMarkerFor", () => {
+  // Wording is load-bearing: codex echoes its own "[Attached file: …]" form
+  // back in the mirrored transcript, while claude/pi/cursor use "[Attached: …]".
+  it("uses the 'Attached file:' wording for codex", () => {
+    expect(mentionMarkerFor("codex-native", "src/a.ts")).toBe("[Attached file: src/a.ts]");
+  });
+
+  it("uses the plain 'Attached:' wording for claude/pi/cursor", () => {
+    expect(mentionMarkerFor("claude-native", "src/a.ts")).toBe("[Attached: src/a.ts]");
+    expect(mentionMarkerFor("pi-native", "src/a.ts")).toBe("[Attached: src/a.ts]");
+    expect(mentionMarkerFor("cursor-native", "src/a.ts")).toBe("[Attached: src/a.ts]");
+  });
+
+  it("resolves an aliased harness through the registry, not a raw string compare", () => {
+    // WHY (H6): "native-pi" is a reversed spelling the registry folds to
+    // "pi-native"; routing through nativeCodingAgentForHarness means it still
+    // produces the plain wording rather than being treated as unknown.
+    // (The codex reversed form "native-codex" is NOT in the frontend alias map
+    // — aligning that map with the server is M10, out of this staged scope.)
+    expect(mentionMarkerFor("native-pi", "a.ts")).toBe("[Attached: a.ts]");
+  });
+
+  it("falls back to the plain wording for a null / unknown harness", () => {
+    // WHY (L11): the drain effect can apply a queued chip before sessionHarness
+    // resolves, so mentionMarkerFor(null, …) must not throw and must pick a
+    // sane default.
+    expect(mentionMarkerFor(null, "a.ts")).toBe("[Attached: a.ts]");
+    expect(mentionMarkerFor("some-sdk-harness", "a.ts")).toBe("[Attached: a.ts]");
+  });
+});
+
+describe("Composer @-file-mention browser (native sessions)", () => {
+  // Each test gets a fresh conversation id and a cleared draft store: the
+  // module-scoped ``sessionDrafts`` map (persisted to localStorage) is keyed by
+  // conversationId, so reusing one id leaks an unsent "@…" draft into the next
+  // test's freshly-mounted composer, which then re-derives the wrong mention
+  // state (L12). Distinct ids keep every test self-contained.
+  let convSeq = 0;
+  beforeEach(() => {
+    resetWorkspaceMock();
+    localStorage.clear();
+    useChatStore.setState({
+      conversationId: `conv_test_${++convSeq}`,
+      sessionHarness: "claude-native",
+      pendingComposerAttachments: [],
+    });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("lists the root directory's folders and files when '@' is typed", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    expect(screen.getByTitle("Open src")).toBeInTheDocument();
+    expect(screen.getByTitle("Attach readme.md")).toBeInTheDocument();
+  });
+
+  it("opens a folder to reveal nested files, then delivers the chosen file", () => {
+    const onSend = vi.fn();
+    renderWithTooltips(<Composer {...composerProps({ onSend })} />);
+
+    type("@src");
+    // Nested files are NOT visible until the folder is opened (drill-down).
+    expect(screen.queryByTitle("Attach server.ts")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTitle("Open src"));
+
+    // Now inside src: nested files appear.
+    fireEvent.click(screen.getByTitle("Attach server.ts"));
+    expect(screen.getByText("@src/server.ts")).toBeInTheDocument();
+
+    type("explain this");
+    fireEvent.submit(textarea().closest("form")!);
+
+    // The WHY: the agent reads the on-disk nested file from this exact marker.
+    // No File is uploaded (second arg undefined).
+    expect(onSend).toHaveBeenCalledWith("[Attached: src/server.ts]\n\nexplain this", undefined);
+  });
+
+  it("attaches a whole folder as a single trailing-slash marker", () => {
+    const onSend = vi.fn();
+    renderWithTooltips(<Composer {...composerProps({ onSend })} />);
+
+    type("@src");
+    fireEvent.click(screen.getByLabelText("Attach whole folder src"));
+    expect(screen.getByText("@src/")).toBeInTheDocument();
+
+    type("review the module");
+    fireEvent.submit(textarea().closest("form")!);
+
+    // A folder is delivered with a trailing "/" so the agent opens the dir.
+    expect(onSend).toHaveBeenCalledWith("[Attached: src/]\n\nreview the module", undefined);
+  });
+
+  it.each([
+    ["claude-native", "[Attached: src/server.ts]\n\ngo"],
+    ["pi-native", "[Attached: src/server.ts]\n\ngo"],
+    ["cursor-native", "[Attached: src/server.ts]\n\ngo"],
+    ["codex-native", "[Attached file: src/server.ts]\n\ngo"],
+  ])("delivers the harness-correct marker on %s", (harness, expected) => {
+    useChatStore.setState({ sessionHarness: harness });
+    const onSend = vi.fn();
+    renderWithTooltips(<Composer {...composerProps({ onSend })} />);
+    type("@src");
+    fireEvent.click(screen.getByTitle("Open src"));
+    fireEvent.click(screen.getByTitle("Attach server.ts"));
+    type("go");
+    fireEvent.submit(textarea().closest("form")!);
+    expect(onSend).toHaveBeenCalledWith(expected, undefined);
+  });
+
+  it("drains a file-viewer 'Attach to agent' line range into a chip and marker", () => {
+    const onSend = vi.fn();
+    // Simulate the file viewer's button having queued a line span.
+    useChatStore.setState({
+      pendingComposerAttachments: [
+        { path: "bob-max-gain/docker-compose.yml", isDir: false, lineRange: { start: 2, end: 9 } },
+      ],
+    });
+    renderWithTooltips(<Composer {...composerProps({ onSend })} />);
+
+    // The composer drained the queue into a chip showing the path + lines
+    // (the line span renders in its own node so it never truncates away)...
+    expect(screen.getByText("@bob-max-gain/docker-compose.yml")).toBeInTheDocument();
+    expect(screen.getByText(":2-9")).toBeInTheDocument();
+    // ...and the store queue was cleared so it can't double-apply.
+    expect(useChatStore.getState().pendingComposerAttachments).toEqual([]);
+
+    type("explain this service");
+    fireEvent.submit(textarea().closest("form")!);
+
+    // Delivered as "path:start-end" inside the marker so the agent reads
+    // exactly those lines.
+    expect(onSend).toHaveBeenCalledWith(
+      "[Attached: bob-max-gain/docker-compose.yml:2-9]\n\nexplain this service",
+      undefined,
+    );
+  });
+
+  it("does NOT show the mention menu on non-native (in-process SDK) harnesses", () => {
+    useChatStore.setState({ sessionHarness: "claude-sdk" });
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@src");
+    expect(screen.queryByTitle("Open src")).not.toBeInTheDocument();
+  });
+
+  it("opens the menu on an aliased native harness (native-pi → pi-native)", () => {
+    // WHY (H6): the composer's "@" gate and the file viewer's attach gate must
+    // agree on "is this native?". Both now resolve through the agent registry,
+    // which folds the reversed "native-pi" spelling — a literal string compare
+    // would open the viewer's attach button but leave "@" dead here.
+    useChatStore.setState({ sessionHarness: "native-pi" });
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    expect(screen.getByTitle("Open src")).toBeInTheDocument();
+  });
+
+  // ── Keyboard navigation (H4) ────────────────────────────────────────────
+  // The slash menu has keyboard tests; the mention menu's Arrow/Enter/Tab/Esc
+  // branches were entirely uncovered, so a regression would pass silently.
+
+  it("ArrowDown moves to the next row and Enter acts on the highlighted one", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    const ta = textarea();
+    // Row 0 (src, folders-first) is preselected; move to row 1 (readme.md).
+    fireEvent.keyDown(ta, { key: "ArrowDown" });
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(screen.getByText("@readme.md")).toBeInTheDocument();
+  });
+
+  it("ArrowUp from the top row wraps to the last row", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    // From row 0, ArrowUp wraps to the last row (readme.md), not -1.
+    fireEvent.keyDown(textarea(), { key: "ArrowUp" });
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(screen.getByText("@readme.md")).toBeInTheDocument();
+  });
+
+  it("Enter on a directory row drills in rather than attaching", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    // Row 0 is the "src" folder: Enter must open it (reveal nested files), and
+    // must NOT produce a chip — drilling is navigation, not attachment. (The
+    // token becomes "@src/" in the textarea; a chip would instead surface a
+    // "Remove src" button, which must be absent.)
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(screen.getByTitle("Attach server.ts")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove src")).not.toBeInTheDocument();
+  });
+
+  it("Tab attaches the highlighted folder as a whole-directory unit", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    // Tab on the "src" folder attaches it as a unit (trailing-slash chip),
+    // distinct from Enter's drill-in.
+    fireEvent.keyDown(textarea(), { key: "Tab" });
+    expect(screen.getByText("@src/")).toBeInTheDocument();
+  });
+
+  it("Escape closes the mention menu", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    expect(screen.getByTitle("Open src")).toBeInTheDocument();
+    fireEvent.keyDown(textarea(), { key: "Escape" });
+    expect(screen.queryByTitle("Open src")).not.toBeInTheDocument();
+  });
+
+  // ── Chip lifecycle + dedup (M8, M2) ──────────────────────────────────────
+
+  it("removes a tagged chip when its ✕ is clicked", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    fireEvent.click(screen.getByTitle("Attach readme.md"));
+    expect(screen.getByText("@readme.md")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Remove readme.md"));
+    expect(screen.queryByText("@readme.md")).not.toBeInTheDocument();
+  });
+
+  it("dedups re-attaching the same file via '@' to a single chip", () => {
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    fireEvent.click(screen.getByTitle("Attach readme.md"));
+    type("@");
+    fireEvent.click(screen.getByTitle("Attach readme.md"));
+    // Same path + dir-ness + (no) range → same identity key → one chip.
+    expect(screen.getAllByText("@readme.md")).toHaveLength(1);
+  });
+
+  it("keeps two distinct line ranges of the same file as separate chips", () => {
+    // WHY (M2): the dedup key is path + dir-ness + line range, NOT path alone.
+    // A path-only key would silently drop the second range — but two ranges of
+    // one file are genuinely distinct attachments the agent should receive.
+    useChatStore.setState({
+      pendingComposerAttachments: [
+        { path: "a.ts", isDir: false, lineRange: { start: 2, end: 9 } },
+        { path: "a.ts", isDir: false, lineRange: { start: 20, end: 30 } },
+      ],
+    });
+    renderWithTooltips(<Composer {...composerProps()} />);
+    expect(screen.getAllByText("@a.ts")).toHaveLength(2);
+    expect(screen.getByText(":2-9")).toBeInTheDocument();
+    expect(screen.getByText(":20-30")).toBeInTheDocument();
+  });
+
+  it("collapses identical queued attachments to one chip on drain", () => {
+    // The store dedups on insert, but the drain must also dedup within a batch
+    // (and against already-tagged chips) so a duplicated queue can't double up.
+    useChatStore.setState({
+      pendingComposerAttachments: [
+        { path: "a.ts", isDir: false, lineRange: { start: 2, end: 9 } },
+        { path: "a.ts", isDir: false, lineRange: { start: 2, end: 9 } },
+      ],
+    });
+    renderWithTooltips(<Composer {...composerProps()} />);
+    expect(screen.getAllByText(":2-9")).toHaveLength(1);
+  });
+
+  // ── Dismissal + loading feedback (M3, M1, M6) ─────────────────────────────
+
+  it("dismisses the menu when the textarea loses focus", () => {
+    // WHY (M3): the menu's visibility derives from the caret on change; without
+    // a blur dismiss it lingers when the user clicks a chip ✕ or another field.
+    renderWithTooltips(<Composer {...composerProps()} />);
+    type("@");
+    expect(screen.getByTitle("Open src")).toBeInTheDocument();
+    fireEvent.blur(textarea());
+    expect(screen.queryByTitle("Open src")).not.toBeInTheDocument();
+  });
+
+  it("shows a loading row and swallows Enter while the listing is still fetching", () => {
+    // WHY (M1+M6): during the cold-boot/drill fetch window the listing is empty
+    // so the menu is closed — a stray Enter must not send the half-typed token
+    // as a chat message, and the user needs feedback that "@" is alive.
+    ws.rootLoading = true;
+    ws.rootEntries = [];
+    const onSend = vi.fn();
+    renderWithTooltips(<Composer {...composerProps({ onSend })} />);
+    type("@comp");
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("still sends a settled zero-match token literally (not gated)", () => {
+    // WHY (M1 boundary): the gate is for the *loading* window only. A token
+    // that simply matches no file ("@nomatch") is the user's literal text and
+    // Enter must send it — gating all non-null mentions would trap that.
+    const onSend = vi.fn();
+    renderWithTooltips(<Composer {...composerProps({ onSend })} />);
+    type("ping @nomatch");
+    fireEvent.keyDown(textarea(), { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("ping @nomatch", undefined);
+  });
+});

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -2,6 +2,19 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useChatStore } from "@/store/chatStore";
+
+// Composer reads workspace files via a TanStack query hook (for "@"-file
+// mentions); these status-line tests don't exercise it, so stub the hook to
+// avoid wrapping every render in a QueryClientProvider.
+vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useWorkspaceChangedFiles")>();
+  return {
+    ...actual,
+    useWorkspaceAllFiles: () => ({ data: undefined }),
+    useWorkspaceDirectory: () => ({ data: undefined }),
+  };
+});
+
 import { Composer, composerHarnessLabel, formatModelEffortStatusLabel } from "./ChatPage";
 
 // Pins the visibility rules for the status-line tray under the composer:

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -21,6 +21,7 @@ import {
   CornerUpLeftIcon,
   CopyIcon,
   FileTextIcon,
+  FolderIcon,
   GitBranchIcon,
   GitForkIcon,
   ImageIcon,
@@ -102,11 +103,24 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { codexEffortLevelsForModel, findCodexModelOption } from "@/lib/codexNativeModels";
 import {
+  composerAttachmentKey,
   consumePendingInitialPrompt,
   type PendingInitialPrompt,
   type PendingUserMessage,
   useChatStore,
 } from "@/store/chatStore";
+import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
+import {
+  detectMentionAt,
+  type MentionItem,
+  mentionItemPath,
+  mentionMarkerFor,
+  type MentionState,
+} from "@/lib/composerMentions";
+// Re-exported so existing tests importing these from "./ChatPage" keep working
+// after the pure helpers moved to the shared lib.
+export { detectMentionAt, mentionMarkerFor };
+export type { MentionItem, MentionState };
 import { useSession } from "@/hooks/useSession";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { useRefreshSessionStateOnRunnerOnline } from "@/hooks/useSessionOnlineRefresh";
@@ -124,6 +138,12 @@ import {
   isSlashCommandText,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
+import { FileMentionMenu } from "@/components/FileMentionMenu";
+import {
+  useWorkspaceAllFiles,
+  useWorkspaceDirectory,
+  type WorkspaceFile,
+} from "@/hooks/useWorkspaceChangedFiles";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
 import {
   IntelligentModelControl,
@@ -150,7 +170,10 @@ import {
   type CodexGoal,
 } from "@/components/codex";
 
-const ATTACHED_RE = /\[Attached:[^\]]*\]\s*/g;
+// Matches both wordings the native executors emit: "[Attached: <path>]"
+// (claude/pi/cursor) and "[Attached file: <path>]" (codex). Capturing group
+// is the path. Global so all markers in a message are found / stripped.
+const ATTACHED_RE = /\[Attached(?: file)?:\s*([^\]]*)\]\s*/g;
 
 function extractUserText(content: MessageContentBlock[]): string {
   return content
@@ -161,6 +184,39 @@ function extractUserText(content: MessageContentBlock[]): string {
     .join("")
     .replace(ATTACHED_RE, "")
     .trim();
+}
+
+/**
+ * Pull the paths out of the "[Attached: …]" markers an "@"-mention adds to a
+ * user message, so the bubble can show what was attached (the marker text
+ * itself is stripped from the rendered text by {@link extractUserText}). A
+ * trailing "/" marks a folder. Returns [] for ordinary messages.
+ */
+function extractAttachedPaths(content: MessageContentBlock[]): MentionItem[] {
+  const text = content
+    .filter(
+      (c): c is Extract<MessageContentBlock, { type: "input_text" }> => c.type === "input_text",
+    )
+    .map((c) => c.text)
+    .join("");
+  const out: MentionItem[] = [];
+  for (const m of text.matchAll(ATTACHED_RE)) {
+    const raw = m[1].trim();
+    if (!raw) continue;
+    // Split a trailing ":start-end" line span back out so the chip can show
+    // it without truncation (it's the whole point of a partial-file attach).
+    const range = /^(.*):(\d+)-(\d+)$/.exec(raw);
+    if (range) {
+      out.push({
+        path: range[1],
+        isDir: false,
+        lineRange: { start: Number(range[2]), end: Number(range[3]) },
+      });
+    } else {
+      out.push({ path: raw.replace(/\/$/, ""), isDir: raw.endsWith("/") });
+    }
+  }
+  return out;
 }
 
 // Leading whitespace + the command token, so the composer overlay can tint
@@ -2707,11 +2763,15 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const fileChips = bubble.content.filter(
     (c): c is Extract<MessageContentBlock, { type: "input_file" }> => c.type === "input_file",
   );
+  // "@"-mentioned workspace files/folders ride in as "[Attached: …]" text
+  // markers (no input_file block), so surface them as chips — otherwise the
+  // marker is stripped and the user can't see what they attached.
+  const mentionedChips = extractAttachedPaths(bubble.content);
   // Runtime-injected `[System: ...]` notifications (task completion,
   // timer firings, terminal idle) ride in on role=user. When the content
   // is a pure system marker — no attached images or files — swap the
   // normal bubble for a muted centered indicator.
-  if (images.length === 0 && fileChips.length === 0) {
+  if (images.length === 0 && fileChips.length === 0 && mentionedChips.length === 0) {
     const parsed = parseSystemMessage(text);
     if (parsed) return <SystemMessageView message={parsed} />;
   }
@@ -2801,6 +2861,32 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                 >
                   <FileTextIcon className="size-3 shrink-0" />
                   <span className="max-w-[180px] truncate">{att.filename ?? att.file_id}</span>
+                </span>
+              ))}
+            </div>
+          )}
+          {/* "@"-mentioned workspace files/folders (delivered as text markers) */}
+          {mentionedChips.length > 0 && (
+            <div className="mb-1.5 flex flex-wrap gap-1.5">
+              {mentionedChips.map((item) => (
+                <span
+                  key={mentionItemPath(item)}
+                  className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                >
+                  {item.isDir ? (
+                    <FolderIcon className="size-3 shrink-0" />
+                  ) : (
+                    <FileTextIcon className="size-3 shrink-0" />
+                  )}
+                  <span className="max-w-[180px] truncate" title={mentionItemPath(item)}>
+                    @{item.path}
+                    {item.isDir ? "/" : ""}
+                  </span>
+                  {item.lineRange && (
+                    <span className="shrink-0">
+                      :{item.lineRange.start}-{item.lineRange.end}
+                    </span>
+                  )}
                 </span>
               ))}
             </div>
@@ -3400,6 +3486,19 @@ export function Composer({
   // opens with matches the reset logic below pre-selects the first item (0)
   // so Tab/Enter complete it immediately.
   const [menuIndex, setMenuIndex] = useState(-1);
+  // Active "@"-file-mention being typed, plus its highlighted row and the
+  // workspace paths the user has already tagged. ``@``-mention is wired for
+  // the native coding-agent sessions (see ``mentionEnabled``): those harnesses
+  // run in the workspace and read a file from an "[Attached: …]" marker, so a
+  // tagged path is delivered by prepending that marker at send time — no
+  // upload, the agent reads the on-disk file directly.
+  const [mention, setMention] = useState<MentionState | null>(null);
+  const [mentionIndex, setMentionIndex] = useState(-1);
+  const [mentionedItems, setMentionedItems] = useState<MentionItem[]>([]);
+  // Attachments pushed in from outside the composer (e.g. the file viewer's
+  // "Attach to agent" button). Drained into ``mentionedItems`` below, then
+  // cleared from the store so they aren't re-applied.
+  const pendingComposerAttachments = useChatStore((s) => s.pendingComposerAttachments);
   // Nonce bumped when bare "/model" is submitted; opens the AgentPicker
   // dropdown instead of sending (see submit()).
   const [pickerOpenNonce, setPickerOpenNonce] = useState(0);
@@ -3410,6 +3509,34 @@ export function Composer({
   // `/skill` token stays aligned once the draft grows past the visible rows.
   const backdropRef = useRef<HTMLDivElement>(null);
   const isStreaming = status === "streaming";
+
+  // Drain externally-queued attachments (file viewer "Attach to agent") into
+  // the local mention chips, deduping against what's already tagged, then
+  // clear the store queue so they aren't re-applied on the next render.
+  useEffect(() => {
+    if (pendingComposerAttachments.length === 0) return;
+    setMentionedItems((prev) => {
+      // Dedup against already-tagged chips AND within this batch (accumulate
+      // into ``seen`` as we go) so a duplicated queue can't double-apply.
+      const seen = new Set(prev.map(composerAttachmentKey));
+      const fresh: MentionItem[] = [];
+      for (const a of pendingComposerAttachments) {
+        const k = composerAttachmentKey(a);
+        if (seen.has(k)) continue;
+        seen.add(k);
+        fresh.push(a);
+      }
+      return fresh.length > 0 ? [...prev, ...fresh] : prev;
+    });
+    useChatStore.getState().clearPendingComposerAttachments();
+    textareaRef.current?.focus();
+    // Defense-in-depth against the cross-session leak: if the composer unmounts
+    // while an entry is still queued (route change, panel close, the
+    // loading-conversation gate during a session switch), clear the queue so
+    // the next-mounted composer doesn't drain a stale chip. ``switchTo`` also
+    // resets the queue, but this closes the non-switch unmount paths too.
+    return () => useChatStore.getState().clearPendingComposerAttachments();
+  }, [pendingComposerAttachments]);
   // Read-only when either the user lacks a write grant OR the session
   // is structurally non-interactive (``readOnlyReason``). The
   // structural reason takes priority for the placeholder text since it
@@ -3459,6 +3586,21 @@ export function Composer({
     conversationId,
     showCodexGoal,
   );
+  // "@"-file-mention is scoped to the native coding-agent harnesses: their
+  // vendor CLIs run in the workspace and read an on-disk file from an
+  // attachment marker the executor already emits. In-process SDK sessions
+  // get no mention menu, so the workspace listing is never fetched for them
+  // (``enabled`` gate below). Codex's marker says "Attached file:" while the
+  // others say "Attached:" — see ``mentionMarkerFor``.
+  const sessionHarness = useChatStore((s) => s.sessionHarness);
+  // Derive from the canonical native-agent registry (which folds reversed
+  // spellings like ``native-pi``) rather than a literal harness-string compare,
+  // so the composer's "@" entry point can't split-brain from the file viewer's
+  // "Attach to agent" gate (``canAttachToAgent``), which already uses it.
+  const mentionEnabled = nativeCodingAgentForHarness(sessionHarness) !== undefined;
+  const workspaceFilesQuery = useWorkspaceAllFiles(conversationId ?? undefined, {
+    enabled: mentionEnabled,
+  });
   const valueRef = useRef(value);
   valueRef.current = value;
   const filesRef = useRef(files);
@@ -3554,7 +3696,7 @@ export function Composer({
   // Tint the `/skill` token blue while the draft reads as a slash command, so
   // the command shape is signalled as the user types it.
   const composerIsCommand = files.length === 0 && isSlashCommandText(value);
-  const hasDraft = value.trim().length > 0 || files.length > 0;
+  const hasDraft = value.trim().length > 0 || files.length > 0 || mentionedItems.length > 0;
   const showInterruptButton = isWorking && !hasDraft;
   const toggleCodexPlanMode = async () => {
     if (planModeBusy) return;
@@ -3589,6 +3731,123 @@ export function Composer({
     prevMenuMatchesRef.current = menuMatches;
     setMenuIndex(menuMatches.length > 0 ? 0 : -1);
   }
+
+  // "@"-mention is a drill-down file/folder browser. The token after "@"
+  // doubles as a path: text up to the last "/" is the directory being
+  // browsed; text after it filters that directory's entries. Opening a
+  // folder rewrites the token to "<dir>/" so the menu re-lists it — that
+  // is how nested files are reached (recursion via navigation, mirroring
+  // the terminal's git-tracked walk). At any level the user can attach a
+  // single file or the whole folder.
+  const MENTION_MATCH_CAP = 50;
+  const mentionRawToken = mention?.query ?? "";
+  const mentionSlash = mentionRawToken.lastIndexOf("/");
+  const mentionDir = mentionSlash >= 0 ? mentionRawToken.slice(0, mentionSlash) : "";
+  const mentionFilter = mentionSlash >= 0 ? mentionRawToken.slice(mentionSlash + 1) : mentionRawToken;
+  // Root listing reuses the gate's useWorkspaceAllFiles; a sub-directory
+  // uses the lazy per-dir hook (disabled — null path — at the root). Both
+  // return files AND directories with a ``type`` discriminator.
+  const mentionDirQuery = useWorkspaceDirectory(
+    conversationId ?? undefined,
+    mentionEnabled && mention && mentionDir ? mentionDir : null,
+  );
+  const mentionSourceEntries: WorkspaceFile[] = mentionDir
+    ? (mentionDirQuery.data ?? [])
+    : (workspaceFilesQuery.data?.data ?? []);
+  // Folders first (navigation targets on top), then files; each filtered by
+  // the typed segment and capped so a huge directory can't render thousands
+  // of rows. The cap trims only the *list*, never what gets delivered.
+  const mentionEntries: WorkspaceFile[] =
+    mentionEnabled && mention
+      ? mentionSourceEntries
+          .filter((e) => e.name.toLowerCase().includes(mentionFilter.toLowerCase()))
+          .sort((a, b) => {
+            if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+            return a.name.localeCompare(b.name);
+          })
+          .slice(0, MENTION_MATCH_CAP)
+      : [];
+  const mentionOpen = mentionEntries.length > 0;
+  // True while a mention token is active but its listing hasn't resolved yet:
+  // the cold-boot root fetch, or a sub-directory's first load after drilling
+  // in. During this window ``mentionEntries`` is transiently empty (so the
+  // menu is closed), and a stray Enter must NOT fall through to ``submit`` and
+  // send the half-typed "@dir/" token as a chat message. A *settled*
+  // zero-match (e.g. "@notafile") is deliberately excluded — sending that
+  // literally is the user's intent.
+  const mentionListingPending =
+    mentionEnabled &&
+    mention != null &&
+    (mentionDir ? mentionDirQuery.isLoading : workspaceFilesQuery.isLoading);
+
+  // Pre-select the top row whenever the listing changes — same rationale as
+  // the slash menu's reset (lets Enter/Tab act on the top hit without
+  // arrowing first). Keyed by type+path so a file and a dir of the same name
+  // are distinct.
+  const prevMentionMatchesRef = useRef<string[]>([]);
+  const mentionEntryKeys = mentionEntries.map((e) => `${e.type}:${e.path}`);
+  if (
+    mentionEntryKeys.length !== prevMentionMatchesRef.current.length ||
+    mentionEntryKeys.some((k, i) => k !== prevMentionMatchesRef.current[i])
+  ) {
+    prevMentionMatchesRef.current = mentionEntryKeys;
+    setMentionIndex(mentionEntryKeys.length > 0 ? 0 : -1);
+  }
+
+  /**
+   * Attach a file or whole folder the user chose: strip the "@…" token from
+   * the textarea (a chip below carries it) and record the path. Delivered as
+   * an "[Attached: <path>]" marker at send time (see ``submit``), which the
+   * native vendor reads from its own workspace — no upload, full fidelity.
+   */
+  const attachMention = (path: string, isDir: boolean) => {
+    if (!mention) return;
+    const next = value.slice(0, mention.start) + value.slice(mention.end);
+    setValue(next);
+    dirtyRef.current = true;
+    // Dedup on the shared attachment key (path + dir-ness + range), the same
+    // identity the store queue and drain effect use — not path alone — so the
+    // "@" menu and the file viewer's "Attach to agent" never disagree about
+    // what counts as a duplicate.
+    const item: MentionItem = { path, isDir };
+    const itemKey = composerAttachmentKey(item);
+    setMentionedItems((prev) =>
+      prev.some((it) => composerAttachmentKey(it) === itemKey) ? prev : [...prev, item],
+    );
+    setMention(null);
+    setMentionIndex(-1);
+    // Restore the caret to where the token was so typing continues naturally.
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      if (ta) ta.setSelectionRange(mention.start, mention.start);
+      ta?.focus();
+    });
+  };
+
+  /**
+   * Open a folder: rewrite the "@…" token to "<dir>/" so the menu re-lists
+   * that directory, keeping the mention active (caret after the slash) so
+   * the user keeps navigating or filtering deeper.
+   */
+  const openMentionDir = (path: string) => {
+    if (!mention) return;
+    const inserted = `@${path}/`;
+    const next = value.slice(0, mention.start) + inserted + value.slice(mention.end);
+    setValue(next);
+    dirtyRef.current = true;
+    const caret = mention.start + inserted.length;
+    setMention({ query: `${path}/`, start: mention.start, end: caret });
+    setMentionIndex(0);
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      if (ta) ta.setSelectionRange(caret, caret);
+      ta?.focus();
+    });
+  };
+
+  const removeMentionedItem = (index: number) => {
+    setMentionedItems((prev) => prev.filter((_, i) => i !== index));
+  };
 
   /**
    * Execute a slash command by name + optional argument string.
@@ -3783,8 +4042,13 @@ export function Composer({
 
   const submit = () => {
     const trimmed = value.trim();
-    // Allow send if there's text OR attached files.
-    if ((!trimmed && files.length === 0) || disabled || hasPendingElicitation) return;
+    // Allow send if there's text, attached files, OR "@"-tagged paths.
+    if (
+      (!trimmed && files.length === 0 && mentionedItems.length === 0) ||
+      disabled ||
+      hasPendingElicitation
+    )
+      return;
 
     // Slash command path: the first token must read as "/name" (the shared
     // isSlashCommandText guard — file paths like "/Users/foo/bar.txt" don't
@@ -3796,7 +4060,7 @@ export function Composer({
     // Anything else (unknown command, or a skill on a native-terminal
     // session where ``onSendSlashCommand`` is undefined) falls through to the
     // plaintext send path below.
-    if (isSlashCommandText(trimmed) && files.length === 0) {
+    if (isSlashCommandText(trimmed) && files.length === 0 && mentionedItems.length === 0) {
       const parts = trimmed.split(/\s+/);
       const cmd = parts[0].toLowerCase();
       const arg = parts[1] ?? "";
@@ -3857,7 +4121,19 @@ export function Composer({
             )
             .join("\n\n") + "\n\n"
         : "";
-    const messageText = quotePreamble + trimmed;
+    // Prepend each "@"-tagged path as an attachment marker on its own line —
+    // the same format the native executors emit for attachments and that
+    // title-seeding strips (_ATTACHMENT_MARKER_RE). Wording is harness-aware
+    // (codex says "Attached file:"). Folders carry a trailing "/" so the
+    // agent knows to open the directory. The native vendor reads the on-disk
+    // workspace file/folder from this marker; no upload happens.
+    const mentionPreamble =
+      mentionedItems.length > 0
+        ? mentionedItems
+            .map((it) => mentionMarkerFor(sessionHarness, mentionItemPath(it)))
+            .join("\n") + "\n\n"
+        : "";
+    const messageText = mentionPreamble + quotePreamble + trimmed;
     // Sending while a prior response is streaming is fine — the
     // server queues the message and delivers it to the running task
     // (or starts a fresh one once the current drains). Escape still
@@ -3868,6 +4144,8 @@ export function Composer({
     setValue("");
     setFiles([]);
     setAttachmentError(null);
+    setMentionedItems([]);
+    setMention(null);
     onClearAllQuotes();
   };
 
@@ -3895,6 +4173,42 @@ export function Composer({
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (isImeCompositionKeyEvent(e, isComposingRef.current)) {
       return;
+    }
+
+    // "@"-mention menu navigation — same model as the slash menu below, and
+    // mutually exclusive with it (a mention token can't also read as a
+    // "/"-command). Takes priority over history recall and submission.
+    if (mentionOpen) {
+      const active = mentionIndex >= 0 ? mentionEntries[mentionIndex] : undefined;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setMentionIndex((i) => (i + 1) % mentionEntries.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setMentionIndex((i) => (i <= 0 ? mentionEntries.length - 1 : i - 1));
+        return;
+      }
+      // Enter: open a folder (drill in) or attach a file. Tab: attach the
+      // highlighted row as a unit — whole folder or file — without drilling.
+      if (e.key === "Enter" && !e.shiftKey && !isMobile && active) {
+        e.preventDefault();
+        if (active.type === "directory") openMentionDir(active.path);
+        else attachMention(active.path, false);
+        return;
+      }
+      if (e.key === "Tab" && active) {
+        e.preventDefault();
+        attachMention(active.path, active.type === "directory");
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMention(null);
+        setMentionIndex(-1);
+        return;
+      }
     }
 
     // When the suggestions menu is open, ArrowUp/Down navigate it and
@@ -3929,6 +4243,10 @@ export function Composer({
     // newline (no Shift available on-screen) and Send must be tapped instead.
     if (e.key === "Enter" && !e.shiftKey && !isMobile && !e.nativeEvent.isComposing) {
       e.preventDefault();
+      // The mention menu is briefly closed while its listing loads (see
+      // ``mentionListingPending``); swallow Enter so the in-progress "@dir/"
+      // token isn't sent as a chat message. The menu reopens when entries land.
+      if (mentionListingPending) return;
       submit();
       return;
     }
@@ -4049,6 +4367,19 @@ export function Composer({
             commands={slashCommands}
           />
         )}
+        {/* "@"-file-mention browser — native coding-agent sessions only.
+            Also shown (as a loading row) while the listing is still fetching,
+            so "@" isn't silently dead during runner cold-boot or a drill-in. */}
+        {(mentionOpen || mentionListingPending) && (
+          <FileMentionMenu
+            currentDir={mentionDir}
+            activeIndex={mentionIndex}
+            entries={mentionEntries}
+            loading={mentionListingPending}
+            onOpenDir={openMentionDir}
+            onAttach={attachMention}
+          />
+        )}
         {/* Quote chips — one per quoted selection, shown above the textarea */}
         {replyQuotes.length > 0 && (
           <div className="flex flex-col gap-1.5 px-4 pt-3 pb-0">
@@ -4104,6 +4435,16 @@ export function Composer({
               setValue(e.target.value);
               dirtyRef.current = true;
               if (commandError !== null) setCommandError(null);
+              // Recompute the active "@"-mention from the caret on every
+              // keystroke (native coding-agent sessions — ``mentionEnabled``).
+              setMention(
+                mentionEnabled
+                  ? detectMentionAt(
+                      e.target.value,
+                      e.target.selectionStart ?? e.target.value.length,
+                    )
+                  : null,
+              );
               // Treat user-driven changes as exiting recall mode. Recall-
               // driven setValue toggles `recallingRef` first so we skip the
               // reset for that one tick.
@@ -4117,6 +4458,17 @@ export function Composer({
               isComposingRef.current = false;
             }}
             onKeyDown={handleKeyDown}
+            onBlur={() => {
+              // Dismiss the "@"-mention menu when focus leaves the textarea
+              // (clicking a chip's ✕, the Send button, or another field).
+              // Menu rows ``preventDefault`` on mousedown so selecting an entry
+              // keeps focus and does NOT blur — this only fires for genuine
+              // focus-out, where the lingering menu would otherwise float.
+              if (mention) {
+                setMention(null);
+                setMentionIndex(-1);
+              }
+            }}
             onPaste={handlePaste}
             onScroll={(e) => {
               // Keep the overlay's scroll position locked to the textarea's.
@@ -4183,6 +4535,41 @@ export function Composer({
         {attachmentError !== null && (
           <div className="px-4 pb-2 text-xs text-destructive whitespace-pre-wrap">
             {attachmentError}
+          </div>
+        )}
+        {/* "@"-mention chips — one per tagged workspace file/folder. Each is
+            delivered as a "[Attached: <path>]" marker at send time. */}
+        {mentionedItems.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-4 pb-2">
+            {mentionedItems.map((item, i) => (
+              <span
+                key={mentionItemPath(item)}
+                className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+              >
+                {item.isDir ? (
+                  <FolderIcon className="size-3 shrink-0" />
+                ) : (
+                  <FileTextIcon className="size-3 shrink-0" />
+                )}
+                <span className="max-w-[200px] truncate" title={mentionItemPath(item)}>
+                  @{item.path}
+                  {item.isDir ? "/" : ""}
+                </span>
+                {item.lineRange && (
+                  <span className="shrink-0">
+                    :{item.lineRange.start}-{item.lineRange.end}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => removeMentionedItem(i)}
+                  className="ml-0.5 rounded-full hover:text-foreground"
+                  aria-label={`Remove ${item.path}`}
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </span>
+            ))}
           </div>
         )}
         {/* Inline slash-command feedback: errors and /help output */}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -111,12 +111,16 @@ import {
 } from "@/store/chatStore";
 import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
 import {
+  buildMentionPreamble,
   detectMentionAt,
   type MentionItem,
   mentionItemPath,
   mentionMarkerFor,
   type MentionState,
+  parseMentionToken,
+  rankMentionEntries,
 } from "@/lib/composerMentions";
+import { useMentionBrowser } from "@/hooks/useMentionBrowser";
 // Re-exported so existing tests importing these from "./ChatPage" keep working
 // after the pure helpers moved to the shared lib.
 export { detectMentionAt, mentionMarkerFor };
@@ -3492,9 +3496,9 @@ export function Composer({
   // run in the workspace and read a file from an "[Attached: …]" marker, so a
   // tagged path is delivered by prepending that marker at send time — no
   // upload, the agent reads the on-disk file directly.
+  // Active "@"-mention token (owned here; the shared useMentionBrowser hook
+  // owns the selection index, tagged chips, and attach/drill/keyboard glue).
   const [mention, setMention] = useState<MentionState | null>(null);
-  const [mentionIndex, setMentionIndex] = useState(-1);
-  const [mentionedItems, setMentionedItems] = useState<MentionItem[]>([]);
   // Attachments pushed in from outside the composer (e.g. the file viewer's
   // "Attach to agent" button). Drained into ``mentionedItems`` below, then
   // cleared from the store so they aren't re-applied.
@@ -3510,33 +3514,6 @@ export function Composer({
   const backdropRef = useRef<HTMLDivElement>(null);
   const isStreaming = status === "streaming";
 
-  // Drain externally-queued attachments (file viewer "Attach to agent") into
-  // the local mention chips, deduping against what's already tagged, then
-  // clear the store queue so they aren't re-applied on the next render.
-  useEffect(() => {
-    if (pendingComposerAttachments.length === 0) return;
-    setMentionedItems((prev) => {
-      // Dedup against already-tagged chips AND within this batch (accumulate
-      // into ``seen`` as we go) so a duplicated queue can't double-apply.
-      const seen = new Set(prev.map(composerAttachmentKey));
-      const fresh: MentionItem[] = [];
-      for (const a of pendingComposerAttachments) {
-        const k = composerAttachmentKey(a);
-        if (seen.has(k)) continue;
-        seen.add(k);
-        fresh.push(a);
-      }
-      return fresh.length > 0 ? [...prev, ...fresh] : prev;
-    });
-    useChatStore.getState().clearPendingComposerAttachments();
-    textareaRef.current?.focus();
-    // Defense-in-depth against the cross-session leak: if the composer unmounts
-    // while an entry is still queued (route change, panel close, the
-    // loading-conversation gate during a session switch), clear the queue so
-    // the next-mounted composer doesn't drain a stale chip. ``switchTo`` also
-    // resets the queue, but this closes the non-switch unmount paths too.
-    return () => useChatStore.getState().clearPendingComposerAttachments();
-  }, [pendingComposerAttachments]);
   // Read-only when either the user lacks a write grant OR the session
   // is structurally non-interactive (``readOnlyReason``). The
   // structural reason takes priority for the placeholder text since it
@@ -3696,8 +3673,6 @@ export function Composer({
   // Tint the `/skill` token blue while the draft reads as a slash command, so
   // the command shape is signalled as the user types it.
   const composerIsCommand = files.length === 0 && isSlashCommandText(value);
-  const hasDraft = value.trim().length > 0 || files.length > 0 || mentionedItems.length > 0;
-  const showInterruptButton = isWorking && !hasDraft;
   const toggleCodexPlanMode = async () => {
     if (planModeBusy) return;
     setCommandError(null);
@@ -3739,11 +3714,7 @@ export function Composer({
   // is how nested files are reached (recursion via navigation, mirroring
   // the terminal's git-tracked walk). At any level the user can attach a
   // single file or the whole folder.
-  const MENTION_MATCH_CAP = 50;
-  const mentionRawToken = mention?.query ?? "";
-  const mentionSlash = mentionRawToken.lastIndexOf("/");
-  const mentionDir = mentionSlash >= 0 ? mentionRawToken.slice(0, mentionSlash) : "";
-  const mentionFilter = mentionSlash >= 0 ? mentionRawToken.slice(mentionSlash + 1) : mentionRawToken;
+  const { dir: mentionDir, filter: mentionFilter } = parseMentionToken(mention?.query ?? "");
   // Root listing reuses the gate's useWorkspaceAllFiles; a sub-directory
   // uses the lazy per-dir hook (disabled — null path — at the root). Both
   // return files AND directories with a ``type`` discriminator.
@@ -3754,20 +3725,9 @@ export function Composer({
   const mentionSourceEntries: WorkspaceFile[] = mentionDir
     ? (mentionDirQuery.data ?? [])
     : (workspaceFilesQuery.data?.data ?? []);
-  // Folders first (navigation targets on top), then files; each filtered by
-  // the typed segment and capped so a huge directory can't render thousands
-  // of rows. The cap trims only the *list*, never what gets delivered.
+  // Folders first, filtered by the typed segment, capped (see rankMentionEntries).
   const mentionEntries: WorkspaceFile[] =
-    mentionEnabled && mention
-      ? mentionSourceEntries
-          .filter((e) => e.name.toLowerCase().includes(mentionFilter.toLowerCase()))
-          .sort((a, b) => {
-            if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
-            return a.name.localeCompare(b.name);
-          })
-          .slice(0, MENTION_MATCH_CAP)
-      : [];
-  const mentionOpen = mentionEntries.length > 0;
+    mentionEnabled && mention ? rankMentionEntries(mentionSourceEntries, mentionFilter) : [];
   // True while a mention token is active but its listing hasn't resolved yet:
   // the cold-boot root fetch, or a sub-directory's first load after drilling
   // in. During this window ``mentionEntries`` is transiently empty (so the
@@ -3780,74 +3740,66 @@ export function Composer({
     mention != null &&
     (mentionDir ? mentionDirQuery.isLoading : workspaceFilesQuery.isLoading);
 
-  // Pre-select the top row whenever the listing changes — same rationale as
-  // the slash menu's reset (lets Enter/Tab act on the top hit without
-  // arrowing first). Keyed by type+path so a file and a dir of the same name
-  // are distinct.
-  const prevMentionMatchesRef = useRef<string[]>([]);
-  const mentionEntryKeys = mentionEntries.map((e) => `${e.type}:${e.path}`);
-  if (
-    mentionEntryKeys.length !== prevMentionMatchesRef.current.length ||
-    mentionEntryKeys.some((k, i) => k !== prevMentionMatchesRef.current[i])
-  ) {
-    prevMentionMatchesRef.current = mentionEntryKeys;
-    setMentionIndex(mentionEntryKeys.length > 0 ? 0 : -1);
-  }
+  // Shared selection/chip/keyboard glue (see useMentionBrowser). The token
+  // state and the data source above stay here; everything stateful is shared
+  // so this composer and the launcher can't drift. ``setText`` also flags the
+  // draft dirty so attach/drill participate in draft persistence.
+  const {
+    mentionIndex,
+    mentionOpen,
+    mentionedItems,
+    setMentionedItems,
+    attachMention,
+    openMentionDir,
+    removeMentionedItem,
+    handleKeyDown: handleMentionKeyDown,
+    dismiss: dismissMention,
+  } = useMentionBrowser({
+    mention,
+    setMention,
+    mentionEntries,
+    text: value,
+    setText: (next) => {
+      setValue(next);
+      dirtyRef.current = true;
+    },
+    textareaRef,
+    isMobile,
+  });
 
-  /**
-   * Attach a file or whole folder the user chose: strip the "@…" token from
-   * the textarea (a chip below carries it) and record the path. Delivered as
-   * an "[Attached: <path>]" marker at send time (see ``submit``), which the
-   * native vendor reads from its own workspace — no upload, full fidelity.
-   */
-  const attachMention = (path: string, isDir: boolean) => {
-    if (!mention) return;
-    const next = value.slice(0, mention.start) + value.slice(mention.end);
-    setValue(next);
-    dirtyRef.current = true;
-    // Dedup on the shared attachment key (path + dir-ness + range), the same
-    // identity the store queue and drain effect use — not path alone — so the
-    // "@" menu and the file viewer's "Attach to agent" never disagree about
-    // what counts as a duplicate.
-    const item: MentionItem = { path, isDir };
-    const itemKey = composerAttachmentKey(item);
-    setMentionedItems((prev) =>
-      prev.some((it) => composerAttachmentKey(it) === itemKey) ? prev : [...prev, item],
-    );
-    setMention(null);
-    setMentionIndex(-1);
-    // Restore the caret to where the token was so typing continues naturally.
-    queueMicrotask(() => {
-      const ta = textareaRef.current;
-      if (ta) ta.setSelectionRange(mention.start, mention.start);
-      ta?.focus();
+  // Depends on mentionedItems (from the hook above), so it's computed here.
+  const hasDraft = value.trim().length > 0 || files.length > 0 || mentionedItems.length > 0;
+  const showInterruptButton = isWorking && !hasDraft;
+
+  // Drain externally-queued attachments (file viewer "Attach to agent") into
+  // the local mention chips, deduping against what's already tagged, then
+  // clear the store queue so they aren't re-applied. Placed after
+  // ``useMentionBrowser`` since it owns ``setMentionedItems``.
+  useEffect(() => {
+    if (pendingComposerAttachments.length === 0) return;
+    setMentionedItems((prev) => {
+      // Dedup against already-tagged chips AND within this batch (accumulate
+      // into ``seen`` as we go) so a duplicated queue can't double-apply.
+      const seen = new Set(prev.map(composerAttachmentKey));
+      const fresh: MentionItem[] = [];
+      for (const a of pendingComposerAttachments) {
+        const k = composerAttachmentKey(a);
+        if (seen.has(k)) continue;
+        seen.add(k);
+        fresh.push(a);
+      }
+      return fresh.length > 0 ? [...prev, ...fresh] : prev;
     });
-  };
-
-  /**
-   * Open a folder: rewrite the "@…" token to "<dir>/" so the menu re-lists
-   * that directory, keeping the mention active (caret after the slash) so
-   * the user keeps navigating or filtering deeper.
-   */
-  const openMentionDir = (path: string) => {
-    if (!mention) return;
-    const inserted = `@${path}/`;
-    const next = value.slice(0, mention.start) + inserted + value.slice(mention.end);
-    setValue(next);
-    dirtyRef.current = true;
-    const caret = mention.start + inserted.length;
-    setMention({ query: `${path}/`, start: mention.start, end: caret });
-    setMentionIndex(0);
-    queueMicrotask(() => {
-      const ta = textareaRef.current;
-      if (ta) ta.setSelectionRange(caret, caret);
-      ta?.focus();
-    });
-  };
-
-  const removeMentionedItem = (index: number) => {
-    setMentionedItems((prev) => prev.filter((_, i) => i !== index));
-  };
+    useChatStore.getState().clearPendingComposerAttachments();
+    textareaRef.current?.focus();
+    // Defense-in-depth against the cross-session leak: if the composer unmounts
+    // while an entry is still queued (route change, panel close, the
+    // loading-conversation gate during a session switch), clear the queue so
+    // the next-mounted composer doesn't drain a stale chip. ``switchTo`` also
+    // resets the queue, but this closes the non-switch unmount paths too.
+    return () => useChatStore.getState().clearPendingComposerAttachments();
+    // setMentionedItems is a stable useState setter (from useMentionBrowser).
+  }, [pendingComposerAttachments, setMentionedItems]);
 
   /**
    * Execute a slash command by name + optional argument string.
@@ -4127,13 +4079,8 @@ export function Composer({
     // (codex says "Attached file:"). Folders carry a trailing "/" so the
     // agent knows to open the directory. The native vendor reads the on-disk
     // workspace file/folder from this marker; no upload happens.
-    const mentionPreamble =
-      mentionedItems.length > 0
-        ? mentionedItems
-            .map((it) => mentionMarkerFor(sessionHarness, mentionItemPath(it)))
-            .join("\n") + "\n\n"
-        : "";
-    const messageText = mentionPreamble + quotePreamble + trimmed;
+    const messageText =
+      buildMentionPreamble(mentionedItems, sessionHarness) + quotePreamble + trimmed;
     // Sending while a prior response is streaming is fine — the
     // server queues the message and delivers it to the running task
     // (or starts a fresh one once the current drains). Escape still
@@ -4175,41 +4122,10 @@ export function Composer({
       return;
     }
 
-    // "@"-mention menu navigation — same model as the slash menu below, and
-    // mutually exclusive with it (a mention token can't also read as a
+    // "@"-mention menu navigation (shared useMentionBrowser) — mutually
+    // exclusive with the slash menu below (a mention token can't also read as a
     // "/"-command). Takes priority over history recall and submission.
-    if (mentionOpen) {
-      const active = mentionIndex >= 0 ? mentionEntries[mentionIndex] : undefined;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setMentionIndex((i) => (i + 1) % mentionEntries.length);
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setMentionIndex((i) => (i <= 0 ? mentionEntries.length - 1 : i - 1));
-        return;
-      }
-      // Enter: open a folder (drill in) or attach a file. Tab: attach the
-      // highlighted row as a unit — whole folder or file — without drilling.
-      if (e.key === "Enter" && !e.shiftKey && !isMobile && active) {
-        e.preventDefault();
-        if (active.type === "directory") openMentionDir(active.path);
-        else attachMention(active.path, false);
-        return;
-      }
-      if (e.key === "Tab" && active) {
-        e.preventDefault();
-        attachMention(active.path, active.type === "directory");
-        return;
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setMention(null);
-        setMentionIndex(-1);
-        return;
-      }
-    }
+    if (handleMentionKeyDown(e)) return;
 
     // When the suggestions menu is open, ArrowUp/Down navigate it and
     // Enter/Tab complete the highlighted item. These take priority over
@@ -4464,10 +4380,7 @@ export function Composer({
               // Menu rows ``preventDefault`` on mousedown so selecting an entry
               // keeps focus and does NOT blur — this only fires for genuine
               // focus-out, where the lingering menu would otherwise float.
-              if (mention) {
-                setMention(null);
-                setMentionIndex(-1);
-              }
+              dismissMention();
             }}
             onPaste={handlePaste}
             onScroll={(e) => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3568,8 +3568,8 @@ export function Composer({
   // attachment marker the executor already emits. In-process SDK sessions
   // get no mention menu, so the workspace listing is never fetched for them
   // (``enabled`` gate below). Codex's marker says "Attached file:" while the
-  // others say "Attached:" — see ``mentionMarkerFor``.
-  const sessionHarness = useChatStore((s) => s.sessionHarness);
+  // others say "Attached:" — see ``mentionMarkerFor``. ``sessionHarness`` is
+  // already read above for the status-tray harness label.
   // Derive from the canonical native-agent registry (which folds reversed
   // spellings like ``native-pi``) rather than a literal harness-string compare,
   // so the composer's "@" entry point can't split-brain from the file viewer's

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -114,3 +114,32 @@ describe("AssistantBubble lifecycle rendering", () => {
     expect(screen.queryByTestId("assistant-interrupted-indicator")).toBeNull();
   });
 });
+
+describe("UserBubble @-mention attachment chips", () => {
+  it("shows file and folder chips from [Attached: …] markers and hides the markers", () => {
+    renderBubble(
+      userBubble(
+        "[Attached: src/server.ts]\n[Attached: docs/]\n\nsummarize these",
+      ),
+    );
+
+    // The marker paths surface as chips (folder keeps its trailing slash)...
+    expect(screen.getByText("@src/server.ts")).toBeInTheDocument();
+    expect(screen.getByText("@docs/")).toBeInTheDocument();
+    // ...while the raw "[Attached: …]" marker text is stripped from the body.
+    expect(screen.queryByText(/\[Attached:/)).toBeNull();
+    expect(screen.getByText("summarize these")).toBeInTheDocument();
+  });
+
+  it("renders chips for the codex 'Attached file:' wording too", () => {
+    renderBubble(userBubble("[Attached file: src/a.ts]\n\ncheck this"));
+    expect(screen.getByText("@src/a.ts")).toBeInTheDocument();
+    expect(screen.queryByText(/\[Attached/)).toBeNull();
+  });
+
+  it("shows the line span of a partial-file attach in its own (non-truncating) node", () => {
+    renderBubble(userBubble("[Attached: bob-max-gain/docker-compose.yml:2-9]\n\nreview"));
+    expect(screen.getByText("@bob-max-gain/docker-compose.yml")).toBeInTheDocument();
+    expect(screen.getByText(":2-9")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -117,11 +117,7 @@ describe("AssistantBubble lifecycle rendering", () => {
 
 describe("UserBubble @-mention attachment chips", () => {
   it("shows file and folder chips from [Attached: …] markers and hides the markers", () => {
-    renderBubble(
-      userBubble(
-        "[Attached: src/server.ts]\n[Attached: docs/]\n\nsummarize these",
-      ),
-    );
+    renderBubble(userBubble("[Attached: src/server.ts]\n[Attached: docs/]\n\nsummarize these"));
 
     // The marker paths surface as chips (folder keeps its trailing slash)...
     expect(screen.getByText("@src/server.ts")).toBeInTheDocument();

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -411,9 +411,7 @@ export function CodeViewer({
   // attached. Monaco does the equivalent via ``onDidScrollChange``.
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
-      if (
-        !(e.target as HTMLElement).closest("[data-add-comment-btn], [data-attach-agent-btn]")
-      ) {
+      if (!(e.target as HTMLElement).closest("[data-add-comment-btn], [data-attach-agent-btn]")) {
         setSelectionAnchor(null);
       }
     };

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -22,12 +22,15 @@ import {
   type RefObject,
 } from "react";
 import {
+  AtSignIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   MessageSquarePlusIcon,
   SearchIcon,
   XIcon,
 } from "lucide-react";
+import { useChatStore } from "@/store/chatStore";
+import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
 import type { BundledLanguage, ThemedToken } from "shiki";
 import { highlightCode } from "@/components/ai-elements/code-block";
 import ReactMarkdown from "react-markdown";
@@ -247,6 +250,15 @@ export function CodeViewer({
   // Only the Shiki DOM path needs the per-line split; skip it in Monaco mode.
   const rawLines = useMemo(() => (showMonaco ? [] : content.split("\n")), [content, showMonaco]);
 
+  // "Attach to agent" delivers a "[Attached: path:start-end]" marker the
+  // composer reads — only the native coding-agent harnesses act on it, so
+  // gate the button to them (same set as the "@"-mention feature).
+  const sessionHarness = useChatStore((s) => s.sessionHarness);
+  // ``!!path`` mirrors the Monaco hook's guard: without it an empty path would
+  // emit a malformed ``[Attached: :start-end]`` marker. ``path`` is typed
+  // non-optional here, but the guard keeps the two surfaces in lockstep.
+  const canAttachToAgent = !!path && nativeCodingAgentForHarness(sessionHarness) !== undefined;
+
   // Kick off Shiki highlighting whenever content or language changes.
   useEffect(() => {
     if (showMonaco) return; // Monaco does its own highlighting.
@@ -388,16 +400,38 @@ export function CodeViewer({
     return () => container.removeEventListener("mouseup", handleMouseUp);
   }, [rawLines]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Dismiss the floating button on any mousedown outside of it.
+  // Dismiss the floating buttons on any mousedown outside of them, or on any
+  // scroll. Both the "Add comment" and "Attach to agent" buttons must be
+  // exempted from the mousedown dismiss — otherwise a click on "Attach to
+  // agent" clears the anchor and unmounts the portal before its own onClick
+  // runs. The buttons are ``position: fixed`` at captured viewport coords, so
+  // a scroll leaves them hovering over unrelated lines while the anchor's
+  // char offsets still point at the original selection; clear on scroll
+  // (capture phase, since scroll doesn't bubble) so a stale span can't be
+  // attached. Monaco does the equivalent via ``onDidScrollChange``.
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
-      if (!(e.target as HTMLElement).closest("[data-add-comment-btn]")) {
+      if (
+        !(e.target as HTMLElement).closest("[data-add-comment-btn], [data-attach-agent-btn]")
+      ) {
         setSelectionAnchor(null);
       }
     };
+    const handleScroll = () => setSelectionAnchor(null);
     document.addEventListener("mousedown", handleMouseDown);
-    return () => document.removeEventListener("mousedown", handleMouseDown);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
   }, []);
+
+  // Switching renderer (Shiki↔Monaco), view mode (preview↔editor), or file
+  // invalidates the captured viewport coords + char offsets, so drop the
+  // floating buttons rather than re-render them at a stale position.
+  useEffect(() => {
+    setSelectionAnchor(null);
+  }, [showMonaco, viewMode, path]);
 
   // When Cmd/Ctrl+A selected the entire container, intercept the copy event
   // and write the raw file content so line numbers and flex-layout artifacts
@@ -737,32 +771,71 @@ export function CodeViewer({
         })}
       </div>
 
-      {/* Floating "Add Comment" button — rendered into document.body so that
+      {/* Floating selection actions — rendered into document.body so that
           CSS transforms on ancestor elements don't break fixed positioning. */}
       {selectionAnchor &&
         createPortal(
-          <button
-            data-add-comment-btn
-            type="button"
-            className="fixed z-50 flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+          <div
+            className="fixed z-50 flex items-center gap-1"
             style={{
-              left: selectionAnchor.x,
+              // Clamp so the (one- or two-) button group can't clip off the
+              // right edge near the viewport boundary. Width is an estimate of
+              // the rendered buttons ("Add comment" ≈ 130px, + "Attach to
+              // agent" ≈ 150px).
+              left: Math.min(
+                selectionAnchor.x,
+                Math.max(8, window.innerWidth - (canAttachToAgent ? 288 : 138)),
+              ),
               top: selectionAnchor.y,
               transform: "translateY(-100%)",
             }}
-            onClick={() => {
-              onSetActiveSelection({
-                start_index: selectionAnchor.start_index,
-                end_index: selectionAnchor.end_index,
-                anchor_content: selectionAnchor.anchor_content,
-              });
-              setSelectionAnchor(null);
-              window.getSelection()?.removeAllRanges();
-            }}
           >
-            <MessageSquarePlusIcon className="size-3.5" />
-            Add comment
-          </button>,
+            <button
+              data-add-comment-btn
+              type="button"
+              className="flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+              onClick={() => {
+                onSetActiveSelection({
+                  start_index: selectionAnchor.start_index,
+                  end_index: selectionAnchor.end_index,
+                  anchor_content: selectionAnchor.anchor_content,
+                });
+                setSelectionAnchor(null);
+                window.getSelection()?.removeAllRanges();
+              }}
+            >
+              <MessageSquarePlusIcon className="size-3.5" />
+              Add comment
+            </button>
+            {canAttachToAgent && (
+              <button
+                data-attach-agent-btn
+                type="button"
+                className="flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+                onClick={() => {
+                  // Convert the selection's char offsets to a 1-based inclusive
+                  // line span. ``end_index`` is exclusive, so step back one char
+                  // (clamped) before mapping so a trailing newline doesn't bleed
+                  // into the next line.
+                  const startLine = indexToLine(selectionAnchor.start_index, rawLines);
+                  const endLine = indexToLine(
+                    Math.max(selectionAnchor.start_index, selectionAnchor.end_index - 1),
+                    rawLines,
+                  );
+                  useChatStore.getState().addComposerAttachment({
+                    path,
+                    isDir: false,
+                    lineRange: { start: startLine, end: endLine },
+                  });
+                  setSelectionAnchor(null);
+                  window.getSelection()?.removeAllRanges();
+                }}
+              >
+                <AtSignIcon className="size-3.5" />
+                Attach to agent
+              </button>
+            )}
+          </div>,
           getEmbedRoot() ?? document.body,
         )}
     </>

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -384,6 +384,7 @@ function MonacoCodeEditorInner({
     onSetActiveSelection,
     canComment: canEdit && !isDirty,
     pendingBodyRef,
+    path,
   });
 
   const options = useMemo<EditorOptions>(

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -130,6 +130,7 @@ export function MonacoDiffViewer({
     onSetActiveSelection,
     canComment: canEdit,
     pendingBodyRef,
+    path,
   });
 
   const options = useMemo<DiffEditorProps["options"]>(

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -29,6 +29,7 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import type { Conversation } from "@/hooks/useConversations";
 import { setOmnigentHostConfig } from "@/lib/host";
+import { setPendingInitialPrompt } from "@/store/chatStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 // Only authenticatedFetch is stubbed (the create POST under test);
@@ -58,6 +59,13 @@ vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/hooks/useConversations")>()),
   useProjects: () => ({ data: [] }),
 }));
+// Partial mock: only spy on the first-message handoff so the "@"-mention
+// tests can assert the prepended attachment marker. Everything else
+// (composerAttachmentKey, useChatStore, …) stays real for the render tree.
+vi.mock("@/store/chatStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/chatStore")>()),
+  setPendingInitialPrompt: vi.fn(),
+}));
 
 const authenticatedFetchMock = vi.mocked(authenticatedFetch);
 const useHostsMock = vi.mocked(useHosts);
@@ -65,6 +73,7 @@ const useAvailableAgentsMock = vi.mocked(useAvailableAgents);
 const useHostFilesystemMock = vi.mocked(useHostFilesystem);
 const useDirectorySessionsMock = vi.mocked(useDirectorySessions);
 const useRunnerHealthMock = vi.mocked(useRunnerHealthRegistration);
+const setPendingInitialPromptMock = vi.mocked(setPendingInitialPrompt);
 
 const RECENT_KEY = "omnigent:recent-workspaces";
 
@@ -1647,5 +1656,142 @@ describe("NewChatLandingScreen attachments", () => {
     // state clears rather than sticking when moving between child elements.
     fireEvent.dragLeave(composer, { dataTransfer: { files: [] } });
     expect(screen.queryByText("Drop files here")).toBeNull();
+  });
+});
+
+// The "@"-file-mention browser on the launcher mirrors the in-session
+// composer, but its file source is the *host filesystem* (no session/runner
+// exists yet) and its paths are converted from the host's absolute form to
+// workspace-relative for the chip and the "[Attached: …]" marker.
+describe("NewChatLandingScreen @-file-mention", () => {
+  const ROOT = "/Users/corey/repo";
+  function dir(path: string): HostFilesystemEntry {
+    return { name: path.split("/").pop() ?? "", path, type: "directory", bytes: null, modified_at: 0 };
+  }
+  function file(path: string): HostFilesystemEntry {
+    return { name: path.split("/").pop() ?? "", path, type: "file", bytes: 10, modified_at: 0 };
+  }
+  // Path-aware listing: the workspace root holds an "omnigent" folder + a
+  // README; drilling into "omnigent" reveals a nested folder + a file. Keyed by
+  // the absolute path so drill-down and relative-path mapping are exercised for
+  // real (a fixed stub couldn't distinguish the two levels).
+  function mockFsByPath() {
+    useHostFilesystemMock.mockImplementation(((_hostId: string | null, path: string | null) => {
+      let entries: HostFilesystemEntry[] = [];
+      if (path === ROOT) entries = [dir(`${ROOT}/omnigent`), file(`${ROOT}/README.md`)];
+      else if (path === `${ROOT}/omnigent`)
+        entries = [dir(`${ROOT}/omnigent/inner`), file(`${ROOT}/omnigent/cli.py`)];
+      return {
+        data: { entries, truncated: false },
+        isLoading: false,
+        error: null,
+        isPlaceholderData: false,
+      };
+    }) as unknown as typeof useHostFilesystem);
+  }
+
+  beforeEach(() => {
+    setupLandingMocks();
+    setPendingInitialPromptMock.mockReset();
+    mockFsByPath();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  function input() {
+    return screen.getByTestId("new-chat-landing-input");
+  }
+
+  it("opens the menu listing workspace files when '@' is typed (native agent)", async () => {
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    fireEvent.change(input(), { target: { value: "@", selectionStart: 1 } });
+    // Host absolute paths are shown as workspace-relative rows (folders first).
+    expect(screen.getByTitle("Open omnigent")).toBeInTheDocument();
+    expect(screen.getByTitle("Attach README.md")).toBeInTheDocument();
+  });
+
+  it("does NOT open the menu for a non-native (SDK) agent", () => {
+    // Gate parity with the in-session composer: mentions are native-only.
+    mockAgents([
+      {
+        id: "sdk1",
+        name: "my-sdk-agent",
+        display_name: "SDK Agent",
+        description: null,
+        harness: "claude-sdk",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    fireEvent.change(input(), { target: { value: "@", selectionStart: 1 } });
+    expect(screen.queryByTitle("Open omnigent")).not.toBeInTheDocument();
+  });
+
+  it("drills into a folder and delivers the chosen file as a workspace-relative marker", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.change(input(), { target: { value: "@", selectionStart: 1 } });
+    // Nested files are hidden until the folder is opened (drill-down).
+    expect(screen.queryByTitle("Attach cli.py")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTitle("Open omnigent"));
+    fireEvent.click(screen.getByTitle("Attach cli.py"));
+    // The chip shows the workspace-relative path, not the host-absolute one.
+    expect(screen.getByText("@omnigent/cli.py")).toBeInTheDocument();
+
+    fireEvent.change(input(), { target: { value: "explain this", selectionStart: 12 } });
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    // The contract: the first message carries "[Attached: <relpath>]" so the
+    // runner (rooted at the workspace) reads the on-disk file — relative, never
+    // the "/Users/corey/repo/…" absolute path the host filesystem returned.
+    await waitFor(() => expect(setPendingInitialPromptMock).toHaveBeenCalled());
+    const [, payload] = setPendingInitialPromptMock.mock.calls[0]!;
+    expect((payload as { text: string }).text).toBe(
+      "[Attached: omnigent/cli.py]\n\nexplain this",
+    );
+  });
+
+  it("attaches a whole folder with a trailing-slash marker", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.change(input(), { target: { value: "@", selectionStart: 1 } });
+    // The folder row's "+" button attaches the directory as a unit.
+    fireEvent.click(screen.getByLabelText("Attach whole folder omnigent"));
+    expect(screen.getByText("@omnigent/")).toBeInTheDocument();
+
+    fireEvent.change(input(), { target: { value: "review it", selectionStart: 9 } });
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(setPendingInitialPromptMock).toHaveBeenCalled());
+    const [, payload] = setPendingInitialPromptMock.mock.calls[0]!;
+    expect((payload as { text: string }).text).toBe("[Attached: omnigent/]\n\nreview it");
+  });
+
+  it("removes a tagged chip when its ✕ is clicked", () => {
+    renderLanding();
+    fireEvent.change(input(), { target: { value: "@", selectionStart: 1 } });
+    fireEvent.click(screen.getByTitle("Attach README.md"));
+    expect(screen.getByText("@README.md")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Remove README.md"));
+    expect(screen.queryByText("@README.md")).not.toBeInTheDocument();
   });
 });

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1666,7 +1666,13 @@ describe("NewChatLandingScreen attachments", () => {
 describe("NewChatLandingScreen @-file-mention", () => {
   const ROOT = "/Users/corey/repo";
   function dir(path: string): HostFilesystemEntry {
-    return { name: path.split("/").pop() ?? "", path, type: "directory", bytes: null, modified_at: 0 };
+    return {
+      name: path.split("/").pop() ?? "",
+      path,
+      type: "directory",
+      bytes: null,
+      modified_at: 0,
+    };
   }
   function file(path: string): HostFilesystemEntry {
     return { name: path.split("/").pop() ?? "", path, type: "file", bytes: 10, modified_at: 0 };
@@ -1758,9 +1764,7 @@ describe("NewChatLandingScreen @-file-mention", () => {
     // the "/Users/corey/repo/…" absolute path the host filesystem returned.
     await waitFor(() => expect(setPendingInitialPromptMock).toHaveBeenCalled());
     const [, payload] = setPendingInitialPromptMock.mock.calls[0]!;
-    expect((payload as { text: string }).text).toBe(
-      "[Attached: omnigent/cli.py]\n\nexplain this",
-    );
+    expect((payload as { text: string }).text).toBe("[Attached: omnigent/cli.py]\n\nexplain this");
   });
 
   it("suppresses stale parent rows while a drilled directory is still loading", async () => {

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1763,6 +1763,44 @@ describe("NewChatLandingScreen @-file-mention", () => {
     );
   });
 
+  it("suppresses stale parent rows while a drilled directory is still loading", async () => {
+    // ``useHostFilesystem`` keeps the previous directory's rows on screen as
+    // placeholder data while the next fetch is in flight (keepPreviousData):
+    // ``isLoading`` is false, only ``isPlaceholderData`` is true. If the menu
+    // rendered that placeholder it would show the *parent's* files as though
+    // they lived inside the drilled child, and a click/Enter would attach the
+    // wrong entry. The menu must collapse to "Loading…" until the child's own
+    // listing arrives.
+    const rootEntries = [dir(`${ROOT}/omnigent`), file(`${ROOT}/README.md`)];
+    useHostFilesystemMock.mockImplementation(((_hostId: string | null, path: string | null) => {
+      // Root resolves normally; the drilled path is still serving the parent's
+      // rows as placeholder data (the mid-fetch window we're regression-testing).
+      const isPlaceholderData = path !== ROOT;
+      return {
+        data: { entries: rootEntries, truncated: false },
+        isLoading: false,
+        error: null,
+        isPlaceholderData,
+      };
+    }) as unknown as typeof useHostFilesystem);
+
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+
+    fireEvent.change(input(), { target: { value: "@", selectionStart: 1 } });
+    // Root listing renders its rows.
+    expect(screen.getByTitle("Open omnigent")).toBeInTheDocument();
+    fireEvent.click(screen.getByTitle("Open omnigent"));
+
+    // Drilled-but-loading: the loading row shows and the parent's stale rows are
+    // gone (without the isPlaceholderData guard they'd appear as the child's).
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByTitle("Attach README.md")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Open omnigent")).not.toBeInTheDocument();
+  });
+
   it("attaches a whole folder with a trailing-slash marker", async () => {
     authenticatedFetchMock.mockResolvedValue({
       ok: true,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1959,7 +1959,11 @@ export function NewChatLandingScreen() {
   const workspaceRoot = workspaceTrimmed.replace(/\/+$/, "");
   // Absolute dir to list = workspace root + the drilled sub-path.
   const mentionAbsDir =
-    mentionEnabled && mention ? (mentionDir ? `${workspaceRoot}/${mentionDir}` : workspaceRoot) : null;
+    mentionEnabled && mention
+      ? mentionDir
+        ? `${workspaceRoot}/${mentionDir}`
+        : workspaceRoot
+      : null;
   const mentionFsQuery = useHostFilesystem(
     mentionEnabled && mention ? selectedHostId : null,
     mentionAbsDir,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -80,13 +80,14 @@ import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
 import { useProjects, PROJECT_LABEL_KEY } from "@/hooks/useConversations";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
-import { composerAttachmentKey } from "@/store/chatStore";
+import { useMentionBrowser } from "@/hooks/useMentionBrowser";
 import {
+  buildMentionPreamble,
   detectMentionAt,
-  type MentionItem,
   mentionItemPath,
-  mentionMarkerFor,
   type MentionState,
+  parseMentionToken,
+  rankMentionEntries,
 } from "@/lib/composerMentions";
 import { OttoEyes } from "@/components/OttoEyes";
 import { SkillPills } from "@/components/SkillPills";
@@ -1952,15 +1953,9 @@ export function NewChatLandingScreen() {
   // workspace API; each tagged path is delivered as an "[Attached: …]" marker
   // prepended to the first message, which the runner reads from that workspace.
   const [mention, setMention] = useState<MentionState | null>(null);
-  const [mentionIndex, setMentionIndex] = useState(-1);
-  const [mentionedItems, setMentionedItems] = useState<MentionItem[]>([]);
   const mentionEnabled =
     isNativeTerminalAgent && !sandboxSelected && !!selectedHostId && workspaceValid;
-  const mentionRawToken = mention?.query ?? "";
-  const mentionSlash = mentionRawToken.lastIndexOf("/");
-  const mentionDir = mentionSlash >= 0 ? mentionRawToken.slice(0, mentionSlash) : "";
-  const mentionFilter =
-    mentionSlash >= 0 ? mentionRawToken.slice(mentionSlash + 1) : mentionRawToken;
+  const { dir: mentionDir, filter: mentionFilter } = parseMentionToken(mention?.query ?? "");
   const workspaceRoot = workspaceTrimmed.replace(/\/+$/, "");
   // Absolute dir to list = workspace root + the drilled sub-path.
   const mentionAbsDir =
@@ -1969,12 +1964,11 @@ export function NewChatLandingScreen() {
     mentionEnabled && mention ? selectedHostId : null,
     mentionAbsDir,
   );
-  const MENTION_MATCH_CAP = 50;
-  // Map host entries (absolute paths) to workspace-relative WorkspaceFile rows
-  // the shared FileMentionMenu renders: folders first, filtered, capped.
+  // Map host entries (absolute paths) to workspace-relative WorkspaceFile rows,
+  // then rank (folders-first, filtered, capped) via the shared helper.
   const mentionEntries: WorkspaceFile[] = useMemo(() => {
     if (!mentionEnabled || !mention) return [];
-    return (mentionFsQuery.data?.entries ?? [])
+    const rows = (mentionFsQuery.data?.entries ?? [])
       .filter((e) => e.type === "directory" || e.type === "file")
       .map(
         (e): WorkspaceFile => ({
@@ -1986,61 +1980,31 @@ export function NewChatLandingScreen() {
           bytes: e.bytes,
           modified_at: e.modified_at,
         }),
-      )
-      .filter((e) => e.name.toLowerCase().includes(mentionFilter.toLowerCase()))
-      .sort((a, b) => {
-        if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
-        return a.name.localeCompare(b.name);
-      })
-      .slice(0, MENTION_MATCH_CAP);
+      );
+    return rankMentionEntries(rows, mentionFilter);
   }, [mentionEnabled, mention, mentionFsQuery.data, mentionFilter, workspaceRoot]);
   const mentionOpen = mentionEntries.length > 0;
   // Closed-but-loading window: don't let Enter send the half-typed "@dir/".
   const mentionListingPending = mentionEnabled && mention != null && mentionFsQuery.isLoading;
 
-  // Pre-select the top row whenever the listing changes (same reset as slash).
-  const prevMentionMatchesRef = useRef<string[]>([]);
-  const mentionEntryKeys = mentionEntries.map((e) => `${e.type}:${e.path}`);
-  if (
-    mentionEntryKeys.length !== prevMentionMatchesRef.current.length ||
-    mentionEntryKeys.some((k, i) => k !== prevMentionMatchesRef.current[i])
-  ) {
-    prevMentionMatchesRef.current = mentionEntryKeys;
-    setMentionIndex(mentionEntryKeys.length > 0 ? 0 : -1);
-  }
-
-  const attachMention = (path: string, isDir: boolean) => {
-    if (!mention) return;
-    setMessage(message.slice(0, mention.start) + message.slice(mention.end));
-    const item: MentionItem = { path, isDir };
-    const itemKey = composerAttachmentKey(item);
-    setMentionedItems((prev) =>
-      prev.some((it) => composerAttachmentKey(it) === itemKey) ? prev : [...prev, item],
-    );
-    setMention(null);
-    setMentionIndex(-1);
-    queueMicrotask(() => {
-      const ta = textareaRef.current;
-      if (ta) ta.setSelectionRange(mention.start, mention.start);
-      ta?.focus();
-    });
-  };
-  const openMentionDir = (path: string) => {
-    if (!mention) return;
-    const inserted = `@${path}/`;
-    const next = message.slice(0, mention.start) + inserted + message.slice(mention.end);
-    setMessage(next);
-    const caret = mention.start + inserted.length;
-    setMention({ query: `${path}/`, start: mention.start, end: caret });
-    setMentionIndex(0);
-    queueMicrotask(() => {
-      const ta = textareaRef.current;
-      if (ta) ta.setSelectionRange(caret, caret);
-      ta?.focus();
-    });
-  };
-  const removeMentionedItem = (index: number) =>
-    setMentionedItems((prev) => prev.filter((_, i) => i !== index));
+  // Shared selection/chip/keyboard glue — see useMentionBrowser. Only the
+  // host-filesystem source + token state above are launcher-specific.
+  const {
+    mentionIndex,
+    mentionedItems,
+    attachMention,
+    openMentionDir,
+    removeMentionedItem,
+    handleKeyDown: handleMentionKeyDown,
+    dismiss: dismissMention,
+  } = useMentionBrowser({
+    mention,
+    setMention,
+    mentionEntries,
+    text: message,
+    setText: setMessage,
+    textareaRef,
+  });
 
   const canSubmit =
     message.trim().length > 0 &&
@@ -2275,13 +2239,9 @@ export function NewChatLandingScreen() {
       // the same wording the native executors emit and that title-seeding
       // strips. The runner, rooted at this workspace, reads the on-disk file
       // from the marker; no upload happens. Folders carry a trailing "/".
-      const mentionPreamble =
-        mentionedItems.length > 0
-          ? mentionedItems
-              .map((it) => mentionMarkerFor(selectedAgent?.harness ?? null, mentionItemPath(it)))
-              .join("\n") + "\n\n"
-          : "";
-      const initialPrompt = mentionPreamble + sanitizeInitialPrompt(message);
+      const initialPrompt =
+        buildMentionPreamble(mentionedItems, selectedAgent?.harness ?? null) +
+        sanitizeInitialPrompt(message);
       // A first message matching one of the agent's bundled skills is
       // handed off as a structured invocation so ChatPage auto-sends it
       // as a `slash_command` event (server resolves the skill) instead
@@ -2415,10 +2375,7 @@ export function NewChatLandingScreen() {
               onBlur={() => {
                 // Dismiss the mention menu when focus leaves the textarea; menu
                 // rows preventDefault on mousedown so selecting one doesn't blur.
-                if (mention) {
-                  setMention(null);
-                  setMentionIndex(-1);
-                }
+                dismissMention();
               }}
               onCompositionStart={() => {
                 isComposingRef.current = true;
@@ -2431,39 +2388,10 @@ export function NewChatLandingScreen() {
                   return;
                 }
 
-                // "@"-mention menu navigation — mutually exclusive with the
-                // slash menu (a token can't be both), and takes priority over
-                // submission. Mirrors the in-session composer.
-                if (mentionOpen) {
-                  const active = mentionIndex >= 0 ? mentionEntries[mentionIndex] : undefined;
-                  if (e.key === "ArrowDown") {
-                    e.preventDefault();
-                    setMentionIndex((i) => (i + 1) % mentionEntries.length);
-                    return;
-                  }
-                  if (e.key === "ArrowUp") {
-                    e.preventDefault();
-                    setMentionIndex((i) => (i <= 0 ? mentionEntries.length - 1 : i - 1));
-                    return;
-                  }
-                  if (e.key === "Enter" && !e.shiftKey && active) {
-                    e.preventDefault();
-                    if (active.type === "directory") openMentionDir(active.path);
-                    else attachMention(active.path, false);
-                    return;
-                  }
-                  if (e.key === "Tab" && active) {
-                    e.preventDefault();
-                    attachMention(active.path, active.type === "directory");
-                    return;
-                  }
-                  if (e.key === "Escape") {
-                    e.preventDefault();
-                    setMention(null);
-                    setMentionIndex(-1);
-                    return;
-                  }
-                }
+                // "@"-mention menu navigation (shared useMentionBrowser) —
+                // mutually exclusive with the slash menu (a token can't be both)
+                // and takes priority over submission.
+                if (handleMentionKeyDown(e)) return;
 
                 // While the skills menu is open, ArrowUp/Down navigate it and
                 // Enter/Tab complete the highlighted item — these take

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -76,8 +76,18 @@ import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
 import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
+import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
 import { useProjects, PROJECT_LABEL_KEY } from "@/hooks/useConversations";
+import { FileMentionMenu } from "@/components/FileMentionMenu";
+import { composerAttachmentKey } from "@/store/chatStore";
+import {
+  detectMentionAt,
+  type MentionItem,
+  mentionItemPath,
+  mentionMarkerFor,
+  type MentionState,
+} from "@/lib/composerMentions";
 import { OttoEyes } from "@/components/OttoEyes";
 import { SkillPills } from "@/components/SkillPills";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
@@ -1935,6 +1945,103 @@ export function NewChatLandingScreen() {
     textareaRef.current?.focus();
   }
 
+  // ── "@"-file-mention browser (parity with the in-session composer) ────────
+  // Only for native terminal agents on a real local host with an absolute
+  // workspace. No session/runner exists yet, so the listing comes from the
+  // host filesystem endpoint (absolute paths) rather than the session-scoped
+  // workspace API; each tagged path is delivered as an "[Attached: …]" marker
+  // prepended to the first message, which the runner reads from that workspace.
+  const [mention, setMention] = useState<MentionState | null>(null);
+  const [mentionIndex, setMentionIndex] = useState(-1);
+  const [mentionedItems, setMentionedItems] = useState<MentionItem[]>([]);
+  const mentionEnabled =
+    isNativeTerminalAgent && !sandboxSelected && !!selectedHostId && workspaceValid;
+  const mentionRawToken = mention?.query ?? "";
+  const mentionSlash = mentionRawToken.lastIndexOf("/");
+  const mentionDir = mentionSlash >= 0 ? mentionRawToken.slice(0, mentionSlash) : "";
+  const mentionFilter =
+    mentionSlash >= 0 ? mentionRawToken.slice(mentionSlash + 1) : mentionRawToken;
+  const workspaceRoot = workspaceTrimmed.replace(/\/+$/, "");
+  // Absolute dir to list = workspace root + the drilled sub-path.
+  const mentionAbsDir =
+    mentionEnabled && mention ? (mentionDir ? `${workspaceRoot}/${mentionDir}` : workspaceRoot) : null;
+  const mentionFsQuery = useHostFilesystem(
+    mentionEnabled && mention ? selectedHostId : null,
+    mentionAbsDir,
+  );
+  const MENTION_MATCH_CAP = 50;
+  // Map host entries (absolute paths) to workspace-relative WorkspaceFile rows
+  // the shared FileMentionMenu renders: folders first, filtered, capped.
+  const mentionEntries: WorkspaceFile[] = useMemo(() => {
+    if (!mentionEnabled || !mention) return [];
+    return (mentionFsQuery.data?.entries ?? [])
+      .filter((e) => e.type === "directory" || e.type === "file")
+      .map(
+        (e): WorkspaceFile => ({
+          path: e.path.startsWith(workspaceRoot)
+            ? e.path.slice(workspaceRoot.length).replace(/^\/+/, "")
+            : e.name,
+          name: e.name,
+          type: e.type === "directory" ? "directory" : "file",
+          bytes: e.bytes,
+          modified_at: e.modified_at,
+        }),
+      )
+      .filter((e) => e.name.toLowerCase().includes(mentionFilter.toLowerCase()))
+      .sort((a, b) => {
+        if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      })
+      .slice(0, MENTION_MATCH_CAP);
+  }, [mentionEnabled, mention, mentionFsQuery.data, mentionFilter, workspaceRoot]);
+  const mentionOpen = mentionEntries.length > 0;
+  // Closed-but-loading window: don't let Enter send the half-typed "@dir/".
+  const mentionListingPending = mentionEnabled && mention != null && mentionFsQuery.isLoading;
+
+  // Pre-select the top row whenever the listing changes (same reset as slash).
+  const prevMentionMatchesRef = useRef<string[]>([]);
+  const mentionEntryKeys = mentionEntries.map((e) => `${e.type}:${e.path}`);
+  if (
+    mentionEntryKeys.length !== prevMentionMatchesRef.current.length ||
+    mentionEntryKeys.some((k, i) => k !== prevMentionMatchesRef.current[i])
+  ) {
+    prevMentionMatchesRef.current = mentionEntryKeys;
+    setMentionIndex(mentionEntryKeys.length > 0 ? 0 : -1);
+  }
+
+  const attachMention = (path: string, isDir: boolean) => {
+    if (!mention) return;
+    setMessage(message.slice(0, mention.start) + message.slice(mention.end));
+    const item: MentionItem = { path, isDir };
+    const itemKey = composerAttachmentKey(item);
+    setMentionedItems((prev) =>
+      prev.some((it) => composerAttachmentKey(it) === itemKey) ? prev : [...prev, item],
+    );
+    setMention(null);
+    setMentionIndex(-1);
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      if (ta) ta.setSelectionRange(mention.start, mention.start);
+      ta?.focus();
+    });
+  };
+  const openMentionDir = (path: string) => {
+    if (!mention) return;
+    const inserted = `@${path}/`;
+    const next = message.slice(0, mention.start) + inserted + message.slice(mention.end);
+    setMessage(next);
+    const caret = mention.start + inserted.length;
+    setMention({ query: `${path}/`, start: mention.start, end: caret });
+    setMentionIndex(0);
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      if (ta) ta.setSelectionRange(caret, caret);
+      ta?.focus();
+    });
+  };
+  const removeMentionedItem = (index: number) =>
+    setMentionedItems((prev) => prev.filter((_, i) => i !== index));
+
   const canSubmit =
     message.trim().length > 0 &&
     selectedAgent != null &&
@@ -2164,7 +2271,17 @@ export function NewChatLandingScreen() {
       // loads from the session id and never reads the sidebar cache.
       void queryClient.refetchQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
-      const initialPrompt = sanitizeInitialPrompt(message);
+      // Prepend each "@"-tagged path as an attachment marker on its own line —
+      // the same wording the native executors emit and that title-seeding
+      // strips. The runner, rooted at this workspace, reads the on-disk file
+      // from the marker; no upload happens. Folders carry a trailing "/".
+      const mentionPreamble =
+        mentionedItems.length > 0
+          ? mentionedItems
+              .map((it) => mentionMarkerFor(selectedAgent?.harness ?? null, mentionItemPath(it)))
+              .join("\n") + "\n\n"
+          : "";
+      const initialPrompt = mentionPreamble + sanitizeInitialPrompt(message);
       // A first message matching one of the agent's bundled skills is
       // handed off as a structured invocation so ChatPage auto-sends it
       // as a `slash_command` event (server resolves the skill) instead
@@ -2268,10 +2385,41 @@ export function NewChatLandingScreen() {
                 commands={skillCommands}
               />
             )}
+            {/* "@"-file-mention browser — native terminal agents with a workspace */}
+            {(mentionOpen || mentionListingPending) && (
+              <FileMentionMenu
+                currentDir={mentionDir}
+                activeIndex={mentionIndex}
+                entries={mentionEntries}
+                loading={mentionListingPending}
+                onOpenDir={openMentionDir}
+                onAttach={attachMention}
+              />
+            )}
             <textarea
               ref={textareaRef}
               value={message}
-              onChange={(e) => setMessage(e.target.value)}
+              onChange={(e) => {
+                setMessage(e.target.value);
+                // Recompute the active "@"-mention from the caret each keystroke
+                // (native terminal agents with a workspace — ``mentionEnabled``).
+                setMention(
+                  mentionEnabled
+                    ? detectMentionAt(
+                        e.target.value,
+                        e.target.selectionStart ?? e.target.value.length,
+                      )
+                    : null,
+                );
+              }}
+              onBlur={() => {
+                // Dismiss the mention menu when focus leaves the textarea; menu
+                // rows preventDefault on mousedown so selecting one doesn't blur.
+                if (mention) {
+                  setMention(null);
+                  setMentionIndex(-1);
+                }
+              }}
               onCompositionStart={() => {
                 isComposingRef.current = true;
               }}
@@ -2281,6 +2429,40 @@ export function NewChatLandingScreen() {
               onKeyDown={(e) => {
                 if (isImeCompositionKeyEvent(e, isComposingRef.current)) {
                   return;
+                }
+
+                // "@"-mention menu navigation — mutually exclusive with the
+                // slash menu (a token can't be both), and takes priority over
+                // submission. Mirrors the in-session composer.
+                if (mentionOpen) {
+                  const active = mentionIndex >= 0 ? mentionEntries[mentionIndex] : undefined;
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setMentionIndex((i) => (i + 1) % mentionEntries.length);
+                    return;
+                  }
+                  if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setMentionIndex((i) => (i <= 0 ? mentionEntries.length - 1 : i - 1));
+                    return;
+                  }
+                  if (e.key === "Enter" && !e.shiftKey && active) {
+                    e.preventDefault();
+                    if (active.type === "directory") openMentionDir(active.path);
+                    else attachMention(active.path, false);
+                    return;
+                  }
+                  if (e.key === "Tab" && active) {
+                    e.preventDefault();
+                    attachMention(active.path, active.type === "directory");
+                    return;
+                  }
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    setMention(null);
+                    setMentionIndex(-1);
+                    return;
+                  }
                 }
 
                 // While the skills menu is open, ArrowUp/Down navigate it and
@@ -2318,6 +2500,9 @@ export function NewChatLandingScreen() {
                 // Enter sends; Shift+Enter inserts a newline.
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault();
+                  // The mention menu is briefly closed while its listing loads;
+                  // swallow Enter so the in-progress "@dir/" token isn't sent.
+                  if (mentionListingPending) return;
                   void handleCreate();
                 }
               }}
@@ -2376,6 +2561,37 @@ export function NewChatLandingScreen() {
                 }
               }}
             />
+            {/* "@"-mention chips — one per tagged workspace file/folder. Each is
+                delivered as an "[Attached: <path>]" marker prepended to the
+                first message at create time. */}
+            {mentionedItems.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 px-4 pb-2">
+                {mentionedItems.map((item, i) => (
+                  <span
+                    key={mentionItemPath(item)}
+                    className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                  >
+                    {item.isDir ? (
+                      <FolderIcon className="size-3 shrink-0" />
+                    ) : (
+                      <FileTextIcon className="size-3 shrink-0" />
+                    )}
+                    <span className="max-w-[200px] truncate" title={mentionItemPath(item)}>
+                      @{item.path}
+                      {item.isDir ? "/" : ""}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeMentionedItem(i)}
+                      className="ml-0.5 rounded-full hover:text-foreground"
+                      aria-label={`Remove ${item.path}`}
+                    >
+                      <XIcon className="size-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
             {/* File chips — shown below the textarea when files are attached. */}
             {files.length > 0 && (
               <div className="flex flex-wrap gap-1.5 px-4 pb-2">

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1968,6 +1968,14 @@ export function NewChatLandingScreen() {
   // then rank (folders-first, filtered, capped) via the shared helper.
   const mentionEntries: WorkspaceFile[] = useMemo(() => {
     if (!mentionEnabled || !mention) return [];
+    // ``useHostFilesystem`` keeps the previous directory's rows as placeholder
+    // data (no flicker on navigate). When the user drills into a folder a new
+    // fetch starts but ``data`` still holds the *parent's* entries — ``isLoading``
+    // is false, only ``isPlaceholderData`` is true. Returning those stale rows
+    // here would show the parent's files while purporting to be inside the
+    // child, so a click/Enter could attach the wrong entry. Suppress them until
+    // the current directory's own listing arrives.
+    if (mentionFsQuery.isPlaceholderData) return [];
     const rows = (mentionFsQuery.data?.entries ?? [])
       .filter((e) => e.type === "directory" || e.type === "file")
       .map(
@@ -1982,10 +1990,22 @@ export function NewChatLandingScreen() {
         }),
       );
     return rankMentionEntries(rows, mentionFilter);
-  }, [mentionEnabled, mention, mentionFsQuery.data, mentionFilter, workspaceRoot]);
+  }, [
+    mentionEnabled,
+    mention,
+    mentionFsQuery.data,
+    mentionFsQuery.isPlaceholderData,
+    mentionFilter,
+    workspaceRoot,
+  ]);
   const mentionOpen = mentionEntries.length > 0;
   // Closed-but-loading window: don't let Enter send the half-typed "@dir/".
-  const mentionListingPending = mentionEnabled && mention != null && mentionFsQuery.isLoading;
+  // ``isPlaceholderData`` covers the drill-down window where react-query is
+  // still serving the previous directory's rows (``isLoading`` stays false).
+  const mentionListingPending =
+    mentionEnabled &&
+    mention != null &&
+    (mentionFsQuery.isLoading || mentionFsQuery.isPlaceholderData);
 
   // Shared selection/chip/keyboard glue — see useMentionBrowser. Only the
   // host-filesystem source + token state above are launcher-specific.

--- a/web/src/shell/useMonacoCommentLayer.tsx
+++ b/web/src/shell/useMonacoCommentLayer.tsx
@@ -13,11 +13,13 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { MessageSquarePlusIcon } from "lucide-react";
+import { AtSignIcon, MessageSquarePlusIcon } from "lucide-react";
 import type { OnMount } from "@monaco-editor/react";
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";
 import { getEmbedRoot } from "@/lib/host";
+import { useChatStore } from "@/store/chatStore";
+import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
 
 // The IStandaloneCodeEditor instance, derived from the onMount signature so we
 // don't deep-import Monaco's types here. The diff editor's getModifiedEditor()
@@ -98,6 +100,12 @@ interface UseMonacoCommentLayerOptions {
   canComment: boolean;
   /** In-progress comment body; clicking away won't clear an active draft. */
   pendingBodyRef?: React.RefObject<string>;
+  /**
+   * Workspace-relative path of the file being viewed. When set on a native
+   * coding-agent session, an "Attach to agent" button appears beside "Add
+   * comment" that tags the selected line span into the chat composer.
+   */
+  path?: string;
 }
 
 /**
@@ -114,7 +122,10 @@ export function useMonacoCommentLayer({
   onSetActiveSelection,
   canComment,
   pendingBodyRef,
+  path,
 }: UseMonacoCommentLayerOptions): React.ReactNode {
+  const sessionHarness = useChatStore((s) => s.sessionHarness);
+  const canAttachToAgent = !!path && nativeCodingAgentForHarness(sessionHarness) !== undefined;
   const decorationsRef = useRef<DecorationsCollection | null>(null);
   // Floating "Add comment" button position in viewport coords, or null.
   const [buttonPos, setButtonPos] = useState<{ left: number; top: number } | null>(null);
@@ -272,25 +283,70 @@ export function useMonacoCommentLayer({
     setButtonPos(null);
   }, [editorRef]);
 
+  // Tag the selected line span into the chat composer. Monaco gives line
+  // numbers directly; a selection ending at column 1 of a line means the last
+  // line's content isn't included, so step back a line in that case.
+  const handleAttachToAgent = useCallback(() => {
+    const ed = editorRef.current;
+    const sel = ed?.getSelection();
+    if (!ed || !sel || sel.isEmpty() || !path) return;
+    const start = sel.getStartPosition();
+    const end = sel.getEndPosition();
+    const endLine = end.column === 1 && end.lineNumber > start.lineNumber ? end.lineNumber - 1 : end.lineNumber;
+    useChatStore.getState().addComposerAttachment({
+      path,
+      isDir: false,
+      lineRange: { start: start.lineNumber, end: endLine },
+    });
+    setButtonPos(null);
+  }, [editorRef, path]);
+
   if (!buttonPos) return null;
   // Rendered into document.body so ancestor CSS transforms don't break fixed
   // positioning.
   return createPortal(
-    <button
-      data-add-comment-btn
-      type="button"
-      // preventDefault on mousedown keeps the editor selection live so
-      // handleAddComment can read it.
-      onMouseDown={(e) => {
-        e.preventDefault();
-        handleAddComment();
+    <div
+      className="fixed z-50 flex items-center gap-1"
+      style={{
+        // Clamp so the (one- or two-) button group can't clip off the right
+        // edge near the viewport boundary (mirrors CodeViewer's clamp).
+        left: Math.min(
+          buttonPos.left,
+          Math.max(8, window.innerWidth - (canAttachToAgent ? 288 : 138)),
+        ),
+        top: buttonPos.top,
+        transform: "translateY(-100%)",
       }}
-      className="fixed z-50 flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
-      style={{ left: buttonPos.left, top: buttonPos.top, transform: "translateY(-100%)" }}
     >
-      <MessageSquarePlusIcon className="size-3.5" />
-      Add comment
-    </button>,
+      <button
+        data-add-comment-btn
+        type="button"
+        // preventDefault on mousedown keeps the editor selection live so
+        // handleAddComment can read it.
+        onMouseDown={(e) => {
+          e.preventDefault();
+          handleAddComment();
+        }}
+        className="flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+      >
+        <MessageSquarePlusIcon className="size-3.5" />
+        Add comment
+      </button>
+      {canAttachToAgent && (
+        <button
+          data-attach-agent-btn
+          type="button"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            handleAttachToAgent();
+          }}
+          className="flex items-center gap-1.5 rounded-md border border-border bg-popover backdrop-blur-xl backdrop-saturate-150 px-2.5 py-1 text-xs font-medium text-foreground shadow-md hover:bg-secondary transition-colors"
+        >
+          <AtSignIcon className="size-3.5" />
+          Attach to agent
+        </button>
+      )}
+    </div>,
     getEmbedRoot() ?? document.body,
   );
 }

--- a/web/src/shell/useMonacoCommentLayer.tsx
+++ b/web/src/shell/useMonacoCommentLayer.tsx
@@ -292,7 +292,8 @@ export function useMonacoCommentLayer({
     if (!ed || !sel || sel.isEmpty() || !path) return;
     const start = sel.getStartPosition();
     const end = sel.getEndPosition();
-    const endLine = end.column === 1 && end.lineNumber > start.lineNumber ? end.lineNumber - 1 : end.lineNumber;
+    const endLine =
+      end.column === 1 && end.lineNumber > start.lineNumber ? end.lineNumber - 1 : end.lineNumber;
     useChatStore.getState().addComposerAttachment({
       path,
       isDir: false,

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -171,6 +171,30 @@ export interface StashedPending {
   committedTexts: string[];
 }
 
+/**
+ * A workspace path queued for the composer's "@"-mention chips. ``isDir``
+ * marks a folder (delivered with a trailing ``/``); ``lineRange`` marks a
+ * specific span of a file (delivered as ``path:start-end``), e.g. from the
+ * file viewer's "Attach to agent" button.
+ */
+export interface ComposerAttachment {
+  path: string;
+  isDir: boolean;
+  lineRange?: { start: number; end: number };
+}
+
+/**
+ * Identity key for a composer attachment, used to dedup the queue and the
+ * drained chips. Keyed on path + dir-ness + line range (not path alone) so a
+ * whole-file attach and a partial-line attach of the same file — or two
+ * distinct line ranges from the file viewer — remain separate, while an exact
+ * re-attach is collapsed. The single source of truth for "same attachment?"
+ * across the store queue, the drain effect, and ``attachMention``.
+ */
+export function composerAttachmentKey(a: ComposerAttachment): string {
+  return `${a.path}|${a.isDir}|${a.lineRange ? `${a.lineRange.start}-${a.lineRange.end}` : ""}`;
+}
+
 export interface ChatState {
   // Reactive — subscribed to by UI components.
   conversationId: string | null;
@@ -338,6 +362,13 @@ export interface ChatState {
   oldestItemId: string | null;
   /** Bubble that should pulse briefly (highlight on nav jump). */
   flashItemId: string | null;
+  /**
+   * Workspace files/folders queued to drop into the active composer's
+   * "@"-mention chips from outside the composer — e.g. the file viewer's
+   * "Attach to agent" button, which lives far from the composer in the tree.
+   * The composer drains this on change and clears it.
+   */
+  pendingComposerAttachments: ComposerAttachment[];
   /**
    * LLM model identifier from the bound agent's spec for the active
    * session, e.g. ``"anthropic/claude-sonnet-4-6"``. Populated from
@@ -518,6 +549,10 @@ export interface ChatState {
   loadMoreHistory: () => Promise<void>;
   /** Flash a bubble briefly; rapid calls reschedule so the latest target wins. */
   flashUserMessage: (itemId: string) => void;
+  /** Queue an "@"-mention chip into the active composer from outside it. */
+  addComposerAttachment: (attachment: ComposerAttachment) => void;
+  /** Drain the queued composer attachments (called by the composer). */
+  clearPendingComposerAttachments: () => void;
   /**
    * Compact the active session's context. Posts a ``compact`` event to the
    * server, which summarises the conversation history in-place. No-ops when
@@ -719,6 +754,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadingMoreHistory: false,
   oldestItemId: null,
   flashItemId: null,
+  pendingComposerAttachments: [],
   llmModel: null,
   sessionHarness: null,
   subAgentName: null,
@@ -1212,6 +1248,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
         codexModelOptions: [],
         terminalPending: false,
         viewers: [],
+        // Drop any queued "Attach to agent" chip that the outgoing session's
+        // composer hadn't drained yet, so it can't bleed into the incoming
+        // session's composer (which drains the store on mount). Same reset
+        // discipline as ``viewers`` above.
+        pendingComposerAttachments: [],
         sandboxStatus: null,
         abortController: null,
         historyGeneration: s.historyGeneration + 1,
@@ -1280,6 +1321,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
       set({ flashItemId: null });
     }, FLASH_DURATION_MS);
   },
+
+  addComposerAttachment: (attachment) => {
+    set((s) => {
+      const k = composerAttachmentKey(attachment);
+      if (s.pendingComposerAttachments.some((a) => composerAttachmentKey(a) === k)) return s;
+      return { pendingComposerAttachments: [...s.pendingComposerAttachments, attachment] };
+    });
+  },
+
+  clearPendingComposerAttachments: () => set({ pendingComposerAttachments: [] }),
 
   compact: async () => {
     const { conversationId } = get();


### PR DESCRIPTION
Closes #1037

## Summary

Adds a way to point native coding agents (Claude Code, Codex, Cursor, Pi) at
specific workspace files, folders, or line ranges from the web UI. Native
sessions run the vendor CLI directly in the workspace, so attachments are
delivered as a lightweight `[Attached: <path>]` text marker the CLI reads from
disk — no upload, full fidelity.

## What's included

Three coordinated entry points, all producing the same marker:

1. **`@`-mention in the in-session composer** — type `@` to drill through the
   workspace one directory at a time; attach a file or a whole folder. Filtered
   as you type, keyboard-navigable (↑/↓ wrap, Enter drills, Tab attaches, Esc
   closes), with removable chips.
2. **`@`-mention in the new-session launcher** (`NewChatDialog`) — the same
   browser *before* a session exists, backed by the host-filesystem endpoint, so
   the first message can carry attachments.
3. **"Attach to agent" in the file/diff viewer** — select a line span in the
   Shiki or Monaco viewer and queue `[Attached: <path>:start-end]` into the
   composer.

## Notes

- Paths are workspace-relative; marker wording is harness-aware (Codex emits
  `[Attached file: …]`).
- Scoped to native terminal harnesses — in-process SDK sessions don't read these
  markers and don't show the UI.
- Shared pure helpers (`detectMentionAt` / `mentionMarkerFor` / path
  serialization) live in `lib/composerMentions.ts` so the composer, launcher,
  and viewer behave identically.
- The launcher requires a non-empty message (no attachments-only first send),
  unlike the in-session composer — flagged for a conscious call.

## Testing

- `tsc -b` clean; full `ap-web` suite green (2919 passing).
- New coverage: in-session `@`-menu (keyboard nav, drill, dedup, chip removal,
  marker delivery), launcher `@`-menu (gate, drill-down, relative-path marker
  contract, folder attach, chip removal), and the shared pure helpers.
