### PR TITLE
feat(examples): add Scribe documentation orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,14 @@ omnigent codex                       # Codex
 omnigent run path/to/agent.yaml      # your own agent (see "Write your own agent")
 ```
 
-#### 🐙 Polly and 🟠🔵 Debby
+#### 🐙 Polly, 🟠🔵 Debby, and ✍️ Scribe
 
-Two example agents ship with the repo, and they make good first sessions:
+Three example agents ship with the repo, and they make good first sessions:
 
 ```bash
 omnigent run examples/polly/
 omnigent run examples/debby/
+omnigent run examples/scribe/
 
 # Run an orchestrator on a different harness (sub-agents keep their own):
 omnigent run examples/polly/ --harness pi
@@ -188,6 +189,13 @@ Every question you ask goes to both heads, and she lays the two answers out
 side by side. Type `/debate` and the heads critique each other for a few
 rounds before converging. (She needs both a Claude and an OpenAI credential;
 see step 3.)
+
+**✍️ Scribe** is a documentation orchestrator, the docs counterpart to Polly.
+She turns git diffs, commit history, and PRs into release notes, changelogs, and
+migration guides. She authors the prose herself and delegates only read-only
+code investigation to a researcher sub-agent, then can route a draft through an
+independent different-vendor reviewer to fact-check its claims before it ships.
+(The cross-model fact-check needs an OpenAI credential; the rest runs on one.)
 
 **Prefer the browser?** Start a server and register your machine as a host:
 

--- a/examples/scribe/agents/researcher/config.yaml
+++ b/examples/scribe/agents/researcher/config.yaml
@@ -1,0 +1,56 @@
+spec_version: 1
+name: researcher
+description: >-
+  Read-only repo explorer for Scribe. Answers "how does this work" / "what did
+  this change" by reading code, history, and diffs, and returns a findings
+  report. Never edits files.
+
+# Read-only explorer on the Claude Agent SDK. No model is pinned, so it runs on
+# whatever Claude provider you configured (`omnigent setup`).
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+# Filesystem access so the researcher can read files, grep, and inspect git
+# history. `sandbox: type: none` runs unsandboxed in the caller's repo. The
+# read-only discipline is enforced by the prompt, not the sandbox — this agent
+# is only ever dispatched with `purpose: explore` / `search`.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Same blast-radius guardrail the rest of the bundle uses.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+prompt: |
+  You are Scribe's researcher: a read-only explorer. You answer documentation
+  questions about a codebase by READING it — source files, git history, diffs,
+  PR metadata — and reporting what you find. You never write or edit files; your
+  report is the deliverable.
+
+  Use your `sys_os_*` tools to read and search: `sys_os_read` for files,
+  `sys_os_shell` for `grep`/`rg`, `git log`, `git show`, `git diff`, and `gh`.
+  Go to the actual code and history — never answer from assumption or stale
+  knowledge.
+
+  Return a structured findings report:
+  - A direct answer to the question asked.
+  - The specific evidence: file paths with line numbers, commit hashes, PR
+    numbers, function or symbol names.
+  - Anything that contradicts the premise of the question, or that the doc
+    author should be careful about (edge cases, recently changed behavior).
+
+  Be precise about facts a doc will commit to print — exact flag names, default
+  values, version numbers, signatures. If you cannot confirm something from the
+  code, say so plainly rather than guessing.

--- a/examples/scribe/agents/reviewer/config.yaml
+++ b/examples/scribe/agents/reviewer/config.yaml
@@ -1,0 +1,57 @@
+spec_version: 1
+name: reviewer
+description: >-
+  Independent doc fact-checker for Scribe, on a different vendor (codex). Checks
+  a draft's claims against the actual code and reports inaccuracies. Never edits
+  the draft.
+
+# Fact-checker on the Codex harness — deliberately a DIFFERENT vendor than
+# Scribe's claude-sdk brain, so it catches claims the author's own model would
+# wave through. No model is pinned, so it runs on whatever OpenAI provider you
+# configured (`omnigent setup`). Booting this agent needs an OpenAI provider; if
+# none is configured, Scribe finalizes without the cross-check.
+executor:
+  type: omnigent
+  config:
+    harness: codex
+
+# Filesystem access so the reviewer can verify claims against the real files.
+# `sandbox: type: none` runs unsandboxed in the caller's repo. The reviewer is
+# only ever dispatched with `purpose: review` and reports rather than edits.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Same blast-radius guardrail the rest of the bundle uses.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+prompt: |
+  You are Scribe's reviewer: an independent fact-checker for documentation. You
+  are given a draft (release notes, a changelog, a migration guide, API docs)
+  plus the relevant change context, and your job is to find claims that are
+  wrong, unsupported, or misleading. You do NOT edit the draft — you report.
+
+  Verify against the actual code with your `sys_os_*` tools: read the files,
+  history, and diffs the draft refers to. For each claim that matters — a flag
+  name, default value, version, signature, behavior, or "this was removed /
+  renamed / added" — confirm it or flag it.
+
+  Return a concise report:
+  - BLOCKING: claims that are factually wrong or unsupported by the code, each
+    with the correct fact and the evidence (file:line, commit, PR).
+  - NITS: imprecise or potentially confusing phrasing worth tightening.
+  - Otherwise, state plainly that the draft's factual claims check out.
+
+  You are a different vendor than the author on purpose: be skeptical, check the
+  things that are easy to assume, and ground every correction in the code rather
+  than in style preference.

--- a/examples/scribe/config.yaml
+++ b/examples/scribe/config.yaml
@@ -1,0 +1,147 @@
+# Scribe — the documentation orchestrator.
+#
+# Scribe turns change context (git diffs, commit history, PR metadata) into
+# release notes, README updates, and migration guides. It is the docs
+# counterpart to Polly: Scribe authors the prose itself and delegates only
+# read-only code investigation to a `researcher` sub-agent (claude-sdk), then
+# can fact-check a draft with a `reviewer` on a different vendor (codex). It
+# writes no product source code or tests.
+#
+# Usage:
+#   omnigent run examples/scribe
+#
+# Minimal setup needs one provider (Scribe's brain and the researcher both run
+# on claude-sdk). For the optional cross-model fact-check, also configure an
+# OpenAI provider so the codex reviewer can boot (`omnigent setup`, or export
+# ANTHROPIC_API_KEY and OPENAI_API_KEY).
+
+spec_version: 1
+name: scribe
+description: >-
+  A documentation orchestrator. Scribe collects change context (git diff,
+  commit history, PR metadata), delegates read-only code investigation to a
+  researcher sub-agent, authors release notes / README updates / migration
+  guides itself, and can route a draft's factual claims through an independent
+  different-vendor reviewer before it ships. Writes prose, never product code.
+
+# Scribe's "brain" runs on the Claude Agent SDK. It does the doc authoring
+# itself and orchestrates the sub-agents. No model is pinned, so the claude-sdk
+# harness runs on whatever Claude provider you configured (`omnigent setup`) —
+# an Anthropic API key, a Claude subscription, an OpenAI-compatible gateway, or
+# a Databricks workspace — resolving that provider's default Claude model (the
+# bundled catalog default is claude-opus-4-8).
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are Scribe, a documentation lead. You turn change context into clear
+  docs: release notes, changelogs, README updates, migration guides, and API
+  reference. Your one hard rule: **you do NOT write or edit product source code
+  or tests** — you author prose. The line is by KIND, not size: documentation
+  and other prose/text files (Markdown, plain text) are yours to write directly,
+  even across several files; any change to source code or tests, and any deep
+  code investigation, goes to a sub-agent.
+
+  You have exactly TWO sub-agents (see agents/<name>/):
+  - `researcher` — a read-only repo explorer (claude-sdk). Ask it how something
+    actually works, what a diff changed, or to trace behavior across files; it
+    returns a findings report and edits nothing.
+  - `reviewer` — an independent fact-checker on a DIFFERENT vendor (codex).
+    Give it your draft plus the relevant change context and it reports
+    inaccuracies; it never edits your prose.
+
+  ## Collect the change context yourself
+
+  Gathering change context is plumbing, not investigation, so do it directly
+  with your `sys_os_*` tools — `git diff`, `git log`, `git show`, and the `gh`
+  CLI (`gh pr view`, `gh pr diff`) through `sys_os_shell`. A quick read of a
+  file or two to orient yourself is fine. The moment you need to understand HOW
+  the code works or trace a change across the codebase, stop and dispatch the
+  researcher — do not sprawl across the repo yourself.
+
+  ## Delegate read-only investigation
+
+  Dispatch the researcher via `sys_session_send` with `args.purpose` set to
+  `explore` or `search`. Set a `title` that names the question, e.g.
+  `explore-auth-rename` or `search-deprecated-flags` — never the bare agent or
+  vendor name. The researcher runs autonomously and notifies you through the
+  inbox; collect its report with a SINGLE `sys_read_inbox`. Do not busy-poll: if
+  it is still running, just END YOUR TURN and you are woken when it finishes. Do
+  not use `sys_timer_set` to check on it. Ground your docs in the researcher's
+  report, not in guesses or stale knowledge.
+
+  ## Author the docs
+
+  Write and edit documentation directly with your `sys_os_*` tools. Default to
+  editing the repo's existing docs in place (README, CHANGELOG, docs/) rather
+  than dropping new files, unless the user asks for a new document. Keep prose
+  tight and accurate; never invent a version number, date, flag, or API name —
+  if you are unsure of a fact, send the researcher to confirm it.
+
+  ## Optional cross-model fact-check
+
+  When accuracy matters (release notes, migration guides, anything users act
+  on), route the draft through the `reviewer` before finalizing: dispatch it via
+  `sys_session_send` with `args.purpose: review`, passing your draft plus the
+  change context as text. The reviewer is a different vendor than your brain, so
+  it catches claims your own model would wave through. Fold in the corrections
+  it reports, then present the final docs. The reviewer needs an OpenAI provider
+  to boot — if it returns a boot failure (missing CLI / provider), say so and
+  finalize without the cross-check rather than retrying into the same wall.
+
+  ## Act in the same turn you announce
+
+  Never end a turn after only saying what you are about to do. If a sentence
+  describes a next action ("I'll fetch the diff", "let me dispatch the
+  researcher"), the tool calls that perform it MUST be in the same turn, after
+  the text. You may only end a turn once you have emitted this turn's tool calls,
+  or you are genuinely just waiting on an already-running sub-agent.
+
+  ## Load the right skill
+
+  Skills compose; load and follow the one that fits:
+  - changelog — turn a commit/PR range into a changelog entry.
+  - migration-guide — turn a breaking change into upgrade steps.
+  - api-docs — document a module or public API surface.
+
+  Skills are prose, so you author new ones yourself into Scribe's OWN skills
+  directory (`examples/scribe/skills/<name>/SKILL.md`), never the host
+  `~/.claude/skills/` directory.
+
+async: true
+cancellable: true
+
+# `os_env` registers the `sys_os_read` / `sys_os_write` / `sys_os_edit` /
+# `sys_os_shell` tools (filesystem access bundled with a shell). `sandbox:
+# type: none` runs unsandboxed so it can read the repo and write docs, and keeps
+# the bundle loadable on macOS.
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+# Same blast-radius guardrail Polly and Debby use: the catastrophic set
+# (force-push, `rm -rf /`, hard-reset to a remote ref) is denied outright, while
+# everything else — including the read-only git/gh Scribe relies on — runs
+# without an ASK (`gate_pushes: false`), since a headless orchestrator can't
+# answer an approval prompt.
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+tools:
+  # The two sub-agents — see agents/<name>/. `researcher` explores read-only on
+  # claude-sdk; `reviewer` fact-checks on codex (a different vendor) so the
+  # cross-model check is meaningful.
+  agents:
+    - researcher
+    - reviewer

--- a/examples/scribe/skills/api-docs/SKILL.md
+++ b/examples/scribe/skills/api-docs/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: api-docs
+description: Document a module or public API surface (functions, classes, CLI commands, endpoints) from the code itself. Use when the user asks for API reference, to document a module, or to write usage docs for a public interface.
+---
+
+# api-docs — document a public API surface from the code
+
+Produce reference docs that match the code exactly, derived from the source, not
+from assumptions about what the API "probably" does.
+
+## Read the surface
+
+Identify the public surface to document (a module, class, CLI command group, or
+set of endpoints). Then have the researcher read it carefully:
+- Dispatch the researcher (`purpose: explore`) to enumerate the public
+  entry points and report each one's real signature, parameters, defaults,
+  return shape, and raised errors — with file:line evidence.
+- Prefer what the code declares (signatures, type hints, docstrings, default
+  values) over prose descriptions. Public vs. private follows the project's
+  convention (e.g. a leading underscore, or an `__all__` / export list).
+
+## Structure
+
+For each entry point:
+
+    ### `<name>(<signature>)`
+
+    <one-line summary of what it does>
+
+    **Parameters**
+    - `<name>` (`<type>`, default `<value>`) — <meaning>
+
+    **Returns** — `<type>`: <meaning>
+
+    **Raises** — `<Error>`: <when>
+
+    **Example**
+    ```
+    <minimal, runnable usage>
+    ```
+
+## Write the entries
+
+- Keep the summary to one line; put detail in the parameter and example
+  sections.
+- Document every public parameter, including defaults, in the order they appear
+  in the signature.
+- Give one minimal example per entry point that actually runs against the
+  documented signature.
+- Do not document private/internal helpers unless the user asks; a reference is
+  the contract, not a code tour.
+
+## Verify
+
+Signatures, defaults, and error types drift fastest, so route the finished
+reference through the `reviewer` (`purpose: review`) to confirm every signature
+and default matches the current code.

--- a/examples/scribe/skills/changelog/SKILL.md
+++ b/examples/scribe/skills/changelog/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: changelog
+description: Turn a range of commits or merged PRs into a changelog entry grouped by change type. Use when the user asks for release notes, a changelog, or "what changed" between two points.
+---
+
+# changelog — write a changelog from a commit/PR range
+
+Turn a range of history into a clear changelog entry that a user can read to
+decide whether and how to upgrade.
+
+## Gather the range
+
+Establish the range first. Honor an explicit one ("since v1.2.0", "the last 10
+commits", "PRs merged this week"); otherwise default to commits since the most
+recent tag (`git describe --tags --abbrev=0` then `git log <tag>..HEAD`).
+
+Collect the raw material yourself with `sys_os_shell`:
+- `git log <range> --no-merges --pretty=format:'%h %s'` for the commit subjects.
+- `git log <range> --merges` or `gh pr list --search "merged:>=<date>"` for PRs.
+- `git diff <range> --stat` to see the surface area, and `gh pr view <n>` for a
+  PR's intent when a subject line is terse.
+
+When a subject is unclear about user impact, dispatch the researcher
+(`purpose: explore`) to read the diff and report what actually changed for
+users — do not guess from the subject alone.
+
+## Group by change type
+
+Use the Keep a Changelog categories, dropping any that are empty:
+
+    ## <version or range> — <YYYY-MM-DD>
+
+    ### Added
+    ### Changed
+    ### Deprecated
+    ### Removed
+    ### Fixed
+    ### Security
+
+## Write each entry
+
+- One line per user-visible change, in the imperative or past tense, describing
+  the effect on the user — not the internal mechanics.
+- Lead with the change, link the PR or commit in parentheses at the end.
+- Omit pure-internal churn (refactors, test-only changes, CI) unless it changes
+  behavior. A changelog is for users, not a commit dump.
+- Call out breaking changes explicitly and point to the migration-guide skill
+  if upgrade steps are needed.
+
+## Verify
+
+Before finalizing, route the draft through the `reviewer` (`purpose: review`)
+when the changelog will ship — version numbers, "removed"/"breaking" claims, and
+flag names are exactly what a fact-check catches.

--- a/examples/scribe/skills/migration-guide/SKILL.md
+++ b/examples/scribe/skills/migration-guide/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: migration-guide
+description: Turn a breaking change (an API rename, removed flag, changed default, or moved module) into concrete upgrade steps with before/after examples. Use when the user asks how to migrate, upgrade, or adapt to a breaking change.
+---
+
+# migration-guide — write upgrade steps for a breaking change
+
+Produce a guide that lets a user on the old version land on the new one with the
+least friction.
+
+## Pin down what actually broke
+
+Identify the precise breaking change before writing a word. Get it from the diff
+and history, not from the description alone:
+- `git diff <old>..<new>` on the affected surface, and `gh pr view <n>` for the
+  PR that introduced it.
+- Dispatch the researcher (`purpose: explore`) to confirm the exact old and new
+  shapes: the old name/signature/default, the new one, and whether a
+  compatibility shim or deprecation window exists.
+
+Never document a rename or signature change from memory — the exact symbols are
+what users will copy.
+
+## Structure
+
+    # Migrating to <version>
+
+    ## What changed
+    <one paragraph: the change and why, in user terms>
+
+    ## Upgrade steps
+    1. <ordered, mechanical steps>
+
+    ## Before / after
+    ```
+    # before
+    ...
+    # after
+    ...
+    ```
+
+    ## If you can't upgrade yet
+    <deprecation window, shim, or flag to opt out — if one exists>
+
+## Write the steps
+
+- Make each step mechanical and verifiable ("rename `--foo` to `--bar`", not
+  "update your flags"). A user should be able to follow it without rereading the
+  whole guide.
+- Show a minimal, real before/after for each distinct change. Keep examples
+  copy-pasteable.
+- State explicitly when there is no automated path and a manual edit is
+  required.
+
+## Verify
+
+Route the finished guide through the `reviewer` (`purpose: review`). Migration
+guides are acted on directly, so a wrong flag name or step is high-cost — the
+cross-vendor fact-check is worth it here.

--- a/tests/e2e/omnigent/test_example_scribe.py
+++ b/tests/e2e/omnigent/test_example_scribe.py
@@ -1,0 +1,92 @@
+"""Structural test for the Scribe documentation bundle (examples/scribe).
+
+Scribe is the docs counterpart to Polly: it authors prose itself and delegates
+read-only code investigation to a ``researcher`` sub-agent (claude-sdk), with an
+optional cross-vendor fact-check by a ``reviewer`` sub-agent (codex). Pure
+spec-load — no LLM, no credentials — modeled on ``test_example_debby.py``.
+
+What breaks if this fails:
+- a sub-agent is dropped or renamed (Scribe loses investigation or the
+  fact-check),
+- the reviewer collapses onto claude-sdk (the cross-model fact-check stops being
+  independent),
+- a sub-agent silently pins a model (re-coupling it to one provider — a
+  Databricks-only id would 404 on a plain Anthropic / OpenAI key),
+- a doc skill (changelog / migration-guide / api-docs) is dropped or renamed,
+- the ``os_env`` block disappears (Scribe loses the file/shell tools it reads
+  context and writes docs with).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_scribe.py -> repo root is 3 parents up.
+_SCRIBE_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "scribe"
+
+
+@pytest.fixture(scope="module")
+def scribe_spec() -> AgentSpec:
+    """Load and validate the scribe bundle once for the module."""
+    return load(_SCRIBE_BUNDLE)
+
+
+def test_scribe_has_researcher_and_cross_vendor_reviewer(scribe_spec: AgentSpec) -> None:
+    """
+    Scribe has exactly two sub-agents: a ``researcher`` on claude-sdk and a
+    ``reviewer`` on codex.
+
+    The reviewer running a different vendor than Scribe's claude-sdk brain is
+    the whole point of the fact-check — it catches claims the author's own model
+    would wave through. If the reviewer lands on claude-sdk too, the cross-model
+    check is no longer independent.
+    """
+    assert scribe_spec.name == "scribe"
+    fam = {a.name: a.executor.config.get("harness") for a in scribe_spec.sub_agents}
+    assert sorted(scribe_spec.tools.agents) == ["researcher", "reviewer"]
+    assert fam["researcher"] == "claude-sdk"
+    assert fam["reviewer"] == "codex"
+    # Reviewer is a different vendor than the brain → the fact-check is independent.
+    assert fam["researcher"] != fam["reviewer"]
+
+
+def test_scribe_sub_agents_are_unpinned(scribe_spec: AgentSpec) -> None:
+    """
+    Neither sub-agent pins a model: each inherits whatever Claude / OpenAI
+    provider the user configured.
+
+    Un-pinning is load-bearing for OSS — a Databricks-specific model id would
+    404 on a plain Anthropic / OpenAI key. Re-introducing a pin re-couples a
+    sub-agent to one provider, so fail here if a model reappears.
+    """
+    by_name = {a.name: a for a in scribe_spec.sub_agents}
+    for name in ("researcher", "reviewer"):
+        assert by_name[name].executor.model is None, name
+        assert by_name[name].executor.profile is None, name
+
+
+def test_scribe_doc_skills_present(scribe_spec: AgentSpec) -> None:
+    """The three doc skills are discovered from skills/<name>/SKILL.md."""
+    assert sorted(s.name for s in scribe_spec.skills) == [
+        "api-docs",
+        "changelog",
+        "migration-guide",
+    ]
+
+
+def test_scribe_has_os_env(scribe_spec: AgentSpec) -> None:
+    """
+    Scribe carries an ``os_env`` block so the bridged ``sys_os_*`` tools register
+    — it reads change context (git/gh) and writes docs through them. The shipped
+    sandbox is ``type: none`` so the bundle loads on macOS too. Dropping
+    ``os_env`` would leave Scribe with no file/shell tools at all.
+    """
+    assert scribe_spec.os_env is not None
+    assert scribe_spec.os_env.type == "caller_process"
+    assert scribe_spec.os_env.sandbox is not None
+    assert scribe_spec.os_env.sandbox.type == "none"


### PR DESCRIPTION
## Related issue

Closes #110

## Summary

Adds `examples/scribe/`, a documentation orchestrator and the docs counterpart
to Polly. Scribe collects change context (git diff, commit history, PR
metadata), delegates read-only code investigation to a `researcher` sub-agent,
authors release notes / changelogs / migration guides itself, and can route a
draft's factual claims through an independent different-vendor `reviewer` (codex)
before it ships. It writes prose, never product code.

- Orchestrator on claude-sdk; `researcher` (claude-sdk, read-only) for
  investigation; `reviewer` (codex) for the optional cross-model fact-check.
- Three doc skills: `changelog`, `migration-guide`, `api-docs`.
- Mirrors the existing `examples/polly` and `examples/debby` bundle shape, and
  lists Scribe alongside them in the README.

The issue floats a `writer` sub-agent as optional ("or orchestrator authors
directly"); I took that option and used the second sub-agent slot for a
genuinely cross-vendor reviewer, which is what makes the fact-check meaningful.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added `tests/e2e/omnigent/test_example_scribe.py`, a structural spec-load test
modeled on `test_example_debby.py` (no LLM, no credentials). It asserts the
load-bearing invariants: the two sub-agents resolve to different vendors
(researcher=claude-sdk, reviewer=codex) so the fact-check stays independent,
both sub-agents are unpinned (a Databricks-only model id would 404 on a plain
Anthropic/OpenAI key), the three doc skills are discovered, and `os_env` carries
`sandbox: none`. `test_examples_coverage_sync.py` requires this file for the new
bundle.

Commands run:
- `pytest tests/e2e/omnigent/test_example_scribe.py tests/e2e/omnigent/test_examples_coverage_sync.py` -> 5 passed
- Verified the guard fails without the test file, and the cross-vendor assertion
  fails if the reviewer is moved to claude-sdk (the test has teeth).
- `ruff check` + `ruff format --check` on the test -> clean.
- `omnigent.spec.load('examples/scribe')` loads the bundle cleanly.
