### PR TITLE
ci: guard package-lock.json against the npm-proxy registry leak

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Check uv.lock uses the public PyPI index
         run: python scripts/normalize_uv_lock_registry.py --check uv.lock
 
+      # Same guard for the npm lockfile: a committed Databricks-proxy `resolved`
+      # URL makes every frontend job fail at `npm ci` (it fetches from the locked
+      # URL regardless of the registry env). Check the committed file as-is,
+      # before any `npm` command can re-resolve and mask it (stdlib only).
+      - name: Check ap-web/package-lock.json uses the public npm registry
+        run: python scripts/normalize_npm_lock_registry.py --check ap-web/package-lock.json
+
       - name: Set up uv
         uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,19 @@ repos:
         files: ^uv\.lock$
         pass_filenames: true
 
+      # Same hazard for npm: a local `npm install` against the Databricks npm
+      # proxy bakes that host into package-lock.json `resolved` URLs, and
+      # `npm ci` fetches from those URLs regardless of NPM_CONFIG_REGISTRY —
+      # breaking every frontend CI job (the proxy is unreachable from public
+      # runners). Normalize tarball hosts back to registry.npmjs.org before they
+      # land. Fixer: re-stage if it changes.
+      - id: normalize-npm-lock-registry
+        name: normalize ap-web/package-lock.json registry to npmjs.org
+        language: system
+        entry: .venv/bin/python scripts/normalize_npm_lock_registry.py
+        files: ^ap-web/package-lock\.json$
+        pass_filenames: true
+
   # ── File hygiene ────────────────────────────────────────────────
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/scripts/normalize_npm_lock_registry.py
+++ b/scripts/normalize_npm_lock_registry.py
@@ -1,0 +1,111 @@
+"""Normalize the package registry in ``ap-web/package-lock.json`` to public npm.
+
+Local ``npm`` runs resolve against whatever registry is configured on the
+developer's machine (e.g. the Databricks npm proxy
+``npm-proxy.cloud.databricks.com``), and ``npm`` bakes that host into every
+``"resolved"`` tarball URL it writes to ``package-lock.json``. Crucially,
+``npm ci`` then fetches each package from its locked ``resolved`` URL —
+**ignoring** ``NPM_CONFIG_REGISTRY`` — so a single committed proxy URL makes
+every frontend CI job (pre-commit's ap-web install, ``npm test``, the UI-snapshot
+build, the E2E-UI shards) fail at install with ``ETIMEDOUT`` against an internal
+proxy the public OSS runners can't reach. For this OSS repo the committed
+lockfile must always resolve from public npm (``https://registry.npmjs.org``).
+
+This is the npm analog of :mod:`scripts.normalize_uv_lock_registry`. As a
+pre-commit *fixer* it rewrites each registry-tarball ``resolved`` host to
+npmjs.org and exits non-zero when it changed anything, so the commit aborts and
+the developer re-stages the normalized lockfile. Pass ``--check`` to validate
+without writing (CI runs this against the committed file *before* any ``npm``
+command — a later ``npm ci``/``install`` would re-resolve and mask a committed
+proxy URL otherwise). Only registry tarball URLs (``.../-/<name>-<ver>.tgz``) are
+touched; ``git+``/``file:``/workspace ``resolved`` entries are left alone.
+
+Usage::
+
+    python scripts/normalize_npm_lock_registry.py ap-web/package-lock.json
+    python scripts/normalize_npm_lock_registry.py --check ap-web/package-lock.json
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The canonical public registry host the committed lockfile must always use.
+_CANONICAL_HOST = "registry.npmjs.org"
+
+# Matches a registry-tarball ``"resolved"`` URL, capturing the ``"resolved": "``
+# prefix and the ``/<path>/-/<file>.tgz"`` suffix so only the scheme+host between
+# them is rewritten. The ``/-/ … .tgz`` shape is unique to registry tarballs, so
+# ``git+https://`` / ``file:`` / workspace ``resolved`` entries never match.
+_RESOLVED_TARBALL_RE = re.compile(r'("resolved":\s*")https://[^/"]+(/[^"]*?/-/[^"]+\.tgz")')
+
+# Same shape, capturing just the host — used by the ``--check`` reporter.
+_RESOLVED_HOST_RE = re.compile(r'"resolved":\s*"https://([^/"]+)/[^"]*?/-/[^"]+\.tgz"')
+
+
+def non_canonical_hosts(text: str) -> list[str]:
+    """Return registry-tarball ``resolved`` hosts that are not public npm.
+
+    :param text: Full contents of a ``package-lock.json`` file.
+    :returns: Each non-canonical tarball host, in order, with duplicates
+        preserved (one per offending ``resolved`` entry).
+    """
+    return [h for h in _RESOLVED_HOST_RE.findall(text) if h != _CANONICAL_HOST]
+
+
+def normalize_text(text: str) -> str:
+    """Return *text* with every registry-tarball ``resolved`` host set to npmjs.
+
+    :param text: Full contents of a ``package-lock.json`` file.
+    :returns: The same text with each registry-tarball URL's scheme+host
+        replaced by ``https://registry.npmjs.org`` (path preserved).
+    """
+    return _RESOLVED_TARBALL_RE.sub(rf"\g<1>https://{_CANONICAL_HOST}\g<2>", text)
+
+
+def main(argv: list[str]) -> int:
+    """Normalize (or, with ``--check``, validate) each given lockfile.
+
+    :param argv: Filenames to process, optionally with the ``--check`` flag
+        (passed by pre-commit or CI).
+    :returns: In fix mode, ``1`` when a file was modified (so the commit aborts
+        and the change is re-staged) else ``0``. In ``--check`` mode, ``1`` when
+        any file has a non-canonical tarball host (printing the offenders) else
+        ``0``; no file is written.
+    """
+    check = "--check" in argv
+    files = [a for a in argv if a != "--check"]
+
+    if check:
+        ok = True
+        for name in files:
+            offenders = non_canonical_hosts(Path(name).read_text())
+            if offenders:
+                ok = False
+                unique = sorted(set(offenders))
+                print(
+                    f"{name}: {len(offenders)} non-canonical registry tarball "
+                    f"host(s) (expected {_CANONICAL_HOST}): {', '.join(unique)}"
+                )
+                print(
+                    "Fix with: python scripts/normalize_npm_lock_registry.py "
+                    f"{name} && git add {name}"
+                )
+        return 0 if ok else 1
+
+    changed = False
+    for name in files:
+        path = Path(name)
+        original = path.read_text()
+        normalized = normalize_text(original)
+        if normalized != original:
+            path.write_text(normalized)
+            print(f"{name}: normalized registry tarball hosts to {_CANONICAL_HOST}")
+            changed = True
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_normalize_npm_lock_registry.py
+++ b/tests/test_normalize_npm_lock_registry.py
@@ -1,0 +1,133 @@
+"""Unit tests for ``scripts/normalize_npm_lock_registry.py``.
+
+The pre-commit fixer rewrites every registry-tarball ``"resolved"`` URL in
+``ap-web/package-lock.json`` back to public npm so a developer's local
+index/proxy (e.g. the Databricks npm proxy) never leaks into the committed
+lockfile and breaks ``npm ci`` on public CI. These tests pin that contract:
+proxy tarball hosts are normalized, ``git+``/``file:`` resolved entries are left
+alone, the fixer is idempotent, and ``main`` signals modifications via its exit
+code (1 = changed → commit aborts and re-stages; 0 = clean).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "normalize_npm_lock_registry.py"
+
+# The canonical host the fixer must always produce — kept as an independent
+# literal so a change to the script's constant is caught.
+_HOST = "registry.npmjs.org"
+_PROXY = "npm-proxy.cloud.databricks.com"
+
+
+def _load_module() -> Any:
+    """Import ``scripts/normalize_npm_lock_registry.py`` from its file path.
+
+    ``scripts/`` is not a package on ``sys.path`` (mirrors the uv-lock test's
+    loader), so load it directly.
+
+    :returns: The module, exposing ``normalize_text`` / ``non_canonical_hosts`` /
+        ``main``.
+    """
+    spec = importlib.util.spec_from_file_location("scripts_normalize_npm_lock", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not locate the script at {_SCRIPT_PATH}."
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MOD = _load_module()
+
+# The exact shape that broke CI: the `yaml` dep pinned to the Databricks proxy.
+_PROXY_LINE = f'      "resolved": "https://{_PROXY}/yaml/-/yaml-1.10.3.tgz",\n'
+_CANONICAL_LINE = f'      "resolved": "https://{_HOST}/yaml/-/yaml-1.10.3.tgz",\n'
+
+
+def test_normalize_text_rewrites_proxy_tarball_host() -> None:
+    """A Databricks-proxy tarball host is rewritten to public npm; path kept."""
+    assert _MOD.normalize_text(_PROXY_LINE) == _CANONICAL_LINE
+
+
+def test_normalize_text_rewrites_scoped_package() -> None:
+    """Scoped-package tarball URLs (``@scope/pkg``) are normalized too."""
+    text = f'    "resolved": "https://{_PROXY}/@lobehub/icons/-/icons-2.0.0.tgz",\n'
+    expected = f'    "resolved": "https://{_HOST}/@lobehub/icons/-/icons-2.0.0.tgz",\n'
+    assert _MOD.normalize_text(text) == expected
+
+
+def test_normalize_text_rewrites_any_internal_host() -> None:
+    """Normalization is proxy-agnostic — any non-npmjs tarball host collapses."""
+    text = '"resolved": "https://nexus.internal.example.com/left-pad/-/left-pad-1.3.0.tgz"'
+    expected = f'"resolved": "https://{_HOST}/left-pad/-/left-pad-1.3.0.tgz"'
+    assert _MOD.normalize_text(text) == expected
+
+
+def test_normalize_text_leaves_git_and_file_resolved_untouched() -> None:
+    """``git+``/``file:``/workspace ``resolved`` entries are not registry tarballs."""
+    text = (
+        '"resolved": "git+ssh://git@github.com/org/repo.git#abc123",\n'
+        '"resolved": "file:../local-pkg",\n'
+        '"resolved": "https://github.com/org/repo/archive/refs/tags/v1.0.0.tar.gz",\n'
+    )
+    assert _MOD.normalize_text(text) == text
+
+
+def test_normalize_text_already_canonical_is_noop() -> None:
+    assert _MOD.normalize_text(_CANONICAL_LINE) == _CANONICAL_LINE
+
+
+def test_normalize_text_rewrites_every_occurrence() -> None:
+    text = _PROXY_LINE * 3
+    result = _MOD.normalize_text(text)
+    assert _PROXY not in result
+    assert result.count(f"https://{_HOST}/yaml/-/yaml-1.10.3.tgz") == 3
+
+
+def test_non_canonical_hosts_lists_offenders() -> None:
+    text = _PROXY_LINE + _CANONICAL_LINE + _PROXY_LINE
+    assert _MOD.non_canonical_hosts(text) == [_PROXY, _PROXY]
+
+
+def test_non_canonical_hosts_empty_when_canonical() -> None:
+    assert _MOD.non_canonical_hosts(_CANONICAL_LINE) == []
+
+
+def test_main_rewrites_file_and_returns_one_when_changed(tmp_path: Path) -> None:
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_PROXY_LINE)
+    assert _MOD.main([str(lock)]) == 1
+    assert lock.read_text() == _CANONICAL_LINE
+
+
+def test_main_returns_zero_when_already_canonical(tmp_path: Path) -> None:
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_CANONICAL_LINE)
+    assert _MOD.main([str(lock)]) == 0
+    assert lock.read_text() == _CANONICAL_LINE
+
+
+def test_main_is_idempotent(tmp_path: Path) -> None:
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_PROXY_LINE)
+    assert _MOD.main([str(lock)]) == 1
+    assert _MOD.main([str(lock)]) == 0
+
+
+def test_main_check_fails_without_writing(tmp_path: Path) -> None:
+    """``--check`` returns 1 for a proxy lockfile and does NOT modify it."""
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_PROXY_LINE)
+    assert _MOD.main(["--check", str(lock)]) == 1
+    assert lock.read_text() == _PROXY_LINE  # read-only
+
+
+def test_main_check_passes_when_canonical(tmp_path: Path) -> None:
+    lock = tmp_path / "package-lock.json"
+    lock.write_text(_CANONICAL_LINE)
+    assert _MOD.main([str(lock), "--check"]) == 0  # flag position-independent


### PR DESCRIPTION
## What

Adds a guard that keeps the internal npm-proxy URL out of `ap-web/package-lock.json` — the npm analog of the repo's existing `normalize-uv-lock-registry` guard for `uv.lock`.

## Why

A local `npm install` against the Databricks npm proxy bakes that proxy host into every `"resolved"` tarball URL it writes to `package-lock.json`. **`npm ci` then fetches each package from its locked `resolved` URL regardless of `NPM_CONFIG_REGISTRY`** — so a single committed proxy URL makes *every* frontend CI job fail at the install step with `ETIMEDOUT` against a proxy the public OSS runners can't reach:

- Pre-commit checks (ap-web prettier install)
- npm test
- UI Snapshot (SPA build)
- E2E UI shards

This is exactly what recently turned frontend CI red across PRs — one poisoned `yaml-1.10.3.tgz` `resolved` line. The current leak has already been cleaned out of `main`; this change **prevents it from recurring**.

## How

- **`scripts/normalize_npm_lock_registry.py`** — fixer (rewrite each registry-tarball `resolved` host to `registry.npmjs.org`, exit 1 if it changed anything so the commit aborts and re-stages) + `--check` (read-only verify). Only registry tarball URLs (`.../-/<name>-<ver>.tgz`) are rewritten; `git+`/`file:`/workspace `resolved` entries are left alone.
- **pre-commit hook** `normalize-npm-lock-registry` scoped to `ap-web/package-lock.json`.
- **`lint.yml`** runs `--check` on the committed lockfile *before* any `npm` command (a later `npm ci`/`install` would re-resolve and mask a committed proxy URL), mirroring the `uv.lock` check.
- 13 unit tests.

## Scope

This fixes the lockfile-proxy leak that broke the frontend jobs wholesale. The separate **E2E UI shard-2/3 flakes** (locator-visibility timeouts; a different test fails per run) and the **chat-snapshot baseline drift** are pre-existing issues unrelated to this guard and are not addressed here.

This pull request and its description were written by Isaac.