### PR TITLE
fix(executor): fail closed on tool-call policy checks when turn context is missing

### DIFF
--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -60,6 +60,7 @@ from omnigent.inner.executor import (
     TurnComplete,
 )
 from omnigent.inner.tracing import TracingContext, is_tracing_enabled
+from omnigent.policies.types import FAIL_CLOSED_PHASES
 from omnigent.runtime.harnesses._scaffold import HarnessApp, PolicyVerdictPayload, TurnContext
 from omnigent.runtime.tool_output import cap_tool_output
 from omnigent.server.schemas import (
@@ -784,12 +785,27 @@ class ExecutorAdapter(HarnessApp):
         """
         ctx = self._current_ctx
         if ctx is None:
+            # Orphaned callback after a turn-context desync (#1026). Blanket
+            # ALLOW here silently bypasses guardrails: for a PHASE_TOOL_CALL this
+            # adapter is the only enforcement point (the call is never re-checked
+            # server-side), so an unevaluable verdict must fail closed. Mirror
+            # the runner's phase-aware default in _evaluate_policy_via_omnigent —
+            # tool calls DENY; advisory LLM phases and the post-execution result
+            # phase ALLOW so a transient desync never needlessly wedges them.
+            fail_closed = phase in FAIL_CLOSED_PHASES
+            action = "POLICY_ACTION_DENY" if fail_closed else "POLICY_ACTION_ALLOW"
             _logger.warning(
                 "policy evaluator fired with no active turn context (phase=%s); "
-                "returning ALLOW by default",
+                "returning %s by default",
                 phase,
+                "DENY" if fail_closed else "ALLOW",
             )
-            return PolicyVerdictPayload(action="POLICY_ACTION_ALLOW")
+            return PolicyVerdictPayload(
+                action=action,
+                reason=(
+                    f"No active turn context; failing closed for {phase}." if fail_closed else None
+                ),
+            )
         evaluation_id = f"poleval_{secrets.token_hex(16)}"
         return await ctx.evaluate_policy(evaluation_id, phase, data)
 

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -1959,3 +1959,25 @@ def test_idless_tool_complete_is_suppressed() -> None:
         f"downstream and only ghosts a 'Waiting for output' card); got "
         f"{[e.item.get('type') for e in ctx.emitted]}"
     )
+
+
+async def test_policy_evaluator_no_active_turn_context_is_phase_aware() -> None:
+    """With no active turn context (turn-context desync, #1026) the policy
+    evaluator must not blanket-ALLOW. PHASE_TOOL_CALL fails closed (this adapter
+    is the only enforcement point, never re-checked server-side); advisory LLM
+    phases and the post-execution result phase fail open so a transient desync
+    does not needlessly wedge them — matching the runner's phase-aware default.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    adapter._current_ctx = None
+
+    tool_verdict = await adapter._stable_policy_evaluator("PHASE_TOOL_CALL", {})
+    assert tool_verdict.action == "POLICY_ACTION_DENY"
+    assert tool_verdict.reason == "No active turn context; failing closed for PHASE_TOOL_CALL."
+
+    for advisory_phase in ("PHASE_LLM_REQUEST", "PHASE_LLM_RESPONSE", "PHASE_TOOL_RESULT"):
+        verdict = await adapter._stable_policy_evaluator(advisory_phase, {})
+        assert verdict.action == "POLICY_ACTION_ALLOW", advisory_phase
+        assert verdict.reason is None, advisory_phase


### PR DESCRIPTION
When the turn-context desyncs (#1026) the policy-evaluator callback fires with no active turn context, and the adapter returned ALLOW for every phase — silently bypassing guardrails. For PHASE_TOOL_CALL this adapter is the only enforcement point (never re-checked server-side), so it should fail closed like the runner's _evaluate_policy_via_omnigent already does. Made the no-context default phase-aware (tool calls deny, advisory LLM + result phases allow) and added a test. Note this only addresses the fail-open policy default called out in #1026, not the underlying turn-context wedge. Refs #1026.