### PR TITLE
feat(setup): offer to install the copilot extra in `omnigent setup`

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9384,6 +9384,62 @@ def _manage_goose_harness() -> None:
             status = None
 
 
+def _prompt_install_copilot() -> str | None:
+    """Offer to install the missing ``copilot`` extra; return a status line.
+
+    Shown atop the Copilot drill-in when the optional-extra ``github-copilot-sdk``
+    is absent. Three-choice ``select`` like :func:`_prompt_install_cursor` /
+    :func:`_prompt_install_antigravity` (install now / set token anyway / show
+    command), and like them does NOT gate token management on the SDK: the
+    ``copilot:`` token is stored independently and is useful once the SDK lands,
+    so declining falls through to the token menu. Install is portable and
+    index-free — see
+    :func:`omnigent.onboarding.copilot_auth.copilot_install_command`.
+
+    :returns: Status string for the drill-in's transient status line, or
+        ``None`` (set-token-anyway / Esc / printed-command, no actionable result).
+    """
+    from rich.markup import escape as _rich_escape
+
+    from omnigent.onboarding.copilot_auth import (
+        COPILOT_EXTRA_INSTALL_COMMAND,
+        install_copilot_sdk,
+    )
+    from omnigent.onboarding.interactive import console, select
+
+    cmd = COPILOT_EXTRA_INSTALL_COMMAND
+    # ``select`` renders text through Rich markup; escape the literal
+    # ``[copilot]`` so it renders verbatim.
+    cmd_markup = _rich_escape(cmd)
+    choice = select(
+        "Copilot's SDK (github-copilot-sdk) isn't installed. Install it now?",
+        [
+            f"Install it now ({cmd_markup})",
+            "Set the GitHub token anyway",
+            "I'll run it myself (show the command)",
+        ],
+        descriptions=[
+            f"Runs `{cmd_markup}` (uses uv when available), then continues.",
+            "Skip the install — store the token now; the SDK can be added later.",
+            "Print the command so you can install it yourself, then continue.",
+        ],
+        default=0,
+        clear_on_exit=True,
+    )
+    if choice == 0:
+        console.print(f"  [dim]Installing the copilot extra — running `{cmd_markup}`…[/dim]")
+        if install_copilot_sdk():
+            console.print("  [green]✓ github-copilot-sdk installed[/green]")
+            return "✓ github-copilot-sdk installed"
+        console.print(f"  [red]Install failed.[/red] Run it manually: [bold]{cmd_markup}[/bold]")
+        return "✗ Install failed — set the token anyway, or install by hand"
+    if choice == 2:  # run it yourself
+        console.print(f"  Install the copilot extra with:\n    [bold]{cmd_markup}[/bold]")
+        return None
+    # choice == 1 (set token anyway) or Esc: fall through to the token menu silently.
+    return None
+
+
 def _manage_copilot_harness() -> None:
     """Run the level-2 loop for Copilot: manage its GitHub token.
 
@@ -9394,8 +9450,15 @@ def _manage_copilot_harness() -> None:
     how cursor / antigravity persist theirs (the secret in the store, a
     ``keychain:``/``env:`` reference in ``~/.omnigent/config.yaml``).
 
-    :returns: None. Side effects: may write the ``copilot:`` block of
-        ``~/.omnigent/config.yaml`` and the secret store.
+    When the optional ``github-copilot-sdk`` is missing, the drill-in first
+    offers to install it (:func:`_prompt_install_copilot`). Unlike the CLI-backed
+    harnesses (which gate on the CLI), declining still drops into the token
+    menu — the ``copilot:`` token is independently storable. Mirrors cursor /
+    antigravity.
+
+    :returns: None. Side effects: may install the ``copilot`` extra, and may
+        write the ``copilot:`` block of ``~/.omnigent/config.yaml`` and the
+        secret store.
     """
     from omnigent.onboarding import secrets as secret_store
     from omnigent.onboarding.copilot_auth import (
@@ -9403,10 +9466,16 @@ def _manage_copilot_harness() -> None:
         COPILOT_SECRET_NAME,
         copilot_github_token_configured,
         copilot_github_token_ref,
+        copilot_sdk_installed,
     )
     from omnigent.onboarding.interactive import select
 
+    # Offer the install once on entry (not per loop iteration) when the SDK is
+    # absent; the result seeds the menu's status line. Declining falls through
+    # to token management, since the token is SDK-independent.
     status: str | None = None
+    if not copilot_sdk_installed():
+        status = _prompt_install_copilot()
     while True:
         config = _load_global_config()
         token_set = copilot_github_token_configured(config)
@@ -10018,8 +10087,10 @@ def _run_configure_harnesses_interactive() -> None:
     )
     from omnigent.onboarding.configure_models import family_label
     from omnigent.onboarding.copilot_auth import (
+        COPILOT_EXTRA_INSTALL_COMMAND,
         COPILOT_TOKEN_ENV_VARS,
         copilot_github_token_configured,
+        copilot_sdk_installed,
     )
     from omnigent.onboarding.cursor_auth import (
         CURSOR_EXTRA_INSTALL_COMMAND,
@@ -10285,14 +10356,28 @@ def _run_configure_harnesses_interactive() -> None:
         options.append(f"{'  ' if copilot_token_set else '[red]✗[/] '}Copilot")
         selectable.append(True)
         row_target.append(COPILOT_KEY)
-        copilot_sub = (
+        # ``github-copilot-sdk`` ships in an OPTIONAL extra, so the token can be
+        # set with no SDK present. When the extra is missing, lead with that gap
+        # and the install command (parallel to Cursor / Antigravity), then still
+        # report token status. ``[copilot]`` is escaped — sub-lines render through
+        # Rich markup, where bare brackets parse as a tag.
+        copilot_sub_lines: list[str] = []
+        if not copilot_sdk_installed():
+            from rich.markup import escape as _rich_escape
+
+            copilot_sub_lines.append(
+                f"[dim]not installed — open to install "
+                f"({_rich_escape(COPILOT_EXTRA_INSTALL_COMMAND)})[/]"
+            )
+        copilot_sub_lines.append(
             "[green]✓[/] GitHub token configured"
             if copilot_token_set
             else "[dim]no GitHub token yet — open to add one[/]"
         )
-        options.append(f"  {copilot_sub}")
-        selectable.append(False)
-        row_target.append(None)
+        for copilot_sub in copilot_sub_lines:
+            options.append(f"  {copilot_sub}")
+            selectable.append(False)
+            row_target.append(None)
         options.append("Quit")
         selectable.append(True)
         row_target.append(_QUIT)

--- a/omnigent/onboarding/copilot_auth.py
+++ b/omnigent/onboarding/copilot_auth.py
@@ -30,6 +30,11 @@ accepted by Copilot.
 
 from __future__ import annotations
 
+import importlib.util
+import shutil
+import subprocess
+import sys
+
 from omnigent.errors import OmnigentError
 from omnigent.onboarding.provider_config import load_config, resolve_secret
 
@@ -62,6 +67,79 @@ def looks_like_github_copilot_token(value: str) -> bool:
         a classic ``ghp_`` PAT (which Copilot rejects).
     """
     return value.startswith(_GITHUB_TOKEN_PREFIXES)
+
+
+# The OPTIONAL pip extra that ships the Copilot SDK (``github-copilot-sdk``,
+# imported as ``copilot``) — not in the default install, so the ``copilot:``
+# token can be set with no SDK present. Setup surfaces the command verbatim when
+# the extra is missing. Mirrors cursor's ``CURSOR_EXTRA`` / antigravity's
+# ``ANTIGRAVITY_EXTRA``. The name carries literal brackets — markup-rendered
+# surfaces must escape it.
+COPILOT_EXTRA = "copilot"
+COPILOT_EXTRA_INSTALL_COMMAND = 'pip install "omnigent[copilot]"'
+
+
+def copilot_sdk_installed() -> bool:
+    """Return whether the Copilot SDK (the optional extra) is importable.
+
+    The executor imports it lazily on the first turn
+    (:mod:`omnigent.inner.copilot_executor`), so a token can be set with no SDK;
+    setup uses this to detect that and offer to install it. The
+    ``github-copilot-sdk`` package is imported as ``copilot``. Mirrors
+    :func:`omnigent.onboarding.cursor_auth.cursor_sdk_installed` /
+    :func:`omnigent.onboarding.antigravity_auth.antigravity_sdk_installed`:
+    :func:`importlib.util.find_spec` avoids importing the heavy SDK, and the
+    guard catches the ``ModuleNotFoundError`` it raises when a parent package is
+    absent.
+
+    :returns: ``True`` when ``copilot`` is importable.
+    """
+    try:
+        return importlib.util.find_spec("copilot") is not None
+    except ModuleNotFoundError:
+        # Guard like the cursor/antigravity checks: find_spec can raise (not
+        # return None) when a parent package is absent.
+        return False
+
+
+def copilot_install_command() -> list[str]:
+    """Return the argv that installs the ``copilot`` extra into this env.
+
+    Prefers ``uv pip install`` when ``uv`` is on ``PATH``, else this
+    interpreter's own pip (``sys.executable -m pip``) so the package lands in the
+    running install. Carries **no index URL** — pip/uv pick up the user's
+    configured index, so a private proxy is honored without hardcoding one.
+    Mirrors :func:`omnigent.onboarding.cursor_auth.cursor_install_command`.
+
+    :returns: The install argv, e.g.
+        ``["uv", "pip", "install", "omnigent[copilot]"]`` or
+        ``[sys.executable, "-m", "pip", "install", "omnigent[copilot]"]``.
+    """
+    target = f"omnigent[{COPILOT_EXTRA}]"
+    if shutil.which("uv") is not None:
+        return ["uv", "pip", "install", target]
+    return [sys.executable, "-m", "pip", "install", target]
+
+
+def install_copilot_sdk() -> bool:
+    """Install the ``copilot`` extra; return whether the SDK is now present.
+
+    Shells out to :func:`copilot_install_command` and re-checks
+    :func:`copilot_sdk_installed`; pip/uv output is not captured so failures are
+    visible. Mirrors :func:`omnigent.onboarding.cursor_auth.install_cursor_sdk`.
+
+    :returns: ``True`` when ``copilot`` is importable after the attempt;
+        ``False`` if the process failed to spawn, timed out, or the SDK is still
+        absent.
+    """
+    try:
+        subprocess.run(copilot_install_command(), check=False, timeout=600)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    # Invalidate import caches so a just-installed package is seen without
+    # restarting the process.
+    importlib.invalidate_caches()
+    return copilot_sdk_installed()
 
 
 def copilot_github_token_ref(config: dict[str, object] | None = None) -> str | None:

--- a/tests/onboarding/test_copilot_auth.py
+++ b/tests/onboarding/test_copilot_auth.py
@@ -17,12 +17,17 @@ from pathlib import Path
 import pytest
 import yaml
 
+from omnigent.onboarding import copilot_auth
 from omnigent.onboarding import secrets as secret_store
 from omnigent.onboarding.copilot_auth import (
+    COPILOT_EXTRA_INSTALL_COMMAND,
     COPILOT_SECRET_NAME,
     copilot_github_token_configured,
     copilot_github_token_ref,
     copilot_github_token_settings,
+    copilot_install_command,
+    copilot_sdk_installed,
+    install_copilot_sdk,
     looks_like_github_copilot_token,
     resolve_copilot_github_token,
 )
@@ -131,3 +136,101 @@ def test_settings_shape() -> None:
     assert copilot_github_token_settings("keychain:copilot") == {
         "copilot": {"github_token_ref": "keychain:copilot"}
     }
+
+
+# ---------------------------------------------------------------------------
+# Optional-SDK extra (parity with cursor / antigravity)
+# ---------------------------------------------------------------------------
+
+
+def test_copilot_extra_install_command_shape() -> None:
+    """The surfaced install command targets the optional ``copilot`` extra."""
+    assert COPILOT_EXTRA_INSTALL_COMMAND == 'pip install "omnigent[copilot]"'
+
+
+def test_copilot_sdk_installed_true_when_spec_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detection returns True when ``find_spec`` resolves ``copilot``."""
+    monkeypatch.setattr(copilot_auth.importlib.util, "find_spec", lambda name: object())
+    assert copilot_sdk_installed() is True
+
+
+def test_copilot_sdk_installed_false_when_spec_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detection returns False when ``find_spec`` returns ``None`` (extra absent)."""
+    monkeypatch.setattr(copilot_auth.importlib.util, "find_spec", lambda name: None)
+    assert copilot_sdk_installed() is False
+
+
+def test_copilot_sdk_installed_false_when_module_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``ModuleNotFoundError`` from ``find_spec`` reads as not-installed.
+
+    ``find_spec`` can raise (not return ``None``) when a parent package is
+    absent; the guard must swallow that rather than crash setup.
+    """
+
+    def _raise(name: str) -> object:
+        raise ModuleNotFoundError("No module named 'copilot'")
+
+    monkeypatch.setattr(copilot_auth.importlib.util, "find_spec", _raise)
+    assert copilot_sdk_installed() is False
+
+
+def test_copilot_install_command_prefers_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ``uv`` on PATH, the install runs ``uv pip install`` — no index URL."""
+    monkeypatch.setattr(copilot_auth.shutil, "which", lambda name: "/usr/bin/uv")
+    cmd = copilot_install_command()
+    assert cmd == ["uv", "pip", "install", "omnigent[copilot]"]
+    # No hardcoded index / proxy leaks into committed code.
+    assert not any("index" in part or "://" in part for part in cmd)
+
+
+def test_copilot_install_command_falls_back_to_pip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``uv``, it falls back to this interpreter's pip — still no index."""
+    monkeypatch.setattr(copilot_auth.shutil, "which", lambda name: None)
+    cmd = copilot_install_command()
+    assert cmd == [
+        copilot_auth.sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "omnigent[copilot]",
+    ]
+    assert not any("index" in part or "://" in part for part in cmd)
+
+
+def test_install_copilot_sdk_runs_command_then_rechecks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shells the install argv, then reports the post-install detection verdict.
+
+    Mocks the subprocess (never really installs): the SDK "appears" only after
+    the install runs, so the function must re-check and return True.
+    """
+    import subprocess
+
+    calls: list[list[str]] = []
+    state = {"installed": False}
+
+    def _run(argv: list[str], *, check: bool = False, timeout: float | None = None):
+        calls.append(argv)
+        state["installed"] = True
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(copilot_auth.shutil, "which", lambda name: None)
+    monkeypatch.setattr(copilot_auth.subprocess, "run", _run)
+    monkeypatch.setattr(copilot_auth, "copilot_sdk_installed", lambda: state["installed"])
+
+    assert install_copilot_sdk() is True
+    assert calls == [[copilot_auth.sys.executable, "-m", "pip", "install", "omnigent[copilot]"]]
+
+
+def test_install_copilot_sdk_false_on_spawn_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A subprocess that can't spawn (OSError) is caught and reported as False."""
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise OSError("no pip")
+
+    monkeypatch.setattr(copilot_auth.shutil, "which", lambda name: None)
+    monkeypatch.setattr(copilot_auth.subprocess, "run", _boom)
+    assert install_copilot_sdk() is False


### PR DESCRIPTION
## Summary

Brings the GitHub Copilot harness's `omnigent setup` flow to parity with **cursor** and **antigravity**: when the optional `github-copilot-sdk` extra is missing, setup now **offers to install it** instead of silently assuming it's present.

Previously the Copilot drill-in only managed the GitHub token, so a user who installed `omnigent` without the `copilot` extra would hit a runtime import error on first use rather than being guided to install it. Cursor and antigravity already detect their missing optional SDK and offer `pip install "omnigent[...]"`; Copilot was the only key/SDK harness without this.

- **`omnigent/onboarding/copilot_auth.py`** — add `COPILOT_EXTRA` / `COPILOT_EXTRA_INSTALL_COMMAND`, `copilot_sdk_installed()` (via `importlib.util.find_spec("copilot")`), `copilot_install_command()` (uv → pip fallback, no hardcoded index), and `install_copilot_sdk()`. Direct mirror of `cursor_auth` / `antigravity_auth`.
- **`omnigent/cli.py`** — add `_prompt_install_copilot()` (install now / set token anyway / show command); `_manage_copilot_harness` offers the install on entry when the SDK is absent (declining still drops into token management, since the token is SDK-independent); the harness picker row gains a "not installed — open to install (`pip install "omnigent[copilot]"`)" sub-line.
- **`tests/onboarding/test_copilot_auth.py`** — 8 new cases mirroring the cursor SDK-install suite.

No behavior change when the SDK is already installed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage rationale

Added 8 unit tests in `tests/onboarding/test_copilot_auth.py` mirroring the cursor SDK-install suite: detection (`find_spec` found / `None` / raises `ModuleNotFoundError`), install-command argv (`uv pip install` vs `python -m pip` fallback, asserting no index/proxy URL leaks), install-then-recheck, and spawn-failure (`OSError`). Ran `pytest tests/onboarding/` (578 passed) and pre-commit (ruff format/check) clean. The interactive drill-in functions (`_prompt_install_copilot` / `_manage_copilot_harness`) follow the established cursor/antigravity pattern, which likewise carries no CLI-level unit tests.

This pull request and its description were written by Isaac.
