### PR TITLE
test(server): fix flaky test_list_hosts_stale_host_reported_offline (cross-test host leak)

### DIFF
--- a/tests/server/integration/test_hosts_management_e2e.py
+++ b/tests/server/integration/test_hosts_management_e2e.py
@@ -208,13 +208,17 @@ async def test_list_hosts_stale_host_reported_offline(
     # Register the host so it has status="online" in the DB.
     host_store.upsert_on_connect("host_stale", "stale-laptop", "local")
 
-    # Verify it initially shows as online.
+    # Verify it initially shows as online. Other tests sharing this
+    # xdist worker's host store leave rows behind (host rows are not
+    # isolated per-test within a worker), so scope the assertion to the
+    # host this test registered rather than the global host count.
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/v1/hosts")
     assert resp.status_code == 200, resp.text
     hosts = resp.json()["hosts"]
-    assert len(hosts) == 1
-    assert hosts[0]["status"] == "online"
+    stale = next((h for h in hosts if h["host_id"] == "host_stale"), None)
+    assert stale is not None, f"host_stale missing from {[h['host_id'] for h in hosts]}"
+    assert stale["status"] == "online"
 
     # Manually backdate updated_at to simulate a crashed host.
     # The liveness window is typically 60-120s; setting it 10 minutes
@@ -235,9 +239,9 @@ async def test_list_hosts_stale_host_reported_offline(
         resp = await client.get("/v1/hosts")
     assert resp.status_code == 200, resp.text
     hosts = resp.json()["hosts"]
-    assert len(hosts) == 1
-    assert hosts[0]["host_id"] == "host_stale"
-    assert hosts[0]["status"] == "offline", (
+    stale = next((h for h in hosts if h["host_id"] == "host_stale"), None)
+    assert stale is not None, f"host_stale missing from {[h['host_id'] for h in hosts]}"
+    assert stale["status"] == "offline", (
         "A host with a stale last_seen_at should be reported as offline. "
         "The liveness check (host_is_live) is missing from the list route."
     )


### PR DESCRIPTION
## What

Scope the assertions in `test_list_hosts_stale_host_reported_offline` to the `host_stale` row the test registers, instead of asserting `len(hosts) == 1` on the global `GET /v1/hosts` list.

## Why

The test flaked in CI ([run 28074176038](https://github.com/omnigent-ai/omnigent/actions/runs/28074176038/job/83114885520)) with:

```
AssertionError: assert 4 == 1
  where 4 = len([host_detail, host_fs_test, host_validate2, host_stale])
```

Host rows are **not isolated per-test within an xdist worker**, so sibling tests leak their hosts into the list:
- `host_detail`, `host_validate2` — sibling tests in this same file
- `host_fs_test` — `test_hosts_filesystem.py`

The test assumed a pristine store and checked the total count. Whether those sibling tests land on the same worker (and run first) varies run-to-run, so it flakes. This is **not** a timing stall, and `@pytest.mark.flaky` reruns wouldn't help — the leaked rows persist for the whole worker session, so a rerun would see the same 4 hosts.

The sibling tests in this file already avoid the problem by hitting host-specific endpoints (`/v1/hosts/{id}`). This change makes the list test consistent: it finds its own `host_stale` row and asserts it reads `online` before backdating `updated_at` and `offline` after — exactly the liveness behavior under test, now order-independent.

## Test

`uv run pytest tests/server/integration/test_hosts_management_e2e.py` → 8 passed. ruff format + check clean.