### PR TITLE
test(inbox): fix re-park test selector for the remember button (#1033 follow-up)

### DIFF
--- a/tests/e2e_ui/approvals/test_inbox_approval.py
+++ b/tests/e2e_ui/approvals/test_inbox_approval.py
@@ -308,7 +308,12 @@ def test_reparked_elicitation_reliably_resurfaces_in_inbox(
         sink = _park_in_thread(base_url, session_id, eid, workers)
         first = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]')
         expect(first).to_be_visible(timeout=_REPARK_TIMEOUT_MS)
-        first.get_by_role("button", name="Approve").click()
+        # ``exact=True`` is load-bearing: a claude-native Bash prompt also
+        # renders a "Approve & don't ask again for Bash" remember button
+        # (data-testid="approval-card-remember"), so a substring "Approve"
+        # match is ambiguous. We want the plain accept, not the remember
+        # variant (which would set a session-wide auto-approve scope).
+        first.get_by_role("button", name="Approve", exact=True).click()
         _assert_allow(sink, "initial park")
         _settle_after_drain(page, base_url, session_id, rng)
 
@@ -327,11 +332,11 @@ def test_reparked_elicitation_reliably_resurfaces_in_inbox(
             expect(resurfaced).to_have_attribute(
                 "data-state", "pending", timeout=_REPARK_TIMEOUT_MS
             )
-            expect(resurfaced.get_by_role("button", name="Approve")).to_be_visible()
+            expect(resurfaced.get_by_role("button", name="Approve", exact=True)).to_be_visible()
 
             # Approve again (re-arming the stale verdict), then settle so the
             # next retry is a clean 0→1 diff the socket won't coalesce.
-            resurfaced.get_by_role("button", name="Approve").click()
+            resurfaced.get_by_role("button", name="Approve", exact=True).click()
             _assert_allow(sink, f"re-park {cycle}")
             _settle_after_drain(page, base_url, session_id, rng)
     finally:


### PR DESCRIPTION
## What

Follow-up to #1033. The re-park regression test that merged in #1033 is **broken against `main`** and will fail the next nightly E2E UI run. This pins its `Approve` interactions to an exact match.

## Why it's broken

`main`'s `ApprovalCard` renders an extra remember button — `Approve & don't ask again for <tool>` (`data-testid="approval-card-remember"`) — for claude-native permission prompts. The test's `get_by_role("button", name="Approve")` is a **substring** match, so it now resolves to **two** elements (the plain Approve *and* the remember button) → a Playwright strict-mode violation that errors the test before it can assert anything.

## Why #1033's CI didn't catch it

The `e2e-ui.yml` workflow excludes `@pytest.mark.nightly` on `pull_request` events:

```yaml
NIGHTLY_FULL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
MARKER="not visual"; if [[ "$NIGHTLY_FULL" != "true" ]]; then MARKER="$MARKER and not nightly"; fi
```

So this nightly-marked test never ran on the PR — it would first execute (and fail) on the 09:00 UTC scheduled run or a manual `workflow_dispatch`.

## Fix

Pin the three `Approve` interactions to `exact=True` — the plain accept, **not** the remember variant (which would set a session-wide auto-approve scope and change server behavior). The sibling `test_pending_approval_surfaces_and_resolves_in_inbox` is untouched (its policy-driven elicitation has no remember button).

## Verification (against current `main`'s built tree)

- `main` as-is → **fails** (strict-mode selector violation — the merged breakage).
- `main` + this fix → **passes** (`1 passed in 60.63s`).
- `main` + this fix but with the #927 `InboxPage` clearing-effect removed → **fails** (card stuck `data-state="responded"`), confirming it still catches the original regression.
