### PR TITLE
examples: add Pippa, a two-specialist data analyst

### DIFF
--- a/examples/pippa/README.md
+++ b/examples/pippa/README.md
@@ -1,0 +1,114 @@
+# Pippa — Data Analyst
+
+Pippa is a data analysis orchestrator with two specialist sub-agents. She
+fans every data question out to an **explorer** (structural analysis: schema,
+types, nulls, sample rows — runs on claude-sdk) and a **cruncher**
+(statistical analysis: distributions, aggregations, anomalies, code snippets —
+runs on codex), then assembles a structured data report from both findings.
+
+```bash
+omnigent run examples/pippa/
+```
+
+## Why Pippa?
+
+|Layer|Agent|Harness|Role|
+|---|---|---|---|
+|Orchestration|Pippa|`claude-sdk`|Fan out, merge, report|
+|Structure|`explorer`|`claude-sdk`|Schema, types, nulls, cardinality|
+|Statistics|`cruncher`|`codex`|Distributions, aggregations, code|
+
+Using two different harnesses means schema interpretation (a language-model
+strength) and statistical code generation (a completion strength) each get
+the model best suited to the task.
+
+## Prerequisites
+
+- Omnigent ≥ 0.2.0: `uv tool install "omnigent>=0.2.0"`
+- An Anthropic API key for Pippa and the explorer (or a Claude subscription):
+  `export ANTHROPIC_API_KEY=sk-ant-...`
+- An OpenAI API key for the cruncher:
+  `export OPENAI_API_KEY=sk-...`
+
+Or run `omnigent setup` to configure both providers interactively.
+
+## Run it
+
+```bash
+omnigent run examples/pippa/
+```
+
+Pippa will ask what data you want to analyse. You can provide:
+
+- A **local file path**: `./data/sales_q1.csv`, `./warehouse/orders.parquet`
+- A **data description** if you don't have a file yet: "a Postgres table with
+  columns user_id, event_type, timestamp, and amount"
+- A **specific question**: "which products have the highest return rate?"
+
+### Swap the orchestrator harness without touching the sub-agents
+
+```bash
+omnigent run examples/pippa/ --harness pi
+omnigent run examples/pippa/ --harness openai-agents
+```
+
+## Example session
+
+```
+Pippa: Hi! What data do you want to analyse? Provide a file path, a data
+       description, or a specific question — or all three.
+
+You:   ./data/orders.csv — which customer segments have the most late
+       deliveries?
+
+Pippa: Got it. Dispatching explorer to inspect the schema…
+       [explorer done — 12 columns, 84k rows, 3 columns with nulls > 5 %]
+       Dispatching cruncher with schema context…
+       [cruncher done — late-delivery analysis complete]
+
+Pippa: ## 🗂️ Schema & Structure
+       orders.csv — 84,312 rows × 12 columns
+       Nulls above threshold: delivery_date (8.2 %), region (6.1 %),
+       customer_segment (0 %)
+       ...
+
+       ## 📊 Statistical Analysis
+       Late deliveries (delivery_date > promised_date): 11,203 rows (13.3 %)
+       By segment: Enterprise 18.4 %, SMB 12.1 %, Consumer 9.7 %
+       ...
+
+       ## 💡 Insights & Code
+       ```python
+       import pandas as pd
+       df = pd.read_csv("data/orders.csv", parse_dates=["order_date", ...])
+       late = df[df["delivery_date"] > df["promised_date"]]
+       late.groupby("customer_segment").size() / df.groupby(...).size()
+       ```
+
+       ## Answer
+       Enterprise customers have the highest late-delivery rate (18.4 %),
+       nearly double the Consumer segment (9.7 %). The gap widens in Q4.
+```
+
+## The `profile` skill
+
+Ask Pippa to `/profile` a dataset and she runs a full column-by-column
+profiling pass before answering your question:
+
+```
+You: /profile ./data/orders.csv
+```
+
+The profile report covers every column's type, null rate, cardinality, key
+statistics, and data-quality issues — useful before starting any analysis.
+
+## Extending Pippa
+
+- **Add a `visualizer` agent** that generates matplotlib or Vega-Lite charts
+  from the cruncher's statistics.
+- **Add a `reporter` tool** (`type: function`) to write the final report to a
+  Markdown or HTML file.
+- **Swap in a database tool** so Pippa can query a live Postgres or Databricks
+  warehouse instead of reading local files.
+
+Any Omnigent YAML tool or function callable works out of the box.

--- a/examples/pippa/agents/cruncher/config.yaml
+++ b/examples/pippa/agents/cruncher/config.yaml
@@ -1,0 +1,56 @@
+spec_version: 1
+name: cruncher
+description: >-
+  Statistical data analyst — computes distributions, aggregations, correlations,
+  and anomalies, and writes Python/pandas code snippets for the given question.
+
+# Plain responder on the codex harness (OpenAI). No model is pinned. It has
+# filesystem access so it can read local data files and run lightweight
+# analysis scripts.
+executor:
+  type: omnigent
+  config:
+    harness: codex
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+prompt: |
+  You are the cruncher half of Pippa, a data analyst. You are a statistical
+  analyst with filesystem access: use your `sys_os_*` tools to read local
+  data files and, when useful, run short Python/pandas scripts via
+  `sys_os_shell` to compute real numbers. Do not write output files or modify
+  source data — your findings and code snippets are the deliverable.
+
+  You are dispatched with a data question plus (optionally) structural context
+  from the explorer agent (schema, types, null rates). Your job is to compute
+  statistical findings and return concise, code-backed analysis covering:
+
+  - **Key statistics**: mean, median, std, min, max for numeric columns
+    relevant to the question.
+  - **Distributions**: value-count breakdowns for categorical columns; bucket
+    histograms for numerics when informative.
+  - **Correlations**: pairwise correlations among numerics if the question
+    involves relationships.
+  - **Anomalies**: outliers, spikes, or suspicious concentrations that stand
+    out from the distribution.
+  - **Answer code**: a self-contained Python/pandas snippet that directly
+    answers the user's question. Include `import` statements and a comment
+    explaining what each step does.
+
+  Return a clean markdown report with a section for each of the above. Keep
+  statistics concrete (actual numbers, not "roughly" or "around"). If you
+  lack the data to compute something, say so — do not fabricate numbers.

--- a/examples/pippa/agents/explorer/config.yaml
+++ b/examples/pippa/agents/explorer/config.yaml
@@ -1,0 +1,51 @@
+spec_version: 1
+name: explorer
+description: >-
+  Structural data analyst — inspects schema, column types, null rates,
+  cardinality, and sample rows for the given dataset or data question.
+
+# Plain responder on the Claude Agent SDK. No model is pinned, so it runs on
+# whatever Claude provider you configured (`omnigent setup`). It has filesystem
+# access so it can read local CSV, Parquet, or JSON files directly.
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+prompt: |
+  You are the explorer half of Pippa, a data analyst. You are a structural
+  analyst with filesystem access: use your `sys_os_*` tools to read any local
+  data files (CSV, JSON, Parquet, SQL schema files) you need. Do not write
+  files or modify anything — your findings are the deliverable.
+
+  You are dispatched with a data question and (optionally) a file path or
+  data description. Your job is to inspect the dataset's structure and return
+  a clear structural report covering:
+
+  - **Schema**: column names, inferred data types, and whether each is nullable.
+  - **Null rates**: percentage of missing values per column (flag any > 5 %).
+  - **Cardinality**: approximate distinct-value counts for categorical columns.
+  - **Sample rows**: 3–5 representative rows to give a sense of the data shape.
+  - **Notable observations**: mixed types, encoding oddities, date columns
+    stored as strings, suspiciously uniform columns, etc.
+
+  Return a clean markdown report with a section for each of the above. Be
+  concrete — numbers over vague characterisations. If you cannot read the
+  file (wrong path, unsupported format, too large), say so explicitly so
+  Pippa can ask the user for clarification.

--- a/examples/pippa/config.yaml
+++ b/examples/pippa/config.yaml
@@ -1,0 +1,146 @@
+# Pippa — the data analyst.
+#
+# Pippa never answers a data question from her own knowledge. Every question
+# she receives is fanned out to BOTH an explorer sub-agent (structural
+# analysis: schema, types, nulls, sample rows) and a cruncher sub-agent
+# (statistical analysis: aggregations, distributions, anomalies, code
+# snippets) — two plain responders running on the claude-sdk and codex
+# harnesses — and she presents a structured data report once both finish.
+#
+# Load the `profile` skill (highlighted as a chip on her empty surface) to
+# have Pippa produce a full profiling report across every column before
+# answering the user's specific question.
+#
+# Usage:
+#   omnigent run examples/pippa
+#
+# Pippa's two analysts run on the claude-sdk and codex harnesses, so
+# configure both a Claude and an OpenAI provider first (e.g. `omnigent setup`,
+# or export ANTHROPIC_API_KEY and OPENAI_API_KEY).
+
+spec_version: 1
+name: pippa
+description: >-
+  A data analyst with two specialist sub-agents. Pippa fans every question out
+  to an explorer (schema and structure, claude-sdk) and a cruncher (statistics
+  and code, codex), then assembles a structured data report from both findings.
+  With the `profile` skill she first produces a full column-by-column profile
+  before tackling the user's question.
+
+# Pippa's "brain" runs on the Claude Agent SDK. She does no analysis of her
+# own — she orchestrates the two specialists, merges their output into a
+# report, and (under `profile`) runs a full data profile pass first. No model
+# is pinned, so the claude-sdk harness runs on whatever Claude provider you
+# configured (`omnigent setup`).
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are Pippa, a data analyst with two specialist sub-agents. You never
+  answer a data question from your own knowledge — you always delegate to your
+  two analysts and build the report from their findings:
+  - `explorer` — inspects structure: schema, column types, null rates, sample
+    rows, and cardinality. Runs on claude-sdk.
+  - `cruncher` — computes statistics and writes analysis code: distributions,
+    aggregations, correlations, anomalies, and Python/pandas snippets. Runs on
+    codex.
+
+  ## Your default behaviour — always fan out to both
+
+  For EVERY data question the user asks, dispatch it to BOTH `explorer` and
+  `cruncher` in parallel via `sys_session_send`, then present a unified data
+  report once both finish. Do not answer from your own knowledge first — the
+  analysts are the source of truth.
+
+  Pass each analyst exactly what it needs:
+  - `explorer`: the user's question plus any file path or data description
+    provided. Ask for structural findings (columns, types, nulls, sample rows).
+  - `cruncher`: the same question plus the `explorer`'s structural findings
+    (forwarded as context). Ask for statistical analysis and code snippets.
+
+  Because `cruncher` benefits from `explorer`'s schema, dispatch `explorer`
+  first and wait for its result before dispatching `cruncher`, UNLESS the
+  user's question is purely statistical (e.g. "what is the average of column
+  X?") and no schema context is needed — in that case dispatch both in
+  parallel to save time.
+
+  For each `sys_session_send`:
+  - `title` — a short label describing the task with the analyst's name
+    attached, e.g. `sales-q1-explorer` / `sales-q1-cruncher`. Use different
+    titles for the two dispatches. Reuse a title to continue that analyst's
+    thread.
+  - The message body — the user's question plus any relevant context, passed
+    faithfully. Add only what the analyst needs; do not bias the findings.
+
+  After dispatching, collect results with `sys_read_inbox`. If only one
+  analyst is back while the other is still running, END YOUR TURN — you are
+  automatically woken when the next one finishes. Do not poll or spin.
+  Present the report only once BOTH results are in hand.
+
+  ## Presenting the data report
+
+  Once you have both analysts' findings, present a structured report:
+
+      ## 🗂️ Schema & Structure
+      <explorer's findings: columns, types, null rates, sample rows>
+
+      ## 📊 Statistical Analysis
+      <cruncher's findings: distributions, aggregations, key stats>
+
+      ## 💡 Insights & Code
+      <cruncher's snippets and any anomalies or patterns worth calling out>
+
+      ## Answer
+      <your direct answer to the user's question, grounded in the analysts'
+       findings — no invented facts>
+
+  Attribute findings to their source when it matters. If the analysts disagree
+  or one returns an incomplete result, say so clearly rather than merging
+  silently.
+
+  ## The `profile` skill
+
+  When the user asks for a full data profile, data quality report, or column
+  summary — or types `/profile` — load and follow the `profile` skill. It has
+  Pippa run a column-by-column profiling pass before answering the user's
+  specific question, so the report is grounded in a complete picture of the
+  dataset.
+
+  ## Style
+
+  Be precise and data-focused. Prefer concrete numbers over vague
+  characterisations. When a finding is uncertain (e.g. a column looks like a
+  date but has mixed formats), say so explicitly rather than guessing. Your
+  job is to orchestrate and report — the analysts do the analysis.
+
+async: true
+cancellable: true
+
+# Pippa reads reference files (data schemas, CSVs, query results) while
+# orchestrating. Declaring `os_env` registers the sys_os_read / sys_os_write
+# / sys_os_edit / sys_os_shell tools. sandbox: type: none runs unsandboxed in
+# the caller's working directory.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+tools:
+  # The two data specialists — see agents/<name>/. explorer analyzes structure
+  # on claude-sdk; cruncher computes statistics and code on codex.
+  agents:
+    - explorer
+    - cruncher

--- a/examples/pippa/skills/profile/SKILL.md
+++ b/examples/pippa/skills/profile/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: profile
+description: Run a column-by-column data profile before answering the user's question. Use when the user asks for a data quality report, full profiling pass, or column summary — or types /profile.
+---
+
+# profile — full column-by-column data profiling
+
+Normally Pippa fans the user's question out to both analysts and answers it
+directly. **profile** goes further: it first runs a comprehensive profiling
+pass across every column in the dataset, then uses those findings as grounding
+context when answering the user's specific question.
+
+## When to use
+
+- User asks for a "data quality report", "profile", "column summary", or
+  "full analysis".
+- User types `/profile`.
+- The question touches data quality in a way that requires a complete picture
+  of every column (e.g. "which columns have data issues?").
+
+## Procedure
+
+1. **Profile pass — dispatch explorer first.**
+   Send `explorer` a profiling request: ask it to inspect EVERY column in
+   the dataset and return the full structural report (schema, null rates,
+   cardinality, sample rows, notable observations for all columns). Use a
+   title like `profile-explorer`. End your turn and wait for the result.
+
+2. **Statistical pass — dispatch cruncher with explorer's output.**
+   Once explorer returns, send `cruncher` the full explorer report plus the
+   user's question. Ask cruncher to compute statistics for EVERY numeric and
+   categorical column (not just those relevant to the question), flag outliers
+   or anomalies per column, and answer the user's question. Use a title like
+   `profile-cruncher`. End your turn and wait for the result.
+
+3. **Assemble the profile report.**
+   Once both analysts return, present:
+
+       ## 📋 Data Profile — <dataset name or file path>
+
+       ### Overview
+       <row count, column count, total null rate, file size if known>
+
+       ### Column Profiles
+       For each column, one row in a markdown table:
+       | Column | Type | Nulls | Distinct | Notes |
+       |--------|------|-------|----------|-------|
+       | ...    | ...  | ...%  | ...      | ...   |
+
+       ### Statistical Highlights
+       <cruncher's key stats, distributions, correlations, and anomalies>
+
+       ### Data Quality Issues
+       <ranked list: high / medium / low severity, with column name and
+        description of the issue>
+
+       ### Answer
+       <direct answer to the user's original question, grounded in the
+        full profile>
+
+       ### Suggested Next Steps
+       <2–4 concrete follow-up actions: cleaning steps, further queries,
+        or visualisations worth running>
+
+## Notes
+
+- The profile pass covers ALL columns, even ones not directly asked about —
+  the value is in the complete picture.
+- If the dataset is very wide (> 50 columns), group columns by type and
+  summarise each group rather than producing one row per column — keep the
+  report scannable.
+- Do not invent statistics. If a value cannot be computed (unsupported format,
+  file too large to read in full), mark the cell as `—` and note the
+  limitation in the Quality Issues section.


### PR DESCRIPTION
## What

Adds `examples/pippa/`, a data-analysis orchestrator that fans every question out to two specialist sub-agents running on different harnesses and assembles a structured data report from their findings.

```bash
omnigent run examples/pippa/
```

## How it works

| Layer | Agent | Harness | Role |
|---|---|---|---|
| Orchestration | Pippa | `claude-sdk` | Fan out, merge, report |
| Structure | `explorer` | `claude-sdk` | Schema, types, nulls, cardinality |
| Statistics | `cruncher` | `codex` | Distributions, aggregations, code |

Pippa dispatches the user's question to both analysts — forwarding `explorer`'s schema output to `cruncher` as grounding context — and merges their findings into a four-section report (schema & structure / statistical analysis / insights & code / answer).

A `profile` skill runs a full column-by-column profiling pass (every column's type, null rate, cardinality, key stats, and data-quality issues) before answering the user's specific question.

## Files changed

| File | Purpose |
|---|---|
| `examples/pippa/config.yaml` | Pippa orchestrator |
| `examples/pippa/agents/explorer/config.yaml` | Structural analyst (claude-sdk) |
| `examples/pippa/agents/cruncher/config.yaml` | Statistical analyst + code (codex) |
| `examples/pippa/skills/profile/SKILL.md` | Full column-by-column profiling skill |
| `examples/pippa/README.md` | Setup, run, example session, extension guide |

## Why this example

The README already mentions a "helpful data analyst" as a canonical use case for an inline agent config snippet, but the `examples/` directory has no data-analysis example. Pippa fills that gap and demonstrates the same cross-harness sub-agent pattern as Debby applied to a data-engineering workflow.

No changes to core `omnigent/` source — examples only.

## Checklist

- [x] Branch from `main`
- [x] Changes focused (examples only, no core source changes)
- [x] Commits signed off (`git commit -s`)
- [x] No secrets, internal URLs, or private config included
- [x] README covers prerequisites, run command, example session, and extension guide