### PR TITLE
test(e2e_ui): rerun two harness-stall-prone chat tests on failure

### DIFF
--- a/tests/e2e_ui/mobile/test_mobile_workflow.py
+++ b/tests/e2e_ui/mobile/test_mobile_workflow.py
@@ -250,6 +250,13 @@ def test_mobile_files_drawer_opens_seeded_file(
     expect(file_viewer.get_by_text(_SEEDED_FILE_CONTENT).first).to_be_visible(timeout=20_000)
 
 
+# The agent turn is dispatched to the in-process harness, which
+# occasionally produces no assistant output on the first turn (the
+# runner goes idle after dispatch — a nondeterministic harness
+# scheduling stall, not a real-LLM artifact since this drives the mock
+# LLM). Rerun on failure rather than widen the already-generous 60s
+# wait, which a stalled turn would never satisfy.
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_mobile_chat_send_and_response(
     page: Page,
     seeded_session: tuple[str, str],

--- a/tests/e2e_ui/sessions/test_clone_session.py
+++ b/tests/e2e_ui/sessions/test_clone_session.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import re
 
 import httpx
+import pytest
 from playwright.sync_api import Page, expect
 
 # Unique marker so the copied-transcript assertion can't match
@@ -99,6 +100,14 @@ def test_clone_session_copies_transcript_and_navigates(
     expect(copied_user.first).to_be_visible(timeout=30_000)
 
 
+# Forking needs a real assistant bubble to anchor "Fork from here", so
+# this sends a turn and waits on the reply. The in-process harness
+# occasionally produces no assistant output on the first turn (the
+# runner goes idle after dispatch — a nondeterministic harness
+# scheduling stall, not a real-LLM artifact since this drives the mock
+# LLM). Rerun on failure rather than widen the already-generous 60s
+# wait, which a stalled turn would never satisfy.
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 def test_clone_dialog_offers_cross_family_native_target_and_forks(
     page: Page,
     seeded_session: tuple[str, str],


### PR DESCRIPTION
## What

Mark two e2e UI chat tests with `@pytest.mark.flaky(reruns=2, reruns_delay=5)`:

- `tests/e2e_ui/mobile/test_mobile_workflow.py::test_mobile_chat_send_and_response`
- `tests/e2e_ui/sessions/test_clone_session.py::test_clone_dialog_offers_cross_family_native_target_and_forks`

## Why

Both tests send a turn and wait up to 60s for the assistant bubble to render. They flaked in CI (e.g. [run 28070865994 shard 0](https://github.com/omnigent-ai/omnigent/actions/runs/28070865994/job/83104957231)) with `Locator expected to be visible … element(s) not found`.

Tracing the failed shard's `runner.log` artifact: the user message reaches the server and a background turn starts —

```
post_session_events: starting background turn
openai-agents gateway routing: … model=gpt-4o-mini
policies/evaluate "HTTP/1.1 200 OK"
POST http://harness.local/…/events "HTTP/1.1 204 No Content"
```

— but the in-process harness then occasionally yields **no assistant output**, and the runner sits idle until the 60s wait expires. It's a nondeterministic harness turn-dispatch/scheduling stall under the **mock LLM**, not a real-LLM artifact and unrelated to any product change.

Per the repo's marker taxonomy in `pyproject.toml`, this is the `flaky` category ("timing/scheduling races … NOT real-LLM nondeterminism"), not `llm_flaky`. Reruns are the right mitigation here — widening the already-generous 60s wait can't help a turn that produces nothing.

## Caveat / follow-up

Reruns mask the flake rather than eliminate it. The underlying bug — the harness occasionally producing no output for a turn dispatched to the mock LLM — is a larger server-side investigation worth a follow-up issue if it keeps surfacing across other e2e_ui tests.