### PR TITLE
backcompat: runner waiting-status fix + e2e guard (no 500 on old servers)

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -78,6 +78,63 @@ from omnigent.tools.builtins.load_skill import (
 _logger = logging.getLogger(__name__)
 
 
+# ── session.status "waiting" backwards-compat (new runner ↔ old server) ──
+# The runner emits ``session.status: "waiting"`` when a turn ends with sub-agents
+# still running (PR #930, for the headless ``-p`` fast-exit). Servers older than
+# 0.3.0 don't model "waiting" — their ``SessionResponse.status`` is
+# ``Literal["idle","running","failed"]`` — and 500 on ``GET /v1/sessions`` when
+# they try to serialize the cached value. So the runner probes the server's
+# version once and downgrades "waiting"→"running" for older servers. ``None``
+# until probed; any probe failure leaves it falsey → downgrade (never 500s).
+_WAITING_STATUS_MIN_SERVER_VERSION = "0.3.0"
+_server_supports_waiting_status: bool | None = None
+
+
+def _version_supports_waiting_status(server_version: str) -> bool:
+    """
+    Whether *server_version* can serialize ``session.status: "waiting"``.
+
+    :param server_version: The server's reported version, e.g. ``"0.2.0"`` or
+        ``"0.3.0.dev0"``.
+    :returns: ``True`` iff the server's PEP 440 release tuple is ``>= 0.3.0``
+        (the release that added "waiting" to the session-status model).
+    """
+    from packaging.version import Version
+
+    return Version(server_version).release >= Version(_WAITING_STATUS_MIN_SERVER_VERSION).release
+
+
+async def _ensure_server_waiting_support(server_client: httpx.AsyncClient) -> None:
+    """
+    Probe ``GET /api/version`` once; cache whether the server accepts "waiting".
+
+    Memoized — returns immediately once probed. Degrades to "unsupported" on any
+    error so the runner never emits a status an older server would 500 on.
+
+    :param server_client: The runner's httpx client pointed at the server.
+    """
+    global _server_supports_waiting_status
+    if _server_supports_waiting_status is not None:
+        return
+    try:
+        resp = await server_client.get("/api/version")
+        resp.raise_for_status()
+        version = resp.json()["version"]
+        _server_supports_waiting_status = _version_supports_waiting_status(version)
+        _logger.info(
+            "server version %s: session.status 'waiting' %s",
+            version,
+            "supported" if _server_supports_waiting_status else "downgraded to 'running'",
+        )
+    except Exception as exc:  # noqa: BLE001 — degrade gracefully; never 500 an old server
+        _server_supports_waiting_status = False
+        _logger.warning(
+            "could not probe server /api/version (%s); downgrading session.status "
+            "'waiting'->'running' for safety",
+            exc,
+        )
+
+
 def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
     """
     Log *exc* in full and return a generic detail string safe for clients.
@@ -5354,6 +5411,12 @@ def create_runner_app(
                 },
             )
 
+        # Probe the server's version once so _publish_turn_status can downgrade
+        # session.status "waiting"->"running" for servers too old to accept it
+        # (< 0.3.0) — they'd otherwise 500 on GET /v1/sessions. Memoized; only
+        # the first session-create on this runner pays the cheap GET.
+        await _ensure_server_waiting_support(server_client)
+
         # Resolve the spec once — derive harness config from it and
         # cache it for resource endpoints (filesystem, terminals)
         # that may fire before the first turn dispatches.
@@ -6804,6 +6867,12 @@ def create_runner_app(
             ``None`` for ``running`` / ``idle``.
         :returns: None.
         """
+        # Backwards-compat: servers older than 0.3.0 can't serialize "waiting"
+        # and 500 on GET /v1/sessions, so downgrade it to "running" unless the
+        # server was positively probed as supporting it (see
+        # _ensure_server_waiting_support). None/False → downgrade (safe default).
+        if status == "waiting" and _server_supports_waiting_status is not True:
+            status = "running"
         # An unresolved spec (``_session_harness_name`` → ``None``) means the
         # session hasn't resolved a terminal-backed harness yet, so no native
         # observer is known and the turn lifecycle is still the only status

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -89,11 +89,10 @@ _logger = logging.getLogger(__name__)
 # (``_version_supports_waiting_status``). An unknown version — unprobed or a
 # probe failure — downgrades too, so an old server is never 500'd.
 _WAITING_STATUS_MIN_SERVER_VERSION = "0.3.0"
-# Cached server version from the one-time /api/version probe. ``_probed`` guards
-# the memoization: a failed probe leaves the version ``None`` but still probed,
-# so it is not retried on every session-create.
+# Cached server version from the /api/version probe; ``None`` until a probe
+# succeeds. A failed probe stays ``None`` and is retried on the next
+# session-create — the GET is cheap and self-heals a transient failure.
 _server_version: str | None = None
-_server_version_probed = False
 
 
 def _version_supports_waiting_status(server_version: str) -> bool:
@@ -114,16 +113,16 @@ async def _get_server_version(server_client: httpx.AsyncClient) -> str | None:
     """
     Resolve the server's version via a one-time ``GET /api/version`` probe.
 
-    Memoized — the probe runs at most once per runner; later calls return the
-    cached value. Returns ``None`` if the probe failed, so callers fail safe
+    Memoized once it succeeds: later calls return the cached version. A failed
+    probe returns ``None`` and is retried on the next call, so callers fail safe
     (treat an unknown version as not supporting newer behavior).
 
     :param server_client: The runner's httpx client pointed at the server.
     :returns: The server's reported version (e.g. ``"0.2.0"``), or ``None`` when
-        the probe has not succeeded.
+        the probe has not yet succeeded.
     """
-    global _server_version, _server_version_probed
-    if _server_version_probed:
+    global _server_version
+    if _server_version is not None:
         return _server_version
     try:
         resp = await server_client.get("/api/version")
@@ -131,9 +130,7 @@ async def _get_server_version(server_client: httpx.AsyncClient) -> str | None:
         _server_version = resp.json()["version"]
         _logger.info("resolved server version: %s", _server_version)
     except Exception as exc:  # noqa: BLE001 — degrade gracefully; never 500 an old server
-        _server_version = None
         _logger.warning("could not probe server /api/version (%s); treating as unknown", exc)
-    _server_version_probed = True
     return _server_version
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -83,11 +83,17 @@ _logger = logging.getLogger(__name__)
 # still running (PR #930, for the headless ``-p`` fast-exit). Servers older than
 # 0.3.0 don't model "waiting" — their ``SessionResponse.status`` is
 # ``Literal["idle","running","failed"]`` — and 500 on ``GET /v1/sessions`` when
-# they try to serialize the cached value. So the runner probes the server's
-# version once and downgrades "waiting"→"running" for older servers. ``None``
-# until probed; any probe failure leaves it falsey → downgrade (never 500s).
+# they try to serialize the cached value. So we resolve the server version once
+# (``_get_server_version``) and, when publishing status, downgrade
+# "waiting"→"running" unless that version supports it
+# (``_version_supports_waiting_status``). An unknown version — unprobed or a
+# probe failure — downgrades too, so an old server is never 500'd.
 _WAITING_STATUS_MIN_SERVER_VERSION = "0.3.0"
-_server_supports_waiting_status: bool | None = None
+# Cached server version from the one-time /api/version probe. ``_probed`` guards
+# the memoization: a failed probe leaves the version ``None`` but still probed,
+# so it is not retried on every session-create.
+_server_version: str | None = None
+_server_version_probed = False
 
 
 def _version_supports_waiting_status(server_version: str) -> bool:
@@ -104,35 +110,31 @@ def _version_supports_waiting_status(server_version: str) -> bool:
     return Version(server_version).release >= Version(_WAITING_STATUS_MIN_SERVER_VERSION).release
 
 
-async def _ensure_server_waiting_support(server_client: httpx.AsyncClient) -> None:
+async def _get_server_version(server_client: httpx.AsyncClient) -> str | None:
     """
-    Probe ``GET /api/version`` once; cache whether the server accepts "waiting".
+    Resolve the server's version via a one-time ``GET /api/version`` probe.
 
-    Memoized — returns immediately once probed. Degrades to "unsupported" on any
-    error so the runner never emits a status an older server would 500 on.
+    Memoized — the probe runs at most once per runner; later calls return the
+    cached value. Returns ``None`` if the probe failed, so callers fail safe
+    (treat an unknown version as not supporting newer behavior).
 
     :param server_client: The runner's httpx client pointed at the server.
+    :returns: The server's reported version (e.g. ``"0.2.0"``), or ``None`` when
+        the probe has not succeeded.
     """
-    global _server_supports_waiting_status
-    if _server_supports_waiting_status is not None:
-        return
+    global _server_version, _server_version_probed
+    if _server_version_probed:
+        return _server_version
     try:
         resp = await server_client.get("/api/version")
         resp.raise_for_status()
-        version = resp.json()["version"]
-        _server_supports_waiting_status = _version_supports_waiting_status(version)
-        _logger.info(
-            "server version %s: session.status 'waiting' %s",
-            version,
-            "supported" if _server_supports_waiting_status else "downgraded to 'running'",
-        )
+        _server_version = resp.json()["version"]
+        _logger.info("resolved server version: %s", _server_version)
     except Exception as exc:  # noqa: BLE001 — degrade gracefully; never 500 an old server
-        _server_supports_waiting_status = False
-        _logger.warning(
-            "could not probe server /api/version (%s); downgrading session.status "
-            "'waiting'->'running' for safety",
-            exc,
-        )
+        _server_version = None
+        _logger.warning("could not probe server /api/version (%s); treating as unknown", exc)
+    _server_version_probed = True
+    return _server_version
 
 
 def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
@@ -5411,11 +5413,11 @@ def create_runner_app(
                 },
             )
 
-        # Probe the server's version once so _publish_turn_status can downgrade
+        # Resolve the server version once so _publish_turn_status can downgrade
         # session.status "waiting"->"running" for servers too old to accept it
         # (< 0.3.0) — they'd otherwise 500 on GET /v1/sessions. Memoized; only
         # the first session-create on this runner pays the cheap GET.
-        await _ensure_server_waiting_support(server_client)
+        await _get_server_version(server_client)
 
         # Resolve the spec once — derive harness config from it and
         # cache it for resource endpoints (filesystem, terminals)
@@ -6868,10 +6870,12 @@ def create_runner_app(
         :returns: None.
         """
         # Backwards-compat: servers older than 0.3.0 can't serialize "waiting"
-        # and 500 on GET /v1/sessions, so downgrade it to "running" unless the
-        # server was positively probed as supporting it (see
-        # _ensure_server_waiting_support). None/False → downgrade (safe default).
-        if status == "waiting" and _server_supports_waiting_status is not True:
+        # and 500 on GET /v1/sessions. Downgrade it to "running" unless the
+        # resolved server version supports it; an unknown version (unprobed or
+        # probe failure) downgrades too (safe default). See _get_server_version.
+        if status == "waiting" and not (
+            _server_version is not None and _version_supports_waiting_status(_server_version)
+        ):
             status = "running"
         # An unresolved spec (``_session_harness_name`` → ``None``) means the
         # session hasn't resolved a terminal-backed harness yet, so no native

--- a/tests/e2e/test_waiting_status_compat_e2e.py
+++ b/tests/e2e/test_waiting_status_compat_e2e.py
@@ -45,10 +45,13 @@ from tests.e2e.conftest import (
     send_user_message_to_session,
 )
 
-# Statuses a server may legitimately report. ``"waiting"`` is accepted because a
-# CURRENT server serializes it natively; the guard is the HTTP 200, not the
-# absence of ``"waiting"`` (an old server WITH the runner fix never sees it,
-# because the runner downgrades it to ``"running"`` before publishing).
+# Statuses a GET may legitimately return. The guard is the HTTP 200 (no
+# serialization 500), not the specific status value. In practice GET never
+# returns "waiting": a current server collapses cached "waiting"->"running" when
+# building the response (server ``_session_status_from_cache``), and the runner
+# downgrades "waiting"->"running" for old servers before publishing. "waiting"
+# is kept here only defensively — a server that serialized it natively would
+# also be a valid 200.
 _SERIALIZABLE_STATUSES = {"idle", "running", "failed", "waiting"}
 
 
@@ -146,11 +149,18 @@ def test_runner_does_not_500_old_server_emitting_waiting_status(
         content="Dispatch the researcher sub-agent.",
     )
 
-    # Poll the snapshot across the dispatch + waiting window. The parent runs its
-    # dispatch turn (running), then goes ``waiting`` once the sub-agent is live.
-    # Every response must be 200 with a serializable status — never a 500. Mirror
-    # the suite's poll-with-sleep convention (see poll_session_until_terminal).
+    # Poll the parent snapshot across the dispatch + waiting window. Every GET
+    # must stay 200 (the regression: a pre-0.3.0 server 500s on an un-downgraded
+    # "waiting"). The parent runs its dispatch turn, then — once the sub-agent is
+    # live and its turn ends — enters "waiting"; against an un-fixed old server
+    # that is sustained (auto-wake never lands), so any GET in the window 500s.
+    # Poll the full window (no early break) so that sustained 500 is reliably hit.
+    # Separately confirm the sub-agent actually dispatched (a child session
+    # exists): otherwise an all-200 result is vacuous — a silently-failed dispatch
+    # leaves the parent idle, never entering "waiting", and the test would pass
+    # without ever exercising the regression it guards.
     deadline = time.monotonic() + 30.0
+    dispatched = False
     polls = 0
     while time.monotonic() < deadline:
         resp = http_client.get(f"/v1/sessions/{session_id}")
@@ -163,6 +173,17 @@ def test_runner_does_not_500_old_server_emitting_waiting_status(
         status = resp.json().get("status")
         assert status in _SERIALIZABLE_STATUSES, f"unexpected session status {status!r}"
         polls += 1
+        children = http_client.get(f"/v1/sessions/{session_id}/child_sessions")
+        assert children.status_code == 200, (
+            f"GET child_sessions returned {children.status_code}: {children.text[:200]}"
+        )
+        if children.json().get("data"):
+            dispatched = True
         time.sleep(1.0)
 
     assert polls >= 5, f"expected a sustained poll of the waiting window; got {polls} polls"
+    assert dispatched, (
+        "sub-agent was never dispatched (no child session) during the window — the "
+        "parent never entered 'waiting', so the all-200 result would be vacuous. "
+        "Check the agent / mock-LLM wiring."
+    )

--- a/tests/e2e/test_waiting_status_compat_e2e.py
+++ b/tests/e2e/test_waiting_status_compat_e2e.py
@@ -1,0 +1,168 @@
+"""E2E backward-compat guard: a runner that emits ``session.status: waiting``
+must not 500 an older server.
+
+When a parent turn ends while a dispatched sub-agent is still running, the
+runner publishes ``session.status = "waiting"``. Servers older than 0.3.0 model
+``SessionResponse.status`` as ``Literal["idle", "running", "failed"]`` — there
+is no ``"waiting"`` — so a naive emit raises a Pydantic ``ValidationError`` and
+a 500 on ``GET /v1/sessions/{id}``. The runner's ``/api/version`` gate downgrades
+``"waiting"`` -> ``"running"`` against such servers so the response stays
+serializable.
+
+This test guards that downgrade end to end: it dispatches a sub-agent (forcing
+the parent into the waiting state) and asserts the session stays queryable
+(HTTP 200, never 500) across a sustained poll window. It deliberately does NOT
+assert the sub-agent result surfaces — auto-wake is a server-side feature older
+servers lack, and against such a server the parent sits in the waiting state
+the whole time, which is exactly when the un-downgraded 500 would fire. Only the
+no-500 runner-side guarantee is checked, and that must hold on EVERY server.
+
+This is the regression guard for the runner waiting-status fix, so unlike the
+sub-agent auto-wake tests it is **intentionally NOT** ``min_server_version``-
+marked: it must run against pre-0.3.0 servers (that is the whole point). It
+fails against such a server when the runner does not downgrade (the 500), and
+passes once the runner gates the status — while remaining a trivial pass on a
+current server (which serializes ``"waiting"`` natively).
+
+Excluded from default ``pytest`` runs via ``--ignore=tests/e2e``. Invoke with::
+
+    pytest tests/e2e/test_waiting_status_compat_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+import httpx
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+
+# Statuses a server may legitimately report. ``"waiting"`` is accepted because a
+# CURRENT server serializes it natively; the guard is the HTTP 200, not the
+# absence of ``"waiting"`` (an old server WITH the runner fix never sees it,
+# because the runner downgrades it to ``"running"`` before publishing).
+_SERIALIZABLE_STATUSES = {"idle", "running", "failed", "waiting"}
+
+
+def _sys_session_send_tool_call(agent: str, title: str, child_args: str) -> dict:
+    """Build a ``sys_session_send`` tool_calls entry for the mock LLM queue.
+
+    :param agent: Sub-agent tool name to dispatch, e.g. ``"researcher"``.
+    :param title: Child session title, e.g. ``"probe"``.
+    :param child_args: Free-text task handed to the child, e.g. ``"Investigate"``.
+    :returns: A mock-LLM response dict with a single ``sys_session_send`` call.
+    """
+    return {
+        "call_id": "call_1",
+        "name": "sys_session_send",
+        "arguments": json.dumps({"agent": agent, "title": title, "args": child_args}),
+    }
+
+
+def test_runner_does_not_500_old_server_emitting_waiting_status(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """
+    Dispatching a sub-agent forces ``session.status: waiting`` at parent
+    turn-end; the session must stay queryable (HTTP 200, never 500) — proving
+    the runner downgrades a status the server cannot serialize.
+
+    Does not wait for the sub-agent result (auto-wake is server-gated); it only
+    asserts no 500 occurs across a sustained poll of the waiting window. Against
+    a pre-0.3.0 server the parent sits in ``waiting`` the whole window, so a
+    runner that fails to downgrade would 500 here repeatedly.
+
+    :param http_client: HTTP client pointed at the live server.
+    :param live_runner_id: Registered runner id to bind the session to.
+    :param mock_llm_server_url: Mock LLM base URL (without ``/v1``).
+    """
+    uid = uuid.uuid4().hex[:6]
+    parent_model = f"mock-waitcompat-parent-{uid}"
+    researcher_model = f"mock-waitcompat-researcher-{uid}"
+    mock_base = f"{mock_llm_server_url}/v1"
+
+    reset_mock_llm(mock_llm_server_url)
+
+    parent_name = register_inline_agent(
+        http_client,
+        name=f"waitcompat-parent-{uid}",
+        harness="openai-agents",
+        model=parent_model,
+        profile="",
+        prompt="Dispatch the researcher sub-agent via sys_session_send, then stop.",
+        mock_llm_base_url=mock_base,
+        extra_config={
+            "tools": {
+                "researcher": {
+                    "type": "agent",
+                    "description": "Test-fixture researcher.",
+                    "executor": {
+                        "harness": "openai-agents",
+                        "model": researcher_model,
+                        "auth": {
+                            "type": "api_key",
+                            "api_key": "mock-key",
+                            "base_url": mock_base,
+                        },
+                    },
+                    "prompt": "You are the test-fixture researcher.",
+                },
+            },
+        },
+    )
+
+    # Parent: dispatch the sub-agent, then acknowledge. No auto-wake
+    # continuation is queued — the point is the waiting window, not the result.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {"tool_calls": [_sys_session_send_tool_call("researcher", "probe", "Investigate")]},
+            {"text": "Dispatched researcher."},
+        ],
+        key=parent_model,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Researcher result."}],
+        key=researcher_model,
+    )
+
+    session_id = create_runner_bound_session(
+        http_client, agent_name=parent_name, runner_id=live_runner_id
+    )
+    send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Dispatch the researcher sub-agent.",
+    )
+
+    # Poll the snapshot across the dispatch + waiting window. The parent runs its
+    # dispatch turn (running), then goes ``waiting`` once the sub-agent is live.
+    # Every response must be 200 with a serializable status — never a 500. Mirror
+    # the suite's poll-with-sleep convention (see poll_session_until_terminal).
+    deadline = time.monotonic() + 30.0
+    polls = 0
+    while time.monotonic() < deadline:
+        resp = http_client.get(f"/v1/sessions/{session_id}")
+        assert resp.status_code == 200, (
+            f"GET /v1/sessions/{session_id} returned {resp.status_code} (expected 200) — "
+            f"the server could not serialize the runner's session status. A pre-0.3.0 "
+            f"server 500s on an un-downgraded 'waiting'; the runner must downgrade it. "
+            f"Body: {resp.text[:300]}"
+        )
+        status = resp.json().get("status")
+        assert status in _SERIALIZABLE_STATUSES, f"unexpected session status {status!r}"
+        polls += 1
+        time.sleep(1.0)
+
+    assert polls >= 5, f"expected a sustained poll of the waiting window; got {polls} polls"

--- a/tests/runner/test_waiting_status_compat.py
+++ b/tests/runner/test_waiting_status_compat.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for the runner's session.status "waiting" backwards-compat gate.
+
+The runner emits ``session.status: "waiting"`` (PR #930) only to servers new
+enough to serialize it; older servers (< 0.3.0) 500 on ``GET /v1/sessions``, so
+the runner downgrades "waiting"→"running" for them. Here we test the pure
+version-comparison; the probe + downgrade are exercised end-to-end by the
+backwards-compat smoke (old server + new runner -> no 500).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.runner.app import _version_supports_waiting_status
+
+
+@pytest.mark.parametrize(
+    ("server_version", "expected"),
+    [
+        ("0.2.0", False),  # the released version that 500s on "waiting"
+        ("0.2.5", False),
+        ("0.1.1", False),
+        ("0.3.0", True),  # first release that models "waiting"
+        ("0.3.0.dev0", True),  # main: dev of the supporting release still supports it
+        ("0.3.1", True),
+        ("1.0.0", True),
+    ],
+)
+def test_version_supports_waiting_status(server_version: str, expected: bool) -> None:
+    assert _version_supports_waiting_status(server_version) is expected

--- a/tests/runner/test_waiting_status_compat.py
+++ b/tests/runner/test_waiting_status_compat.py
@@ -4,8 +4,8 @@ Unit tests for the runner's session.status "waiting" backwards-compat gate.
 The runner emits ``session.status: "waiting"`` (PR #930) only to servers new
 enough to serialize it; older servers (< 0.3.0) 500 on ``GET /v1/sessions``, so
 the runner downgrades "waiting"→"running" for them. Here we test the pure
-version-comparison; the probe + downgrade are exercised end-to-end by the
-backwards-compat smoke (old server + new runner -> no 500).
+version-comparison; the probe + downgrade are exercised end-to-end by
+tests/e2e/test_waiting_status_compat_e2e.py (old server + new runner -> no 500).
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ from omnigent.runner.app import _version_supports_waiting_status
         ("0.3.0", True),  # first release that models "waiting"
         ("0.3.0.dev0", True),  # main: dev of the supporting release still supports it
         ("0.3.1", True),
+        ("0.4.0", True),  # later minor: still supports "waiting"
         ("1.0.0", True),
     ],
 )


### PR DESCRIPTION
## What
Fix the runner→old-server **`waiting`-status 500** backward-compat bug, with unit + e2e guards. **Self-contained** (fix + tests in one PR).

## The bug
When a parent turn ends with a sub-agent still running, the runner publishes `session.status = "waiting"`. A server **< 0.3.0** lacks the server-side collapse a current server has — its `SessionResponse.status` is `Literal["idle","running","failed"]` and it tries to serialize the raw cached `"waiting"` → `ValidationError` → **500** on `GET /v1/sessions/{id}`.

(For accuracy: a *current* server does **not** return `"waiting"` either — `_session_status_from_cache` **collapses** cached `"waiting"`→`"running"` when building the response, so GET returns `"running"`. The old server is missing exactly that collapse.)

## The fix (runner)
The runner resolves the server version once (`_get_server_version`, memoized `/api/version` probe; `None`/unknown → fail safe) and, when publishing, **downgrades `waiting`→`running` unless `_version_supports_waiting_status(version)`** — so an old server never receives a status it can't serialize.

## Tests
- **Unit** (`tests/runner/test_waiting_status_compat.py`): 8 parametrized cases over the version gate (0.1.1/0.2.x → downgrade; 0.3.0/0.3.0.dev0/0.4.0/1.0.0 → keep).
- **E2E guard** (`tests/e2e/test_waiting_status_compat_e2e.py`): dispatch a sub-agent to force the `waiting` state, then assert `GET /v1/sessions` stays **200 (never 500)** across the window. It **positively confirms the sub-agent dispatched** (a child session is created) so an all-200 result can't pass vacuously, and polls the full window so a pre-0.3.0 server's sustained-`waiting` 500 is reliably caught. Isolated from auto-wake (doesn't require the result to surface); **not** `min_server_version`-marked — it must run against old servers.

## Validation (local)
- Unit: 8/8.
- E2E guard, full matrix: **main → PASS**; **v0.2.0 without this fix → FAIL (the exact 500)**; **v0.2.0 with this fix → PASS** (dispatch confirmed both passing runs).

No merge-order dependency (fix + guard ship together). Related: #994 carries the `min_server_version` test markers; matrix floor #1034 + pairwise-star already merged.
