### PR TITLE
fix(server): derive omnigent.ui terminal label from native agent identity

### DIFF
--- a/omnigent/server/routes/sessions.py
+++ b/omnigent/server/routes/sessions.py
@@ -2240,6 +2240,15 @@ def _build_session_response(
     # usage. Shared by the cost indicator and the per-model breakdown so
     # both read the same numbers.
     display_usage = subtree_usage if subtree_usage is not None else (conv.session_usage or {})
+    # Native-terminal-wrapper sessions (claude-native-ui / codex-native-ui) are
+    # always terminal-first: the web UI's Chat/Terminal pill is gated on the
+    # ``omnigent.ui = "terminal"`` label. That flag is fully determined by the
+    # agent identity, so derive it here from ``agent_name`` rather than relying
+    # solely on the stored label — the pill then stays correct even if the
+    # stored value is missing or stale. Idempotent: a no-op when already present.
+    labels = labels_with_closed_status(conv.labels, conv.title)
+    if agent_name in (_CLAUDE_NATIVE_MODEL, _CODEX_NATIVE_MODEL):
+        labels = {**labels, _CLAUDE_NATIVE_UI_LABEL_KEY: _CLAUDE_NATIVE_UI_LABEL_VALUE}
     return SessionResponse(
         id=conv.id,
         agent_id=conv.agent_id,
@@ -2247,7 +2256,7 @@ def _build_session_response(
         status=status,
         created_at=conv.created_at,
         title=title_without_closed_marker(conv.title),
-        labels=labels_with_closed_status(conv.labels, conv.title),
+        labels=labels,
         runner_id=conv.runner_id,
         host_id=conv.host_id,
         runner_online=runner_online,


### PR DESCRIPTION
## Summary

Native-terminal-wrapper sessions (`claude-native-ui` / `codex-native-ui`) are always terminal-first. The web UI gates the Chat/Terminal pill on the `omnigent.ui="terminal"` label, which is stamped at session create. This derives the label in `_build_session_response` from the agent identity as well, so the pill stays correct even if a `ConversationStore` whose `set_labels` is a non-atomic whole-map read-merge-write drops the stored value when a concurrent label write lands.

## Notes

Idempotent: a no-op when the stored label is already present — the bundled SqlAlchemy store's per-key UPSERT never loses it, so this only changes behavior for backends that replace the whole metadata map on write.