### PR TITLE
Add keyboard shortcut for session search

### DIFF
--- a/ap-web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/ap-web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -34,6 +34,7 @@ describe("KeyboardShortcutsDialog", () => {
     expect(screen.getByText("Show keyboard shortcuts")).toBeTruthy();
     expect(screen.getByText("Send message")).toBeTruthy();
     expect(screen.getByText("Recall previous prompt")).toBeTruthy();
+    expect(screen.getByText("Search sessions")).toBeTruthy();
     expect(screen.getByText("Previous session")).toBeTruthy();
     expect(screen.getByText("Navigate suggestions")).toBeTruthy();
   });

--- a/ap-web/src/components/KeyboardShortcutsDialog.tsx
+++ b/ap-web/src/components/KeyboardShortcutsDialog.tsx
@@ -44,6 +44,7 @@ const ENTER = "↵";
 const SHIFT = "⇧";
 const UP = "↑";
 const DOWN = "↓";
+const F = "F";
 
 interface Shortcut {
   label: string;
@@ -80,6 +81,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "Navigation",
     items: [
+      { label: "Search sessions", keys: [MOD_KEY, SHIFT, F] },
       { label: "Previous session", keys: [MOD_KEY, UP] },
       { label: "Next session", keys: [MOD_KEY, DOWN] },
     ],

--- a/ap-web/src/hooks/useSessionSearchHotkey.test.tsx
+++ b/ap-web/src/hooks/useSessionSearchHotkey.test.tsx
@@ -1,0 +1,87 @@
+// Cmd/Ctrl+Shift+F focuses sidebar session search. If the sidebar is closed,
+// the hook opens it first; it ignores bare/Cmd-only/Alt-modified keys.
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isSessionSearchHotkey, useSessionSearchHotkey } from "./useSessionSearchHotkey";
+
+function press(
+  key: string,
+  mods: Partial<Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">> = {
+    metaKey: true,
+    shiftKey: true,
+  },
+): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...mods });
+  window.dispatchEvent(e);
+  return e;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("isSessionSearchHotkey", () => {
+  it("matches Cmd/Ctrl+Shift+F without Alt", () => {
+    expect(isSessionSearchHotkey(press("F", { metaKey: true, shiftKey: true }))).toBe(true);
+    expect(isSessionSearchHotkey(press("f", { ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+
+  it("rejects incomplete or conflicting chords", () => {
+    expect(isSessionSearchHotkey(press("f", { metaKey: true }))).toBe(false);
+    expect(isSessionSearchHotkey(press("f", { shiftKey: true }))).toBe(false);
+    expect(isSessionSearchHotkey(press("f", { metaKey: true, shiftKey: true, altKey: true }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("useSessionSearchHotkey", () => {
+  it("focuses search without opening when the sidebar is already open", () => {
+    const onOpenSidebar = vi.fn();
+    const onFocusSearch = vi.fn();
+    renderHook(() => useSessionSearchHotkey({ sidebarOpen: true, onOpenSidebar, onFocusSearch }));
+
+    const e = press("F");
+
+    expect(e.defaultPrevented).toBe(true);
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+    expect(onFocusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the sidebar before focusing search when closed", () => {
+    const onOpenSidebar = vi.fn();
+    const onFocusSearch = vi.fn();
+    renderHook(() => useSessionSearchHotkey({ sidebarOpen: false, onOpenSidebar, onFocusSearch }));
+
+    press("F");
+
+    expect(onOpenSidebar).toHaveBeenCalledTimes(1);
+    expect(onFocusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports Ctrl+Shift+F for Windows/Linux", () => {
+    const onOpenSidebar = vi.fn();
+    const onFocusSearch = vi.fn();
+    renderHook(() => useSessionSearchHotkey({ sidebarOpen: true, onOpenSidebar, onFocusSearch }));
+
+    press("F", { ctrlKey: true, shiftKey: true });
+
+    expect(onFocusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-matching chords", () => {
+    const onOpenSidebar = vi.fn();
+    const onFocusSearch = vi.fn();
+    renderHook(() => useSessionSearchHotkey({ sidebarOpen: false, onOpenSidebar, onFocusSearch }));
+
+    press("F", { metaKey: true });
+    press("F", { metaKey: true, shiftKey: true, altKey: true });
+
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+    expect(onFocusSearch).not.toHaveBeenCalled();
+  });
+});

--- a/ap-web/src/hooks/useSessionSearchHotkey.ts
+++ b/ap-web/src/hooks/useSessionSearchHotkey.ts
@@ -1,0 +1,42 @@
+// Cmd/Ctrl+Shift+F focuses the sidebar session search. This intentionally
+// avoids Cmd/Ctrl+K so that chord stays available for a future command palette.
+
+import { useEffect, useRef } from "react";
+
+interface SessionSearchHotkeyOptions {
+  sidebarOpen: boolean;
+  onOpenSidebar: () => void;
+  onFocusSearch: () => void;
+}
+
+export function isSessionSearchHotkey(e: KeyboardEvent): boolean {
+  return (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === "f";
+}
+
+export function useSessionSearchHotkey({
+  sidebarOpen,
+  onOpenSidebar,
+  onFocusSearch,
+}: SessionSearchHotkeyOptions): void {
+  const latest = useRef({ sidebarOpen, onOpenSidebar, onFocusSearch });
+  latest.current = { sidebarOpen, onOpenSidebar, onFocusSearch };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (!isSessionSearchHotkey(e)) return;
+
+      e.preventDefault();
+
+      const {
+        sidebarOpen: open,
+        onOpenSidebar: openSidebar,
+        onFocusSearch: focusSearch,
+      } = latest.current;
+      if (!open) openSidebar();
+      focusSearch();
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+}

--- a/ap-web/src/shell/AppShell.tsx
+++ b/ap-web/src/shell/AppShell.tsx
@@ -983,6 +983,7 @@ export function AppShell() {
             <Sidebar
               open={sidebarOpen}
               dragProgress={sidebarDragProgress}
+              onOpen={() => setSidebarOpen(true)}
               onClose={() => setSidebarOpen(false)}
             />
 

--- a/ap-web/src/shell/Sidebar.test.tsx
+++ b/ap-web/src/shell/Sidebar.test.tsx
@@ -5,7 +5,7 @@
 // Recent / Shared with me / Archived).
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -83,13 +83,13 @@ function mockConversations(convs: Conversation[]) {
   useConvMock.mockImplementation(() => result(convs));
 }
 
-function renderSidebar(open = true) {
+function renderSidebar(open = true, onOpen = vi.fn()) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
       <TooltipProvider>
         <MemoryRouter initialEntries={["/"]}>
-          <Sidebar open={open} onClose={vi.fn()} />
+          <Sidebar open={open} onOpen={onOpen} onClose={vi.fn()} />
         </MemoryRouter>
       </TooltipProvider>
     </QueryClientProvider>,
@@ -103,6 +103,29 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("Sidebar session list", () => {
+  it("focuses and selects the session search input on Cmd/Ctrl+Shift+F", async () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    renderSidebar();
+
+    const search = screen.getByRole("searchbox", { name: "Search sessions" });
+    fireEvent.change(search, { target: { value: "claude" } });
+    fireEvent.keyDown(window, { key: "F", metaKey: true, shiftKey: true });
+
+    await waitFor(() => expect(search).toHaveFocus());
+    expect((search as HTMLInputElement).selectionStart).toBe(0);
+    expect((search as HTMLInputElement).selectionEnd).toBe("claude".length);
+  });
+
+  it("requests the sidebar to open before focusing search when collapsed", () => {
+    mockConversations(THREE_TYPE_CONVERSATIONS);
+    const onOpen = vi.fn();
+    renderSidebar(false, onOpen);
+
+    fireEvent.keyDown(window, { key: "F", metaKey: true, shiftKey: true });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
   it("renders no filter funnel and requests the list with archived included", () => {
     mockConversations(THREE_TYPE_CONVERSATIONS);
     renderSidebar();

--- a/ap-web/src/shell/Sidebar.tsx
+++ b/ap-web/src/shell/Sidebar.tsx
@@ -72,6 +72,7 @@ import { cn } from "@/lib/utils";
 import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { useSessionSwitchHotkey } from "@/hooks/useSessionSwitchHotkey";
 import { usePinnedSessionHotkeys } from "@/hooks/usePinnedSessionHotkeys";
+import { useSessionSearchHotkey } from "@/hooks/useSessionSearchHotkey";
 import { absoluteTime, relativeTime } from "@/lib/relativeTime";
 import { ThemeModeMenu } from "@/components/theme/ThemeModeMenu";
 import { AccountMenu } from "./AccountMenu";
@@ -96,6 +97,7 @@ const TIME_MARKER_SLOT_CLASS =
 
 interface SidebarProps {
   open: boolean;
+  onOpen?: () => void;
   onClose: () => void;
   /**
    * Live open fraction (0 = closed, 1 = open) while the iOS shell's left-edge
@@ -143,12 +145,13 @@ function useActiveNavItem(): { isNewChatPage: boolean; isInboxPage: boolean } {
  *     scrollback is fine; users typically want the conversations list
  *     to stay visible while they switch around.
  */
-export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
+export function Sidebar({ open, onOpen, onClose, dragProgress = null }: SidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [pinnedConversationIds, setPinnedConversationIds] = useState(readPinnedConversationIds);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const toggleSelected = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -239,6 +242,20 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
   // visually open so it isn't `inert`/`aria-hidden` mid-gesture.
   const dragging = dragProgress != null;
   const effectiveOpen = open || dragging;
+  const focusSessionSearch = useCallback(() => {
+    setSelectionMode(false);
+    window.setTimeout(() => {
+      const input = searchInputRef.current;
+      if (!input) return;
+      input.focus();
+      input.select();
+    }, 0);
+  }, []);
+  useSessionSearchHotkey({
+    sidebarOpen: effectiveOpen,
+    onOpenSidebar: onOpen ?? (() => {}),
+    onFocusSearch: focusSessionSearch,
+  });
 
   return (
     <aside
@@ -401,6 +418,7 @@ export function Sidebar({ open, onClose, dragProgress = null }: SidebarProps) {
             <div className="relative flex-1">
               <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 size-3.5 text-muted-foreground" />
               <input
+                ref={searchInputRef}
                 type="search"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}

--- a/ap-web/src/test-setup.ts
+++ b/ap-web/src/test-setup.ts
@@ -1,6 +1,37 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+function createStorageShim(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key: string) {
+      return entries.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, String(value));
+    },
+  };
+}
+
+// Node 25 exposes experimental global web storage, but without a backing file
+// its localStorage methods are unavailable. Keep tests on jsdom-style storage.
+const storage = createStorageShim();
+Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+
 // The @lobehub icon packages have broken nested-module resolution
 // under vitest; stub presentational glyphs so component modules that
 // import them can still load in tests.

--- a/tests/e2e_ui/sessions/test_sidebar_search.py
+++ b/tests/e2e_ui/sessions/test_sidebar_search.py
@@ -70,3 +70,25 @@ def test_search_filters_sessions(
     # filters server-side on the title, not just hides everything.
     search.fill(marker)
     expect(row).to_be_visible()
+
+
+def test_search_shortcut_opens_sidebar_and_focuses_search(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Ctrl+Shift+F opens the sidebar and selects the session search query."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    search = page.get_by_role("searchbox", name="Search sessions")
+    expect(search).to_be_visible(timeout=30_000)
+    search.fill("existing query")
+
+    page.get_by_role("button", name="Close sidebar").click()
+    expect(page.get_by_role("button", name="Open sidebar")).to_be_visible()
+
+    page.keyboard.press("Control+Shift+F")
+
+    expect(search).to_be_focused()
+    assert search.evaluate("el => el.selectionStart") == 0
+    assert search.evaluate("el => el.selectionEnd") == len("existing query")


### PR DESCRIPTION
## Related issue

Closes #1059

## Summary

- Adds Cmd/Ctrl+Shift+F to open the sidebar if needed, focus the sidebar "Search sessions" input, and select the current query.
- Documents the shortcut in the keyboard shortcuts dialog while leaving Cmd/Ctrl+K available for a future command palette.
- Adds Vitest and Playwright coverage for the shortcut path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Vitest coverage exercises the hotkey predicate, Cmd/Ctrl variants, ignored chords, sidebar open-before-focus behavior, actual search input focus/selection, and the keyboard shortcuts dialog row.

Playwright coverage in `tests/e2e_ui/sessions/test_sidebar_search.py` verifies Ctrl+Shift+F opens a collapsed sidebar and focuses/selects the search input in the browser.

Validated locally:

- `npm test -- src/hooks/useSessionSearchHotkey.test.tsx src/components/KeyboardShortcutsDialog.test.tsx src/shell/Sidebar.test.tsx src/lib/panelSizePreferences.test.ts src/hooks/useResizableSidebar.test.tsx`
- `npx oxlint src/hooks/useSessionSearchHotkey.ts src/hooks/useSessionSearchHotkey.test.tsx src/shell/Sidebar.tsx src/shell/Sidebar.test.tsx src/components/KeyboardShortcutsDialog.tsx src/components/KeyboardShortcutsDialog.test.tsx src/test-setup.ts`
- `npm run type-check`
- `npm run format:check -- src/hooks/useSessionSearchHotkey.ts src/hooks/useSessionSearchHotkey.test.tsx src/shell/Sidebar.tsx src/shell/Sidebar.test.tsx src/components/KeyboardShortcutsDialog.tsx src/components/KeyboardShortcutsDialog.test.tsx src/test-setup.ts`
- `npm run build`
- `uv run --python /opt/homebrew/bin/python3.13 pytest tests/e2e_ui/sessions/test_sidebar_search.py --ui-skip-build -q`

Note: full `npm run lint` currently reports existing errors outside this change; focused `oxlint` on the touched TS/TSX files passes.
