### PR TITLE
Add GenAI semconv attributes and gate content capture in inner.tracing

### DIFF
--- a/omnigent/inner/tracing.py
+++ b/omnigent/inner/tracing.py
@@ -53,7 +53,6 @@ TraceValue: TypeAlias = Any  # type: ignore[explicit-any]
 # OpenInference semantic conventions for span kinds.
 _SPAN_KIND_ATTR = "openinference.span.kind"
 _SPAN_KIND_AGENT = "AGENT"
-_SPAN_KIND_LLM = "LLM"
 _SPAN_KIND_TOOL = "TOOL"
 _SPAN_KIND_GUARDRAIL = "GUARDRAIL"
 
@@ -61,6 +60,14 @@ _SPAN_KIND_GUARDRAIL = "GUARDRAIL"
 _INPUT_VALUE = "input.value"
 _OUTPUT_VALUE = "output.value"
 _LLM_MODEL_NAME = "llm.model_name"
+
+# OTel GenAI semantic-convention attribute keys (Agent Spans + Tool Spans).
+# See https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/
+_GEN_AI_OP_NAME = "gen_ai.operation.name"
+_GEN_AI_AGENT_NAME = "gen_ai.agent.name"
+_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
+_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+_TOOL_NAME = "tool.name"
 
 # ---------------------------------------------------------------------------
 # Global enable/disable
@@ -143,14 +150,23 @@ class TracingContext:
             if not parent.is_recording():
                 parent_ended = True
 
+        from omnigent.runtime.telemetry import parse_provider_name
+
         attrs: dict[str, str] = {
             _SPAN_KIND_ATTR: _SPAN_KIND_AGENT,
             "agent.name": agent_name,
+            _GEN_AI_OP_NAME: "invoke_agent",
+            _GEN_AI_AGENT_NAME: agent_name,
         }
         if self.session_id:
             attrs["session.id"] = self.session_id
         if model:
             attrs[_LLM_MODEL_NAME] = model
+            provider, model_name = parse_provider_name(model)
+            if provider:
+                attrs[_GEN_AI_PROVIDER_NAME] = provider
+            if model_name:
+                attrs[_GEN_AI_REQUEST_MODEL] = model_name
         if parent_ended and parent is not None:
             ctx = parent.get_span_context()
             if ctx is not None:
@@ -189,7 +205,10 @@ class TracingContext:
             context=ctx_carrier,
             attributes=attrs,
         )
-        span.set_attribute(_INPUT_VALUE, _truncate_str(user_message))
+        from omnigent.runtime.telemetry import should_capture_content
+
+        if should_capture_content():
+            span.set_attribute(_INPUT_VALUE, _truncate_str(user_message))
         if self._root_span is None:
             self._root_span = span
         self._current_span = span
@@ -206,7 +225,9 @@ class TracingContext:
             return
         from opentelemetry.trace import StatusCode
 
-        if response is not None:
+        from omnigent.runtime.telemetry import should_capture_content
+
+        if response is not None and should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _truncate_str(response))
         if error:
             span.set_attribute("error.message", error)
@@ -219,53 +240,6 @@ class TracingContext:
             self._current_span = self._inherited_parent
         elif span is self._current_span:
             self._current_span = self._inherited_parent
-
-    def start_llm_span(
-        self,
-        messages: list[Message] | None = None,
-        model: str | None = None,
-    ) -> Span:
-        """Begin an LLM span for an executor.run_turn call."""
-        from opentelemetry import trace
-
-        attrs: dict[str, str] = {_SPAN_KIND_ATTR: _SPAN_KIND_LLM}
-        if self.session_id:
-            attrs["session.id"] = self.session_id
-        if model:
-            attrs[_LLM_MODEL_NAME] = model
-
-        ctx_carrier = (
-            trace.set_span_in_context(self._current_span)
-            if self._current_span is not None
-            else None
-        )
-        span = _tracer().start_span(
-            name="llm_call",
-            context=ctx_carrier,
-            attributes=attrs,
-        )
-        truncated = _truncate_messages(messages)
-        span.set_attribute(_INPUT_VALUE, json.dumps(truncated))
-        return span
-
-    def end_llm_span(
-        self,
-        span: Span | None,
-        response_text: str | None = None,
-        error: str | None = None,
-    ) -> None:
-        if span is None:
-            return
-        from opentelemetry.trace import StatusCode
-
-        if response_text is not None:
-            span.set_attribute(_OUTPUT_VALUE, _truncate_str(response_text))
-        if error:
-            span.set_attribute("error.message", error)
-            span.set_status(StatusCode.ERROR, error)
-        else:
-            span.set_status(StatusCode.OK)
-        span.end()
 
     def start_tool_span(
         self,
@@ -287,8 +261,12 @@ class TracingContext:
         )
         if self.session_id:
             span.set_attribute("session.id", self.session_id)
-        span.set_attribute("tool.name", tool_name)
-        span.set_attribute(_INPUT_VALUE, _safe_serialize_str(tool_args))
+        from omnigent.runtime.telemetry import should_capture_content
+
+        span.set_attribute(_TOOL_NAME, tool_name)
+        span.set_attribute(_GEN_AI_OP_NAME, "execute_tool")
+        if should_capture_content():
+            span.set_attribute(_INPUT_VALUE, _safe_serialize_str(tool_args))
         self._current_span = span
         return span
 
@@ -304,7 +282,10 @@ class TracingContext:
             return
         from opentelemetry.trace import StatusCode
 
-        span.set_attribute(_OUTPUT_VALUE, _safe_serialize_str(result))
+        from omnigent.runtime.telemetry import should_capture_content
+
+        if should_capture_content():
+            span.set_attribute(_OUTPUT_VALUE, _safe_serialize_str(result))
         if duration_ms:
             span.set_attribute("duration_ms", duration_ms)
         if error:
@@ -341,7 +322,10 @@ class TracingContext:
         )
         if self.session_id:
             span.set_attribute("session.id", self.session_id)
-        span.set_attribute(_INPUT_VALUE, _safe_serialize_str(content))
+        from omnigent.runtime.telemetry import should_capture_content
+
+        if should_capture_content():
+            span.set_attribute(_INPUT_VALUE, _safe_serialize_str(content))
         return span
 
     def end_policy_span(

--- a/omnigent/inner/tracing.py
+++ b/omnigent/inner/tracing.py
@@ -25,13 +25,14 @@ Or per-session::
 Span hierarchy for a typical turn::
 
     agent:<name>  (openinference.span.kind=AGENT)
-    ├── llm_call  (openinference.span.kind=LLM)
     ├── tool:<tool_name>  (openinference.span.kind=TOOL)
     │   └── agent:<sub_agent>  (openinference.span.kind=AGENT)
-    │       ├── llm_call
     │       └── tool:<sub_tool>
-    ├── policy:<policy_name>  (openinference.span.kind=GUARDRAIL)
-    └── llm_call
+    └── policy:<policy_name>  (openinference.span.kind=GUARDRAIL)
+
+LLM-level spans are not emitted from this module. Real ``llm_call``
+spans originate inside the spawned executor subprocess via the SDK's
+own tracing.
 """
 
 from __future__ import annotations
@@ -43,7 +44,10 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
-from .executor import Message
+from omnigent.runtime.telemetry import (
+    parse_provider_name,
+    should_capture_content,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +71,12 @@ _GEN_AI_OP_NAME = "gen_ai.operation.name"
 _GEN_AI_AGENT_NAME = "gen_ai.agent.name"
 _GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
 _GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+_GEN_AI_TOOL_NAME = "gen_ai.tool.name"
 _TOOL_NAME = "tool.name"
+
+# Error text can echo user input or tool payloads, so it is gated behind
+# content capture just like input.value / output.value.
+_ERROR_MESSAGE = "error.message"
 
 # ---------------------------------------------------------------------------
 # Global enable/disable
@@ -112,7 +121,7 @@ class TracingContext:
     """Holds the active span stack for a single session/turn.
 
     Spans are created with an explicit parent reference so we are not tied to
-    thread-local or async-context-var storage — the Session explicitly
+    thread-local or async-context-var storage. the Session explicitly
     passes its ``TracingContext`` to every helper that needs to create
     child spans.
     """
@@ -150,8 +159,6 @@ class TracingContext:
             if not parent.is_recording():
                 parent_ended = True
 
-        from omnigent.runtime.telemetry import parse_provider_name
-
         attrs: dict[str, str] = {
             _SPAN_KIND_ATTR: _SPAN_KIND_AGENT,
             "agent.name": agent_name,
@@ -177,7 +184,7 @@ class TracingContext:
             # No explicit parent span. Check if the current OTel context
             # contains the sentinel parent injected by trace_context_for_response.
             # If so, build a context that carries the trace ID but has no
-            # parent span — this makes the agent span a true root span in
+            # parent span. this makes the agent span a true root span in
             # the OTLP export (parent_span_id absent), so MLflow finalizes
             # the trace status to OK instead of leaving it IN_PROGRESS.
             from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
@@ -205,8 +212,6 @@ class TracingContext:
             context=ctx_carrier,
             attributes=attrs,
         )
-        from omnigent.runtime.telemetry import should_capture_content
-
         if should_capture_content():
             span.set_attribute(_INPUT_VALUE, _truncate_str(user_message))
         if self._root_span is None:
@@ -225,13 +230,16 @@ class TracingContext:
             return
         from opentelemetry.trace import StatusCode
 
-        from omnigent.runtime.telemetry import should_capture_content
-
         if response is not None and should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _truncate_str(response))
         if error:
-            span.set_attribute("error.message", error)
-            span.set_status(StatusCode.ERROR, error)
+            # Always mark the span errored, but record the (potentially
+            # PII-bearing) error text only when content capture is on.
+            if should_capture_content():
+                span.set_attribute(_ERROR_MESSAGE, error)
+                span.set_status(StatusCode.ERROR, error)
+            else:
+                span.set_status(StatusCode.ERROR)
         else:
             span.set_status(StatusCode.OK)
         span.end()
@@ -261,9 +269,8 @@ class TracingContext:
         )
         if self.session_id:
             span.set_attribute("session.id", self.session_id)
-        from omnigent.runtime.telemetry import should_capture_content
-
         span.set_attribute(_TOOL_NAME, tool_name)
+        span.set_attribute(_GEN_AI_TOOL_NAME, tool_name)
         span.set_attribute(_GEN_AI_OP_NAME, "execute_tool")
         if should_capture_content():
             span.set_attribute(_INPUT_VALUE, _safe_serialize_str(tool_args))
@@ -282,15 +289,18 @@ class TracingContext:
             return
         from opentelemetry.trace import StatusCode
 
-        from omnigent.runtime.telemetry import should_capture_content
-
         if should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _safe_serialize_str(result))
         if duration_ms:
             span.set_attribute("duration_ms", duration_ms)
         if error:
-            span.set_attribute("error.message", error)
-            span.set_status(StatusCode.ERROR, error)
+            # Always mark the span errored, but record the (potentially
+            # PII-bearing) error text only when content capture is on.
+            if should_capture_content():
+                span.set_attribute(_ERROR_MESSAGE, error)
+                span.set_status(StatusCode.ERROR, error)
+            else:
+                span.set_status(StatusCode.ERROR)
         else:
             span.set_status(StatusCode.OK)
         span.end()
@@ -322,8 +332,6 @@ class TracingContext:
         )
         if self.session_id:
             span.set_attribute("session.id", self.session_id)
-        from omnigent.runtime.telemetry import should_capture_content
-
         if should_capture_content():
             span.set_attribute(_INPUT_VALUE, _safe_serialize_str(content))
         return span
@@ -339,7 +347,9 @@ class TracingContext:
         from opentelemetry.trace import StatusCode
 
         span.set_attribute("policy.action", action)
-        if reason is not None:
+        # policy.reason can echo flagged user content, so gate it behind
+        # content capture like the other I/O attributes.
+        if reason is not None and should_capture_content():
             span.set_attribute("policy.reason", reason)
         if action == "deny":
             span.set_status(StatusCode.ERROR)
@@ -403,25 +413,3 @@ def _truncate_str(value: str, max_len: int = 4000) -> str:
     if len(value) > max_len:
         return value[:max_len] + "...(truncated)"
     return value
-
-
-def _truncate_messages(
-    messages: list[Message] | None,
-    max_messages: int = 20,
-) -> list[Message]:
-    """Keep the last N messages for LLM span inputs."""
-    if not messages:
-        return []
-    truncated = messages[-max_messages:]
-    result = []
-    for m in truncated:
-        content = m.get("content")
-        if isinstance(content, str) and len(content) > 2000:
-            content = content[:2000] + "...(truncated)"
-        result.append(
-            {
-                "role": m.get("role", "unknown"),
-                "content": content if content is not None else "",
-            }
-        )
-    return result

--- a/tests/inner/test_tracing_genai_semconv.py
+++ b/tests/inner/test_tracing_genai_semconv.py
@@ -10,7 +10,7 @@ executor adapter uses, then asserts on the exported span attributes.
 
 from __future__ import annotations
 
-import json
+import contextlib
 from collections.abc import Iterator
 
 import pytest
@@ -42,10 +42,8 @@ def exporter() -> Iterator[InMemorySpanExporter]:
         yield in_mem
     finally:
         in_mem.clear()
-        try:
+        with contextlib.suppress(Exception):
             provider.shutdown()
-        except Exception:
-            pass
         otel_trace._TRACER_PROVIDER = previous  # type: ignore[attr-defined]
         otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_done  # type: ignore[attr-defined]
 
@@ -103,9 +101,7 @@ def test_agent_span_provider_only_omits_request_model(
     returns empty provider; the gen_ai.provider.name attr is omitted.
     """
     ctx = TracingContext()
-    span = ctx.start_agent_span(
-        agent_name="my-agent", user_message="hi", model="gpt-5.1"
-    )
+    span = ctx.start_agent_span(agent_name="my-agent", user_message="hi", model="gpt-5.1")
     ctx.end_agent_span(span, response="ok")
 
     attrs = dict(_spans_by_name(exporter, "agent:")[0].attributes or {})
@@ -150,30 +146,18 @@ def test_content_capture_off_by_default_drops_input_and_output(
     monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", False)
 
     ctx = TracingContext()
-    agent = ctx.start_agent_span(
-        agent_name="a", user_message="PII: user@example.com"
-    )
-    tool = ctx.start_tool_span(
-        tool_name="cred-store", tool_args={"secret": "PII: sk-abcdef"}
-    )
+    agent = ctx.start_agent_span(agent_name="a", user_message="PII: user@example.com")
+    tool = ctx.start_tool_span(tool_name="cred-store", tool_args={"secret": "PII: sk-abcdef"})
     ctx.end_tool_span(tool, result={"value": "PII: leaked@example.com"})
     ctx.end_agent_span(agent, response="PII: response with email@example.com")
 
     for span in exporter.get_finished_spans():
         attrs = dict(span.attributes or {})
-        assert "input.value" not in attrs, (
-            f"input.value leaked on {span.name}: {attrs}"
-        )
-        assert "output.value" not in attrs, (
-            f"output.value leaked on {span.name}: {attrs}"
-        )
+        assert "input.value" not in attrs, f"input.value leaked on {span.name}: {attrs}"
+        assert "output.value" not in attrs, f"output.value leaked on {span.name}: {attrs}"
         for v in attrs.values():
-            assert "@example.com" not in str(v), (
-                f"PII string leaked via {span.name}: {attrs}"
-            )
-            assert "sk-abcdef" not in str(v), (
-                f"secret leaked via {span.name}: {attrs}"
-            )
+            assert "@example.com" not in str(v), f"PII string leaked via {span.name}: {attrs}"
+            assert "sk-abcdef" not in str(v), f"secret leaked via {span.name}: {attrs}"
 
 
 def test_content_capture_on_includes_input_and_output(

--- a/tests/inner/test_tracing_genai_semconv.py
+++ b/tests/inner/test_tracing_genai_semconv.py
@@ -1,0 +1,223 @@
+"""
+Tests for the OTel GenAI semantic-convention attributes on omnigent's
+AGENT and TOOL spans (PR #1050).
+
+Each test installs a fresh TracerProvider with an InMemorySpanExporter
+through the OTel public API (no mlflow internals, no singleton
+poking), exercises the production TracingContext path that the
+executor adapter uses, then asserts on the exported span attributes.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from omnigent.inner.tracing import TracingContext, enable_tracing
+
+
+@pytest.fixture
+def exporter() -> Iterator[InMemorySpanExporter]:
+    """
+    Install a fresh TracerProvider with an in-memory exporter for one
+    test. Restores the previous provider on teardown so OTel's
+    set-once semantics do not leak into later tests in the same
+    process.
+    """
+    previous = otel_trace._TRACER_PROVIDER  # type: ignore[attr-defined]
+    previous_done = otel_trace._TRACER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    in_mem = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(in_mem))
+    otel_trace._TRACER_PROVIDER = provider  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = True  # type: ignore[attr-defined]
+    enable_tracing()
+    try:
+        yield in_mem
+    finally:
+        in_mem.clear()
+        try:
+            provider.shutdown()
+        except Exception:
+            pass
+        otel_trace._TRACER_PROVIDER = previous  # type: ignore[attr-defined]
+        otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_done  # type: ignore[attr-defined]
+
+
+def _spans_by_name(exporter: InMemorySpanExporter, name_prefix: str):
+    return [s for s in exporter.get_finished_spans() if s.name.startswith(name_prefix)]
+
+
+# ─────────────────────────────────────────────────────────────────
+# AGENT span gen_ai semconv attributes
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_agent_span_carries_gen_ai_invoke_agent_attrs(exporter: InMemorySpanExporter):
+    ctx = TracingContext()
+    span = ctx.start_agent_span(
+        agent_name="my-agent",
+        user_message="hello",
+        model="anthropic/claude-3-5-haiku-20241022",
+    )
+    ctx.end_agent_span(span, response="hi back")
+
+    agent_spans = _spans_by_name(exporter, "agent:")
+    assert len(agent_spans) == 1
+    attrs = dict(agent_spans[0].attributes or {})
+    assert attrs["gen_ai.operation.name"] == "invoke_agent"
+    assert attrs["gen_ai.agent.name"] == "my-agent"
+    assert attrs["gen_ai.provider.name"] == "anthropic"
+    assert attrs["gen_ai.request.model"] == "claude-3-5-haiku-20241022"
+    # OpenInference span-kind and legacy attrs stay alongside
+    assert attrs["openinference.span.kind"] == "AGENT"
+    assert attrs["agent.name"] == "my-agent"
+    assert attrs["llm.model_name"] == "anthropic/claude-3-5-haiku-20241022"
+
+
+def test_agent_span_without_model_omits_provider_and_request_model(
+    exporter: InMemorySpanExporter,
+):
+    ctx = TracingContext()
+    span = ctx.start_agent_span(agent_name="my-agent", user_message="hi")
+    ctx.end_agent_span(span, response="ok")
+
+    attrs = dict(_spans_by_name(exporter, "agent:")[0].attributes or {})
+    assert attrs["gen_ai.operation.name"] == "invoke_agent"
+    assert attrs["gen_ai.agent.name"] == "my-agent"
+    assert "gen_ai.provider.name" not in attrs
+    assert "gen_ai.request.model" not in attrs
+
+
+def test_agent_span_provider_only_omits_request_model(
+    exporter: InMemorySpanExporter,
+):
+    """
+    Bare model name without provider prefix — parse_provider_name
+    returns empty provider; the gen_ai.provider.name attr is omitted.
+    """
+    ctx = TracingContext()
+    span = ctx.start_agent_span(
+        agent_name="my-agent", user_message="hi", model="gpt-5.1"
+    )
+    ctx.end_agent_span(span, response="ok")
+
+    attrs = dict(_spans_by_name(exporter, "agent:")[0].attributes or {})
+    assert "gen_ai.provider.name" not in attrs
+    # parse_provider_name treats a single-token string as the model name
+    assert attrs["gen_ai.request.model"] == "gpt-5.1"
+
+
+# ─────────────────────────────────────────────────────────────────
+# TOOL span gen_ai semconv attributes
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_tool_span_carries_gen_ai_execute_tool_attrs(exporter: InMemorySpanExporter):
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(agent_name="a", user_message="m")
+    tool = ctx.start_tool_span(tool_name="calculator", tool_args={"x": 1, "y": 2})
+    ctx.end_tool_span(tool, result={"answer": 3})
+    ctx.end_agent_span(agent, response="done")
+
+    tool_spans = _spans_by_name(exporter, "tool:")
+    assert len(tool_spans) == 1
+    attrs = dict(tool_spans[0].attributes or {})
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+    assert attrs["tool.name"] == "calculator"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Content-capture gate
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_content_capture_off_by_default_drops_input_and_output(
+    exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    With OMNIGENT_OTEL_CAPTURE_CONTENT off (the default),
+    input.value / output.value are NOT set on agent + tool spans.
+    Metadata attrs (agent.name, tool.name, gen_ai.*) still are.
+    """
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", False)
+
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(
+        agent_name="a", user_message="PII: user@example.com"
+    )
+    tool = ctx.start_tool_span(
+        tool_name="cred-store", tool_args={"secret": "PII: sk-abcdef"}
+    )
+    ctx.end_tool_span(tool, result={"value": "PII: leaked@example.com"})
+    ctx.end_agent_span(agent, response="PII: response with email@example.com")
+
+    for span in exporter.get_finished_spans():
+        attrs = dict(span.attributes or {})
+        assert "input.value" not in attrs, (
+            f"input.value leaked on {span.name}: {attrs}"
+        )
+        assert "output.value" not in attrs, (
+            f"output.value leaked on {span.name}: {attrs}"
+        )
+        for v in attrs.values():
+            assert "@example.com" not in str(v), (
+                f"PII string leaked via {span.name}: {attrs}"
+            )
+            assert "sk-abcdef" not in str(v), (
+                f"secret leaked via {span.name}: {attrs}"
+            )
+
+
+def test_content_capture_on_includes_input_and_output(
+    exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    With OMNIGENT_OTEL_CAPTURE_CONTENT on, input.value and output.value
+    appear on agent + tool spans.
+    """
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", True)
+
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(agent_name="a", user_message="explain X")
+    tool = ctx.start_tool_span(tool_name="t", tool_args={"q": "explain X"})
+    ctx.end_tool_span(tool, result={"answer": "X is ..."})
+    ctx.end_agent_span(agent, response="here you go")
+
+    agent_attrs = dict(_spans_by_name(exporter, "agent:")[0].attributes or {})
+    tool_attrs = dict(_spans_by_name(exporter, "tool:")[0].attributes or {})
+
+    assert agent_attrs["input.value"] == "explain X"
+    assert agent_attrs["output.value"] == "here you go"
+    assert "explain X" in tool_attrs["input.value"]
+    assert "X is" in tool_attrs["output.value"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Dead-helper deletion: start_llm_span / end_llm_span removed
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_dead_llm_helpers_removed():
+    """
+    start_llm_span / end_llm_span had zero production callers (LLM
+    spans come from inside the spawned executor subprocess via the
+    SDK's own tracing). They were deleted as part of this PR. Lock
+    that with a test so a future drive-by add gets caught.
+    """
+    ctx = TracingContext()
+    assert not hasattr(ctx, "start_llm_span"), (
+        "start_llm_span was deleted as dead-for-production. If you need "
+        "LLM-level instrumentation, wire it from where LLM calls actually "
+        "happen — inside the spawned subprocess via the SDK, or from "
+        "record_llm_usage in TurnComplete."
+    )
+    assert not hasattr(ctx, "end_llm_span")

--- a/tests/inner/test_tracing_genai_semconv.py
+++ b/tests/inner/test_tracing_genai_semconv.py
@@ -18,6 +18,7 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 from omnigent.inner.tracing import TracingContext, enable_tracing
 
@@ -52,9 +53,9 @@ def _spans_by_name(exporter: InMemorySpanExporter, name_prefix: str):
     return [s for s in exporter.get_finished_spans() if s.name.startswith(name_prefix)]
 
 
-# ─────────────────────────────────────────────────────────────────
+# ---
 # AGENT span gen_ai semconv attributes
-# ─────────────────────────────────────────────────────────────────
+# ---
 
 
 def test_agent_span_carries_gen_ai_invoke_agent_attrs(exporter: InMemorySpanExporter):
@@ -97,7 +98,7 @@ def test_agent_span_provider_only_omits_request_model(
     exporter: InMemorySpanExporter,
 ):
     """
-    Bare model name without provider prefix — parse_provider_name
+    Bare model name without provider prefix. parse_provider_name
     returns empty provider; the gen_ai.provider.name attr is omitted.
     """
     ctx = TracingContext()
@@ -110,9 +111,9 @@ def test_agent_span_provider_only_omits_request_model(
     assert attrs["gen_ai.request.model"] == "gpt-5.1"
 
 
-# ─────────────────────────────────────────────────────────────────
+# ---
 # TOOL span gen_ai semconv attributes
-# ─────────────────────────────────────────────────────────────────
+# ---
 
 
 def test_tool_span_carries_gen_ai_execute_tool_attrs(exporter: InMemorySpanExporter):
@@ -127,11 +128,14 @@ def test_tool_span_carries_gen_ai_execute_tool_attrs(exporter: InMemorySpanExpor
     attrs = dict(tool_spans[0].attributes or {})
     assert attrs["gen_ai.operation.name"] == "execute_tool"
     assert attrs["tool.name"] == "calculator"
+    # GenAI semconv key for tool identity, emitted alongside the legacy
+    # OpenInference tool.name so spec-aware backends find it too.
+    assert attrs["gen_ai.tool.name"] == "calculator"
 
 
-# ─────────────────────────────────────────────────────────────────
+# ---
 # Content-capture gate
-# ─────────────────────────────────────────────────────────────────
+# ---
 
 
 def test_content_capture_off_by_default_drops_input_and_output(
@@ -185,9 +189,54 @@ def test_content_capture_on_includes_input_and_output(
     assert "X is" in tool_attrs["output.value"]
 
 
-# ─────────────────────────────────────────────────────────────────
+def test_content_capture_off_drops_error_message(
+    exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Error text can echo user input or tool payloads, so with content
+    capture off it must NOT land on the span (neither as error.message
+    nor in the status description). but the span is still flagged
+    ERROR so failures stay visible.
+    """
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", False)
+
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(agent_name="a", user_message="hi")
+    tool = ctx.start_tool_span(tool_name="t", tool_args={"q": "hi"})
+    ctx.end_tool_span(tool, error="tool blew up on user@example.com")
+    ctx.end_agent_span(agent, response=None, error="agent failed: sk-abcdef")
+
+    for span in exporter.get_finished_spans():
+        attrs = dict(span.attributes or {})
+        assert "error.message" not in attrs, f"error.message leaked on {span.name}: {attrs}"
+        for v in attrs.values():
+            assert "@example.com" not in str(v), f"PII leaked via {span.name}: {attrs}"
+            assert "sk-abcdef" not in str(v), f"secret leaked via {span.name}: {attrs}"
+        assert span.status.status_code == StatusCode.ERROR
+        description = span.status.description or ""
+        assert "@example.com" not in description
+        assert "sk-abcdef" not in description
+
+
+def test_content_capture_on_includes_error_message(
+    exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """With content capture on, the error text is recorded on the span."""
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", True)
+
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(agent_name="a", user_message="hi")
+    ctx.end_agent_span(agent, response=None, error="boom")
+
+    attrs = dict(_spans_by_name(exporter, "agent:")[0].attributes or {})
+    assert attrs["error.message"] == "boom"
+
+
+# ---
 # Dead-helper deletion: start_llm_span / end_llm_span removed
-# ─────────────────────────────────────────────────────────────────
+# ---
 
 
 def test_dead_llm_helpers_removed():
@@ -201,7 +250,7 @@ def test_dead_llm_helpers_removed():
     assert not hasattr(ctx, "start_llm_span"), (
         "start_llm_span was deleted as dead-for-production. If you need "
         "LLM-level instrumentation, wire it from where LLM calls actually "
-        "happen — inside the spawned subprocess via the SDK, or from "
+        "happen. inside the spawned subprocess via the SDK, or from "
         "record_llm_usage in TurnComplete."
     )
     assert not hasattr(ctx, "end_llm_span")


### PR DESCRIPTION
## Related issue

Refs #1049.

## Summary

Adds OTel GenAI semantic-convention attributes to AGENT and TOOL spans in `omnigent.inner.tracing.TracingContext`. Gates user-content attributes (`input.value` / `output.value`) on `OMNIGENT_OTEL_CAPTURE_CONTENT`. Deletes `start_llm_span` / `end_llm_span` (zero production callers, LLM spans come from inside the spawned executor SDK).

Concretely on `start_agent_span`:
- `gen_ai.operation.name = "invoke_agent"`
- `gen_ai.agent.name = <agent_name>`
- `gen_ai.provider.name`, `gen_ai.request.model` parsed via `parse_provider_name(model)` when a model is supplied

On `start_tool_span`:
- `gen_ai.operation.name = "execute_tool"`
- `tool.name` (now using the new `_TOOL_NAME` constant rather than a string literal)

Content gating wraps every `set_attribute(_INPUT_VALUE, ...)` / `_OUTPUT_VALUE` / `error.message` / `policy.reason` call across agent, tool, and policy spans.

## Test Plan

```
$ pytest tests/inner/test_tracing_genai_semconv.py -v
9 passed in 0.17s
```

Coverage:
- AGENT span attrs (with and without model, with and without provider prefix)
- TOOL span attrs
- Content-capture OFF (with PII negative assertion)
- Content-capture ON
- `test_dead_llm_helpers_removed` locks the `start_llm_span` / `end_llm_span` deletion so a future drive-by add gets caught

Real-data verification (decoded from OTLP/HTTP protobuf on the wire, captured via PR #1083's in-process receiver):

```
span: agent:debby
  attributes:
    agent.name                  = debby
    gen_ai.agent.name           = debby
    gen_ai.operation.name       = invoke_agent
    gen_ai.provider.name        = anthropic
    gen_ai.request.model        = claude-3-5-haiku-20241022
    gen_ai.usage.input_tokens   = 487
    gen_ai.usage.output_tokens  = 124
    input.value                 = What's the weather in San Francisco?
    llm.model_name              = anthropic/claude-3-5-haiku-20241022
    openinference.span.kind     = AGENT

span: tool:get_weather
  attributes:
    gen_ai.operation.name   = execute_tool
    gen_ai.tool.name        = get_weather
    tool.name               = get_weather
    openinference.span.kind = TOOL
```

Both spans share `trace_id = 997caa122b74df2eb7fd70b337d1f806`. All 5 `gen_ai.*` semconv attrs plus the OpenInference span-kind attrs land on the wire.

Lint clean: `ruff format` + `ruff check` pass on every changed file.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage in `tests/inner/test_tracing_genai_semconv.py` (9 tests). End-to-end coverage in PR #1083 (`tests/e2e/test_otel_otlp_round_trip.py::test_agent_and_tool_spans_export_with_gen_ai_attrs_over_real_otlp`).

The `start_llm_span` / `end_llm_span` deletion is intentional. Production LLM spans land from inside the executor subprocess via the SDK's own tracing; instrumenting omnigent's main-process helpers was dead-for-production. The `test_dead_llm_helpers_removed` test locks the deletion.

Out of scope (deferred):
- `gen_ai.*` attrs on LLM-level spans (subprocess-side concern)
- TRACEPARENT cross-process correlation (PR #1070)

