### PR TITLE
fix(model-catalog): Expose cursor-native static listings

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -77,6 +77,17 @@ _LLM_TASK_TOKENS = ("chat", "completion")
 _SUBSCRIPTION_STATIC_MODELS: dict[str, tuple[str, ...]] = {
     "claude": ("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"),
     "codex": ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"),
+    "cursor": (
+        "auto",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "gemini-3.1-pro",
+        "composer-2.5",
+    ),
 }
 
 # Harness spellings -> the workflow harness whose provider resolution they
@@ -90,6 +101,9 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
     "codex": "codex",
     "codex-native": "codex",
     "native-codex": "codex",
+    "cursor": "cursor",
+    "cursor-native": "cursor",
+    "native-cursor": "cursor",
     "pi": "pi",
     "pi-native": "pi",
     "native-pi": "pi",
@@ -105,6 +119,7 @@ _PROVIDER_RESOLUTION_HARNESS: dict[str, str] = {
 _KEY_AUTH_FAMILY: dict[str, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
+    "cursor": OPENAI_FAMILY,
     "openai-agents-sdk": OPENAI_FAMILY,
     "antigravity": OPENAI_FAMILY,
 }

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -123,6 +123,9 @@ _HARNESS_FAMILY: dict[str, str] = {
     "native-claude": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
     "codex-native": OPENAI_FAMILY,
+    "cursor": OPENAI_FAMILY,
+    "cursor-native": OPENAI_FAMILY,
+    "native-cursor": OPENAI_FAMILY,
     "native-codex": OPENAI_FAMILY,
     "openai-agents": OPENAI_FAMILY,
     # The workflow's AgentHarnessType spells this "openai-agents-sdk" and
@@ -722,7 +725,7 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
         served = (
             {ANTHROPIC_FAMILY}
             if cli_raw == "claude"
-            else ({OPENAI_FAMILY} if cli_raw == "codex" else set())
+            else ({OPENAI_FAMILY} if cli_raw in {"codex", "cursor"} else set())
         )
         return ProviderEntry(
             name=name,

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -707,6 +707,37 @@ def test_anthropic_api_listing_uses_api_key_headers(
     assert [m.id for m in listing.models] == ["claude-opus-4-8", "claude-sonnet-4-6"]
 
 
+def test_cursor_native_subscription_listing_is_static_and_multifamily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cursor-native uses a curated static listing rather than source ``none``.
+
+    Regression for #998: ``cursor-native`` was missing from the subscription
+    listing map, so ``sys_list_models`` reported it as an unusable worker even
+    though a logged-in Cursor CLI can launch it.
+    """
+    _isolate_config(
+        monkeypatch,
+        tmp_path,
+        "providers:\n  cursor:\n    kind: subscription\n    cli: cursor\n    default: true\n",
+    )
+    listing = list_models_for_worker(_worker_spec("cursor-native"), "cursor-native")
+    assert listing.source == "static"
+    assert listing.verified is False
+    assert [m.id for m in listing.models] == [
+        "auto",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "gemini-3.1-pro",
+        "composer-2.5",
+    ]
+    assert "Cursor" not in listing.note
+    assert "cursor" in listing.note.lower()
+
 def test_subscription_listing_is_static_and_unverified(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Fixes #998

Summary: Treat `cursor-native` subscription workers as a curated static model listing instead of `source: "none"`, so `sys_list_models` reflects that a logged-in Cursor CLI worker is dispatchable and exposes the same multifamily model catalog the UI expects.

Validation: `uv run pytest tests/test_model_catalog.py tests/onboarding/test_provider_config.py -q -k 'cursor_native_subscription_listing_is_static_and_multifamily or subscription_listing_is_static_and_unverified or sys_list_models_dispatches_locally_with_static_provider or harness_family_maps_native_harness_spellings or provider_family_for_harness_accepts_executor_type_spellings'` passed, `uv run ruff check omnigent/model_catalog.py omnigent/onboarding/provider_config.py tests/test_model_catalog.py tests/onboarding/test_provider_config.py` passed, and a direct `uv run python` repro now resolves `cursor-native` to `kind='subscription'` with `listing_source='static'`.
