### PR TITLE
feat(server): serve the Web UI + API under a configurable base path (#1031)

### DIFF
--- a/ap-web/src/components/PermissionsModal.tsx
+++ b/ap-web/src/components/PermissionsModal.tsx
@@ -41,6 +41,7 @@ import {
   useRevokePermission,
 } from "@/hooks/usePermissions";
 import { useUserSearch } from "@/hooks/useUserSearch";
+import { withBasePath } from "@/lib/basePath";
 import { getOmnigentTransformShareLink, getOmnigentUserSearch } from "@/lib/host";
 import { useRebasePath } from "@/lib/routing";
 import { cn } from "@/lib/utils";
@@ -384,7 +385,10 @@ function AddUserCombobox({ value, onChange }: AddUserFieldProps) {
 function getShareableLink(sessionId: string, rebasePath: (path: string) => string): string {
   const path = rebasePath(`/c/${sessionId}`);
   const transform = getOmnigentTransformShareLink();
-  return transform ? transform(path) : `${window.location.origin}${path}`;
+  // Standalone: `rebasePath` is identity, so apply the deployment base path
+  // (e.g. `/proxy/6767`) before prepending the origin. The embed supplies its
+  // own `transform`, which already includes the host mount path.
+  return transform ? transform(path) : `${window.location.origin}${withBasePath(path)}`;
 }
 
 function CopyLinkButton({ sessionId }: { sessionId: string }) {

--- a/ap-web/src/lib/accountsApi.test.ts
+++ b/ap-web/src/lib/accountsApi.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getMe, login, logout } from "./accountsApi";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.__OMNIGENT_BASE_PATH__;
+});
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, status: ok ? 200 : 401, json: async () => body } as unknown as Response;
+}
+
+describe("accountsApi base path", () => {
+  it("prefixes POST /auth/login", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ user: { id: "u1", is_admin: false }, token: "t", expires_in: 1 }),
+    );
+    await login({ username: "a", password: "b" });
+    expect(fetchMock.mock.calls[0][0]).toBe("/proxy/6767/auth/login");
+  });
+
+  it("prefixes POST /auth/logout", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(null));
+    await logout();
+    expect(fetchMock.mock.calls[0][0]).toBe("/proxy/6767/auth/logout");
+  });
+
+  it("prefixes GET /auth/me", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: "u1", is_admin: false }));
+    await getMe();
+    expect(fetchMock.mock.calls[0][0]).toBe("/proxy/6767/auth/me");
+  });
+});

--- a/ap-web/src/lib/accountsApi.ts
+++ b/ap-web/src/lib/accountsApi.ts
@@ -16,6 +16,8 @@
  * without try/catch every call site.
  */
 
+import { withBasePath } from "./basePath";
+
 /** Body of POST /auth/login. */
 export interface LoginRequest {
   username: string;
@@ -60,7 +62,7 @@ export interface CurrentAccount {
 export async function login(body: LoginRequest): Promise<LoginResult> {
   let res: Response;
   try {
-    res = await fetch("/auth/login", {
+    res = await fetch(withBasePath("/auth/login"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -107,7 +109,7 @@ export async function login(body: LoginRequest): Promise<LoginResult> {
  */
 export async function logout(): Promise<void> {
   try {
-    await fetch("/auth/logout", { method: "POST" });
+    await fetch(withBasePath("/auth/logout"), { method: "POST" });
   } catch {
     // Network error — the cookie is still in the browser, but the
     // next authenticated request will 401 and bounce to login.
@@ -128,7 +130,7 @@ export async function logout(): Promise<void> {
 export async function getMe(): Promise<CurrentAccount | null> {
   let res: Response;
   try {
-    res = await fetch("/auth/me", { cache: "no-store" });
+    res = await fetch(withBasePath("/auth/me"), { cache: "no-store" });
   } catch {
     return null;
   }
@@ -154,7 +156,7 @@ export interface RegisterRequest {
 export async function register(body: RegisterRequest): Promise<LoginResult> {
   let res: Response;
   try {
-    res = await fetch("/auth/register", {
+    res = await fetch(withBasePath("/auth/register"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -207,7 +209,7 @@ export type ChangePasswordResult = { ok: true } | { ok: false; error: string };
 export async function changePassword(body: ChangePasswordRequest): Promise<ChangePasswordResult> {
   let res: Response;
   try {
-    res = await fetch("/auth/users/me/password", {
+    res = await fetch(withBasePath("/auth/users/me/password"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -248,7 +250,7 @@ export interface SetupRequest {
 export async function setup(body: SetupRequest): Promise<LoginResult> {
   let res: Response;
   try {
-    res = await fetch("/auth/setup", {
+    res = await fetch(withBasePath("/auth/setup"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -364,7 +366,7 @@ async function _admin<T extends { ok: true }>(
 export async function listUsers(): Promise<AccountListEntry[] | null> {
   let res: Response;
   try {
-    res = await fetch("/auth/users", { cache: "no-store" });
+    res = await fetch(withBasePath("/auth/users"), { cache: "no-store" });
   } catch {
     return null;
   }
@@ -383,7 +385,7 @@ export async function listUsers(): Promise<AccountListEntry[] | null> {
 export async function createInvite(isAdmin: boolean): Promise<InviteCreated | AdminFailure> {
   return _admin<InviteCreated>(
     () =>
-      fetch("/auth/invite", {
+      fetch(withBasePath("/auth/invite"), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ is_admin: isAdmin }),
@@ -415,7 +417,7 @@ export async function createInvite(isAdmin: boolean): Promise<InviteCreated | Ad
 export async function deleteUser(userId: string): Promise<{ ok: true } | AdminFailure> {
   let res: Response;
   try {
-    res = await fetch(`/auth/users/${encodeURIComponent(userId)}`, {
+    res = await fetch(withBasePath(`/auth/users/${encodeURIComponent(userId)}`), {
       method: "DELETE",
     });
   } catch {
@@ -441,7 +443,7 @@ export async function deleteUser(userId: string): Promise<{ ok: true } | AdminFa
 export async function resetUserPassword(userId: string): Promise<PasswordReset | AdminFailure> {
   return _admin<PasswordReset>(
     () =>
-      fetch(`/auth/users/${encodeURIComponent(userId)}/reset`, {
+      fetch(withBasePath(`/auth/users/${encodeURIComponent(userId)}/reset`), {
         method: "POST",
       }),
     (body) => {

--- a/ap-web/src/lib/basePath.test.ts
+++ b/ap-web/src/lib/basePath.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getBasePath, stripBasePath, withBasePath } from "./basePath";
+
+declare global {
+  interface Window {
+    __OMNIGENT_BASE_PATH__?: string;
+  }
+}
+
+afterEach(() => {
+  delete window.__OMNIGENT_BASE_PATH__;
+});
+
+function setBase(value: string | undefined): void {
+  if (value === undefined) {
+    delete window.__OMNIGENT_BASE_PATH__;
+  } else {
+    window.__OMNIGENT_BASE_PATH__ = value;
+  }
+}
+
+describe("getBasePath", () => {
+  it("returns empty string when unset", () => {
+    setBase(undefined);
+    expect(getBasePath()).toBe("");
+  });
+
+  it("treats empty string and bare slash as root (empty)", () => {
+    setBase("");
+    expect(getBasePath()).toBe("");
+    setBase("/");
+    expect(getBasePath()).toBe("");
+  });
+
+  it("returns a normalized leading-slash, no-trailing-slash path", () => {
+    setBase("/proxy/6767");
+    expect(getBasePath()).toBe("/proxy/6767");
+  });
+
+  it("strips a trailing slash", () => {
+    setBase("/proxy/6767/");
+    expect(getBasePath()).toBe("/proxy/6767");
+  });
+
+  it("adds a missing leading slash", () => {
+    setBase("proxy/6767");
+    expect(getBasePath()).toBe("/proxy/6767");
+  });
+
+  it("trims surrounding whitespace", () => {
+    setBase("  /proxy/6767  ");
+    expect(getBasePath()).toBe("/proxy/6767");
+  });
+});
+
+describe("withBasePath", () => {
+  it("returns the path unchanged when no base is set", () => {
+    setBase(undefined);
+    expect(withBasePath("/v1/sessions")).toBe("/v1/sessions");
+  });
+
+  it("prepends the base to an app-absolute path", () => {
+    setBase("/proxy/6767");
+    expect(withBasePath("/v1/sessions")).toBe("/proxy/6767/v1/sessions");
+  });
+
+  it("is idempotent for an already-prefixed path", () => {
+    setBase("/proxy/6767");
+    expect(withBasePath("/proxy/6767/v1/sessions")).toBe("/proxy/6767/v1/sessions");
+  });
+
+  it("returns the base itself when the path equals the base", () => {
+    setBase("/proxy/6767");
+    expect(withBasePath("/proxy/6767")).toBe("/proxy/6767");
+  });
+
+  it("leaves non-absolute paths (full URLs, blob:) untouched", () => {
+    setBase("/proxy/6767");
+    expect(withBasePath("https://example.com/x")).toBe("https://example.com/x");
+    expect(withBasePath("blob:abc")).toBe("blob:abc");
+  });
+});
+
+describe("stripBasePath", () => {
+  it("returns the pathname unchanged when no base is set", () => {
+    setBase(undefined);
+    expect(stripBasePath("/login")).toBe("/login");
+  });
+
+  it("removes the base prefix from a pathname", () => {
+    setBase("/proxy/6767");
+    expect(stripBasePath("/proxy/6767/login")).toBe("/login");
+  });
+
+  it("returns root when the pathname equals the base", () => {
+    setBase("/proxy/6767");
+    expect(stripBasePath("/proxy/6767")).toBe("/");
+  });
+
+  it("leaves a pathname not under the base untouched", () => {
+    setBase("/proxy/6767");
+    expect(stripBasePath("/login")).toBe("/login");
+  });
+});

--- a/ap-web/src/lib/basePath.ts
+++ b/ap-web/src/lib/basePath.ts
@@ -1,0 +1,68 @@
+/**
+ * Standalone deployment base-path support.
+ *
+ * When the Omnigent server is served behind a reverse proxy at a subpath
+ * (e.g. code-server's port proxy at `/proxy/6767/`), the SPA must prefix
+ * every browser-issued URL — REST/SSE/WebSocket calls, navigation, and
+ * static assets — with that subpath so the proxy routes them to the right
+ * origin. The server injects the configured base path into `index.html` as
+ * `window.__OMNIGENT_BASE_PATH__`; this module reads and applies it.
+ *
+ * Default (unset / root deployment, and all embedded usage) → `getBasePath()`
+ * returns `""` and every helper is an identity, preserving today's behavior.
+ *
+ * The value is read fresh from `window` on each call: it is fixed for the life
+ * of the page in production (set once by the injected script), so re-reading is
+ * negligible, and it keeps the helpers free of module-load caching that would
+ * be awkward to exercise from tests.
+ */
+
+declare global {
+  interface Window {
+    /** Public base path injected by the server, e.g. `"/proxy/6767"`. */
+    __OMNIGENT_BASE_PATH__?: string;
+  }
+}
+
+/**
+ * The normalized base path: a leading-slash, no-trailing-slash string
+ * (`"/proxy/6767"`), or `""` for a root deployment.
+ */
+export function getBasePath(): string {
+  if (typeof window === "undefined") return "";
+  const raw = window.__OMNIGENT_BASE_PATH__;
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "/") return "";
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.replace(/\/+$/, "");
+}
+
+/**
+ * Prepend the base path to an app-absolute path (`/v1/...`, `/auth/...`).
+ *
+ * Idempotent — a path already under the base is returned unchanged — and a
+ * no-op for non-absolute inputs (full URLs, `blob:` URLs) and when no base is
+ * configured.
+ */
+export function withBasePath(path: string): string {
+  const base = getBasePath();
+  if (!base) return path;
+  if (!path.startsWith("/")) return path;
+  if (path === base || path.startsWith(`${base}/`)) return path;
+  return `${base}${path}`;
+}
+
+/**
+ * Remove the base prefix from a `window.location.pathname` for in-app path
+ * comparisons (e.g. "is this the login page?"). Returns `"/"` when the
+ * pathname is exactly the base, and leaves a pathname not under the base
+ * unchanged.
+ */
+export function stripBasePath(pathname: string): string {
+  const base = getBasePath();
+  if (!base) return pathname;
+  if (pathname === base) return "/";
+  if (pathname.startsWith(`${base}/`)) return pathname.slice(base.length);
+  return pathname;
+}

--- a/ap-web/src/lib/host.test.ts
+++ b/ap-web/src/lib/host.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getCliServerUrl, setOmnigentHostConfig } from "./host";
+import { getCliServerUrl, hostFetch, resolveWebSocketUrl, setOmnigentHostConfig } from "./host";
 
 afterEach(() => {
   setOmnigentHostConfig({});
+  delete window.__OMNIGENT_BASE_PATH__;
+  vi.restoreAllMocks();
 });
 
 describe("getCliServerUrl", () => {
@@ -22,5 +24,53 @@ describe("getCliServerUrl", () => {
   it("handles an empty string suffix the same as no suffix", () => {
     setOmnigentHostConfig({ cliServerUrlSuffix: "" });
     expect(getCliServerUrl()).toBe(window.location.origin);
+  });
+
+  it("includes the base path before the suffix when one is configured", () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    setOmnigentHostConfig({ cliServerUrlSuffix: "/api" });
+    expect(getCliServerUrl()).toBe(`${window.location.origin}/proxy/6767/api`);
+  });
+});
+
+describe("hostFetch base path", () => {
+  it("prepends the base path to standalone fetch calls", async () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    await hostFetch("/v1/sessions");
+    expect(fetchSpy).toHaveBeenCalledWith("/proxy/6767/v1/sessions", undefined);
+  });
+
+  it("leaves the path unchanged when no base path is set", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    await hostFetch("/v1/sessions");
+    expect(fetchSpy).toHaveBeenCalledWith("/v1/sessions", undefined);
+  });
+
+  it("passes the un-prefixed path to a host fetcher (host owns rebasing)", async () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    setOmnigentHostConfig({ fetcher });
+    await hostFetch("/v1/sessions");
+    expect(fetcher).toHaveBeenCalledWith("/v1/sessions", undefined);
+  });
+});
+
+describe("resolveWebSocketUrl base path", () => {
+  it("prepends the base path to the WebSocket path", () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    const url = resolveWebSocketUrl("/v1/sessions/updates");
+    const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
+    expect(url).toBe(`${scheme}//${window.location.host}/proxy/6767/v1/sessions/updates`);
+  });
+
+  it("builds a root-relative WebSocket URL when no base path is set", () => {
+    const url = resolveWebSocketUrl("/v1/sessions/updates");
+    const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
+    expect(url).toBe(`${scheme}//${window.location.host}/v1/sessions/updates`);
   });
 });

--- a/ap-web/src/lib/host.ts
+++ b/ap-web/src/lib/host.ts
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { getBasePath, withBasePath } from "./basePath";
+
 /**
  * Embed host integration seam.
  *
@@ -135,9 +137,11 @@ export function getEmbedRoot(): HTMLElement | null {
  */
 export function hostFetch(path: string, init?: RequestInit): Promise<Response> {
   if (_config.fetcher) {
+    // The host owns path rebasing (it proxies onto its own API surface), so
+    // the path is passed through untouched — `withBasePath` is standalone-only.
     return _config.fetcher(path, init);
   }
-  return fetch(path, init);
+  return fetch(withBasePath(path), init);
 }
 
 export function resolveWebSocketUrl(path: string): string {
@@ -145,7 +149,7 @@ export function resolveWebSocketUrl(path: string): string {
     return _config.resolveWebSocketUrl(path);
   }
   const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${scheme}//${window.location.host}${path}`;
+  return `${scheme}//${window.location.host}${withBasePath(path)}`;
 }
 
 /**
@@ -155,5 +159,5 @@ export function resolveWebSocketUrl(path: string): string {
  */
 export function getCliServerUrl(): string {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
-  return origin + (_config.cliServerUrlSuffix ?? "");
+  return origin + getBasePath() + (_config.cliServerUrlSuffix ?? "");
 }

--- a/ap-web/src/lib/identity.test.ts
+++ b/ap-web/src/lib/identity.test.ts
@@ -120,6 +120,61 @@ describe("getCurrentUserId", () => {
   });
 });
 
+describe("resolveIdentity base-path login redirect", () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+    delete window.__OMNIGENT_BASE_PATH__;
+  });
+
+  function mockLocation(pathname: string): void {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname,
+        search: "",
+        href: "",
+        origin: "http://localhost",
+        host: "localhost",
+        protocol: "http:",
+      },
+    });
+  }
+
+  it("redirects to the base-prefixed login URL on 401", async () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    mockLocation("/proxy/6767/c/abc");
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ user_id: null, login_url: "/login" }, { ok: false, status: 401 }),
+    );
+    const { resolveIdentity } = await import("./identity");
+
+    await resolveIdentity();
+
+    expect(window.location.href).toBe(
+      `/proxy/6767/login?return_to=${encodeURIComponent("/proxy/6767/c/abc")}`,
+    );
+  });
+
+  it("does not redirect when already on the base-prefixed login path", async () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    mockLocation("/proxy/6767/login");
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ user_id: null, login_url: "/login" }, { ok: false, status: 401 }),
+    );
+    const { resolveIdentity } = await import("./identity");
+
+    await resolveIdentity();
+
+    expect(window.location.href).toBe("");
+  });
+});
+
 describe("authenticatedFetch", () => {
   it("injects X-Forwarded-Email header once the identity is resolved", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({ user_id: "alice" }));

--- a/ap-web/src/lib/identity.ts
+++ b/ap-web/src/lib/identity.ts
@@ -15,6 +15,7 @@
  * into a login redirect.
  */
 
+import { stripBasePath, withBasePath } from "./basePath";
 import { getCachedServerInfo } from "./capabilities";
 import { getOmnigentHostConfig, hostFetch } from "./host";
 
@@ -45,7 +46,10 @@ let _serverLoginUrl: string | null = null;
  * every mode.
  */
 function _isOnLoginPath(): boolean {
-  const path = window.location.pathname;
+  // Compare against base-relative paths so the guard still recognizes the
+  // login/register pages when the app is served under a subpath proxy
+  // (e.g. `/proxy/6767/login`).
+  const path = stripBasePath(window.location.pathname);
   return path === "/login" || path === "/register" || path.startsWith("/auth/login");
 }
 
@@ -78,7 +82,7 @@ export async function resolveIdentity(): Promise<string | null> {
               const returnTo = encodeURIComponent(
                 window.location.pathname + window.location.search,
               );
-              window.location.href = `${data.login_url}?return_to=${returnTo}`;
+              window.location.href = `${withBasePath(data.login_url)}?return_to=${returnTo}`;
               return null;
             }
           }
@@ -171,7 +175,7 @@ export async function authenticatedFetch(
     // fallback for the brief window before capabilities resolves.)
     const loginUrl = getCachedServerInfo()?.login_url ?? _serverLoginUrl;
     if (loginUrl) {
-      window.location.href = `${loginUrl}?return_to=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+      window.location.href = `${withBasePath(loginUrl)}?return_to=${encodeURIComponent(window.location.pathname + window.location.search)}`;
     }
   }
   return res;

--- a/ap-web/src/lib/lastAssistantText.test.ts
+++ b/ap-web/src/lib/lastAssistantText.test.ts
@@ -106,4 +106,16 @@ describe("fetchLastAssistantText", () => {
     fetchMock.mockRejectedValue(new Error("network"));
     expect(await fetchLastAssistantText("conv_a")).toBeUndefined();
   });
+
+  it("prefixes the items endpoint with the configured base path", async () => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+    try {
+      fetchMock.mockResolvedValue(okResponse([]));
+      await fetchLastAssistantText("conv_a");
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain("/proxy/6767/v1/sessions/conv_a/items");
+    } finally {
+      delete window.__OMNIGENT_BASE_PATH__;
+    }
+  });
 });

--- a/ap-web/src/lib/lastAssistantText.ts
+++ b/ap-web/src/lib/lastAssistantText.ts
@@ -13,6 +13,8 @@
 // unexpected wire shape all resolve to `undefined`, and the caller falls back
 // to the generic body. This module never takes down the notification path.
 
+import { hostFetch } from "./host";
+
 /**
  * How many trailing items to scan for the last assistant message. A turn
  * usually ends on the assistant's final message, but it may be followed by a
@@ -104,7 +106,9 @@ export async function fetchLastAssistantText(
 ): Promise<string | undefined> {
   try {
     const params = new URLSearchParams({ limit: String(SCAN_ITEMS), order: "desc" });
-    const res = await fetch(`/v1/sessions/${encodeURIComponent(sessionId)}/items?${params}`);
+    // `hostFetch` applies the deployment base path (e.g. `/proxy/6767`) in
+    // standalone and routes through the embed host transport when embedded.
+    const res = await hostFetch(`/v1/sessions/${encodeURIComponent(sessionId)}/items?${params}`);
     if (!res.ok) return undefined;
     const json = (await res.json()) as { data?: unknown };
     const items = Array.isArray(json.data) ? json.data : [];

--- a/ap-web/src/main.tsx
+++ b/ap-web/src/main.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "./components/theme/ThemeProvider";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { RunnerHealthProvider } from "./hooks/RunnerHealthProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
+import { getBasePath } from "./lib/basePath";
 import { resolveServerInfo, type ServerInfo } from "./lib/capabilities";
 import { CapabilitiesProvider } from "./lib/CapabilitiesContext";
 import { resolveIdentity } from "./lib/identity";
@@ -66,7 +67,7 @@ void _bootProbe.then((info) => {
         <QueryClientProvider client={queryClient}>
           <ThemeProvider>
             <TooltipProvider>
-              <BrowserRouter>
+              <BrowserRouter basename={getBasePath() || undefined}>
                 <SessionUpdatesProvider>
                   <RunnerHealthProvider>
                     <App />

--- a/ap-web/src/pages/LoginPage.test.tsx
+++ b/ap-web/src/pages/LoginPage.test.tsx
@@ -114,3 +114,33 @@ describe("LoginPage sanitizeReturnTo open-redirect defense", () => {
     expect(hrefWrites[0]).not.toContain("evil.com");
   });
 });
+
+describe("LoginPage return_to under a base path", () => {
+  beforeEach(() => {
+    window.__OMNIGENT_BASE_PATH__ = "/proxy/6767";
+  });
+  afterEach(() => {
+    delete window.__OMNIGENT_BASE_PATH__;
+  });
+
+  it("defaults to the base root (not origin root) when no return_to is given", async () => {
+    renderLoginAt("");
+    await waitFor(() => expect(hrefWrites.length).toBeGreaterThan(0));
+    expect(hrefWrites[0]).toBe("/proxy/6767/");
+  });
+
+  it("falls back to the base root for an off-origin return_to", async () => {
+    renderLoginAt("https://evil.com");
+    await waitFor(() => expect(hrefWrites.length).toBeGreaterThan(0));
+    expect(hrefWrites[0]).toBe("/proxy/6767/");
+    expect(hrefWrites[0]).not.toContain("evil.com");
+  });
+
+  it("preserves a legitimate base-prefixed return_to unchanged", async () => {
+    // The captured return_to already carries the base prefix; it must be used
+    // as-is so the post-reload BrowserRouter (basename) matches the route.
+    renderLoginAt("%2Fproxy%2F6767%2Fsessions%2Fabc");
+    await waitFor(() => expect(hrefWrites.length).toBeGreaterThan(0));
+    expect(hrefWrites[0]).toBe("/proxy/6767/sessions/abc");
+  });
+});

--- a/ap-web/src/pages/LoginPage.tsx
+++ b/ap-web/src/pages/LoginPage.tsx
@@ -30,6 +30,7 @@ import { useSearchParams } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { getMe, login as loginRequest } from "@/lib/accountsApi";
+import { withBasePath } from "@/lib/basePath";
 
 const DEFAULT_RETURN_TO = "/";
 const LAST_USERNAME_KEY = "omnigent.lastLoginUsername";
@@ -205,21 +206,24 @@ export function LoginPage() {
  * trusting it.
  */
 function sanitizeReturnTo(raw: string | null): string {
-  if (raw === null || raw === "") return DEFAULT_RETURN_TO;
+  // The default lands the user at the app root under the active base path
+  // (e.g. `/proxy/6767/` behind a subpath proxy), not the origin root.
+  const fallback = withBasePath(DEFAULT_RETURN_TO);
+  if (raw === null || raw === "") return fallback;
   // Must be an absolute path, not protocol-relative (`//host`) or a
   // backslash variant (`/\host`) the URL parser rewrites to one.
   if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) {
-    return DEFAULT_RETURN_TO;
+    return fallback;
   }
   try {
     const resolved = new URL(raw, window.location.origin);
-    if (resolved.origin !== window.location.origin) return DEFAULT_RETURN_TO;
+    if (resolved.origin !== window.location.origin) return fallback;
     // Re-serialize so the sink gets the parser's normalized path, never
     // the raw backslash-laden input.
     return resolved.pathname + resolved.search + resolved.hash;
   } catch {
     // `new URL` throws on malformed input — treat anything unparseable
     // as untrusted and fall back to the safe default.
-    return DEFAULT_RETURN_TO;
+    return fallback;
   }
 }

--- a/ap-web/src/pages/MembersPage.tsx
+++ b/ap-web/src/pages/MembersPage.tsx
@@ -24,6 +24,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "@/lib/routing";
+import { withBasePath } from "@/lib/basePath";
 import { CopyIcon, KeyRoundIcon, RefreshCwIcon, Trash2Icon, UserPlusIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -434,7 +435,11 @@ function CopyableValue({ value }: { value: string }) {
 function rebaseUrl(serverUrl: string): string {
   try {
     const parsed = new URL(serverUrl);
-    return `${window.location.origin}${parsed.pathname}${parsed.search}${parsed.hash}`;
+    // Apply the deployment base path (e.g. `/proxy/6767`) so the invite link
+    // resolves under a subpath proxy. `withBasePath` is idempotent, so a server
+    // that already emits a prefixed path (via OMNIGENT_ACCOUNTS_BASE_URL) is
+    // left unchanged.
+    return `${window.location.origin}${withBasePath(parsed.pathname)}${parsed.search}${parsed.hash}`;
   } catch {
     return serverUrl;
   }

--- a/ap-web/src/pages/RegisterPage.tsx
+++ b/ap-web/src/pages/RegisterPage.tsx
@@ -22,6 +22,7 @@ import { useSearchParams } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { register as registerRequest } from "@/lib/accountsApi";
+import { withBasePath } from "@/lib/basePath";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -62,7 +63,7 @@ export function RegisterPage() {
     setSubmitting(true);
     const result = await registerRequest({ invite, username, password });
     if (result.ok) {
-      window.location.href = "/";
+      window.location.href = withBasePath("/");
       return;
     }
     setSubmitting(false);

--- a/ap-web/src/pages/SetupPage.tsx
+++ b/ap-web/src/pages/SetupPage.tsx
@@ -26,6 +26,7 @@ import { useEffect, useState, type FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { setup as setupRequest } from "@/lib/accountsApi";
+import { withBasePath } from "@/lib/basePath";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -59,13 +60,13 @@ export function SetupPage() {
     const result = await setupRequest({ username, password });
     if (result.ok) {
       // Hard-navigate so identity.ts re-runs against the new session.
-      window.location.href = "/";
+      window.location.href = withBasePath("/");
       return;
     }
     setSubmitting(false);
     // A 409 means someone else just claimed the admin — send them to login.
     if (result.status === 409) {
-      window.location.href = "/login";
+      window.location.href = withBasePath("/login");
       return;
     }
     setError(result.error);

--- a/ap-web/src/shell/AccountMenu.tsx
+++ b/ap-web/src/shell/AccountMenu.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { changePassword, type CurrentAccount, getMe, logout } from "@/lib/accountsApi";
+import { withBasePath } from "@/lib/basePath";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 
 export function AccountMenu() {
@@ -80,7 +81,7 @@ export function AccountMenu() {
   const onSignOut = useCallback(async () => {
     await logout();
     // Hard navigation so the chat store / react-query cache reset.
-    window.location.href = "/login";
+    window.location.href = withBasePath("/login");
   }, []);
 
   const resetPwForm = useCallback(() => {

--- a/ap-web/vite.config.ts
+++ b/ap-web/vite.config.ts
@@ -123,7 +123,14 @@ if (useAuth) {
 
 const proxyConfig = createProxyConfig(OMNIGENT_URL, useAuth);
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // Relative asset base for production builds so the SPA can be served under
+  // any path prefix (e.g. code-server's `/proxy/6767/`): dynamic code-split
+  // chunks and the Monaco worker then resolve relative to `import.meta.url`
+  // instead of a hardcoded `/assets/...`. The server rewrites the entry/preload
+  // refs in `index.html` to absolute `{base}/assets/...` at serve time (see
+  // `_rewrite_web_ui_index`). Dev (`vite serve`) stays at root.
+  base: command === "build" ? "./" : "/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -160,4 +167,4 @@ export default defineConfig({
     outDir: path.resolve(__dirname, "../omnigent/server/static/web-ui"),
     emptyOutDir: true,
   },
-});
+}));

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -179,6 +179,38 @@ accept over HTTPS. Three options:
    from the host). Examples: AWS ALB with ACM cert, Cloudflare in
    "Full" SSL mode, Fly.io / Cloud Run / Render platform certs.
 
+## Serving under a subpath (`OMNIGENT_WEB_BASE_PATH`)
+
+By default the Web UI is served from the origin root (`/`). To serve it
+under a path prefix instead — e.g. behind code-server's port proxy at
+`https://<host>/proxy/6767/`, or an nginx/Traefik `location /omnigent/`
+block — set the base path:
+
+```bash
+OMNIGENT_WEB_BASE_PATH=/proxy/6767 omnigent server
+# or, equivalently:
+omnigent server --base-path /proxy/6767
+```
+
+The Web UI then prefixes its API, SSE, WebSocket, and asset URLs with that
+path, and the server accepts requests **whether or not** the proxy forwards
+the prefix. That covers both code-server modes from one value:
+
+- **`/proxy/<port>/`** strips the prefix before forwarding — the server sees
+  `/v1/...` and serves it.
+- **`/absproxy/<port>/`** (and plain non-rewriting proxies) forward the full
+  `/proxy/6767/v1/...` — the server strips the configured prefix before
+  routing.
+
+Notes:
+- Leading slash, no trailing slash (`/proxy/6767`). Empty/unset = root
+  deployment (unchanged).
+- The root deployment (`http://localhost:6767/`) is unaffected.
+- For accounts/OIDC login behind a subpath, also set
+  `OMNIGENT_ACCOUNTS_BASE_URL` to the full public URL including the prefix
+  (e.g. `https://<host>/proxy/6767`) so login/invite redirects and cookies
+  resolve correctly.
+
 ## Header-proxy mode (for deploys behind an existing SSO proxy)
 
 If you already have oauth2-proxy, Databricks Apps, AWS ALB OIDC,

--- a/docs/superpowers/specs/2026-06-23-web-ui-base-path-design.md
+++ b/docs/superpowers/specs/2026-06-23-web-ui-base-path-design.md
@@ -1,0 +1,135 @@
+# Web UI base-path support (issue #1031)
+
+**Date:** 2026-06-23
+**Issue:** [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) — Support serving the standalone Web UI under a subpath, e.g. code-server `/proxy/<port>/`.
+
+## Problem
+
+The standalone Omnigent Web UI assumes it is served from the origin root (`/`).
+When a reverse proxy exposes the server under a path prefix — most notably
+code-server's port proxy at `/proxy/<port>/` or `/absproxy/<port>/` — the SPA
+loads but its API, SSE, and WebSocket calls target root-relative paths
+(`/v1/...`), which the browser resolves against the proxy host root instead of
+the prefixed path. Session loading, live streams, and terminal attach all fail.
+Static assets (especially the ~700 lazily-loaded code-split chunks) also fail to
+resolve under a prefix.
+
+## code-server proxy semantics (the two modes we must support)
+
+- **`/proxy/<port>/` — strips the prefix.** The backend receives `/v1/...`.
+  The app must emit *prefixed* URLs from the browser (so code-server routes to
+  the right port) but the server itself sees root-relative paths.
+- **`/absproxy/<port>/` — does NOT strip.** The backend receives
+  `/absproxy/<port>/v1/...`. The app must be configured with its base path AND
+  the server must accept the prefixed paths.
+
+A generic reverse proxy (nginx/Traefik `location /omnigent/ { proxy_pass ... }`
+without path rewriting) behaves like `/absproxy/`.
+
+## Goal
+
+A single configuration value makes the whole app work behind any of these:
+
+```
+omnigent server --base-path /proxy/6767
+OMNIGENT_WEB_BASE_PATH=/proxy/6767 omnigent server
+```
+
+Acceptance criteria (from the issue):
+- Opening Omnigent at `/proxy/6767/` works in code-server.
+- Session list and chat load; SSE streams connect; terminal WebSocket attaches.
+- Static assets load without the app living at `/`.
+- Root deployment at `http://localhost:6767/` is unchanged.
+
+## Design
+
+One config value (`base_path`), normalized to a leading-slash / no-trailing-slash
+string (`/proxy/6767`); empty default preserves today's root behavior exactly.
+
+### 1. Frontend — apply the base at every network/navigation seam
+
+`ap-web` already funnels **all** HTTP through `hostFetch()` and **all**
+WebSockets through `resolveWebSocketUrl()` (`src/lib/host.ts`). New module
+`src/lib/basePath.ts`:
+
+```ts
+getBasePath(): string          // "" or "/proxy/6767", read once from window.__OMNIGENT_BASE_PATH__
+withBasePath(path): string     // prepend base to an app-absolute path, idempotent
+stripBasePath(pathname): string // remove base prefix for in-app path comparisons
+```
+
+`window.__OMNIGENT_BASE_PATH__` is injected by the server into `index.html`
+(absent in dev / root → `getBasePath()` returns `""`).
+
+Apply points:
+- `host.ts` `hostFetch` (standalone branch only — embed's host fetcher is left
+  untouched) and `resolveWebSocketUrl` prepend the base. This covers the REST
+  API, SSE session stream (fetch-stream), terminal-attach WS, session-updates WS.
+- `accountsApi.ts` `/auth/*` calls and `lastAssistantText.ts` use plain `fetch`
+  (bypassing the choke point) → wrap their paths with `withBasePath`.
+- `main.tsx`: `<BrowserRouter basename={getBasePath() || undefined}>`. react-router
+  then natively rebases every in-app `<Link>` / `navigate()` / `useHref`.
+- `identity.ts`: `_isOnLoginPath()` compares `stripBasePath(pathname)`; login
+  redirects use `withBasePath(login_url)`.
+- Full-page redirects that bypass react-router (`window.location.href = "/login"`
+  etc. in `AccountMenu`, `RegisterPage`, `SetupPage`, `LoginPage` return-to
+  default) → `withBasePath`.
+- Manual absolute-URL builders: share link (`PermissionsModal`), invite link
+  (`MembersPage`), and `getCliServerUrl()` include the base.
+
+### 2. Assets — Vite relative base + server HTML rewrite
+
+The app is heavily code-split (~700 chunks). With `base: "/"` (absolute) Vite
+bakes `/assets/...` into dynamic-chunk URLs, which break under a prefix. Switch
+the **build** to `base: "./"` (relative; dev stays `/`) so dynamic chunks and the
+Monaco worker resolve relative to `import.meta.url` — correct under any prefix.
+
+Relative `./assets/...` in `index.html` would break on deep-link refresh, so the
+**server rewrites `index.html` once at startup**: `src="./` / `href="./` →
+`src="{base}/` / `href="{base}/` (absolute), and injects the
+`window.__OMNIGENT_BASE_PATH__` script. With the default empty base this yields
+absolute `/assets/...` — identical to today's output, so the root deployment is
+unchanged. No `<base href>` tag is used (avoids the SVG `url(#id)` fragment
+gotcha).
+
+### 3. Server — config + base-path-strip ASGI middleware
+
+- **Config:** `base_path` flows from `--base-path` (CLI) / `OMNIGENT_WEB_BASE_PATH`
+  (env) into `create_app()`. Normalized centrally.
+- **`BasePathMiddleware`** (outermost ASGI layer): if an incoming `http`/`websocket`
+  path equals or starts with `{base}`, strip the prefix and set `scope["root_path"]`.
+  This is the single piece that unifies both proxy modes from one config value:
+  - `/proxy/` (strip) → server already sees `/v1/...` → middleware no-ops.
+  - `/absproxy/` or generic non-stripping proxy → server sees `/proxy/6767/v1/...`
+    → middleware strips → normal `/v1` routing.
+  Routing stays defined at `/v1` regardless; no per-router prefixing.
+- **`index.html` serving** (`_SPAStaticFiles`): serve the cached, base-rewritten
+  HTML for `index.html` / SPA-fallback responses.
+
+### 4. CLI / docs
+
+- `--base-path` option on the `omnigent server` command; folds into
+  `OMNIGENT_WEB_BASE_PATH` consumed by `create_app()`.
+- Document the code-server subpath setup in `deploy/` docs.
+
+## Testing
+
+- **Frontend (Vitest):** `basePath.test.ts` (normalize/with/strip incl. idempotency,
+  trailing slash, empty); `host.test.ts` (fetch + ws prefixing when base set, no-op
+  when empty, embed fetcher untouched); identity login-path check under base.
+- **Python (pytest):** `BasePathMiddleware` strips/no-ops/sets root_path for http +
+  websocket; `index.html` rewrite injects base + rewrites asset refs; empty base
+  leaves output byte-identical; assets/API reachable at both `/v1/...` and
+  `/{base}/v1/...` when base is set.
+
+## Out of scope / follow-ups
+
+- Full OIDC-behind-subpath (IdP `redirect_uri` must be the public prefixed URL) is
+  governed by `OMNIGENT_ACCOUNTS_BASE_URL`; documented, not re-plumbed here.
+- Dev server (`vite`) base-path serving — dev runs at root; the existing
+  `OMNIGENT_URL` dev-proxy path handling is unchanged.
+
+## Non-goals
+
+- No change to runner↔server / host↔server URL construction (those already parse
+  a base path from the server URL and connect directly, not through the proxy).

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2800,6 +2800,17 @@ def _assert_server_port_bindable(host: str, port: int) -> None:
         "ignored with a warning if an admin already exists."
     ),
 )
+@click.option(
+    "--base-path",
+    default=None,
+    help=(
+        "Public URL path prefix when serving behind a subpath reverse proxy, "
+        "e.g. --base-path /proxy/6767 for code-server's port proxy "
+        "(alternative to OMNIGENT_WEB_BASE_PATH). The Web UI prefixes its "
+        "API/WebSocket/asset URLs with this, and the server accepts requests "
+        "with or without the prefix. Default: served at the origin root."
+    ),
+)
 @click.pass_context
 def server(
     ctx: click.Context,
@@ -2812,6 +2823,7 @@ def server(
     agent_dirs: tuple[str, ...],
     auto_open: bool,
     admin_password: str | None,
+    base_path: str | None,
 ) -> None:
     """Start the Omnigent server in the foreground, or manage the background server.
 
@@ -2842,6 +2854,10 @@ def server(
         from ``--admin-password``, e.g. ``"hunter2"``. Folded into the
         ``OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD`` env var that
         bootstrap reads; ``None`` leaves the env var untouched.
+    :param base_path: Optional public URL path prefix from
+        ``--base-path``, e.g. ``"/proxy/6767"``. Folded into the
+        ``OMNIGENT_WEB_BASE_PATH`` env var that ``create_app`` reads;
+        ``None`` leaves the env var untouched.
     :returns: None.
     """
     if ctx.invoked_subcommand is not None:
@@ -2861,6 +2877,13 @@ def server(
     # because an admin already exists) is decided in bootstrap_admin.
     if admin_password:
         os.environ.setdefault("OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD", admin_password)
+
+    # --base-path is sugar for OMNIGENT_WEB_BASE_PATH, which create_app reads.
+    # An env var (not a create_app kwarg) so the same toggle reaches every
+    # startup path (Docker entrypoint, canonical local server, e2e harness)
+    # that builds the app outside this command. setdefault → explicit env wins.
+    if base_path:
+        os.environ.setdefault("OMNIGENT_WEB_BASE_PATH", base_path)
 
     # Translate --no-open into the env var the lifespan hook reads.
     # We use an env var rather than threading the flag through

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2025,6 +2025,16 @@ def _apply_web_ui_cache_headers(response: Response, path: str) -> Response:
     return response
 
 
+# URL-path characters safe to splice into both an HTML attribute and a routing
+# prefix without escaping: RFC 3986 unreserved + the path separator + percent
+# (for encoded segments). Anything else — quotes, angle brackets, spaces,
+# backslashes — is rejected so a misconfigured base path can't break out of the
+# index.html it is rewritten into.
+_BASE_PATH_ALLOWED = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~/%"
+)
+
+
 def _normalize_base_path(value: str | None) -> str:
     """
     Normalize a public base path to a leading-slash, no-trailing-slash string.
@@ -2035,6 +2045,8 @@ def _normalize_base_path(value: str | None) -> str:
 
     :param value: Raw base path, e.g. ``"/proxy/6767/"`` or ``"proxy/6767"``.
     :returns: Normalized path (``"/proxy/6767"``) or ``""``.
+    :raises ValueError: If the path contains characters outside the safe
+        URL-path set (it is spliced into ``index.html`` unescaped).
     """
     if not value:
         return ""
@@ -2043,7 +2055,14 @@ def _normalize_base_path(value: str | None) -> str:
         return ""
     if not trimmed.startswith("/"):
         trimmed = f"/{trimmed}"
-    return trimmed.rstrip("/")
+    trimmed = trimmed.rstrip("/")
+    invalid = set(trimmed) - _BASE_PATH_ALLOWED
+    if invalid:
+        raise ValueError(
+            f"Invalid base path {value!r}: only URL path characters "
+            f"(letters, digits, '-._~/%') are allowed, got {sorted(invalid)!r}."
+        )
+    return trimmed
 
 
 def _rewrite_web_ui_index(html: str, base_path: str) -> str:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1,6 +1,8 @@
 """FastAPI application — main entry point for the omnigent server."""
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 import tarfile
@@ -733,6 +735,7 @@ def create_app(
     admins: list[str] | None = None,
     allowed_domains: list[str] | None = None,
     sandbox_config: ManagedSandboxConfig | None = None,
+    base_path: str | None = None,
 ) -> FastAPI:
     """
     Build and return the FastAPI application with all routes mounted.
@@ -790,12 +793,23 @@ def create_app(
         ``host_type="managed"`` create fails with a clear error).
         Managed-host credentials live on the ``hosts`` table, so no
         extra store is wired.
+    :param base_path: Public URL prefix the server is served under by a
+        reverse proxy, e.g. ``"/proxy/6767"`` (code-server port proxy).
+        ``None`` reads ``OMNIGENT_WEB_BASE_PATH``; empty/``"/"`` is a normal
+        root deployment.
     :returns: A fully configured :class:`FastAPI` application.
     :raises ValueError: If ``permission_store`` is provided
         without an ``auth_provider``.
     """
     if permission_store is not None and auth_provider is None:
         raise ValueError("auth_provider is required when permission_store is provided")
+
+    # Public base path for serving behind a subpath reverse proxy (issue
+    # #1031). Falls back to OMNIGENT_WEB_BASE_PATH so Docker/PaaS entrypoints
+    # pick it up without threading a kwarg. Empty → root deployment (default).
+    resolved_base_path = _normalize_base_path(
+        base_path if base_path is not None else os.environ.get("OMNIGENT_WEB_BASE_PATH")
+    )
 
     # First-boot admin bootstrap for the accounts auth provider.
     # Runs before any route is mounted so the login page is never
@@ -1835,7 +1849,7 @@ def create_app(
         app.mount(
             "/",
             _RangeAwareGZipMiddleware(
-                _SPAStaticFiles(directory=web_ui_dist, html=True),
+                _SPAStaticFiles(directory=web_ui_dist, html=True, base_path=resolved_base_path),
                 minimum_size=_WEB_UI_GZIP_MINIMUM_SIZE,
             ),
             name="web-ui",
@@ -1862,6 +1876,13 @@ def create_app(
                 "docs": "/docs",
             }
 
+    if resolved_base_path:
+        # Added last → outermost ASGI layer, so the prefix is stripped before
+        # routing and every other middleware sees canonical `/v1/...` paths.
+        # Only wired when a base path is configured: a root deployment pays no
+        # per-request cost.
+        app.add_middleware(BasePathMiddleware, base_path=resolved_base_path)
+
     return app
 
 
@@ -1880,7 +1901,33 @@ class _SPAStaticFiles(StaticFiles):
     an asset request and a 404 is returned verbatim — that surfaces
     real broken-asset bugs rather than masking them with the HTML
     shell. Extensionless paths fall back to ``index.html``.
+
+    The HTML shell is rebased for the deployment ``base_path`` once at
+    startup (see :func:`_rewrite_web_ui_index`) and served from memory with
+    a content ``etag`` so ``If-None-Match`` revalidation still yields ``304``.
     """
+
+    def __init__(self, *args: Any, base_path: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._index_html: bytes | None = None
+        self._index_etag: str | None = None
+        index_file = Path(self.directory) / "index.html"  # type: ignore[arg-type]
+        if index_file.is_file():
+            html = _rewrite_web_ui_index(index_file.read_text(encoding="utf-8"), base_path)
+            self._index_html = html.encode("utf-8")
+            self._index_etag = f'"{hashlib.md5(self._index_html).hexdigest()}"'
+
+    def _shell_response(self, scope: Scope) -> Response:
+        """Serve the rebased HTML shell from memory, honoring ``If-None-Match``."""
+        assert self._index_html is not None
+        if_none_match = next(
+            (v.decode("latin-1") for k, v in scope.get("headers", []) if k == b"if-none-match"),
+            None,
+        )
+        if self._index_etag is not None and if_none_match == self._index_etag:
+            return Response(status_code=304, headers={"etag": self._index_etag})
+        headers = {"etag": self._index_etag} if self._index_etag else {}
+        return Response(self._index_html, media_type="text/html", headers=headers)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         # The mount is at "/" so it catches *every* unmatched path —
@@ -1897,12 +1944,20 @@ class _SPAStaticFiles(StaticFiles):
 
     async def get_response(self, path: str, scope: Scope) -> Response:  # type: ignore[override]
         served_path = path
+        # The HTML shell (root, directory, or SPA history fallback) is served
+        # from the rebased in-memory copy rather than the file on disk.
+        if self._index_html is not None and path in ("", ".", "index.html"):
+            return _apply_web_ui_cache_headers(self._shell_response(scope), "index.html")
         try:
             response = await super().get_response(path, scope)
         except StarletteHTTPException as exc:
             if exc.status_code == 404 and "." not in path.rsplit("/", 1)[-1]:
                 served_path = "index.html"
-                response = await super().get_response("index.html", scope)
+                response = (
+                    self._shell_response(scope)
+                    if self._index_html is not None
+                    else await super().get_response("index.html", scope)
+                )
             else:
                 raise
         return _apply_web_ui_cache_headers(response, served_path)
@@ -1968,3 +2023,88 @@ def _apply_web_ui_cache_headers(response: Response, path: str) -> Response:
     else:
         response.headers["Cache-Control"] = _WEB_UI_STATIC_CACHE_CONTROL
     return response
+
+
+def _normalize_base_path(value: str | None) -> str:
+    """
+    Normalize a public base path to a leading-slash, no-trailing-slash string.
+
+    Mirrors the frontend's ``getBasePath`` (``ap-web/src/lib/basePath.ts``) so
+    the two agree on the prefix. ``None``, ``""`` and ``"/"`` all map to ``""``
+    (root deployment, today's behavior).
+
+    :param value: Raw base path, e.g. ``"/proxy/6767/"`` or ``"proxy/6767"``.
+    :returns: Normalized path (``"/proxy/6767"``) or ``""``.
+    """
+    if not value:
+        return ""
+    trimmed = value.strip()
+    if trimmed in ("", "/"):
+        return ""
+    if not trimmed.startswith("/"):
+        trimmed = f"/{trimmed}"
+    return trimmed.rstrip("/")
+
+
+def _rewrite_web_ui_index(html: str, base_path: str) -> str:
+    """
+    Rebase the built ``index.html`` for the configured deployment base path.
+
+    The standalone build emits relative asset references (``./assets/...``,
+    ``./favicon.svg``) so dynamic code-split chunks resolve via
+    ``import.meta.url`` under any path prefix. Relative references break on a
+    deep-link refresh, so they are rewritten here to absolute
+    ``{base}/assets/...``. With an empty base this yields root-absolute
+    ``/assets/...`` — byte-identical in spirit to a non-prefixed deployment.
+
+    When a base path is configured, a small inline script publishes it as
+    ``window.__OMNIGENT_BASE_PATH__`` ahead of the entry module so the SPA can
+    prefix its own API/WebSocket/navigation URLs (see ``basePath.ts``).
+
+    :param html: Raw built ``index.html`` contents.
+    :param base_path: Normalized base path (``""`` or ``"/proxy/6767"``).
+    :returns: Rewritten HTML.
+    """
+    rewritten = html.replace('="./', f'="{base_path}/')
+    if base_path:
+        # JSON-encode and neutralize any ``</`` so a hostile base path can't
+        # break out of the inline script element.
+        literal = json.dumps(base_path).replace("</", "<\\/")
+        injection = f"<script>window.__OMNIGENT_BASE_PATH__ = {literal};</script>"
+        rewritten = rewritten.replace("<head>", f"<head>{injection}", 1)
+    return rewritten
+
+
+class BasePathMiddleware:
+    """
+    Strip a configured public base path prefix from incoming request paths.
+
+    Lets one server work whether the reverse proxy forwards the prefix
+    (code-server ``/absproxy/<port>/``, a plain nginx/Traefik subpath) or
+    strips it (code-server ``/proxy/<port>/``): when the prefix is present it
+    is removed so routing matches the canonical ``/v1/...`` paths, and
+    ``root_path`` is set so server-generated URLs stay under the mount. A
+    no-op when no base path is configured, or for a request that does not
+    carry the prefix (the stripping-proxy case).
+
+    :param app: The wrapped ASGI application.
+    :param base_path: Normalized base path (``""`` disables the middleware).
+    """
+
+    def __init__(self, app: ASGIApp, base_path: str) -> None:
+        self.app = app
+        self.base_path = base_path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.base_path and scope["type"] in ("http", "websocket"):
+            path = scope.get("path", "")
+            if path == self.base_path or path.startswith(f"{self.base_path}/"):
+                scope = dict(scope)
+                scope["path"] = path[len(self.base_path) :] or "/"
+                raw_path = scope.get("raw_path")
+                if isinstance(raw_path, (bytes, bytearray)):
+                    prefix = self.base_path.encode()
+                    if raw_path.startswith(prefix):
+                        scope["raw_path"] = raw_path[len(prefix) :] or b"/"
+                scope["root_path"] = self.base_path
+        await self.app(scope, receive, send)

--- a/tests/server/integration/test_base_path.py
+++ b/tests/server/integration/test_base_path.py
@@ -40,6 +40,28 @@ def test_normalize_base_path(raw: str | None, expected: str) -> None:
     assert app_module._normalize_base_path(raw) == expected
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '"/><img src=x onerror=alert(1)>',  # HTML-attribute breakout
+        '/proxy" onload="alert(1)',  # quote breakout
+        "/proxy/6767</script><script>",  # script breakout
+        "/a b",  # space
+        "/a\\b",  # backslash
+    ],
+)
+def test_normalize_base_path_rejects_unsafe_chars(raw: str) -> None:
+    """A base path with non-URL-path characters is rejected loudly, not served."""
+    with pytest.raises(ValueError, match="base path"):
+        app_module._normalize_base_path(raw)
+
+
+@pytest.mark.parametrize("raw", ["/proxy/6767", "/a-b_c.d~e/f%20g", "/v1/app"])
+def test_normalize_base_path_allows_safe_url_chars(raw: str) -> None:
+    """Ordinary URL path characters (incl. percent-encoding) are accepted."""
+    assert app_module._normalize_base_path(raw) == raw
+
+
 def test_rewrite_web_ui_index_absolute_when_no_base() -> None:
     """With no base, relative Vite asset refs become root-absolute and no global is injected."""
     html = (

--- a/tests/server/integration/test_base_path.py
+++ b/tests/server/integration/test_base_path.py
@@ -1,0 +1,268 @@
+"""Tests for serving the Web UI + API under a base-path prefix (issue #1031)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server import app as app_module
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, ""),
+        ("", ""),
+        ("/", ""),
+        ("/proxy/6767", "/proxy/6767"),
+        ("/proxy/6767/", "/proxy/6767"),
+        ("proxy/6767", "/proxy/6767"),
+        ("  /proxy/6767  ", "/proxy/6767"),
+        ("/absproxy/6767//", "/absproxy/6767"),
+    ],
+)
+def test_normalize_base_path(raw: str | None, expected: str) -> None:
+    """The base path is normalized to leading-slash, no-trailing-slash (or '')."""
+    assert app_module._normalize_base_path(raw) == expected
+
+
+def test_rewrite_web_ui_index_absolute_when_no_base() -> None:
+    """With no base, relative Vite asset refs become root-absolute and no global is injected."""
+    html = (
+        '<!doctype html><head><link rel="icon" href="./favicon.svg" />'
+        '<script type="module" src="./assets/index-AbCd1234.js"></script></head>'
+    )
+    out = app_module._rewrite_web_ui_index(html, "")
+    assert 'src="/assets/index-AbCd1234.js"' in out
+    assert 'href="/favicon.svg"' in out
+    assert "./assets/" not in out
+    assert "__OMNIGENT_BASE_PATH__" not in out
+
+
+def test_rewrite_web_ui_index_prefixes_and_injects_with_base() -> None:
+    """With a base, asset refs are prefixed and the base path is injected for the SPA."""
+    html = (
+        "<!doctype html><head>"
+        '<link rel="icon" href="./favicon.svg" />'
+        '<script type="module" src="./assets/index-AbCd1234.js"></script></head>'
+    )
+    out = app_module._rewrite_web_ui_index(html, "/proxy/6767")
+    assert 'src="/proxy/6767/assets/index-AbCd1234.js"' in out
+    assert 'href="/proxy/6767/favicon.svg"' in out
+    assert 'window.__OMNIGENT_BASE_PATH__ = "/proxy/6767"' in out
+    # The injected global must precede the entry module script so it runs first.
+    assert out.index("__OMNIGENT_BASE_PATH__") < out.index("assets/index-AbCd1234.js")
+
+
+# --------------------------------------------------------------------------- #
+# BasePathMiddleware (pure ASGI)
+# --------------------------------------------------------------------------- #
+
+
+async def _run_middleware(base_path: str, scope: dict[str, Any]) -> dict[str, Any]:
+    """Drive BasePathMiddleware over ``scope`` and return the scope the inner app saw."""
+    seen: dict[str, Any] = {}
+
+    async def inner(s: dict[str, Any], receive: Any, send: Any) -> None:
+        seen["path"] = s.get("path")
+        seen["root_path"] = s.get("root_path")
+        seen["raw_path"] = s.get("raw_path")
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request"}
+
+    async def send(_message: dict[str, Any]) -> None:
+        return None
+
+    mw = app_module.BasePathMiddleware(inner, base_path)
+    await mw(scope, receive, send)
+    return seen
+
+
+@pytest.mark.parametrize("scope_type", ["http", "websocket"])
+async def test_base_path_middleware_strips_prefix(scope_type: str) -> None:
+    """A request carrying the prefix is rewritten to the canonical path + root_path."""
+    seen = await _run_middleware(
+        "/proxy/6767",
+        {
+            "type": scope_type,
+            "path": "/proxy/6767/v1/sessions",
+            "raw_path": b"/proxy/6767/v1/sessions",
+        },
+    )
+    assert seen["path"] == "/v1/sessions"
+    assert seen["root_path"] == "/proxy/6767"
+    assert seen["raw_path"] == b"/v1/sessions"
+
+
+async def test_base_path_middleware_maps_bare_prefix_to_root() -> None:
+    """The bare prefix (no trailing slash) maps to '/'."""
+    seen = await _run_middleware(
+        "/proxy/6767", {"type": "http", "path": "/proxy/6767", "raw_path": b"/proxy/6767"}
+    )
+    assert seen["path"] == "/"
+
+
+async def test_base_path_middleware_passes_through_unprefixed_path() -> None:
+    """A path that does NOT carry the prefix (stripping proxy) is left untouched."""
+    seen = await _run_middleware(
+        "/proxy/6767", {"type": "http", "path": "/v1/sessions", "raw_path": b"/v1/sessions"}
+    )
+    assert seen["path"] == "/v1/sessions"
+    assert seen["root_path"] is None
+
+
+async def test_base_path_middleware_does_not_match_partial_segment() -> None:
+    """`/proxy/67670` must not be treated as living under `/proxy/6767`."""
+    seen = await _run_middleware(
+        "/proxy/6767", {"type": "http", "path": "/proxy/67670", "raw_path": b"/proxy/67670"}
+    )
+    assert seen["path"] == "/proxy/67670"
+
+
+async def test_base_path_middleware_noop_without_base() -> None:
+    """With no configured base, the middleware is a pure pass-through."""
+    seen = await _run_middleware(
+        "",
+        {
+            "type": "http",
+            "path": "/proxy/6767/v1/sessions",
+            "raw_path": b"/proxy/6767/v1/sessions",
+        },
+    )
+    assert seen["path"] == "/proxy/6767/v1/sessions"
+    assert seen["root_path"] is None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the real app
+# --------------------------------------------------------------------------- #
+
+
+def _make_web_ui(tmp_path: Path) -> Path:
+    """Write a minimal Vite-style build (relative asset refs) and return its dir."""
+    web_ui_dist = tmp_path / "web-ui"
+    assets_dir = web_ui_dist / "assets"
+    assets_dir.mkdir(parents=True)
+    (web_ui_dist / "index.html").write_text(
+        "<!doctype html><html><head>"
+        '<link rel="icon" href="./favicon.svg" />'
+        '<script type="module" crossorigin src="./assets/index-AbCd1234.js"></script>'
+        "</head><body><div id='root'></div></body></html>"
+    )
+    (assets_dir / "index-AbCd1234.js").write_text("console.log('hi');")
+    (web_ui_dist / "favicon.svg").write_text("<svg/>")
+    return web_ui_dist
+
+
+def _make_app(db_uri: str, tmp_path: Path, base_path: str | None) -> Any:
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return app_module.create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        base_path=base_path,
+    )
+
+
+async def test_web_ui_served_under_base_path(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SPA, its assets, and the API are reachable under the prefixed path."""
+    monkeypatch.setattr(app_module, "_WEB_UI_DIST", _make_web_ui(tmp_path))
+    app = _make_app(db_uri, tmp_path, "/proxy/6767")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        root = await client.get("/proxy/6767/")
+        deep = await client.get("/proxy/6767/c/session_123")
+        asset = await client.get("/proxy/6767/assets/index-AbCd1234.js")
+        favicon = await client.get("/proxy/6767/favicon.svg")
+        info = await client.get("/proxy/6767/v1/info")
+
+    assert root.status_code == 200
+    assert 'window.__OMNIGENT_BASE_PATH__ = "/proxy/6767"' in root.text
+    assert 'src="/proxy/6767/assets/index-AbCd1234.js"' in root.text
+    assert "./assets/" not in root.text
+    # Deep client-route refresh serves the same prefixed shell.
+    assert deep.status_code == 200
+    assert 'src="/proxy/6767/assets/index-AbCd1234.js"' in deep.text
+    assert asset.status_code == 200
+    assert favicon.status_code == 200
+    # The API is reachable through the prefix (middleware strips it before routing).
+    assert info.status_code == 200
+
+
+async def test_unprefixed_paths_still_served_under_base_path(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stripping proxy (code-server /proxy/) delivers unprefixed paths — still served."""
+    monkeypatch.setattr(app_module, "_WEB_UI_DIST", _make_web_ui(tmp_path))
+    app = _make_app(db_uri, tmp_path, "/proxy/6767")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        root = await client.get("/")
+        info = await client.get("/v1/info")
+    assert root.status_code == 200
+    # The shell still advertises the configured base so the SPA prefixes its calls.
+    assert 'window.__OMNIGENT_BASE_PATH__ = "/proxy/6767"' in root.text
+    assert info.status_code == 200
+
+
+async def test_root_deployment_unchanged_without_base_path(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default (no base) serves an absolute-asset shell with no injected global."""
+    monkeypatch.setattr(app_module, "_WEB_UI_DIST", _make_web_ui(tmp_path))
+    app = _make_app(db_uri, tmp_path, None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        root = await client.get("/")
+    assert root.status_code == 200
+    assert 'src="/assets/index-AbCd1234.js"' in root.text
+    assert "./assets/" not in root.text
+    assert "__OMNIGENT_BASE_PATH__" not in root.text
+
+
+async def test_base_path_read_from_env(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no base_path arg is given, OMNIGENT_WEB_BASE_PATH is honored."""
+    monkeypatch.setattr(app_module, "_WEB_UI_DIST", _make_web_ui(tmp_path))
+    monkeypatch.setenv("OMNIGENT_WEB_BASE_PATH", "/absproxy/6767")
+    app = _make_app(db_uri, tmp_path, None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        root = await client.get("/absproxy/6767/")
+    assert root.status_code == 200
+    assert 'window.__OMNIGENT_BASE_PATH__ = "/absproxy/6767"' in root.text


### PR DESCRIPTION
## Summary

Adds first-class **base-path support** so the standalone Web UI + server work when served under a path prefix by a reverse proxy — most notably code-server's port proxy at `https://<host>/proxy/6767/` or `/absproxy/6767/` (the use case in #1031, running Omnigent inside a Coder workspace).

Configure with either:

```bash
omnigent server --base-path /proxy/6767
# or
OMNIGENT_WEB_BASE_PATH=/proxy/6767 omnigent server
```

Empty/unset (the default) leaves the existing root deployment **completely unchanged**.

Closes #1031.

## How it works

One config value handles **both** code-server proxy modes (and plain reverse proxies):

| Proxy | Forwards to server | Handled by |
| --- | --- | --- |
| code-server `/proxy/<port>/` | strips prefix → `/v1/...` | middleware no-ops; frontend prefixes browser-side URLs |
| code-server `/absproxy/<port>/`, nginx/Traefik subpath | keeps prefix → `/proxy/6767/v1/...` | middleware strips the prefix before routing |

### Frontend (`ap-web`)
- New `lib/basePath.ts` reads `window.__OMNIGENT_BASE_PATH__` (injected by the server) and exposes `getBasePath` / `withBasePath` / `stripBasePath`.
- The base is applied at every egress seam: the `hostFetch` + `resolveWebSocketUrl` choke points (REST, SSE session stream, terminal-attach WS, session-updates WS), the `/auth/*` calls, the items fetch (now via `hostFetch`), `<BrowserRouter basename>`, login-path checks + redirects, and the share / invite / CLI-server URL builders.
- **Embed mode is untouched** — the host owns rebasing (`hostFetch` uses the host fetcher; the global is never set there).
- The build now uses a relative base (`base: "./"`) so the ~700 code-split chunks and the Monaco worker resolve via `import.meta.url` under any prefix; dev stays at `/`.

### Server
- `BasePathMiddleware` strips the configured prefix when present (and sets `root_path`), so routing always matches canonical `/v1/...`. Wired only when a base path is set — root deployments pay zero per-request cost.
- The SPA shell is rebased once at startup: relative `./assets/...` → absolute `{base}/assets/...`, with `window.__OMNIGENT_BASE_PATH__` injected ahead of the entry module. Served from memory with a content `etag` (304 revalidation preserved). With an empty base this yields the same absolute `/assets/...` as before.
- `--base-path` on `omnigent server`; `create_app` reads `OMNIGENT_WEB_BASE_PATH`.
- `_normalize_base_path` validates the value and **rejects non-URL-path characters** (fails loud at startup) so a misconfigured base path can't be spliced unescaped into `index.html`.

### Docs
- code-server subpath setup documented in `deploy/docker/README.md`, including the `OMNIGENT_ACCOUNTS_BASE_URL` note for login behind a subpath.

## Testing
- **Frontend (Vitest):** new `basePath.test.ts`; base-path coverage added to `host`, `identity`, `accountsApi`, `lastAssistantText`, and `LoginPage` tests. Full suite green (2985 passed).
- **Python (pytest):** new `tests/server/integration/test_base_path.py` — normalizer (incl. rejection of unsafe chars), HTML rewrite, `BasePathMiddleware` (http + websocket strip / no-op / partial-segment / bare-prefix), and end-to-end through the real app for both proxy modes + the env var. Existing `test_app.py` (etag/304/cache) still green.
- **Live smoke:** started the real server with `--base-path /proxy/6767` against the actual built frontend and verified the injected global, all 24 asset refs rewritten, a real chunk fetch (200), deep-link refresh (200), API through the prefix (200), and the unprefixed strip-proxy path (200).
- Reviewed via an adversarial multi-agent pass; confirmed findings (input validation + a login test gap) are fixed in this PR.

## Out of scope
Full OIDC-behind-subpath (the IdP `redirect_uri` must be the public prefixed URL) is governed by `OMNIGENT_ACCOUNTS_BASE_URL` and documented rather than re-plumbed here.
