### PR TITLE
backcompat: only test main vs a released version (drop release×release cells)

### DIFF
--- a/.github/scripts/ci/backcompat-pairwise-matrix.sh
+++ b/.github/scripts/ci/backcompat-pairwise-matrix.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-# Emit the FULL pairwise (server, runner) backwards-compat matrices on
-# $GITHUB_OUTPUT as `e2e_matrix` and `integration_matrix`.
+# Emit the backwards-compat (server, runner) matrices on $GITHUB_OUTPUT as
+# `e2e_matrix` and `integration_matrix`.
 #
-# The version universe is `main` (the checked-out code = client + tests, always)
-# plus every non-rc release tag AT OR ABOVE the backcompat floor (MIN_VERSION,
-# default 0.2.0 — the first release with the mock-LLM e2e infra; see below).
-# We cross every server version with every runner
-# version — each cell pins the server and/or runner subprocess to that build
-# (an empty/"main" value leaves that component on the checked-out code). The
-# (main, main) cell is omitted: it pins nothing and is exactly the normal e2e
-# gate. Integration is the single openai-agents leg (claude-sdk/codex reject the
-# mock LLM's "mock-model" — see integration-matrix.sh), crossed with the pairs.
+# We test `main` (the checked-out code = client + tests, always) against each
+# non-rc release tag AT OR ABOVE the backcompat floor (MIN_VERSION, default
+# 0.2.0 — the first release with the mock-LLM e2e infra; see below), on BOTH
+# axes — and ONLY those cells:
+#   (server=main,      runner=<release>)  — new server vs a previously-shipped runner
+#   (server=<release>, runner=main)       — previously-shipped server vs new runner/client/tests
+# That is the only meaningful cross-version surface. We deliberately do NOT emit
+# release×release cells (both sides already shipped together — covered by that
+# release's own CI, not a compat signal) nor the all-main cell (== the normal
+# e2e gate). So the job count grows linearly (2 per release), not quadratically.
+# Integration is the single openai-agents leg (claude-sdk/codex reject the mock
+# LLM's "mock-model" — see integration-matrix.sh), one per cell.
 #
 # Env in:
 #   VERSIONS    optional comma-separated override of the version set used for
@@ -82,16 +85,17 @@ done
 
 num_shards="${NUM_SHARDS:-4}"
 
-# GitHub caps a matrix at 256 jobs. e2e jobs = (|V|² − [main present]) × shards.
-# If we'd exceed it, drop the OLDEST versions (V is newest-first in auto mode)
-# until under, logging each drop — never silently truncate.
-_pairs() {
+# Cells = 2 per release (both axes) when main is present, else 0 (every cell
+# pairs main with a release). GitHub caps a matrix at 256 jobs; if e2e jobs
+# (cells × shards) would exceed it, drop the OLDEST releases (V is newest-first
+# in auto mode) until under, logging each drop — never silently truncate.
+_cell_count() {
   local n=${#V[@]} mm=0 x
   for x in "${V[@]}"; do [ "$x" = "main" ] && mm=1 && break; done
-  echo "$((n * n - mm))"
+  [ "$mm" = 1 ] && echo "$((2 * (n - 1)))" || echo 0
 }
 max_e2e=256
-while [ "${#V[@]}" -gt 2 ] && [ "$(($(_pairs) * num_shards))" -gt "$max_e2e" ]; do
+while [ "${#V[@]}" -gt 2 ] && [ "$(($(_cell_count) * num_shards))" -gt "$max_e2e" ]; do
   dropped="${V[${#V[@]} - 1]}"
   unset 'V[${#V[@]}-1]'
   V=("${V[@]}")
@@ -108,8 +112,13 @@ e2e_items=()
 integ_items=()
 for s in "${V[@]}"; do
   for r in "${V[@]}"; do
-    # Skip the all-main cell: it pins nothing (== the normal e2e gate).
-    if [ "$s" = "main" ] && [ "$r" = "main" ]; then
+    # Emit iff EXACTLY ONE axis is main: main-vs-release on each direction.
+    # Skips the all-main cell (== the normal e2e gate) and every
+    # release×release cell (both already shipped together — not a
+    # cross-version-compat scenario).
+    s_main=0; [ "$s" = "main" ] && s_main=1
+    r_main=0; [ "$r" = "main" ] && r_main=1
+    if [ "$s_main" = "$r_main" ]; then
       continue
     fi
     integ_items+=("{\"server\":\"$s\",\"runner\":\"$r\",\"harness\":\"$integ_harness\",\"model\":\"$integ_model\",\"workers\":$integ_workers}")


### PR DESCRIPTION
## What
Make the backwards-compat matrix test **only `main` vs a previously-released version**, on both axes — never release×release.

## Why
The matrix was a full pairwise cross-product, so (with the v0.2.0 floor) it still emitted the **`server v0.2.0 / runner v0.2.0`** cell — both sides are already-shipped versions, exercised by that release's own CI. That's not a forward/backward-compat signal; it just burns 4 e2e shards per release.

## How
Emit a cell **iff exactly one axis is `main`**:
- `(server=main, runner=<release>)` — new server vs a previously-shipped runner
- `(server=<release>, runner=main)` — previously-shipped server vs new runner/client/tests

Still skips the all-main cell (== the normal e2e gate). Job count is now **linear (2 cells per release)** instead of quadratic; the 256-job cap-guard counts cells accordingly.

## Validation (local)
- Auto (`main` + `v0.2.0`) → only `(main, v0.2.0)` + `(v0.2.0, main)` — the `v0.2.0/v0.2.0` cell is gone (e2e jobs 12 → 8 at 4 shards).
- Multi-release (`main, v0.2.0, v0.3.0`) → 4 cells, all main-vs-release, **no** release×release.
- No `main` in the set → 0 cells, exit 0 (valid empty matrix).

Follow-up to #1034 (the v0.2.0 floor). Backcompat is dispatch/nightly-only; no PR gates affected.
