### PR TITLE
ci(images): publish server + host images multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/oss-publish-images.yml
+++ b/.github/workflows/oss-publish-images.yml
@@ -78,10 +78,20 @@ jobs:
     # drive the promote-nightly / reconcile-floating jobs.
     if: github.repository == 'omnigent-ai/omnigent' && github.event_name != 'schedule' && !inputs.force_nightly && !inputs.reconcile_floating
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Multi-arch: the linux/arm64 leg cross-builds under QEMU emulation on this
+    # amd64 runner, which roughly doubles the host-image build time (emulated
+    # npm/pip native steps). 30m was tight for two native amd64 builds; give the
+    # four-variant (server+host × amd64+arm64) build headroom.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      # Register binfmt handlers so Buildx can cross-build the linux/arm64
+      # variant on this amd64 runner (emulated). Without it the arm64 leg of
+      # the multi-arch builds below fails with "exec format error".
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -163,6 +173,10 @@ jobs:
           echo "host_tags=${HOST_TAGS}" >> "$GITHUB_OUTPUT"
 
       # No build-args: the Dockerfile ARGs default to public registries.
+      # Multi-arch: each tag publishes as a manifest list spanning amd64 + arm64,
+      # so the image runs natively on Apple Silicon / arm64 clusters. Amd64-only
+      # consumers (Modal, Daytona, CoreWeave) keep pulling the amd64 variant —
+      # the list is a superset, so nothing changes for them.
       - name: Build and push
         id: build-server
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
@@ -170,15 +184,18 @@ jobs:
           context: .
           file: deploy/docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
           sbom: true
 
-      # Host image: same Dockerfile, `host` target. Runs after the server build
-      # so it reuses the shared builder-stage layers from the gha cache.
+      # Host image: same Dockerfile, `host` target, also multi-arch (amd64 +
+      # arm64). The harness CLIs it bakes in all ship arm64 — claude-code and
+      # codex publish linux-arm64 npm binaries, pi is pure-JS. Runs after the
+      # server build so it reuses the shared builder-stage layers from the gha
+      # cache (cached per platform).
       - name: Build and push host image
         id: build-host
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
@@ -187,7 +204,7 @@ jobs:
           file: deploy/docker/Dockerfile
           target: host
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.host_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -21,9 +21,16 @@
 # and the coding-harness CLIs (claude / codex / pi, via Node) — and
 # skips everything server-only: no SPA bundle, no psycopg, no
 # uvicorn entrypoint. Modal's `Image.from_registry` requirements shape
-# it: built for linux/amd64, `python` + `pip` on $PATH, and CMD-only
-# (an ENTRYPOINT that doesn't exec its args would block Modal's own
-# runtime from running).
+# it: `python` + `pip` on $PATH, and CMD-only (an ENTRYPOINT that
+# doesn't exec its args would block Modal's own runtime from running).
+#
+# Both images publish multi-arch (linux/amd64 + linux/arm64) — see
+# .github/workflows/oss-publish-images.yml — so they run natively on
+# arm64 hosts (Apple Silicon laptops, arm64 clusters) as well as amd64.
+# Nothing below is arch-specific: the python/node base images are
+# multi-arch and apt/pip/npm/COPY-from-node all resolve per-arch under
+# buildx. Amd64-only consumers (Modal, Daytona, CoreWeave) keep pulling
+# the amd64 variant from the manifest list, unchanged.
 #
 # Build (from repo root):
 #

--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -55,11 +55,12 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | 
 (Apple Silicon macOS installs the Homebrew formula; Linux installs the deb/rpm.)
 
 > [!IMPORTANT]
-> **The gateway host must be amd64 Linux.** The official host image is amd64-only,
-> and OpenShell's supervisor (Landlock/seccomp/netns) does not run reliably under
-> emulation — on an arm64 host (e.g. Apple Silicon via colima) the sandbox never
-> reaches READY. An arm64 host image can't be built either (a transitive
-> dependency, `cel-expr-python`, publishes no linux-arm64 wheel). On an
+> **The gateway host must be amd64 Linux.** OpenShell's supervisor
+> (Landlock/seccomp/netns) does not run reliably under emulation — on an arm64
+> host (e.g. Apple Silicon via colima) the sandbox never reaches READY. The
+> official host image now publishes multi-arch (amd64 + arm64), but its arm64
+> variant omits `cel-expr-python` (no linux-arm64 wheel — CEL policies degrade to
+> unavailable there), so the amd64 variant is the one to run with OpenShell. On an
 > Apple-Silicon laptop, point the gateway at a remote **amd64 Linux** box (and the
 > server at that gateway) rather than the local Docker VM.
 


### PR DESCRIPTION
## What

Publish the official **omnigent-server** and **omnigent-host** images as
multi-arch manifest lists spanning **linux/amd64 + linux/arm64**, so they run
natively on arm64 hosts (Apple Silicon laptops, arm64 Kubernetes nodes) — while
**retaining amd64** unchanged for every existing consumer.

## Why

Both images were built `linux/amd64`-only because the publish job was pinned to
that platform — not because anything underneath is arch-specific. On Apple
Silicon this forces emulation (or makes the image unrunnable, e.g. a local arm64
kind cluster can't run the host image). Surfaced while validating the Kubernetes
sandbox provider on an arm64 Mac: the launcher correctly diagnosed the
amd64-only host image as unschedulable on an arm64 node.

## Changes

- **`.github/workflows/oss-publish-images.yml`**
  - Add `docker/setup-qemu-action` (binfmt handlers for the cross-built arm64 leg).
  - Set both build steps to `platforms: linux/amd64,linux/arm64`.
  - Bump the build job timeout `30m → 60m` — the emulated arm64 leg roughly
    doubles the host-image build time (emulated npm/pip native steps).
- **`deploy/docker/Dockerfile`** — correct the now-outdated "built for
  linux/amd64" note; document that the images publish multi-arch and that
  nothing in the Dockerfile is arch-specific.
- **`deploy/openshell/README.md`** — the "official host image is amd64-only /
  an arm64 image can't be built" claim is no longer accurate. Keep the amd64
  gateway recommendation (OpenShell's supervisor doesn't run reliably under
  emulation; the arm64 host variant also omits `cel-expr-python`), with the
  correct justification.

## Why this is safe

- **The Dockerfile is already arch-agnostic.** Multi-arch `python:3.12-slim` /
  `node:20-slim` bases, and `apt`/`pip`/`npm`/`COPY --from=node` all resolve
  per-arch under buildx. No functional Dockerfile change.
- **amd64 consumers are unaffected.** The amd64 variant stays in every manifest
  list (a superset), so Modal / Daytona / CoreWeave keep pulling amd64.
- **Harness CLIs ship arm64.** `@anthropic-ai/claude-code` and `@openai/codex`
  publish `linux-arm64` npm binaries; `pi` is pure-JS.
- **The one arm64-Linux-incompatible dep is already handled.**
  `cel-expr-python` has no manylinux-aarch64 wheel, but it's excluded on
  `aarch64` via an env marker (added in #308) and imported under
  `try/except ImportError`, so `uv pip install -e .` resolves on arm64 and the
  CEL policy module degrades gracefully.

## Verification

- Static: confirmed the dependency tree resolves on linux/arm64 (cel-expr-python
  marker + guarded import), and harness CLIs publish arm64.
- Workflow: `check-yaml` parses clean; QEMU action pinned to the same `v4.1.0`
  SHA convention as the existing buildx pin.
- A full local arm64 image build was attempted but blocked by network egress
  restrictions in the dev sandbox (pypi/npm unreachable — would block an amd64
  build identically). The real multi-arch build runs in CI, which has registry
  access.
