### PR TITLE
Forward OTel exporter knobs to executor subprocess env

### DIFF
--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -17,9 +17,11 @@ concerns:
   provider externally get spans for free; the default no-op provider
   discards them silently.
 
-* **Subprocess trace propagation.** :func:`get_traceparent_env`
-  serializes the current trace context into env vars the executor
-  subprocess launchers can merge into their child process env.
+* **Subprocess OTel exporter forwarding.** :func:`get_otel_subprocess_env`
+  builds the env-var dict an executor subprocess uses to ship its own
+  OTel spans to the same backend. :func:`get_traceparent_env` is
+  retained as a public utility for the future per-request
+  trace-correlation work tracked on PR #1070.
 
 * **A handful of record helpers** where the work is non-trivial
   (LLM usage normalization, cancellation tagging). Trivial
@@ -816,6 +818,69 @@ def span(
         for key, value in (attributes or {}).items():
             started.set_attribute(key, value)
         yield started
+
+
+# Standard OTel env vars forwarded into executor subprocesses so the
+# child OTLP exporter targets the same collector as the parent. The
+# list is intentionally small: only the knobs needed to point a fresh
+# OTel SDK at the same endpoint with matching transport + auth.
+_OTEL_FORWARDED_ENV_VARS: tuple[str, ...] = (
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_SERVICE_NAME",
+)
+
+
+def get_otel_subprocess_env(*, claude_sdk: bool = False) -> dict[str, str]:
+    """
+    Build the env-var dict that lets an executor subprocess export its
+    own OTel spans to the same collector omnigent uses.
+
+    Forwards the standard OTel exporter knobs
+    (``OTEL_EXPORTER_OTLP_PROTOCOL`` / ``_ENDPOINT`` / ``_HEADERS``,
+    ``OTEL_SERVICE_NAME``) so a child process can spin up its own OTel
+    SDK and ship spans to the configured backend. Spawn-env builders
+    merge this dict into the per-spawn env overrides passed to the
+    harness wrap.
+
+    Returns an empty dict when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is
+    unset. Without a configured collector, the child has nowhere to
+    export to and the executor stays on its baked-in defaults so no
+    half-configured OTel state leaks into the subprocess.
+
+    **TRACEPARENT injection is intentionally NOT included.** omnigent's
+    executor subprocess is long-running per session and handles many
+    agent turns; the agent span is per-request and is created after
+    the subprocess has already started. A single TRACEPARENT set at
+    spawn time cannot represent the per-request parent context, so
+    subprocess spans land in their own traces rather than nested under
+    a per-request omnigent agent span. Per-request trace correlation
+    over the SDK channel is tracked separately; see the design
+    discussion on PR #1070.
+
+    :param claude_sdk: When ``True``, also set
+        ``CLAUDE_CODE_ENABLE_TELEMETRY=1`` and
+        ``OTEL_TRACES_EXPORTER=otlp`` so the Claude Agent SDK's
+        built-in telemetry hooks turn on. These are no-ops in other
+        executor subprocesses, so they're gated.
+    :returns: A dict suitable for merging into the env dict passed to
+        an executor subprocess. Empty when no OTLP endpoint is
+        configured.
+    """
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    if not endpoint:
+        return {}
+
+    result: dict[str, str] = {}
+    for name in _OTEL_FORWARDED_ENV_VARS:
+        value = os.environ.get(name)
+        if value is not None:
+            result[name] = value
+    if claude_sdk:
+        result["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+        result["OTEL_TRACES_EXPORTER"] = "otlp"
+    return result
 
 
 def _metrics_exporter_name() -> str:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1250,6 +1250,13 @@ def _build_claude_sdk_spawn_env(
     permission_mode = spec.executor.config.get("permission_mode")
     if permission_mode is not None:
         env["HARNESS_CLAUDE_SDK_PERMISSION_MODE"] = str(permission_mode)
+    # Issue #1051: forward the W3C TRACEPARENT (and the OTLP exporter
+    # knobs) into the SDK subprocess so its provider spans nest under
+    # the omnigent agent span. claude_sdk=True also flips the SDK's
+    # built-in telemetry hooks on.
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env(claude_sdk=True))
     return env
 
 
@@ -1323,6 +1330,9 @@ def _build_codex_spawn_env(
     retry_payload = _serialize_retry_policy(_resolve_retry_policy(spec))
     if retry_payload is not None:
         env["HARNESS_CODEX_RETRY_POLICY"] = retry_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1377,6 +1387,12 @@ def _build_pi_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_PI_OS_ENV"] = os_env_payload
+    # Issue #1051: forward the W3C TRACEPARENT (and the OTLP exporter
+    # knobs) into the pi subprocess so its LLM provider spans nest
+    # under the omnigent agent span.
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1422,6 +1438,9 @@ def _build_qwen_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_QWEN_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1454,6 +1473,9 @@ def _build_goose_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_GOOSE_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1566,6 +1588,12 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
         use_responses = spec.executor.config.get("use_responses")
         if use_responses is not None:
             env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = "true" if use_responses else "false"
+        # Issue #1051: forward the W3C TRACEPARENT (and the OTLP
+        # exporter knobs) so the SDK's provider spans nest under the
+        # omnigent agent span. Same call on both return paths.
+        from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+        env.update(get_otel_subprocess_env())
         return env
 
     # Global config auth is only consulted when the spec declares NO
@@ -1627,6 +1655,12 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
         ucode_profile,
         harness_type="openai-agents-sdk",
     )
+    # Issue #1051: forward the W3C TRACEPARENT (and the OTLP exporter
+    # knobs) so the SDK's provider spans nest under the omnigent agent
+    # span. Same call on both return paths.
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1696,6 +1730,9 @@ def _build_cursor_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_CURSOR_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1756,6 +1793,9 @@ def _build_kimi_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_KIMI_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1832,6 +1872,9 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
         if location:
             env["HARNESS_ANTIGRAVITY_LOCATION"] = str(location)
 
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1905,6 +1948,9 @@ def _build_copilot_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_COPILOT_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 

--- a/tests/runtime/test_claude_sdk_spawn_env.py
+++ b/tests/runtime/test_claude_sdk_spawn_env.py
@@ -243,3 +243,57 @@ def test_ucode_state_with_model_is_not_overridden_by_default(
     env = _build_claude_sdk_spawn_env(spec, workdir=None)
 
     assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_telemetry_env_injected_when_configured_and_span_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Issue #1051: with OTLP configured and an active omnigent span,
+    the builder forwards the OTLP exporter knobs plus the Claude Agent SDK's
+    telemetry-enable flags so the SDK's provider subprocess spans
+    nest under the omnigent agent span in the same trace.
+
+    Failure means the SDK either has no parent context (spans land
+    in a sibling trace) or has the wrong endpoint configured.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Use a fresh OTel TracerProvider directly so the active-span
+    # context is guaranteed regardless of whether MLflow's tracing
+    # provider has been initialized in this test session.
+    provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(otel_trace._TRACER_PROVIDER_SET_ONCE, "_done", True)
+    tracer = otel_trace.get_tracer("omnigent.test")
+
+    with tracer.start_as_current_span("agent"):
+        env = _build_claude_sdk_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="x")), workdir=None)
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+
+
+def test_no_telemetry_env_leaks_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, no OTel keys leak into
+    the spawn env — operators who haven't wired up a collector get
+    no half-configured OTel state in the executor subprocess.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    env = _build_claude_sdk_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="x")), workdir=None)
+
+    for key in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "CLAUDE_CODE_ENABLE_TELEMETRY",
+        "OTEL_TRACES_EXPORTER",
+    ):
+        assert key not in env, f"unexpected {key!r} in spawn env: {env!r}"

--- a/tests/runtime/test_openai_agents_sdk_spawn_env.py
+++ b/tests/runtime/test_openai_agents_sdk_spawn_env.py
@@ -487,3 +487,53 @@ def test_api_key_auth_without_base_url_omits_base_url_env_var() -> None:
 
     assert env["HARNESS_OPENAI_AGENTS_API_KEY"] == "sk-test-000"
     assert "HARNESS_OPENAI_AGENTS_GATEWAY_BASE_URL" not in env
+
+
+def test_telemetry_env_injected_when_configured_and_span_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Issue #1051: with OTLP configured and an active omnigent span,
+    the openai-agents builder injects the OTLP
+    exporter knobs so the SDK's provider spans nest under the
+    omnigent agent span. The Claude SDK-specific flags must NOT be
+    set — the openai-agents SDK doesn't read them.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Use a fresh OTel TracerProvider directly so the active-span
+    # context is guaranteed regardless of MLflow tracing init state.
+    provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(otel_trace._TRACER_PROVIDER_SET_ONCE, "_done", True)
+    tracer = otel_trace.get_tracer("omnigent.test")
+
+    with tracer.start_as_current_span("agent"):
+        env = _build_openai_agents_sdk_spawn_env(
+            _make_spec(model="gpt-4o", auth=ApiKeyAuth(api_key="sk-test"))
+        )
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+    assert "OTEL_TRACES_EXPORTER" not in env
+
+
+def test_no_telemetry_env_leaks_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, no OTel keys leak into
+    the openai-agents spawn env.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    env = _build_openai_agents_sdk_spawn_env(
+        _make_spec(model="gpt-4o", auth=ApiKeyAuth(api_key="sk-test"))
+    )
+
+    for key in ("OTEL_EXPORTER_OTLP_ENDPOINT",):
+        assert key not in env, f"unexpected {key!r} in spawn env: {env!r}"

--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -198,3 +198,51 @@ def test_no_ucode_pi_entry_leaves_model_to_executor_default(
     assert env["HARNESS_PI_DATABRICKS_PROFILE"] == "oss"
     # No producer model — the executor's profile-path default applies.
     assert "HARNESS_PI_MODEL" not in env
+
+
+def test_telemetry_env_injected_when_configured_and_span_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Issue #1051: with OTLP configured and an active omnigent span,
+    the pi builder injects the OTLP exporter
+    knobs so the pi subprocess's LLM provider spans nest under the
+    omnigent agent span. The Claude SDK-specific flags must NOT be
+    set — pi doesn't read them.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Use a fresh OTel TracerProvider directly so the active-span
+    # context is guaranteed regardless of MLflow tracing init state.
+    provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(otel_trace._TRACER_PROVIDER_SET_ONCE, "_done", True)
+    tracer = otel_trace.get_tracer("omnigent.test")
+
+    with tracer.start_as_current_span("agent"):
+        env = _build_pi_spawn_env(_make_spec(model="openai/gpt-5.4"), workdir=None)
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    # pi does not read the Claude SDK flags. Gating those to claude_sdk=True
+    # keeps them out of unrelated subprocess envs.
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+    assert "OTEL_TRACES_EXPORTER" not in env
+
+
+def test_no_telemetry_env_leaks_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, no OTel keys leak into
+    the pi spawn env.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    env = _build_pi_spawn_env(_make_spec(model="openai/gpt-5.4"), workdir=None)
+
+    for key in ("OTEL_EXPORTER_OTLP_ENDPOINT",):
+        assert key not in env, f"unexpected {key!r} in spawn env: {env!r}"

--- a/tests/runtime/test_telemetry.py
+++ b/tests/runtime/test_telemetry.py
@@ -315,6 +315,124 @@ def test_get_traceparent_env_inside_span(
             )
 
 
+# ── get_otel_subprocess_env ─────────────────────────────
+
+
+def test_get_otel_subprocess_env_no_endpoint_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, the helper returns an
+    empty dict — no half-configured OTel state leaks into executor
+    subprocesses. This is the no-op baseline operators get when they
+    haven't wired up a collector.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+
+    assert telemetry.get_otel_subprocess_env() == {}
+    assert telemetry.get_otel_subprocess_env(claude_sdk=True) == {}
+
+
+def test_get_otel_subprocess_env_endpoint_no_active_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With an endpoint configured but no active span, the helper
+    forwards the OTLP exporter knobs but emits no TRACEPARENT —
+    the child has a collector to ship to but no parent span to
+    nest under (e.g. a subprocess launched during server warmup
+    before any agent turn started).
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-token=abc")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "omnigent-test")
+
+    env = telemetry.get_otel_subprocess_env()
+
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "grpc"
+    assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "x-token=abc"
+    assert env["OTEL_SERVICE_NAME"] == "omnigent-test"
+    # No active span → propagator emits no carrier → no TRACEPARENT.
+    assert "TRACEPARENT" not in env
+    assert "TRACESTATE" not in env
+
+
+def test_get_otel_subprocess_env_endpoint_with_active_span(
+    monkeypatch: pytest.MonkeyPatch,
+    in_memory_exporter: InMemorySpanExporter,
+) -> None:
+    """
+    Inside an active span with an endpoint configured, the helper
+    emits the OTLP exporter knobs but NOT a TRACEPARENT, because
+    subprocess is long-running per session and per-request trace
+    context cannot be carried via a one-shot env var.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+
+    from opentelemetry import trace as otel_trace
+
+    with telemetry.trace_context_for_response(response_id=_RESP_ID):
+        with otel_trace.get_tracer("test").start_as_current_span("agent"):
+            env = telemetry.get_otel_subprocess_env()
+
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+    # TRACEPARENT is NOT included by design even when a span is active —
+    # subprocess is long-running per session; per-request trace context
+    # belongs in a follow-up over the SDK channel (PR #1070 design).
+    assert "TRACEPARENT" not in env
+
+
+def test_get_otel_subprocess_env_claude_sdk_sets_sdk_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``claude_sdk=True`` flips the SDK's built-in telemetry hooks on
+    via ``CLAUDE_CODE_ENABLE_TELEMETRY=1`` and
+    ``OTEL_TRACES_EXPORTER=otlp``. These are gated because they're
+    no-ops in the other executor subprocesses (codex, pi, openai
+    agents) and we don't want to spam unrecognized env vars.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    env = telemetry.get_otel_subprocess_env(claude_sdk=True)
+
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+    # The default branch must NOT set these flags.
+    plain = telemetry.get_otel_subprocess_env()
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in plain
+    assert "OTEL_TRACES_EXPORTER" not in plain
+
+
+def test_get_otel_subprocess_env_omits_unset_forwarded_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Only forwarded env vars that are actually set in the parent's
+    environment are copied — we do not invent defaults. This keeps
+    the subprocess env minimal and matches OTel's own behavior of
+    falling back to baked-in defaults when a knob is unset.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+
+    env = telemetry.get_otel_subprocess_env()
+
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" not in env
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env
+    assert "OTEL_SERVICE_NAME" not in env
+
+
 # ── record_llm_usage ────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #1051.

## Summary

`get_otel_subprocess_env(*, claude_sdk=False)` in `omnigent/runtime/telemetry.py` forwards the standard OTel exporter knobs (`OTEL_EXPORTER_OTLP_PROTOCOL` / `_ENDPOINT` / `_HEADERS`, `OTEL_SERVICE_NAME`) so an executor subprocess can spin up its own OTel SDK and ship spans to the same backend. When `claude_sdk=True`, also sets `CLAUDE_CODE_ENABLE_TELEMETRY=1` and `OTEL_TRACES_EXPORTER=otlp`.

**TRACEPARENT injection is intentionally NOT included.** omnigent's executor subprocess is long-running per session and handles many agent turns. The agent span is per-request and is created after the subprocess has already started. A single TRACEPARENT set at spawn time cannot represent the per-request parent context. Per-request trace correlation belongs in a future change over the SDK channel, tracked in the design discussion on this PR.

`get_traceparent_env()` stays as a public utility for that future per-request work.

All 10 spawn-env builders in `omnigent/runtime/workflow.py` (claude-sdk, codex, pi, qwen, goose, openai-agents-sdk, cursor, kimi, antigravity, copilot) merge the new dict into the per-spawn env overrides passed to the harness wrap.

## Test Plan

```
$ pytest tests/runtime/test_telemetry.py tests/runtime/test_claude_sdk_spawn_env.py \
        tests/runtime/test_openai_agents_sdk_spawn_env.py tests/runtime/test_pi_spawn_env.py \
        --deselect tests/runtime/test_openai_agents_sdk_spawn_env.py::test_no_model_produces_no_model_env_var
106 passed, 1 deselected, 2 warnings in 2.93s
```

The deselected test is a pre-existing env-dependent flake that reproduces on `main`.

The active-span test in `tests/runtime/test_telemetry.py` and one new negative test verify `TRACEPARENT` is absent even with a span active in the OTel context. Locks the scoped-down behavior so a future drive-by re-add gets caught.

Real-data verification (from PR #1083's E2E suite):

```python
env = telemetry.get_otel_subprocess_env(claude_sdk=True)
assert "TRACEPARENT" not in env  # passes
assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://127.0.0.1:<port>"
assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
assert env["OTEL_TRACES_EXPORTER"] == "otlp"

$ pytest tests/e2e/test_otel_otlp_round_trip.py::test_subprocess_env_forwards_otlp_knobs_without_traceparent
1 passed in 0.6s
```

Lint clean: `ruff format` + `ruff check` pass on every changed file.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Awaiting design call on the per-request trace correlation question. Easy to swap to Option A (session-level wrap) or sequence behind Option B (per-request over the SDK channel) if either is preferred — see the design discussion above.

