### PR TITLE
feat(qwen): track per-turn token usage from the ACP stream

### DIFF
--- a/docs/QWEN_FOLLOWUPS.md
+++ b/docs/QWEN_FOLLOWUPS.md
@@ -23,6 +23,15 @@ Tracks pending work and known limitations for the Qwen Code harness
   Verified end-to-end against an OpenAI-compatible endpoint. **Caveat:** this is
   authoritative only when qwen has no conflicting ambient `~/.qwen/settings.json`
   — see Pending work for the precedence limitation.
+- **Cost / token tracking.** Per-turn token usage is parsed from qwen's ACP
+  stream and emitted on `TurnComplete.usage` (and fed to the cost observer).
+  qwen rides usage out-of-band on an `agent_message_chunk` whose text is empty
+  and whose `_meta.usage` carries `{inputTokens, outputTokens, totalTokens,
+  thoughtTokens, cachedReadTokens}` (qwen-code `emitUsageMetadata`). The
+  executor sums these across a turn's internal model calls and splits
+  `cachedReadTokens` out of `input_tokens` (qwen's `inputTokens` is cache-
+  inclusive; cost wants the non-cached portion) — see `_accumulate_usage`.
+  Verified end-to-end against a live `qwen --acp` turn.
 - **OS sandbox.** When the spec's `os_env.sandbox` is not `none`, the whole
   `qwen` process tree is wrapped in the platform sandbox (bwrap / seatbelt) at
   spawn (`_sandbox_launch_path`), confining qwen's own file/shell tools to the
@@ -40,13 +49,12 @@ comments; this is the *what*, not the *how*.)
   the session is reused across turns, so switching models mid-session (`/model`)
   has no effect. Supporting it means re-creating the ACP session on a model
   change (or passing a per-turn model if qwen accepts one).
-- [ ] **Cost / token tracking.** `TurnComplete.usage` is never populated for
-  qwen (the executor yields a turn with no token counts), so per-turn token and
-  cost reporting is blank. Parse usage from qwen's ACP stream (if it reports
-  token counts) and emit it on `TurnComplete`.
-- [ ] **Context status.** The executor surfaces no context-window usage and
-  overrides no `max_context_tokens`, so the UI's context meter stays empty.
-  Report the model's context limit and per-turn context consumed.
+- [ ] **Context status.** Per-turn context *consumed* is now available
+  (qwen's `_meta.usage.totalTokens`, surfaced via cost/token tracking — see
+  What works today), but the executor still overrides no `max_context_tokens`,
+  so the UI's context meter has the numerator without the denominator. Report
+  the model's context-window *limit* (a model-capability lookup, not in the ACP
+  stream) so the meter can show used/total.
 - [ ] **Native TUI variant (`native-qwen`).** Attach to the live `qwen` terminal
   (like `pi-native`) for a fully interactive experience instead of a piped turn.
 

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -42,6 +42,7 @@ from omnigent.inner.executor import (
     TextChunk,
     TurnComplete,
 )
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 
 logger = logging.getLogger(__name__)
 
@@ -724,6 +725,51 @@ class QwenExecutor(Executor):
         return {"outcome": "selected", "optionId": chosen.get("optionId")}
 
     @staticmethod
+    def _accumulate_usage(  # type: ignore[explicit-any]
+        acc: dict[str, int], update: dict[str, Any]
+    ) -> None:
+        """Fold a ``session/update``'s ``_meta.usage`` into the turn accumulator.
+
+        qwen reports token usage out-of-band on an ``agent_message_chunk`` update
+        whose text is empty and whose ``_meta`` carries
+        ``{"usage": {"inputTokens", "outputTokens", "totalTokens",
+        "thoughtTokens", "cachedReadTokens"}}`` (see qwen-code
+        ``MessageEmitter.emitUsageMetadata``). A single Omnigent turn can drive
+        several internal model calls (tool loops), each emitting its own usage —
+        so we **sum** across the turn rather than keep only the last; each API
+        call bills its own full input, so summing matches actual cost.
+
+        qwen's ``inputTokens`` (Gemini ``promptTokenCount``) is **inclusive of
+        cached tokens**, but :func:`compute_llm_cost` expects ``input_tokens`` to
+        be the *non-cached* portion (cached tokens bill at a lower rate). So we
+        split ``cachedReadTokens`` out into ``cache_read_input_tokens`` and keep
+        only the remainder in ``input_tokens`` — mirroring the codex executor.
+
+        :param acc: The running per-turn accumulator (wire-shape keys), mutated
+            in place. Absent of any usage update it stays empty.
+        :param update: The ``session/update`` ``update`` object.
+        """
+        meta = update.get("_meta")
+        if not isinstance(meta, dict):
+            return
+        usage = meta.get("usage")
+        if not isinstance(usage, dict):
+            return
+
+        def _int(value: Any) -> int:  # type: ignore[explicit-any]
+            return int(value) if isinstance(value, (int, float)) else 0
+
+        cached = _int(usage.get("cachedReadTokens"))
+        # Non-cached input = prompt tokens minus the cached portion; clamp so a
+        # malformed cached > input never drives the running total negative.
+        non_cached = max(0, _int(usage.get("inputTokens")) - cached)
+        acc["input_tokens"] = acc.get("input_tokens", 0) + non_cached
+        acc["output_tokens"] = acc.get("output_tokens", 0) + _int(usage.get("outputTokens"))
+        acc["total_tokens"] = acc.get("total_tokens", 0) + _int(usage.get("totalTokens"))
+        if cached:
+            acc["cache_read_input_tokens"] = acc.get("cache_read_input_tokens", 0) + cached
+
+    @staticmethod
     def _image_blocks_from_content(content: Any) -> list[dict[str, Any]]:  # type: ignore[explicit-any]
         """Build ACP ``image`` prompt blocks from a message's ``input_image`` blocks.
 
@@ -926,6 +972,9 @@ class QwenExecutor(Executor):
         # human approval or slow stream won't trip a spurious timeout.
         deadline = loop.time() + _PROMPT_TIMEOUT_SECONDS
         accumulated_text: list[str] = []
+        # Per-turn token usage, summed across qwen's per-call usage emissions
+        # (see _accumulate_usage). Stays empty when qwen reports none.
+        turn_usage: dict[str, int] = {}
 
         while True:
             remaining = deadline - loop.time()
@@ -957,12 +1006,14 @@ class QwenExecutor(Executor):
                         self._system_prompt_sent = False
                     yield ExecutorError(message=error_msg, retryable=True)
                     return
-                # Successful completion.
+                # Successful completion. Attach the per-turn token usage qwen
+                # reported over the stream (None when it reported none) and feed
+                # the cost observer, mirroring the codex executor.
+                usage = turn_usage or None
+                if usage is not None:
+                    _notify_usage_from_dict(model=self._model, usage=usage)
                 final_text = "".join(accumulated_text)
-                if final_text:
-                    yield TurnComplete(response=final_text)
-                else:
-                    yield TurnComplete(response="")
+                yield TurnComplete(response=final_text if final_text else "", usage=usage)
                 return
 
             # Otherwise consume queued notifications.
@@ -981,6 +1032,10 @@ class QwenExecutor(Executor):
                 update_type = update.get("sessionUpdate", "")
 
                 if update_type == _UPDATE_AGENT_MESSAGE_CHUNK:
+                    # qwen rides per-call token usage on an agent_message_chunk
+                    # with empty text + a populated _meta.usage, so fold usage
+                    # before the text check (the usage-bearing chunk has none).
+                    self._accumulate_usage(turn_usage, update)
                     content = update.get("content", {})
                     if isinstance(content, dict):
                         text = content.get("text", "")

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -516,6 +516,193 @@ async def test_run_turn_yields_text_chunks_and_turn_complete() -> None:
     assert turn_completes[0].response == "Hello!"
 
 
+# ---------------------------------------------------------------------------
+# Token usage — parsed from qwen's _meta.usage and emitted on TurnComplete
+# ---------------------------------------------------------------------------
+
+
+def test_accumulate_usage_maps_and_splits_cached() -> None:
+    """_meta.usage maps to wire keys; cached tokens split out of input_tokens.
+
+    qwen's inputTokens (Gemini promptTokenCount) is inclusive of cached tokens,
+    but compute_llm_cost wants the non-cached portion in input_tokens.
+    """
+    acc: dict[str, int] = {}
+    QwenExecutor._accumulate_usage(
+        acc,
+        {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": ""},
+            "_meta": {
+                "usage": {
+                    "inputTokens": 1000,
+                    "outputTokens": 200,
+                    "totalTokens": 1200,
+                    "cachedReadTokens": 300,
+                    "thoughtTokens": 50,
+                }
+            },
+        },
+    )
+    assert acc == {
+        "input_tokens": 700,  # 1000 - 300 cached
+        "output_tokens": 200,
+        "total_tokens": 1200,
+        "cache_read_input_tokens": 300,
+    }
+
+
+def test_accumulate_usage_sums_across_calls_and_ignores_non_usage() -> None:
+    """Multiple emissions sum; updates without _meta.usage are ignored."""
+    acc: dict[str, int] = {}
+    # A plain text chunk carries no usage — must not perturb the accumulator.
+    QwenExecutor._accumulate_usage(acc, {"content": {"type": "text", "text": "hi"}})
+    assert acc == {}
+    for _ in range(2):
+        QwenExecutor._accumulate_usage(
+            acc,
+            {"_meta": {"usage": {"inputTokens": 100, "outputTokens": 10, "totalTokens": 110}}},
+        )
+    # Summed across the two calls; no cached key when cachedReadTokens absent.
+    assert acc == {"input_tokens": 200, "output_tokens": 20, "total_tokens": 220}
+
+
+def test_accumulate_usage_clamps_negative_input() -> None:
+    """A malformed cached > input never drives input_tokens negative."""
+    acc: dict[str, int] = {}
+    QwenExecutor._accumulate_usage(
+        acc,
+        {"_meta": {"usage": {"inputTokens": 100, "cachedReadTokens": 500, "totalTokens": 100}}},
+    )
+    assert acc["input_tokens"] == 0
+    assert acc["cache_read_input_tokens"] == 500
+
+
+@pytest.mark.asyncio
+async def test_run_turn_emits_usage_on_turn_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A usage-bearing chunk surfaces as TurnComplete.usage and notifies cost."""
+    notified: list[dict] = []
+    monkeypatch.setattr(
+        "omnigent.inner.qwen_executor._notify_usage_from_dict",
+        lambda model, usage: notified.append({"model": model, "usage": usage}),
+    )
+
+    executor = QwenExecutor(model="qwen/qwen3-coder")
+    executor._initialized = True
+    executor._session_id = "sess-usage"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    session_id = executor._session_id
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            base = {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": session_id},
+            }
+            # 1. Real text chunk.
+            await executor._queue.put(
+                {
+                    **base,
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": "done"},
+                        },
+                    },
+                }
+            )
+            # 2. Usage-bearing chunk (empty text + _meta.usage).
+            await executor._queue.put(
+                {
+                    **base,
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": ""},
+                            "_meta": {
+                                "usage": {
+                                    "inputTokens": 500,
+                                    "outputTokens": 80,
+                                    "totalTokens": 580,
+                                    "cachedReadTokens": 100,
+                                }
+                            },
+                        },
+                    },
+                }
+            )
+            fut = executor._pending.get(msg["id"])
+            if fut and not fut.done():
+                fut.set_result(
+                    {"jsonrpc": "2.0", "id": msg["id"], "result": {"stopReason": "end_turn"}}
+                )
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    assert completes[0].response == "done"
+    assert completes[0].usage == {
+        "input_tokens": 400,  # 500 - 100 cached
+        "output_tokens": 80,
+        "total_tokens": 580,
+        "cache_read_input_tokens": 100,
+    }
+    # Cost observer was notified with the same usage + the configured model.
+    assert notified == [{"model": "qwen/qwen3-coder", "usage": completes[0].usage}]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_usage_none_when_unreported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No usage chunk → TurnComplete.usage is None and the observer isn't called."""
+    notified: list[dict] = []
+    monkeypatch.setattr(
+        "omnigent.inner.qwen_executor._notify_usage_from_dict",
+        lambda model, usage: notified.append({"model": model, "usage": usage}),
+    )
+
+    executor = QwenExecutor()
+    executor._initialized = True
+    executor._session_id = "sess-no-usage"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+    session_id = executor._session_id
+
+    async def fake_send(msg: dict) -> None:
+        if msg.get("method") == "session/prompt":
+            await executor._queue.put(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": "hi"},
+                        },
+                    },
+                }
+            )
+            fut = executor._pending.get(msg["id"])
+            if fut and not fut.done():
+                fut.set_result(
+                    {"jsonrpc": "2.0", "id": msg["id"], "result": {"stopReason": "end_turn"}}
+                )
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    completes = [e for e in events if isinstance(e, TurnComplete)]
+    assert len(completes) == 1
+    assert completes[0].usage is None
+    assert notified == []
+
+
 @pytest.mark.asyncio
 async def test_run_turn_drains_all_chunks_before_completing() -> None:
     """All buffered chunks are yielded even if the future resolves first.


### PR DESCRIPTION
## What

Populates `TurnComplete.usage` for the qwen (`qwen --acp`) harness, so per-turn token usage is reported instead of staying blank.

qwen reports usage out-of-band: on an `agent_message_chunk` whose text is empty and whose `_meta.usage` carries `inputTokens` / `outputTokens` / `totalTokens` / `cachedReadTokens` (qwen-code `emitUsageMetadata`). The executor previously read only `content.text` and ignored `_meta`, so usage was dropped.

## Changes

- **`_accumulate_usage`** folds each update's `_meta.usage` into a per-turn accumulator:
  - **Sums** across the turn's internal model calls (each API call bills its own full input).
  - **Splits `cachedReadTokens` out of `input_tokens`** — qwen's `inputTokens` (Gemini `promptTokenCount`) is cache-inclusive, but `compute_llm_cost` wants the non-cached portion. Mirrors `_extract_codex_last_turn_usage`.
- `run_turn` emits the accumulated usage on `TurnComplete(usage=...)` and feeds `_notify_usage_from_dict` (cost observer), matching the codex executor. `usage` is `None` when qwen reports none.
- Doc updates in `QWEN_FOLLOWUPS.md`: cost/token tracking moved to "What works today"; the context-status item narrowed to just the context-window *limit* (per-turn consumed now comes from `totalTokens`).

## Testing

- 5 new unit tests (key-mapping/cached-split, summing across calls, negative-clamp, `run_turn` usage-emitted + observer-notified, and usage-`None`-when-unreported). Full `tests/inner/test_qwen_executor.py` suite passes (61).
- **Verified end-to-end against a live `qwen --acp` turn**: `inputTokens 19434`, `cachedReadTokens 64` → `input_tokens 19370` + `cache_read_input_tokens 64`, output 25, total 19459.

## Note

Dollar **cost** still shows blank for qwen because qwen models aren't in the MLflow pricing catalog (`fetch_model_pricing` returns `None`) — a separate pricing-data layer, not a usage-reporting gap. Cost would populate automatically for a model the catalog prices (e.g. a Databricks-served endpoint).