### PR TITLE
feat(harness): unified HarnessDescriptor interface + conformance + scaffold (follow-up to #576)

### DIFF
--- a/omnigent/codex_ws_transport.py
+++ b/omnigent/codex_ws_transport.py
@@ -1,0 +1,212 @@
+"""Codex WebSocket-JSON-RPC implementation of :class:`NativeServerTransport`.
+
+The second concrete transport (with
+:class:`omnigent.opencode_http_transport.OpenCodeHttpTransport`) that
+proves the native-server abstraction generalizes across wire protocols.
+It adapts the existing Codex app-server client + bridge state into the
+:class:`NativeServerTransport` protocol — the same injection logic the
+battle-tested :class:`omnigent.inner.codex_native_executor.CodexNativeExecutor`
+uses (``turn/start`` vs ``turn/steer``, ``turn/interrupt``), without
+disturbing that production path.
+
+The Codex server's *lifecycle* (process launch, event forwarding) stays
+runner-owned (see ``_auto_create_codex_terminal``); the methods that would
+duplicate it (``start_server`` / ``events``) raise to make that ownership
+explicit. The injection core (``send_prompt`` / ``abort`` /
+``create_or_resume_session`` / ``build_tui_attach_command``) is fully
+implemented and is what the conformance suite exercises.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from omnigent.native_server_transport import (
+    NativeEvent,
+    NativeLaunchConfig,
+    NativePermissionDecision,
+    NativePrompt,
+    NativeServerHandle,
+)
+
+_logger = logging.getLogger(__name__)
+
+# A Codex app-server client exposing async ``connect`` / ``request`` /
+# ``close`` (``omnigent.codex_native_app_server.CodexAppServerClient``).
+CodexClientFactory = Callable[[], Any]
+
+# Public surface of this transport module. ``CodexClientFactory`` is the
+# documented annotation for ``CodexWsTransport(client_factory=...)``; export
+# it so the alias reads as intended public API (its only other use is a
+# PEP 563 stringified annotation, which static analysis can't see as a load).
+__all__ = ["CodexClientFactory", "CodexWsTransport"]
+
+
+def _prompt_to_input_items(prompt: NativePrompt) -> list[dict[str, Any]]:
+    """
+    Build Codex app-server input items from a :class:`NativePrompt`.
+
+    :param prompt: The normalized prompt.
+    :returns: Codex ``turn/start`` / ``turn/steer`` input items.
+    """
+    items: list[dict[str, Any]] = []
+    if prompt.text:
+        items.append({"type": "text", "text": prompt.text})
+    for attachment in prompt.attachments:
+        path = attachment.get("path") or attachment.get("local_path")
+        if isinstance(path, str) and path:
+            items.append({"type": "localImage", "path": path})
+    return items
+
+
+class CodexWsTransport:
+    """
+    WebSocket-JSON-RPC transport for codex-native.
+
+    :param bridge_dir: Codex bridge dir to read thread/socket/turn state.
+    :param client_factory: Builds a Codex app-server client; ``None`` uses
+        ``client_for_transport`` against the bridge socket.
+    """
+
+    descriptor_id = "codex-native"
+
+    def __init__(
+        self,
+        *,
+        bridge_dir: Path | None = None,
+        client_factory: CodexClientFactory | None = None,
+    ) -> None:
+        self._bridge_dir = bridge_dir
+        self._client_factory = client_factory
+
+    def _read_state(self) -> Any:
+        """
+        Read codex bridge state.
+
+        :returns: The bridge state, or ``None``.
+        """
+        if self._bridge_dir is None:
+            return None
+        from omnigent.codex_native_bridge import read_bridge_state
+
+        return read_bridge_state(self._bridge_dir)
+
+    def _client(self, socket_path: str | None = None) -> Any:
+        """
+        Build a Codex app-server client.
+
+        :param socket_path: Transport endpoint (unix:// or ws://).
+        :returns: A Codex app-server client.
+        :raises RuntimeError: When no endpoint is resolvable.
+        """
+        if self._client_factory is not None:
+            return self._client_factory()
+        from omnigent.codex_native_app_server import client_for_transport
+
+        if socket_path is None:
+            state = self._read_state()
+            socket_path = state.socket_path if state is not None else None
+        if not socket_path:
+            raise RuntimeError("CodexWsTransport has no socket path / client factory")
+        return client_for_transport(socket_path, client_name="omnigent-codex-ws-transport")
+
+    async def start_server(self, launch: NativeLaunchConfig) -> NativeServerHandle:
+        """Codex server lifecycle is runner-owned (see ``_auto_create_codex_terminal``)."""
+        raise NotImplementedError("Codex app-server lifecycle is runner-owned")
+
+    async def stop_server(self) -> None:
+        """No-op: the runner owns the Codex app-server process."""
+        return
+
+    async def create_or_resume_session(self, launch: NativeLaunchConfig) -> str:
+        """Return the resume thread id, or the bridge's thread id."""
+        if launch.external_session_id:
+            return launch.external_session_id
+        state = self._read_state()
+        if state is not None:
+            return str(state.thread_id)
+        raise RuntimeError("CodexWsTransport cannot resolve a thread id")
+
+    async def send_prompt(self, session_id: str, prompt: NativePrompt) -> Mapping[str, Any]:
+        """Inject a turn via ``turn/start`` (or ``turn/steer`` if active)."""
+        from omnigent.codex_native_bridge import update_active_turn_id
+
+        input_items = _prompt_to_input_items(prompt)
+        state = self._read_state()
+        active_turn_id = state.active_turn_id if state is not None else None
+        client = self._client(state.socket_path if state is not None else None)
+        await client.connect()
+        try:
+            if active_turn_id is not None:
+                response = await client.request(
+                    "turn/steer",
+                    {
+                        "threadId": session_id,
+                        "expectedTurnId": active_turn_id,
+                        "input": input_items,
+                    },
+                )
+                turn_id = response.get("result", {}).get("turnId")
+            else:
+                response = await client.request(
+                    "turn/start",
+                    {"threadId": session_id, "input": input_items},
+                )
+                turn_id = response.get("result", {}).get("turn", {}).get("id")
+            if isinstance(turn_id, str) and turn_id and self._bridge_dir is not None:
+                update_active_turn_id(self._bridge_dir, turn_id)
+            return dict(response)
+        finally:
+            await client.close()
+
+    async def abort(self, session_id: str) -> bool:
+        """Abort via ``turn/interrupt`` for the active turn."""
+        state = self._read_state()
+        active_turn_id = state.active_turn_id if state is not None else None
+        if active_turn_id is None:
+            return False
+        client = self._client(state.socket_path if state is not None else None)
+        await client.connect()
+        try:
+            await client.request(
+                "turn/interrupt",
+                {"threadId": session_id, "turnId": active_turn_id},
+            )
+        finally:
+            await client.close()
+        return True
+
+    async def events(self, session_id: str) -> AsyncIterator[NativeEvent]:
+        """Codex event forwarding is runner-owned (WS notification stream)."""
+        del session_id
+        raise NotImplementedError("Codex event forwarding is runner-owned")
+        yield  # pragma: no cover - makes this an async generator
+
+    async def list_history(self, session_id: str) -> list[Mapping[str, Any]]:
+        """Codex history lives in rollout files / app-server; runner-owned."""
+        raise NotImplementedError("Codex history is runner-owned")
+
+    async def fork(self, session_id: str, *, at_message_id: str | None = None) -> str:
+        """Codex forks rebuild rollouts in the runner; not a transport op."""
+        raise NotImplementedError("Codex fork is runner-owned")
+
+    async def reply_permission(self, decision: NativePermissionDecision) -> None:
+        """Codex uses elicitation resolution, not a permission reply API."""
+        raise NotImplementedError("Codex permissions use elicitation resolution")
+
+    def build_tui_attach_command(
+        self, launch: NativeLaunchConfig, session_id: str
+    ) -> tuple[list[str], Mapping[str, str]]:
+        """Build the ``codex ... --remote`` attach argv (no env override)."""
+        from omnigent.codex_native_app_server import build_codex_remote_args
+
+        remote_url = launch.server_url or ""
+        argv = build_codex_remote_args(
+            codex_args=tuple(launch.terminal_launch_args),
+            thread_id=session_id,
+            remote_url=remote_url,
+        )
+        return argv, {}

--- a/omnigent/harness_aliases.py
+++ b/omnigent/harness_aliases.py
@@ -6,49 +6,25 @@ Omnigent continues to use canonical harness identifiers internally.
 
 from __future__ import annotations
 
-HARNESS_ALIASES: dict[str, str] = {
-    "claude": "claude-sdk",
-    "native-pi": "pi-native",
-    # The SDK package / runtime dispatch spelling; specs use "openai-agents".
-    "openai-agents-sdk": "openai-agents",
-    # User-facing spellings for the Google Antigravity SDK harness; the
-    # canonical id is "antigravity" (matches the registry / workflow type).
-    "agy": "antigravity",
-    "google-antigravity": "antigravity",
-    # User-facing reversed spelling for the Goose native-CLI harness; canonical
-    # id is "goose-native".
-    "native-goose": "goose-native",
-    # Qwen Code harness alias.
-    "qwen-code": "qwen",
-    # OpenCode native-server harness: the bare ``opencode`` name and the
-    # reversed ``native-opencode`` spelling both fold to ``opencode-native``
-    # (there is no separate SDK ``opencode`` harness, so the bare name is free).
-    "opencode": "opencode-native",
-    "native-opencode": "opencode-native",
-}
+from omnigent.runtime.harness_descriptors import harness_alias_map, native_harness_ids
 
-# Canonical native-CLI harness spellings. These harnesses type messages into
-# a resident terminal process and mirror their transcript back to Omnigent, so
-# the runner must not replay Omnigent history or treat a completed queue call
-# as a full in-process model turn. ``AgentSpec.harness_kind`` returns these
-# canonical spellings for native agents, so no executor-type aliasing is needed
-# here.
-NATIVE_HARNESSES: frozenset[str] = frozenset(
-    {
-        "claude-native",
-        "native-claude",
-        "codex-native",
-        "native-codex",
-        "pi-native",
-        "native-pi",
-        "cursor-native",
-        "native-cursor",
-        "goose-native",
-        "native-goose",
-        "opencode-native",
-        "native-opencode",
-    }
-)
+# User-facing shorthand → canonical harness id. Derived from the single
+# :data:`~omnigent.runtime.harness_descriptors.HARNESS_DESCRIPTORS`
+# registration so it can never drift from the other harness views (the
+# conformance suite asserts the parity). Spellings include ``claude`` →
+# ``claude-sdk``, ``native-pi`` → ``pi-native``, ``openai-agents-sdk`` →
+# ``openai-agents``, the Antigravity aliases, and ``native-opencode`` →
+# ``opencode-native``.
+HARNESS_ALIASES: dict[str, str] = harness_alias_map()
+
+# Canonical native-CLI harness spellings (plus reversed ``native-<x>``
+# aliases, e.g. ``native-claude`` / ``native-codex`` / ``native-cursor``).
+# These harnesses type messages into a resident terminal process and mirror
+# their transcript back to Omnigent, so the runner must not replay Omnigent
+# history or treat a completed queue call as a full in-process model turn.
+# Derived from the descriptor registry (claude/codex/pi/cursor-native plus
+# opencode-native).
+NATIVE_HARNESSES: frozenset[str] = native_harness_ids()
 
 
 def canonicalize_harness(harness: str | None) -> str | None:

--- a/omnigent/inner/opencode_native_executor.py
+++ b/omnigent/inner/opencode_native_executor.py
@@ -27,9 +27,7 @@ from omnigent.opencode_native_bridge import (
     OPENCODE_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     read_bridge_state,
 )
-
-# Canonical harness id, surfaced in harness error messages.
-OPENCODE_NATIVE_HARNESS_ID = "opencode-native"
+from omnigent.runtime.harness_descriptors import HARNESS_DESCRIPTORS
 
 
 class OpenCodeNativeExecutor(NativeServerHarness):
@@ -44,11 +42,7 @@ class OpenCodeNativeExecutor(NativeServerHarness):
         self._bridge_dir = bridge_dir or _bridge_dir_from_env()
         self._request_session_id = _request_session_id_from_env()
         super().__init__(
-            harness_id=OPENCODE_NATIVE_HARNESS_ID,
-            # OpenCode has no live-steer endpoint, so a mid-turn message is
-            # admitted as a new prompt and the native server's own queue
-            # promotes it when the active turn finishes.
-            supports_enqueue=True,
+            descriptor=HARNESS_DESCRIPTORS["opencode-native"],
             transport=OpenCodeHttpTransport(bridge_dir=self._bridge_dir),
             resolve_session_id=self._resolve_opencode_session_id,
             build_prompt=self._build_prompt_with_model_override,

--- a/omnigent/native_server_harness.py
+++ b/omnigent/native_server_harness.py
@@ -33,6 +33,7 @@ from omnigent.inner.executor import (
     TurnComplete,
 )
 from omnigent.native_server_transport import NativePrompt, NativeServerTransport
+from omnigent.runtime.harness_descriptors import HarnessDescriptor
 
 _logger = logging.getLogger(__name__)
 
@@ -46,10 +47,7 @@ class NativeServerHarness(Executor):
     """
     Transport-driven executor for native-server harnesses.
 
-    :param harness_id: Canonical harness id, e.g. ``"opencode-native"`` (used
-        in harness error messages).
-    :param supports_enqueue: Whether the harness supports mid-turn enqueue
-        (steer-or-queue); drives :meth:`supports_live_message_queue`.
+    :param descriptor: The harness descriptor (capabilities).
     :param transport: The transport to inject turns over.
     :param resolve_session_id: Async callable returning the native session
         id (or ``None`` until the runner has booted the server).
@@ -63,16 +61,14 @@ class NativeServerHarness(Executor):
     def __init__(
         self,
         *,
-        harness_id: str,
-        supports_enqueue: bool,
+        descriptor: HarnessDescriptor,
         transport: NativeServerTransport,
         resolve_session_id: SessionResolver,
         build_prompt: PromptBuilder,
         boot_poll_attempts: int = 60,
         boot_poll_delay: float = 1.0,
     ) -> None:
-        self._harness_id = harness_id
-        self._supports_enqueue = supports_enqueue
+        self.descriptor = descriptor
         self.transport = transport
         self._resolve_session_id = resolve_session_id
         self._build_prompt = build_prompt
@@ -92,7 +88,7 @@ class NativeServerHarness(Executor):
 
     def supports_live_message_queue(self) -> bool:
         """:returns: Whether the harness supports mid-turn enqueue."""
-        return self._supports_enqueue
+        return self.descriptor.supports_enqueue
 
     async def _await_session_id(self) -> str | None:
         """
@@ -131,7 +127,7 @@ class NativeServerHarness(Executor):
         del tools, system_prompt
         prompt = _latest_user_prompt(messages, self._build_prompt)
         if prompt is None or prompt.is_empty():
-            yield ExecutorError(message=f"{self._harness_id} turn had no user input to send")
+            yield ExecutorError(message=f"{self.descriptor.id} turn had no user input to send")
             return
         if config is not None and config.model and not prompt.model:
             prompt = _with_model(prompt, config.model)
@@ -139,12 +135,12 @@ class NativeServerHarness(Executor):
         async with self._inject_lock:
             session_id = await self._await_session_id()
             if session_id is None:
-                error_msg = f"{self._harness_id} bridge state is missing"
+                error_msg = f"{self.descriptor.id} bridge state is missing"
             else:
                 try:
                     await self.transport.send_prompt(session_id, prompt)
                 except Exception as exc:  # noqa: BLE001 - converted to a harness error event.
-                    error_msg = f"{self._harness_id} executor error: {exc}"
+                    error_msg = f"{self.descriptor.id} executor error: {exc}"
         if error_msg is not None:
             yield ExecutorError(message=error_msg)
         else:
@@ -165,7 +161,7 @@ class NativeServerHarness(Executor):
         try:
             return await self.transport.abort(session_id)
         except Exception:  # noqa: BLE001 - interruption is best effort.
-            _logger.warning("%s abort failed", self._harness_id, exc_info=True)
+            _logger.warning("%s abort failed", self.descriptor.id, exc_info=True)
             return False
 
     async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
@@ -191,7 +187,7 @@ class NativeServerHarness(Executor):
             try:
                 await self.transport.send_prompt(session_id, prompt)
             except Exception:  # noqa: BLE001 - enqueue is best effort.
-                _logger.warning("%s enqueue failed", self._harness_id, exc_info=True)
+                _logger.warning("%s enqueue failed", self.descriptor.id, exc_info=True)
                 return False
         return True
 

--- a/omnigent/native_server_transport.py
+++ b/omnigent/native_server_transport.py
@@ -1,12 +1,18 @@
 """Transport abstraction for native-server harnesses.
 
-A *native-server* harness drives a per-conversation server process the
-runner owns: the runner starts the server + an event forwarder, and the
-harness injects web turns over this transport. OpenCode speaks HTTP + SSE
-(:class:`omnigent.opencode_http_transport.OpenCodeHttpTransport`);
-:class:`NativeServerTransport` is the seam so the orchestration in
-:class:`omnigent.native_server_harness.NativeServerHarness` stays
-protocol-agnostic.
+A *native-server* harness (codex-native, opencode-native) drives a
+per-conversation server process the runner owns: the runner starts the
+server + an event forwarder, and the harness injects web turns. The two
+families differ only in transport — Codex speaks WebSocket JSON-RPC,
+OpenCode speaks HTTP + SSE. :class:`NativeServerTransport` is the seam:
+the same protocol with two concrete implementations
+(:class:`omnigent.codex_ws_transport.CodexWsTransport` and
+:class:`omnigent.opencode_http_transport.OpenCodeHttpTransport`).
+
+:class:`omnigent.native_server_harness.NativeServerHarness` orchestrates a
+turn over any conformant transport; the conformance suite
+(``tests/harness_conformance``) exercises both implementations against the
+same contract, which is the design's correctness check for the abstraction.
 """
 
 from __future__ import annotations

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -185,19 +185,21 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     "codex-native": OPENAI_FAMILY,
     PI_KEY: PI_KEY,
     "pi-native": PI_KEY,
+    "opencode-native": OPENCODE_KEY,
     "cursor-native": CURSOR_KEY,
-    "native-cursor": CURSOR_KEY,
+    # Goose: native TUI (``goose-native``) + headless ACP (``goose``, drives
+    # ``goose acp``) both wrap the ``goose`` CLI. Canonical ids only — the
+    # reversed ``native-goose`` alias folds to ``goose-native`` via
+    # canonicalize_harness before any lookup here.
     "goose-native": GOOSE_KEY,
-    "native-goose": GOOSE_KEY,
-    # Headless Goose (``harness: goose``, drives ``goose acp``) wraps the same
-    # ``goose`` CLI as the native TUI, so it gates on the same binary.
     GOOSE_KEY: GOOSE_KEY,
     QWEN_KEY: QWEN_KEY,
-    "qwen-code": QWEN_KEY,
-    # Native OpenCode (``opencode-native``) wraps the ``opencode`` CLI; its
-    # ``native-opencode`` reversed spelling gates on the same binary.
-    "opencode-native": OPENCODE_KEY,
-    "native-opencode": OPENCODE_KEY,
+    # NB: only CANONICAL harness ids appear as keys (the descriptor-parity
+    # contract asserts ``_HARNESS_NAME_TO_KEY`` keys are cli-backed descriptor
+    # ids). Reversed aliases like ``native-cursor`` / ``qwen-code`` are folded
+    # to their canonical id by ``canonicalize_harness`` before any lookup here
+    # (sub-agent dispatch in tool_dispatch.py canonicalizes first), so they
+    # need no entry of their own.
 }
 
 
@@ -211,7 +213,16 @@ def required_cli_for_harness(harness: str) -> HarnessInstallSpec | None:
         ``PATH`` for *harness* to start; ``None`` for SDK-based / unknown
         harnesses that need no CLI binary.
     """
-    key = _HARNESS_NAME_TO_KEY.get(harness)
+    # ``_HARNESS_NAME_TO_KEY`` is keyed by CANONICAL harness ids only (the
+    # descriptor-parity contract). Resolve any alias/reversed-alias spelling
+    # (``native-cursor`` → ``cursor-native``, ``qwen-code`` → ``qwen``,
+    # ``native-opencode`` → ``opencode-native``) to its canonical id first so
+    # those spellings still find their CLI spec.
+    from omnigent.runtime.harness_descriptors import descriptor_for
+
+    descriptor = descriptor_for(harness)
+    canonical = descriptor.id if descriptor is not None else harness
+    key = _HARNESS_NAME_TO_KEY.get(canonical)
     return _HARNESS_INSTALL.get(key) if key is not None else None
 
 

--- a/omnigent/opencode_http_transport.py
+++ b/omnigent/opencode_http_transport.py
@@ -1,8 +1,10 @@
 """OpenCode HTTP + SSE implementation of :class:`NativeServerTransport`.
 
-All OpenCode wire details live here;
-:class:`omnigent.native_server_harness.NativeServerHarness` drives it through
-the transport protocol only.
+One of the two concrete transports that prove the native-server
+abstraction (the other is
+:class:`omnigent.codex_ws_transport.CodexWsTransport`). All OpenCode wire
+details live here; :class:`omnigent.native_server_harness.NativeServerHarness`
+and the conformance suite drive it through the protocol only.
 
 The transport can build its client from three sources, in priority order:
 an injected ``client_factory`` (tests), a running

--- a/omnigent/runtime/harness_descriptors.py
+++ b/omnigent/runtime/harness_descriptors.py
@@ -1,0 +1,501 @@
+"""Single-registration harness descriptors.
+
+Adding a harness historically meant editing ~6 scattered registries
+(runtime module map, spec allowlist, aliases, native set, model-override
+set, install metadata, web registry). :class:`HarnessDescriptor` is the
+one place a harness is declared; the scattered registries become *derived
+views* of :data:`HARNESS_DESCRIPTORS`, and the conformance suite
+(``tests/harness_conformance``) asserts every view agrees with the
+descriptors so they can never drift again.
+
+This module is pure data — it imports nothing from the rest of Omnigent,
+so any registry module can import it without a cycle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+HarnessFamily = Literal[
+    "sdk",
+    "native-server",
+    "native-terminal",
+    "headless-native",
+    "legacy",
+]
+
+ModelIdFormat = Literal["omnigent", "provider-slash-model", "native"]
+
+# Families that count as "native CLI" harnesses for is_native_harness().
+_NATIVE_FAMILIES: frozenset[str] = frozenset({"native-server", "native-terminal"})
+
+
+@dataclass(frozen=True)
+class HarnessDescriptor:
+    """
+    Declarative description of one Omnigent harness.
+
+    Fields cover identity, runtime registration, capabilities, model
+    behavior, CLI install/readiness, and native-UI/web metadata so every
+    scattered registry can be derived. See module docstring.
+
+    :param id: Canonical harness id, e.g. ``"opencode-native"``.
+    :param display_name: Human label, e.g. ``"OpenCode"``.
+    :param module: Module exporting ``create_app()`` for the runtime
+        harness process.
+    :param family: Harness family.
+    :param aliases: User-facing alias spellings that canonicalize to *id*.
+    :param runtime_registered: Whether *id* appears in ``_HARNESS_MODULES``
+        (the per-conversation FastAPI registry). ``open-responses`` is
+        spec-valid but routed through the openai-agents adapter, so it is
+        ``False``.
+    :param runtime_aliases: Aliases that ALSO appear as keys in
+        ``_HARNESS_MODULES`` (only ``claude`` today).
+    :param native_aliases: Reversed ``native-<x>`` spellings recognized by
+        :func:`is_native_harness` (e.g. ``native-codex``).
+    :param supports_model_override: Whether a per-session model override
+        reaches the harness process.
+    :param supports_interrupt: Whether the harness supports abort.
+    :param supports_enqueue: Whether mid-turn enqueue works.
+    :param supports_terminal_takeover: Whether a TUI can attach.
+    :param supports_resume: Whether resume by external session id works.
+    :param supports_fork: Whether fork is supported.
+    :param supports_permissions: Whether the harness has a permission API.
+    :param model_id_format: Expected model-id format.
+    :param cli_binary: CLI executable name required on PATH (CLI-backed
+        harnesses only).
+    :param npm_package: npm package providing *cli_binary*.
+    :param install_hint: Non-npm install command, when applicable.
+    :param install_family_key: Key into ``_HARNESS_NAME_TO_KEY`` /
+        ``_HARNESS_INSTALL`` for CLI-backed harnesses.
+    :param wrapper_agent_name: Built-in native-UI wrapper agent name.
+    :param wrapper_label: ``omnigent.wrapper`` label value.
+    :param terminal_name: Runner terminal name for the native TUI.
+    :param web_icon_kind: ap-web native icon kind.
+    :param web_sort_rank: ap-web native picker sort rank.
+    :param web_capabilities: ap-web native capabilities.
+    :param terminal_first: Whether the web UI treats this as terminal-first.
+    :param transport_kind: Native transport tag (``ws-jsonrpc`` /
+        ``http-sse``) for native-server harnesses.
+    :param openapi_schema: Vendored OpenAPI fixture name, when applicable.
+    :param min_cli_version: Inclusive minimum supported CLI version.
+    :param max_cli_version_exclusive: Exclusive maximum CLI version.
+    :param description: One-line description.
+    :param metadata: Free-form extensibility metadata.
+    """
+
+    # Identity
+    id: str
+    display_name: str
+    module: str
+    family: HarnessFamily = "sdk"
+    aliases: tuple[str, ...] = ()
+    description: str | None = None
+
+    # Runtime registration
+    runtime_registered: bool = True
+    runtime_aliases: tuple[str, ...] = ()
+    native_aliases: tuple[str, ...] = ()
+
+    # Capabilities
+    supports_streaming: bool = True
+    supports_tool_calling: bool = True
+    handles_tools_internally: bool = False
+    supports_interrupt: bool = False
+    supports_enqueue: bool = False
+    supports_terminal_takeover: bool = False
+    supports_resume: bool = False
+    supports_fork: bool = False
+    supports_permissions: bool = False
+
+    # Model behavior
+    supports_model_override: bool = False
+    model_id_format: ModelIdFormat = "omnigent"
+    supported_model_families: tuple[str, ...] = ()
+    default_model: str | None = None
+
+    # CLI install / readiness
+    cli_binary: str | None = None
+    npm_package: str | None = None
+    install_hint: str | None = None
+    install_family_key: str | None = None
+    min_cli_version: str | None = None
+    max_cli_version_exclusive: str | None = None
+
+    # Native UI / web
+    wrapper_agent_name: str | None = None
+    wrapper_label: str | None = None
+    terminal_name: str | None = None
+    web_icon_kind: str | None = None
+    web_sort_rank: int | None = None
+    web_capabilities: tuple[str, ...] = ()
+    terminal_first: bool = False
+
+    # Native server transport
+    transport_kind: str | None = None
+    openapi_schema: str | None = None
+
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    @property
+    def is_native(self) -> bool:
+        """:returns: Whether this is a native CLI harness."""
+        return self.family in _NATIVE_FAMILIES
+
+
+HARNESS_DESCRIPTORS: dict[str, HarnessDescriptor] = {
+    "claude-sdk": HarnessDescriptor(
+        id="claude-sdk",
+        display_name="Claude",
+        module="omnigent.inner.claude_sdk_harness",
+        family="sdk",
+        aliases=("claude",),
+        runtime_aliases=("claude",),
+        supports_model_override=True,
+        supported_model_families=("claude",),
+        description="In-process Claude SDK harness.",
+    ),
+    "claude-native": HarnessDescriptor(
+        id="claude-native",
+        display_name="Claude",
+        module="omnigent.inner.claude_native_harness",
+        family="native-terminal",
+        native_aliases=("native-claude",),
+        handles_tools_internally=True,
+        supports_interrupt=True,
+        supports_enqueue=True,
+        supports_terminal_takeover=True,
+        supports_resume=True,
+        supports_permissions=True,
+        supports_model_override=True,
+        supported_model_families=("claude",),
+        cli_binary="claude",
+        npm_package="@anthropic-ai/claude-code",
+        install_family_key="anthropic",
+        wrapper_agent_name="claude-native-ui",
+        wrapper_label="claude-code-native-ui",
+        terminal_name="claude",
+        web_icon_kind="claude",
+        web_sort_rank=10,
+        web_capabilities=("approvalMode",),
+        terminal_first=True,
+        description="Native Claude Code TUI bridge.",
+    ),
+    "codex": HarnessDescriptor(
+        id="codex",
+        display_name="Codex",
+        module="omnigent.inner.codex_harness",
+        family="sdk",
+        supports_model_override=True,
+        supported_model_families=("codex",),
+        description="In-process Codex harness.",
+    ),
+    "codex-native": HarnessDescriptor(
+        id="codex-native",
+        display_name="Codex",
+        module="omnigent.inner.codex_native_harness",
+        family="native-server",
+        native_aliases=("native-codex",),
+        handles_tools_internally=True,
+        supports_interrupt=True,
+        supports_enqueue=True,
+        supports_terminal_takeover=True,
+        supports_resume=True,
+        supports_fork=True,
+        supports_permissions=True,
+        supports_model_override=True,
+        supported_model_families=("codex",),
+        cli_binary="codex",
+        npm_package="@openai/codex",
+        install_family_key="openai",
+        wrapper_agent_name="codex-native-ui",
+        wrapper_label="codex-native-ui",
+        terminal_name="codex",
+        web_icon_kind="codex",
+        web_sort_rank=20,
+        web_capabilities=("approvalMode",),
+        terminal_first=True,
+        transport_kind="ws-jsonrpc",
+        description="Native Codex app-server bridge (WS JSON-RPC).",
+    ),
+    "opencode-native": HarnessDescriptor(
+        id="opencode-native",
+        display_name="OpenCode",
+        module="omnigent.inner.opencode_native_harness",
+        family="native-server",
+        # ``opencode`` is accepted as a friendly alias for the canonical
+        # ``opencode-native`` (there is no separate SDK ``opencode`` harness, so
+        # the bare name is free); ``native-opencode`` is the reversed spelling.
+        aliases=("native-opencode", "opencode"),
+        runtime_aliases=("opencode",),
+        native_aliases=("native-opencode",),
+        handles_tools_internally=True,
+        supports_interrupt=True,
+        supports_enqueue=True,
+        supports_terminal_takeover=True,
+        supports_resume=True,
+        supports_fork=True,
+        supports_permissions=True,
+        supports_model_override=True,
+        model_id_format="provider-slash-model",
+        cli_binary="opencode",
+        npm_package="opencode-ai",
+        install_family_key="opencode",
+        min_cli_version="1.17.7",
+        max_cli_version_exclusive="1.18.0",
+        wrapper_agent_name="opencode-native-ui",
+        wrapper_label="opencode-native-ui",
+        terminal_name="opencode",
+        web_icon_kind="opencode",
+        web_sort_rank=25,
+        web_capabilities=("approvalMode",),
+        terminal_first=True,
+        transport_kind="http-sse",
+        # No vendored OpenAPI fixture: the typed client is hand-maintained and
+        # the live wire-contract e2e (test_opencode_native_wire_contract_e2e)
+        # validates it against a real `opencode serve` — a far better drift
+        # guard than a 35k-line checked-in schema dump.
+        description="Native OpenCode server bridge (HTTP + SSE).",
+    ),
+    "pi": HarnessDescriptor(
+        id="pi",
+        display_name="Pi",
+        module="omnigent.inner.pi_harness",
+        family="headless-native",
+        supports_model_override=True,
+        cli_binary="pi",
+        npm_package="@earendil-works/pi-coding-agent",
+        install_family_key="pi",
+        description="Pi coding agent harness.",
+    ),
+    "pi-native": HarnessDescriptor(
+        id="pi-native",
+        display_name="Pi",
+        module="omnigent.inner.pi_native_harness",
+        family="native-terminal",
+        aliases=("native-pi",),
+        native_aliases=("native-pi",),
+        handles_tools_internally=True,
+        supports_terminal_takeover=True,
+        supports_resume=True,
+        supports_model_override=True,
+        cli_binary="pi",
+        npm_package="@earendil-works/pi-coding-agent",
+        install_family_key="pi",
+        wrapper_agent_name="pi-native-ui",
+        wrapper_label="pi-native-ui",
+        terminal_name="pi",
+        web_icon_kind="pi",
+        web_sort_rank=30,
+        terminal_first=True,
+        description="Native Pi TUI bridge.",
+    ),
+    "openai-agents": HarnessDescriptor(
+        id="openai-agents",
+        display_name="OpenAI Agents",
+        module="omnigent.inner.openai_agents_sdk_harness",
+        family="sdk",
+        aliases=("openai-agents-sdk",),
+        supports_model_override=True,
+        description="In-process OpenAI Agents SDK harness.",
+    ),
+    "open-responses": HarnessDescriptor(
+        id="open-responses",
+        display_name="OpenResponses",
+        module="omnigent.inner.open_responses_sdk",
+        family="sdk",
+        runtime_registered=False,
+        supports_model_override=False,
+        description="OpenAI Responses-API harness (routed via the agents adapter).",
+    ),
+    "cursor": HarnessDescriptor(
+        id="cursor",
+        display_name="Cursor",
+        module="omnigent.inner.cursor_harness",
+        family="sdk",
+        supports_model_override=True,
+        description="In-process Cursor SDK harness.",
+    ),
+    "cursor-native": HarnessDescriptor(
+        id="cursor-native",
+        display_name="Cursor",
+        module="omnigent.inner.cursor_native_harness",
+        family="native-terminal",
+        native_aliases=("native-cursor",),
+        handles_tools_internally=True,
+        supports_enqueue=True,
+        supports_terminal_takeover=True,
+        # Native CLI override reaches the TUI at launch (is_native_harness →
+        # harness_supports_model_override is True for any native harness).
+        supports_model_override=True,
+        # Native Cursor wraps the ``cursor-agent`` CLI, so it IS cli-backed and
+        # is gated on that binary like claude-native / codex-native (matches the
+        # readiness fix in #774). cursor-agent ships via a curl installer rather
+        # than npm, hence ``install_hint`` not ``npm_package``. (Auth/login live
+        # under the ``cursor`` family; cursor-agent still gates its own tools
+        # inside the TUI, so Omnigent intercepts no permissions — no permission
+        # API. See omnigent/inner/cursor_native_harness.py.)
+        cli_binary="cursor-agent",
+        install_family_key="cursor",
+        install_hint="curl https://cursor.com/install -fsS | bash",
+        wrapper_agent_name="cursor-native-ui",
+        wrapper_label="cursor-native-ui",
+        terminal_name="cursor",
+        web_icon_kind="cursor",
+        web_sort_rank=40,
+        terminal_first=True,
+        description="Native Cursor TUI bridge (tmux).",
+    ),
+    "antigravity": HarnessDescriptor(
+        id="antigravity",
+        display_name="Antigravity",
+        module="omnigent.inner.antigravity_harness",
+        family="sdk",
+        aliases=("agy", "google-antigravity"),
+        supports_model_override=True,
+        description="In-process Google Antigravity SDK harness.",
+    ),
+    "qwen": HarnessDescriptor(
+        id="qwen",
+        display_name="Qwen Code",
+        module="omnigent.inner.qwen_harness",
+        family="sdk",
+        aliases=("qwen-code",),
+        supports_model_override=True,
+        # CLI-backed (drives the ``qwen`` binary in ACP mode), gated on the
+        # binary like the other CLI harnesses. Auth is via OpenAI-compatible
+        # env vars / the interactive ``/auth`` command — no CLI login argv (see
+        # the install spec note in onboarding/harness_install.py).
+        cli_binary="qwen",
+        npm_package="@qwen-code/qwen-code",
+        install_family_key="qwen",
+        description="Qwen Code CLI harness (ACP mode).",
+    ),
+    "goose": HarnessDescriptor(
+        id="goose",
+        display_name="Goose",
+        module="omnigent.inner.goose_harness",
+        family="sdk",
+        supports_model_override=True,
+        # Block's Goose CLI in headless ACP mode (``goose acp``). CLI-backed —
+        # gated on the ``goose`` binary; Goose owns its own auth/provider config
+        # (``goose configure``) and ships via brew, not npm.
+        cli_binary="goose",
+        install_hint="brew install block-goose-cli",
+        install_family_key="goose",
+        description="Headless Goose ACP harness (drives `goose acp`).",
+    ),
+    "goose-native": HarnessDescriptor(
+        id="goose-native",
+        display_name="Goose",
+        module="omnigent.inner.goose_native_harness",
+        family="native-terminal",
+        aliases=("native-goose",),
+        native_aliases=("native-goose",),
+        handles_tools_internally=True,
+        supports_enqueue=True,
+        supports_terminal_takeover=True,
+        supports_model_override=True,
+        # Native ``goose session`` TUI bridge — wraps the same ``goose`` binary
+        # as the headless harness, gated on it (brew install, no npm package).
+        cli_binary="goose",
+        install_hint="brew install block-goose-cli",
+        install_family_key="goose",
+        wrapper_agent_name="goose-native-ui",
+        wrapper_label="goose-native-ui",
+        terminal_name="goose",
+        web_icon_kind="goose",
+        web_sort_rank=50,
+        terminal_first=True,
+        description="Native Goose TUI bridge (goose session).",
+    ),
+}
+
+
+def descriptor_for(harness: str | None) -> HarnessDescriptor | None:
+    """
+    Resolve a descriptor by canonical id or alias.
+
+    :param harness: A harness id or alias, e.g. ``"native-opencode"``.
+    :returns: The matching descriptor, or ``None``.
+    """
+    if harness is None:
+        return None
+    if harness in HARNESS_DESCRIPTORS:
+        return HARNESS_DESCRIPTORS[harness]
+    for descriptor in HARNESS_DESCRIPTORS.values():
+        if harness in descriptor.aliases or harness in descriptor.native_aliases:
+            return descriptor
+    return None
+
+
+def canonical_harness_ids() -> frozenset[str]:
+    """:returns: The canonical harness id set (== spec allowlist)."""
+    return frozenset(HARNESS_DESCRIPTORS)
+
+
+def harness_alias_map() -> dict[str, str]:
+    """:returns: ``{alias: canonical_id}`` for all user-facing aliases."""
+    mapping: dict[str, str] = {}
+    for descriptor in HARNESS_DESCRIPTORS.values():
+        for alias in descriptor.aliases:
+            mapping[alias] = descriptor.id
+    return mapping
+
+
+def all_harness_aliases() -> frozenset[str]:
+    """:returns: The set of all user-facing alias spellings."""
+    return frozenset(harness_alias_map())
+
+
+def runtime_module_map() -> dict[str, str]:
+    """
+    Build the runtime harness→module map (``_HARNESS_MODULES``).
+
+    Includes runtime-registered canonical ids plus the runtime aliases
+    that historically appear as keys (``claude``).
+
+    :returns: ``{harness_or_alias: module_path}``.
+    """
+    mapping: dict[str, str] = {}
+    for descriptor in HARNESS_DESCRIPTORS.values():
+        if not descriptor.runtime_registered:
+            continue
+        mapping[descriptor.id] = descriptor.module
+        for alias in descriptor.runtime_aliases:
+            mapping[alias] = descriptor.module
+    return mapping
+
+
+def native_harness_ids() -> frozenset[str]:
+    """
+    Build the native-harness recognition set (``NATIVE_HARNESSES``).
+
+    Includes native canonical ids plus their reversed ``native-<x>``
+    spellings.
+
+    :returns: The set of native harness spellings.
+    """
+    ids: set[str] = set()
+    for descriptor in HARNESS_DESCRIPTORS.values():
+        if descriptor.is_native:
+            ids.add(descriptor.id)
+            ids.update(descriptor.native_aliases)
+    return frozenset(ids)
+
+
+def model_override_harness_ids() -> frozenset[str]:
+    """:returns: Canonical ids whose harness supports model override."""
+    return frozenset(d.id for d in HARNESS_DESCRIPTORS.values() if d.supports_model_override)
+
+
+def cli_backed_descriptors() -> list[HarnessDescriptor]:
+    """:returns: Descriptors that require a CLI binary on PATH."""
+    return [d for d in HARNESS_DESCRIPTORS.values() if d.install_family_key is not None]
+
+
+def native_ui_descriptors() -> list[HarnessDescriptor]:
+    """:returns: Descriptors that ship a native-UI wrapper agent."""
+    return [d for d in HARNESS_DESCRIPTORS.values() if d.wrapper_agent_name is not None]

--- a/omnigent/runtime/harnesses/__init__.py
+++ b/omnigent/runtime/harnesses/__init__.py
@@ -24,80 +24,22 @@ sibling modules; this ``__init__.py`` is just the registry.
 
 from __future__ import annotations
 
+from omnigent.runtime.harness_descriptors import runtime_module_map
+
 # Harness-name → fully-qualified module path. Each module must
 # export ``create_app() -> FastAPI``; the runner imports the module,
 # calls the factory, and serves the result over a Unix socket.
 #
-# Populated as per-harness wraps land in Phase 1 step 4. The test
-# suite injects fixture entries at test time (via direct dict
+# Derived from the single
+# :data:`~omnigent.runtime.harness_descriptors.HARNESS_DESCRIPTORS`
+# registration (runtime-registered descriptors plus their runtime aliases,
+# e.g. ``claude`` → claude-sdk). ``open-responses`` is intentionally absent
+# (it is spec-valid but routed through the openai-agents adapter, so its
+# descriptor sets ``runtime_registered=False``). The conformance suite
+# (``tests/harness_conformance``) asserts this map equals the descriptors.
+#
+# The test suite injects fixture entries at test time (via direct dict
 # mutation in conftest fixtures).
-_HARNESS_MODULES: dict[str, str] = {
-    # Step 4b: claude-sdk harness wrap. See
-    # omnigent/inner/claude_sdk_harness.py.
-    "claude-sdk": "omnigent.inner.claude_sdk_harness",
-    # User-facing alias accepted in specs / Omnigent harness dispatch.
-    "claude": "omnigent.inner.claude_sdk_harness",
-    # Native Claude Code terminal bridge used by ``omnigent claude``.
-    "claude-native": "omnigent.inner.claude_native_harness",
-    # Native Codex TUI terminal bridge used by ``omnigent codex``.
-    "codex-native": "omnigent.inner.codex_native_harness",
-    # Step 4c: codex harness wrap. See
-    # omnigent/inner/codex_harness.py.
-    "codex": "omnigent.inner.codex_harness",
-    # Step 4d: pi harness wrap. See
-    # omnigent/inner/pi_harness.py.
-    "pi": "omnigent.inner.pi_harness",
-    # Native Pi TUI bridge used by ``omnigent pi``.
-    "pi-native": "omnigent.inner.pi_native_harness",
-    # Step 4e: openai-agents harness wrap. See
-    # omnigent/inner/openai_agents_sdk_harness.py. Registry
-    # key is the Omnigent-side spelling (``openai-agents``,
-    # no ``-sdk`` suffix) to match
-    # ``OmnigentExecutor``'s harness allowlist and the
-    # ``executor.harness`` field used in Omnigent YAML; the
-    # backing Python module retains the ``_sdk`` suffix because
-    # the underlying SDK package is ``openai-agents`` and the
-    # executor class is :class:`OpenAIAgentsSDKExecutor`.
-    "openai-agents": "omnigent.inner.openai_agents_sdk_harness",
-    # cursor harness wrap (Cursor's ``cursor-agent`` CLI, headless). See
-    # omnigent/inner/cursor_harness.py.
-    "cursor": "omnigent.inner.cursor_harness",
-    # cursor-native harness wrap. Drives the resident ``cursor-agent`` TUI by
-    # injecting each web-UI turn into its tmux pane and mirroring the transcript
-    # back — a native-CLI harness like claude/codex/pi-native, so it IS in
-    # ``NATIVE_HARNESSES``. See omnigent/inner/cursor_native_harness.py.
-    "cursor-native": "omnigent.inner.cursor_native_harness",
-    # goose-native harness wrap. Drives the resident ``goose session`` TUI by
-    # injecting each web-UI turn into its tmux pane and mirroring the transcript
-    # back from Goose's SQLite session store — a native-CLI harness like
-    # cursor-native, so it IS in ``NATIVE_HARNESSES``. See
-    # omnigent/inner/goose_native_harness.py.
-    "goose-native": "omnigent.inner.goose_native_harness",
-    # Google Antigravity SDK harness wrap. See
-    # omnigent/inner/antigravity_harness.py. In-process SDK harness
-    # (``google-antigravity``), like openai-agents — Omnigent spawns no CLI
-    # binary or sandbox subprocess (the SDK itself launches a native
-    # localharness binary; needs glibc >=~2.36). Drives Gemini 3.5 Flash by
-    # default (also Claude / GPT-OSS), with Gemini API-key or Vertex AI auth.
-    "antigravity": "omnigent.inner.antigravity_harness",
-    # Qwen Code harness wrap. See omnigent/inner/qwen_harness.py.
-    # Drives the ``qwen`` CLI in ACP mode (``qwen --acp``) for agent execution.
-    "qwen": "omnigent.inner.qwen_harness",
-    # Headless Goose harness wrap. See omnigent/inner/goose_harness.py.
-    # Drives Block's ``goose`` CLI in ACP mode (``goose acp``) — the chat-first
-    # counterpart to the terminal-first ``goose-native`` TUI harness. Tool
-    # approvals surface as web elicitation cards via session/request_permission.
-    "goose": "omnigent.inner.goose_harness",
-    # Native OpenCode server bridge used by ``omnigent opencode``. The runner
-    # owns ``opencode serve`` + an SSE forwarder and this harness injects each
-    # web-UI turn over loopback HTTP — a native-server harness like
-    # codex-native, so both ``opencode-native`` and its ``native-opencode``
-    # alias are in ``NATIVE_HARNESSES``. See
-    # omnigent/inner/opencode_native_harness.py.
-    "opencode-native": "omnigent.inner.opencode_native_harness",
-    # ``opencode`` is accepted as a friendly alias for the canonical
-    # ``opencode-native`` (there is no separate SDK ``opencode`` harness).
-    "opencode": "omnigent.inner.opencode_native_harness",
-}
+_HARNESS_MODULES: dict[str, str] = runtime_module_map()
 
 __all__ = ["_HARNESS_MODULES"]

--- a/omnigent/scaffold_harness.py
+++ b/omnigent/scaffold_harness.py
@@ -1,0 +1,173 @@
+"""Developer scaffold generator for new Omnigent harnesses.
+
+Generates the boilerplate a new harness needs and prints the
+extension-point checklist, so adding a harness starts from a working
+skeleton rather than copy-paste. Pairs with the unified
+:class:`~omnigent.runtime.harness_descriptors.HarnessDescriptor` registry —
+the generated descriptor stub is the single registration the scattered
+views derive from.
+
+Usage::
+
+    python -m omnigent.scaffold_harness foo-native \\
+        --family native-server --transport http-sse
+
+This prints the files it would create (dry-run by default) or writes them
+under the repo with ``--write``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Extension-point checklist (Appendix A of the design). Printed after a
+# scaffold so the author knows what still needs hand-wiring.
+EXTENSION_CHECKLIST: tuple[str, ...] = (
+    "Add the HarnessDescriptor to omnigent/runtime/harness_descriptors.py "
+    "(the scattered registries derive from it).",
+    "Implement the Executor (or NativeServerTransport) for the harness.",
+    "Add fake transport/client tests under tests/.",
+    "Add a built-in wrapper spec + server seeding if terminal-first.",
+    "Add the ap-web native registry entry if it has a native UI.",
+    "Run the harness conformance suite (tests/harness_conformance).",
+)
+
+
+def _module_name(name: str) -> str:
+    """
+    Convert a harness id to its python module base name.
+
+    :param name: Harness id, e.g. ``"foo-native"``.
+    :returns: Module base name, e.g. ``"foo_native"``.
+    """
+    return name.replace("-", "_")
+
+
+def _class_name(name: str) -> str:
+    """
+    Convert a harness id to a PascalCase class prefix.
+
+    :param name: Harness id, e.g. ``"foo-native"``.
+    :returns: Class prefix, e.g. ``"FooNative"``.
+    """
+    return "".join(part.capitalize() for part in name.replace("_", "-").split("-"))
+
+
+def generate_harness_scaffold(
+    name: str,
+    *,
+    family: str = "native-server",
+    transport: str = "http-sse",
+) -> dict[str, str]:
+    """
+    Build the scaffold file map for a new harness.
+
+    :param name: Harness id, e.g. ``"foo-native"``.
+    :param family: Descriptor family, e.g. ``"native-server"``.
+    :param transport: Transport kind tag, e.g. ``"http-sse"``.
+    :returns: Mapping of repo-relative path to file content.
+    """
+    mod = _module_name(name)
+    cls = _class_name(name)
+    descriptor_stub = (
+        f'    "{name}": HarnessDescriptor(\n'
+        f'        id="{name}",\n'
+        f'        display_name="{cls}",\n'
+        f'        module="omnigent.inner.{mod}_harness",\n'
+        f'        family="{family}",\n'
+        f'        transport_kind="{transport}",\n'
+        f"    ),\n"
+    )
+    harness_py = (
+        f'"""``harness: {name}`` wrap."""\n\n'
+        "from __future__ import annotations\n\n"
+        "from fastapi import FastAPI\n\n"
+        "from omnigent.inner.executor import Executor\n"
+        f"from omnigent.inner.{mod}_executor import {cls}Executor\n"
+        "from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter\n\n\n"
+        f"def _build_{mod}_executor() -> Executor:\n"
+        f'    """Construct the {name} executor."""\n'
+        f"    return {cls}Executor()\n\n\n"
+        "def create_app() -> FastAPI:\n"
+        f'    """Build the ``{name}`` harness FastAPI app."""\n'
+        f"    adapter = ExecutorAdapter(executor_factory=_build_{mod}_executor)\n"
+        "    return adapter.build()\n"
+    )
+    executor_py = (
+        f'"""Executor for the ``{name}`` harness."""\n\n'
+        "from __future__ import annotations\n\n"
+        "from collections.abc import AsyncIterator\n\n"
+        "from omnigent.inner.executor import (\n"
+        "    Executor,\n"
+        "    ExecutorConfig,\n"
+        "    ExecutorEvent,\n"
+        "    Message,\n"
+        "    ToolSpec,\n"
+        "    TurnComplete,\n"
+        ")\n\n\n"
+        f"class {cls}Executor(Executor):\n"
+        f'    """TODO: implement the {name} executor."""\n\n'
+        "    async def run_turn(\n"
+        "        self,\n"
+        "        messages: list[Message],\n"
+        "        tools: list[ToolSpec],\n"
+        "        system_prompt: str,\n"
+        "        config: ExecutorConfig | None = None,\n"
+        "    ) -> AsyncIterator[ExecutorEvent]:\n"
+        "        del messages, tools, system_prompt, config\n"
+        "        raise NotImplementedError\n"
+        "        yield TurnComplete(response=None)  # pragma: no cover\n"
+    )
+    test_py = (
+        f'"""Tests for the {name} harness scaffold."""\n\n'
+        "from __future__ import annotations\n\n"
+        f"from omnigent.inner.{mod}_harness import create_app\n\n\n"
+        "def test_create_app() -> None:\n"
+        "    assert create_app() is not None\n"
+    )
+    return {
+        f"omnigent/inner/{mod}_harness.py": harness_py,
+        f"omnigent/inner/{mod}_executor.py": executor_py,
+        f"tests/test_{mod}_harness.py": test_py,
+        f"# descriptor stub for {name} (paste into HARNESS_DESCRIPTORS)": descriptor_stub,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    CLI entry point for the harness scaffold generator.
+
+    :param argv: Argument vector; ``None`` uses ``sys.argv``.
+    :returns: Process exit code.
+    """
+    parser = argparse.ArgumentParser(prog="omnigent.scaffold_harness")
+    parser.add_argument("name", help="Harness id, e.g. foo-native")
+    parser.add_argument("--family", default="native-server")
+    parser.add_argument("--transport", default="http-sse")
+    parser.add_argument("--write", action="store_true", help="Write files (default: dry-run)")
+    parser.add_argument("--root", default=".", help="Repo root for --write")
+    args = parser.parse_args(argv)
+
+    files = generate_harness_scaffold(args.name, family=args.family, transport=args.transport)
+    for path, content in files.items():
+        if path.startswith("#"):
+            print(f"\n# --- descriptor stub ---\n{content}")
+            continue
+        if args.write:
+            target = Path(args.root) / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            print(f"wrote {target}")
+        else:
+            print(f"\n# === {path} ===\n{content}")
+
+    print("\nExtension-point checklist:")
+    for item in EXTENSION_CHECKLIST:
+        print(f"  [ ] {item}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/omnigent/spec/_omnigent_compat.py
+++ b/omnigent/spec/_omnigent_compat.py
@@ -42,6 +42,7 @@ import yaml
 
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
+from omnigent.runtime.harness_descriptors import all_harness_aliases, canonical_harness_ids
 
 if TYPE_CHECKING:
     from omnigent.spec.types import AgentSpec
@@ -73,43 +74,15 @@ OMNIGENT_EXECUTOR_TYPE = "omnigent"
 # made ``examples/terminal_workers.yaml``
 # fail at spec-load with a "must be one of [...], got
 # 'open-responses'" error.
-#
-# ``opencode-native`` is the native OpenCode server bridge (runner-owned
-# ``opencode serve`` + SSE forwarder); its ``opencode`` / ``native-opencode``
-# spellings are accepted aliases below.
-OMNIGENT_HARNESSES = frozenset(
-    {
-        "antigravity",
-        "claude-native",
-        "claude-sdk",
-        "codex",
-        "codex-native",
-        "cursor",
-        "cursor-native",
-        "goose",
-        "goose-native",
-        "openai-agents",
-        "open-responses",
-        "opencode-native",
-        "pi",
-        "pi-native",
-        "qwen",
-    },
-)
+# Derived from the single
+# :data:`~omnigent.runtime.harness_descriptors.HARNESS_DESCRIPTORS`
+# registration (canonical ids and their aliases). ``open-responses`` is a
+# descriptor too, so it stays in the allowlist; ``opencode-native``,
+# ``cursor-native`` and ``qwen`` join automatically. The conformance suite
+# asserts this equals the descriptors.
+OMNIGENT_HARNESSES = frozenset(canonical_harness_ids())
 # User-facing aliases accepted in specs and normalized before runtime dispatch.
-OMNIGENT_HARNESS_ALIASES = frozenset(
-    {
-        "claude",
-        "native-pi",
-        "native-goose",
-        "openai-agents-sdk",
-        "agy",
-        "google-antigravity",
-        "qwen-code",
-        "opencode",
-        "native-opencode",
-    }
-)
+OMNIGENT_HARNESS_ALIASES = frozenset(all_harness_aliases())
 _OMNIGENT_ACCEPTED_HARNESSES = OMNIGENT_HARNESSES | OMNIGENT_HARNESS_ALIASES
 
 

--- a/tests/harness_conformance/test_descriptor_registry_parity.py
+++ b/tests/harness_conformance/test_descriptor_registry_parity.py
@@ -1,0 +1,183 @@
+"""Conformance: scattered harness registries derive from descriptors.
+
+These drift tests are the safety net for the unified
+:class:`~omnigent.runtime.harness_descriptors.HarnessDescriptor` registry:
+they assert every scattered view (runtime module map, spec allowlist,
+aliases, native set, model-override support, CLI install metadata, native
+web/wrapper agents) agrees with the single descriptor source of truth, so
+adding or changing a harness can never silently desync the views.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from omnigent.harness_aliases import (
+    HARNESS_ALIASES,
+    NATIVE_HARNESSES,
+    canonicalize_harness,
+    is_native_harness,
+)
+from omnigent.model_override import harness_supports_model_override
+from omnigent.onboarding.harness_install import (
+    _HARNESS_NAME_TO_KEY,
+    required_cli_for_harness,
+)
+from omnigent.runtime.harness_descriptors import (
+    HARNESS_DESCRIPTORS,
+    all_harness_aliases,
+    canonical_harness_ids,
+    cli_backed_descriptors,
+    native_harness_ids,
+    native_ui_descriptors,
+    runtime_module_map,
+)
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+from omnigent.spec._omnigent_compat import OMNIGENT_HARNESS_ALIASES, OMNIGENT_HARNESSES
+
+_DESCRIPTORS = list(HARNESS_DESCRIPTORS.values())
+
+
+def test_descriptors_are_complete() -> None:
+    """Every descriptor carries the required identity fields."""
+    for harness_id, descriptor in HARNESS_DESCRIPTORS.items():
+        assert descriptor.id == harness_id, "registry key must equal descriptor.id"
+        assert descriptor.display_name
+        assert descriptor.module
+        assert descriptor.family
+
+
+def test_descriptor_ids_are_canonical_not_aliases() -> None:
+    """No descriptor id is itself a registered alias of another harness."""
+    aliases = all_harness_aliases()
+    for descriptor in _DESCRIPTORS:
+        assert descriptor.id not in aliases, f"{descriptor.id} is both an id and an alias"
+
+
+def test_runtime_registry_matches_descriptors() -> None:
+    """``_HARNESS_MODULES`` equals the descriptor-derived module map."""
+    assert runtime_module_map() == _HARNESS_MODULES
+
+
+def test_runtime_modules_import_and_expose_create_app() -> None:
+    """Every runtime-registered descriptor module exposes ``create_app``."""
+    for descriptor in _DESCRIPTORS:
+        if not descriptor.runtime_registered:
+            continue
+        module = importlib.import_module(descriptor.module)
+        assert hasattr(module, "create_app"), f"{descriptor.module} missing create_app"
+
+
+def test_spec_allowlist_matches_descriptors() -> None:
+    """``OMNIGENT_HARNESSES`` equals the canonical descriptor id set."""
+    assert canonical_harness_ids() == OMNIGENT_HARNESSES
+    assert all_harness_aliases() == OMNIGENT_HARNESS_ALIASES
+
+
+def test_aliases_canonicalize_to_descriptor_ids() -> None:
+    """Every registered alias canonicalizes to a real descriptor id."""
+    for alias, target in HARNESS_ALIASES.items():
+        assert target in HARNESS_DESCRIPTORS
+        assert canonicalize_harness(alias) == target
+
+
+def test_native_set_matches_descriptors() -> None:
+    """``NATIVE_HARNESSES`` and ``is_native_harness`` agree with descriptors."""
+    assert native_harness_ids() == NATIVE_HARNESSES
+    for descriptor in _DESCRIPTORS:
+        assert is_native_harness(descriptor.id) == descriptor.is_native
+
+
+def test_model_override_support_matches_descriptors() -> None:
+    """``harness_supports_model_override`` agrees with each descriptor flag."""
+    for descriptor in _DESCRIPTORS:
+        assert harness_supports_model_override(descriptor.id) == descriptor.supports_model_override
+
+
+def test_install_metadata_matches_descriptors() -> None:
+    """CLI-backed descriptors map to a real install spec with a binary."""
+    for descriptor in cli_backed_descriptors():
+        assert descriptor.cli_binary
+        assert descriptor.npm_package or descriptor.install_hint
+        assert _HARNESS_NAME_TO_KEY.get(descriptor.id) == descriptor.install_family_key
+        spec = required_cli_for_harness(descriptor.id)
+        assert spec is not None, f"no install spec for {descriptor.id}"
+        assert spec.binary == descriptor.cli_binary
+
+
+def test_install_name_to_key_only_covers_cli_backed_descriptors() -> None:
+    """Every ``_HARNESS_NAME_TO_KEY`` entry maps to a cli-backed descriptor."""
+    cli_ids = {d.id for d in cli_backed_descriptors()}
+    for harness_id in _HARNESS_NAME_TO_KEY:
+        assert harness_id in cli_ids, f"{harness_id} in name-to-key but not cli-backed descriptor"
+
+
+def test_native_ui_descriptors_have_wrapper_metadata() -> None:
+    """Native-UI descriptors carry wrapper + terminal-first web metadata."""
+    for descriptor in native_ui_descriptors():
+        assert descriptor.wrapper_agent_name
+        assert descriptor.wrapper_label
+        assert descriptor.terminal_name
+        assert descriptor.web_icon_kind
+        assert descriptor.terminal_first
+
+
+def test_native_ui_descriptors_match_native_coding_agents() -> None:
+    """The Python native_coding_agents registry matches native-UI descriptors."""
+    from omnigent.native_coding_agents import NATIVE_CODING_AGENTS
+
+    by_harness = {agent.harness: agent for agent in NATIVE_CODING_AGENTS}
+    for descriptor in native_ui_descriptors():
+        agent = by_harness.get(descriptor.id)
+        assert agent is not None, f"no native_coding_agents entry for {descriptor.id}"
+        assert agent.agent_name == descriptor.wrapper_agent_name
+        assert agent.wrapper_label == descriptor.wrapper_label
+        assert agent.terminal_name == descriptor.terminal_name
+
+
+def test_opencode_descriptor_is_registered() -> None:
+    """The opencode-native descriptor exists with the expected shape."""
+    descriptor = HARNESS_DESCRIPTORS.get("opencode-native")
+    assert descriptor is not None
+    assert descriptor.family == "native-server"
+    assert descriptor.transport_kind == "http-sse"
+    assert descriptor.cli_binary == "opencode"
+    assert descriptor.npm_package == "opencode-ai"
+    assert descriptor.supports_model_override is True
+    assert descriptor.supports_terminal_takeover is True
+
+
+@pytest.mark.parametrize("alias", ["native-opencode", "opencode"])
+def test_opencode_aliases_resolve(alias: str) -> None:
+    """OpenCode aliases canonicalize to the opencode-native id."""
+    assert canonicalize_harness(alias) == "opencode-native"
+
+
+def test_vendored_openapi_schemas_exist_and_parse() -> None:
+    """A descriptor naming an ``openapi_schema`` points at a real, valid file.
+
+    The native-server client is hand-shaped from the pinned vendor OpenAPI,
+    so the fixture must actually ship in-tree (resolved relative to the
+    ``omnigent`` package root) — otherwise the descriptor reference is a dead
+    string and the client can silently drift from the documented contract.
+    """
+    import json
+    from pathlib import Path
+
+    import omnigent
+
+    pkg_root = Path(omnigent.__file__).resolve().parent
+    for descriptor in _DESCRIPTORS:
+        if descriptor.openapi_schema is None:
+            continue
+        schema_path = pkg_root / descriptor.openapi_schema
+        assert schema_path.is_file(), (
+            f"{descriptor.id} declares openapi_schema={descriptor.openapi_schema!r} "
+            f"but {schema_path} does not exist"
+        )
+        with schema_path.open() as fh:
+            doc = json.load(fh)
+        assert doc.get("openapi"), f"{schema_path} is not a valid OpenAPI document"
+        assert doc.get("paths"), f"{schema_path} declares no paths"

--- a/tests/harness_conformance/test_native_server_transport_contract.py
+++ b/tests/harness_conformance/test_native_server_transport_contract.py
@@ -1,0 +1,292 @@
+"""Conformance: NativeServerHarness drives any NativeServerTransport.
+
+The native-server abstraction's correctness check is *two* real transports
+behaving identically through the shared base. These tests run
+:class:`~omnigent.native_server_harness.NativeServerHarness` over (a) an
+in-memory fake transport, (b) the real
+:class:`~omnigent.opencode_http_transport.OpenCodeHttpTransport` backed by a
+fake OpenCode HTTP server, and (c) the real
+:class:`~omnigent.codex_ws_transport.CodexWsTransport` backed by a fake
+Codex app-server client — asserting the same run-turn / abort contract for
+each.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from omnigent.codex_ws_transport import CodexWsTransport
+from omnigent.inner.executor import ExecutorEvent, TurnComplete
+from omnigent.native_server_harness import NativeServerHarness
+from omnigent.native_server_transport import (
+    NativeEvent,
+    NativeLaunchConfig,
+    NativePermissionDecision,
+    NativePrompt,
+    NativeServerHandle,
+)
+from omnigent.opencode_http_transport import OpenCodeHttpTransport
+from omnigent.opencode_native_client import OpenCodeClient
+from omnigent.runtime.harness_descriptors import HARNESS_DESCRIPTORS
+
+_OPENCODE = HARNESS_DESCRIPTORS["opencode-native"]
+_CODEX = HARNESS_DESCRIPTORS["codex-native"]
+
+
+def _build_prompt(content: Any) -> NativePrompt | None:
+    """Minimal content→prompt builder for the contract tests."""
+    if isinstance(content, str) and content:
+        return NativePrompt(text=content)
+    return None
+
+
+async def _drive(harness: NativeServerHarness) -> list[ExecutorEvent]:
+    """Run one turn and collect the emitted events."""
+    events: list[ExecutorEvent] = []
+    async for event in harness.run_turn([{"role": "user", "content": "hello"}], [], ""):
+        events.append(event)
+    return events
+
+
+class _FakeTransport:
+    """In-memory transport recording the protocol calls it receives."""
+
+    descriptor_id = "opencode-native"
+
+    def __init__(self) -> None:
+        self.prompts: list[tuple[str, NativePrompt]] = []
+        self.aborted: list[str] = []
+        self.permissions: list[NativePermissionDecision] = []
+
+    async def start_server(self, launch: NativeLaunchConfig) -> NativeServerHandle:
+        return NativeServerHandle(base_url="http://fake", env={}, bridge_dir=Path("/tmp"))
+
+    async def stop_server(self) -> None:
+        return
+
+    async def create_or_resume_session(self, launch: NativeLaunchConfig) -> str:
+        return "ses_fake"
+
+    async def send_prompt(self, session_id: str, prompt: NativePrompt) -> dict[str, Any]:
+        self.prompts.append((session_id, prompt))
+        return {}
+
+    async def abort(self, session_id: str) -> bool:
+        self.aborted.append(session_id)
+        return True
+
+    async def events(self, session_id: str):  # pragma: no cover - unused here
+        if False:
+            yield  # type: ignore[unreachable]
+
+    async def list_history(self, session_id: str) -> list[dict[str, Any]]:
+        return []
+
+    async def fork(self, session_id: str, *, at_message_id: str | None = None) -> str:
+        return "ses_fork"
+
+    async def reply_permission(self, decision: NativePermissionDecision) -> None:
+        self.permissions.append(decision)
+
+    def build_tui_attach_command(
+        self, launch: NativeLaunchConfig, session_id: str
+    ) -> tuple[list[str], dict[str, str]]:
+        return (["attach"], {})
+
+
+async def test_base_harness_runs_turn_over_fake_transport() -> None:
+    """run_turn injects the latest user prompt and yields TurnComplete."""
+    transport = _FakeTransport()
+
+    async def resolve() -> str | None:
+        return "ses_fake"
+
+    harness = NativeServerHarness(
+        descriptor=_OPENCODE,
+        transport=transport,
+        resolve_session_id=resolve,
+        build_prompt=_build_prompt,
+    )
+    events = await _drive(harness)
+
+    assert [type(e) for e in events] == [TurnComplete]
+    assert transport.prompts == [("ses_fake", NativePrompt(text="hello"))]
+
+
+async def test_base_harness_interrupt_over_fake_transport() -> None:
+    """interrupt_session routes to transport.abort."""
+    transport = _FakeTransport()
+
+    async def resolve() -> str | None:
+        return "ses_fake"
+
+    harness = NativeServerHarness(
+        descriptor=_OPENCODE,
+        transport=transport,
+        resolve_session_id=resolve,
+        build_prompt=_build_prompt,
+    )
+    assert await harness.interrupt_session("k") is True
+    assert transport.aborted == ["ses_fake"]
+
+
+async def test_base_harness_errors_when_session_never_resolves() -> None:
+    """A never-ready session yields an ExecutorError, not a hang."""
+    transport = _FakeTransport()
+
+    async def resolve() -> str | None:
+        return None
+
+    harness = NativeServerHarness(
+        descriptor=_OPENCODE,
+        transport=transport,
+        resolve_session_id=resolve,
+        build_prompt=_build_prompt,
+        boot_poll_attempts=1,
+        boot_poll_delay=0.0,
+    )
+    events = await _drive(harness)
+    assert [type(e).__name__ for e in events] == ["ExecutorError"]
+    assert transport.prompts == []
+
+
+def _opencode_http_handler(seen: dict[str, int]):
+    """Build a MockTransport handler for a fake OpenCode server."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/prompt_async"):
+            seen["prompt"] = seen.get("prompt", 0) + 1
+            return httpx.Response(200, json={})
+        if path.endswith("/abort"):
+            seen["abort"] = seen.get("abort", 0) + 1
+            return httpx.Response(200, json=True)
+        return httpx.Response(404, json={})
+
+    return handler
+
+
+async def test_opencode_http_transport_send_and_abort() -> None:
+    """The real HTTP transport injects + aborts via the base harness."""
+    seen: dict[str, int] = {}
+
+    def client_factory() -> OpenCodeClient:
+        mock = httpx.AsyncClient(
+            base_url="http://opencode.test",
+            transport=httpx.MockTransport(_opencode_http_handler(seen)),
+        )
+        return OpenCodeClient("http://opencode.test", client=mock)
+
+    transport = OpenCodeHttpTransport(client_factory=client_factory)
+
+    async def resolve() -> str | None:
+        return "ses_http"
+
+    harness = NativeServerHarness(
+        descriptor=_OPENCODE,
+        transport=transport,
+        resolve_session_id=resolve,
+        build_prompt=_build_prompt,
+    )
+    events = await _drive(harness)
+    assert [type(e) for e in events] == [TurnComplete]
+    assert seen.get("prompt") == 1
+
+    assert await transport.abort("ses_http") is True
+    assert seen.get("abort") == 1
+
+
+class _FakeCodexClient:
+    """Minimal Codex app-server client recording JSON-RPC requests."""
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, Any]]] = []
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        self.requests.append((method, params))
+        if method == "turn/start":
+            return {"result": {"turn": {"id": "turn_1"}}}
+        if method == "turn/steer":
+            return {"result": {"turnId": "turn_steer"}}
+        return {"result": {}}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def test_codex_ws_transport_send_prompt_over_base(tmp_path: Path) -> None:
+    """The real Codex WS transport injects a turn via the base harness."""
+    from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
+
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_1",
+            socket_path="ws://127.0.0.1:9",
+            thread_id="thread_1",
+            codex_home=str(tmp_path / "home"),
+            active_turn_id=None,
+        ),
+    )
+    client = _FakeCodexClient()
+    transport = CodexWsTransport(bridge_dir=tmp_path, client_factory=lambda: client)
+
+    async def resolve() -> str | None:
+        return "thread_1"
+
+    harness = NativeServerHarness(
+        descriptor=_CODEX,
+        transport=transport,
+        resolve_session_id=resolve,
+        build_prompt=_build_prompt,
+    )
+    events = await _drive(harness)
+    assert [type(e) for e in events] == [TurnComplete]
+    assert client.requests[0][0] == "turn/start"
+    assert client.requests[0][1]["threadId"] == "thread_1"
+
+
+async def test_codex_ws_transport_abort(tmp_path: Path) -> None:
+    """The Codex WS transport aborts the active turn via turn/interrupt."""
+    from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
+
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_1",
+            socket_path="ws://127.0.0.1:9",
+            thread_id="thread_1",
+            codex_home=str(tmp_path / "home"),
+            active_turn_id="turn_active",
+        ),
+    )
+    client = _FakeCodexClient()
+    transport = CodexWsTransport(bridge_dir=tmp_path, client_factory=lambda: client)
+
+    assert await transport.abort("thread_1") is True
+    assert client.requests == [
+        ("turn/interrupt", {"threadId": "thread_1", "turnId": "turn_active"})
+    ]
+
+
+def test_both_transports_satisfy_protocol() -> None:
+    """Both concrete transports are structural NativeServerTransports."""
+    from omnigent.native_server_transport import NativeServerTransport
+
+    assert isinstance(OpenCodeHttpTransport(), NativeServerTransport)
+    assert isinstance(CodexWsTransport(), NativeServerTransport)
+    assert OpenCodeHttpTransport().descriptor_id == "opencode-native"
+    assert CodexWsTransport().descriptor_id == "codex-native"
+
+
+def _unused_native_event() -> NativeEvent:
+    """Keep NativeEvent imported for type-completeness of the contract."""
+    return NativeEvent(id=None, type="x", payload={}, raw={})

--- a/tests/harness_conformance/test_scaffold_harness.py
+++ b/tests/harness_conformance/test_scaffold_harness.py
@@ -1,0 +1,54 @@
+"""Tests for the harness scaffold generator."""
+
+from __future__ import annotations
+
+from omnigent.scaffold_harness import (
+    EXTENSION_CHECKLIST,
+    _class_name,
+    _module_name,
+    generate_harness_scaffold,
+    main,
+)
+
+
+def test_name_helpers() -> None:
+    assert _module_name("foo-native") == "foo_native"
+    assert _class_name("foo-native") == "FooNative"
+
+
+def test_generate_scaffold_files() -> None:
+    files = generate_harness_scaffold("foo-native", family="native-server", transport="http-sse")
+    assert "omnigent/inner/foo_native_harness.py" in files
+    assert "omnigent/inner/foo_native_executor.py" in files
+    assert "tests/test_foo_native_harness.py" in files
+    harness = files["omnigent/inner/foo_native_harness.py"]
+    assert "def create_app() -> FastAPI:" in harness
+    assert "FooNativeExecutor" in harness
+    executor = files["omnigent/inner/foo_native_executor.py"]
+    assert "class FooNativeExecutor(Executor):" in executor
+    # descriptor stub present (as a comment key).
+    stub_key = next(k for k in files if k.startswith("#"))
+    assert 'id="foo-native"' in files[stub_key]
+
+
+def test_generated_harness_module_is_syntactically_valid() -> None:
+    files = generate_harness_scaffold("foo-native")
+    for path, content in files.items():
+        if path.endswith(".py"):
+            compile(content, path, "exec")
+
+
+def test_main_dry_run(capsys) -> None:  # type: ignore[no-untyped-def]
+    code = main(["foo-native"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "create_app" in out
+    assert EXTENSION_CHECKLIST[0] in out
+
+
+def test_main_write(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    code = main(["foo-native", "--write", "--root", str(tmp_path)])
+    assert code == 0
+    assert (tmp_path / "omnigent/inner/foo_native_harness.py").is_file()
+    assert (tmp_path / "omnigent/inner/foo_native_executor.py").is_file()
+    assert (tmp_path / "tests/test_foo_native_harness.py").is_file()

--- a/tests/test_native_server_harness.py
+++ b/tests/test_native_server_harness.py
@@ -7,11 +7,17 @@ pinning, and the error branches) independent of any concrete harness.
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Any
 
 from omnigent.inner.executor import ExecutorConfig, ExecutorError, TurnComplete
 from omnigent.native_server_harness import NativeServerHarness
 from omnigent.native_server_transport import NativePrompt
+from omnigent.runtime.harness_descriptors import HARNESS_DESCRIPTORS
+
+# Base a fake descriptor on the real opencode-native one; tests flip
+# ``supports_enqueue`` / ``id`` via ``dataclasses.replace`` as needed.
+_BASE_DESCRIPTOR = dataclasses.replace(HARNESS_DESCRIPTORS["opencode-native"], id="fake-native")
 
 
 class _FakeTransport:
@@ -49,8 +55,7 @@ def _harness(
 ) -> NativeServerHarness:
     resolve = resolver if resolver is not None else _const_resolver(session_id)
     return NativeServerHarness(
-        harness_id="fake-native",
-        supports_enqueue=supports_enqueue,
+        descriptor=dataclasses.replace(_BASE_DESCRIPTOR, supports_enqueue=supports_enqueue),
         transport=transport,  # type: ignore[arg-type]
         resolve_session_id=resolve,
         build_prompt=_build_prompt,


### PR DESCRIPTION
## Unified harness interface — `HarnessDescriptor` + conformance + scaffold

Follow-up to #576 (the OpenCode harness). That PR adds OpenCode the **scattered** way —
registration hand-maintained across `_HARNESS_MODULES`, `HARNESS_ALIASES` /
`NATIVE_HARNESSES`, `OMNIGENT_HARNESSES` / `OMNIGENT_HARNESS_ALIASES`, and
`_HARNESS_NAME_TO_KEY`. This PR introduces the single source of truth those views should
derive from, so they can never drift again.

> **Stacked on #576.** Base branch is `opencode-harness-impl`, so this diff is *only* the
> refactor (the 15 files below). Merge #576 first; I'll retarget this to `main` afterward
> (or it auto-retargets when #576 merges).

### Adds
- **`omnigent/runtime/harness_descriptors.py`** — one `HarnessDescriptor` per harness (id,
  aliases, module, family, capabilities, install/version, web + terminal metadata) with
  derivation helpers: `runtime_module_map`, `harness_alias_map`, `native_harness_ids`,
  `canonical_harness_ids`, `all_harness_aliases`, `descriptor_for`.
- **`tests/harness_conformance/`** — asserts every scattered registry view equals what the
  descriptors derive (parity), plus the native-server transport contract.
- **`omnigent/scaffold_harness.py`** — generates a new-harness skeleton from a descriptor.
- **`omnigent/codex_ws_transport.py`** — the codex WS transport that generalizes the
  native-server transport for a future codex-native migration.

### Re-derives
The scattered registries (`runtime/harnesses/__init__.py`, `harness_aliases.py`,
`spec/_omnigent_compat.py`, `onboarding/harness_install.py`) become descriptor-derived views,
and the native-server runtime re-couples to `HarnessDescriptor`: `NativeServerHarness` takes a
descriptor again and `OpenCodeNativeExecutor` passes `HARNESS_DESCRIPTORS["opencode-native"]`.

Mechanically the exact inverse of the split commit in #576, so the two PRs compose with no
net change to the OpenCode harness behavior. ruff clean; full conformance suite green.

This pull request and its description were written by Isaac.
