### PR TITLE
fix(login): set the logged-in server as the default

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10221,6 +10221,29 @@ def _databricks_workspace_token(workspace_host: str) -> str | None:
         return None
 
 
+def _remember_default_server(server: str) -> None:
+    """
+    Persist *server* as the user-level default after a successful login.
+
+    A bare ``omnigent`` (and ``omnigent host``) fall back to the
+    configured ``server`` key when no ``--server`` is passed (see
+    :func:`run` and :func:`host`). Without this, a user who runs
+    ``omnigent login <server>`` and then bare ``omnigent`` is still routed
+    at whatever default ``setup`` baked in — the confusing "I just logged
+    in, yet I'm asked to log in again to a different server" path.
+    Recording the just-logged-in server as the default closes that gap.
+
+    Any existing default is overwritten: targeting more than one server is
+    rare, and the server the user most recently logged in to is the best
+    available signal of intent.
+
+    :param server: Normalized server URL the login succeeded against, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    """
+    _save_global_config({"server": server})
+    click.echo(f"Set {server} as your default server (a bare `omnigent` now targets it).")
+
+
 @cli.command("login")
 @click.argument("server_url")
 def login(server_url: str) -> None:
@@ -10244,12 +10267,16 @@ def login(server_url: str) -> None:
       the ``databricks`` extra.
 
     Subsequent ``omnigent run --server <url>`` commands then
-    use the stored token via the runner / host-tunnel auth chain.
+    use the stored token via the runner / host-tunnel auth chain. A
+    successful login also records the server as the user-level default
+    (the ``server`` key in ``~/.omnigent/config.yaml``), so a bare
+    ``omnigent`` afterwards targets it instead of whatever default
+    ``setup`` baked in.
 
     \b
     Example:
       omnigent login http://localhost:6767
-      omnigent run --server http://localhost:6767
+      omnigent          # connects to the server just logged in to
 
     :param server_url: The remote server URL, e.g.
         ``"http://localhost:6767"``.
@@ -10276,6 +10303,7 @@ def login(server_url: str) -> None:
     databricks_workspace = _databricks_workspace_login_target(server, probe)
     if databricks_workspace is not None:
         _databricks_login(server, databricks_workspace)
+        _remember_default_server(server)
         return
 
     detected_login_url: str | None = None
@@ -10295,10 +10323,12 @@ def login(server_url: str) -> None:
             "The proxy in front of it injects your identity on every "
             "request."
         )
+        _remember_default_server(server)
         return
 
     if detected_login_url == "/login":
         _accounts_login(server)
+        _remember_default_server(server)
         return
 
     # Fall through: OIDC mode (or unknown — let the ticket endpoint's
@@ -10353,6 +10383,7 @@ def login(server_url: str) -> None:
                 expires_at=_time.time() + expires_in,
             )
             click.echo(f"Logged in as {user_id}")
+            _remember_default_server(server)
             return
         # 410 or other error — ticket expired.
         raise click.ClickException("Login ticket expired or was rejected. Please try again.")

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10241,7 +10241,7 @@ def _remember_default_server(server: str) -> None:
         ``"https://example.databricks.com/api/2.0/omnigent"``.
     """
     _save_global_config({"server": server})
-    click.echo(f"Set {server} as your default server (a bare `omnigent` now targets it).")
+    click.echo(f"Set {server} as your default server.")
 
 
 @cli.command("login")

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 from click.testing import CliRunner
 
+from omnigent.cli import _load_global_config, _save_global_config
 from omnigent.cli import cli as cli_group
 
 _APPS_URL = "https://myapp-1234.aws.databricksapps.com"
@@ -366,8 +367,6 @@ def test_login_sets_default_server(monkeypatch: pytest.MonkeyPatch, token_dir: P
     just-logged-in server must become the configured default so the next
     bare run targets it.
     """
-    import omnigent.cli as cli_mod
-
     fake = _FakeHttpx(
         responses=[
             _response(302, headers={"location": _APPS_REDIRECT}),
@@ -379,7 +378,7 @@ def test_login_sets_default_server(monkeypatch: pytest.MonkeyPatch, token_dir: P
     result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
 
     assert result.exit_code == 0, result.output
-    assert cli_mod._load_global_config().get("server") == _APPS_URL
+    assert _load_global_config().get("server") == _APPS_URL
 
 
 def test_login_header_mode_sets_default_server(
@@ -394,8 +393,6 @@ def test_login_header_mode_sets_default_server(
     targets it. This also proves the default is set for a non-Databricks
     posture, not just the Apps branch.
     """
-    import omnigent.cli as cli_mod
-
     fake = _FakeHttpx(responses=[_response(200, body={"user_id": "proxied"})])
     _patch_login_env(monkeypatch, fake_httpx=fake)
 
@@ -403,7 +400,7 @@ def test_login_header_mode_sets_default_server(
 
     assert result.exit_code == 0, result.output
     assert "header-auth mode" in result.output
-    assert cli_mod._load_global_config().get("server") == "http://proxy.internal:6767"
+    assert _load_global_config().get("server") == "http://proxy.internal:6767"
 
 
 def test_login_accounts_mode_sets_default_server(
@@ -419,16 +416,14 @@ def test_login_accounts_mode_sets_default_server(
     (success) to isolate that wiring — its own HTTP flow is a separate
     concern.
     """
-    import omnigent.cli as cli_mod
-
     fake = _FakeHttpx(responses=[_response(401, body={"login_url": "/login"})])
     _patch_login_env(monkeypatch, fake_httpx=fake)
-    monkeypatch.setattr(cli_mod, "_accounts_login", lambda server: None)
+    monkeypatch.setattr("omnigent.cli._accounts_login", lambda server: None)
 
     result = CliRunner().invoke(cli_group, ["login", "http://omni.internal:6767"])
 
     assert result.exit_code == 0, result.output
-    assert cli_mod._load_global_config().get("server") == "http://omni.internal:6767"
+    assert _load_global_config().get("server") == "http://omni.internal:6767"
 
 
 def test_login_oidc_mode_sets_default_server(
@@ -443,8 +438,6 @@ def test_login_oidc_mode_sets_default_server(
     """
     import time
     import webbrowser
-
-    import omnigent.cli as cli_mod
 
     server = "http://omni-oidc.internal:6767"
     fake = _FakeHttpx(
@@ -467,7 +460,7 @@ def test_login_oidc_mode_sets_default_server(
     result = CliRunner().invoke(cli_group, ["login", server])
 
     assert result.exit_code == 0, result.output
-    assert cli_mod._load_global_config().get("server") == server
+    assert _load_global_config().get("server") == server
 
 
 def test_login_failure_leaves_default_server_unchanged(
@@ -480,10 +473,8 @@ def test_login_failure_leaves_default_server_unchanged(
     otherwise a failed login against a server the user can't actually
     reach would strand every later bare ``omnigent`` on that dead URL.
     """
-    import omnigent.cli as cli_mod
-
     # Seed an existing default so we can prove it survives a failed login.
-    cli_mod._save_global_config({"server": "https://existing.example.com"})
+    _save_global_config({"server": "https://existing.example.com"})
     fake = _FakeHttpx(
         responses=[
             _response(302, headers={"location": _APPS_REDIRECT}),
@@ -495,7 +486,7 @@ def test_login_failure_leaves_default_server_unchanged(
     result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
 
     assert result.exit_code != 0
-    assert cli_mod._load_global_config().get("server") == "https://existing.example.com"
+    assert _load_global_config().get("server") == "https://existing.example.com"
 
 
 # ── bare-workspace URL expansion ────────────────────────────────────

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -78,7 +78,13 @@ def _response(
 
 @pytest.fixture()
 def token_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect auth_tokens.json to a temp dir (same seam as test_cli_auth).
+    """Redirect auth_tokens.json and the global config to a temp dir.
+
+    Logging in stores an auth record (auth_tokens.json, same seam as
+    test_cli_auth) and, on success, persists the just-logged-in server as
+    the user-level default (config.yaml, via OMNIGENT_CONFIG_HOME). Both
+    are redirected here so tests never touch the developer's real
+    ``~/.omnigent``.
 
     :param tmp_path: Pytest temp directory.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -88,6 +94,7 @@ def token_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "omnigent.cli_auth._token_file_path",
         lambda: tmp_path / "auth_tokens.json",
     )
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     return tmp_path
 
 
@@ -344,6 +351,87 @@ def test_login_stale_cached_grant_triggers_fresh_login_and_retry(
     # The retry verify presented the freshly minted token, not the stale one.
     assert fake.requests[-1]["authorization"] == "Bearer tok-fresh"
     assert load_databricks_workspace_host(_APPS_URL) == _WORKSPACE
+
+
+# ── login sets the default server ───────────────────────────────────
+
+
+def test_login_sets_default_server(monkeypatch: pytest.MonkeyPatch, token_dir: Path) -> None:
+    """
+    A successful login records the server as the user-level default.
+
+    Without this, a freshly-logged-in user who runs a bare ``omnigent`` is
+    still routed at whatever default ``setup`` baked in — the "logged in,
+    yet asked to log in again to a different server" CUJ. The
+    just-logged-in server must become the configured default so the next
+    bare run targets it.
+    """
+    import omnigent.cli as cli_mod
+
+    fake = _FakeHttpx(
+        responses=[
+            _response(302, headers={"location": _APPS_REDIRECT}),
+            _response(200, body={"user_id": "alice@example.com"}),
+        ]
+    )
+    _patch_login_env(monkeypatch, fake_httpx=fake)
+
+    result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
+
+    assert result.exit_code == 0, result.output
+    assert cli_mod._load_global_config().get("server") == _APPS_URL
+
+
+def test_login_header_mode_sets_default_server(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """
+    Header-auth mode logs in nothing but still records the default.
+
+    ``omnigent login <url>`` against a header-mode server needs no
+    credentials (a proxy injects identity), but the user's intent — "make
+    this my server" — is the same, so a bare ``omnigent`` afterwards
+    targets it. This also proves the default is set for a non-Databricks
+    posture, not just the Apps branch.
+    """
+    import omnigent.cli as cli_mod
+
+    fake = _FakeHttpx(responses=[_response(200, body={"user_id": "proxied"})])
+    _patch_login_env(monkeypatch, fake_httpx=fake)
+
+    result = CliRunner().invoke(cli_group, ["login", "http://proxy.internal:6767"])
+
+    assert result.exit_code == 0, result.output
+    assert "header-auth mode" in result.output
+    assert cli_mod._load_global_config().get("server") == "http://proxy.internal:6767"
+
+
+def test_login_failure_leaves_default_server_unchanged(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """
+    A login the server rejects must NOT repoint the default.
+
+    The default is persisted only after the server accepts the token —
+    otherwise a failed login against a server the user can't actually
+    reach would strand every later bare ``omnigent`` on that dead URL.
+    """
+    import omnigent.cli as cli_mod
+
+    # Seed an existing default so we can prove it survives a failed login.
+    cli_mod._save_global_config({"server": "https://existing.example.com"})
+    fake = _FakeHttpx(
+        responses=[
+            _response(302, headers={"location": _APPS_REDIRECT}),
+            _response(403),  # the app rejects the workspace token
+        ]
+    )
+    _patch_login_env(monkeypatch, fake_httpx=fake)
+
+    result = CliRunner().invoke(cli_group, ["login", _APPS_URL])
+
+    assert result.exit_code != 0
+    assert cli_mod._load_global_config().get("server") == "https://existing.example.com"
 
 
 # ── bare-workspace URL expansion ────────────────────────────────────

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -406,6 +406,70 @@ def test_login_header_mode_sets_default_server(
     assert cli_mod._load_global_config().get("server") == "http://proxy.internal:6767"
 
 
+def test_login_accounts_mode_sets_default_server(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """
+    A successful accounts-mode (username/password) login records the default.
+
+    Accounts mode is the common self-hosted, non-Databricks posture. The
+    default-setting lives in the login command *after* ``_accounts_login``
+    returns, so a successful sign-in repoints the default just like the
+    Databricks path. ``_accounts_login`` is stubbed to a clean return
+    (success) to isolate that wiring — its own HTTP flow is a separate
+    concern.
+    """
+    import omnigent.cli as cli_mod
+
+    fake = _FakeHttpx(responses=[_response(401, body={"login_url": "/login"})])
+    _patch_login_env(monkeypatch, fake_httpx=fake)
+    monkeypatch.setattr(cli_mod, "_accounts_login", lambda server: None)
+
+    result = CliRunner().invoke(cli_group, ["login", "http://omni.internal:6767"])
+
+    assert result.exit_code == 0, result.output
+    assert cli_mod._load_global_config().get("server") == "http://omni.internal:6767"
+
+
+def test_login_oidc_mode_sets_default_server(
+    monkeypatch: pytest.MonkeyPatch, token_dir: Path
+) -> None:
+    """
+    A successful OIDC (browser-ticket) login records the default.
+
+    OIDC is the other non-Databricks posture, and its success path is
+    inline in the login command (no helper to stub), so this drives the
+    full ticket → poll flow to prove the default is repointed there too.
+    """
+    import time
+    import webbrowser
+
+    import omnigent.cli as cli_mod
+
+    server = "http://omni-oidc.internal:6767"
+    fake = _FakeHttpx(
+        responses=[
+            # Probe: OIDC 401 (login_url present but not "/login").
+            _response(401, body={"login_url": "/auth/login"}),
+            # Poll: the browser flow completed and the ticket is fulfilled.
+            _response(200, body={"token": "jwt", "user_id": "alice", "expires_in": 3600}),
+        ]
+    )
+    _patch_login_env(monkeypatch, fake_httpx=fake)
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, **kw: _response(200, body={"ticket": "t", "login_url": "/auth/go"}),
+    )
+    monkeypatch.setattr(webbrowser, "open", lambda url: True)
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+
+    result = CliRunner().invoke(cli_group, ["login", server])
+
+    assert result.exit_code == 0, result.output
+    assert cli_mod._load_global_config().get("server") == server
+
+
 def test_login_failure_leaves_default_server_unchanged(
     monkeypatch: pytest.MonkeyPatch, token_dir: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — surfaced from a CUJ report in Slack (a fresh `go/omni` install: user logged in
to their workspace, but a bare `omnigent` then asked them to log in again to a
*different* server).

## Summary

- A successful `omnigent login <server>` now records that server as the user-level
  default (the `server` key in `~/.omnigent/config.yaml`), so a subsequent bare
  `omnigent` targets it.
- Previously `login` stored only credentials. A bare `omnigent` resolves its server
  from `cfg.get("server")`, which still held whatever `setup` baked in — so right
  after logging in to a workspace, users hit *"Not signed in to `<other-server>` —
  running `omnigent login` first"* against a different server.
- Persisted on **every** login-success path (Databricks-fronted, header, accounts,
  OIDC), **after** the flow returns — so a failed login never repoints the default.
  An existing default is overwritten (the multi-server case is rare; the
  just-logged-in server is the best signal of intent, and the change is echoed so
  it isn't silent).

**ELI5:** Before, logging in handed you a key but didn't change which door you walk
through by default — so you'd log into door A, then `omnigent` would still walk you
to door B and ask for a key you don't have. Now logging into door A makes door A
your default.

```
omnigent login <A>        bare `omnigent`
  store creds for A          server = cfg["server"]  ──► before: <B baked in by setup>  ✗ re-prompt
  set cfg["server"] = A ◄───────────────────────────────  after:  <A>                   ✓ connects
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

The default-setting lives in one shared helper (`_remember_default_server`) called
from **all four** login-success branches, so it's posture-agnostic. Added to the
existing suite `tests/cli/test_login_databricks.py`, one focused test per branch:

- `test_login_sets_default_server` — the core CUJ (Databricks-fronted): a successful
  login persists the server as the default.
- `test_login_header_mode_sets_default_server` — header-auth posture.
- `test_login_accounts_mode_sets_default_server` — accounts (username/password), the
  common self-hosted non-Databricks posture (stubbed at the `_accounts_login` seam).
- `test_login_oidc_mode_sets_default_server` — OIDC browser-ticket flow (full
  ticket → poll, since its success path is inline with no stub seam).
- `test_login_failure_leaves_default_server_unchanged` — guards the "only on
  success" invariant (a rejected login must not repoint the default).
- Extended the shared `token_dir` fixture to redirect `OMNIGENT_CONFIG_HOME` so every
  login test stays hermetic now that success writes config.

Commands run (conda `mlflow` env):

```
python -m pytest tests/cli/test_login_databricks.py -q   # 20 passed
ruff check / ruff format --check omnigent/cli.py tests/cli/test_login_databricks.py  # clean
```

Manual: drove the **real** `login` command end-to-end (only network/subprocess
stubbed) reproducing the reporter's exact scenario — a stale `…aws.databricksapps.com`
default, then `omnigent login <workspace>`; afterwards `_load_effective_config()["server"]`
(exactly what a bare `omnigent run` reads) returns the just-logged-in server.
