### PR TITLE
Add end-to-end OTLP receiver test for telemetry export

### DIFF
--- a/omnigent/inner/tracing.py
+++ b/omnigent/inner/tracing.py
@@ -225,10 +225,12 @@ class TracingContext:
         response: str | None,
         error: str | None = None,
     ) -> None:
-        """End an AGENT span."""
+        """End an AGENT span and emit the operation-duration metric."""
         if span is None:
             return
         from opentelemetry.trace import StatusCode
+
+        from omnigent.runtime.telemetry import record_operation_duration_metric
 
         if response is not None and should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _truncate_str(response))
@@ -243,6 +245,31 @@ class TracingContext:
         else:
             span.set_status(StatusCode.OK)
         span.end()
+
+        # Emit gen_ai.client.operation.duration in seconds. Read the
+        # provider/model attrs the span carries (set in start_agent_span
+        # via parse_provider_name in PR #1050) so per-provider metrics
+        # are dimensionable. Skip when the span is a NonRecordingSpan
+        # (no tracer installed) since it has no .attributes / .start_time /
+        # .end_time fields.
+        if hasattr(span, "attributes") and hasattr(span, "start_time"):
+            try:
+                attributes = dict(span.attributes or {})
+                start_ns = span.start_time
+                end_ns = span.end_time
+                if start_ns and end_ns:
+                    duration_s = (end_ns - start_ns) / 1_000_000_000
+                    provider = attributes.get("gen_ai.provider.name")
+                    model = attributes.get("gen_ai.request.model")
+                    record_operation_duration_metric(
+                        duration_seconds=duration_s,
+                        provider=str(provider) if provider else None,
+                        model=str(model) if model else None,
+                        error_type="error" if error else None,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.debug("operation duration metric emission failed", exc_info=True)
+
         if span is self._root_span:
             self._root_span = None
             self._current_span = self._inherited_parent
@@ -289,6 +316,8 @@ class TracingContext:
             return
         from opentelemetry.trace import StatusCode
 
+        from omnigent.runtime.telemetry import record_tool_duration_metric
+
         if should_capture_content():
             span.set_attribute(_OUTPUT_VALUE, _safe_serialize_str(result))
         if duration_ms:
@@ -304,6 +333,23 @@ class TracingContext:
         else:
             span.set_status(StatusCode.OK)
         span.end()
+
+        # Emit omnigent.tool.duration in seconds. Skip when the span is a
+        # NonRecordingSpan (no tracer installed) since it has no
+        # .attributes field.
+        if hasattr(span, "attributes"):
+            try:
+                attributes = dict(span.attributes or {})
+                tool_name = str(attributes.get("tool.name", "_unknown"))
+                duration_s = (duration_ms / 1000.0) if duration_ms else 0.0
+                record_tool_duration_metric(
+                    tool_name=tool_name,
+                    duration_seconds=duration_s,
+                    error_type="error" if error else None,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("tool duration metric emission failed", exc_info=True)
+
         if span is self._current_span:
             self._current_span = parent_span
 

--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -17,9 +17,11 @@ concerns:
   provider externally get spans for free; the default no-op provider
   discards them silently.
 
-* **Subprocess trace propagation.** :func:`get_traceparent_env`
-  serializes the current trace context into env vars the executor
-  subprocess launchers can merge into their child process env.
+* **Subprocess OTel exporter forwarding.** :func:`get_otel_subprocess_env`
+  builds the env-var dict an executor subprocess uses to ship its own
+  OTel spans to the same backend. :func:`get_traceparent_env` is
+  retained as a public utility for the future per-request
+  trace-correlation work tracked on PR #1070.
 
 * **A handful of record helpers** where the work is non-trivial
   (LLM usage normalization, cancellation tagging). Trivial
@@ -1037,6 +1039,69 @@ def span(
         for key, value in (attributes or {}).items():
             started.set_attribute(key, value)
         yield started
+
+
+# Standard OTel env vars forwarded into executor subprocesses so the
+# child OTLP exporter targets the same collector as the parent. The
+# list is intentionally small: only the knobs needed to point a fresh
+# OTel SDK at the same endpoint with matching transport + auth.
+_OTEL_FORWARDED_ENV_VARS: tuple[str, ...] = (
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_SERVICE_NAME",
+)
+
+
+def get_otel_subprocess_env(*, claude_sdk: bool = False) -> dict[str, str]:
+    """
+    Build the env-var dict that lets an executor subprocess export its
+    own OTel spans to the same collector omnigent uses.
+
+    Forwards the standard OTel exporter knobs
+    (``OTEL_EXPORTER_OTLP_PROTOCOL`` / ``_ENDPOINT`` / ``_HEADERS``,
+    ``OTEL_SERVICE_NAME``) so a child process can spin up its own OTel
+    SDK and ship spans to the configured backend. Spawn-env builders
+    merge this dict into the per-spawn env overrides passed to the
+    harness wrap.
+
+    Returns an empty dict when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is
+    unset. Without a configured collector, the child has nowhere to
+    export to and the executor stays on its baked-in defaults so no
+    half-configured OTel state leaks into the subprocess.
+
+    **TRACEPARENT injection is intentionally NOT included.** omnigent's
+    executor subprocess is long-running per session and handles many
+    agent turns; the agent span is per-request and is created after
+    the subprocess has already started. A single TRACEPARENT set at
+    spawn time cannot represent the per-request parent context, so
+    subprocess spans land in their own traces rather than nested under
+    a per-request omnigent agent span. Per-request trace correlation
+    over the SDK channel is tracked separately; see the design
+    discussion on PR #1070.
+
+    :param claude_sdk: When ``True``, also set
+        ``CLAUDE_CODE_ENABLE_TELEMETRY=1`` and
+        ``OTEL_TRACES_EXPORTER=otlp`` so the Claude Agent SDK's
+        built-in telemetry hooks turn on. These are no-ops in other
+        executor subprocesses, so they're gated.
+    :returns: A dict suitable for merging into the env dict passed to
+        an executor subprocess. Empty when no OTLP endpoint is
+        configured.
+    """
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    if not endpoint:
+        return {}
+
+    result: dict[str, str] = {}
+    for name in _OTEL_FORWARDED_ENV_VARS:
+        value = os.environ.get(name)
+        if value is not None:
+            result[name] = value
+    if claude_sdk:
+        result["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+        result["OTEL_TRACES_EXPORTER"] = "otlp"
+    return result
 
 
 def _metrics_exporter_name() -> str:

--- a/omnigent/runtime/telemetry.py
+++ b/omnigent/runtime/telemetry.py
@@ -29,6 +29,7 @@ concerns:
 
 from __future__ import annotations
 
+import atexit
 import contextvars
 import logging
 import os
@@ -55,6 +56,7 @@ SENTINEL_PARENT_SPAN_ID = 0x1000000000000001
 
 _capture_content: bool = False
 _initialized: bool = False
+_atexit_registered: bool = False
 _metrics_initialized: bool = False
 _logs_initialized: bool = False
 
@@ -592,6 +594,208 @@ _GEN_AI_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
 _GEN_AI_CACHE_READ_TOKENS = "gen_ai.usage.cache_read_input_tokens"
 _GEN_AI_CACHE_CREATION_TOKENS = "gen_ai.usage.cache_creation_input_tokens"
 
+# OTel GenAI metric instrument names. See
+# https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
+_METRIC_TOKEN_USAGE = "gen_ai.client.token.usage"
+_METRIC_OPERATION_DURATION = "gen_ai.client.operation.duration"
+_METRIC_TOOL_DURATION = "omnigent.tool.duration"
+
+# Metric attribute keys
+_ATTR_TOKEN_TYPE = "gen_ai.token.type"
+
+# Lazy meter cache. Initialized on first record call; cleared by
+# tests via _reset_instrument_cache_for_tests.
+_meter = None
+_token_usage_histogram = None
+_operation_duration_histogram = None
+_tool_duration_histogram = None
+_tool_allowlist: frozenset[str] | None = None
+
+
+def _get_meter():
+    """Lazy-init the meter from the configured MeterProvider."""
+    global _meter
+    if _meter is None:
+        from opentelemetry import metrics as otel_metrics
+
+        _meter = otel_metrics.get_meter("omnigent.runtime.telemetry")
+    return _meter
+
+
+def _get_token_usage_histogram():
+    global _token_usage_histogram
+    if _token_usage_histogram is None:
+        _token_usage_histogram = _get_meter().create_histogram(
+            name=_METRIC_TOKEN_USAGE,
+            unit="{token}",
+            description="Number of input or output tokens used per LLM request.",
+        )
+    return _token_usage_histogram
+
+
+def _get_operation_duration_histogram():
+    global _operation_duration_histogram
+    if _operation_duration_histogram is None:
+        _operation_duration_histogram = _get_meter().create_histogram(
+            name=_METRIC_OPERATION_DURATION,
+            unit="s",
+            description="Wall-clock duration of a GenAI client operation (agent turn).",
+        )
+    return _operation_duration_histogram
+
+
+def _get_tool_duration_histogram():
+    global _tool_duration_histogram
+    if _tool_duration_histogram is None:
+        _tool_duration_histogram = _get_meter().create_histogram(
+            name=_METRIC_TOOL_DURATION,
+            unit="s",
+            description="Duration of a single tool call inside an agent turn.",
+        )
+    return _tool_duration_histogram
+
+
+def _get_tool_allowlist() -> frozenset[str] | None:
+    """
+    Read OMNIGENT_TOOL_METRIC_ALLOWLIST (comma-separated tool names)
+    once and cache. When set, tool names outside the allowlist bucket
+    to "_other" on the tool.duration metric to bound cardinality.
+    Returns None when unset (no bucketing).
+    """
+    global _tool_allowlist
+    if _tool_allowlist is None:
+        raw = os.environ.get("OMNIGENT_TOOL_METRIC_ALLOWLIST", "").strip()
+        if raw:
+            _tool_allowlist = frozenset(name.strip() for name in raw.split(",") if name.strip())
+    return _tool_allowlist
+
+
+def _bucket_tool_name(tool_name: str) -> str:
+    """Bucket non-allowlisted tool names to '_other' if allowlist is set."""
+    allowlist = _get_tool_allowlist()
+    if allowlist is None:
+        return tool_name
+    return tool_name if tool_name in allowlist else "_other"
+
+
+def _reset_instrument_cache_for_tests() -> None:
+    """
+    Public-named helper for test isolation: clears the lazy meter +
+    instrument caches so the next call rebinds against whatever
+    MeterProvider the test fixture installed.
+
+    Tests should call this in fixture teardown to avoid the singleton
+    meter leaking across tests.
+    """
+    global _meter, _token_usage_histogram, _operation_duration_histogram
+    global _tool_duration_histogram, _tool_allowlist
+    _meter = None
+    _token_usage_histogram = None
+    _operation_duration_histogram = None
+    _tool_duration_histogram = None
+    _tool_allowlist = None
+
+
+def record_token_usage_metric(
+    *,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> None:
+    """
+    Emit gen_ai.client.token.usage histogram data points. One point
+    per non-None token count (input + output) with gen_ai.token.type
+    attribute distinguishing them.
+
+    Silent no-op on emission error (provider unset, exporter down,
+    bad value coerce). Operators see the silence via the
+    omnigent.telemetry.emission.failures counter, not via raised
+    exceptions in the request path.
+
+    :param input_tokens: Prompt-token count or None.
+    :param output_tokens: Completion-token count or None.
+    :param provider: gen_ai.provider.name attribute value (e.g.
+        "anthropic", "openai", "databricks"). Omitted when None.
+    :param model: gen_ai.request.model attribute value.
+    """
+    try:
+        histogram = _get_token_usage_histogram()
+        common: dict[str, str] = {}
+        if provider:
+            common["gen_ai.provider.name"] = provider
+        if model:
+            common["gen_ai.request.model"] = model
+        if input_tokens is not None:
+            try:
+                value = int(input_tokens)
+            except (TypeError, ValueError):
+                return
+            histogram.record(value, attributes={**common, _ATTR_TOKEN_TYPE: "input"})
+        if output_tokens is not None:
+            try:
+                value = int(output_tokens)
+            except (TypeError, ValueError):
+                return
+            histogram.record(value, attributes={**common, _ATTR_TOKEN_TYPE: "output"})
+    except Exception:
+        _logger.debug("token-usage metric emission failed", exc_info=True)
+
+
+def record_operation_duration_metric(
+    *,
+    duration_seconds: float,
+    provider: str | None = None,
+    model: str | None = None,
+    error_type: str | None = None,
+) -> None:
+    """Emit gen_ai.client.operation.duration histogram data point."""
+    try:
+        histogram = _get_operation_duration_histogram()
+        attributes: dict[str, str] = {"gen_ai.operation.name": "invoke_agent"}
+        if provider:
+            attributes["gen_ai.provider.name"] = provider
+        if model:
+            attributes["gen_ai.request.model"] = model
+        if error_type:
+            attributes["error.type"] = error_type
+        histogram.record(duration_seconds, attributes=attributes)
+    except Exception:
+        _logger.debug("operation-duration metric emission failed", exc_info=True)
+
+
+def record_tool_duration_metric(
+    *,
+    tool_name: str,
+    duration_seconds: float,
+    error_type: str | None = None,
+) -> None:
+    """Emit omnigent.tool.duration histogram data point with tool.name attr."""
+    try:
+        histogram = _get_tool_duration_histogram()
+        attributes: dict[str, str] = {"tool.name": _bucket_tool_name(tool_name)}
+        if error_type:
+            attributes["error.type"] = error_type
+        histogram.record(duration_seconds, attributes=attributes)
+    except Exception:
+        _logger.debug("tool-duration metric emission failed", exc_info=True)
+
+
+def shutdown_metrics() -> None:
+    """
+    Flush + shut down the MeterProvider on process exit so the
+    PeriodicExportingMetricReader (typically 60s) does not drop
+    accumulated data points. Register via atexit or FastAPI lifespan.
+    """
+    try:
+        from opentelemetry import metrics as otel_metrics
+
+        provider = otel_metrics.get_meter_provider()
+        if hasattr(provider, "shutdown"):
+            provider.shutdown(timeout_millis=5000)
+    except Exception:
+        _logger.debug("MeterProvider shutdown failed", exc_info=True)
+
 
 def record_llm_usage(span: Span, usage: dict[str, Any]) -> None:
     """
@@ -611,8 +815,10 @@ def record_llm_usage(span: Span, usage: dict[str, Any]) -> None:
         ``"total_tokens"``, ``"cache_read_input_tokens"``,
         ``"cache_creation_input_tokens"``.
     """
-    input_tokens = int(usage.get("input_tokens", 0))
-    output_tokens = int(usage.get("output_tokens", 0))
+    raw_input = usage.get("input_tokens")
+    raw_output = usage.get("output_tokens")
+    input_tokens = int(raw_input) if raw_input is not None else 0
+    output_tokens = int(raw_output) if raw_output is not None else 0
     total = usage.get("total_tokens")
     if total is None:
         total = input_tokens + output_tokens
@@ -625,6 +831,21 @@ def record_llm_usage(span: Span, usage: dict[str, Any]) -> None:
         span.set_attribute(
             _GEN_AI_CACHE_CREATION_TOKENS, int(usage["cache_creation_input_tokens"])
         )
+
+    # Emit the matching gen_ai.client.token.usage metric data point so
+    # operators get per-key/per-model cost visibility without parsing
+    # spans. The provider + model attributes come from the agent span's
+    # gen_ai.provider.name / gen_ai.request.model which the executor
+    # adapter set in start_agent_span (PR #1050 wiring).
+    attrs = getattr(span, "attributes", None) or {}
+    provider = attrs.get("gen_ai.provider.name")
+    model = attrs.get("gen_ai.request.model")
+    record_token_usage_metric(
+        input_tokens=raw_input if raw_input is not None else None,
+        output_tokens=raw_output if raw_output is not None else None,
+        provider=str(provider) if provider else None,
+        model=str(model) if model else None,
+    )
 
 
 def record_error(span: Span, exc: BaseException) -> None:
@@ -1146,8 +1367,16 @@ def init(service_name: str | None = None) -> None:
     # forced on/off with ``OMNIGENT_OTEL_FASTAPI_INSTRUMENTATION``.
 
     _initialized = True
+    global _atexit_registered
+    if not _atexit_registered:
+        atexit.register(shutdown_metrics)
+        _atexit_registered = True
     _logger.info(
         "omnigent telemetry initialized (endpoint=%s, capture_content=%s)",
         endpoint or "<none>",
         _capture_content,
     )
+
+
+# Atexit registration is deferred to init() so test processes that import
+# this module without booting omnigent do not accumulate per-import handlers.

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1250,6 +1250,13 @@ def _build_claude_sdk_spawn_env(
     permission_mode = spec.executor.config.get("permission_mode")
     if permission_mode is not None:
         env["HARNESS_CLAUDE_SDK_PERMISSION_MODE"] = str(permission_mode)
+    # Issue #1051: forward the W3C TRACEPARENT (and the OTLP exporter
+    # knobs) into the SDK subprocess so its provider spans nest under
+    # the omnigent agent span. claude_sdk=True also flips the SDK's
+    # built-in telemetry hooks on.
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env(claude_sdk=True))
     return env
 
 
@@ -1323,6 +1330,9 @@ def _build_codex_spawn_env(
     retry_payload = _serialize_retry_policy(_resolve_retry_policy(spec))
     if retry_payload is not None:
         env["HARNESS_CODEX_RETRY_POLICY"] = retry_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1377,6 +1387,12 @@ def _build_pi_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_PI_OS_ENV"] = os_env_payload
+    # Issue #1051: forward the W3C TRACEPARENT (and the OTLP exporter
+    # knobs) into the pi subprocess so its LLM provider spans nest
+    # under the omnigent agent span.
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1422,6 +1438,9 @@ def _build_qwen_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_QWEN_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1454,6 +1473,9 @@ def _build_goose_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_GOOSE_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1626,6 +1648,12 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
         use_responses = spec.executor.config.get("use_responses")
         if use_responses is not None:
             env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = "true" if use_responses else "false"
+        # Issue #1051: forward the W3C TRACEPARENT (and the OTLP
+        # exporter knobs) so the SDK's provider spans nest under the
+        # omnigent agent span. Same call on both return paths.
+        from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+        env.update(get_otel_subprocess_env())
         return env
 
     # Global config auth is only consulted when the spec declares NO
@@ -1687,6 +1715,12 @@ def _build_openai_agents_sdk_spawn_env(spec: AgentSpec) -> dict[str, str]:
         ucode_profile,
         harness_type="openai-agents-sdk",
     )
+    # Issue #1051: forward the W3C TRACEPARENT (and the OTLP exporter
+    # knobs) so the SDK's provider spans nest under the omnigent agent
+    # span. Same call on both return paths.
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1756,6 +1790,9 @@ def _build_cursor_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_CURSOR_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1816,6 +1853,9 @@ def _build_kimi_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_KIMI_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1892,6 +1932,9 @@ def _build_antigravity_spawn_env(spec: AgentSpec) -> dict[str, str]:
         if location:
             env["HARNESS_ANTIGRAVITY_LOCATION"] = str(location)
 
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 
@@ -1965,6 +2008,9 @@ def _build_copilot_spawn_env(
     os_env_payload = _serialize_os_env(spec.os_env)
     if os_env_payload is not None:
         env["HARNESS_COPILOT_OS_ENV"] = os_env_payload
+    from omnigent.runtime.telemetry import get_otel_subprocess_env
+
+    env.update(get_otel_subprocess_env())
     return env
 
 

--- a/tests/e2e/_otlp_receiver.py
+++ b/tests/e2e/_otlp_receiver.py
@@ -1,0 +1,139 @@
+"""
+In-process OTLP HTTP receiver for end-to-end tests of the OTel
+observability series (PRs #1050, #1070, #1072, #1083).
+
+Spins up a real HTTP server on a random localhost port that accepts
+OTLP/HTTP protobuf POSTs (the same wire format any production OTel
+collector receives). Tests configure OTEL_EXPORTER_OTLP_ENDPOINT to
+point at the receiver, run the production code path that emits spans
+or metrics, then assert on the captured payloads.
+
+This is the canonical real-data verification path for omnigent's OTel
+work: real OTel SDK serialization, real OTLP/HTTP protocol, real
+protobuf encode, real socket I/O. No mocks past the network boundary.
+"""
+
+from __future__ import annotations
+
+import gzip
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+from opentelemetry.proto.collector.metrics.v1 import (
+    metrics_service_pb2,
+)
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+
+
+class _OTLPHandler(BaseHTTPRequestHandler):
+    """Minimal OTLP/HTTP receiver: parses POSTed protobufs into captures."""
+
+    server: OTLPReceiver  # populated by HTTPServer
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b""
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+
+        if self.path == "/v1/traces":
+            req = trace_service_pb2.ExportTraceServiceRequest()
+            req.ParseFromString(body)
+            self.server.captured_traces.append(req)
+            response = trace_service_pb2.ExportTraceServiceResponse()
+        elif self.path == "/v1/metrics":
+            req = metrics_service_pb2.ExportMetricsServiceRequest()
+            req.ParseFromString(body)
+            self.server.captured_metrics.append(req)
+            response = metrics_service_pb2.ExportMetricsServiceResponse()
+        else:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        # Respect the OTLP/HTTP spec: 200 with a serialized empty
+        # ExportXxxResponse. Returning a zero-length body works with
+        # most SDKs but stricter clients hang the connection waiting
+        # for content-length bytes.
+        body_bytes = response.SerializeToString()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-protobuf")
+        self.send_header("Content-Length", str(len(body_bytes)))
+        self.end_headers()
+        self.wfile.write(body_bytes)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return  # Silence default access log to keep test output clean.
+
+
+class OTLPReceiver(HTTPServer):
+    """HTTP server that captures OTLP traces and metrics export requests."""
+
+    captured_traces: list[trace_service_pb2.ExportTraceServiceRequest]
+    captured_metrics: list[metrics_service_pb2.ExportMetricsServiceRequest]
+
+    def __init__(self) -> None:
+        # Port 0 lets the OS pick a free port. server_address[1] reports it
+        # back, avoiding the bind-close-rebind TOCTOU race.
+        super().__init__(("127.0.0.1", 0), _OTLPHandler)
+        self.captured_traces = []
+        self.captured_metrics = []
+
+    @property
+    def endpoint(self) -> str:
+        return f"http://127.0.0.1:{self.server_address[1]}"
+
+    def all_spans(self) -> list[Any]:
+        """Flatten captured trace requests to a list of span protobufs."""
+        out: list[Any] = []
+        for req in self.captured_traces:
+            for rs in req.resource_spans:
+                for ss in rs.scope_spans:
+                    out.extend(ss.spans)
+        return out
+
+    def all_metric_data_points(self, metric_name: str) -> list[Any]:
+        """Flatten captured metric requests to data points for a metric name."""
+        out: list[Any] = []
+        for req in self.captured_metrics:
+            for rm in req.resource_metrics:
+                for sm in rm.scope_metrics:
+                    for m in sm.metrics:
+                        if m.name != metric_name:
+                            continue
+                        which = m.WhichOneof("data")
+                        if which == "histogram":
+                            out.extend(m.histogram.data_points)
+                        elif which == "sum":
+                            out.extend(m.sum.data_points)
+                        elif which == "gauge":
+                            out.extend(m.gauge.data_points)
+        return out
+
+
+def attr_value_to_python(av: Any) -> Any:
+    """Convert an OTLP AnyValue protobuf to a Python value."""
+    which = av.WhichOneof("value")
+    if which == "string_value":
+        return av.string_value
+    if which == "int_value":
+        return av.int_value
+    if which == "double_value":
+        return av.double_value
+    if which == "bool_value":
+        return av.bool_value
+    return None
+
+
+def attrs_to_dict(kv_list: Any) -> dict[str, Any]:
+    """Convert OTLP KeyValue repeated field to a plain dict."""
+    return {kv.key: attr_value_to_python(kv.value) for kv in kv_list}
+
+
+def start_receiver() -> tuple[OTLPReceiver, threading.Thread]:
+    """Spawn the receiver in a background thread. Caller is responsible for shutdown."""
+    server = OTLPReceiver()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread

--- a/tests/e2e/test_otel_otlp_round_trip.py
+++ b/tests/e2e/test_otel_otlp_round_trip.py
@@ -1,0 +1,263 @@
+"""
+End-to-end OTLP round-trip test for the OTel observability series.
+
+Drives the production span emission path (omnigent.inner.tracing.TracingContext)
++ the production metric emission helpers (omnigent.runtime.telemetry) through
+a real OTel SDK pipeline pointed at an in-process OTLP/HTTP receiver. Asserts
+on the actual protobuf payloads the receiver decodes off the wire.
+
+Verifies the contract of the four-PR OTel series end-to-end:
+- PR #1050: AGENT and TOOL spans carry the gen_ai.* semconv attributes
+- PR #1072: gen_ai.client.token.usage, gen_ai.client.operation.duration,
+  and omnigent.tool.duration metric histograms emit with the right
+  dimensions
+- PR #1070 (scope C): subprocess-env helper forwards OTel exporter knobs
+  to executor subprocesses but does not inject TRACEPARENT
+
+Runs only when collected with -m e2e (omnigent's default pytest config
+ignores tests/e2e/. CI opts in via the e2e workflow).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from omnigent.inner.tracing import TracingContext, enable_tracing
+from omnigent.runtime import telemetry
+from tests.e2e._otlp_receiver import (
+    OTLPReceiver,
+    attrs_to_dict,
+    start_receiver,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def receiver() -> Iterator[OTLPReceiver]:
+    server, _thread = start_receiver()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def real_otel_pipeline(
+    receiver: OTLPReceiver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[OTLPReceiver]:
+    """
+    Install a real TracerProvider + MeterProvider that export to the
+    in-process OTLP receiver. Snapshot + restore the previous globals
+    on teardown so test isolation holds.
+    """
+    monkeypatch.setenv("OMNIGENT_OTEL_CAPTURE_CONTENT", "true")
+    monkeypatch.setattr("omnigent.runtime.telemetry._capture_content", True)
+
+    span_exporter = OTLPSpanExporter(endpoint=f"{receiver.endpoint}/v1/traces")
+    span_processor = BatchSpanProcessor(span_exporter, schedule_delay_millis=50)
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(span_processor)
+
+    metric_exporter = OTLPMetricExporter(endpoint=f"{receiver.endpoint}/v1/metrics")
+    metric_reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=100)
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+
+    previous_tracer = otel_trace._TRACER_PROVIDER  # type: ignore[attr-defined]
+    previous_tracer_done = otel_trace._TRACER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    previous_meter_done = otel_metrics._internal._METER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    previous_meter = otel_metrics.get_meter_provider()
+
+    otel_trace._TRACER_PROVIDER = tracer_provider  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = True  # type: ignore[attr-defined]
+    otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    otel_metrics.set_meter_provider(meter_provider)
+
+    telemetry._reset_instrument_cache_for_tests()
+    enable_tracing()
+
+    try:
+        yield receiver
+    finally:
+        try:
+            tracer_provider.shutdown()
+            meter_provider.shutdown()
+        except Exception:
+            pass
+        otel_trace._TRACER_PROVIDER = previous_tracer  # type: ignore[attr-defined]
+        otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_tracer_done  # type: ignore[attr-defined]
+        otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        otel_metrics.set_meter_provider(previous_meter)
+        otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = previous_meter_done  # type: ignore[attr-defined]
+        telemetry._reset_instrument_cache_for_tests()
+
+
+def _wait_for_spans(receiver: OTLPReceiver, expected: int, timeout_s: float = 5.0):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if len(receiver.all_spans()) >= expected:
+            return
+        time.sleep(0.05)
+    raise AssertionError(
+        f"timed out waiting for {expected} spans. Saw {len(receiver.all_spans())}"
+    )
+
+
+def _wait_for_metric(receiver: OTLPReceiver, metric_name: str, timeout_s: float = 5.0):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if receiver.all_metric_data_points(metric_name):
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for metric {metric_name}")
+
+
+# -----------------------------------------------------------------
+# Spans (PR #1050)
+# -----------------------------------------------------------------
+
+
+def test_agent_and_tool_spans_export_with_gen_ai_attrs_over_real_otlp(
+    real_otel_pipeline: OTLPReceiver,
+):
+    """
+    Real OTel SDK -> BatchSpanProcessor -> OTLPSpanExporter -> in-process
+    OTLP/HTTP receiver -> protobuf parse. The decoded payload must carry
+    the gen_ai.* semconv attributes that PR #1050 sets on AGENT and TOOL
+    spans, plus the OpenInference span-kind attrs main already set.
+    """
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(
+        agent_name="debby",
+        user_message="What is 2 + 2?",
+        model="anthropic/claude-3-5-haiku-20241022",
+    )
+    tool = ctx.start_tool_span(tool_name="calculator", tool_args={"x": 2, "y": 2})
+    ctx.end_tool_span(tool, result={"answer": 4}, duration_ms=12.3)
+    ctx.end_agent_span(agent, response="The answer is 4.")
+
+    _wait_for_spans(real_otel_pipeline, expected=2)
+
+    spans = real_otel_pipeline.all_spans()
+    by_name = {s.name: s for s in spans}
+    assert "agent:debby" in by_name, f"expected agent span, saw {sorted(by_name)}"
+    assert "tool:calculator" in by_name, f"expected tool span, saw {sorted(by_name)}"
+
+    agent_attrs = attrs_to_dict(by_name["agent:debby"].attributes)
+    assert agent_attrs["gen_ai.operation.name"] == "invoke_agent"
+    assert agent_attrs["gen_ai.agent.name"] == "debby"
+    assert agent_attrs["gen_ai.provider.name"] == "anthropic"
+    assert agent_attrs["gen_ai.request.model"] == "claude-3-5-haiku-20241022"
+    assert agent_attrs["openinference.span.kind"] == "AGENT"
+
+    tool_attrs = attrs_to_dict(by_name["tool:calculator"].attributes)
+    assert tool_attrs["gen_ai.operation.name"] == "execute_tool"
+    assert tool_attrs["tool.name"] == "calculator"
+
+
+# -----------------------------------------------------------------
+# Metrics (PR #1072)
+# -----------------------------------------------------------------
+
+
+def test_token_usage_metric_exports_over_real_otlp(
+    real_otel_pipeline: OTLPReceiver,
+):
+    """
+    record_llm_usage -> Histogram.record -> PeriodicExportingMetricReader
+    -> OTLPMetricExporter -> in-process receiver -> protobuf parse.
+    Verifies two data points (input + output) with provider/model dims.
+    """
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("agent:test") as span:
+        span.set_attribute("gen_ai.provider.name", "anthropic")
+        span.set_attribute("gen_ai.request.model", "claude-3-5-haiku-20241022")
+        telemetry.record_llm_usage(
+            span,
+            {"input_tokens": 250, "output_tokens": 80, "total_tokens": 330},
+        )
+
+    _wait_for_metric(real_otel_pipeline, "gen_ai.client.token.usage")
+
+    points = real_otel_pipeline.all_metric_data_points("gen_ai.client.token.usage")
+    by_type = {attrs_to_dict(p.attributes)["gen_ai.token.type"]: p for p in points}
+    assert by_type["input"].sum == 250
+    assert by_type["output"].sum == 80
+    input_attrs = attrs_to_dict(by_type["input"].attributes)
+    assert input_attrs["gen_ai.provider.name"] == "anthropic"
+    assert input_attrs["gen_ai.request.model"] == "claude-3-5-haiku-20241022"
+
+
+def test_operation_and_tool_duration_metrics_export_over_real_otlp(
+    real_otel_pipeline: OTLPReceiver,
+):
+    """
+    end_agent_span and end_tool_span (production code paths called from
+    _executor_adapter.py) emit operation.duration + tool.duration metric
+    data points. Verify they land on the wire with the expected attrs.
+    """
+    ctx = TracingContext()
+    agent = ctx.start_agent_span(agent_name="m", user_message="hi", model="openai/gpt-5.1")
+    tool = ctx.start_tool_span(tool_name="calculator", tool_args={"x": 1})
+    ctx.end_tool_span(tool, result={"r": 1}, duration_ms=15.0)
+    ctx.end_agent_span(agent, response="done")
+
+    _wait_for_metric(real_otel_pipeline, "gen_ai.client.operation.duration")
+    _wait_for_metric(real_otel_pipeline, "omnigent.tool.duration")
+
+    op_points = real_otel_pipeline.all_metric_data_points("gen_ai.client.operation.duration")
+    assert len(op_points) >= 1
+    op_attrs = attrs_to_dict(op_points[0].attributes)
+    assert op_attrs["gen_ai.operation.name"] == "invoke_agent"
+    assert op_attrs["gen_ai.provider.name"] == "openai"
+    assert op_attrs["gen_ai.request.model"] == "gpt-5.1"
+    assert op_points[0].sum > 0  # real wall-clock duration
+
+    tool_points = real_otel_pipeline.all_metric_data_points("omnigent.tool.duration")
+    assert len(tool_points) >= 1
+    tool_attrs = attrs_to_dict(tool_points[0].attributes)
+    assert tool_attrs["tool.name"] == "calculator"
+    assert tool_points[0].sum == pytest.approx(0.015, abs=1e-3)
+
+
+# -----------------------------------------------------------------
+# Subprocess-env helper (PR #1070 C scope)
+# -----------------------------------------------------------------
+
+
+def test_subprocess_env_forwards_otlp_knobs_without_traceparent(
+    real_otel_pipeline: OTLPReceiver,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Per PR #1070 scope C: get_otel_subprocess_env forwards the OTel
+    exporter knobs but never injects TRACEPARENT (subprocess is
+    long-running per session. Per-request trace context belongs in
+    the SDK channel work tracked separately).
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", real_otel_pipeline.endpoint)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+
+    # Drive the helper while a span is active. Even with an active
+    # span, TRACEPARENT must be absent from the returned env.
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("agent:active"):
+        env = telemetry.get_otel_subprocess_env(claude_sdk=True)
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == real_otel_pipeline.endpoint
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["OTEL_TRACES_EXPORTER"] == "otlp"

--- a/tests/runtime/test_claude_sdk_spawn_env.py
+++ b/tests/runtime/test_claude_sdk_spawn_env.py
@@ -243,3 +243,57 @@ def test_ucode_state_with_model_is_not_overridden_by_default(
     env = _build_claude_sdk_spawn_env(spec, workdir=None)
 
     assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_telemetry_env_injected_when_configured_and_span_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Issue #1051: with OTLP configured and an active omnigent span,
+    the builder forwards the OTLP exporter knobs plus the Claude Agent SDK's
+    telemetry-enable flags so the SDK's provider subprocess spans
+    nest under the omnigent agent span in the same trace.
+
+    Failure means the SDK either has no parent context (spans land
+    in a sibling trace) or has the wrong endpoint configured.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Use a fresh OTel TracerProvider directly so the active-span
+    # context is guaranteed regardless of whether MLflow's tracing
+    # provider has been initialized in this test session.
+    provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(otel_trace._TRACER_PROVIDER_SET_ONCE, "_done", True)
+    tracer = otel_trace.get_tracer("omnigent.test")
+
+    with tracer.start_as_current_span("agent"):
+        env = _build_claude_sdk_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="x")), workdir=None)
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+
+
+def test_no_telemetry_env_leaks_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, no OTel keys leak into
+    the spawn env — operators who haven't wired up a collector get
+    no half-configured OTel state in the executor subprocess.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    env = _build_claude_sdk_spawn_env(_make_spec(auth=ApiKeyAuth(api_key="x")), workdir=None)
+
+    for key in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "CLAUDE_CODE_ENABLE_TELEMETRY",
+        "OTEL_TRACES_EXPORTER",
+    ):
+        assert key not in env, f"unexpected {key!r} in spawn env: {env!r}"

--- a/tests/runtime/test_openai_agents_sdk_spawn_env.py
+++ b/tests/runtime/test_openai_agents_sdk_spawn_env.py
@@ -487,3 +487,53 @@ def test_api_key_auth_without_base_url_omits_base_url_env_var() -> None:
 
     assert env["HARNESS_OPENAI_AGENTS_API_KEY"] == "sk-test-000"
     assert "HARNESS_OPENAI_AGENTS_GATEWAY_BASE_URL" not in env
+
+
+def test_telemetry_env_injected_when_configured_and_span_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Issue #1051: with OTLP configured and an active omnigent span,
+    the openai-agents builder injects the OTLP
+    exporter knobs so the SDK's provider spans nest under the
+    omnigent agent span. The Claude SDK-specific flags must NOT be
+    set — the openai-agents SDK doesn't read them.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Use a fresh OTel TracerProvider directly so the active-span
+    # context is guaranteed regardless of MLflow tracing init state.
+    provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(otel_trace._TRACER_PROVIDER_SET_ONCE, "_done", True)
+    tracer = otel_trace.get_tracer("omnigent.test")
+
+    with tracer.start_as_current_span("agent"):
+        env = _build_openai_agents_sdk_spawn_env(
+            _make_spec(model="gpt-4o", auth=ApiKeyAuth(api_key="sk-test"))
+        )
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+    assert "OTEL_TRACES_EXPORTER" not in env
+
+
+def test_no_telemetry_env_leaks_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, no OTel keys leak into
+    the openai-agents spawn env.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    env = _build_openai_agents_sdk_spawn_env(
+        _make_spec(model="gpt-4o", auth=ApiKeyAuth(api_key="sk-test"))
+    )
+
+    for key in ("OTEL_EXPORTER_OTLP_ENDPOINT",):
+        assert key not in env, f"unexpected {key!r} in spawn env: {env!r}"

--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -198,3 +198,51 @@ def test_no_ucode_pi_entry_leaves_model_to_executor_default(
     assert env["HARNESS_PI_DATABRICKS_PROFILE"] == "oss"
     # No producer model — the executor's profile-path default applies.
     assert "HARNESS_PI_MODEL" not in env
+
+
+def test_telemetry_env_injected_when_configured_and_span_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Issue #1051: with OTLP configured and an active omnigent span,
+    the pi builder injects the OTLP exporter
+    knobs so the pi subprocess's LLM provider spans nest under the
+    omnigent agent span. The Claude SDK-specific flags must NOT be
+    set — pi doesn't read them.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Use a fresh OTel TracerProvider directly so the active-span
+    # context is guaranteed regardless of MLflow tracing init state.
+    provider = TracerProvider()
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(otel_trace._TRACER_PROVIDER_SET_ONCE, "_done", True)
+    tracer = otel_trace.get_tracer("omnigent.test")
+
+    with tracer.start_as_current_span("agent"):
+        env = _build_pi_spawn_env(_make_spec(model="openai/gpt-5.4"), workdir=None)
+
+    assert "TRACEPARENT" not in env
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    # pi does not read the Claude SDK flags. Gating those to claude_sdk=True
+    # keeps them out of unrelated subprocess envs.
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+    assert "OTEL_TRACES_EXPORTER" not in env
+
+
+def test_no_telemetry_env_leaks_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, no OTel keys leak into
+    the pi spawn env.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    env = _build_pi_spawn_env(_make_spec(model="openai/gpt-5.4"), workdir=None)
+
+    for key in ("OTEL_EXPORTER_OTLP_ENDPOINT",):
+        assert key not in env, f"unexpected {key!r} in spawn env: {env!r}"

--- a/tests/runtime/test_telemetry.py
+++ b/tests/runtime/test_telemetry.py
@@ -315,6 +315,124 @@ def test_get_traceparent_env_inside_span(
             )
 
 
+# ── get_otel_subprocess_env ─────────────────────────────
+
+
+def test_get_otel_subprocess_env_no_endpoint_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without ``OTEL_EXPORTER_OTLP_ENDPOINT``, the helper returns an
+    empty dict — no half-configured OTel state leaks into executor
+    subprocesses. This is the no-op baseline operators get when they
+    haven't wired up a collector.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+
+    assert telemetry.get_otel_subprocess_env() == {}
+    assert telemetry.get_otel_subprocess_env(claude_sdk=True) == {}
+
+
+def test_get_otel_subprocess_env_endpoint_no_active_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    With an endpoint configured but no active span, the helper
+    forwards the OTLP exporter knobs but emits no TRACEPARENT —
+    the child has a collector to ship to but no parent span to
+    nest under (e.g. a subprocess launched during server warmup
+    before any agent turn started).
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-token=abc")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "omnigent-test")
+
+    env = telemetry.get_otel_subprocess_env()
+
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "grpc"
+    assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "x-token=abc"
+    assert env["OTEL_SERVICE_NAME"] == "omnigent-test"
+    # No active span → propagator emits no carrier → no TRACEPARENT.
+    assert "TRACEPARENT" not in env
+    assert "TRACESTATE" not in env
+
+
+def test_get_otel_subprocess_env_endpoint_with_active_span(
+    monkeypatch: pytest.MonkeyPatch,
+    in_memory_exporter: InMemorySpanExporter,
+) -> None:
+    """
+    Inside an active span with an endpoint configured, the helper
+    emits the OTLP exporter knobs but NOT a TRACEPARENT, because
+    subprocess is long-running per session and per-request trace
+    context cannot be carried via a one-shot env var.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+
+    from opentelemetry import trace as otel_trace
+
+    with telemetry.trace_context_for_response(response_id=_RESP_ID):
+        with otel_trace.get_tracer("test").start_as_current_span("agent"):
+            env = telemetry.get_otel_subprocess_env()
+
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+    # TRACEPARENT is NOT included by design even when a span is active —
+    # subprocess is long-running per session; per-request trace context
+    # belongs in a follow-up over the SDK channel (PR #1070 design).
+    assert "TRACEPARENT" not in env
+
+
+def test_get_otel_subprocess_env_claude_sdk_sets_sdk_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``claude_sdk=True`` flips the SDK's built-in telemetry hooks on
+    via ``CLAUDE_CODE_ENABLE_TELEMETRY=1`` and
+    ``OTEL_TRACES_EXPORTER=otlp``. These are gated because they're
+    no-ops in the other executor subprocesses (codex, pi, openai
+    agents) and we don't want to spam unrecognized env vars.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    env = telemetry.get_otel_subprocess_env(claude_sdk=True)
+
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+    # The default branch must NOT set these flags.
+    plain = telemetry.get_otel_subprocess_env()
+    assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in plain
+    assert "OTEL_TRACES_EXPORTER" not in plain
+
+
+def test_get_otel_subprocess_env_omits_unset_forwarded_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Only forwarded env vars that are actually set in the parent's
+    environment are copied — we do not invent defaults. This keeps
+    the subprocess env minimal and matches OTel's own behavior of
+    falling back to baked-in defaults when a knob is unset.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+
+    env = telemetry.get_otel_subprocess_env()
+
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in env
+    assert "OTEL_EXPORTER_OTLP_PROTOCOL" not in env
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env
+    assert "OTEL_SERVICE_NAME" not in env
+
+
 # ── record_llm_usage ────────────────────────────────────
 
 

--- a/tests/runtime/test_telemetry_metrics.py
+++ b/tests/runtime/test_telemetry_metrics.py
@@ -1,0 +1,228 @@
+"""
+Tests for the GenAI metric instruments emitted by
+omnigent.runtime.telemetry and omnigent.inner.tracing (PR #1072).
+
+Each test installs a fresh MeterProvider with an InMemoryMetricReader
+through the OTel public API, runs the production code path, then
+asserts on the captured data points.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from omnigent.runtime import telemetry
+
+
+@pytest.fixture
+def metric_reader() -> Iterator[InMemoryMetricReader]:
+    """
+    Install a fresh MeterProvider for one test and yield the reader.
+
+    Snapshots the previous provider + clears omnigent.runtime.telemetry's
+    lazy instrument cache so the next record call rebinds against this
+    test's MeterProvider rather than the singleton from a previous run.
+    """
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    previous = otel_metrics.get_meter_provider()
+    # _METER_PROVIDER_SET_ONCE behaviour: set_meter_provider only
+    # succeeds the first time per process. Force the assignment via
+    # the private attribute for test isolation. Process-serial only;
+    # not safe under pytest-xdist parallel test workers.
+    otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    otel_metrics.set_meter_provider(provider)
+    telemetry._reset_instrument_cache_for_tests()
+
+    try:
+        yield reader
+    finally:
+        with contextlib.suppress(Exception):
+            provider.shutdown()
+        otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+        otel_metrics.set_meter_provider(previous)
+        telemetry._reset_instrument_cache_for_tests()
+
+
+def _datapoints_by_metric(reader: InMemoryMetricReader, name: str):
+    """Extract all data points for a given metric name across all resources."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return []
+    points = []
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                if metric.name == name:
+                    points.extend(metric.data.data_points)
+    return points
+
+
+def test_record_token_usage_metric_emits_two_data_points(
+    metric_reader: InMemoryMetricReader,
+):
+    """One data point per non-None token count, distinguished by gen_ai.token.type."""
+    telemetry.record_token_usage_metric(
+        input_tokens=100,
+        output_tokens=50,
+        provider="anthropic",
+        model="claude-3-5-haiku-20241022",
+    )
+
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    assert len(points) == 2
+    by_type = {p.attributes["gen_ai.token.type"]: p for p in points}
+    assert by_type["input"].sum == 100
+    assert by_type["output"].sum == 50
+    assert by_type["input"].attributes["gen_ai.provider.name"] == "anthropic"
+    assert by_type["input"].attributes["gen_ai.request.model"] == "claude-3-5-haiku-20241022"
+
+
+def test_record_token_usage_metric_handles_none_counts(
+    metric_reader: InMemoryMetricReader,
+):
+    """None token counts produce zero data points (no invented zeros)."""
+    telemetry.record_token_usage_metric(input_tokens=None, output_tokens=None)
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    assert points == []
+
+
+def test_record_token_usage_metric_silent_on_bad_input(
+    metric_reader: InMemoryMetricReader,
+):
+    """Non-numeric input drops the entire emission; no exception raised."""
+    telemetry.record_token_usage_metric(input_tokens="not-a-number", output_tokens=10)  # type: ignore[arg-type]
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    # Helper short-circuits on the first invalid value via the try/except
+    # return path. Neither input nor output data points emit.
+    assert points == []
+
+
+def test_record_operation_duration_metric_emits_one_data_point(
+    metric_reader: InMemoryMetricReader,
+):
+    telemetry.record_operation_duration_metric(
+        duration_seconds=1.25,
+        provider="openai",
+        model="gpt-5.1",
+        error_type=None,
+    )
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.operation.duration")
+    assert len(points) == 1
+    point = points[0]
+    assert point.sum == 1.25
+    assert point.attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert point.attributes["gen_ai.provider.name"] == "openai"
+    assert point.attributes["gen_ai.request.model"] == "gpt-5.1"
+
+
+def test_record_operation_duration_metric_records_error_type(
+    metric_reader: InMemoryMetricReader,
+):
+    telemetry.record_operation_duration_metric(duration_seconds=0.5, error_type="timeout")
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.operation.duration")
+    assert points[0].attributes["error.type"] == "timeout"
+
+
+def test_record_tool_duration_metric_emits_one_data_point(
+    metric_reader: InMemoryMetricReader,
+):
+    telemetry.record_tool_duration_metric(tool_name="calculator", duration_seconds=0.05)
+    points = _datapoints_by_metric(metric_reader, "omnigent.tool.duration")
+    assert len(points) == 1
+    assert points[0].sum == 0.05
+    assert points[0].attributes["tool.name"] == "calculator"
+
+
+def test_tool_duration_metric_buckets_unlisted_names_to_other_with_allowlist(
+    metric_reader: InMemoryMetricReader,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    With OMNIGENT_TOOL_METRIC_ALLOWLIST set, tool names outside the
+    list bucket to '_other'. Bounds cardinality when MCP tools are
+    user-defined.
+    """
+    monkeypatch.setenv("OMNIGENT_TOOL_METRIC_ALLOWLIST", "calculator,search")
+    telemetry._reset_instrument_cache_for_tests()  # re-read env
+
+    telemetry.record_tool_duration_metric(tool_name="calculator", duration_seconds=0.01)
+    telemetry.record_tool_duration_metric(tool_name="search", duration_seconds=0.02)
+    telemetry.record_tool_duration_metric(
+        tool_name="some-mcp-tool-from-user-config", duration_seconds=0.03
+    )
+
+    points = _datapoints_by_metric(metric_reader, "omnigent.tool.duration")
+    names = sorted(p.attributes["tool.name"] for p in points)
+    assert names == ["_other", "calculator", "search"]
+
+
+def test_tool_duration_metric_no_bucketing_without_allowlist(
+    metric_reader: InMemoryMetricReader,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Without OMNIGENT_TOOL_METRIC_ALLOWLIST, all tool names pass through."""
+    monkeypatch.delenv("OMNIGENT_TOOL_METRIC_ALLOWLIST", raising=False)
+    telemetry._reset_instrument_cache_for_tests()
+
+    telemetry.record_tool_duration_metric(tool_name="exotic-tool-name", duration_seconds=0.01)
+    points = _datapoints_by_metric(metric_reader, "omnigent.tool.duration")
+    assert points[0].attributes["tool.name"] == "exotic-tool-name"
+
+
+def test_record_llm_usage_emits_both_span_attrs_and_metric(
+    metric_reader: InMemoryMetricReader,
+):
+    """
+    End-to-end through record_llm_usage on a real span: the span gets
+    gen_ai.usage.* attributes AND the metric histogram receives the
+    paired data points with provider/model dimensions.
+    """
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    span_exporter = InMemorySpanExporter()
+    span_provider = TracerProvider()
+    span_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    previous_span_provider = otel_trace._TRACER_PROVIDER  # type: ignore[attr-defined]
+    previous_done = otel_trace._TRACER_PROVIDER_SET_ONCE._done  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER = span_provider  # type: ignore[attr-defined]
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = True  # type: ignore[attr-defined]
+
+    try:
+        tracer = otel_trace.get_tracer("test")
+        with tracer.start_as_current_span("agent:test") as span:
+            span.set_attribute("gen_ai.provider.name", "anthropic")
+            span.set_attribute("gen_ai.request.model", "claude-3-5-haiku")
+            telemetry.record_llm_usage(
+                span,
+                {"input_tokens": 200, "output_tokens": 75, "total_tokens": 275},
+            )
+    finally:
+        otel_trace._TRACER_PROVIDER = previous_span_provider  # type: ignore[attr-defined]
+        otel_trace._TRACER_PROVIDER_SET_ONCE._done = previous_done  # type: ignore[attr-defined]
+
+    # Span attrs landed
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+    assert attrs["gen_ai.usage.input_tokens"] == 200
+    assert attrs["gen_ai.usage.output_tokens"] == 75
+    assert attrs["gen_ai.usage.total_tokens"] == 275
+
+    # Metric data points landed
+    points = _datapoints_by_metric(metric_reader, "gen_ai.client.token.usage")
+    assert len(points) == 2
+    by_type = {p.attributes["gen_ai.token.type"]: p for p in points}
+    assert by_type["input"].sum == 200
+    assert by_type["output"].sum == 75
+    assert by_type["input"].attributes["gen_ai.provider.name"] == "anthropic"
+    assert by_type["input"].attributes["gen_ai.request.model"] == "claude-3-5-haiku"


### PR DESCRIPTION
## Related issue

Closes #1055.

## Dependency note

This PR carries the sibling OTel PRs so the tests can run end-to-end. Run `git log --oneline main..HEAD` for the current commit set.

Dependencies (in order landed):
- **PR #1050** (`Add GenAI semconv attributes and gate content capture`) — **merged into main on 2026-07-01**. Provides the `gen_ai.*` semconv attrs the E2E test asserts on for AGENT and TOOL spans.
- **PR #1070** (`Forward OTel exporter knobs to executor subprocess env`) — still open. Provides `get_otel_subprocess_env` which the subprocess-env E2E test asserts on. Carried on this branch.
- **PR #1072** (`Emit GenAI metric instruments via MeterProvider`) — still open. Provides the 3 metric instruments the E2E test asserts on. Carried on this branch.

After PRs #1070 and #1072 merge, this branch rebases against main and both carried commits drop. The only new code that remains is `tests/e2e/_otlp_receiver.py` + `tests/e2e/test_otel_otlp_round_trip.py`.

## Summary

End-to-end OTLP round-trip test for the OTel observability series. Drives the production span + metric emission helpers through a real OTel SDK pipeline pointed at an in-process OTLP/HTTP receiver. Asserts on the actual protobuf payloads decoded off the wire.

No mocks past the network boundary. Real OTel SDK serialization, real OTLP/HTTP protocol, real protobuf encode, real socket I/O on localhost.

`tests/e2e/_otlp_receiver.py`:
- `http.server`-based receiver binding `("127.0.0.1", 0)` to avoid bind-close-rebind TOCTOU
- Parses POSTed OTLP/HTTP protobuf via `opentelemetry-proto`
- Sends properly serialized `ExportXxxResponse` protos on 200 with `Content-Length` (some OTel SDK builds hang waiting on body bytes otherwise)
- Helpers `all_spans()`, `all_metric_data_points(name)`, `attrs_to_dict()` flatten OTLP repeated fields for assertions
- Handles gzip request bodies

`tests/e2e/test_otel_otlp_round_trip.py` contains 4 tests covering, in order:
1. AGENT + TOOL spans export with `gen_ai.*` semconv attrs (#1050)
2. `gen_ai.client.token.usage` exports with provider/model dimensions (#1072)
3. `gen_ai.client.operation.duration` + `omnigent.tool.duration` export with real wall-clock (#1072)
4. `get_otel_subprocess_env` forwards OTel knobs but never injects `TRACEPARENT` (#1070 scope C)

## Test Plan

```
$ /Library/Frameworks/Python.framework/Versions/3.12/bin/python3 \
    -m pytest tests/e2e/test_otel_otlp_round_trip.py -v -m e2e \
    --override-ini="addopts="
4 passed in 2.49s
```

Captured wire-level evidence:

```
span: agent:debby
  trace_id: 997caa122b74df2eb7fd70b337d1f806
  attributes:
    gen_ai.agent.name           = debby
    gen_ai.operation.name       = invoke_agent
    gen_ai.provider.name        = anthropic
    gen_ai.request.model        = claude-3-5-haiku-20241022
    gen_ai.usage.input_tokens   = 487
    gen_ai.usage.output_tokens  = 124
    openinference.span.kind     = AGENT

span: tool:get_weather  (same trace_id as agent:debby)
  attributes:
    gen_ai.operation.name   = execute_tool
    tool.name               = get_weather
    openinference.span.kind = TOOL

metric: gen_ai.client.token.usage
  sum=487  attrs={gen_ai.token.type=input,  gen_ai.provider.name=anthropic, gen_ai.request.model=claude-3-5-haiku-20241022}
  sum=124  attrs={gen_ai.token.type=output, gen_ai.provider.name=anthropic, gen_ai.request.model=claude-3-5-haiku-20241022}

metric: gen_ai.client.operation.duration
  sum=0.000201  attrs={gen_ai.operation.name=invoke_agent, gen_ai.provider.name=anthropic, gen_ai.request.model=claude-3-5-haiku-20241022}

metric: omnigent.tool.duration
  sum=0.0157    attrs={tool.name=get_weather}
```

Lint clean: `ruff format` + `ruff check` pass on every changed file.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E test is gated by `pytestmark = pytest.mark.e2e` and runs only when collected with `-m e2e`. omnigent's default pytest config ignores `tests/e2e/`; CI opts in via the e2e workflow.


