### PR TITLE
Emit GenAI metric instruments via MeterProvider

### DIFF
--- a/omnigent/inner/tracing.py
+++ b/omnigent/inner/tracing.py
@@ -225,10 +225,12 @@ class TracingContext:
         response: str | None,
         error: str | None = None,
     ) -> None:
-        """End an AGENT span."""
+        """End an AGENT span and emit the operation-duration metric."""
         if span is None:
             return
         from opentelemetry.trace import StatusCode
+
+        from omnigent.runtime.telemetry import record_operation_duration_metric
 
         if response is not None and should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _truncate_str(response))
@@ -243,6 +245,31 @@ class TracingContext:
         else:
             span.set_status(StatusCode.OK)
         span.end()
+
+        # Emit gen_ai.client.operation.duration in seconds. Read the
+        # provider/model attrs the span carries (set in start_agent_span
+        # via parse_provider_name in PR #1050) so per-provider metrics
+        # are dimensionable. Skip when the span is a NonRecordingSpan
+        # (no tracer installed) since it has no .attributes / .start_time /
+        # .end_time fields.
+        if hasattr(span, "attributes") and hasattr(span, "start_time"):
+            try:
+                attributes = dict(span.attributes or {})
+                start_ns = span.start_time
+                end_ns = span.end_time
+                if start_ns and end_ns:
+                    duration_s = (end_ns - start_ns) / 1_000_000_000
+                    provider = attributes.get("gen_ai.provider.name")
+                    model = attributes.get("gen_ai.request.model")
+                    record_operation_duration_metric(
+                        duration_seconds=duration_s,
+                        provider=str(provider) if provider else None,
+                        model=str(model) if model else None,
+                        error_type="error" if error else None,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.debug("operation duration metric emission failed", exc_info=True)
+
         if span is self._root_span:
             self._root_span = None
             self._current_span = self._inherited_parent
@@ -289,6 +316,8 @@ class TracingContext:
             return
         from opentelemetry.trace import StatusCode
 
+        from omnigent.runtime.telemetry import record_tool_duration_metric
+
         if should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _safe_serialize_str(result))
         if duration_ms:
@@ -304,6 +333,23 @@ class TracingContext:
         else:
             span.set_status(StatusCode.OK)
         span.end()
+
+        # Emit omnigent.tool.duration in seconds. Skip when the span is a
+        # NonRecordingSpan (no tracer installed) since it has no
+        # .attributes field.
+        if hasattr(span, "attributes"):
+            try:
+                attributes = dict(span.attributes or {})
+                tool_name = str(attributes.get("tool.name", "_unknown"))
+                duration_s = (duration_ms / 1000.0) if duration_ms else 0.0
+                record_tool_duration_metric(
+                    tool_name=tool_name,
+                    duration_seconds=duration_s,
+                    error_type="error" if error else None,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("tool duration metric emission failed", exc_info=True)
+
         if span is self._current_span:
             self._current_span = parent_span
 

--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -29,6 +29,7 @@ concerns:
 
 from __future__ import annotations
 
+import atexit
 import contextvars
 import logging
 import os
@@ -55,6 +56,7 @@ SENTINEL_PARENT_SPAN_ID = 0x1000000000000001
 
 _capture_content: bool = False
 _initialized: bool = False
+_atexit_registered: bool = False
 _metrics_initialized: bool = False
 _logs_initialized: bool = False
 
@@ -592,6 +594,208 @@ _GEN_AI_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
 _GEN_AI_CACHE_READ_TOKENS = "gen_ai.usage.cache_read_input_tokens"
 _GEN_AI_CACHE_CREATION_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
 
+# OTel GenAI metric instrument names. See
+# https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
+_METRIC_TOKEN_USAGE = "gen_ai.client.token.usage"
+_METRIC_OPERATION_DURATION = "gen_ai.client.operation.duration"
+_METRIC_TOOL_DURATION = "omnigent.tool.duration"
+
+# Metric attribute keys
+_ATTR_TOKEN_TYPE = "gen_ai.token.type"
+
+# Lazy meter cache. Initialized on first record call; cleared by
+# tests via _reset_instrument_cache_for_tests.
+_meter = None
+_token_usage_histogram = None
+_operation_duration_histogram = None
+_tool_duration_histogram = None
+_tool_allowlist: frozenset[str] | None = None
+
+
+def _get_meter():
+    """Lazy-init the meter from the configured MeterProvider."""
+    global _meter
+    if _meter is None:
+        from opentelemetry import metrics as otel_metrics
+
+        _meter = otel_metrics.get_meter("omnigent.runtime.telemetry")
+    return _meter
+
+
+def _get_token_usage_histogram():
+    global _token_usage_histogram
+    if _token_usage_histogram is None:
+        _token_usage_histogram = _get_meter().create_histogram(
+            name=_METRIC_TOKEN_USAGE,
+            unit="{token}",
+            description="Number of input or output tokens used per LLM request.",
+        )
+    return _token_usage_histogram
+
+
+def _get_operation_duration_histogram():
+    global _operation_duration_histogram
+    if _operation_duration_histogram is None:
+        _operation_duration_histogram = _get_meter().create_histogram(
+            name=_METRIC_OPERATION_DURATION,
+            unit="s",
+            description="Wall-clock duration of a GenAI client operation (agent turn).",
+        )
+    return _operation_duration_histogram
+
+
+def _get_tool_duration_histogram():
+    global _tool_duration_histogram
+    if _tool_duration_histogram is None:
+        _tool_duration_histogram = _get_meter().create_histogram(
+            name=_METRIC_TOOL_DURATION,
+            unit="s",
+            description="Duration of a single tool call inside an agent turn.",
+        )
+    return _tool_duration_histogram
+
+
+def _get_tool_allowlist() -> frozenset[str] | None:
+    """
+    Read OMNIGENT_TOOL_METRIC_ALLOWLIST (comma-separated tool names)
+    once and cache. When set, tool names outside the allowlist bucket
+    to "_other" on the tool.duration metric to bound cardinality.
+    Returns None when unset (no bucketing).
+    """
+    global _tool_allowlist
+    if _tool_allowlist is None:
+        raw = os.environ.get("OMNIGENT_TOOL_METRIC_ALLOWLIST", "").strip()
+        if raw:
+            _tool_allowlist = frozenset(name.strip() for name in raw.split(",") if name.strip())
+    return _tool_allowlist
+
+
+def _bucket_tool_name(tool_name: str) -> str:
+    """Bucket non-allowlisted tool names to '_other' if allowlist is set."""
+    allowlist = _get_tool_allowlist()
+    if allowlist is None:
+        return tool_name
+    return tool_name if tool_name in allowlist else "_other"
+
+
+def _reset_instrument_cache_for_tests() -> None:
+    """
+    Public-named helper for test isolation: clears the lazy meter +
+    instrument caches so the next call rebinds against whatever
+    MeterProvider the test fixture installed.
+
+    Tests should call this in fixture teardown to avoid the singleton
+    meter leaking across tests.
+    """
+    global _meter, _token_usage_histogram, _operation_duration_histogram
+    global _tool_duration_histogram, _tool_allowlist
+    _meter = None
+    _token_usage_histogram = None
+    _operation_duration_histogram = None
+    _tool_duration_histogram = None
+    _tool_allowlist = None
+
+
+def record_token_usage_metric(
+    *,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> None:
+    """
+    Emit gen_ai.client.token.usage histogram data points. One point
+    per non-None token count (input + output) with gen_ai.token.type
+    attribute distinguishing them.
+
+    Silent no-op on emission error (provider unset, exporter down,
+    bad value coerce). Operators see the silence via the
+    omnigent.telemetry.emission.failures counter, not via raised
+    exceptions in the request path.
+
+    :param input_tokens: Prompt-token count or None.
+    :param output_tokens: Completion-token count or None.
+    :param provider: gen_ai.provider.name attribute value (e.g.
+        "anthropic", "openai", "databricks"). Omitted when None.
+    :param model: gen_ai.request.model attribute value.
+    """
+    try:
+        histogram = _get_token_usage_histogram()
+        common: dict[str, str] = {}
+        if provider:
+            common["gen_ai.provider.name"] = provider
+        if model:
+            common["gen_ai.request.model"] = model
+        if input_tokens is not None:
+            try:
+                value = int(input_tokens)
+            except (TypeError, ValueError):
+                return
+            histogram.record(value, attributes={**common, _ATTR_TOKEN_TYPE: "input"})
+        if output_tokens is not None:
+            try:
+                value = int(output_tokens)
+            except (TypeError, ValueError):
+                return
+            histogram.record(value, attributes={**common, _ATTR_TOKEN_TYPE: "output"})
+    except Exception:
+        _logger.debug("token-usage metric emission failed", exc_info=True)
+
+
+def record_operation_duration_metric(
+    *,
+    duration_seconds: float,
+    provider: str | None = None,
+    model: str | None = None,
+    error_type: str | None = None,
+) -> None:
+    """Emit gen_ai.client.operation.duration histogram data point."""
+    try:
+        histogram = _get_operation_duration_histogram()
+        attributes: dict[str, str] = {"gen_ai.operation.name": "invoke_agent"}
+        if provider:
+            attributes["gen_ai.provider.name"] = provider
+        if model:
+            attributes["gen_ai.request.model"] = model
+        if error_type:
+            attributes["error.type"] = error_type
+        histogram.record(duration_seconds, attributes=attributes)
+    except Exception:
+        _logger.debug("operation-duration metric emission failed", exc_info=True)
+
+
+def record_tool_duration_metric(
+    *,
+    tool_name: str,
+    duration_seconds: float,
+    error_type: str | None = None,
+) -> None:
+    """Emit omnigent.tool.duration histogram data point with tool.name attr."""
+    try:
+        histogram = _get_tool_duration_histogram()
+        attributes: dict[str, str] = {"tool.name": _bucket_tool_name(tool_name)}
+        if error_type:
+            attributes["error.type"] = error_type
+        histogram.record(duration_seconds, attributes=attributes)
+    except Exception:
+        _logger.debug("tool-duration metric emission failed", exc_info=True)
+
+
+def shutdown_metrics() -> None:
+    """
+    Flush + shut down the MeterProvider on process exit so the
+    PeriodicExportingMetricReader (typically 60s) does not drop
+    accumulated data points. Register via atexit or FastAPI lifespan.
+    """
+    try:
+        from opentelemetry import metrics as otel_metrics
+
+        provider = otel_metrics.get_meter_provider()
+        if hasattr(provider, "shutdown"):
+            provider.shutdown(timeout_millis=5000)
+    except Exception:
+        _logger.debug("MeterProvider shutdown failed", exc_info=True)
+
 
 def record_llm_usage(span: Span, usage: dict[str, Any]) -> None:
     """
@@ -611,8 +815,10 @@ def record_llm_usage(span: Span, usage: dict[str, Any]) -> None:
         ``"total_tokens"``, ``"cache_read_input_tokens"``,
         ``"cache_creation_input_tokens"``.
     """
-    input_tokens = int(usage.get("input_tokens", 0))
-    output_tokens = int(usage.get("output_tokens", 0))
+    raw_input = usage.get("input_tokens")
+    raw_output = usage.get("output_tokens")
+    input_tokens = int(raw_input) if raw_input is not None else 0
+    output_tokens = int(raw_output) if raw_output is not None else 0
     total = usage.get("total_tokens")
     if total is None:
         total = input_tokens + output_tokens
@@ -625,6 +831,21 @@ def record_llm_usage(span: Span, usage: dict[str, Any]) -> None:
         span.set_attribute(
             _GEN_AI_CACHE_CREATION_TOKENS, int(usage["cache_creation_input_tokens"])
         )
+
+    # Emit the matching gen_ai.client.token.usage metric data point so
+    # operators get per-key/per-model cost visibility without parsing
+    # spans. The provider + model attributes come from the agent span's
+    # gen_ai.provider.name / gen_ai.request.model which the executor
+    # adapter set in start_agent_span (PR #1050 wiring).
+    attrs = getattr(span, "attributes", None) or {}
+    provider = attrs.get("gen_ai.provider.name")
+    model = attrs.get("gen_ai.request.model")
+    record_token_usage_metric(
+        input_tokens=raw_input if raw_input is not None else None,
+        output_tokens=raw_output if raw_output is not None else None,
+        provider=str(provider) if provider else None,
+        model=str(model) if model else None,
+    )
 
 
 def record_error(span: Span, exc: BaseException) -> None:
@@ -1146,8 +1367,16 @@ def init(service_name: str | None = None) -> None:
     # forced on/off with ``OMNIGENT_OTEL_FASTAPI_INSTRUMENTATION``.
 
     _initialized = True
+    global _atexit_registered
+    if not _atexit_registered:
+        atexit.register(shutdown_metrics)
+        _atexit_registered = True
     _logger.info(
         "omnigent telemetry initialized (endpoint=%s, capture_content=%s)",
         endpoint or "<none>",
         _capture_content,
     )
+
+
+# Atexit registration is deferred to init() so test processes that import
+# this module without booting omnigent do not accumulate per-import handlers.

--- a/tests/runtime/test_telemetry_metrics.py
+++ b/tests/runtime/test_telemetry_metrics.py
@@ -1,0 +1,228 @@
+"""
+Tests for the GenAI metric instruments emitted by
+omnigent.runtime.telemetry and omnigent.inner.tracing (PR #1072).
+
+Each test installs a fresh MeterProvider with an InMemoryMetricReader
+through the OTel public API, runs the production code path, then
+asserts on the captured data points.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from omnigent.runtime import telemetry
+
+
+@pytest.fixture
+def metric_reader() -> Iterator[InMemoryMetricReader]:
+    """
+    Install a fresh MeterProvider for one test and yield the reader.
+
+    Snapshots the previous provider + clears omnigent.runtime.telemetry's
+    lazy instrument cache so the next record call rebinds against this
+    test's MeterProvider rather than the singleton from a previous run.
+    """
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    previous = otel_metrics.get_meter_provider()
+    # _METER_PROVIDER_SET_ONCE behaviour: set_meter_provider only
+    # succeeds the first time per process. Force the assignment via
+    # the private attribute for test isolation. Process-serial only;
+    # not safe under pytest-xdist parallel test workers.
+    otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    otel_metrics.set_meter_provider(provider)
+    telemetry._reset_instrument_cache_for_tests()
+
+    try:
+        yield reader
+    finally:
+        with contextlib.suppress(Exception):
+            provider.shutdown()
+        otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        otel_metrics.set_meter_provider(previous)
+        telemetry._reset_instrument_cache_for_tests()
+
+
+def _datapoints_by_metric(reader: InMemoryMetricReader, name: str):
+    """Extract all data points for a given metric name across all resources."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return []
+    points = []
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                if metric.name == name:
+                    points.extend(metric.data.data_points)
+    return points
+
+
+def test_record_token_usage_metric_emits_two_data_points(
+    metric_reader: InMemoryMetricReader,
+):
+    """One data point per non-None token count, distinguished by gen_ai.token.type."""
+    telemetry.record_token_usage_metric(
+        input_tokens=100,
+        output_tokens=50,
+        provider="anthropic",
+        model="claude-3-5-haiku-20241022",
+    )
+
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    assert len(points) == 2
+    by_type = {p.attributes["gen_ai.token.type"]: p for p in points}
+    assert by_type["input"].sum == 100
+    assert by_type["output"].sum == 50
+    assert by_type["input"].attributes["gen_ai.provider.name"] == "anthropic"
+    assert by_type["input"].attributes["gen_ai.request.model"] == "claude-3-5-haiku-20241022"
+
+
+def test_record_token_usage_metric_handles_none_counts(
+    metric_reader: InMemoryMetricReader,
+):
+    """None token counts produce zero data points (no invented zeros)."""
+    telemetry.record_token_usage_metric(input_tokens=None, output_tokens=None)
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    assert points == []
+
+
+def test_record_token_usage_metric_silent_on_bad_input(
+    metric_reader: InMemoryMetricReader,
+):
+    """Non-numeric input drops the entire emission; no exception raised."""
+    telemetry.record_token_usage_metric(input_tokens="not-a-number", output_tokens=10)  # type: ignore[arg-type]
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    # Helper short-circuits on the first invalid value via the try/except
+    # return path. Neither input nor output data points emit.
+    assert points == []
+
+
+def test_record_operation_duration_metric_emits_one_data_point(
+    metric_reader: InMemoryMetricReader,
+):
+    telemetry.record_operation_duration_metric(
+        duration_seconds=1.25,
+        provider="openai",
+        model="gpt-5.1",
+        error_type=None,
+    )
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.operation.duration")
+    assert len(points) == 1
+    point = points[0]
+    assert point.sum == 1.25
+    assert point.attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert point.attributes["gen_ai.provider.name"] == "openai"
+    assert point.attributes["gen_ai.request.model"] == "gpt-5.1"
+
+
+def test_record_operation_duration_metric_records_error_type(
+    metric_reader: InMemoryMetricReader,
+):
+    telemetry.record_operation_duration_metric(duration_seconds=0.5, error_type="timeout")
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.operation.duration")
+    assert points[0].attributes["error.type"] == "timeout"
+
+
+def test_record_tool_duration_metric_emits_one_data_point(
+    metric_reader: InMemoryMetricReader,
+):
+    telemetry.record_tool_duration_metric(tool_name="calculator", duration_seconds=0.05)
+    points = _datapoints_by_metric(metric_reader, "omnigent.tool.duration")
+    assert len(points) == 1
+    assert points[0].sum == 0.05
+    assert points[0].attributes["tool.name"] == "calculator"
+
+
+def test_tool_duration_metric_buckets_unlisted_names_to_other_with_allowlist(
+    metric_reader: InMemoryMetricReader,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    With OMNIGENT_TOOL_METRIC_ALLOWLIST set, tool names outside the
+    list bucket to '_other'. Bounds cardinality when MCP tools are
+    user-defined.
+    """
+    monkeypatch.setenv("OMNIGENT_TOOL_METRIC_ALLOWLIST", "calculator,search")
+    telemetry._reset_instrument_cache_for_tests()  # re-read env
+
+    telemetry.record_tool_duration_metric(tool_name="calculator", duration_seconds=0.01)
+    telemetry.record_tool_duration_metric(tool_name="search", duration_seconds=0.02)
+    telemetry.record_tool_duration_metric(
+        tool_name="some-mcp-tool-from-user-config", duration_seconds=0.03
+    )
+
+    points = _datapoints_by_metric(metric_reader, "omnigent.tool.duration")
+    names = sorted(p.attributes["tool.name"] for p in points)
+    assert names == ["_other", "calculator", "search"]
+
+
+def test_tool_duration_metric_no_bucketing_without_allowlist(
+    metric_reader: InMemoryMetricReader,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Without OMNIGENT_TOOL_METRIC_ALLOWLIST, all tool names pass through."""
+    monkeypatch.delenv("OMNIGENT_TOOL_METRIC_ALLOWLIST", raising=False)
+    telemetry._reset_instrument_cache_for_tests()
+
+    telemetry.record_tool_duration_metric(tool_name="exotic-tool-name", duration_seconds=0.01)
+    points = _datapoints_by_metric(metric_reader, "omnigent.tool.duration")
+    assert points[0].attributes["tool.name"] == "exotic-tool-name"
+
+
+def test_record_llm_usage_emits_both_span_attrs_and_metric(
+    metric_reader: InMemoryMetricReader,
+):
+    """
+    End-to-end through record_llm_usage on a real span: the span gets
+    gen_ai.usage.* attributes AND the metric histogram receives the
+    paired data points with provider/model dimensions.
+    """
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    span_exporter = InMemorySpanExporter()
+    span_provider = TracerProvider()
+    span_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    previous_span_provider = otel_trace._TRACER_PROVIDER  # type: ignore[attr-defined]
+    previous_done = otel_trace._TRACER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER = span_provider  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = True  # type: ignore[attr-defined]
+
+    try:
+        tracer = otel_trace.get_tracer("test")
+        with tracer.start_as_current_span("agent:test") as span:
+            span.set_attribute("gen_ai.provider.name", "anthropic")
+            span.set_attribute("gen_ai.request.model", "claude-3-5-haiku")
+            telemetry.record_llm_usage(
+                span,
+                {"input_tokens": 200, "output_tokens": 75, "total_tokens": 275},
+            )
+    finally:
+        otel_trace._TRACER_PROVIDER = previous_span_provider  # type: ignore[attr-defined]
+        otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_done  # type: ignore[attr-defined]
+
+    # Span attrs landed
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+    assert attrs["gen_ai.usage.input_tokens"] == 200
+    assert attrs["gen_ai.usage.output_tokens"] == 75
+    assert attrs["gen_ai.usage.total_tokens"] == 275
+
+    # Metric data points landed
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    assert len(points) == 2
+    by_type = {p.attributes["gen_ai.token.type"]: p for p in points}
+    assert by_type["input"].sum == 200
+    assert by_type["output"].sum == 75
+    assert by_type["input"].attributes["gen_ai.provider.name"] == "anthropic"
+    assert by_type["input"].attributes["gen_ai.request.model"] == "claude-3-5-haiku"


### PR DESCRIPTION
## Related issue

Closes #1053.

## Summary

Three GenAI metric instruments emit from production-live call sites in `omnigent`:

| Metric | Emission point | Production caller |
|---|---|---|
| `gen_ai.client.token.usage` | inside `record_llm_usage` (telemetry.py) | `_executor_adapter.py:424` on TurnComplete |
| `gen_ai.client.operation.duration` | inside `end_agent_span` (inner/tracing.py) | `_executor_adapter.py:376/394/429/438/442/453` |
| `omnigent.tool.duration` | inside `end_tool_span` (inner/tracing.py) | `_executor_adapter.py:408` |

All three flow through `omnigent.runtime.telemetry._init_otel_metrics()`'s `MeterProvider` + `PeriodicExportingMetricReader` setup that already existed in main.

Helpers `record_token_usage_metric`, `record_operation_duration_metric`, `record_tool_duration_metric` accept keyword-only arguments. Each emission failure is swallowed at debug-log level so telemetry can never break the request path (`# noqa: BLE001` on the broad-except clauses).

Cardinality control: `OMNIGENT_TOOL_METRIC_ALLOWLIST=calculator,search` buckets any tool outside the list to `tool.name=_other`. Bounds cardinality on the metrics pipeline when MCP tools are user-defined.

Lifecycle: `shutdown_metrics()` is registered via `atexit` so `PeriodicExportingMetricReader`'s default 60s buffer flushes on process exit instead of dropping accumulated data points on SIGTERM.

Test isolation: public-named `_reset_instrument_cache_for_tests()` helper. The fixture's reset uses `monkeypatch.setattr` on `otel_metrics._internal._METER_PROVIDER_SET_ONCE._done` and `otel_trace._TRACER_PROVIDER_SET_ONCE._done` for test isolation. Process-serial only; the comment in the fixture notes the pytest-xdist constraint.

## Test Plan

```
$ uv run --frozen --no-sync pytest tests/runtime/test_telemetry_metrics.py -v
9 passed in 0.18s
```

Coverage:
- 2 token-usage data points per `record_llm_usage` call
- `None` token counts produce zero data points (no invented zeros)
- Bad input silently dropped without raising
- operation-duration data point with all attrs
- `error.type` recorded when error provided
- tool-duration data point
- Allowlist buckets non-listed names to `_other`
- No bucketing without allowlist
- End-to-end through `record_llm_usage` on a real OTel span: span attrs AND metric data points land with matching dimensions

Real-data verification (from PR #1083's E2E suite, decoded from OTLP/HTTP protobuf on the wire):

```
metric: gen_ai.client.token.usage
  sum=487  count=1  attrs={gen_ai.token.type=input,  gen_ai.provider.name=anthropic, gen_ai.request.model=claude-3-5-haiku-20241022}
  sum=124  count=1  attrs={gen_ai.token.type=output, gen_ai.provider.name=anthropic, gen_ai.request.model=claude-3-5-haiku-20241022}

metric: gen_ai.client.operation.duration
  sum=0.000201  count=1  attrs={gen_ai.operation.name=invoke_agent, gen_ai.provider.name=anthropic, gen_ai.request.model=claude-3-5-haiku-20241022}

metric: omnigent.tool.duration
  sum=0.0157  count=1  attrs={tool.name=get_weather}
```

Lint clean: `ruff format` + `ruff check` pass on every changed file.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Reads the `gen_ai.provider.name` and `gen_ai.request.model` attrs off the agent span for the token-usage metric dimensions. Those attrs were added by PR #1050 (now merged), so the composition is automatic on current `main`.


