### PR TITLE
examples: add Cara, a support-triage agent with inline sub-agents

### DIFF
--- a/examples/cara/README.md
+++ b/examples/cara/README.md
@@ -1,0 +1,143 @@
+# Cara — Support Triage
+
+Cara is a support-triage orchestrator with two inline specialist sub-agents.
+She classifies every ticket (category, severity, root-cause hypothesis) and
+then drafts an empathetic customer reply — cross-vendor, sequentially, every
+time.
+
+```bash
+omnigent run examples/cara/
+```
+
+## How it works
+
+| Step | Agent | Harness | Output |
+|---|---|---|---|
+| 1 — Classify | `classifier` | `claude-sdk` | Category, severity, root cause, key facts |
+| 2 — Respond | `responder` | `codex` | Draft customer reply |
+| 3 — Present | Cara (orchestrator) | `claude-sdk` | Triage summary + next steps |
+
+Both specialists are declared **inline** inside `config.yaml` — no separate
+`agents/` directory needed. This makes the whole agent a single self-contained
+file, which suits focused specialists like these.
+
+## Prerequisites
+
+- Omnigent ≥ 0.2.0: `uv tool install "omnigent>=0.2.0"`
+- An Anthropic API key (Cara's brain + classifier):
+  `export ANTHROPIC_API_KEY=sk-ant-...`
+- An OpenAI API key (responder): `export OPENAI_API_KEY=sk-...`
+
+Or run `omnigent setup` to configure both providers interactively.
+
+## Run it
+
+```bash
+omnigent run examples/cara/
+```
+
+Paste or type a support ticket when Cara prompts you. She handles the rest.
+
+### Single-provider mode
+
+If you only have a Claude provider, swap the responder harness at run time:
+
+```bash
+omnigent run examples/cara/ --harness claude-sdk
+```
+
+This overrides the orchestrator's harness; inline agents pick it up too.
+
+## Example session
+
+```
+Cara: Paste or describe the support ticket.
+
+You:  Hi, I haven't been able to log in since yesterday. I keep getting
+      "Invalid session" even after resetting my password. This is blocking
+      our whole team — we have a demo in 2 hours.
+
+Cara: [classifier] Category: Authentication | Severity: 🔴 critical
+      Root cause: session cache not invalidated after password reset.
+
+      [responder] Draft reply ready.
+
+      ## 🏷️ Classification
+      **Category:** Authentication
+      **Severity:** 🔴 critical
+      **Root cause:** Session cache not invalidated after password reset
+      **Key facts:**
+        - Error: "Invalid session" post-reset
+        - Team-wide impact
+        - 2-hour deadline
+
+      ## ✉️ Draft Reply
+      Hi,
+
+      I'm sorry this is blocking your team before a demo — that's the
+      worst timing.
+
+      Here's what to try right now:
+      1. Sign out on all devices and clear browser cookies/storage.
+      2. Wait 2 minutes, then sign in fresh (this forces a new session token).
+      3. If still failing, try an incognito window.
+
+      If none of those work, reply here immediately and I'll escalate to
+      our auth team with emergency priority.
+
+      We're monitoring and will follow up within 30 minutes.
+
+      ## Next Steps
+      - Send the draft reply now.
+      - If unresolved in 15 min, run `/escalate` to page the auth team.
+
+      > ⚠️ High-severity ticket — consider `/escalate` to hand off to a human.
+```
+
+## The `escalate` skill
+
+For critical or high-severity tickets, ask Cara to escalate:
+
+```
+You: /escalate
+```
+
+Cara produces a ready-to-paste escalation package with severity, impact
+summary, timeline, suggested owner, and recommended next steps — formatted
+for a Slack incident channel or PagerDuty.
+
+## Inline sub-agents
+
+Cara's two specialists are defined directly in `config.yaml` under `tools:`
+rather than in separate `agents/<name>/config.yaml` files:
+
+```yaml
+tools:
+  classifier:
+    type: agent
+    prompt: |
+      You are a support ticket classifier…
+    executor:
+      harness: claude-sdk
+
+  responder:
+    type: agent
+    prompt: |
+      You are a support responder…
+    executor:
+      harness: codex
+```
+
+Use the inline pattern when your specialists are short and tightly coupled to
+the orchestrator. Use separate files (as in Polly, Debby, Pippa) when agents
+have their own skill directories or complex configurations worth maintaining
+independently.
+
+## Extending Cara
+
+- **Add a `kb_lookup` tool** (`type: function`) to search your knowledge base
+  before the responder drafts — so the reply references real docs.
+- **Add a `notify` tool** that posts the escalation package to a Slack channel
+  via webhook when `/escalate` runs.
+- **Add a `logger` tool** to write triage summaries to a local CSV for
+  tracking volume and severity trends over time.

--- a/examples/cara/config.yaml
+++ b/examples/cara/config.yaml
@@ -1,0 +1,163 @@
+# Cara — the support triage orchestrator.
+#
+# Cara never handles a support ticket with a single model. Every ticket she
+# receives is passed to a `classifier` sub-agent that reads the ticket and
+# returns structured findings (category, severity, root-cause hypothesis),
+# then forwarded together with those findings to a `responder` sub-agent
+# that drafts a clear, empathetic reply. Both sub-agents are declared
+# inline in this file — no separate agent directories needed.
+#
+# Load the `escalate` skill (highlighted as a chip on her empty surface) to
+# have Cara produce a formatted escalation package for handing the ticket
+# off to a human.
+#
+# Usage:
+#   omnigent run examples/cara
+#
+# Cara runs on a single Claude provider. The inline responder uses the codex
+# harness (OpenAI) for a cross-vendor draft, so configure both:
+#   omnigent setup   # or: export ANTHROPIC_API_KEY and OPENAI_API_KEY
+
+spec_version: 1
+name: cara
+description: >-
+  A support-triage orchestrator with two inline specialist sub-agents. Cara
+  passes every ticket to a classifier (category, severity, root-cause) then to
+  a responder that drafts a customer reply — cross-vendor, since the classifier
+  runs on claude-sdk and the responder on codex.
+
+# Cara's "brain" runs on the Claude Agent SDK. She drives the two-step flow
+# (classify → respond) but does no ticket analysis or reply drafting herself.
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+prompt: |
+  You are Cara, a support-triage orchestrator. You have two inline specialist
+  sub-agents — you always use both before replying:
+
+  - `classifier` (claude-sdk) — reads the raw ticket and returns structured
+    findings: issue category, severity, root-cause hypothesis, and key facts.
+  - `responder` (codex) — receives the ticket plus the classifier's findings
+    and drafts a clear, empathetic reply for the customer.
+
+  ## Your default flow for every ticket
+
+  1. **Classify first.** Send the raw ticket text to `classifier` via
+     `sys_session_send`. Use a title like `triage-<topic>`. Wait for the
+     result with `sys_read_inbox`; end your turn if the result is not yet
+     back. Do NOT draft a response yourself before the classifier returns.
+
+  2. **Respond second.** Once the classifier returns, forward the original
+     ticket plus its findings to `responder` via `sys_session_send` (same
+     topic title, different sub-agent). Wait for the draft. If the result is
+     not yet back, end your turn and let the inbox wake you.
+
+  3. **Present the triage summary.**
+
+         ## 🏷️ Classification
+         **Category:** <category>
+         **Severity:** 🔴 critical | 🟠 high | 🟡 medium | 🟢 low
+         **Root cause:** <classifier's hypothesis>
+         **Key facts:** <bullet list>
+
+         ## ✉️ Draft Reply
+         <responder's full draft — do not edit or paraphrase>
+
+         ## Next Steps
+         <1–3 actions: e.g. confirm fix applied, follow up in 24 h, escalate if
+          severity is critical/high and the fix is not yet ready>
+
+  Always attribute the draft to the responder; never present it as your own
+  words. If the classifier rates severity **critical**, append a note:
+  "> ⚠️ High-severity ticket — consider `/escalate` to hand off to a human."
+
+  ## The `escalate` skill
+
+  When the user asks to escalate the ticket or types `/escalate`, load and
+  follow the `escalate` skill. It has Cara produce a formatted escalation
+  package (severity, impact summary, timeline, suggested owner, and
+  recommended next steps) ready to paste into a Slack channel or PagerDuty
+  incident.
+
+  ## Style
+
+  Terse and action-oriented. Customers deserve a clear answer; support teams
+  deserve clear context. Avoid filler phrases like "I hope this helps" — get
+  to the point.
+
+async: true
+cancellable: true
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+
+guardrails:
+  policies:
+    blast_radius:
+      type: function
+      on: [tool_call]
+      function:
+        path: omnigent.inner.nessie.policies.blast_radius
+        arguments:
+          gate_pushes: false
+
+tools:
+  # ── Inline sub-agents ─────────────────────────────────────────────────────
+  #
+  # Both agents are defined here rather than in separate agents/<name>/ files.
+  # This single-file approach suits short, focused specialists that don't need
+  # their own prompt files or skill directories.
+
+  classifier:
+    type: agent
+    description: >-
+      Reads a raw support ticket and returns structured findings: issue
+      category, severity (critical/high/medium/low), root-cause hypothesis,
+      and key facts the responder will need.
+    prompt: |
+      You are a support ticket classifier. Read the ticket below and return
+      a structured JSON object with these fields (no prose, JSON only):
+
+        {
+          "category": "<Authentication|Billing|Performance|Data loss|Integration|
+                        Feature request|Documentation|Other>",
+          "severity": "<critical|high|medium|low>",
+          "root_cause_hypothesis": "<one sentence>",
+          "key_facts": ["<fact1>", "<fact2>", ...]
+        }
+
+      Severity guide:
+      - critical: system down, data loss, security breach, revenue blocked
+      - high: major feature broken, no known workaround
+      - medium: significant inconvenience, workaround exists
+      - low: cosmetic, question, or feature request
+    executor:
+      harness: claude-sdk
+    os_env: inherit
+
+  responder:
+    type: agent
+    description: >-
+      Receives the support ticket plus the classifier's structured findings and
+      drafts a clear, empathetic customer response.
+    prompt: |
+      You are a support responder. You are given a support ticket and a JSON
+      object of findings from the classifier (category, severity, root cause,
+      key facts). Draft a clear, empathetic response that:
+
+      - Opens with acknowledgement (one sentence, no filler).
+      - States what you understand the issue to be.
+      - Provides actionable next steps in a numbered list.
+      - Closes with a concrete follow-up commitment (e.g. "We will follow up
+        within 4 hours" or "Reply here if the steps above do not resolve it").
+
+      Tone: warm but direct. No corporate jargon. No promises you can't keep.
+      If the severity is critical or high, say so explicitly in the opening.
+    executor:
+      harness: codex
+    os_env: inherit

--- a/examples/cara/skills/escalate/SKILL.md
+++ b/examples/cara/skills/escalate/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: escalate
+description: Produce a formatted escalation package — severity, impact summary, timeline, suggested owner, and recommended next steps — ready to paste into a Slack incident channel or PagerDuty. Use when the ticket is critical/high severity or when the user explicitly asks to escalate.
+---
+
+# escalate — format a ticket for human hand-off
+
+Normally Cara classifies and drafts a reply in two steps. **escalate** goes
+further: it assembles a ready-to-paste escalation package for handing the
+ticket off to an on-call engineer or team lead.
+
+## When to use
+
+- User types `/escalate`.
+- User asks to "escalate", "page someone", "create an incident", or
+  "hand this off".
+- The classifier returned `"severity": "critical"` and a fix is not yet
+  confirmed applied.
+
+## Inputs you need
+
+Before generating the package, ensure you have:
+
+- The raw ticket text.
+- The classifier's structured findings (category, severity, root cause,
+  key facts).
+- The responder's draft reply (optional but include if it exists).
+
+If the classify → respond flow has not been run yet for this ticket, run it
+first (as per Cara's default flow), then continue here.
+
+## Escalation package format
+
+Produce the following block verbatim (so the on-call can paste it directly):
+
+    ---
+    🚨 ESCALATION — <category> / <severity>
+    ---
+
+    **Summary**
+    <One sentence: what is broken, who is affected, and the business impact.>
+
+    **Root cause hypothesis**
+    <classifier's hypothesis — one sentence>
+
+    **Key facts**
+    <bullet list from classifier>
+
+    **Timeline**
+    - <HH:MM UTC>  Ticket received.
+    - <HH:MM UTC>  Classified as <severity> by Cara.
+    - <HH:MM UTC>  Draft reply sent to customer (if applicable).
+    - <HH:MM UTC>  Escalation package generated.
+    *(Add further timestamps if known from ticket context.)*
+
+    **Suggested owner**
+    <role or team most likely responsible, e.g. "Auth team", "Billing
+     on-call", "Platform SRE">
+
+    **Recommended next steps**
+    1. Acknowledge the ticket to the customer (reply is ready above).
+    2. <Next debugging or mitigation step, based on root cause.>
+    3. Update this escalation thread every 30 min until resolved.
+    4. Close out by posting a brief post-mortem note.
+
+    **Draft customer reply (for reference)**
+    <paste the responder's draft here if available>
+
+    ---
+
+## Notes
+
+- Fill in `<HH:MM UTC>` using the current time; if you do not know the
+  current time, use `[time]` as a placeholder and ask the user to fill it in.
+- Do not invent key facts or a timeline that aren't in the ticket or the
+  classifier output.
+- If the classifier hasn't run yet, say so and run it before producing the
+  package.


### PR DESCRIPTION
## What

Adds `examples/cara/`, a support-triage orchestrator that classifies every ticket and drafts a customer reply in two sequential cross-vendor steps — and demonstrates the **inline sub-agent** pattern for the first time in `examples/`.

```bash
omnigent run examples/cara/
```

## How it works

| Step | Agent | Harness | Output |
|---|---|---|---|
| 1 — Classify | `classifier` | `claude-sdk` | Category, severity, root cause, key facts (JSON) |
| 2 — Respond | `responder` | `codex` | Draft customer reply |
| 3 — Present | Cara (orchestrator) | `claude-sdk` | Triage summary + next steps |

Both specialists are declared **inline** in `config.yaml` under `tools:` rather than in separate `agents/<name>/config.yaml` files:

```yaml
tools:
  classifier:
    type: agent
    prompt: |
      You are a support ticket classifier…
    executor:
      harness: claude-sdk

  responder:
    type: agent
    prompt: |
      You are a support responder…
    executor:
      harness: codex
```

This is the first example in the repo to use this pattern. The README explains when to prefer inline vs. file-based agents.

## Files changed

| File | Purpose |
|---|---|
| `examples/cara/config.yaml` | Orchestrator + both inline sub-agents |
| `examples/cara/skills/escalate/SKILL.md` | Escalation package skill for paging on-call |
| `examples/cara/README.md` | Setup, run, example session, inline-agent explainer, extension guide |

## Why this example

- **New structural pattern.** Existing examples (Polly, Debby, Scribe, Pippa) all use named agent files. Inline agents — defined under `tools:` — appear in the spec and README but not in any example yet. Cara shows when to choose that simpler shape.
- **New domain.** Support triage is a common first AI-agent use case not covered by the existing examples.
- **New skill.** The `escalate` skill produces a structured escalation package rather than a critique or profiling pass — a third skill shape.

No changes to core `omnigent/` source — examples only.

## Checklist

- [x] Branch from `main`
- [x] Changes focused (examples only, no core source changes)
- [x] Commits signed off (`git commit -s`)
- [x] No secrets, internal URLs, or private config included
- [x] README covers prerequisites, run command, example session, and extension guide